### PR TITLE
fix(money): hide debit card/bank Add funds option for Transak-unsupported regions (MUSD-1075) cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -14,7 +14,7 @@ import { updateBgState } from '../../../../../core/redux/slices/engine';
 import { addTransactionBatch } from '../../../../../util/transaction-controller';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
-import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
+import { useRegionHasNativeFiatProvider } from '../../hooks/useRegionHasNativeFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 
@@ -150,8 +150,8 @@ jest.mock(
   '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig',
   () => ({ useMMPayFiatConfig: jest.fn() }),
 );
-jest.mock('../../../Ramp/hooks/useHasNativeFiatProvider', () => ({
-  useHasNativeFiatProvider: jest.fn(),
+jest.mock('../../hooks/useRegionHasNativeFiatProvider', () => ({
+  useRegionHasNativeFiatProvider: jest.fn(),
 }));
 jest.mock('../../../../../selectors/tokenBalancesController', () => ({
   ...jest.requireActual('../../../../../selectors/tokenBalancesController'),
@@ -214,7 +214,7 @@ describe('MoneyAddMoneySheet — Add funds with a pending transaction', () => {
     (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
       true,
     );
-    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+    (useRegionHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
     (useMoneyAnalytics as jest.Mock).mockReturnValue({
       trackBottomSheetViewed: jest.fn(),
       trackSurfaceClicked: jest.fn(),

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -14,6 +14,7 @@ import { updateBgState } from '../../../../../core/redux/slices/engine';
 import { addTransactionBatch } from '../../../../../util/transaction-controller';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
+import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 
@@ -149,6 +150,9 @@ jest.mock(
   '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig',
   () => ({ useMMPayFiatConfig: jest.fn() }),
 );
+jest.mock('../../../Ramp/hooks/useHasNativeFiatProvider', () => ({
+  useHasNativeFiatProvider: jest.fn(),
+}));
 jest.mock('../../../../../selectors/tokenBalancesController', () => ({
   ...jest.requireActual('../../../../../selectors/tokenBalancesController'),
   selectHasAnyNonZeroTokenBalance: jest.fn(),
@@ -210,6 +214,7 @@ describe('MoneyAddMoneySheet — Add funds with a pending transaction', () => {
     (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
       true,
     );
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
     (useMoneyAnalytics as jest.Mock).mockReturnValue({
       trackBottomSheetViewed: jest.fn(),
       trackSurfaceClicked: jest.fn(),

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -8,6 +8,7 @@ import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
+import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
@@ -57,6 +58,10 @@ jest.mock(
     useMMPayFiatConfig: jest.fn(),
   }),
 );
+
+jest.mock('../../../Ramp/hooks/useHasNativeFiatProvider', () => ({
+  useHasNativeFiatProvider: jest.fn(),
+}));
 
 jest.mock('../../../../../selectors/tokenBalancesController', () => ({
   ...jest.requireActual('../../../../../selectors/tokenBalancesController'),
@@ -121,6 +126,7 @@ describe('MoneyAddMoneySheet', () => {
     (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
       true,
     );
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
   });
 
   it('renders all options', () => {
@@ -310,6 +316,41 @@ describe('MoneyAddMoneySheet', () => {
     expect(
       queryByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
     ).toBeNull();
+  });
+
+  it('hides the Deposit funds option when the region has no native fiat provider', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId, getByTestId } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    expect(
+      queryByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeNull();
+    // Other options are unaffected.
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the Deposit funds option when the region has a native fiat provider', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeOnTheScreen();
   });
 
   it('disables the Convert crypto option when no account has any crypto balance', () => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -8,7 +8,7 @@ import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
-import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
+import { useRegionHasNativeFiatProvider } from '../../hooks/useRegionHasNativeFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
@@ -59,8 +59,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../Ramp/hooks/useHasNativeFiatProvider', () => ({
-  useHasNativeFiatProvider: jest.fn(),
+jest.mock('../../hooks/useRegionHasNativeFiatProvider', () => ({
+  useRegionHasNativeFiatProvider: jest.fn(),
 }));
 
 jest.mock('../../../../../selectors/tokenBalancesController', () => ({
@@ -126,7 +126,7 @@ describe('MoneyAddMoneySheet', () => {
     (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
       true,
     );
-    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+    (useRegionHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
   });
 
   it('renders all options', () => {
@@ -319,7 +319,7 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('hides the Deposit funds option when the region has no native fiat provider', () => {
-    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
+    (useRegionHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
 
     const { queryByTestId, getByTestId } = renderWithProvider(
       <MoneyAddMoneySheet />,
@@ -344,7 +344,7 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('shows the Deposit funds option when the region has a native fiat provider', () => {
-    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+    (useRegionHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
 
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -34,7 +34,7 @@ import {
   type InitiateDepositOptions,
 } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
-import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
+import { useRegionHasNativeFiatProvider } from '../../hooks/useRegionHasNativeFiatProvider';
 import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { selectTransactions } from '../../../../../selectors/transactionController';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
@@ -71,7 +71,7 @@ const MoneyAddMoneySheet: React.FC = () => {
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
   const transactions = useSelector(selectTransactions);
-  const hasNativeFiatProvider = useHasNativeFiatProvider();
+  const regionHasNativeFiatProvider = useRegionHasNativeFiatProvider();
   const isFiatDepositEnabled = useMemo(
     () => enabledTransactionTypes.includes(TransactionType.moneyAccountDeposit),
     [enabledTransactionTypes],
@@ -208,7 +208,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       testID: MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       disabled: !hasAnyCryptoBalance,
     },
-    ...(isFiatDepositEnabled && hasNativeFiatProvider
+    ...(isFiatDepositEnabled && regionHasNativeFiatProvider
       ? [
           {
             label: strings(

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -34,6 +34,7 @@ import {
   type InitiateDepositOptions,
 } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
+import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
 import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { selectTransactions } from '../../../../../selectors/transactionController';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
@@ -70,6 +71,7 @@ const MoneyAddMoneySheet: React.FC = () => {
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
   const transactions = useSelector(selectTransactions);
+  const hasNativeFiatProvider = useHasNativeFiatProvider();
   const isFiatDepositEnabled = useMemo(
     () => enabledTransactionTypes.includes(TransactionType.moneyAccountDeposit),
     [enabledTransactionTypes],
@@ -206,7 +208,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       testID: MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       disabled: !hasAnyCryptoBalance,
     },
-    ...(isFiatDepositEnabled
+    ...(isFiatDepositEnabled && hasNativeFiatProvider
       ? [
           {
             label: strings(

--- a/app/components/UI/Money/hooks/useRegionHasNativeFiatProvider.test.ts
+++ b/app/components/UI/Money/hooks/useRegionHasNativeFiatProvider.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-native';
+import { useRegionHasNativeFiatProvider } from './useRegionHasNativeFiatProvider';
+import { useRampsProviders } from '../../Ramp/hooks/useRampsProviders';
+
+jest.mock('../../Ramp/hooks/useRampsProviders', () => ({
+  useRampsProviders: jest.fn(),
+}));
+
+const mockUseRampsProviders = useRampsProviders as jest.Mock;
+
+describe('useRegionHasNativeFiatProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when the region offers at least one native provider', () => {
+    mockUseRampsProviders.mockReturnValue({
+      providers: [{ type: 'aggregator' }, { type: 'native' }],
+    });
+
+    const { result } = renderHook(() => useRegionHasNativeFiatProvider());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the region offers only aggregator providers', () => {
+    mockUseRampsProviders.mockReturnValue({
+      providers: [{ type: 'aggregator' }, { type: 'aggregator' }],
+    });
+
+    const { result } = renderHook(() => useRegionHasNativeFiatProvider());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the region has no providers', () => {
+    mockUseRampsProviders.mockReturnValue({ providers: [] });
+
+    const { result } = renderHook(() => useRegionHasNativeFiatProvider());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/app/components/UI/Money/hooks/useRegionHasNativeFiatProvider.ts
+++ b/app/components/UI/Money/hooks/useRegionHasNativeFiatProvider.ts
@@ -1,0 +1,17 @@
+import { useRampsProviders } from '../../Ramp/hooks/useRampsProviders';
+
+/**
+ * Whether the user's CURRENT region offers a native on-ramp provider
+ * (e.g. Transak Native) for the headless fiat deposit flow.
+ *
+ * Unlike `useHasNativeFiatProvider`, which reflects the sticky *selected*
+ * provider and stays `true` after the user moves to a region Transak does not
+ * serve, this reads the provider list fetched for the active region, so it
+ * correctly turns `false` in unsupported regions (e.g. Brazil).
+ */
+export function useRegionHasNativeFiatProvider(): boolean {
+  const { providers } = useRampsProviders();
+  return providers.some((provider) => provider.type === 'native');
+}
+
+export default useRegionHasNativeFiatProvider;


### PR DESCRIPTION
## **Description**

When a user's region is not supported by Transak (e.g. Brazil), the "Debit card or bank" (Deposit funds) option was still visible and tappable in the Money account "Add funds" bottom sheet. Tapping it dead-ended because the headless fiat deposit quote restricts to native providers only. This was a regression introduced in build 5699.

The sheet gated the deposit option only on the remote feature flag (`isFiatDepositEnabled` / `enabledTransactionTypes.includes(moneyAccountDeposit)`) and never applied the native-provider region gate that already exists in the codebase. Headless fiat deposit is native-only (Transak Native) for v0, so aggregator-only regions have no native provider and must not see the option.

This PR reuses the existing `useHasNativeFiatProvider()` hook and gates the deposit option on `isFiatDepositEnabled && hasNativeFiatProvider`, hiding it entirely when no native (Transak) provider serves the region. No other Add funds options are affected.

## **Changelog**

CHANGELOG entry: Fixed the Money account "Add funds" sheet showing the debit card/bank option in regions not supported by Transak.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1075

## **Manual testing steps**

```gherkin
Feature: Add funds sheet hides debit card/bank for unsupported regions

  Scenario: User in a Transak-unsupported region
    Given my device/app region is set to Brazil
    When I open the Money account and tap "Add funds"
    Then the "Debit card or bank" option is not shown
    And Convert crypto, Add/Move mUSD and the coming-soon rows are still shown

  Scenario: User in a Transak-supported region
    Given my device/app region is set to a supported country (e.g. US)
    When I open the Money account and tap "Add funds"
    Then the "Debit card or bank" option is shown and tappable
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI gating on the Add funds sheet with no auth or payment-flow logic changes; wrong provider data could hide or show deposit incorrectly.
> 
> **Overview**
> Fixes a regression where **Debit card / bank** (Deposit funds) stayed visible in regions with no native on-ramp (e.g. Brazil) even though headless fiat deposit only works with a **native** provider like Transak Native.
> 
> Adds **`useRegionHasNativeFiatProvider`**, which inspects the **current region’s** ramp provider list from `useRampsProviders` for `type === 'native'`—unlike the sticky selected-provider hook, so unsupported regions correctly evaluate to false. **`MoneyAddMoneySheet`** now includes the deposit row only when fiat deposit is enabled **and** that hook is true; other add-funds rows are unchanged. Unit tests cover the hook and sheet visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7e56ec67854bc71c4be1db563e038edb199be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->