### PR TITLE
fix: make trending filter bar horizontally scrollable and left-aligned

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.tsx
+++ b/app/components/UI/Bridge/components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
-  BoxFlexDirection,
   Text,
   TextVariant,
   TextColor,
@@ -31,7 +30,9 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import type { CaipChainId } from '@metamask/utils';
-import { FilterButton } from '../../../Trending/components/FilterBar/FilterBar';
+import FilterBar, {
+  FilterButton,
+} from '../../../Trending/components/FilterBar/FilterBar';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { BridgeTrendingTokensSectionTestIds } from './BridgeTrendingTokensSection.testIds';
 
@@ -152,27 +153,21 @@ const BridgeTrendingTokensSection = ({
         >
           {strings('trending.trending_tokens')}
         </Text>
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          twClassName="gap-2 mb-3 w-full"
-        >
-          <FilterButton
-            testID={BridgeTrendingTokensSectionTestIds.PRICE_FILTER}
-            onPress={() => setActiveBottomSheet('price_change')}
-            label={priceChangeButtonText}
-            twClassName="flex-1"
-          />
-          <FilterButton
-            testID={BridgeTrendingTokensSectionTestIds.NETWORK_FILTER}
-            onPress={() => setActiveBottomSheet('network')}
-            label={selectedNetworkName}
-            twClassName="flex-1"
-          />
-          <FilterButton
-            testID={BridgeTrendingTokensSectionTestIds.TIME_FILTER}
-            onPress={() => setActiveBottomSheet('time')}
-            label={selectedTimeOption}
-            twClassName="w-[72px] shrink-0"
+        <Box twClassName="-mx-4 mb-3">
+          <FilterBar
+            priceChangeButtonText={priceChangeButtonText}
+            onPriceChangePress={() => setActiveBottomSheet('price_change')}
+            networkName={selectedNetworkName}
+            onNetworkPress={() => setActiveBottomSheet('network')}
+            priceChangeTestID={BridgeTrendingTokensSectionTestIds.PRICE_FILTER}
+            networkTestID={BridgeTrendingTokensSectionTestIds.NETWORK_FILTER}
+            extraFilters={
+              <FilterButton
+                testID={BridgeTrendingTokensSectionTestIds.TIME_FILTER}
+                onPress={() => setActiveBottomSheet('time')}
+                label={selectedTimeOption}
+              />
+            }
           />
         </Box>
 

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { ScrollView } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   IconName,
@@ -42,7 +42,7 @@ export const FilterButton: React.FC<FilterButtonProps> = ({
       numberOfLines,
       ellipsizeMode,
     }}
-    twClassName={twClassName}
+    twClassName={twClassName ? `shrink-0 ${twClassName}` : 'shrink-0'}
   />
 );
 
@@ -58,6 +58,10 @@ export interface FilterBarProps {
 
   /** Optional extra filter buttons rendered after the network button */
   extraFilters?: React.ReactNode;
+  /** Optional testID override for the price-change button */
+  priceChangeTestID?: string;
+  /** Optional testID override for the network button */
+  networkTestID?: string;
 }
 
 /**
@@ -73,31 +77,39 @@ const FilterBar: React.FC<FilterBarProps> = ({
   networkName,
   onNetworkPress,
   extraFilters,
+  priceChangeTestID = 'price-change-button',
+  networkTestID = 'all-networks-button',
 }) => {
   const tw = useTailwind();
 
   return (
-    <View style={tw`flex-grow-0 px-4 pb-4`}>
-      <View style={tw`flex-row items-center gap-2`}>
-        <FilterButton
-          testID="price-change-button"
-          label={priceChangeButtonText}
-          onPress={onPriceChangePress}
-          disabled={isPriceChangeDisabled}
-          iconName={priceChangeIconName}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        />
-        <FilterButton
-          testID="all-networks-button"
-          label={networkName}
-          onPress={onNetworkPress}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        />
-        {extraFilters}
-      </View>
-    </View>
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      style={tw`flex-grow-0`}
+      contentContainerStyle={tw.style(
+        'flex-grow-0 flex-row items-center gap-2 px-4 pb-4',
+      )}
+    >
+      <FilterButton
+        testID={priceChangeTestID}
+        label={priceChangeButtonText}
+        onPress={onPriceChangePress}
+        disabled={isPriceChangeDisabled}
+        iconName={priceChangeIconName}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      />
+      <FilterButton
+        testID={networkTestID}
+        label={networkName}
+        onPress={onNetworkPress}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      />
+      {extraFilters}
+    </ScrollView>
   );
 };
 


### PR DESCRIPTION
## **Description**

Trending token filter buttons were stretching to fill the full row width instead of sizing to their label content. This was most visible on the Swap screen, where `BridgeTrendingTokensSection` used a custom flex row with `flex-1` on the Price change and All networks buttons.

This PR updates the shared `FilterBar` to use a horizontal `ScrollView` (scrollbar hidden) with left-aligned buttons at their natural width, and migrates the Swap trending section to reuse that component.

**Changes:**
- **`FilterBar`**: Replaced static `View` layout with a horizontal `ScrollView`; padding lives on `contentContainerStyle`. Buttons use `shrink-0` so they don’t grow. Added optional `priceChangeTestID` / `networkTestID` props for consumers with custom test IDs.
- **`BridgeTrendingTokensSection`**: Replaced the inline `flex-1` filter row with `FilterBar`, passing the time filter via `extraFilters`. Existing E2E test IDs are preserved.

Trending full-view screens (`TokenListPageLayout`) also benefit from horizontal scrolling when filters overflow.

## **Changelog**

CHANGELOG entry: Fixed trending token filter buttons stretching across the full screen width in Swap and Trending views.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-895

## **Manual testing steps**

```gherkin
Feature: Trending filter bar layout

  Scenario: Swap trending filters are left-aligned at natural width
    Given the app is running with Swaps trending tokens enabled
    And the user is on the Swap screen with the Trending section visible

    When the user views the filter row (Price change, All networks, 24h)
    Then the filter buttons are left-aligned and sized to their labels
    And the buttons do not stretch to fill the full screen width
    And tapping each filter opens the corresponding bottom sheet

  Scenario: Trending full view filters scroll when needed
    Given the user navigates to a trending tokens full view (e.g. Explore → Trending)

    When the user views the filter bar
    Then filter buttons are left-aligned at their natural width
    And the row scrolls horizontally if filters exceed the screen width
    And the horizontal scroll indicator is not visible
```

## **Screenshots/Recordings**

### **Before**

<img width="1080" height="2258" alt="image" src="https://github.com/user-attachments/assets/a20f496a-1316-4a9b-9a8e-69bc817a19c0" />

<!-- Attach screenshot from testing -->

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-25 at 15 47 35" src="https://github.com/user-attachments/assets/26761ff4-44f2-4483-b729-c2a3a6a91341" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-25 at 15 48 05" src="https://github.com/user-attachments/assets/a2639e13-7a3e-41a1-9b1e-e528f591192e" />

<!-- Attach screenshot from testing -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labelging guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout refactor in trending/swap filters; behavior and test IDs are preserved via optional props.
> 
> **Overview**
> Fixes trending filter chips stretching full-width (especially on Swap) by changing the shared **`FilterBar`** layout and reusing it in **`BridgeTrendingTokensSection`**.
> 
> **`FilterBar`** now uses a horizontal **`ScrollView`** (indicator hidden, `keyboardShouldPersistTaps="handled"`) instead of a static row; padding moves to `contentContainerStyle`, and **`FilterButton`** always gets **`shrink-0`** so labels size naturally. Optional **`priceChangeTestID`** / **`networkTestID`** props let callers keep custom E2E IDs.
> 
> **`BridgeTrendingTokensSection`** drops the inline `flex-1` filter row in favor of **`FilterBar`**, with the time filter passed via **`extraFilters`** and existing bridge test IDs wired through the new props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8551b0f2733c37fe6c61c6c855aab64feb324112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->