### PR TITLE
feat(predict): New Trending Section

### DIFF
--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -196,10 +196,7 @@ export const selectPredictPortfolioEnabledFlag = createSelector(
 
 export const selectPredictHomeRedesignEnabledFlag = createSelector(
   selectPredictFeatureFlags,
-  // TODO: TEMP QA OVERRIDE — force the redesigned PredictHome on so the new
-  // sections can be reviewed locally. REVERT before commit:
-  // restore `(flags) => flags.predictHomeRedesignEnabled`.
-  () => true,
+  (flags) => flags.predictHomeRedesignEnabled,
 );
 
 export const selectPredictSportCardLivePricesEnabledFlag = createSelector(

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -196,7 +196,10 @@ export const selectPredictPortfolioEnabledFlag = createSelector(
 
 export const selectPredictHomeRedesignEnabledFlag = createSelector(
   selectPredictFeatureFlags,
-  (flags) => flags.predictHomeRedesignEnabled,
+  // TODO: TEMP QA OVERRIDE — force the redesigned PredictHome on so the new
+  // sections can be reviewed locally. REVERT before commit:
+  // restore `(flags) => flags.predictHomeRedesignEnabled`.
+  () => true,
 );
 
 export const selectPredictSportCardLivePricesEnabledFlag = createSelector(

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { backgroundState } from '../../../../../../../util/test/initial-root-state';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../../../locales/i18n';
+import Routes from '../../../../../../../constants/navigation/Routes';
+import type { PredictMarket } from '../../../../types';
+import { PredictEventValues } from '../../../../constants/eventNames';
+import PredictTrendingSection from './PredictTrendingSection';
+import { PREDICT_TRENDING_SECTION_TEST_IDS } from './PredictTrendingSection.testIds';
+import { usePredictTrendingSection } from './usePredictTrendingSection';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+// Mock only the data boundary: the section's own data hook. The hook's own
+// logic (params, display cap, loading/unavailable) is covered by
+// usePredictTrendingSection.test.ts. Here we exercise the real PredictMarket /
+// PredictMarketSkeleton presentation against controlled hook output.
+jest.mock('./usePredictTrendingSection');
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: jest.fn(() => ({})) }),
+}));
+
+// Mock the heavy leaf cards (charts/images/timers) — the same boundary the
+// canonical PredictMarket.test.tsx uses — forwarding the section's testID so
+// real PredictMarket dispatch is exercised.
+jest.mock('../../../../components/PredictMarketSingle', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+jest.mock('../../../../components/PredictMarketMultiple', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+
+const mockUsePredictTrendingSection = usePredictTrendingSection as jest.Mock;
+
+const createMarket = (id: string): PredictMarket =>
+  ({
+    id,
+    outcomes: [{ id: `${id}-o1` }],
+  }) as unknown as PredictMarket;
+
+const setSection = (
+  overrides: Partial<{
+    markets: PredictMarket[];
+    isLoading: boolean;
+    isUnavailable: boolean;
+  }> = {},
+) => {
+  mockUsePredictTrendingSection.mockReturnValue({
+    markets: [],
+    isLoading: false,
+    isUnavailable: false,
+    ...overrides,
+  });
+};
+
+const renderSection = () =>
+  renderWithProvider(<PredictTrendingSection />, {
+    state: { engine: { backgroundState } },
+  });
+
+describe('PredictTrendingSection', () => {
+  beforeEach(() => {
+    setSection();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a market card for each trending item', () => {
+    setSection({ markets: [createMarket('T1'), createMarket('T2')] });
+
+    const { getByTestId } = renderSection();
+
+    expect(
+      getByTestId(`${PREDICT_TRENDING_SECTION_TEST_IDS.CARD_PREFIX}-T1`),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(`${PREDICT_TRENDING_SECTION_TEST_IDS.CARD_PREFIX}-T2`),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders skeleton cards while loading', () => {
+    setSection({ markets: [], isLoading: true });
+
+    const { getByTestId } = renderSection();
+
+    expect(
+      getByTestId(`${PREDICT_TRENDING_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the unable-to-load message when unavailable (never disappears)', () => {
+    setSection({ markets: [], isUnavailable: true });
+
+    const { getByTestId, getByText } = renderSection();
+
+    expect(
+      getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.SECTION),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.ERROR_STATE),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('predict.home.trending_unable_to_load')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a pressable "Trending" header that navigates to the trending feed', () => {
+    setSection({ markets: [createMarket('T1')] });
+
+    const { getByTestId, getByText } = renderSection();
+
+    const header = getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.HEADER);
+    expect(header).toBeOnTheScreen();
+    expect(getByText(strings('predict.home.trending_title'))).toBeOnTheScreen();
+    // The chevron renders only when the header is pressable (onPress set).
+    expect(getByTestId('section-header-arrow-icon')).toBeOnTheScreen();
+
+    fireEvent.press(header);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.FEED,
+      params: {
+        feedId: 'trending',
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
+    });
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
@@ -44,6 +44,20 @@ jest.mock('../../../../components/PredictMarketMultiple', () => {
     default: ({ testID }: { testID?: string }) => <View testID={testID} />,
   };
 });
+jest.mock('../../../../components/PredictMarketSportCard', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+jest.mock('../../../../components/PredictCryptoUpDownMarketCard', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
 
 const mockUsePredictTrendingSection = usePredictTrendingSection as jest.Mock;
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
@@ -71,13 +71,13 @@ const setSection = (
   overrides: Partial<{
     markets: PredictMarket[];
     isLoading: boolean;
-    isUnavailable: boolean;
+    showEmptyState: boolean;
   }> = {},
 ) => {
   mockUsePredictTrendingSection.mockReturnValue({
     markets: [],
     isLoading: false,
-    isUnavailable: false,
+    showEmptyState: false,
     ...overrides,
   });
 };
@@ -120,7 +120,7 @@ describe('PredictTrendingSection', () => {
   });
 
   it('shows the unable-to-load message when unavailable (never disappears)', () => {
-    setSection({ markets: [], isUnavailable: true });
+    setSection({ markets: [], showEmptyState: true });
 
     const { getByTestId, getByText } = renderSection();
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
@@ -1,0 +1,14 @@
+import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
+
+/**
+ * Test selectors for the Predict home "Trending" section.
+ * The section root reuses {@link PredictHomeSelectorsIDs.TRENDING_SECTION} so
+ * the shell's composition test keeps working.
+ */
+export const PREDICT_TRENDING_SECTION_TEST_IDS = {
+  SECTION: PredictHomeSelectorsIDs.TRENDING_SECTION,
+  HEADER: 'predict-home-trending-header',
+  CARD_PREFIX: 'predict-home-trending-card',
+  SKELETON_PREFIX: 'predict-home-trending-skeleton',
+  ERROR_STATE: 'predict-home-trending-error-state',
+} as const;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -38,7 +38,7 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
 }) => {
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
-  const { markets, isLoading, isUnavailable } = usePredictTrendingSection();
+  const { markets, isLoading, showEmptyState } = usePredictTrendingSection();
 
   const handleSeeAll = useCallback(() => {
     navigation.navigate(Routes.PREDICT.ROOT, {
@@ -70,7 +70,7 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
             />
           ))}
         </Box>
-      ) : isUnavailable ? (
+      ) : showEmptyState ? (
         <Box
           testID={PREDICT_TRENDING_SECTION_TEST_IDS.ERROR_STATE}
           twClassName="items-center justify-center rounded-xl bg-muted py-8 px-4"

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -1,32 +1,102 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Box,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { strings } from '../../../../../../../../locales/i18n';
-import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
+import Routes from '../../../../../../../constants/navigation/Routes';
+import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
+import PredictMarket from '../../../../components/PredictMarket';
+import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
+import { PredictEventValues } from '../../../../constants/eventNames';
+import type { PredictNavigationParamList } from '../../../../types/navigation';
+import { PREDICT_TRENDING_SECTION_TEST_IDS } from './PredictTrendingSection.testIds';
+import {
+  TRENDING_DISPLAY_LIMIT,
+  usePredictTrendingSection,
+} from './usePredictTrendingSection';
 
 interface PredictTrendingSectionProps {
   testID?: string;
 }
 
 /**
- * Placeholder for the Predict home "Trending" market cards section.
- * Replaced by the real section in a later ticket; the shell composes it as-is.
+ * Predict home "Trending" section (PRED-834).
+ *
+ * Vertical list of full-width market/event cards ordered by 24h volume (see
+ * {@link usePredictTrendingSection}), reusing the shared `PredictMarket` card.
+ * Renders skeletons while loading. Unlike the other home sections it never
+ * disappears — it is the feed's fallback anchor, so an empty/error result shows
+ * an "Unable to load" message instead. The header opens the generic Trending
+ * feed (`feedId: 'trending'`).
  */
 const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
-  testID = PredictHomeSelectorsIDs.TRENDING_SECTION,
-}) => (
-  <Box
-    testID={testID}
-    twClassName="my-2 items-center justify-center rounded-xl bg-muted py-8 px-4"
-  >
-    <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-      {strings('predict.home.trending_placeholder')}
-    </Text>
-  </Box>
-);
+  testID = PREDICT_TRENDING_SECTION_TEST_IDS.SECTION,
+}) => {
+  const navigation =
+    useNavigation<NavigationProp<PredictNavigationParamList>>();
+  const { markets, isLoading, isUnavailable } = usePredictTrendingSection();
+
+  const handleSeeAll = useCallback(() => {
+    navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.FEED,
+      params: {
+        feedId: 'trending',
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
+    });
+  }, [navigation]);
+
+  return (
+    <Box testID={testID} twClassName="my-2">
+      {/* "See all" navigates to the generic PredictFeedView (feedId 'trending').
+          Passing `onPress` is what renders the chevron + touchable. */}
+      <SectionHeader
+        testID={PREDICT_TRENDING_SECTION_TEST_IDS.HEADER}
+        title={strings('predict.home.trending_title')}
+        onPress={handleSeeAll}
+        twClassName="px-0 mb-2"
+      />
+
+      {isLoading ? (
+        <Box twClassName="gap-3">
+          {Array.from({ length: TRENDING_DISPLAY_LIMIT }).map((_, index) => (
+            <PredictMarketSkeleton
+              key={`${PREDICT_TRENDING_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
+              testID={`${PREDICT_TRENDING_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
+            />
+          ))}
+        </Box>
+      ) : isUnavailable ? (
+        <Box
+          testID={PREDICT_TRENDING_SECTION_TEST_IDS.ERROR_STATE}
+          twClassName="items-center justify-center rounded-xl bg-muted py-8 px-4"
+        >
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            twClassName="text-center"
+          >
+            {strings('predict.home.trending_unable_to_load')}
+          </Text>
+        </Box>
+      ) : (
+        <Box twClassName="gap-3">
+          {markets.map((market) => (
+            <PredictMarket
+              key={market.id}
+              market={market}
+              entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
+              testID={`${PREDICT_TRENDING_SECTION_TEST_IDS.CARD_PREFIX}-${market.id}`}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
 
 export default PredictTrendingSection;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
@@ -83,6 +83,17 @@ describe('usePredictTrendingSection', () => {
     expect(result.current.markets).toHaveLength(0);
   });
 
+  it('caps returned markets to TRENDING_DISPLAY_LIMIT even when the cache holds more', () => {
+    const markets = Array.from({ length: 12 }, (_, i) =>
+      createMarket(`m-${i}`),
+    );
+    setMarketList({ markets });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.markets).toHaveLength(TRENDING_DISPLAY_LIMIT);
+  });
+
   it('shows empty state when the fetch returns an error', () => {
     setMarketList({
       markets: [],

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react-native';
+import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
+import type { PredictMarket } from '../../../../types';
+import {
+  usePredictTrendingSection,
+  TRENDING_DISPLAY_LIMIT,
+  TRENDING_FETCH_LIMIT,
+} from './usePredictTrendingSection';
+
+jest.mock('../../../../hooks/usePredictMarketList');
+
+const mockUsePredictMarketList = usePredictMarketList as jest.Mock;
+
+const createMarket = (id: string): PredictMarket =>
+  ({ id }) as unknown as PredictMarket;
+
+const setMarketList = (
+  overrides: Partial<{
+    markets: PredictMarket[];
+    isLoading: boolean;
+    error: Error | null;
+  }> = {},
+) => {
+  mockUsePredictMarketList.mockReturnValue({
+    markets: [],
+    isLoading: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    error: null,
+    hasNextPage: false,
+    refetch: jest.fn(),
+    fetchNextPage: jest.fn(),
+    ...overrides,
+  });
+};
+
+describe('usePredictTrendingSection', () => {
+  beforeEach(() => {
+    setMarketList();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries markets ordered by 24h volume with the v1 params', () => {
+    renderHook(() => usePredictTrendingSection());
+
+    expect(mockUsePredictMarketList).toHaveBeenCalledWith({
+      order: 'volume24hr',
+      status: 'open',
+      limit: TRENDING_FETCH_LIMIT,
+    });
+  });
+
+  it('caps the displayed markets to the display limit', () => {
+    const markets = Array.from({ length: TRENDING_FETCH_LIMIT }, (_, index) =>
+      createMarket(`m-${index}`),
+    );
+    setMarketList({ markets });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.markets).toHaveLength(TRENDING_DISPLAY_LIMIT);
+    expect(result.current.markets[0].id).toBe('m-0');
+    expect(result.current.markets[TRENDING_DISPLAY_LIMIT - 1].id).toBe(
+      `m-${TRENDING_DISPLAY_LIMIT - 1}`,
+    );
+  });
+
+  it('returns all markets when fewer than the display limit', () => {
+    setMarketList({ markets: [createMarket('a'), createMarket('b')] });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.markets).toHaveLength(2);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it('passes through the loading state and is not unavailable while loading', () => {
+    setMarketList({ markets: [], isLoading: true });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it('is unavailable when no markets are returned after load', () => {
+    setMarketList({ markets: [], isLoading: false });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isUnavailable).toBe(true);
+    expect(result.current.markets).toHaveLength(0);
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
@@ -4,7 +4,6 @@ import type { PredictMarket } from '../../../../types';
 import {
   usePredictTrendingSection,
   TRENDING_DISPLAY_LIMIT,
-  TRENDING_FETCH_LIMIT,
 } from './usePredictTrendingSection';
 
 jest.mock('../../../../hooks/usePredictMarketList');
@@ -43,56 +42,57 @@ describe('usePredictTrendingSection', () => {
     jest.clearAllMocks();
   });
 
-  it('queries markets ordered by 24h volume with the v1 params', () => {
+  it('queries markets with params sourced from the feed registry (order, status, limit)', () => {
     renderHook(() => usePredictTrendingSection());
 
-    expect(mockUsePredictMarketList).toHaveBeenCalledWith({
-      order: 'volume24hr',
-      status: 'open',
-      limit: TRENDING_FETCH_LIMIT,
-    });
+    expect(mockUsePredictMarketList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        order: 'volume24hr',
+        status: 'open',
+        limit: TRENDING_DISPLAY_LIMIT,
+      }),
+    );
   });
 
-  it('caps the displayed markets to the display limit', () => {
-    const markets = Array.from({ length: TRENDING_FETCH_LIMIT }, (_, index) =>
-      createMarket(`m-${index}`),
-    );
+  it('returns the markets from usePredictMarketList directly', () => {
+    const markets = [createMarket('a'), createMarket('b')];
     setMarketList({ markets });
 
     const { result } = renderHook(() => usePredictTrendingSection());
 
-    expect(result.current.markets).toHaveLength(TRENDING_DISPLAY_LIMIT);
-    expect(result.current.markets[0].id).toBe('m-0');
-    expect(result.current.markets[TRENDING_DISPLAY_LIMIT - 1].id).toBe(
-      `m-${TRENDING_DISPLAY_LIMIT - 1}`,
-    );
-  });
-
-  it('returns all markets when fewer than the display limit', () => {
-    setMarketList({ markets: [createMarket('a'), createMarket('b')] });
-
-    const { result } = renderHook(() => usePredictTrendingSection());
-
     expect(result.current.markets).toHaveLength(2);
-    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.showEmptyState).toBe(false);
   });
 
-  it('passes through the loading state and is not unavailable while loading', () => {
+  it('passes through the loading state and does not show empty state while loading', () => {
     setMarketList({ markets: [], isLoading: true });
 
     const { result } = renderHook(() => usePredictTrendingSection());
 
     expect(result.current.isLoading).toBe(true);
-    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.showEmptyState).toBe(false);
   });
 
-  it('is unavailable when no markets are returned after load', () => {
+  it('shows empty state when no markets are returned after load', () => {
     setMarketList({ markets: [], isLoading: false });
 
     const { result } = renderHook(() => usePredictTrendingSection());
 
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.isUnavailable).toBe(true);
+    expect(result.current.showEmptyState).toBe(true);
     expect(result.current.markets).toHaveLength(0);
+  });
+
+  it('shows empty state when the fetch returns an error', () => {
+    setMarketList({
+      markets: [],
+      isLoading: false,
+      error: new Error('network'),
+    });
+
+    const { result } = renderHook(() => usePredictTrendingSection());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.showEmptyState).toBe(true);
   });
 });

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
+import type { PredictMarket } from '../../../../types';
+
+/**
+ * Over-fetch trending markets so the home section has headroom above its
+ * display cap. Matches the ticket's suggested v1 params (`limit: 20`).
+ */
+export const TRENDING_FETCH_LIMIT = 20;
+
+/**
+ * Max trending cards shown on the home section. The epic caps the home feed's
+ * Trending list at 5 by default; the full `trending` feed (reached via
+ * "See all") shows the complete list.
+ */
+export const TRENDING_DISPLAY_LIMIT = 5;
+
+export interface UsePredictTrendingSectionResult {
+  /** Trending markets ready for the vertical list (already display-capped). */
+  markets: PredictMarket[];
+  /** Initial load with nothing to show yet (render skeletons). */
+  isLoading: boolean;
+  /**
+   * No data after load. Unlike the other home sections, Trending does NOT hide
+   * here — it is the feed's fallback anchor, so the section shows an "Unable to
+   * load" message instead. `usePredictMarketList` swallows provider errors
+   * (returns `[]`), so the empty and error cases collapse into this one flag.
+   */
+  isUnavailable: boolean;
+}
+
+/**
+ * Data source for the Predict home "Trending" section (PRED-834).
+ *
+ * Pulls markets via the generic `usePredictMarketList` ordered by 24h volume
+ * (`order: 'volume24hr'`, `status: 'open'`) and caps the result to
+ * {@link TRENDING_DISPLAY_LIMIT} client-side. Section-specific curation lives
+ * here rather than in the generic hook (consistent with the other home
+ * sections).
+ */
+export const usePredictTrendingSection =
+  (): UsePredictTrendingSectionResult => {
+    const { markets, isLoading } = usePredictMarketList({
+      order: 'volume24hr',
+      status: 'open',
+      limit: TRENDING_FETCH_LIMIT,
+    });
+
+    const displayedMarkets = useMemo(
+      () => markets.slice(0, TRENDING_DISPLAY_LIMIT),
+      [markets],
+    );
+
+    const isUnavailable = !isLoading && displayedMarkets.length === 0;
+
+    return { markets: displayedMarkets, isLoading, isUnavailable };
+  };

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
@@ -1,5 +1,5 @@
 import { resolvePredictFeedDefaultFilter } from '../../../../constants/feedConfig';
-import type { PredictMarketListParams , PredictMarket } from '../../../../types';
+import type { PredictMarketListParams, PredictMarket } from '../../../../types';
 import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
 
 /**
@@ -22,7 +22,7 @@ const TRENDING_PARAMS: PredictMarketListParams =
   };
 
 export interface UsePredictTrendingSectionResult {
-  /** Trending markets ready for the vertical list. */
+  /** Trending markets ready for the vertical list, capped to {@link TRENDING_DISPLAY_LIMIT}. */
   markets: PredictMarket[];
   /** Initial load with nothing to show yet (render skeletons). */
   isLoading: boolean;
@@ -48,5 +48,9 @@ export const usePredictTrendingSection =
 
     const showEmptyState = !isLoading && (!!error || markets.length === 0);
 
-    return { markets, isLoading, showEmptyState };
+    return {
+      markets: markets.slice(0, TRENDING_DISPLAY_LIMIT),
+      isLoading,
+      showEmptyState,
+    };
   };

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
@@ -1,12 +1,6 @@
-import { useMemo } from 'react';
+import { resolvePredictFeedDefaultFilter } from '../../../../constants/feedConfig';
+import type { PredictMarketListParams , PredictMarket } from '../../../../types';
 import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
-import type { PredictMarket } from '../../../../types';
-
-/**
- * Over-fetch trending markets so the home section has headroom above its
- * display cap. Matches the ticket's suggested v1 params (`limit: 20`).
- */
-export const TRENDING_FETCH_LIMIT = 20;
 
 /**
  * Max trending cards shown on the home section. The epic caps the home feed's
@@ -15,43 +9,44 @@ export const TRENDING_FETCH_LIMIT = 20;
  */
 export const TRENDING_DISPLAY_LIMIT = 5;
 
+/**
+ * Query params derived from the feed registry so the home section and the
+ * full "See all" feed share the same React Query cache key.
+ * Falls back to hardcoded params if the registry entry is missing.
+ */
+const TRENDING_PARAMS: PredictMarketListParams =
+  resolvePredictFeedDefaultFilter('trending')?.params ?? {
+    order: 'volume24hr',
+    status: 'open',
+    limit: TRENDING_DISPLAY_LIMIT,
+  };
+
 export interface UsePredictTrendingSectionResult {
-  /** Trending markets ready for the vertical list (already display-capped). */
+  /** Trending markets ready for the vertical list. */
   markets: PredictMarket[];
   /** Initial load with nothing to show yet (render skeletons). */
   isLoading: boolean;
   /**
-   * No data after load. Unlike the other home sections, Trending does NOT hide
-   * here — it is the feed's fallback anchor, so the section shows an "Unable to
-   * load" message instead. `usePredictMarketList` swallows provider errors
-   * (returns `[]`), so the empty and error cases collapse into this one flag.
+   * True when load is complete and there is nothing to display (empty result
+   * or fetch error). Unlike other home sections, Trending does NOT hide in
+   * this state — it is the feed's fallback anchor, so the section renders an
+   * "Unable to load" message instead.
    */
-  isUnavailable: boolean;
+  showEmptyState: boolean;
 }
 
 /**
  * Data source for the Predict home "Trending" section (PRED-834).
  *
- * Pulls markets via the generic `usePredictMarketList` ordered by 24h volume
- * (`order: 'volume24hr'`, `status: 'open'`) and caps the result to
- * {@link TRENDING_DISPLAY_LIMIT} client-side. Section-specific curation lives
- * here rather than in the generic hook (consistent with the other home
- * sections).
+ * Pulls markets via the generic `usePredictMarketList` using params sourced
+ * from `feedConfig` so the home section and the "See all" feed share the same
+ * React Query cache entry.
  */
 export const usePredictTrendingSection =
   (): UsePredictTrendingSectionResult => {
-    const { markets, isLoading } = usePredictMarketList({
-      order: 'volume24hr',
-      status: 'open',
-      limit: TRENDING_FETCH_LIMIT,
-    });
+    const { markets, isLoading, error } = usePredictMarketList(TRENDING_PARAMS);
 
-    const displayedMarkets = useMemo(
-      () => markets.slice(0, TRENDING_DISPLAY_LIMIT),
-      [markets],
-    );
+    const showEmptyState = !isLoading && (!!error || markets.length === 0);
 
-    const isUnavailable = !isLoading && displayedMarkets.length === 0;
-
-    return { markets: displayedMarkets, isLoading, isUnavailable };
+    return { markets, isLoading, showEmptyState };
   };

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Jetzt live",
       "categories_placeholder": "Kategorien",
-      "trending_placeholder": "Angesagt"
+      "trending_title": "Angesagt",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC-Preis: {{price}}",

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -2348,9 +2348,7 @@
     "search_account": "Ein Konto suchen",
     "home": {
       "live_now_title": "Jetzt live",
-      "categories_placeholder": "Kategorien",
-      "trending_title": "Angesagt",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Kategorien"
     },
     "homepage_discovery": {
       "btc_title": "BTC-Preis: {{price}}",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -2348,9 +2348,7 @@
     "search_account": "Αναζήτηση λογαριασμού",
     "home": {
       "live_now_title": "Ζωντανά τώρα",
-      "categories_placeholder": "Κατηγορίες",
-      "trending_title": "Δημοφιλή",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Κατηγορίες"
     },
     "homepage_discovery": {
       "btc_title": "Τιμή BTC: {{price}}",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Ζωντανά τώρα",
       "categories_placeholder": "Κατηγορίες",
-      "trending_placeholder": "Δημοφιλή"
+      "trending_title": "Δημοφιλή",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Τιμή BTC: {{price}}",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2350,7 +2350,8 @@
     "home": {
       "live_now_title": "Live now",
       "categories_placeholder": "Categories",
-      "trending_placeholder": "Trending"
+      "trending_title": "Trending",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC Price: {{price}}",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -2348,9 +2348,7 @@
     "search_account": "Buscar una cuenta",
     "home": {
       "live_now_title": "En vivo ahora",
-      "categories_placeholder": "Categorías",
-      "trending_title": "Tendencias",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Categorías"
     },
     "homepage_discovery": {
       "btc_title": "Precio de BTC: {{price}}",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "En vivo ahora",
       "categories_placeholder": "Categorías",
-      "trending_placeholder": "Tendencias"
+      "trending_title": "Tendencias",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Precio de BTC: {{price}}",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Disponible dès maintenant",
       "categories_placeholder": "Catégories",
-      "trending_placeholder": "Tendance"
+      "trending_title": "Tendance",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Prix BTC : {{price}}",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -2348,9 +2348,7 @@
     "search_account": "Rechercher un compte",
     "home": {
       "live_now_title": "Disponible dès maintenant",
-      "categories_placeholder": "Catégories",
-      "trending_title": "Tendance",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Catégories"
     },
     "homepage_discovery": {
       "btc_title": "Prix BTC : {{price}}",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "अब लाइव है",
       "categories_placeholder": "कैटेगरीज़",
-      "trending_placeholder": "ट्रेंडिंग"
+      "trending_title": "ट्रेंडिंग",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC प्राइस: {{price}}",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -2348,9 +2348,7 @@
     "search_account": "किसी अकाउंट को ढूंढें",
     "home": {
       "live_now_title": "अब लाइव है",
-      "categories_placeholder": "कैटेगरीज़",
-      "trending_title": "ट्रेंडिंग",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "कैटेगरीज़"
     },
     "homepage_discovery": {
       "btc_title": "BTC प्राइस: {{price}}",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Sedang live",
       "categories_placeholder": "Kategori",
-      "trending_placeholder": "Sedang tren"
+      "trending_title": "Sedang tren",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Harga BTC: {{price}}",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -2348,9 +2348,7 @@
     "search_account": "Cari akun",
     "home": {
       "live_now_title": "Sedang live",
-      "categories_placeholder": "Kategori",
-      "trending_title": "Sedang tren",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Kategori"
     },
     "homepage_discovery": {
       "btc_title": "Harga BTC: {{price}}",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -2348,9 +2348,7 @@
     "search_account": "アカウントの検索",
     "home": {
       "live_now_title": "現在進行中",
-      "categories_placeholder": "カテゴリー",
-      "trending_title": "人気上昇中",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "カテゴリー"
     },
     "homepage_discovery": {
       "btc_title": "BTCの価格: {{price}}",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "現在進行中",
       "categories_placeholder": "カテゴリー",
-      "trending_placeholder": "人気上昇中"
+      "trending_title": "人気上昇中",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTCの価格: {{price}}",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "지금 진행 중",
       "categories_placeholder": "카테고리",
-      "trending_placeholder": "인기"
+      "trending_title": "인기",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC 가격: {{price}}",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -2348,9 +2348,7 @@
     "search_account": "계정 검색",
     "home": {
       "live_now_title": "지금 진행 중",
-      "categories_placeholder": "카테고리",
-      "trending_title": "인기",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "카테고리"
     },
     "homepage_discovery": {
       "btc_title": "BTC 가격: {{price}}",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Ao vivo agora",
       "categories_placeholder": "Categorias",
-      "trending_placeholder": "Tendência"
+      "trending_title": "Tendência",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Preço do BTC: {{price}}",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -2348,9 +2348,7 @@
     "search_account": "Pesquisar uma conta",
     "home": {
       "live_now_title": "Ao vivo agora",
-      "categories_placeholder": "Categorias",
-      "trending_title": "Tendência",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Categorias"
     },
     "homepage_discovery": {
       "btc_title": "Preço do BTC: {{price}}",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -2348,9 +2348,7 @@
     "search_account": "Поиск счета",
     "home": {
       "live_now_title": "Уже активно",
-      "categories_placeholder": "Категории",
-      "trending_title": "Популярное",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Категории"
     },
     "homepage_discovery": {
       "btc_title": "Цена BTC: {{price}}",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Уже активно",
       "categories_placeholder": "Категории",
-      "trending_placeholder": "Популярное"
+      "trending_title": "Популярное",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Цена BTC: {{price}}",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -2348,9 +2348,7 @@
     "search_account": "Pumili ng isang account",
     "home": {
       "live_now_title": "Live ngayon",
-      "categories_placeholder": "Mga Kategorya",
-      "trending_title": "Nagte-trend",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Mga Kategorya"
     },
     "homepage_discovery": {
       "btc_title": "Presyo ng BTC: {{price}}",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Live ngayon",
       "categories_placeholder": "Mga Kategorya",
-      "trending_placeholder": "Nagte-trend"
+      "trending_title": "Nagte-trend",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Presyo ng BTC: {{price}}",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -2348,9 +2348,7 @@
     "search_account": "Bir hesabı ara",
     "home": {
       "live_now_title": "Şimdi canlı",
-      "categories_placeholder": "Kategoriler",
-      "trending_title": "Trend",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Kategoriler"
     },
     "homepage_discovery": {
       "btc_title": "BTC Fiyatı: {{price}}",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Şimdi canlı",
       "categories_placeholder": "Kategoriler",
-      "trending_placeholder": "Trend"
+      "trending_title": "Trend",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC Fiyatı: {{price}}",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -2348,9 +2348,7 @@
     "search_account": "Tìm kiếm tài khoản",
     "home": {
       "live_now_title": "Đang diễn ra",
-      "categories_placeholder": "Danh mục",
-      "trending_title": "Xu hướng",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Danh mục"
     },
     "homepage_discovery": {
       "btc_title": "Giá BTC: {{price}}",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "Đang diễn ra",
       "categories_placeholder": "Danh mục",
-      "trending_placeholder": "Xu hướng"
+      "trending_title": "Xu hướng",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "Giá BTC: {{price}}",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -2349,7 +2349,8 @@
     "home": {
       "live_now_title": "现已上线",
       "categories_placeholder": "类别",
-      "trending_placeholder": "趋势"
+      "trending_title": "趋势",
+      "trending_unable_to_load": "Unable to load markets, please try again"
     },
     "homepage_discovery": {
       "btc_title": "BTC 价格：{{price}}",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -2348,9 +2348,7 @@
     "search_account": "搜索账户",
     "home": {
       "live_now_title": "现已上线",
-      "categories_placeholder": "类别",
-      "trending_title": "趋势",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "类别"
     },
     "homepage_discovery": {
       "btc_title": "BTC 价格：{{price}}",


### PR DESCRIPTION


## **Description**

Builds the **Trending** section for the redesigned Predict homepage (`PredictHome` shell), replacing the
previous placeholder. It is the last section in the shell, rendered in Figma order under Portfolio /
Live Now / Categories / Popular Today.

What changed and why:

- **Data** — new `usePredictTrendingSection` hook drives the section off the generic
  `usePredictMarketList` with the ticket's suggested v1 params `{ order: 'volume24hr', status: 'open', limit: 20 }`.
  The result is display-capped client-side to `TRENDING_DISPLAY_LIMIT = 5` (the epic's "capped at 5 on the
  feed by default"). The over-fetch-then-cap mirrors the existing Live Now (7) / Popular Today (10) sections.
  Section-specific curation (the slice + the empty/error flag) lives in this section hook, keeping
  `usePredictMarketList` hygiene-only — consistent with the other home sections.
- **UI** — a vertical list of full-width, reused `PredictMarket` cards (no `isCarousel`), under a pressable
  `SectionHeader` ("Trending" + chevron). Rendered with a plain `.map()` rather than a nested vertical
  `FlashList`, since the section is a small capped list living inside the home `Animated.ScrollView`.
- **States (handled locally)** — skeletons while loading; on empty/error the section shows the message
  "Unable to load markets, please try again". Unlike the other home sections (which hide when empty),
  Trending never disappears — per the epic it is the feed's fallback anchor. Because `usePredictMarketList`
  swallows provider errors (returns `[]`, `error` stays `null`), empty effectively == failure, so a single
  `isUnavailable` flag covers both.
- **"See all"** — the header navigates to the generic `PredictFeedView` route with `feedId: 'trending'`
  (`Routes.PREDICT.FEED`, `entryPoint: HOME_SECTION`), the same wiring pattern used by the Live Now section.

Scope/trade-offs:

- The epic's "configurable via remote config (max 10)" cap and Trending ranking changes are intentionally
  **out of scope** here (ranking is tracked in PRED-839). The display cap is a hardcoded constant for v1.
- No market-card redesign (PRED-838) — existing cards are reused unchanged.

## **Changelog**

CHANGELOG entry: null

<!-- Gated behind the `predictHomeRedesign` remote flag, which is disabled by default — not user-facing yet. -->

## **Related issues**

Refs: PRED-834 (sub-ticket: "Build Predict Trending homepage section")

## **Manual testing steps**

```gherkin
Feature: Predict home Trending section

  Background:
    Given the predictHomeRedesign flag is enabled
    And I am on the redesigned Predict home screen

  Scenario: Trending markets load successfully
    Given the markets API returns trending markets ordered by 24h volume
    When the Trending section finishes loading
    Then I see a vertical list of up to 5 market cards under the "Trending" header

  Scenario: Loading state
    Given the markets request is in flight
    When the Trending section is loading
    Then I see market skeleton placeholders

  Scenario: Empty or error state (fallback anchor)
    Given the markets API returns no markets or fails
    When the Trending section settles
    Then the section remains visible
    And I see the message "Unable to load markets, please try again"

  Scenario: See all navigation
    Given the Trending section is visible
    When I tap the "Trending" header
    Then I am navigated to the generic Trending feed (feedId 'trending')
```

## **Screenshots/Recordings**

### **Before**

Placeholder "Trending" box in the `PredictHome` shell. <!-- attach screenshot -->

### **After**

<!-- Attach a screenshot of the rendered Trending section (vertical market-card list + "Trending >" header), QA'd against the Figma Trending section. -->


https://github.com/user-attachments/assets/57d3360f-b85a-4223-881f-3783ae38635e


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

### Notes for reviewers

**Files changed**
- `views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts` (+ `.test.ts`) — data hook (params, display cap, `isUnavailable`).
- `views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx` — placeholder replaced with the real section.
- `views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts` — selectors.
- `views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx` — presentation tests.
- `locales/languages/en.json` — added `predict.home.trending_title` + `predict.home.trending_unable_to_load`, removed `predict.home.trending_placeholder`.
- `selectors/featureFlags/index.ts` — **TEMP QA override (must be reverted before merge — see warning above).**

**Acceptance criteria coverage**
- Section appears in `PredictHome` in Figma order — yes (last section, composed in the shell).
- Section queries markets ordered by `volume24hr` — yes (asserted in `usePredictTrendingSection.test.ts`).
- Vertical list reuses existing card components — yes (`PredictMarket`).
- Loading / empty / error handled locally — yes.
- "See all" opens the generic Trending feed — yes (`feedId: 'trending'`).
- Tests cover data params, rendering, empty/error, navigation — yes (5 hook + 4 component tests; `PredictHome.view.test` still green).

**Verification**
- `usePredictTrendingSection.test.ts` → 5 passed; `PredictTrendingSection.test.tsx` → 4 passed; `PredictHome.view.test.tsx` → 8 passed.
- `yarn lint:tsc` clean; ESLint on changed files clean (1 inherited `SectionHeader` deprecation warning, same as the Live Now section).
- Note: jest needs `NODE_OPTIONS='--max-old-space-size=12288'` on some machines to avoid an OOM at load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Predict home work behind the redesign flag, reusing existing market list and card patterns with new tests; no auth or payment changes.
> 
> **Overview**
> Replaces the Predict home **Trending** placeholder with a real section that loads open markets (24h volume order) via `usePredictTrendingSection`, which wraps `usePredictMarketList` with feed-registry params so the home list shares the same React Query cache as the full `trending` feed.
> 
> The UI shows up to **5** `PredictMarket` cards (skeletons while loading), a tappable **Trending** header that navigates to `PredictFeedView` with `feedId: 'trending'`, and—unlike other home sections—stays visible on empty/error with **Unable to load markets, please try again**. English adds `trending_title` / `trending_unable_to_load` and drops `trending_placeholder`; other locales only remove the placeholder key.
> 
> Hook and component tests cover query params, display cap, loading/empty/error, and header navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80ba74ca510c59b8232a2de498ddf9b6c6d891b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->