### PR TITLE
fix: check and display of withdrawable balance for money accounts cp-8.0.0

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -48,6 +48,8 @@ interface UseMoneyAccountBalanceResult {
   tokenTotal: BigNumber | undefined;
   totalFiatFormatted: string | undefined;
   totalFiatRaw: string | undefined;
+  withdrawableFiatFormatted: string | undefined;
+  withdrawableFiatRaw: string | undefined;
   withdrawableMusd: BigNumber | undefined;
   apyDecimal: number | undefined;
   apyPercent: number | undefined;
@@ -112,59 +114,66 @@ const useMoneyAccountBalance = (
     [moneyAccountAddress],
   );
 
-  const { tokenTotal, totalFiat, withdrawableMusd } = useMemo(() => {
-    // Total balance (mUSD + vmUSD) from the service's Multicall3 response.
-    const totalDecimal = moneyBalanceQuery.data?.totalBalance
-      ? new BigNumber(moneyBalanceQuery.data.totalBalance).shiftedBy(
-          -MUSD_DECIMALS,
-        )
-      : new BigNumber(0);
+  const { tokenTotal, totalFiat, withdrawableFiat, withdrawableMusd } =
+    useMemo(() => {
+      // Total balance (mUSD + vmUSD) from the service's Multicall3 response.
+      const totalDecimal = moneyBalanceQuery.data?.totalBalance
+        ? new BigNumber(moneyBalanceQuery.data.totalBalance).shiftedBy(
+            -MUSD_DECIMALS,
+          )
+        : new BigNumber(0);
 
-    // the withdrawable amount.
-    const vmusdDecimal = moneyBalanceQuery.data?.vmusdValueInMusd
-      ? new BigNumber(moneyBalanceQuery.data.vmusdValueInMusd).shiftedBy(
-          -MUSD_DECIMALS,
-        )
-      : new BigNumber(0);
+      // the withdrawable amount.
+      const vmusdDecimal = moneyBalanceQuery.data?.vmusdValueInMusd
+        ? new BigNumber(moneyBalanceQuery.data.vmusdValueInMusd).shiftedBy(
+            -MUSD_DECIMALS,
+          )
+        : new BigNumber(0);
 
-    // Undefined while loading or on error so callers can distinguish from a genuine zero.
-    const computedWithdrawableMusd =
-      isBalanceLoading || isBalanceFetchError ? undefined : vmusdDecimal;
+      // Undefined while loading or on error so callers can distinguish from a genuine zero.
+      const computedWithdrawableMusd =
+        isBalanceLoading || isBalanceFetchError ? undefined : vmusdDecimal;
 
-    const computedTokenTotal =
-      isBalanceLoading || isBalanceFetchError ? undefined : totalDecimal;
-
-    if (isMusdFiatRateMissing) {
-      // Undefined during loading or error so callers can distinguish from a genuine zero.
-      const settledTokenTotal =
+      const computedTokenTotal =
         isBalanceLoading || isBalanceFetchError ? undefined : totalDecimal;
 
+      if (isMusdFiatRateMissing) {
+        // Undefined during loading or error so callers can distinguish from a genuine zero.
+        const settledTokenTotal =
+          isBalanceLoading || isBalanceFetchError ? undefined : totalDecimal;
+
+        return {
+          musdFiat: undefined,
+          musdSHFvdFiat: undefined,
+          tokenTotal: settledTokenTotal,
+          // A zero balance is $0.00 regardless of the missing rate — 0 tokens
+          // convert to 0 fiat without one. Only a non-zero balance is genuinely
+          // unavailable when there's no rate to convert it.
+          totalFiat: settledTokenTotal?.isZero() ? new BigNumber(0) : undefined,
+          withdrawableFiat: computedWithdrawableMusd?.isZero()
+            ? new BigNumber(0)
+            : undefined,
+          withdrawableMusd: computedWithdrawableMusd,
+        };
+      }
+
       return {
-        musdFiat: undefined,
-        musdSHFvdFiat: undefined,
-        tokenTotal: settledTokenTotal,
-        // A zero balance is $0.00 regardless of the missing rate — 0 tokens
-        // convert to 0 fiat without one. Only a non-zero balance is genuinely
-        // unavailable when there's no rate to convert it.
-        totalFiat: settledTokenTotal?.isZero() ? new BigNumber(0) : undefined,
+        tokenTotal: computedTokenTotal,
+        totalFiat: isBalanceFetchError
+          ? undefined
+          : totalDecimal.times(musdFiatRate),
+        withdrawableFiat: isBalanceFetchError
+          ? undefined
+          : vmusdDecimal.times(musdFiatRate),
         withdrawableMusd: computedWithdrawableMusd,
       };
-    }
-
-    return {
-      tokenTotal: computedTokenTotal,
-      totalFiat: isBalanceFetchError
-        ? undefined
-        : totalDecimal.times(musdFiatRate),
-      withdrawableMusd: computedWithdrawableMusd,
-    };
-  }, [
-    isBalanceLoading,
-    isBalanceFetchError,
-    moneyBalanceQuery.data,
-    isMusdFiatRateMissing,
-    musdFiatRate,
-  ]);
+    }, [
+      isBalanceLoading,
+      isBalanceFetchError,
+      moneyBalanceQuery.data,
+      isMusdFiatRateMissing,
+      musdFiatRate,
+    ]);
 
   const totalFiatFormatted =
     !isBalanceFetchError && totalFiat
@@ -173,6 +182,16 @@ const useMoneyAccountBalance = (
 
   const totalFiatRaw =
     !isBalanceFetchError && totalFiat ? totalFiat.toString() : undefined;
+
+  const withdrawableFiatFormatted =
+    !isBalanceFetchError && withdrawableFiat
+      ? moneyFormatFiat(withdrawableFiat, currentCurrency)
+      : undefined;
+
+  const withdrawableFiatRaw =
+    !isBalanceFetchError && withdrawableFiat
+      ? withdrawableFiat.toString()
+      : undefined;
 
   // If the mUSD price is missing for a non-zero balance, refresh the mUSD price.
   useEffect(() => {
@@ -275,6 +294,8 @@ const useMoneyAccountBalance = (
     tokenTotal,
     totalFiatFormatted,
     totalFiatRaw,
+    withdrawableFiatFormatted,
+    withdrawableFiatRaw,
     withdrawableMusd,
     apyDecimal,
     apyPercent,

--- a/app/components/Views/confirmations/components/info/money-account-withdraw-info/money-account-withdraw-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/money-account-withdraw-info/money-account-withdraw-info.test.tsx
@@ -40,7 +40,7 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw', () => ({
 jest.mock('../../../../../UI/Money/hooks/useMoneyAccountBalance', () => ({
   __esModule: true,
   default: jest.fn(() => ({
-    totalFiatFormatted: '$42.00',
+    withdrawableFiatFormatted: '$42.00',
   })),
 }));
 
@@ -127,12 +127,12 @@ describe('MoneyAccountWithdrawInfo', () => {
     expect(lastCall.hasMax).toBe(true);
   });
 
-  it('renders empty balance when totalFiatFormatted is undefined', () => {
+  it('renders empty balance when withdrawableFiatFormatted is undefined', () => {
     const useMoneyAccountBalance = jest.requireMock(
       '../../../../../UI/Money/hooks/useMoneyAccountBalance',
     ).default;
     useMoneyAccountBalance.mockReturnValueOnce({
-      totalFiatFormatted: undefined,
+      withdrawableFiatFormatted: undefined,
     });
 
     const { getByTestId, getByText } = render(<MoneyAccountWithdrawInfo />);

--- a/app/components/Views/confirmations/components/info/money-account-withdraw-info/money-account-withdraw-info.tsx
+++ b/app/components/Views/confirmations/components/info/money-account-withdraw-info/money-account-withdraw-info.tsx
@@ -33,14 +33,14 @@ export function MoneyAccountWithdrawInfo() {
 }
 
 function MoneyAccountWithdrawBalance() {
-  const { totalFiatFormatted } = useMoneyAccountBalance();
+  const { withdrawableFiatFormatted } = useMoneyAccountBalance();
 
   return (
     <Box alignItems={AlignItems.center} testID="money-account-withdraw-balance">
       <Text
         variant={TextVariant.BodyMDMedium}
         color={TextColor.Alternative}
-      >{`${strings('confirm.available_balance')}${totalFiatFormatted ?? ''}`}</Text>
+      >{`${strings('confirm.available_balance')}${withdrawableFiatFormatted ?? ''}`}</Text>
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -147,7 +147,7 @@ describe('PayWithRow', () => {
 
     jest.mocked(useTransactionMetadataRequest).mockReturnValue(undefined);
     jest.mocked(useMoneyAccountBalance).mockReturnValue({
-      totalFiatFormatted: undefined,
+      withdrawableFiatFormatted: undefined,
     } as ReturnType<typeof useMoneyAccountBalance>);
 
     isHardwareAccountMock.mockReturnValue(false);

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -112,7 +112,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       .mocked(useTransactionPaySelectedFiatPaymentMethod)
       .mockReturnValue(undefined);
     jest.mocked(useMoneyAccountBalance).mockReturnValue({
-      totalFiatRaw: undefined,
+      withdrawableFiatRaw: undefined,
     } as ReturnType<typeof useMoneyAccountBalance>);
 
     useTransactionPayTokenMock.mockReturnValue({
@@ -632,7 +632,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('uses money account balance instead of on-chain balance for input check', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '0.50',
+        withdrawableFiatRaw: '0.50',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTransactionPayTokenMock.mockReturnValue({
@@ -660,7 +660,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('returns no input alert when money account balance covers the amount', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '10.00',
+        withdrawableFiatRaw: '10.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { result } = runHook({}, moneyAccountState);
@@ -670,7 +670,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('skips fee insufficient balance check for money account source', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '10.00',
+        withdrawableFiatRaw: '10.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTransactionPayTokenMock.mockReturnValue({
@@ -688,7 +688,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('skips source network fee check for money account source', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '10.00',
+        withdrawableFiatRaw: '10.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTokenWithBalanceMock.mockReturnValue({
@@ -703,7 +703,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('returns alert when total (amount + fees) exceeds money account balance', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '3.00',
+        withdrawableFiatRaw: '3.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTransactionPayRequiredTokensMock.mockReturnValue([
@@ -733,7 +733,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('returns no alert when total is within money account balance', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '5.00',
+        withdrawableFiatRaw: '5.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTransactionPayRequiredTokensMock.mockReturnValue([
@@ -752,7 +752,7 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
 
     it('skips total check during pending input (keyboard visible)', () => {
       jest.mocked(useMoneyAccountBalance).mockReturnValue({
-        totalFiatRaw: '3.00',
+        withdrawableFiatRaw: '3.00',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       useTransactionPayTotalsMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -60,12 +60,12 @@ export function useInsufficientPayTokenBalanceAlert({
   );
   const isMoneyPaymentOverride =
     paymentOverride === PaymentOverride.MoneyAccount;
-  const { totalFiatRaw } = useMoneyAccountBalance();
+  const { withdrawableFiatRaw } = useMoneyAccountBalance();
   const { balanceUsd: accountBalanceUsd, balanceRaw: accountBalanceRaw } =
     usePayTokenAccountBalance();
 
   const balanceUsd = isMoneyPaymentOverride
-    ? (totalFiatRaw ?? '0')
+    ? (withdrawableFiatRaw ?? '0')
     : accountBalanceUsd;
   const balanceRaw = accountBalanceRaw;
 

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -87,7 +87,7 @@ describe('usePayWithMoneyAccountSection', () => {
     });
 
     useMoneyAccountBalanceMock.mockReturnValue({
-      totalFiatFormatted: '$100.00',
+      withdrawableFiatFormatted: '$100.00',
     } as never);
   });
 
@@ -245,7 +245,7 @@ describe('usePayWithMoneyAccountSection', () => {
 
   it('renders subtitle with formatted balance', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
-      totalFiatFormatted: '$250.50',
+      withdrawableFiatFormatted: '$250.50',
     } as never);
 
     const { result } = renderHook(() => usePayWithMoneyAccountSection());
@@ -253,9 +253,9 @@ describe('usePayWithMoneyAccountSection', () => {
     expect(result.current?.rows[0].subtitle).toBe('$250.50 available');
   });
 
-  it('renders undefined subtitle when totalFiatFormatted is falsy', () => {
+  it('renders undefined subtitle when withdrawableFiatFormatted is falsy', () => {
     useMoneyAccountBalanceMock.mockReturnValue({
-      totalFiatFormatted: '',
+      withdrawableFiatFormatted: '',
     } as never);
 
     const { result } = renderHook(() => usePayWithMoneyAccountSection());

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -37,7 +37,7 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
   const { enableMoneyAccountTransactions } = useSelector(
     selectMetaMaskPayFlags,
   );
-  const { totalFiatFormatted } = useMoneyAccountBalance();
+  const { withdrawableFiatFormatted } = useMoneyAccountBalance();
 
   const paymentOverride = useSelector((state: RootState) =>
     selectPaymentOverrideByTransactionId(state, transactionId),
@@ -68,9 +68,9 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
       return null;
     }
 
-    const subtitle = totalFiatFormatted
+    const subtitle = withdrawableFiatFormatted
       ? strings('confirm.pay_with_bottom_sheet.available_balance', {
-          balance: totalFiatFormatted,
+          balance: withdrawableFiatFormatted,
         })
       : undefined;
 
@@ -99,6 +99,6 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
     handlePress,
     isMoneyAccountSelected,
     moneyAccount,
-    totalFiatFormatted,
+    withdrawableFiatFormatted,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -159,7 +159,7 @@ describe('useTransactionCustomAmount', () => {
     useParamsMock.mockReturnValue({});
     usePredictBalanceMock.mockReturnValue({ data: 0 } as never);
     useMoneyAccountBalanceMock.mockReturnValue({
-      totalFiatRaw: undefined,
+      withdrawableFiatRaw: undefined,
       tokenTotal: undefined,
     } as ReturnType<typeof useMoneyAccountBalance>);
     useConfirmationMetricEventsMock.mockReturnValue({
@@ -547,7 +547,7 @@ describe('useTransactionCustomAmount', () => {
     it('uses predict balance for predictWithdraw even when payment override is MoneyAccount', async () => {
       usePredictBalanceMock.mockReturnValue({ data: 4321.23 } as never);
       useMoneyAccountBalanceMock.mockReturnValue({
-        totalFiatRaw: '750.50',
+        withdrawableFiatRaw: '750.50',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { result } = runHook({
@@ -583,7 +583,7 @@ describe('useTransactionCustomAmount', () => {
     it('uses full predict balance for predictWithdraw max even when payment override is MoneyAccount', async () => {
       usePredictBalanceMock.mockReturnValue({ data: 4321.23 } as never);
       useMoneyAccountBalanceMock.mockReturnValue({
-        totalFiatRaw: '750.50',
+        withdrawableFiatRaw: '750.50',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { result } = runHook({
@@ -912,9 +912,9 @@ describe('useTransactionCustomAmount', () => {
       },
     };
 
-    it('uses totalFiatRaw as balance when payment override is MoneyAccount', async () => {
+    it('uses withdrawableFiatRaw as balance when payment override is MoneyAccount', async () => {
       useMoneyAccountBalanceMock.mockReturnValue({
-        totalFiatRaw: '750.50',
+        withdrawableFiatRaw: '750.50',
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { result } = runHook({
@@ -934,9 +934,9 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('750.50');
     });
 
-    it('returns 0 when payment override is MoneyAccount but totalFiatRaw is undefined', async () => {
+    it('returns 0 when payment override is MoneyAccount but withdrawableFiatRaw is undefined', async () => {
       useMoneyAccountBalanceMock.mockReturnValue({
-        totalFiatRaw: undefined,
+        withdrawableFiatRaw: undefined,
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { result } = runHook({

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -284,7 +284,7 @@ function useTokenBalance(tokenUsdRate: number) {
     .multipliedBy(tokenUsdRate)
     .toNumber();
 
-  const { withdrawableMusd, totalFiatRaw } = useMoneyAccountBalance();
+  const { withdrawableMusd, withdrawableFiatRaw } = useMoneyAccountBalance();
 
   const paymentOverride = useSelector((state: RootState) =>
     selectPaymentOverrideByTransactionId(state, transactionId),
@@ -312,7 +312,7 @@ function useTokenBalance(tokenUsdRate: number) {
   }
 
   if (paymentOverride === PaymentOverride.MoneyAccount) {
-    return totalFiatRaw ? parseFloat(totalFiatRaw) : 0;
+    return withdrawableFiatRaw ? parseFloat(withdrawableFiatRaw) : 0;
   }
 
   return payTokenBalanceUsd;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix check and display of withdrawable balance for money accounts.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1612

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how money-account payment limits and blocking alerts are computed in confirmations; wrong vmUSD/rate data could still allow or block transactions incorrectly, but the scope is limited to money-account pay overrides and related tests were updated.
> 
> **Overview**
> Money account **confirmation and pay flows** now use **withdrawable** fiat (vmUSD converted to fiat) instead of **total** account fiat (mUSD + vmUSD) for what users can actually spend or move.
> 
> `useMoneyAccountBalance` **adds** `withdrawableFiatFormatted` / `withdrawableFiatRaw`, computed from `vmusdValueInMusd` with the same loading, error, and missing-rate handling as total fiat. **Withdraw UI**, **Pay with Money account** subtitles, **insufficient-balance alerts**, and **percentage / Max amount** math when `PaymentOverride.MoneyAccount` all **switch** from `totalFiat*` to `withdrawableFiat*`. Total fiat fields are unchanged for other surfaces (e.g. last-known balance persistence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfeb2902f07bb8a74122795fc0f4996202677ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->