### PR TITLE
fix(activity-details): label Tron resource fees distinctly from network fee

### DIFF
--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
@@ -101,6 +101,64 @@ describe('useActivityAmountsFiat', () => {
     expect(result.current.totalFiat).toBe('$9');
   });
 
+  it('labels a non-native resource fee by its resource and excludes it from fiat/total', () => {
+    const tronFees: ActivityFee[] = [
+      {
+        type: 'base',
+        amount: '1000000',
+        decimals: 6,
+        symbol: 'TRX',
+        assetId: 'tron:728126428/slip44:195',
+      },
+      {
+        type: 'base',
+        amount: '268',
+        decimals: 0,
+        symbol: 'BANDWIDTH',
+        assetId: 'tron:728126428/resource:bandwidth',
+      },
+    ];
+    const tronActivity: ActivityListItem = {
+      type: 'receive',
+      chainId: 'tron:728126428',
+      status: 'success',
+      timestamp: 1,
+      hash: '0xhash',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        token: {
+          amount: '8567000',
+          assetId: 'tron:728126428/slip44:195',
+          decimals: 6,
+          direction: 'in',
+          symbol: 'TRX',
+        },
+        fees: tronFees,
+      },
+    };
+
+    // Tron is non-EVM: there's no native `conversionRate`, so fees render as
+    // token amounts and the total's fiat comes from the token's multichain rate.
+    mockUseSelectorState({
+      currentCurrency: 'usd',
+      conversionRate: undefined,
+      contractExchangeRates: {},
+      multichainAssetRates: {
+        'tron:728126428/slip44:195': { rate: '0.324' },
+      },
+    });
+
+    const { result } = renderHook(() => useActivityAmountsFiat(tronActivity));
+
+    expect(result.current.feeRows).toStrictEqual([
+      { label: 'Network fee', value: '1', fee: tronFees[0] },
+      { label: 'Bandwidth', value: '268', fee: tronFees[1] },
+    ]);
+    // Total = token amount (8.567 TRX * 0.324) only; both fees are token-only.
+    expect(result.current.totalFiat).toBe('$2.78');
+  });
+
   it('falls back to token-denominated fee values when fiat is unavailable', () => {
     mockUseSelectorState({
       currentCurrency: undefined,

--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
@@ -111,11 +111,12 @@ describe('useActivityAmountsFiat', () => {
         assetId: 'tron:728126428/slip44:195',
       },
       {
+        // The Tron snap surfaces resource fees as virtual assets, so `assetId`
+        // is unreliable/absent — detection must rely on the symbol.
         type: 'base',
         amount: '268',
         decimals: 0,
         symbol: 'BANDWIDTH',
-        assetId: 'tron:728126428/resource:bandwidth',
       },
     ];
     const tronActivity: ActivityListItem = {

--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
@@ -133,7 +133,7 @@ function feeToFiatNumber(
   // The conversion rate is the native token's rate, so only native fees can be
   // converted. Resource fees (e.g. Tron Bandwidth/Energy) are non-native and
   // must not be priced at the native rate — that would inflate the total.
-  if (fee.assetId && !isNativeAssetId(fee.assetId)) {
+  if (isResourceFee(fee)) {
     return undefined;
   }
   // Base/network fees are denominated in the chain's native token.
@@ -171,26 +171,43 @@ function titleCaseSymbol(symbol: string): string {
 }
 
 /**
- * Resolves the label for a resource fee paid in a non-native asset. Some chains
- * (e.g. Tron) report resource consumption — Bandwidth, Energy — as a second
- * `base` fee. Labeling these by their resource keeps them distinct from the
- * native "Network fee" row rather than duplicating it.
+ * Known resource symbols reported as fees by chains that meter execution
+ * (e.g. Tron Bandwidth/Energy). The snap surfaces these as virtual assets, so
+ * their CAIP `assetId` is unreliable — the symbol is the dependable signal.
+ */
+const RESOURCE_FEE_LABEL_BY_SYMBOL: Record<string, string> = {
+  BANDWIDTH: 'activity_details.bandwidth_fee',
+  ENERGY: 'activity_details.energy_fee',
+};
+
+/**
+ * A `base` fee is a "resource" fee (not the native network fee) when it is paid
+ * in a recognized resource (Bandwidth/Energy) or, more generally, in a
+ * non-native asset. Such fees get a distinct label so they don't duplicate the
+ * native "Network fee" row, and are kept out of native-rate fiat conversion.
+ */
+function isResourceFee(fee: ActivityFee): boolean {
+  if (fee.symbol && fee.symbol.toUpperCase() in RESOURCE_FEE_LABEL_BY_SYMBOL) {
+    return true;
+  }
+  return Boolean(fee.assetId && !isNativeAssetId(fee.assetId));
+}
+
+/**
+ * Resolves the label for a resource fee. Some chains (e.g. Tron) report
+ * resource consumption — Bandwidth, Energy — as a second `base` fee. Labeling
+ * these by their resource keeps them distinct from the native "Network fee"
+ * row rather than duplicating it.
  */
 function getResourceFeeLabel(symbol: string): string {
-  switch (symbol.toUpperCase()) {
-    case 'BANDWIDTH':
-      return strings('activity_details.bandwidth_fee');
-    case 'ENERGY':
-      return strings('activity_details.energy_fee');
-    default:
-      return titleCaseSymbol(symbol);
-  }
+  const key = RESOURCE_FEE_LABEL_BY_SYMBOL[symbol.toUpperCase()];
+  return key ? strings(key) : titleCaseSymbol(symbol);
 }
 
 function getFeeLabel(fee: ActivityFee): string {
   switch (fee.type) {
     case 'base':
-      if (fee.assetId && !isNativeAssetId(fee.assetId) && fee.symbol) {
+      if (fee.symbol && isResourceFee(fee)) {
         return getResourceFeeLabel(fee.symbol);
       }
       return strings('activity_details.network_fee');

--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
@@ -41,10 +41,15 @@ export interface ActivityAmountsFiat {
 
 const FIAT_DECIMALS = 2;
 
-function isNativeAsset(token: TokenAmount): boolean {
+/** A CAIP asset id refers to the chain's native token (e.g. `slip44`/`native`). */
+function isNativeAssetId(assetId: string | undefined): boolean {
   return Boolean(
-    token.assetId?.includes('/slip44:') || token.assetId?.includes('/native:'),
+    assetId?.includes('/slip44:') || assetId?.includes('/native:'),
   );
+}
+
+function isNativeAsset(token: TokenAmount): boolean {
+  return isNativeAssetId(token.assetId);
 }
 
 /** Mirrors the activity row's market-price lookup (checksum, then lowercase). */
@@ -125,6 +130,12 @@ function feeToFiatNumber(
   if (!conversionRate || fee.amount === undefined) {
     return undefined;
   }
+  // The conversion rate is the native token's rate, so only native fees can be
+  // converted. Resource fees (e.g. Tron Bandwidth/Energy) are non-native and
+  // must not be priced at the native rate — that would inflate the total.
+  if (fee.assetId && !isNativeAssetId(fee.assetId)) {
+    return undefined;
+  }
   // Base/network fees are denominated in the chain's native token.
   const human = getHumanReadableTokenAmount({
     amount: fee.amount,
@@ -154,9 +165,34 @@ function feeToTokenAmount(fee: ActivityFee): string | undefined {
   return Number.isFinite(parsedAmount) && parsedAmount > 0 ? human : undefined;
 }
 
+/** Title-cases a fee symbol for use as a fallback label (e.g. `BANDWIDTH` -> `Bandwidth`). */
+function titleCaseSymbol(symbol: string): string {
+  return symbol.charAt(0).toUpperCase() + symbol.slice(1).toLowerCase();
+}
+
+/**
+ * Resolves the label for a resource fee paid in a non-native asset. Some chains
+ * (e.g. Tron) report resource consumption — Bandwidth, Energy — as a second
+ * `base` fee. Labeling these by their resource keeps them distinct from the
+ * native "Network fee" row rather than duplicating it.
+ */
+function getResourceFeeLabel(symbol: string): string {
+  switch (symbol.toUpperCase()) {
+    case 'BANDWIDTH':
+      return strings('activity_details.bandwidth_fee');
+    case 'ENERGY':
+      return strings('activity_details.energy_fee');
+    default:
+      return titleCaseSymbol(symbol);
+  }
+}
+
 function getFeeLabel(fee: ActivityFee): string {
   switch (fee.type) {
     case 'base':
+      if (fee.assetId && !isNativeAssetId(fee.assetId) && fee.symbol) {
+        return getResourceFeeLabel(fee.symbol);
+      }
       return strings('activity_details.network_fee');
     case 'bridge':
       return strings('activity_details.bridge_fee');

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9681,6 +9681,8 @@
     "network": "Network",
     "transaction_id": "Transaction ID",
     "network_fee": "Network fee",
+    "bandwidth_fee": "Bandwidth",
+    "energy_fee": "Energy",
     "bridge_fee": "Bridge fee",
     "transaction_fee": "Transaction fee",
     "total_amount": "Total amount",


### PR DESCRIPTION
## **Description**

Tron transactions on the redesigned Activity Details screen returned two `base` fees the native TRX fee and a non-native resource fee (Bandwidth/Energy) both of which rendered with the identical "Network fee" label, reading as a duplicated/buggy row.

This labels non-native resource base fees by their resource (Bandwidth/Energy, with a title-cased symbol fallback) so the two rows are distinct. It also excludes non-native resource fees from native-rate fiat conversion, so they can't inflate the transaction total. EVM fees (no `assetId`) are unaffected and keep "Network fee".

## **Changelog**

CHANGELOG entry: Fixed Tron transaction details showing two fee rows both labeled "Network fee"; resource fees (Bandwidth/Energy) are now labeled distinctly.

## **Related issues**

Refs: [TMCU-942](https://consensyssoftware.atlassian.net/browse/TMCU-942)

## **Manual testing steps**

```gherkin
Feature: Activity details fee labels

  Scenario: View a Tron transaction with a resource fee
    Given the activity redesign feature flag is enabled
    And I have a Tron transaction that consumed Bandwidth (or Energy)

    When I open that transaction's details
    Then the native fee row is labeled "Network fee" with the TRX amount
    And the resource fee row is labeled "Bandwidth" (or "Energy") with its amount
    And the total amount is not inflated by the non-native resource fee
```

## **Screenshots/Recordings**

<img width="500" alt="simulator_screenshot_96EC8F05-4C10-48D3-BBA9-9703C02D17B1" src="https://github.com/user-attachments/assets/c3bcafc2-7be6-4000-93ad-ac1aeacfe30d" />

### **Before**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-25 at 16 33 52" src="https://github.com/user-attachments/assets/809cb90e-1313-4ddd-bb4c-4e7fed90cf07" />


### **After**

<img width="500" alt="simulator_screenshot_96EC8F05-4C10-48D3-BBA9-9703C02D17B1" src="https://github.com/user-attachments/assets/c3bcafc2-7be6-4000-93ad-ac1aeacfe30d" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-942]: https://consensyssoftware.atlassian.net/browse/TMCU-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fee labeling and fiat math in activity details; EVM fee behavior is unchanged.
> 
> **Overview**
> Fixes Activity Details when Tron (and similar) transactions expose **two `base` fees**—native TRX plus Bandwidth/Energy—both previously labeled **Network fee** and the resource line could be **priced with the native conversion rate**, inflating the total.
> 
> `useActivityAmountsFiat` now treats resource fees via symbol (`BANDWIDTH`/`ENERGY`) or a non-native `assetId`, shows **Bandwidth** / **Energy** (new i18n keys, title-cased symbol fallback), and **skips native-rate fiat** for those rows while still showing token amounts. EVM `base` fees without `assetId` stay **Network fee**.
> 
> Adds a Tron-focused unit test for labels, token-only fee values, and total fiat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f92b1599fc2e3b79f68c8e8d70a2acb1d17b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->