### PR TITLE
Feat/perps advanced chart loading intervals

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -149,8 +149,9 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const [legendRendered, setLegendRendered] = useState(false);
     const [webViewLoaded, setWebViewLoaded] = useState(false);
     const webViewLoadedRef = useRef(false);
-    const prevPositionLinesRef = useRef(positionLines);
-    const prevPositionLineColorsRef = useRef(positionLineColors);
+    const prevPositionLinesRef = useRef<AdvancedChartProps['positionLines']>();
+    const prevPositionLineColorsRef =
+      useRef<AdvancedChartProps['positionLineColors']>();
     const prevChartTypeRef = useRef(chartType);
     const prevOhlcvDataRef = useRef<OHLCVBar[]>([]);
     const prevOhlcvSeriesKeyRef = useRef<string | undefined>(undefined);

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -149,9 +149,8 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const [legendRendered, setLegendRendered] = useState(false);
     const [webViewLoaded, setWebViewLoaded] = useState(false);
     const webViewLoadedRef = useRef(false);
-    const prevPositionLinesRef = useRef<AdvancedChartProps['positionLines']>();
-    const prevPositionLineColorsRef =
-      useRef<AdvancedChartProps['positionLineColors']>();
+    const prevPositionLinesRef = useRef(positionLines);
+    const prevPositionLineColorsRef = useRef(positionLineColors);
     const prevChartTypeRef = useRef(chartType);
     const prevOhlcvDataRef = useRef<OHLCVBar[]>([]);
     const prevOhlcvSeriesKeyRef = useRef<string | undefined>(undefined);

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -973,6 +973,50 @@ describe('AdvancedChart', () => {
     );
   });
 
+  it('sends initial SET_POSITION_LINES after chart ready when positionLines are already present', () => {
+    const position: PositionLines = {
+      side: 'long',
+      currentPrice: 1991.7,
+      entryPrice: 1900,
+    };
+    const positionLineColors: PositionLineColors = {
+      currentPrice: 'current-price-color',
+      entry: 'entry-color',
+      takeProfit: 'take-profit-color',
+      stopLoss: 'stop-loss-color',
+      liquidation: 'liquidation-color',
+    };
+
+    const { getByTestId } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        positionLines={position}
+        positionLineColors={positionLineColors}
+      />,
+    );
+
+    mockPostMessage.mockClear();
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'SET_POSITION_LINES',
+        payload: {
+          position,
+          positionLineColors,
+        },
+      }),
+    );
+  });
+
   it('sends SET_POSITION_LINES with null when positionLines cleared', () => {
     const position: PositionLines = {
       side: 'long',

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -18,7 +18,11 @@ import {
   selectPerpsAdvancedChartEnabledFlag,
   selectPerpsRelatedMarketsEnabledFlag,
 } from '../../selectors/featureFlags';
-import { TimeDuration, type PerpsMarketData } from '@metamask/perps-controller';
+import {
+  CandlePeriod,
+  TimeDuration,
+  type PerpsMarketData,
+} from '@metamask/perps-controller';
 
 const mockPerpsAdvancedChartMount = jest.fn();
 const mockPerpsAdvancedChartUnmount = jest.fn();
@@ -1479,6 +1483,63 @@ describe('PerpsMarketDetailsView', () => {
 
       expect(mockPerpsAdvancedChartUnmount).toHaveBeenCalledTimes(1);
       expect(mockPerpsAdvancedChartMount).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not remount the advanced chart when only the candle period changes', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      const mockSelectPerpsEligibility = jest.requireMock(
+        '../../selectors/perpsController',
+      ).selectPerpsEligibility;
+      const mockSelectPerpsChartPreferredCandlePeriod = jest.requireMock(
+        '../../selectors/chartPreferences',
+      ).selectPerpsChartPreferredCandlePeriod;
+      let selectedPeriod = CandlePeriod.FifteenMinutes;
+
+      useSelector.mockImplementation((selector: unknown) => {
+        if (selector === mockSelectPerpsEligibility) {
+          return true;
+        }
+        if (selector === selectPerpsAdvancedChartEnabledFlag) {
+          return true;
+        }
+        if (selector === selectPerpsRelatedMarketsEnabledFlag) {
+          return false;
+        }
+        if (selector === mockSelectPerpsChartPreferredCandlePeriod) {
+          return selectedPeriod;
+        }
+        return undefined;
+      });
+
+      const renderView = () => (
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>
+      );
+      const { getByTestId, rerender } = renderWithProvider(renderView(), {
+        state: initialState,
+      });
+
+      const mountCountBeforeIntervalChange =
+        mockPerpsAdvancedChartMount.mock.calls.length;
+      const unmountCountBeforeIntervalChange =
+        mockPerpsAdvancedChartUnmount.mock.calls.length;
+      expect(getByTestId('mock-perps-advanced-chart').props.interval).toBe(
+        CandlePeriod.FifteenMinutes,
+      );
+
+      selectedPeriod = CandlePeriod.FourHours;
+      rerender(renderView());
+
+      expect(mockPerpsAdvancedChartMount).toHaveBeenCalledTimes(
+        mountCountBeforeIntervalChange,
+      );
+      expect(mockPerpsAdvancedChartUnmount).toHaveBeenCalledTimes(
+        unmountCountBeforeIntervalChange,
+      );
+      expect(getByTestId('mock-perps-advanced-chart').props.interval).toBe(
+        CandlePeriod.FourHours,
+      );
     });
 
     it('passes YearToDate pagination to advanced chart and uses its latest price for the header', async () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1440,7 +1440,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
               {isAdvancedChartEnabled && market?.symbol ? (
                 <PerpsAdvancedChart
-                  key={`${market.symbol}-${selectedCandlePeriod}-${advancedChartResetKey}`}
+                  key={`${market.symbol}-${advancedChartResetKey}`}
                   symbol={market.symbol}
                   interval={selectedCandlePeriod}
                   visibleCandleCount={

--- a/app/components/UI/Perps/components/PerpsAdvancedChart/PerpsAdvancedChart.tsx
+++ b/app/components/UI/Perps/components/PerpsAdvancedChart/PerpsAdvancedChart.tsx
@@ -1,14 +1,15 @@
 import React, {
+  type FC,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
-import {
+import type {
   CandlePeriod,
+  CandleData,
   TimeDuration,
-  type CandleData,
 } from '@metamask/perps-controller';
 import AdvancedChart from '../../../Charts/AdvancedChart/AdvancedChart';
 import { advancedChartLineChromePresets } from '../../../Charts/AdvancedChart/advancedChartLineChrome.presets';
@@ -195,27 +196,30 @@ const PerpsAdvancedChart: React.FC<PerpsAdvancedChartProps> = ({
 
   const { colors } = useTheme();
 
+  const tpslEntryPrice = tpslLines?.entryPrice;
+  const tpslTakeProfitPrice = tpslLines?.takeProfitPrice;
+  const tpslStopLossPrice = tpslLines?.stopLossPrice;
+  const tpslLiquidationPrice = tpslLines?.liquidationPrice;
+
   const positionLines = useMemo(
-    () => mapTpslToPositionLines(tpslLines, positionSize),
-    [tpslLines, positionSize],
+    () =>
+      mapTpslToPositionLines(
+        {
+          entryPrice: tpslEntryPrice,
+          takeProfitPrice: tpslTakeProfitPrice,
+          stopLossPrice: tpslStopLossPrice,
+          liquidationPrice: tpslLiquidationPrice,
+        },
+        positionSize,
+      ),
+    [
+      tpslEntryPrice,
+      tpslTakeProfitPrice,
+      tpslStopLossPrice,
+      tpslLiquidationPrice,
+      positionSize,
+    ],
   );
-
-  const advancedChartPositionLines = useMemo(() => {
-    const currentPrice =
-      latestBar && Number.isFinite(latestBar.close)
-        ? latestBar.close
-        : undefined;
-
-    if (currentPrice === undefined) {
-      return positionLines;
-    }
-
-    return {
-      side: positionLines?.side ?? 'long',
-      ...positionLines,
-      currentPrice,
-    };
-  }, [latestBar, positionLines]);
 
   const positionLineColors = useMemo(
     () => getPerpsPositionLineColors(colors),
@@ -415,7 +419,7 @@ const PerpsAdvancedChart: React.FC<PerpsAdvancedChartProps> = ({
       hidePaneSeparator
       gridLineColorOverride={colors.border.muted}
       isLoading={isLoading}
-      positionLines={advancedChartPositionLines}
+      positionLines={positionLines}
       positionLineColors={positionLineColors}
       rnBackedPagination={{ enabled: true }}
       onFetchOlderBarsRequest={handleFetchOlderBarsRequest}
@@ -424,7 +428,7 @@ const PerpsAdvancedChart: React.FC<PerpsAdvancedChartProps> = ({
       onSkeletonHidden={handleSkeletonHidden}
       visibleFromMs={visibleFromMs}
       visibleToMs={visibleToMs}
-      currentPriceLineColorOverride={colors.background.muted}
+      currentPriceLineColorOverride={positionLineColors.currentPrice}
       volumeSuccessColorOverride={volumeColors.success}
       volumeErrorColorOverride={volumeColors.error}
     />

--- a/app/components/UI/Perps/components/PerpsAdvancedChart/PerpsAdvancedChart.tsx
+++ b/app/components/UI/Perps/components/PerpsAdvancedChart/PerpsAdvancedChart.tsx
@@ -223,6 +223,7 @@ const PerpsAdvancedChart: React.FC<PerpsAdvancedChartProps> = ({
   );
 
   const volumeColors = useMemo(() => getPerpsVolumeColors(colors), [colors]);
+  const webViewInstanceKey = useMemo(() => `${symbol}|perps`, [symbol]);
 
   useEffect(() => {
     onLatestPriceChange?.(
@@ -404,6 +405,7 @@ const PerpsAdvancedChart: React.FC<PerpsAdvancedChartProps> = ({
     <AdvancedChart
       ohlcvData={ohlcvData}
       ohlcvSeriesKey={ohlcvSeriesKey}
+      webViewInstanceKey={webViewInstanceKey}
       realtimeBar={realtimeBar}
       height={height}
       chartType={ChartType.Candles}

--- a/app/components/UI/Perps/components/PerpsAdvancedChart/__tests__/PerpsAdvancedChart.test.tsx
+++ b/app/components/UI/Perps/components/PerpsAdvancedChart/__tests__/PerpsAdvancedChart.test.tsx
@@ -94,6 +94,10 @@ describe('PerpsAdvancedChart', () => {
 
   const advancedChartProps = () =>
     mockAdvancedChart.mock.calls[0][0] as AdvancedChartProps;
+  const latestAdvancedChartProps = () =>
+    mockAdvancedChart.mock.calls[
+      mockAdvancedChart.mock.calls.length - 1
+    ][0] as AdvancedChartProps;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -126,6 +130,31 @@ describe('PerpsAdvancedChart', () => {
         paginationDuration: TimeDuration.YearToDate,
       }),
     );
+  });
+
+  it('keeps the AdvancedChart WebView instance stable across interval changes', () => {
+    const { rerender } = renderChart();
+
+    expect(latestAdvancedChartProps().webViewInstanceKey).toBe('BTC|perps');
+    expect(latestAdvancedChartProps().ohlcvSeriesKey).toBe('BTC|1h');
+
+    mockUsePerpsAdvancedChartAdapter.mockReturnValue({
+      ...mockAdapterResult,
+      ohlcvSeriesKey: 'BTC|4h',
+    });
+
+    rerender(
+      <PerpsAdvancedChart
+        symbol="BTC"
+        interval={CandlePeriod.FourHours}
+        visibleCandleCount={100}
+        height={240}
+        fallbackCandleData={null}
+      />,
+    );
+
+    expect(latestAdvancedChartProps().webViewInstanceKey).toBe('BTC|perps');
+    expect(latestAdvancedChartProps().ohlcvSeriesKey).toBe('BTC|4h');
   });
 
   it('notifies the parent when the latest adapter close changes', () => {

--- a/app/components/UI/Perps/components/PerpsAdvancedChart/__tests__/PerpsAdvancedChart.test.tsx
+++ b/app/components/UI/Perps/components/PerpsAdvancedChart/__tests__/PerpsAdvancedChart.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import type React from 'react';
 import { act, render } from '@testing-library/react-native';
 import { CandlePeriod, TimeDuration } from '@metamask/perps-controller';
-import {
-  default as PerpsAdvancedChart,
+import PerpsAdvancedChart, {
   mapTpslToPositionLines,
   getPerpsPositionLineColors,
 } from '../PerpsAdvancedChart';
@@ -105,14 +104,14 @@ describe('PerpsAdvancedChart', () => {
   });
 
   it('passes the visible current-price token to AdvancedChart', () => {
-    const volumeColors = getPerpsVolumeColors(mockTheme.colors as Colors);
+    const volumeColors = getPerpsVolumeColors(mockTheme.colors);
 
     renderChart();
 
     expect(mockAdvancedChart).toHaveBeenCalledWith(
       expect.objectContaining({
         lineChrome: advancedChartLineChromePresets.perps.lineChrome,
-        currentPriceLineColorOverride: mockTheme.colors.background.muted,
+        currentPriceLineColorOverride: mockTheme.colors.text.default,
         volumeSuccessColorOverride: volumeColors.success,
         volumeErrorColorOverride: volumeColors.error,
       }),
@@ -176,7 +175,7 @@ describe('PerpsAdvancedChart', () => {
     expect(onLatestPriceChange).toHaveBeenCalledWith(42050);
   });
 
-  it('passes latest close as the unlabeled current-price guide', () => {
+  it('uses the native price line for latest close instead of a custom position shape', () => {
     mockUsePerpsAdvancedChartAdapter.mockReturnValue({
       ...mockAdapterResult,
       latestBar: {
@@ -193,15 +192,15 @@ describe('PerpsAdvancedChart', () => {
 
     expect(mockAdvancedChart).toHaveBeenCalledWith(
       expect.objectContaining({
-        positionLines: {
-          side: 'long',
-          currentPrice: 42050,
-        },
+        positionLines: undefined,
+        currentPriceLineColorOverride: mockTheme.colors.text.default,
       }),
     );
   });
 
   it('passes mapped position lines to AdvancedChart', () => {
+    const positionLineColors = getPerpsPositionLineColors(mockTheme.colors);
+
     renderChart({
       tpslLines: {
         entryPrice: '42000',
@@ -221,8 +220,39 @@ describe('PerpsAdvancedChart', () => {
           stopLossPrice: 40000,
           liquidationPrice: 38000,
         },
+        positionLineColors,
       }),
     );
+  });
+
+  it('does not recreate custom position lines when only TPSL currentPrice changes', () => {
+    const tpslLines = {
+      entryPrice: '42000',
+      takeProfitPrice: '45000',
+      stopLossPrice: '40000',
+      liquidationPrice: '38000',
+      currentPrice: '42100',
+    };
+    const { rerender } = renderChart({
+      tpslLines,
+      positionSize: '-0.5',
+    });
+
+    const initialPositionLines = latestAdvancedChartProps().positionLines;
+
+    rerender(
+      <PerpsAdvancedChart
+        symbol="BTC"
+        interval={CandlePeriod.FourHours}
+        visibleCandleCount={100}
+        height={240}
+        tpslLines={{ ...tpslLines, currentPrice: '42200' }}
+        positionSize="-0.5"
+        fallbackCandleData={null}
+      />,
+    );
+
+    expect(latestAdvancedChartProps().positionLines).toBe(initialPositionLines);
   });
 
   it('converts crosshair data to string OHLC values and emits haptics on OHLC changes', () => {
@@ -495,7 +525,7 @@ describe('getPerpsPositionLineColors', () => {
 
 describe('getPerpsVolumeColors', () => {
   it('matches the Lightweight chart 30% opacity volume colors', () => {
-    const colors = mockTheme.colors as Colors;
+    const colors = mockTheme.colors;
 
     expect(getPerpsVolumeColors(colors)).toEqual({
       success: hexToRgba(colors.success.default, 0.3),

--- a/app/components/UI/Perps/hooks/__tests__/usePerpsAdvancedChartAdapter.test.ts
+++ b/app/components/UI/Perps/hooks/__tests__/usePerpsAdvancedChartAdapter.test.ts
@@ -9,6 +9,7 @@ import type { FetchOlderBarsRequest } from '../../../Charts/AdvancedChart/Advanc
 import {
   convertCandlesToOHLCVBars,
   INTERVAL_MS,
+  PREWARM_CANDLE_PERIODS,
   usePerpsAdvancedChartAdapter,
 } from '../usePerpsAdvancedChartAdapter';
 
@@ -126,6 +127,7 @@ describe('INTERVAL_MS', () => {
 describe('usePerpsAdvancedChartAdapter loading lifecycle', () => {
   const mockSubscribe = jest.fn();
   const mockFetchHistoricalCandles = jest.fn();
+  const mockPrewarmCandles = jest.fn();
 
   const SYMBOL = 'BTC';
   const INTERVAL = CandlePeriod.OneHour;
@@ -143,7 +145,8 @@ describe('usePerpsAdvancedChartAdapter loading lifecycle', () => {
     );
 
   /** The params object passed into stream.candles.subscribe for the current mount. */
-  const subscribeParams = () => mockSubscribe.mock.calls[0][0];
+  const subscribeParams = (callIndex = 0) =>
+    mockSubscribe.mock.calls[callIndex][0];
 
   const fetchOlderRequest = (
     overrides: Partial<FetchOlderBarsRequest> = {},
@@ -171,10 +174,12 @@ describe('usePerpsAdvancedChartAdapter loading lifecycle', () => {
     jest.clearAllMocks();
     mockSubscribe.mockReturnValue(jest.fn());
     mockFetchHistoricalCandles.mockResolvedValue(undefined);
+    mockPrewarmCandles.mockResolvedValue(undefined);
     (usePerpsStream as jest.Mock).mockReturnValue({
       candles: {
         subscribe: mockSubscribe,
         fetchHistoricalCandles: mockFetchHistoricalCandles,
+        prewarmCandles: mockPrewarmCandles,
       },
     });
   });
@@ -183,6 +188,21 @@ describe('usePerpsAdvancedChartAdapter loading lifecycle', () => {
     const { result } = renderAdapter();
     expect(result.current.isLoading).toBe(true);
     expect(mockSubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('prewarms common candle periods for the active symbol', () => {
+    renderAdapter();
+
+    expect(mockPrewarmCandles).toHaveBeenCalledTimes(
+      PREWARM_CANDLE_PERIODS.length,
+    );
+    PREWARM_CANDLE_PERIODS.forEach((period) => {
+      expect(mockPrewarmCandles).toHaveBeenCalledWith(
+        SYMBOL,
+        period,
+        TimeDuration.OneWeek,
+      );
+    });
   });
 
   it('clears isLoading on the first delivery even when the frame is empty (regression: no hang)', () => {
@@ -213,6 +233,55 @@ describe('usePerpsAdvancedChartAdapter loading lifecycle', () => {
 
     expect(result.current.isLoading).toBe(false);
     expect(result.current.ohlcvData).toHaveLength(1);
+  });
+
+  it('keeps previous candles visible during interval refresh and replaces them when fresh data arrives', () => {
+    const { result, rerender } = renderHook(
+      ({ interval }) =>
+        usePerpsAdvancedChartAdapter({
+          symbol: SYMBOL,
+          interval,
+          visibleCandleCount: 45,
+        }),
+      { initialProps: { interval: INTERVAL } },
+    );
+
+    act(() => {
+      subscribeParams().callback({
+        symbol: SYMBOL,
+        interval: INTERVAL,
+        candles: [candle(1000), candle(2000)],
+      });
+    });
+
+    const previousBars = result.current.ohlcvData;
+    expect(result.current.isLoading).toBe(false);
+    expect(previousBars).toEqual([
+      { time: 1000, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+      { time: 2000, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+    ]);
+
+    rerender({ interval: CandlePeriod.FourHours });
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(2);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.ohlcvData).toBe(previousBars);
+
+    act(() => {
+      subscribeParams(1).callback({
+        symbol: SYMBOL,
+        interval: CandlePeriod.FourHours,
+        candles: [candle(4000), candle(8000)],
+      });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.ohlcvData).toEqual([
+      { time: 4000, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+      { time: 8000, open: 100, high: 110, low: 90, close: 105, volume: 500 },
+    ]);
+    expect(result.current.visibleToMs).toBe(8000);
+    expect(result.current.visibleFromMs).toBe(8000 - INTERVAL_MS['4h'] * 45);
   });
 
   it('clears isLoading when the subscription reports an error', () => {

--- a/app/components/UI/Perps/hooks/usePerpsAdvancedChartAdapter.ts
+++ b/app/components/UI/Perps/hooks/usePerpsAdvancedChartAdapter.ts
@@ -29,6 +29,17 @@ export const INTERVAL_MS: Partial<Record<string, number>> = {
   '1w': 7 * 24 * 60 * 60_000,
 };
 
+export const PREWARM_CANDLE_PERIODS = [
+  CandlePeriod.OneMinute,
+  CandlePeriod.ThreeMinutes,
+  CandlePeriod.FiveMinutes,
+  CandlePeriod.FifteenMinutes,
+  CandlePeriod.OneHour,
+  CandlePeriod.FourHours,
+  CandlePeriod.OneDay,
+  CandlePeriod.OneWeek,
+] as const;
+
 /**
  * Converts Perps CandleData candles (string-typed OHLCV) to OHLCVBar[].
  * Drops any bar whose numeric fields are non-finite after parsing.
@@ -105,11 +116,39 @@ export function usePerpsAdvancedChartAdapter({
   const prevLastBarRef = useRef<OHLCVBar | null>(null);
   /** Cleared once the first delivery (or an error) lands, so the skeleton never hangs. */
   const hasReceivedFirstUpdateRef = useRef(false);
+  /** True once this chart has rendered at least one valid candle batch. */
+  const hasLoadedBarsRef = useRef(false);
+  const previousSymbolRef = useRef<string | null>(null);
 
   useEffect(() => {
-    // Reset on symbol/interval change.
-    setIsLoading(true);
-    setOhlcvData([]);
+    if (!symbol || typeof stream.candles.prewarmCandles !== 'function') {
+      return;
+    }
+
+    PREWARM_CANDLE_PERIODS.forEach((period) => {
+      stream.candles
+        .prewarmCandles(symbol, period, TimeDuration.OneWeek)
+        .catch((error: unknown) => {
+          DevLogger.log('usePerpsAdvancedChartAdapter: prewarm failed', {
+            symbol,
+            interval: period as string,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    });
+  }, [symbol, stream]);
+
+  useEffect(() => {
+    const isIntervalRefresh =
+      previousSymbolRef.current === symbol && hasLoadedBarsRef.current;
+    previousSymbolRef.current = symbol;
+
+    // Reset on symbol change; keep the existing chart visible during interval refresh.
+    setIsLoading(!isIntervalRefresh);
+    if (!isIntervalRefresh) {
+      setOhlcvData([]);
+      hasLoadedBarsRef.current = false;
+    }
     setRealtimeBar(undefined);
     prevLastBarRef.current = null;
     latestCandleDataRef.current = null;
@@ -148,6 +187,7 @@ export function usePerpsAdvancedChartAdapter({
         if (prev === null) {
           // First data for this symbol+interval — send full dataset.
           setOhlcvData(converted);
+          hasLoadedBarsRef.current = true;
           // realtimeBar stays undefined; AdvancedChart uses ohlcvData for initial render.
         } else if (
           lastBar.time !== prev.time ||

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -1065,6 +1065,49 @@ describe('CandleStreamChannel', () => {
     });
   });
 
+  describe('Prewarm Candles', () => {
+    it('fetches latest candles into cache so subscribe can emit them immediately', async () => {
+      const warmedData: CandleData = {
+        symbol: 'BTC',
+        interval: CandlePeriod.OneWeek,
+        candles: [
+          {
+            time: 1700000000000,
+            open: '50000',
+            high: '51000',
+            low: '49000',
+            close: '50500',
+            volume: '100',
+          },
+        ],
+      };
+      mockFetchHistoricalCandles.mockResolvedValue(warmedData);
+      mockSubscribeToCandles.mockReturnValue(jest.fn());
+
+      await channel.prewarmCandles(
+        'BTC',
+        CandlePeriod.OneWeek,
+        TimeDuration.OneWeek,
+      );
+
+      const callback = jest.fn();
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneWeek,
+        duration: TimeDuration.OneWeek,
+        callback,
+      });
+
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneWeek,
+        limit: 50,
+        endTime: expect.any(Number),
+      });
+      expect(callback).toHaveBeenCalledWith(warmedData);
+    });
+  });
+
   describe('Initial Fetch Duration', () => {
     it('uses OneWeek duration on cold cache for lighter initial fetch', () => {
       mockSubscribeToCandles.mockReturnValue(jest.fn());

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -41,6 +41,7 @@ describe('CandleStreamChannel', () => {
     channel = new CandleStreamChannel(mockGetIsInitialized);
     jest.clearAllMocks();
     jest.useFakeTimers();
+    jest.setSystemTime(new Date(1700000060000));
     mockGetIsInitialized.mockReturnValue(true);
 
     // Setup Engine.context.PerpsController mock
@@ -1105,6 +1106,125 @@ describe('CandleStreamChannel', () => {
         endTime: expect.any(Number),
       });
       expect(callback).toHaveBeenCalledWith(warmedData);
+    });
+
+    it('refreshes and merges stale cached candles during prewarm', async () => {
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      const subscriber = jest.fn();
+      mockSubscribeToCandles.mockImplementation(({ callback }) => {
+        capturedCallback = callback;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        duration: TimeDuration.OneWeek,
+        callback: subscriber,
+      });
+      flushConnectDebounce();
+
+      capturedCallback?.({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        candles: [
+          {
+            time: 1700000000000,
+            open: '50000',
+            high: '51000',
+            low: '49000',
+            close: '50500',
+            volume: '100',
+          },
+        ],
+      });
+
+      jest.setSystemTime(new Date(1700000300000));
+      mockFetchHistoricalCandles.mockResolvedValue({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        candles: [
+          {
+            time: 1700000240000,
+            open: '50600',
+            high: '51200',
+            low: '50500',
+            close: '51100',
+            volume: '90',
+          },
+        ],
+      });
+      subscriber.mockClear();
+
+      await channel.prewarmCandles(
+        'BTC',
+        CandlePeriod.OneMinute,
+        TimeDuration.OneWeek,
+      );
+
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        limit: 500,
+        endTime: 1700000300000,
+      });
+      expect(subscriber).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candles: [
+            expect.objectContaining({ time: 1700000000000 }),
+            expect.objectContaining({ time: 1700000240000 }),
+          ],
+        }),
+      );
+    });
+
+    it('does not emit stale cached candles immediately on subscribe', () => {
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation(({ callback }) => {
+        capturedCallback = callback;
+        return jest.fn();
+      });
+
+      const firstSubscriber = jest.fn();
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        duration: TimeDuration.OneWeek,
+        callback: firstSubscriber,
+      });
+      flushConnectDebounce();
+
+      capturedCallback?.({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        candles: [
+          {
+            time: 1700000000000,
+            open: '50000',
+            high: '51000',
+            low: '49000',
+            close: '50500',
+            volume: '100',
+          },
+        ],
+      });
+
+      jest.setSystemTime(new Date(1700000300000));
+      const secondSubscriber = jest.fn();
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        duration: TimeDuration.OneWeek,
+        callback: secondSubscriber,
+      });
+
+      expect(secondSubscriber).not.toHaveBeenCalled();
+      expect(mockFetchHistoricalCandles).toHaveBeenCalledWith({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneMinute,
+        limit: 500,
+        endTime: 1700000300000,
+      });
     });
   });
 

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -130,6 +130,21 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   // Upper bound on cached candles per cacheKey. Matches fetchHistoricalCandles
   // so merge-on-update can't cause unbounded memory growth.
   private static readonly MAX_CACHED_CANDLES = 1000;
+  private static readonly INTERVAL_MS: Partial<Record<string, number>> = {
+    '1m': 60_000,
+    '3m': 3 * 60_000,
+    '5m': 5 * 60_000,
+    '15m': 15 * 60_000,
+    '30m': 30 * 60_000,
+    '1h': 60 * 60_000,
+    '2h': 2 * 60 * 60_000,
+    '4h': 4 * 60 * 60_000,
+    '8h': 8 * 60 * 60_000,
+    '12h': 12 * 60 * 60_000,
+    '1d': 24 * 60 * 60_000,
+    '3d': 3 * 24 * 60 * 60_000,
+    '1w': 7 * 24 * 60 * 60_000,
+  };
   private readonly getIsInitialized: () => boolean;
 
   /**
@@ -181,6 +196,17 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
       interval: incoming.interval,
       candles: capped,
     };
+  }
+
+  private static isCacheFresh(data: CandleData, nowMs = Date.now()): boolean {
+    const latestCandle = data.candles.at(-1);
+    const intervalMs = CandleStreamChannel.INTERVAL_MS[data.interval as string];
+    if (!latestCandle || intervalMs === undefined) {
+      return false;
+    }
+
+    // Allow one missed candle plus transport jitter before treating the cache as stale.
+    return nowMs - latestCandle.time <= intervalMs * 2.5;
   }
 
   /**
@@ -311,9 +337,17 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
 
     // Give immediate cached data if available
     const cached = this.cache.get(cacheKey);
-    if (cached) {
+    if (cached && CandleStreamChannel.isCacheFresh(cached)) {
       callback(cached);
       subscription.hasReceivedFirstUpdate = true;
+    } else if (cached) {
+      this.prewarmCandles(symbol, interval, params.duration).catch((error) => {
+        DevLogger.log('CandleStreamChannel: Failed to refresh stale cache', {
+          symbol,
+          interval,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
 
     // Ensure WebSocket connected for this symbol+interval
@@ -647,7 +681,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
           newCandles: newUnique.length,
           totalCandles: finalCandles.length,
           oldestTime: finalCandles[0]?.time,
-          newestTime: finalCandles[finalCandles.length - 1]?.time,
+          newestTime: finalCandles.at(-1)?.time,
         },
       );
     } catch (error) {
@@ -695,7 +729,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   ): Promise<void> {
     const cacheKey = this.getCacheKey(symbol, interval);
     const cachedData = this.cache.get(cacheKey);
-    if (cachedData?.candles.length) {
+    if (cachedData && CandleStreamChannel.isCacheFresh(cachedData)) {
       return;
     }
     if (this.prewarmRequests.has(cacheKey)) {
@@ -720,17 +754,10 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
         return;
       }
 
-      const sortedCandles = [...candleData.candles].sort(
-        (a, b) => a.time - b.time,
+      const warmedData = CandleStreamChannel.mergeCandleData(
+        cachedData,
+        candleData,
       );
-      const warmedData: CandleData = {
-        symbol: candleData.symbol,
-        interval: candleData.interval,
-        candles:
-          sortedCandles.length > CandleStreamChannel.MAX_CACHED_CANDLES
-            ? sortedCandles.slice(-CandleStreamChannel.MAX_CACHED_CANDLES)
-            : sortedCandles,
-      };
 
       this.cache.set(cacheKey, warmedData);
       this.notifySubscribers(cacheKey, warmedData);

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -125,6 +125,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     ReturnType<typeof setTimeout>
   >();
   private connectRetryCounts = new Map<string, number>();
+  private readonly prewarmRequests = new Set<string>();
   private static readonly MAX_CONNECT_RETRIES = 50;
   // Upper bound on cached candles per cacheKey. Matches fetchHistoricalCandles
   // so merge-on-update can't cause unbounded memory growth.
@@ -193,11 +194,16 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   }
 
   public override clearCache(): void {
-    this.deferConnectTimers.forEach((timer) => clearTimeout(timer));
+    this.deferConnectTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
     this.deferConnectTimers.clear();
-    this.pendingTeardownTimers.forEach((timer) => clearTimeout(timer));
+    this.pendingTeardownTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
     this.pendingTeardownTimers.clear();
     this.connectRetryCounts.clear();
+    this.prewarmRequests.clear();
     super.clearCache();
   }
 
@@ -678,16 +684,87 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   }
 
   /**
+   * Fetches the latest candles for a symbol+interval before the user selects it.
+   * This populates the same cache used by subscribe(), so interval switches can
+   * synchronously receive data instead of waiting for the WebSocket bootstrap.
+   */
+  public async prewarmCandles(
+    symbol: string,
+    interval: CandlePeriod,
+    duration: TimeDuration,
+  ): Promise<void> {
+    const cacheKey = this.getCacheKey(symbol, interval);
+    const cachedData = this.cache.get(cacheKey);
+    if (cachedData?.candles.length) {
+      return;
+    }
+    if (this.prewarmRequests.has(cacheKey)) {
+      return;
+    }
+
+    const dynamicLimit = calculateCandleCount(duration, interval);
+    const limit = Math.min(Math.max(dynamicLimit, 50), 500);
+    const endTime = Date.now();
+
+    this.prewarmRequests.add(cacheKey);
+    try {
+      const candleData =
+        await Engine.context.PerpsController.fetchHistoricalCandles({
+          symbol,
+          interval,
+          limit,
+          endTime,
+        });
+
+      if (!candleData?.candles.length) {
+        return;
+      }
+
+      const sortedCandles = [...candleData.candles].sort(
+        (a, b) => a.time - b.time,
+      );
+      const warmedData: CandleData = {
+        symbol: candleData.symbol,
+        interval: candleData.interval,
+        candles:
+          sortedCandles.length > CandleStreamChannel.MAX_CACHED_CANDLES
+            ? sortedCandles.slice(-CandleStreamChannel.MAX_CACHED_CANDLES)
+            : sortedCandles,
+      };
+
+      this.cache.set(cacheKey, warmedData);
+      this.notifySubscribers(cacheKey, warmedData);
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
+      DevLogger.log('CandleStreamChannel: Failed to prewarm candles', {
+        symbol,
+        interval,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.prewarmRequests.delete(cacheKey);
+    }
+  }
+
+  /**
    * Disconnect all subscriptions
    */
   public disconnectAll(): void {
     // Cancel all deferred connect timers
-    this.deferConnectTimers.forEach((timer) => clearTimeout(timer));
+    this.deferConnectTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
     this.deferConnectTimers.clear();
     // Cancel all deferred teardown timers — explicit disconnect supersedes them
-    this.pendingTeardownTimers.forEach((timer) => clearTimeout(timer));
+    this.pendingTeardownTimers.forEach((timer) => {
+      clearTimeout(timer);
+    });
     this.pendingTeardownTimers.clear();
     this.connectRetryCounts.clear();
+    this.prewarmRequests.clear();
 
     this.subscribers.forEach((subscriber) => {
       if (subscriber.timer) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR improves the Perps Advanced Chart interval switching experience so it behaves more like the Token Details and Social Trading advanced charts.

Previously, changing candle periods could remount the chart or wait on a cold Hyperliquid candle subscription, causing a gray skeleton/opaque overlay, delayed updates, and occasional stale or gapped candle data when returning to intervals like 1m. The current-price/position dotted line could also render noticeably after the candles because initial position lines were not always sent once the WebView became ready.

The solution keeps the AdvancedChart WebView mounted across interval changes, separates the stable WebView identity from the changing OHLCV series key, preserves visible candle data while fresh interval data loads, and prewarms common Perps candle intervals into the shared candle cache. It also refreshes stale prewarmed cache entries before reuse and ensures initial position lines are posted after chart readiness, so overlays render with the chart instead of lagging behind.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved Perps advanced chart interval switching to reduce loading flicker and stale chart data

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3126

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time candle caching, subscription timing, and WebView lifecycle for a core trading UI surface; regressions could show stale candles or overlay sync issues, but changes are scoped to Perps chart loading rather than auth or funds.
> 
> **Overview**
> Improves Perps advanced chart **candle-period switching** so the WebView stays mounted and interval changes feel closer to Token Details / Social Trading charts.
> 
> **Mounting & data:** `PerpsMarketDetailsView` no longer keys `PerpsAdvancedChart` on the selected interval; `PerpsAdvancedChart` passes a stable `webViewInstanceKey` (`symbol|perps`) while `ohlcvSeriesKey` still tracks the interval. The adapter **keeps the previous candles on screen** during an interval refresh instead of clearing to a loading skeleton, and **prewarms** common periods for the active symbol.
> 
> **Cache & subscribe:** `CandleStreamChannel` adds `prewarmCandles`, treats cached candles as usable only when **fresh**, refreshes stale cache on subscribe instead of emitting it immediately, and merges historical fetches into the shared cache.
> 
> **Overlays:** Latest close uses the chart’s **native current-price line** (theme `text.default`) rather than a custom `currentPrice` on position lines; TPSL overlays are memoized so tick-only `currentPrice` updates do not recreate position line props.
> 
> Tests cover WebView stability, interval remount behavior, prewarm/stale-cache paths, adapter interval refresh, and initial `SET_POSITION_LINES` after `CHART_READY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83617253f8f497b503a5074a82a9aa9a6fdaf543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->