### PR TITLE
feat(networking): reapply integrate nitro-fetch with startup prefetching (#31206)

### DIFF
--- a/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch
+++ b/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch
@@ -1,0 +1,17 @@
+diff --git a/build/platforms/android/android.js b/build/platforms/android/android.js
+index 5154abd5f0fdd8fd87bb532b99fb0959c081f0ac..9eb6017ea5aa28e296966ae91c7809ac3520e225 100644
+--- a/build/platforms/android/android.js
++++ b/build/platforms/android/android.js
+@@ -193,7 +193,11 @@ async function findAndroidPackagesAsync(modules) {
+             }
+         }
+     }));
+-    return classes.sort();
++    // react-native-nitro-fetch double-registers its Android package via both autolink
++    // and manual registration, causing a duplicate-class Gradle build failure.
++    // Deduplicate with Set before sorting to work around this.
++    // Remove this patch if the issue is fixed upstream or when upgrading expo-modules-autolinking past 3.0.24.
++    return [...new Set(classes)].sort();
+ }
+ /**
+  * Converts the package name to Android's project name.

--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -31,6 +31,7 @@ import io.metamask.nativeModules.RCTMinimizerPackage
 import io.metamask.nativeModules.RNTar.RNTarPackage
 import io.metamask.nativeModules.NotificationPackage
 import com.braze.BrazeActivityLifecycleCallbackListener
+import com.margelo.nitro.nitrofetch.AutoPrefetcher
 
 class MainApplication : Application(), ShareApplication, ReactApplication {
 
@@ -88,6 +89,24 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
         // Enable debugging WebView from Chrome DevTools
         if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true)
+        }
+
+        try {
+            AutoPrefetcher.registerPrefetch(
+                this,
+                "https://phishing-detection.api.cx.metamask.io/v1/stalelist",
+                "phishing-stalelist",
+                emptyMap(),
+            )
+            AutoPrefetcher.registerPrefetch(
+                this,
+                "https://client-side-detection.api.cx.metamask.io/v1/request-blocklist",
+                "phishing-c2-blocklist",
+                emptyMap(),
+            )
+            AutoPrefetcher.prefetchOnStart(this)
+        } catch (_: Throwable) {
+            // Non-fatal: if prefetch fails the app continues on the standard fetch path.
         }
 
         loadReactNative(this)

--- a/app/core/NitroFetchSetup.test.ts
+++ b/app/core/NitroFetchSetup.test.ts
@@ -1,0 +1,271 @@
+import {
+  fetch as nitroFetch,
+  prefetchOnAppStart,
+} from 'react-native-nitro-fetch';
+import {
+  C2_DOMAIN_BLOCKLIST_URL,
+  METAMASK_STALELIST_URL,
+} from '@metamask/phishing-controller';
+
+jest.mock('react-native-nitro-fetch', () => ({
+  fetch: jest.fn().mockResolvedValue({ ok: true, status: 200 }),
+  prefetchOnAppStart: jest.fn().mockResolvedValue(undefined),
+  Headers: globalThis.Headers,
+  Request: globalThis.Request,
+  Response: globalThis.Response,
+}));
+
+jest.mock('@metamask/phishing-controller', () => ({
+  C2_DOMAIN_BLOCKLIST_URL: 'https://phishing.example.com/c2-blocklist',
+  METAMASK_STALELIST_URL: 'https://phishing.example.com/stalelist',
+}));
+
+jest.mock('@metamask/remote-feature-flag-controller', () => ({
+  ClientType: { Mobile: 'mobile' },
+}));
+
+jest.mock('./Engine/controllers/remote-feature-flag-controller/utils', () => ({
+  getFeatureFlagAppDistribution: jest.fn(() => 'main'),
+  getFeatureFlagAppEnvironment: jest.fn(() => 'production'),
+}));
+
+import './NitroFetchSetup';
+
+const mockNitroFetch = jest.mocked(nitroFetch);
+const mockPrefetchOnAppStart = jest.mocked(prefetchOnAppStart);
+
+const FEATURE_FLAGS_PREFIX =
+  'https://client-config.api.cx.metamask.io/v1/flags';
+
+describe('NitroFetchSetup', () => {
+  describe('startup prefetch registration', () => {
+    it('registers all three startup prefetch endpoints on module load', () => {
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(3);
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        expect.stringContaining(FEATURE_FLAGS_PREFIX),
+        { prefetchKey: 'feature-flags' },
+      );
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        METAMASK_STALELIST_URL,
+        {
+          prefetchKey: 'phishing-stalelist',
+        },
+      );
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        C2_DOMAIN_BLOCKLIST_URL,
+        {
+          prefetchKey: 'phishing-c2-blocklist',
+        },
+      );
+    });
+
+    it('registers feature-flags URL with correct client, distribution, and environment values', () => {
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        `${FEATURE_FLAGS_PREFIX}?client=mobile&distribution=main&environment=production`,
+        { prefetchKey: 'feature-flags' },
+      );
+    });
+  });
+
+  describe('hasTestOverrides guard', () => {
+    it('skips prefetchOnAppStart registration when hasTestOverrides is true', async () => {
+      let localPrefetch: jest.Mock = jest.fn();
+
+      await jest.isolateModulesAsync(async () => {
+        localPrefetch = jest.fn();
+
+        jest.doMock('react-native-nitro-fetch', () => ({
+          fetch: jest.fn().mockResolvedValue({ ok: true, status: 200 }),
+          prefetchOnAppStart: localPrefetch,
+          Headers: global.Headers,
+          Request: global.Request,
+          Response: global.Response,
+        }));
+        jest.doMock('../util/test/utils', () => ({
+          hasTestOverrides: true,
+        }));
+
+        await import('./NitroFetchSetup');
+      });
+
+      expect(localPrefetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('global.fetch', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('replaces global.fetch with a nitro-fetch wrapper', async () => {
+      await global.fetch('https://example.com');
+
+      expect(mockNitroFetch).toHaveBeenCalledWith(
+        'https://example.com',
+        undefined,
+      );
+    });
+
+    it('returns the response resolved by nitroFetch', async () => {
+      const mockResponse = { ok: true, status: 200 } as unknown as Response;
+      mockNitroFetch.mockResolvedValueOnce(mockResponse);
+
+      const result = await global.fetch('https://example.com');
+
+      expect(result).toBe(mockResponse);
+    });
+
+    it('rejects with the error thrown by nitroFetch', async () => {
+      const networkError = new Error('Network request failed');
+      mockNitroFetch.mockRejectedValueOnce(networkError);
+
+      await expect(global.fetch('https://example.com')).rejects.toThrow(
+        'Network request failed',
+      );
+    });
+
+    describe('withPrefetchKey — header injection', () => {
+      it('injects prefetchKey for feature-flags URL with dynamic query params', async () => {
+        const url = `${FEATURE_FLAGS_PREFIX}?client=mobile&distribution=main&environment=production`;
+
+        await global.fetch(url);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'feature-flags',
+        );
+      });
+
+      it('injects prefetchKey for phishing stalelist URL', async () => {
+        await global.fetch(METAMASK_STALELIST_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-stalelist',
+        );
+      });
+
+      it('injects prefetchKey for C2 domain blocklist URL', async () => {
+        await global.fetch(C2_DOMAIN_BLOCKLIST_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-c2-blocklist',
+        );
+      });
+
+      it('preserves existing init options alongside injected prefetchKey', async () => {
+        const init = { method: 'GET' as const };
+
+        await global.fetch(METAMASK_STALELIST_URL, init);
+
+        const [, passedInit] = mockNitroFetch.mock.calls[0];
+        expect(passedInit).toMatchObject({ method: 'GET' });
+        expect((passedInit?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-stalelist',
+        );
+      });
+
+      it('does not overwrite an existing prefetchKey (idempotent)', async () => {
+        const init = { headers: { prefetchKey: 'custom-key' } };
+
+        await global.fetch(METAMASK_STALELIST_URL, init);
+
+        const [, passedInit] = mockNitroFetch.mock.calls[0];
+        expect((passedInit?.headers as Headers).get('prefetchKey')).toBe(
+          'custom-key',
+        );
+      });
+
+      it('passes init through unchanged for non-prefetch URLs', async () => {
+        const init = {
+          method: 'POST' as const,
+          headers: { 'Content-Type': 'application/json' },
+        };
+
+        await global.fetch('https://example.com/api', init);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(
+          'https://example.com/api',
+          init,
+        );
+      });
+
+      it('passes undefined init through unchanged for non-prefetch URLs', async () => {
+        await global.fetch('https://example.com');
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(
+          'https://example.com',
+          undefined,
+        );
+      });
+
+      it('merges injected prefetchKey into an existing Headers instance without overwriting other headers', async () => {
+        const existingHeaders = new Headers({ Authorization: 'Bearer token' });
+
+        await global.fetch(METAMASK_STALELIST_URL, {
+          headers: existingHeaders,
+        });
+
+        const [, passedInit] = mockNitroFetch.mock.calls[0];
+        const headers = passedInit?.headers as Headers;
+        expect(headers.get('prefetchKey')).toBe('phishing-stalelist');
+        expect(headers.get('Authorization')).toBe('Bearer token');
+      });
+
+      it('preserves request body and method when injecting prefetchKey', async () => {
+        const init: RequestInit = {
+          method: 'POST',
+          body: JSON.stringify({ data: 'value' }),
+        };
+
+        await global.fetch(METAMASK_STALELIST_URL, init);
+
+        const [, passedInit] = mockNitroFetch.mock.calls[0];
+        expect(passedInit?.method).toBe('POST');
+        expect(passedInit?.body).toBe(JSON.stringify({ data: 'value' }));
+      });
+    });
+
+    describe('getUrl — input type normalization', () => {
+      it('extracts URL from a URL object for prefix matching', async () => {
+        const url = new URL(METAMASK_STALELIST_URL);
+
+        await global.fetch(url);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-stalelist',
+        );
+      });
+
+      it('extracts URL from a Request-like object for prefix matching', async () => {
+        const request = { url: METAMASK_STALELIST_URL } as Request;
+
+        await global.fetch(request);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-stalelist',
+        );
+      });
+
+      it('passes non-matching URL object through without injecting headers', async () => {
+        const url = new URL('https://example.com');
+
+        await global.fetch(url);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(url, undefined);
+      });
+
+      it('treats plain string input as the URL for prefix matching', async () => {
+        await global.fetch(METAMASK_STALELIST_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'phishing-stalelist',
+        );
+      });
+    });
+  });
+});

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -1,0 +1,129 @@
+/**
+ * NitroFetchSetup — replaces global.fetch with nitro-fetch and registers
+ * critical startup endpoints for native prefetching on cold start.
+ *
+ * Per the nitro-fetch docs, prefetchOnAppStart pre-warms URLs natively before
+ * JS loads. Consuming fetch() calls must pass { headers: { prefetchKey } } to
+ * hit the in-memory FetchCache. The wrapper below injects that header
+ * automatically for registered URLs so upstream controllers that use
+ * global.fetch need no changes.
+ *
+ * Note: prefetchOnAppStart() only seeds the queue for the NEXT cold launch —
+ * JS must run once before the native side knows what to prefetch. First-launch
+ * (fresh install) prefetching is handled by native-side registerPrefetch()
+ * calls in MainApplication.kt (Android) and AppDelegate.swift (iOS), which
+ * write the same URLs into the persistent queue before JS boots.
+ *
+ * https://fetch.margelo.com — "Prefetching for the next app launch"
+ *
+ */
+import {
+  fetch as nitroFetch,
+  prefetchOnAppStart,
+  Headers,
+  Request,
+  Response,
+} from 'react-native-nitro-fetch';
+import { hasTestOverrides } from '../util/test/utils';
+import { ClientType } from '@metamask/remote-feature-flag-controller';
+import {
+  C2_DOMAIN_BLOCKLIST_URL,
+  METAMASK_STALELIST_URL,
+} from '@metamask/phishing-controller';
+import {
+  getFeatureFlagAppDistribution,
+  getFeatureFlagAppEnvironment,
+} from './Engine/controllers/remote-feature-flag-controller/utils';
+
+/**
+ * Single source of truth for startup prefetches.
+ *
+ * url - full URL passed to prefetchOnAppStart (may include query params)
+ * urlPrefix - prefix used to match consuming fetch() calls; stripping query
+ * params allows dynamic suffixes like ?timestamp= to still match
+ * key - stable prefetchKey shared between registration and consumption
+ *
+ * Adding an entry here automatically registers it AND wires up the cache hit.
+ * You cannot add one without the other.
+ */
+const STARTUP_PREFETCHES = [
+  {
+    url:
+      `https://client-config.api.cx.metamask.io/v1/flags` +
+      `?client=${ClientType.Mobile}` +
+      `&distribution=${getFeatureFlagAppDistribution()}` +
+      `&environment=${getFeatureFlagAppEnvironment()}`,
+    urlPrefix: 'https://client-config.api.cx.metamask.io/v1/flags',
+    key: 'feature-flags',
+  },
+  {
+    url: METAMASK_STALELIST_URL,
+    urlPrefix: METAMASK_STALELIST_URL,
+    key: 'phishing-stalelist',
+  },
+  {
+    url: C2_DOMAIN_BLOCKLIST_URL,
+    urlPrefix: C2_DOMAIN_BLOCKLIST_URL,
+    key: 'phishing-c2-blocklist',
+  },
+] as const;
+
+function getUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url ?? '';
+}
+
+/**
+ * Injects the prefetchKey header required by nitro-fetch to serve the
+ * in-memory FetchCache hit. Returns init unchanged when no match is found.
+ */
+function withPrefetchKey(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): RequestInit | undefined {
+  const url = getUrl(input);
+
+  const entry = STARTUP_PREFETCHES.find(({ urlPrefix }) =>
+    url.startsWith(urlPrefix),
+  );
+
+  if (!entry) return init;
+
+  const headers = new Headers(init?.headers);
+
+  if (!headers.has('prefetchKey')) {
+    headers.set('prefetchKey', entry.key);
+  }
+
+  return { ...init, headers };
+}
+
+function installProductionNitroFetch(): void {
+  // NOTE: nitro-fetch uses a buffered transport by default — the full response
+  // body is downloaded natively before the Promise resolves. `response.body.getReader()`
+  // is API-compatible (returns a ReadableStream that delivers all bytes in one chunk)
+  // but does NOT stream incrementally. For true streaming use either:
+  //   - `{ stream: true }` in fetch options (nitro-fetch Cronet streaming transport)
+  //   - import `fetch` from 'expo/fetch' directly (see bridge-controller-init.ts)
+  global.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+    nitroFetch(input, withPrefetchKey(input, init));
+  const _g = globalThis as unknown as {
+    Headers: typeof Headers;
+    Request: typeof Request;
+    Response: typeof Response;
+  };
+  _g.Headers = Headers;
+  _g.Request = Request;
+  _g.Response = Response;
+
+  for (const { url, key } of STARTUP_PREFETCHES) {
+    // Non-fatal: a registration failure means the cache is cold on next launch,
+    // not that the request fails — swallow so it never becomes an unhandled rejection.
+    prefetchOnAppStart(url, { prefetchKey: key }).catch(() => undefined);
+  }
+}
+
+if (!hasTestOverrides) {
+  installProductionNitroFetch();
+}

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ import './app/util/theme/preBootPureBlack';
 // Shim is used to ensure API compatibility for React Native and provides polyfills for globals
 import './shim.js';
 
+import './app/core/NitroFetchSetup';
+
 // TODO: This import may not be required anymore since we've upgraded to v2 - https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/#requirements
 // Legacy - Need to import early for native module initialization - https://docs.swmansion.com/react-native-gesture-handler/docs/1.x/
 import 'react-native-gesture-handler';

--- a/ios/MetaMask-Bridging-Header.h
+++ b/ios/MetaMask-Bridging-Header.h
@@ -4,6 +4,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <Expo/Expo.h>
+#import <NitroFetch/NitroAutoPrefetcher.h>
 
 // Thin C wrappers around BrazeReactBridge / BrazeReactUtils.
 // Implemented in BrazeHelper.mm.

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -56,7 +56,16 @@ class AppDelegate: ExpoAppDelegate {
     window = UIWindow(frame: UIScreen.main.bounds)
     window?.makeKeyAndVisible()
 
-    if FirebaseApp.app() == nil {
+    // Safe Firebase configuration — validates plist before configure() to prevent
+    // FIRInstallations from throwing an uncatchable NSException on launch when
+    // GoogleService-Info.plist is missing or contains a blank/placeholder/mock API_KEY.
+    // Real Firebase API keys always start with "AIzaSy"; anything else (empty, mock-*, etc.)
+    // would cause validateAPIKey: to throw an NSException that Swift cannot catch.
+    if FirebaseApp.app() == nil,
+       let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+       let plist = NSDictionary(contentsOfFile: path),
+       let apiKey = plist["API_KEY"] as? String,
+       apiKey.hasPrefix("AIzaSy") {
       FirebaseApp.configure()
     }
 
@@ -65,6 +74,20 @@ class AppDelegate: ExpoAppDelegate {
 
     RNBranch.branch.checkPasteboardOnInstall()
     RNBranch.initSession(launchOptions: launchOptions, isReferrable: true)
+
+    // Seed native prefetch queue before JS loads (iOS fires it automatically via
+    // NitroBootstrap.mm on UIApplicationDidFinishLaunchingNotification).
+    // Covers first-launch since JS-side prefetchOnAppStart() only runs after first JS execution.
+    // Feature flags omitted — environment value isn't available natively;
+    // JS registers the correct URL after its first run.
+    NitroAutoPrefetcher.registerPrefetch(
+      withUrl: "https://phishing-detection.api.cx.metamask.io/v1/stalelist",
+      prefetchKey: "phishing-stalelist",
+      headers: [:])
+    NitroAutoPrefetcher.registerPrefetch(
+      withUrl: "https://client-side-detection.api.cx.metamask.io/v1/request-blocklist",
+      prefetchKey: "phishing-c2-blocklist",
+      headers: [:])
 
     // Setup Braze
     if let brazeApiKey = Bundle.main.object(forInfoDictionaryKey: "braze_api_key") as? String,

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -105,6 +105,9 @@ def common_target_logic
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
     :hermes_enabled => true
   )
+
+  # NitroFetch (Swift) requires React-RCTNetwork to export module maps
+  pod 'React-RCTNetwork', :path => "#{config[:reactNativePath]}/Libraries/Network", :modular_headers => true
 end
 
 target 'MetaMask' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -592,6 +592,36 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - NitroFetch (1.3.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - NitroModules
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - NitroModules (0.35.5):
     - boost
     - DoubleConversion
@@ -4163,6 +4193,7 @@ DEPENDENCIES:
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - "NativeUtils (from `../node_modules/@metamask/native-utils`)"
+  - NitroFetch (from `../node_modules/react-native-nitro-fetch`)
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - OpenSSL-Universal
   - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral`)
@@ -4413,6 +4444,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/lottie-react-native"
   NativeUtils:
     :path: "../node_modules/@metamask/native-utils"
+  NitroFetch:
+    :path: "../node_modules/react-native-nitro-fetch"
   NitroModules:
     :path: "../node_modules/react-native-nitro-modules"
   Permission-BluetoothPeripheral:
@@ -4730,6 +4763,7 @@ SPEC CHECKSUMS:
   MultiplatformBleAdapter: b1fddd0d499b96b607e00f0faa8e60648343dc1d
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   NativeUtils: 1856148c08a042bbbca306acbe2771db8a9be99b
+  NitroFetch: 232232e9d216dc35be48f6478cf9f6cebd077916
   NitroModules: ea5dc6c43666f4a75e71e372eaca6d3605856e51
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
   Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
@@ -4869,6 +4903,6 @@ SPEC CHECKSUMS:
   Yoga: 728df40394d49f3f471688747cf558158b3a3bd1
   YttriumWrapper: cbddb60c835ebc4232d9f57064084ab30686a18e
 
-PODFILE CHECKSUM: 41ec3b10789f39c64e75ca60eb74e86257e8f76d
+PODFILE CHECKSUM: fdc685be8aca8982e5133ce36ef1c683bc9f32b1
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -215,7 +215,8 @@
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
     "@metamask/transaction-controller": "68.2.0",
     "@metamask/keyring-controller": "^26.0.0",
-    "@metamask/accounts-controller": "^39.0.2"
+    "@metamask/accounts-controller": "^39.0.2",
+    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -500,6 +501,7 @@
     "react-native-material-textfield": "0.16.1",
     "react-native-mmkv": "^3.2.0",
     "react-native-modal": "^14.0.0-rc.1",
+    "react-native-nitro-fetch": "1.3.3",
     "react-native-nitro-modules": "0.35.5",
     "react-native-os": "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch",
     "react-native-pager-view": "6.9.1",

--- a/tests/api-mocking/mock-responses/defaults/static-assets.ts
+++ b/tests/api-mocking/mock-responses/defaults/static-assets.ts
@@ -11,6 +11,12 @@ export const STATIC_ASSETS_MOCKS: MockEventsObject = {
     },
     {
       urlEndpoint:
+        /^https:\/\/static\.cx\.metamask\.io\/api\/v1\/tokenIcons\/.+\.png$/,
+      responseCode: 200,
+      response: '',
+    },
+    {
+      urlEndpoint:
         /^https:\/\/static\.cx\.metamask\.io\/api\/v2\/tokenIcons\/assets\/.+\.png$/,
       responseCode: 200,
       response: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -29218,6 +29218,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-modules-autolinking@patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch":
+  version: 3.0.24
+  resolution: "expo-modules-autolinking@patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch::version=3.0.24&hash=302f0d"
+  dependencies:
+    "@expo/spawn-async": "npm:^1.7.2"
+    chalk: "npm:^4.1.0"
+    commander: "npm:^7.2.0"
+    require-from-string: "npm:^2.0.2"
+    resolve-from: "npm:^5.0.0"
+  bin:
+    expo-modules-autolinking: bin/expo-modules-autolinking.js
+  checksum: 10/599967627a4ab86bd88c210aec1d820aedcc568d4bf1eca44ea8f9368e3ddf7f13a29aa58a2390a1d78ec9a155bbac48ed4ada2de921c78789f0a213bb58ab86
+  languageName: node
+  linkType: hard
+
 "expo-modules-core@npm:3.0.29":
   version: 3.0.29
   resolution: "expo-modules-core@npm:3.0.29"
@@ -35811,6 +35826,7 @@ __metadata:
     react-native-material-textfield: "npm:0.16.1"
     react-native-mmkv: "npm:^3.2.0"
     react-native-modal: "npm:^14.0.0-rc.1"
+    react-native-nitro-fetch: "npm:1.3.3"
     react-native-nitro-modules: "npm:0.35.5"
     react-native-os: "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch"
     react-native-pager-view: "npm:6.9.1"
@@ -40594,6 +40610,23 @@ __metadata:
     react: "*"
     react-native: ">=0.70.0"
   checksum: 10/569ed4419769b120b6a676094f1594801bf3fa7ac6c3eda4fa4f6405ba63afe9998b7e70e67614e20c717b0f181410516a697b5bf40dc3ed8ad3c2db280a6307
+  languageName: node
+  linkType: hard
+
+"react-native-nitro-fetch@npm:1.3.3":
+  version: 1.3.3
+  resolution: "react-native-nitro-fetch@npm:1.3.3"
+  dependencies:
+    web-streams-polyfill: "npm:^4.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-modules: ^0.35.2
+    react-native-worklets: ^0.8.0
+  peerDependenciesMeta:
+    react-native-worklets:
+      optional: true
+  checksum: 10/cc7aecf2edd1ae8568e145e7959aa5f72d029f872a7bb2baac7eda24989fc27f98489cae6b550448f2b8e064ab30a8ab99843af37967f304c139740e17e7d904
   languageName: node
   linkType: hard
 
@@ -46732,6 +46765,13 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "web-streams-polyfill@npm:4.3.0"
+  checksum: 10/70d1ac70d6c155dd5714b09902669954ecb7cc97e636793096daf6b3ba303241c91952ef74c84646e9fd15dcd00e2ec579e4bc3f303ecfc251bd77c6691f19e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Re-applies the exact changes from #31206 (`feat(networking): integrate nitro-fetch with startup prefetching`), which was reverted in #32429 because it was merged prematurely.

This PR exists so the nitro-fetch integration can be merged at the appropriate time.

The diff has been verified to be byte-for-byte identical to the original PR #31206.

## Notes

- Depends on the revert (#32429) landing first; this PR re-introduces nitro-fetch on top of a reverted `main`.
- Hold until the intended merge time.

## Test plan

- [ ] CI passes
- [ ] App builds and starts up with nitro-fetch prefetching active

Made with [Cursor](https://cursor.com)