### PR TITLE
fix: MUSD-1076 fixed formatting for high precision apy values; cleaned up projection surfaces to use apyDecimal  cp-8.0.0 

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -119,6 +119,7 @@ const MoneyHomeView = () => {
     lastKnownTotalFiatFormatted,
     refetchBalance,
     apyPercent,
+    apyDecimal,
   } = useMoneyAccountBalance();
 
   const refreshMusdFiatRate = useRefreshMusdFiatRate();
@@ -220,32 +221,32 @@ const MoneyHomeView = () => {
   );
 
   const monthlyEarnings = useMemo(() => {
-    if (!totalFiatRaw || !apyPercent) return formattedZero;
+    if (!totalFiatRaw || !apyDecimal) return formattedZero;
     const balance = new BigNumber(totalFiatRaw);
     if (balance.isZero() || balance.isNaN()) return formattedZero;
     const earnings = calculateProjectedEarnings(
       balance.toNumber(),
-      apyPercent,
+      apyDecimal,
       1 / 12,
     );
     if (!Number.isFinite(earnings)) return formattedZero;
     const formatted = moneyFormatFiat(new BigNumber(earnings), currentCurrency);
     return formatted === formattedZero ? formatted : `+${formatted}`;
-  }, [totalFiatRaw, apyPercent, currentCurrency, formattedZero]);
+  }, [totalFiatRaw, apyDecimal, currentCurrency, formattedZero]);
 
   const yearlyEarnings = useMemo(() => {
-    if (!totalFiatRaw || !apyPercent) return formattedZero;
+    if (!totalFiatRaw || !apyDecimal) return formattedZero;
     const balance = new BigNumber(totalFiatRaw);
     if (balance.isZero() || balance.isNaN()) return formattedZero;
     const earnings = calculateProjectedEarnings(
       balance.toNumber(),
-      apyPercent,
+      apyDecimal,
       1,
     );
     if (!Number.isFinite(earnings)) return formattedZero;
     const formatted = moneyFormatFiat(new BigNumber(earnings), currentCurrency);
     return formatted === formattedZero ? formatted : `+${formatted}`;
-  }, [totalFiatRaw, apyPercent, currentCurrency, formattedZero]);
+  }, [totalFiatRaw, apyDecimal, currentCurrency, formattedZero]);
 
   const handleMenuPress = useCallback(() => {
     trackButtonClicked({
@@ -709,7 +710,7 @@ const MoneyHomeView = () => {
       node: (
         <MoneyPotentialEarnings
           tokens={depositTokens}
-          apy={apyPercent}
+          apyDecimal={apyDecimal}
           isNoFeeToken={isNoFeeToken}
           onTokenCardPress={handleTokenCardPress}
           onTokenButtonPress={handleTokenButtonPress}

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
@@ -56,11 +56,11 @@ const MoneyPotentialEarningsView = () => {
   const { tokens: depositTokens, isNoFeeToken } = useMoneyEarnableTokens();
 
   const { initiateDeposit } = useMoneyAccountDeposit();
-  const { apyPercent } = useMoneyAccountBalance();
-  const apyPercentForProjection = apyPercent ?? 0;
+  const { apyDecimal } = useMoneyAccountBalance();
+  const apyDecimalForProjection = apyDecimal ?? 0;
 
   const { eligibleTokens, totalAssetsFiat, projectedAmount } =
-    useProjectedEarnings(depositTokens, apyPercent);
+    useProjectedEarnings(depositTokens, apyDecimal);
 
   const {
     trackButtonClicked,
@@ -259,7 +259,7 @@ const MoneyPotentialEarningsView = () => {
             key={`${token.address}-${token.chainId}`}
             token={token}
             hasSubsidizedFee={isNoFeeToken(token)}
-            apyPercent={apyPercentForProjection}
+            apyDecimal={apyDecimalForProjection}
             onCardPress={handleTokenCardPress(token, index)}
             onButtonPress={handleTokenButtonPress(token, index)}
             testID={MoneyPotentialEarningsViewTestIds.TOKEN_ROW(index)}

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
@@ -92,7 +92,7 @@ const MOCK_SOL = makeToken({
 describe('MoneyPotentialEarnings', () => {
   it('returns null when there are no tokens with balance', () => {
     const { queryByTestId } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[]} />,
+      <MoneyPotentialEarnings apyDecimal={0.04} tokens={[]} />,
     );
 
     expect(
@@ -102,7 +102,7 @@ describe('MoneyPotentialEarnings', () => {
 
   it('renders the section title and parameterized description', () => {
     const { getByText, getByTestId } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} />,
+      <MoneyPotentialEarnings apyDecimal={0.04} tokens={[MOCK_USDC]} />,
     );
 
     expect(
@@ -116,7 +116,10 @@ describe('MoneyPotentialEarnings', () => {
   it('computes the aggregate projected amount from token fiat balances', () => {
     // USDC $5000 + USDT $4000 = $9000 × (4% APY × 1 year) = $360.00
     const { getByTestId } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC, MOCK_USDT]} />,
+      <MoneyPotentialEarnings
+        apyDecimal={0.04}
+        tokens={[MOCK_USDC, MOCK_USDT]}
+      />,
     );
 
     expect(getByTestId(MoneyPotentialEarningsTestIds.TEXT)).toHaveTextContent(
@@ -126,7 +129,7 @@ describe('MoneyPotentialEarnings', () => {
 
   it('renders the projected amount as a plain Text (no gradient mask)', () => {
     const { getByTestId, toJSON } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} />,
+      <MoneyPotentialEarnings apyDecimal={0.04} tokens={[MOCK_USDC]} />,
     );
 
     // The filled state should be a plain DSRN Text, not the masked gradient
@@ -149,7 +152,10 @@ describe('MoneyPotentialEarnings', () => {
     });
 
     const { queryByText } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC, zeroBalanceToken]} />,
+      <MoneyPotentialEarnings
+        apyDecimal={0.04}
+        tokens={[MOCK_USDC, zeroBalanceToken]}
+      />,
     );
 
     expect(queryByText('ZERO')).not.toBeOnTheScreen();
@@ -164,7 +170,7 @@ describe('MoneyPotentialEarnings', () => {
     });
     const { queryByText } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL, extra]}
       />,
     );
@@ -175,7 +181,7 @@ describe('MoneyPotentialEarnings', () => {
   it('hides the View all button when fewer than six tokens are eligible', () => {
     const { queryByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL]}
       />,
     );
@@ -194,7 +200,7 @@ describe('MoneyPotentialEarnings', () => {
     });
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL, extra]}
       />,
     );
@@ -214,7 +220,7 @@ describe('MoneyPotentialEarnings', () => {
     const onViewAll = jest.fn();
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL, extra]}
         onViewAllPress={onViewAll}
       />,
@@ -228,7 +234,7 @@ describe('MoneyPotentialEarnings', () => {
     const onTokenPress = jest.fn();
     const { getByText } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC]}
         onTokenButtonPress={onTokenPress}
       />,
@@ -249,7 +255,7 @@ describe('MoneyPotentialEarnings', () => {
     });
     const { getByText } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL, extra]}
         onHeaderPress={onHeader}
       />,
@@ -269,7 +275,7 @@ describe('MoneyPotentialEarnings', () => {
     });
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL, extra]}
         onHeaderPress={jest.fn()}
       />,
@@ -282,7 +288,7 @@ describe('MoneyPotentialEarnings', () => {
     const onHeader = jest.fn();
     const { queryByTestId, getByText } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC, MOCK_USDT, MOCK_DAI, MOCK_ETH, MOCK_SOL]}
         onHeaderPress={onHeader}
       />,
@@ -299,7 +305,7 @@ describe('MoneyPotentialEarnings', () => {
   it('renders the inline info button when onInfoPress is provided', () => {
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC]}
         onInfoPress={jest.fn()}
       />,
@@ -312,7 +318,7 @@ describe('MoneyPotentialEarnings', () => {
 
   it('does not render the info button when onInfoPress is omitted', () => {
     const { queryByTestId } = render(
-      <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} />,
+      <MoneyPotentialEarnings apyDecimal={0.04} tokens={[MOCK_USDC]} />,
     );
 
     expect(
@@ -324,7 +330,7 @@ describe('MoneyPotentialEarnings', () => {
     const onInfoPress = jest.fn();
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={4}
+        apyDecimal={0.04}
         tokens={[MOCK_USDC]}
         onInfoPress={onInfoPress}
       />,
@@ -339,7 +345,7 @@ describe('MoneyPotentialEarnings', () => {
     const onInfoPress = jest.fn();
     const { getByTestId } = render(
       <MoneyPotentialEarnings
-        apy={undefined}
+        apyDecimal={undefined}
         tokens={[MOCK_USDC]}
         onInfoPress={onInfoPress}
       />,
@@ -352,7 +358,7 @@ describe('MoneyPotentialEarnings', () => {
 
   it('hides the projected amount when apy is undefined', () => {
     const { queryByTestId } = render(
-      <MoneyPotentialEarnings apy={undefined} tokens={[MOCK_USDC]} />,
+      <MoneyPotentialEarnings apyDecimal={undefined} tokens={[MOCK_USDC]} />,
     );
 
     expect(
@@ -362,7 +368,7 @@ describe('MoneyPotentialEarnings', () => {
 
   it('hides the per-token projected earning text when apy is zero', () => {
     const { queryByText } = render(
-      <MoneyPotentialEarnings apy={0} tokens={[MOCK_USDC]} />,
+      <MoneyPotentialEarnings apyDecimal={0} tokens={[MOCK_USDC]} />,
     );
 
     // With apy=0 the projected multiplier is 0 so projectedFiatNumber is 0,
@@ -374,7 +380,7 @@ describe('MoneyPotentialEarnings', () => {
     it('renders the No fee badge on a token row when isNoFeeToken returns true', () => {
       const { getByText } = render(
         <MoneyPotentialEarnings
-          apy={4}
+          apyDecimal={0.04}
           tokens={[MOCK_USDC]}
           isNoFeeToken={() => true}
         />,
@@ -388,7 +394,7 @@ describe('MoneyPotentialEarnings', () => {
     it('does not render the No fee badge when isNoFeeToken returns false', () => {
       const { queryByText } = render(
         <MoneyPotentialEarnings
-          apy={4}
+          apyDecimal={0.04}
           tokens={[MOCK_USDC]}
           isNoFeeToken={() => false}
         />,
@@ -401,7 +407,7 @@ describe('MoneyPotentialEarnings', () => {
 
     it('does not render any No fee badge when isNoFeeToken is omitted', () => {
       const { queryByText } = render(
-        <MoneyPotentialEarnings apy={4} tokens={[MOCK_USDC]} />,
+        <MoneyPotentialEarnings apyDecimal={0.04} tokens={[MOCK_USDC]} />,
       );
 
       expect(
@@ -412,7 +418,7 @@ describe('MoneyPotentialEarnings', () => {
     it('renders No fee badge only on eligible token rows', () => {
       const { getAllByText, queryByText } = render(
         <MoneyPotentialEarnings
-          apy={4}
+          apyDecimal={0.04}
           tokens={[MOCK_USDC, MOCK_USDT]}
           isNoFeeToken={(token) => token.symbol === 'USDC'}
         />,

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -30,11 +30,11 @@ const VISIBLE_TOKENS_COUNT = 5;
 interface MoneyPotentialEarningsProps {
   tokens: AssetType[];
   /**
-   * APY expressed as a percentage (e.g. 3 for 3%) used together with the
+   * APY expressed as a decimal (e.g. 0.03 for 3%) used together with the
    * shared projection horizon to compute the projected earnings displayed
    * alongside each token and in the description.
    */
-  apy: number | undefined;
+  apyDecimal: number | undefined;
   /**
    * Returns true when the given token qualifies for a subsidised (no-fee)
    * deposit into the Money account (target: Monad mUSD). Used to render the
@@ -65,7 +65,7 @@ interface MoneyPotentialEarningsProps {
 
 const MoneyPotentialEarnings = ({
   tokens,
-  apy,
+  apyDecimal = 0,
   isNoFeeToken = () => false,
   onTokenCardPress,
   onTokenButtonPress,
@@ -74,14 +74,13 @@ const MoneyPotentialEarnings = ({
   onInfoPress,
 }: MoneyPotentialEarningsProps) => {
   const currentCurrency = useSelector(selectCurrentCurrency);
-  const apyPercent = apy ?? 0;
 
   // Sum across every eligible token (not just the five we render). The "View
   // all" affordance tells users there are more rows than shown, so the
   // headline is intentionally the full projection — clipping the headline to
   // the visible five would contradict that affordance.
   const { eligibleTokens, totalAssetsFiat, projectedAmount } =
-    useProjectedEarnings(tokens, apyPercent);
+    useProjectedEarnings(tokens, apyDecimal);
   const visibleTokens = useMemo(
     () => eligibleTokens.slice(0, VISIBLE_TOKENS_COUNT),
     [eligibleTokens],
@@ -185,7 +184,7 @@ const MoneyPotentialEarnings = ({
             key={`${token.address}-${token.chainId}`}
             token={token}
             hasSubsidizedFee={isNoFeeToken(token)}
-            apyPercent={apyPercent}
+            apyDecimal={apyDecimal}
             onCardPress={handleTokenCardPress(token, index)}
             onButtonPress={handleTokenButtonPress(token, index)}
           />

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
@@ -59,7 +59,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -73,7 +73,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -87,7 +87,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -101,7 +101,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={0}
+        apyDecimal={0}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -115,7 +115,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -131,7 +131,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -147,7 +147,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={jest.fn()}
       />,
@@ -164,7 +164,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={jest.fn()}
         onButtonPress={mockOnPress}
       />,
@@ -181,7 +181,7 @@ describe('PotentialEarningsTokenRow', () => {
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
         hasSubsidizedFee={false}
-        apyPercent={20}
+        apyDecimal={0.2}
         onCardPress={mockOnPress}
         onButtonPress={jest.fn()}
       />,

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
@@ -41,15 +41,15 @@ const styles = StyleSheet.create({
 const PotentialEarningsTokenRow = ({
   token,
   hasSubsidizedFee,
-  apyPercent,
+  apyDecimal,
   onCardPress,
   onButtonPress,
   testID,
 }: {
   token: AssetType;
   hasSubsidizedFee: boolean;
-  /** APY as a percentage (e.g. 4 for 4%). */
-  apyPercent: number;
+  /** APY as a decimal (e.g. 0.04 for 4%). */
+  apyDecimal: number;
   onCardPress: () => void;
   onButtonPress: () => void;
   testID?: string;
@@ -63,7 +63,7 @@ const PotentialEarningsTokenRow = ({
   const fiatBalance = tokenFiatValue(token);
   const projectedFiatNumber = calculateProjectedEarnings(
     fiatBalance,
-    apyPercent,
+    apyDecimal,
     PROJECTION_YEARS,
   );
   const projectedFiatFormatted = moneyFormatFiat(

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -358,7 +358,7 @@ describe('useMoneyAccountBalance', () => {
     expect(result.current.apyPercentFormatted).toBe('5%');
   });
 
-  it('rounds apyPercent half up to one decimal place for high-precision service APY', () => {
+  it('rounds apyPercent half up to one decimal place for high-precision APY', () => {
     const apyDecimal = 0.0377356238130822;
 
     setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
@@ -373,6 +373,23 @@ describe('useMoneyAccountBalance', () => {
     expect(result.current.apyDecimal).toBe(apyDecimal);
     expect(result.current.apyPercent).toBe(3.8);
     expect(result.current.apyPercentFormatted).toBe('3.8%');
+  });
+
+  it('rounds apyPercent down to one decimal place for a high-precision APY', () => {
+    const apyDecimal = 0.03341;
+
+    setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+      data: { apy: apyDecimal },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountBalance());
+
+    expect(result.current.apyDecimal).toBe(apyDecimal);
+    expect(result.current.apyPercent).toBe(3.3);
+    expect(result.current.apyPercentFormatted).toBe('3.3%');
   });
 
   it('returns undefined for all APY fields when vault APY data is not available and no fallback configured', () => {

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -358,6 +358,23 @@ describe('useMoneyAccountBalance', () => {
     expect(result.current.apyPercentFormatted).toBe('5%');
   });
 
+  it('rounds apyPercent half up to one decimal place for high-precision service APY', () => {
+    const apyDecimal = 0.0377356238130822;
+
+    setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+      data: { apy: apyDecimal },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+
+    const { result } = renderHook(() => useMoneyAccountBalance());
+
+    expect(result.current.apyDecimal).toBe(apyDecimal);
+    expect(result.current.apyPercent).toBe(3.8);
+    expect(result.current.apyPercentFormatted).toBe('3.8%');
+  });
+
   it('returns undefined for all APY fields when vault APY data is not available and no fallback configured', () => {
     setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
       data: undefined,

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -36,9 +36,27 @@ export const getLiveVedaVaultExchangeRate = async () =>
     .call('MoneyAccountBalanceService:getExchangeRate', { staleTime: 0 })
     .then(({ rate }) => rate);
 
+interface UseMoneyAccountBalanceResult {
+  moneyBalanceQuery: UseQueryResult<MoneyAccountBalanceResponse>;
+  vaultApyQuery: UseQueryResult<NormalizedVaultApyResponse>;
+  isBalanceLoading: boolean;
+  isBalanceFetchError: boolean;
+  isBalanceFetching: boolean;
+  isBalanceUnavailable: boolean;
+  lastKnownTotalFiatFormatted: string | undefined;
+  refetchBalance: () => void;
+  tokenTotal: BigNumber | undefined;
+  totalFiatFormatted: string | undefined;
+  totalFiatRaw: string | undefined;
+  withdrawableMusd: BigNumber | undefined;
+  apyDecimal: number | undefined;
+  apyPercent: number | undefined;
+  apyPercentFormatted: string | undefined;
+}
+
 const useMoneyAccountBalance = (
   refetchInterval: number = DEFAULT_REFETCH_INTERVAL,
-) => {
+): UseMoneyAccountBalanceResult => {
   const dispatch = useDispatch();
   const { primaryMoneyAccount } = useMoneyAccountInfo();
   const moneyAccountAddress = primaryMoneyAccount?.address;
@@ -234,7 +252,14 @@ const useMoneyAccountBalance = (
       ? vaultApyOverride
       : (serviceApy ?? (shouldUseFallback ? vaultApyFallback : undefined));
 
-  const apyPercent = apyDecimal !== undefined ? apyDecimal * 100 : undefined;
+  const apyPercent =
+    apyDecimal !== undefined
+      ? new BigNumber(apyDecimal)
+          .multipliedBy(100)
+          .dp(1, BigNumber.ROUND_HALF_UP)
+          .toNumber()
+      : undefined;
+
   const apyPercentFormatted =
     apyPercent !== undefined ? `${apyPercent}%` : undefined;
 

--- a/app/components/UI/Money/hooks/useProjectedEarnings.test.ts
+++ b/app/components/UI/Money/hooks/useProjectedEarnings.test.ts
@@ -11,7 +11,7 @@ const makeToken = (fiat: number, symbol = 'USDC'): AssetType =>
 
 describe('useProjectedEarnings', () => {
   it('returns zeros and empty list when tokens is undefined', () => {
-    const { result } = renderHook(() => useProjectedEarnings(undefined, 4));
+    const { result } = renderHook(() => useProjectedEarnings(undefined, 0.04));
 
     expect(result.current.eligibleTokens).toEqual([]);
     expect(result.current.totalAssetsFiat).toBe(0);
@@ -24,7 +24,7 @@ describe('useProjectedEarnings', () => {
     const negative = makeToken(-50);
 
     const { result } = renderHook(() =>
-      useProjectedEarnings([positive, zero, negative], 4),
+      useProjectedEarnings([positive, zero, negative], 0.04),
     );
 
     expect(result.current.eligibleTokens).toEqual([positive]);
@@ -33,23 +33,23 @@ describe('useProjectedEarnings', () => {
 
   it('sums fiat balances across eligible tokens', () => {
     const { result } = renderHook(() =>
-      useProjectedEarnings([makeToken(150), makeToken(75)], 4),
+      useProjectedEarnings([makeToken(150), makeToken(75)], 0.04),
     );
 
     expect(result.current.totalAssetsFiat).toBe(225);
   });
 
   it('projects earnings using the supplied APY across PROJECTION_YEARS', () => {
-    const apyPercent = 4;
+    const apyDecimal = 0.04;
     const tokens = [makeToken(1000), makeToken(500)];
 
     const { result } = renderHook(() =>
-      useProjectedEarnings(tokens, apyPercent),
+      useProjectedEarnings(tokens, apyDecimal),
     );
 
     const expected =
-      1000 * (apyPercent / 100) * PROJECTION_YEARS +
-      500 * (apyPercent / 100) * PROJECTION_YEARS;
+      1000 * apyDecimal * PROJECTION_YEARS +
+      500 * apyDecimal * PROJECTION_YEARS;
 
     expect(result.current.projectedAmount).toBeCloseTo(expected, 5);
   });

--- a/app/components/UI/Money/hooks/useProjectedEarnings.ts
+++ b/app/components/UI/Money/hooks/useProjectedEarnings.ts
@@ -14,9 +14,9 @@ interface ProjectedEarnings {
 
 export function useProjectedEarnings(
   tokens: AssetType[] | undefined,
-  apyPercent: number | undefined,
+  apyDecimal: number | undefined,
 ): ProjectedEarnings {
-  const safeApyPercent = apyPercent ?? 0;
+  const safeApyDecimal = apyDecimal ?? 0;
 
   const eligibleTokens = useMemo(
     () => (tokens ?? []).filter((token) => tokenFiatValue(token) > 0),
@@ -35,12 +35,12 @@ export function useProjectedEarnings(
           sum +
           calculateProjectedEarnings(
             tokenFiatValue(token),
-            safeApyPercent,
+            safeApyDecimal,
             PROJECTION_YEARS,
           ),
         0,
       ),
-    [eligibleTokens, safeApyPercent],
+    [eligibleTokens, safeApyDecimal],
   );
 
   return { eligibleTokens, totalAssetsFiat, projectedAmount };

--- a/app/components/UI/Money/utils/projections.test.ts
+++ b/app/components/UI/Money/utils/projections.test.ts
@@ -16,32 +16,31 @@ describe('calculateProjectedEarnings', () => {
   it('calculates 1-year earnings using the default year parameter', () => {
     const result = calculateProjectedEarnings(1000, 0.04);
 
-    expect(result).toBe(40);
+    expect(result).toBeCloseTo(40, 6);
   });
 
-  it('calculates multi-year earnings with an explicit year parameter', () => {
+  it('compounds multi-year earnings with an explicit year parameter', () => {
     const result = calculateProjectedEarnings(1000, 0.04, 5);
 
-    expect(result).toBe(200);
+    expect(result).toBeCloseTo(216.6529, 4);
   });
 
-  it('uses linear projection, not compound', () => {
-    const linear = calculateProjectedEarnings(1000, 0.04, 5);
-    const compound = 1000 * (Math.pow(1 + 0.04, 5) - 1);
+  it('compounds earnings rather than projecting linearly', () => {
+    const compound = calculateProjectedEarnings(1000, 0.04, 5);
+    const linear = 1000 * 0.04 * 5;
 
-    expect(linear).toBe(200);
-    expect(linear).not.toBeCloseTo(compound, 1);
+    expect(compound).toBeGreaterThan(linear);
   });
 
   it('handles fractional APY values', () => {
     const result = calculateProjectedEarnings(1000, 0.055, 1);
 
-    expect(result).toBe(55);
+    expect(result).toBeCloseTo(55, 6);
   });
 
-  it('handles fractional year values', () => {
+  it('compounds fractional year values below the linear estimate', () => {
     const result = calculateProjectedEarnings(1000, 0.04, 0.5);
 
-    expect(result).toBe(20);
+    expect(result).toBeCloseTo(19.8039, 4);
   });
 });

--- a/app/components/UI/Money/utils/projections.test.ts
+++ b/app/components/UI/Money/utils/projections.test.ts
@@ -2,7 +2,7 @@ import { calculateProjectedEarnings } from './projections';
 
 describe('calculateProjectedEarnings', () => {
   it('returns zero when principal is zero', () => {
-    const result = calculateProjectedEarnings(0, 4);
+    const result = calculateProjectedEarnings(0, 0.04);
 
     expect(result).toBe(0);
   });
@@ -14,33 +14,33 @@ describe('calculateProjectedEarnings', () => {
   });
 
   it('calculates 1-year earnings using the default year parameter', () => {
-    const result = calculateProjectedEarnings(1000, 4);
+    const result = calculateProjectedEarnings(1000, 0.04);
 
     expect(result).toBe(40);
   });
 
   it('calculates multi-year earnings with an explicit year parameter', () => {
-    const result = calculateProjectedEarnings(1000, 4, 5);
+    const result = calculateProjectedEarnings(1000, 0.04, 5);
 
     expect(result).toBe(200);
   });
 
   it('uses linear projection, not compound', () => {
-    const linear = calculateProjectedEarnings(1000, 4, 5);
-    const compound = 1000 * (Math.pow(1 + 4 / 100, 5) - 1);
+    const linear = calculateProjectedEarnings(1000, 0.04, 5);
+    const compound = 1000 * (Math.pow(1 + 0.04, 5) - 1);
 
     expect(linear).toBe(200);
     expect(linear).not.toBeCloseTo(compound, 1);
   });
 
   it('handles fractional APY values', () => {
-    const result = calculateProjectedEarnings(1000, 5.5, 1);
+    const result = calculateProjectedEarnings(1000, 0.055, 1);
 
     expect(result).toBe(55);
   });
 
   it('handles fractional year values', () => {
-    const result = calculateProjectedEarnings(1000, 4, 0.5);
+    const result = calculateProjectedEarnings(1000, 0.04, 0.5);
 
     expect(result).toBe(20);
   });

--- a/app/components/UI/Money/utils/projections.ts
+++ b/app/components/UI/Money/utils/projections.ts
@@ -2,11 +2,13 @@
 export const PROJECTION_YEARS = 1;
 
 /**
- * Linear projection of earnings over a given time period.
+ * Compound projection of earnings over a given time period.
  *
- * We intentionally use simple interest rather than compound interest because
- * the APY rate is variable and may change daily. Compounding a variable rate
- * over multiple years would create unrealistic return expectations.
+ * APY already expresses the effective annual yield with intra-year compounding
+ * baked in, so the honest way to derive earnings for any horizon is to compound
+ * the rate: `(1 + apy)^years - 1`. At exactly one year this equals
+ * `principal * apy`, and for fractional or multi-year horizons it stays
+ * consistent with the compound projection used in BalanceProjection.
  *
  * @param principalFiat - The fiat value of the principal amount.
  * @param apyDecimal - APY expressed as a decimal (e.g. 0.04 for 4%).
@@ -17,4 +19,4 @@ export const calculateProjectedEarnings = (
   principalFiat: number,
   apyDecimal: number,
   years: number = 1,
-): number => principalFiat * apyDecimal * years;
+): number => principalFiat * (Math.pow(1 + apyDecimal, years) - 1);

--- a/app/components/UI/Money/utils/projections.ts
+++ b/app/components/UI/Money/utils/projections.ts
@@ -9,12 +9,12 @@ export const PROJECTION_YEARS = 1;
  * over multiple years would create unrealistic return expectations.
  *
  * @param principalFiat - The fiat value of the principal amount.
- * @param apyPercent - APY expressed as a percentage (e.g. 4 for 4%).
+ * @param apyDecimal - APY expressed as a decimal (e.g. 0.04 for 4%).
  * @param years - The number of years to project over (defaults to 1).
  * @returns The projected earnings in fiat.
  */
 export const calculateProjectedEarnings = (
   principalFiat: number,
-  apyPercent: number,
+  apyDecimal: number,
   years: number = 1,
-): number => principalFiat * (apyPercent / 100) * years;
+): number => principalFiat * apyDecimal * years;


### PR DESCRIPTION
## **Description**

Formats high precision APY values to 1 decimal place (half round up). Also updates projection surfaces to use the `apyDecimal` value instead of `apyPercent`.

Changes:
- `calculateProjectedEarnings` now takes `apyDecimal` (e.g. `0.04`) directly — no internal division.
- `calculateProjectedEarnings` now uses compound formula instead of linear.
- `useMoneyAccountBalance` exports both `apyDecimal` (raw, for calculations) and `apyPercent` (rounded half-up to 1 decimal place via BigNumber). High-precision inputs like `0.0377...` now correctly render as `3.8%`.
- All projection surfaces (`useProjectedEarnings`, `MoneyPotentialEarnings`, `PotentialEarningsTokenRow`, both views) updated to pass `apyDecimal`.
- Explicit return type interface added to `useMoneyAccountBalance`.

## **Changelog**

CHANGELOG entry: fixed unformatted high precision apy values

## **Related issues**

- Fixes: [MUSD-1076](https://consensyssoftware.atlassian.net/browse/MUSD-1076)

## **Manual testing steps**

```gherkin
Feature: Money account APY display

  Scenario: APY with high-precision decimal displays rounded correctly
    Given the user has a Money account with a high-precision APY (e.g. 3.77356%)
    When the user opens the Money home screen
    Then the APY is displayed as "3.8%" (rounded half-up to 1 decimal place)
    And the monthly and yearly projected earnings are calculated using the full precision decimal

  Scenario: Projected earnings on the potential earnings screen
    Given the user has token balances eligible for earning
    When the user views the potential earnings screen
    Then each token row shows projected earnings calculated from the decimal APY
    And the aggregate projected total is accurate
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="735" height="1600" alt="image" src="https://github.com/user-attachments/assets/f1bdd682-7e06-4796-9075-9d9b5e6913a9" />

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/173b09d1-d7b4-4b93-9bbd-b39389193384

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[MUSD-1076]: https://consensyssoftware.atlassian.net/browse/MUSD-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible APY strings and projected earnings math (compound vs linear for non–one-year horizons), though scope is limited to Money UI calculations.
> 
> **Overview**
> Fixes **high-precision vault APY** showing too many digits by rounding **`apyPercent`** to one decimal place (half-up via BigNumber) while keeping **`apyDecimal`** at full precision for math. **`useMoneyAccountBalance`** now documents its return shape explicitly and continues to expose both values.
> 
> **Earnings projections** across Money home, potential earnings UI, **`useProjectedEarnings`**, and token rows now take **`apyDecimal`** instead of a percentage, and **`calculateProjectedEarnings`** compounds with `(1 + apy)^years - 1` rather than simple interest—one-year totals stay equivalent, but fractional and multi-year horizons change.
> 
> Tests were updated for the new APY rounding cases, decimal APY inputs, and compound projection expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6615f9e4904c3359b5936f93ca9a276df3ff44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->