### PR TITLE
chore: add sign prefix to price alert percentage displays

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -191,12 +191,12 @@ describe('CreatePriceAlertView', () => {
     );
 
     expect(getByTestId(CreatePriceAlertTestIds.PERCENT_DIFF)).toHaveTextContent(
-      /5%/,
+      /\+5%/,
     );
     expect(getByText(/above current ETH price/)).toBeOnTheScreen();
   });
 
-  it('shows the percentage and "below" wording when target is less than current price', () => {
+  it('shows the negative percentage and "below" wording when target is less than current price', () => {
     const { getByTestId, getByText } = renderWithToast();
 
     // $1000 is ~17% below 1201.98
@@ -205,7 +205,27 @@ describe('CreatePriceAlertView', () => {
     fireEvent.press(getByTestId('keypad-key-0'));
     fireEvent.press(getByTestId('keypad-key-0'));
 
+    expect(getByTestId(CreatePriceAlertTestIds.PERCENT_DIFF)).toHaveTextContent(
+      /-17%/,
+    );
     expect(getByText(/below current ETH price/)).toBeOnTheScreen();
+  });
+
+  it('shows signed labels on quick percentage buttons', () => {
+    const { getByTestId } = renderWithToast();
+
+    expect(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}--10`),
+    ).toHaveTextContent('-10%');
+    expect(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}--5`),
+    ).toHaveTextContent('-5%');
+    expect(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
+    ).toHaveTextContent('+5%');
+    expect(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-10`),
+    ).toHaveTextContent('+10%');
   });
 
   describe('Set price alert button', () => {

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -378,7 +378,7 @@ const CreatePriceAlertView: React.FC = () => {
                       : TextColor.ErrorDefault
                   }
                 >
-                  {`${percentDiff.rounded}%`}
+                  {`${percentDiff.direction === 'above' ? '+' : '-'}${percentDiff.rounded}%`}
                 </Text>
                 {` ${strings(
                   percentDiff.direction === 'above'
@@ -428,7 +428,9 @@ const CreatePriceAlertView: React.FC = () => {
                 testID={`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-${percentage}`}
                 twClassName="flex-1"
               >
-                {strings('price_alerts.quick_percentage', { percentage })}
+                {strings('price_alerts.quick_percentage', {
+                  percentage: percentage > 0 ? `+${percentage}` : percentage,
+                })}
               </Button>
             ))}
           </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
- Quick percentage buttons now show explicit signs: `-10%`, `-5%`, `+5%`, `+10%`
- Percent diff subtitle now shows `+N%` above / `-N%` below current price
- Updated tests to assert the signed format explicitly

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add sign prefix to price alert percentage displays

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3463

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="449" height="919" alt="image" src="https://github.com/user-attachments/assets/d938bdd5-b00d-4363-94e1-e7b51fef7935" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only string formatting in Create Price Alert; alert submission and threshold math are unchanged.
> 
> **Overview**
> **Create price alert** now shows explicit **+** / **−** signs on percentage copy so above vs below is obvious at a glance.
> 
> The **≈** subtitle uses **`+N%`** when the target is above the current price and **`-N%`** when it is below (still color-coded success/error). Quick-pick chips render signed labels (**`-10%`**, **`-5%`**, **`+5%`**, **`+10%`**) by prefixing **`+`** for positive values before the existing i18n string. Tests were tightened to assert the signed formats, including a new case for quick-button labels and an assertion for **`-17%`** on below-target keypad input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce332df1cf12e2bec32e4eda5f80eabecc86c2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->