### PR TITLE
perf(ci): compress node_modules tarball with zstd to speed up build download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,11 +249,24 @@ jobs:
         with:
           name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
 
+      - name: Ensure zstd is available
+        shell: bash
+        run: |
+          if command -v zstd >/dev/null 2>&1; then
+            echo "✅ zstd present: $(zstd --version)"
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            echo "Installing zstd via Homebrew..."
+            brew install zstd
+          else
+            echo "Installing zstd via apt..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq zstd
+          fi
+
       - name: Extract tarball (preserves symlinks)
         run: |
           echo "📦 Extracting tarball..."
-          tar -xzf node-modules-${{ matrix.platform }}.tar.gz
-          rm node-modules-${{ matrix.platform }}.tar.gz
+          tar --use-compress-program 'zstd -d' -xf node-modules-${{ matrix.platform }}.tar.zst
+          rm node-modules-${{ matrix.platform }}.tar.zst
           echo "✅ Tarball extracted"
 
       - name: Verify artifacts and symlinks

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -215,24 +215,43 @@ jobs:
           echo "📄 install-state.gz exists: $(test -f .yarn/install-state.gz && echo 'yes' || echo 'no')"
           echo "📁 cache dir exists: $(test -d .yarn/cache && echo 'yes' || echo 'no')"
 
+      # zstd compresses ~24% smaller than gzip and, being multithreaded (-T0),
+      # creates the tarball ~10x faster. This shrinks both this step (on the
+      # critical path) and the download in the consuming build job.
+      - name: Ensure zstd is available
+        if: inputs.upload-artifact && inputs.use-tarball
+        shell: bash
+        run: |
+          if command -v zstd >/dev/null 2>&1; then
+            echo "✅ zstd present: $(zstd --version)"
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            echo "Installing zstd via Homebrew..."
+            brew install zstd
+          else
+            echo "Installing zstd via apt..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq zstd
+          fi
+
       - name: Create tarball (preserves symlinks)
         if: inputs.upload-artifact && inputs.use-tarball
         run: |
-          echo "📦 Creating tarball to preserve symlinks..."
-          tar -czf node-modules-${{ inputs.platform }}.tar.gz \
+          echo "📦 Creating zstd tarball to preserve symlinks..."
+          tar --use-compress-program 'zstd -10 -T0' \
+            -cf node-modules-${{ inputs.platform }}.tar.zst \
             node_modules \
             app/util/termsOfUse/termsOfUseContent.ts \
             app/core/InpageBridgeWeb3.js \
             scripts/inpage-bridge/dist
-          echo "✅ Tarball created: $(du -h node-modules-${{ inputs.platform }}.tar.gz)"
+          echo "✅ Tarball created: $(du -h node-modules-${{ inputs.platform }}.tar.zst)"
 
       - name: Upload node_modules tarball
         if: inputs.upload-artifact && inputs.use-tarball
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact-name }}
-          path: node-modules-${{ inputs.platform }}.tar.gz
+          path: node-modules-${{ inputs.platform }}.tar.zst
           retention-days: ${{ inputs.artifact-retention-days }}
+          # Already zstd-compressed; skip the artifact zip's redundant compression.
           compression-level: 0
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

The `build` job downloads the `node_modules` tarball artifact (~2.4 GB) and that step currently takes **~6 minutes**. Root cause is two compounding factors:

1. **Large payload** — `node_modules` is ~9.3 GB uncompressed, ~2.4 GB after `gzip`.
2. **Slow transport** — builds run on **Cirrus/Namespace** runners (not GitHub-hosted), so `download-artifact` pulls from GitHub's Azure blob storage over the public internet (~7 MB/s observed).

This PR addresses factor #1 by switching the tarball codec from **gzip** to **zstd** (`-10 -T0`). It changes only the codec — same files, same artifact name wiring, same `compression-level: 0` on upload (already-compressed payload).

### Benchmark (3.3 GB slice of real `node_modules`, 12 cores)

| Method | Create time | Size | Decompress |
| --- | --- | --- | --- |
| `gzip -6` (old) | 70 s (single-threaded) | 837 MB | 3.3 s |
| `zstd -10 -T0` (new) | 6.6 s (multithreaded) | 639 MB (~24% smaller) | ~2.5 s |

zstd shrinks **both** the create step (in `setup-dependencies`, on the critical path) **and** the download in `build`, while decompressing slightly faster. Level 10 was chosen over 19 because the create step is on the critical path; 19 is ~37% smaller but adds minutes of single-pipeline CPU for marginal download gains.

## Changes

- `setup-node-modules.yml`: create tarball with `zstd -10 -T0` → `*.tar.zst`; upload path updated.
- `build.yml`: extract `*.tar.zst` via zstd.
- Both: a small "Ensure zstd is available" step installs zstd if a runner image lacks it (Homebrew on macOS, apt on Linux).

## Follow-up (not in this PR)

The bigger win is factor #2 — replacing the GitHub-artifact round-trip with a **co-located cache** (Cirrus cache / Namespace `nscloud` volume, as already used for Gradle/Xcode and in `setup-ci-js-deps`). Tracking separately.

## Test plan

- [ ] CI build (iOS + Android) succeeds with the new codec
- [ ] "Download node_modules tarball" + extract steps complete faster than before
- [ ] Confirm `zstd` is present on Cirrus + Namespace runner images (ensure step is a no-op when so)

Made with [Cursor](https://cursor.com)