### PR TITLE
fix(Rewards): Change Rewards mUSD banner to go to correct destination and show correct APY cp-8.0.0

### DIFF
--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
@@ -76,12 +76,14 @@ import {
   selectIsCardholder,
   selectIsCardAuthenticated,
 } from '../../../../../selectors/cardController';
+import { selectMoneyEnableMoneyAccountFlag } from '../../../Money/selectors/featureFlags';
 
 interface SetupOptions {
   geoLocation?: string;
   geoStatus?: 'idle' | 'loading' | 'complete';
   isCardholder?: boolean;
   isAuthenticatedCard?: boolean;
+  isMoneyAccountEnabled?: boolean;
 }
 
 const setupSelectors = ({
@@ -89,11 +91,14 @@ const setupSelectors = ({
   geoStatus = 'complete',
   isCardholder = false,
   isAuthenticatedCard = false,
+  isMoneyAccountEnabled = true,
 }: SetupOptions = {}) => {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectGeolocationLocation)
       return geoLocation === undefined ? undefined : geoLocation;
     if (selector === selectGeolocationStatus) return geoStatus;
+    if (selector === selectMoneyEnableMoneyAccountFlag)
+      return isMoneyAccountEnabled;
     if (selector === selectIsCardholder) return isCardholder;
     if (selector === selectIsCardAuthenticated) return isAuthenticatedCard;
     return undefined;
@@ -195,6 +200,20 @@ describe('EarnRewardsPreview', () => {
       ).toBeOnTheScreen();
     });
 
+    it('hides only the mUSD card when Money account feature flag is disabled, keeps Card card visible', () => {
+      setupSelectors({ geoLocation: 'US', isMoneyAccountEnabled: false });
+      const { queryByTestId } = render(<EarnRewardsPreview />);
+      expect(
+        queryByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_PREVIEW),
+      ).toBeOnTheScreen();
+      expect(
+        queryByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_CARD),
+      ).toBeNull();
+      expect(
+        queryByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_CARD_CARD),
+      ).toBeOnTheScreen();
+    });
+
     it('shows mUSD card when geoLocation is UNKNOWN (treated as non-UK)', () => {
       setupSelectors({ geoLocation: 'UNKNOWN' });
       const { getByTestId } = render(<EarnRewardsPreview />);
@@ -208,6 +227,15 @@ describe('EarnRewardsPreview', () => {
       const { getByText } = render(<EarnRewardsPreview />);
       expect(getByText('Up to 3.8% bonus on mUSD')).toBeOnTheScreen();
       expect(getByText('Money accounts are here')).toBeOnTheScreen();
+    });
+
+    it('falls back to 3% in the mUSD card title when APY is unavailable', () => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        apyPercent: undefined,
+      } as ReturnType<typeof useMoneyAccountBalance>);
+      setupSelectors({ geoLocation: 'US' });
+      const { getByText } = render(<EarnRewardsPreview />);
+      expect(getByText('Up to 3% bonus on mUSD')).toBeOnTheScreen();
     });
 
     it('renders correct text for MetaMask card', () => {

--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
@@ -2,14 +2,9 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import EarnRewardsPreview from './EarnRewardsPreview';
-import Routes from '../../../../../constants/navigation/Routes';
 import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 import { handleDeeplink } from '../../../../../core/DeeplinkManager';
-
-const mockNavigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
-}));
+import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -22,6 +17,10 @@ jest.mock('../../../../../core/DeeplinkManager', () => ({
 const mockHandleDeeplink = handleDeeplink as jest.MockedFunction<
   typeof handleDeeplink
 >;
+
+jest.mock('../../../Money/hooks/useMoneyAccountBalance', () => jest.fn());
+const mockUseMoneyAccountBalance =
+  useMoneyAccountBalance as jest.MockedFunction<typeof useMoneyAccountBalance>;
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -39,17 +38,24 @@ jest.mock('../../../../../util/theme', () => ({
 }));
 
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: (key: string) => {
+  strings: (key: string, params?: Record<string, string | number>) => {
     const map: Record<string, string> = {
       'rewards.earn_rewards.title': 'Earn rewards',
-      'rewards.earn_rewards.musd_title': 'Up to 3% bonus on stables',
-      'rewards.earn_rewards.musd_subtitle': 'Calculate your mUSD bonus',
+      'rewards.earn_rewards.musd_title': 'Up to {{percentage}}% bonus on mUSD',
+      'rewards.earn_rewards.musd_subtitle': 'Money accounts are here',
       'rewards.earn_rewards.card_title': 'Up to 3% back on spend',
       'rewards.earn_rewards.card_subtitle': 'Get your MetaMask Card now',
       'rewards.earn_rewards.card_subtitle_cardholder':
         'Access your MetaMask Card benefits',
     };
-    return map[key] || key;
+    const value = map[key] || key;
+    return params
+      ? Object.entries(params).reduce(
+          (text, [paramKey, paramValue]) =>
+            text.replace(`{{${paramKey}}}`, String(paramValue)),
+          value,
+        )
+      : value;
   },
 }));
 
@@ -97,6 +103,9 @@ const setupSelectors = ({
 describe('EarnRewardsPreview', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseMoneyAccountBalance.mockReturnValue({
+      apyPercent: 3.8,
+    } as ReturnType<typeof useMoneyAccountBalance>);
   });
 
   describe('section title', () => {
@@ -197,8 +206,8 @@ describe('EarnRewardsPreview', () => {
     it('renders correct text for mUSD card', () => {
       setupSelectors({ geoLocation: 'US' });
       const { getByText } = render(<EarnRewardsPreview />);
-      expect(getByText('Up to 3% bonus on stables')).toBeOnTheScreen();
-      expect(getByText('Calculate your mUSD bonus')).toBeOnTheScreen();
+      expect(getByText('Up to 3.8% bonus on mUSD')).toBeOnTheScreen();
+      expect(getByText('Money accounts are here')).toBeOnTheScreen();
     });
 
     it('renders correct text for MetaMask card', () => {
@@ -259,26 +268,25 @@ describe('EarnRewardsPreview', () => {
   });
 
   describe('navigation', () => {
-    it('navigates to mUSD calculator view when mUSD card is pressed', () => {
+    it('opens Money deeplink when mUSD card is pressed', () => {
       setupSelectors({ geoLocation: 'US' });
       const { getByTestId } = render(<EarnRewardsPreview />);
       fireEvent.press(
         getByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_CARD),
       );
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
-        screen: Routes.REWARDS_MUSD_CALCULATOR_VIEW,
-        params: undefined,
+      expect(mockHandleDeeplink).toHaveBeenCalledWith({
+        uri: 'metamask://money',
       });
     });
 
-    it('triggers card-onboarding deeplink when card card is pressed', () => {
+    it('triggers card-home deeplink when card card is pressed', () => {
       setupSelectors({ geoLocation: 'US' });
       const { getByTestId } = render(<EarnRewardsPreview />);
       fireEvent.press(
         getByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_CARD_CARD),
       );
       expect(mockHandleDeeplink).toHaveBeenCalledWith({
-        uri: 'metamask://card-onboarding',
+        uri: 'metamask://card-home',
       });
     });
   });

--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../../../../selectors/cardController';
 import { handleDeeplink } from '../../../../../core/DeeplinkManager';
 import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
+import { selectMoneyEnableMoneyAccountFlag } from '../../../Money/selectors/featureFlags';
 import musdImage from '../../../../../images/rewards/rewards-musd-earn.png';
 import cardImage from '../../../../../images/rewards/rewards-card-earn.png';
 
@@ -139,9 +140,13 @@ const EarnRewardsPreview: React.FC = () => {
   // mUSD geo check - hide for UK users, require positive geo confirmation to avoid flash
   const geoLocation = useSelector(selectGeolocationLocation);
   const geoStatus = useSelector(selectGeolocationStatus);
+  const isMoneyAccountEnabled = useSelector(selectMoneyEnableMoneyAccountFlag);
   const isMusdGeoLoading = geoStatus === 'loading' || geoStatus === 'idle';
   const showMusdCard =
-    geoLocation !== undefined && geoLocation !== UK_COUNTRY_CODE;
+    isMoneyAccountEnabled &&
+    geoLocation !== undefined &&
+    geoLocation !== UK_COUNTRY_CODE;
+  const showMusdSkeleton = isMoneyAccountEnabled && isMusdGeoLoading;
   const { apyPercent } = useMoneyAccountBalance();
 
   // Card check — subtitle varies by cardholder status; card is always rendered
@@ -169,7 +174,7 @@ const EarnRewardsPreview: React.FC = () => {
 
   // Build the ordered list of carousel slots, preserving existing visibility logic.
   const items: CarouselSlotKey[] = [];
-  if (isMusdGeoLoading && !showMusdCard) {
+  if (showMusdSkeleton && !showMusdCard) {
     items.push('musd-skeleton');
   } else if (showMusdCard) {
     items.push('musd');
@@ -209,7 +214,7 @@ const EarnRewardsPreview: React.FC = () => {
         alignItems={BoxAlignItems.Center}
         twClassName="gap-2 px-4"
       >
-        {isMusdGeoLoading && (
+        {showMusdSkeleton && (
           <ActivityIndicator size="small" color={colors.primary.default} />
         )}
         <Text variant={TextVariant.HeadingMd}>
@@ -239,7 +244,7 @@ const EarnRewardsPreview: React.FC = () => {
                 testID={REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_CARD}
                 image={musdImage}
                 title={strings('rewards.earn_rewards.musd_title', {
-                  percentage: apyPercent ?? 0,
+                  percentage: apyPercent ?? 3,
                 })}
                 subtitle={strings('rewards.earn_rewards.musd_subtitle')}
                 onPress={handleMusdPress}

--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
@@ -9,7 +9,6 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -22,8 +21,6 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
-import Routes from '../../../../../constants/navigation/Routes';
-import { navigateToRewardsRoute } from '../../utils';
 import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -35,6 +32,7 @@ import {
   selectIsCardholder,
 } from '../../../../../selectors/cardController';
 import { handleDeeplink } from '../../../../../core/DeeplinkManager';
+import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
 import musdImage from '../../../../../images/rewards/rewards-musd-earn.png';
 import cardImage from '../../../../../images/rewards/rewards-card-earn.png';
 
@@ -46,6 +44,7 @@ const UK_COUNTRY_CODE = 'GB';
 const HORIZONTAL_PADDING = 16;
 const CARD_GAP = 12;
 const PEEK_WIDTH = 24;
+const MUSD_MONEY_URL = 'metamask://money';
 
 const styles = StyleSheet.create({
   avatar: { width: AVATAR_SIZE, height: AVATAR_SIZE },
@@ -130,7 +129,6 @@ type CarouselSlotKey = 'musd-skeleton' | 'musd' | 'card';
  */
 const EarnRewardsPreview: React.FC = () => {
   const tw = useTailwind();
-  const navigation = useNavigation();
   const { colors } = useTheme();
   const { width: screenWidth } = useWindowDimensions();
   // Only the left padding consumes viewport space at scroll position 0.
@@ -144,6 +142,7 @@ const EarnRewardsPreview: React.FC = () => {
   const isMusdGeoLoading = geoStatus === 'loading' || geoStatus === 'idle';
   const showMusdCard =
     geoLocation !== undefined && geoLocation !== UK_COUNTRY_CODE;
+  const { apyPercent } = useMoneyAccountBalance();
 
   // Card check — subtitle varies by cardholder status; card is always rendered
   const isCardholder = useSelector(selectIsCardholder);
@@ -154,11 +153,11 @@ const EarnRewardsPreview: React.FC = () => {
       : strings('rewards.earn_rewards.card_subtitle');
 
   const handleMusdPress = useCallback(() => {
-    navigateToRewardsRoute(navigation, Routes.REWARDS_MUSD_CALCULATOR_VIEW);
-  }, [navigation]);
+    handleDeeplink({ uri: MUSD_MONEY_URL });
+  }, []);
 
   const handleCardPress = useCallback(() => {
-    handleDeeplink({ uri: 'metamask://card-onboarding' });
+    handleDeeplink({ uri: 'metamask://card-home' });
   }, []);
 
   // Disable presses only while the user is actively dragging the carousel.
@@ -239,7 +238,9 @@ const EarnRewardsPreview: React.FC = () => {
               <EarnCard
                 testID={REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_CARD}
                 image={musdImage}
-                title={strings('rewards.earn_rewards.musd_title')}
+                title={strings('rewards.earn_rewards.musd_title', {
+                  percentage: apyPercent ?? 0,
+                })}
                 subtitle={strings('rewards.earn_rewards.musd_subtitle')}
                 onPress={handleMusdPress}
                 disabled={isDragging}

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Belohnungen verdienen",
-      "musd_title": "Bis zu 3 % Bonus auf Stablecoins",
-      "musd_subtitle": "Berechnen Sie Ihren mUSD-Bonus",
+      "musd_title": "Bis zu {{percentage}} % Bonus auf mUSD",
+      "musd_subtitle": "Geldkonten sind hier",
       "card_title": "Bis zu 3 % Rabatt auf Ausgaben",
       "card_subtitle": "Sichern Sie sich jetzt Ihre MetaMask Card",
       "card_subtitle_cardholder": "Nutzen Sie die Vorteile Ihrer MetaMask Card"

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Κερδίστε ανταμοιβές",
-      "musd_title": "Έως 3% μπόνους σε stables",
-      "musd_subtitle": "Υπολογίστε το μπόνους σας σε mUSD",
+      "musd_title": "Έως {{percentage}}% μπόνους σε mUSD",
+      "musd_subtitle": "Οι καταθετικοί λογαριασμοί είναι εδώ",
       "card_title": "Έως 3% επιστροφή σε κάθε αγορά",
       "card_subtitle": "Αποκτήστε τώρα την MetaMask Card",
       "card_subtitle_cardholder": "Δείτε τα προνόμια της MetaMask Card"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9546,8 +9546,8 @@
     },
     "earn_rewards": {
       "title": "Earn rewards",
-      "musd_title": "Up to 3% bonus on stables",
-      "musd_subtitle": "Calculate your mUSD bonus",
+      "musd_title": "Up to {{percentage}}% bonus on mUSD",
+      "musd_subtitle": "Money accounts are here",
       "card_title": "Up to 3% back on spend",
       "card_subtitle": "Get your MetaMask Card now",
       "card_subtitle_cardholder": "Access your MetaMask Card benefits"

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Gana recompensas",
-      "musd_title": "Bono de hasta el 3 % en monedas estables",
-      "musd_subtitle": "Calcula tu bono en mUSD",
+      "musd_title": "Bono de hasta el {{percentage}} % en mUSD",
+      "musd_subtitle": "Ya llegaron las cuentas Finanzas",
       "card_title": "Hasta un 3 % de cashback en tus gastos",
       "card_subtitle": "Obtén tu tarjeta MetaMask ahora",
       "card_subtitle_cardholder": "Accede a los beneficios de tu tarjeta MetaMask"

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Gagner des récompenses",
-      "musd_title": "Jusqu’à 3 % de bonus sur les stablecoins",
-      "musd_subtitle": "Calculer votre bonus en mUSD",
+      "musd_title": "Jusqu’à {{percentage}} % de bonus sur mUSD",
+      "musd_subtitle": "Les comptes Money sont disponibles",
       "card_title": "Jusqu’à 3 % de remise sur vos dépenses",
       "card_subtitle": "Obtenez votre carte MetaMask Card dès maintenant",
       "card_subtitle_cardholder": "Accédez aux avantages de votre carte MetaMask Card"

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "रिवॉर्ड्स कमाएं",
-      "musd_title": "स्टेबल्स पर 3% तक बोनस",
-      "musd_subtitle": "अपना mUSD बोनस कैलकुलेट करें",
+      "musd_title": "mUSD पर {{percentage}}% तक बोनस",
+      "musd_subtitle": "मनी अकाउंट यहां हैं",
       "card_title": "खर्च पर 3% तक वापस",
       "card_subtitle": "अपना MetaMask कार्ड अभी पाएं",
       "card_subtitle_cardholder": "अपने MetaMask कार्ड के फ़ायदे पाएं"

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Dapatkan reward",
-      "musd_title": "Bonus stabil hingga 3%",
-      "musd_subtitle": "Hitung bonus mUSD Anda",
+      "musd_title": "Bonus hingga {{percentage}}% pada mUSD",
+      "musd_subtitle": "Akun Dana telah hadir",
       "card_title": "Pengembalian hingga 3% dari penggunaan",
       "card_subtitle": "Dapatkan Kartu MetaMask sekarang",
       "card_subtitle_cardholder": "Manfaatkan keuntungan Kartu MetaMask"

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "報酬を獲得しましょう",
-      "musd_title": "ステーブルで最大3%のボーナス",
-      "musd_subtitle": "mUSDボーナスの計算",
+      "musd_title": "mUSDで最大{{percentage}}%のボーナス",
+      "musd_subtitle": "マネーアカウントが新登場",
       "card_title": "使用額の最大3%を還元",
       "card_subtitle": "今すぐMetaMaskカードを取得",
       "card_subtitle_cardholder": "MetaMaskカードの特典を利用"

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "보상 받기",
-      "musd_title": "스테이블코인 최대 3% 보너스",
-      "musd_subtitle": "mUSD 보너스 계산하기",
+      "musd_title": "mUSD 최대 {{percentage}}% 보너스",
+      "musd_subtitle": "머니 계정을 소개합니다",
       "card_title": "지출 금액의 최대 3% 캐시백",
       "card_subtitle": "지금 MetaMask 카드를 받으세요",
       "card_subtitle_cardholder": "MetaMask 카드 혜택을 이용하세요"

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Ganhe recompensas",
-      "musd_title": "Até 3% de bônus sobre stablecoins",
-      "musd_subtitle": "Calcule seu bônus em mUSD",
+      "musd_title": "Até {{percentage}}% de bônus sobre mUSD",
+      "musd_subtitle": "As contas Money chegaram",
       "card_title": "Até 3% de reembolso em gastos",
       "card_subtitle": "Peça já o seu Cartão MetaMask",
       "card_subtitle_cardholder": "Acesse os benefícios do seu Cartão MetaMask"

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Заработать вознаграждения",
-      "musd_title": "Бонус до 3% на стейблкойны",
-      "musd_subtitle": "Рассчитайте свой бонус в mUSD",
+      "musd_title": "Бонус до {{percentage}}% на mUSD",
+      "musd_subtitle": "Денежные счета уже здесь",
       "card_title": "Кешбэк до 3% за покупки",
       "card_subtitle": "Получите свою карту MetaMask прямо сейчас",
       "card_subtitle_cardholder": "Воспользуйтесь преимуществами своей карты MetaMask"

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Kumita ng mga reward",
-      "musd_title": "Hanggang 3% bonus sa mga stable",
-      "musd_subtitle": "Kalkulahin ang iyong mUSD bonus",
+      "musd_title": "Hanggang {{percentage}}% bonus sa mUSD",
+      "musd_subtitle": "Narito ang mga money account",
       "card_title": "Hanggang sa 3% ang maibabalik sa ginastos",
       "card_subtitle": "Kunin ang iyong MetaMask Card ngayon",
       "card_subtitle_cardholder": "I-access ang mga benepisyo ng iyong MetaMask Card"

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Ödül kazan",
-      "musd_title": "Stabil kripto paralarda %3'e kadar bonus",
-      "musd_subtitle": "mUSD bonusunuzu hesaplayın",
+      "musd_title": "mUSD'de %{{percentage}}'e kadar bonus",
+      "musd_subtitle": "Para hesapları burada",
       "card_title": "Harcamalarda %3'e varan iade",
       "card_subtitle": "MetaMask Card'ınızı hemen alın",
       "card_subtitle_cardholder": "MetaMask Card faydalarınıza erişim sağlayın"

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "Nhận phần thưởng",
-      "musd_title": "Thưởng lên đến 3% cho đồng ổn định",
-      "musd_subtitle": "Tính toán thưởng mUSD của bạn",
+      "musd_title": "Thưởng lên đến {{percentage}}% cho mUSD",
+      "musd_subtitle": "Tài khoản Tài chính đã ra mắt",
       "card_title": "Hoàn tiền lên đến 3% cho chi tiêu",
       "card_subtitle": "Nhận MetaMask Card của bạn ngay",
       "card_subtitle_cardholder": "Truy cập các quyền lợi MetaMask Card của bạn"

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -9525,8 +9525,8 @@
     },
     "earn_rewards": {
       "title": "赚取奖励",
-      "musd_title": "稳定币最高可享 3% 奖励",
-      "musd_subtitle": "计算您的 mUSD 奖励",
+      "musd_title": "mUSD 最高可享 {{percentage}}% 奖励",
+      "musd_subtitle": "Money 账户已上线",
       "card_title": "消费享最高 3% 返现",
       "card_subtitle": "立即获取您的 MetaMask 卡",
       "card_subtitle_cardholder": "查看您的 MetaMask 卡专属福利"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Correct the APY displayed on the mUSD banner in Rewards and send users to the correct destination

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: n/a

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-25 at 14 49 49" src="https://github.com/user-attachments/assets/863bc669-febb-4c8a-9724-007f3d545b7f" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rewards UI and deeplink routing changes with feature-flag gating and updated tests; no auth or payment logic changes.
> 
> **Overview**
> The Rewards **Earn rewards** mUSD carousel card now reflects live Money account APY in the title (with a **3%** fallback when APY is missing), uses updated **mUSD / Money accounts** copy, and only appears when the **Money account** feature flag is on (still respecting UK geo rules).
> 
> Tapping the mUSD card opens **`metamask://money`** instead of the in-app mUSD calculator route; the MetaMask Card tile now deeplinks to **`metamask://card-home`** instead of card onboarding. Locale strings were updated across languages for the parameterized title and new subtitle; unit tests cover flag gating, APY display, and deeplink behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f583c06130bcd87875c868b1f31f5b39cb72f226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->