### PR TITLE
test(cv): migrate seedless Apple & Google login E2E to component view tests

### DIFF
--- a/app/components/Views/AccountStatus/AccountStatus.view.test.tsx
+++ b/app/components/Views/AccountStatus/AccountStatus.view.test.tsx
@@ -17,10 +17,17 @@ import { fireEvent } from '@testing-library/react-native';
 import {
   describeForPlatforms,
   itEach,
+  itForPlatforms,
 } from '../../../../tests/component-view/platform';
-import { renderAccountAlreadyExists } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import {
+  renderAccountAlreadyExists,
+  renderAccountAlreadyExistsWithOnboardingHistory,
+  renderAccountNotFound,
+  ONBOARDING_PREVIOUS_PROBE_ID,
+} from '../../../../tests/component-view/renderers/seedlessOnboarding';
 import Routes from '../../../constants/navigation/Routes';
 import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
+import { strings } from '../../../../locales/i18n';
 import { AccountStatusSelectorIDs } from './AccountStatus.testIds';
 
 const existingUserProviders = [
@@ -76,6 +83,82 @@ describeForPlatforms('AccountStatus — Account Already Exists', () => {
       await findByTestId(
         `route-${Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE}`,
       );
+    },
+  );
+
+  itEach(existingUserProviders)(
+    'existing $label user taps Use a different login method and returns to onboarding',
+    async ({ provider }) => {
+      const { findByTestId } = renderAccountAlreadyExistsWithOnboardingHistory({
+        routeParams: {
+          type: 'found',
+          provider,
+          oauthLoginSuccess: true,
+        },
+      });
+
+      await findByTestId(AccountStatusSelectorIDs.ACCOUNT_FOUND_CONTAINER);
+
+      fireEvent.press(
+        await findByTestId(
+          AccountStatusSelectorIDs.ACCOUNT_FOUND_DIFFERENT_METHOD_BUTTON,
+        ),
+      );
+
+      await findByTestId(ONBOARDING_PREVIOUS_PROBE_ID);
+    },
+  );
+
+  itEach(existingUserProviders)(
+    'account not found for $label import shows Create wallet and navigates to ChoosePassword',
+    async ({ provider }) => {
+      const { findByTestId } = renderAccountNotFound({
+        routeParams: {
+          type: 'not_exist',
+          provider,
+          accountName: 'seedless-cv@example.com',
+        },
+      });
+
+      expect(
+        await findByTestId(
+          AccountStatusSelectorIDs.ACCOUNT_NOT_FOUND_CONTAINER,
+        ),
+      ).toBeOnTheScreen();
+
+      expect(
+        await findByTestId(AccountStatusSelectorIDs.ACCOUNT_NOT_FOUND_TITLE),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(
+        await findByTestId(
+          AccountStatusSelectorIDs.ACCOUNT_NOT_FOUND_CREATE_BUTTON,
+        ),
+      );
+
+      await findByTestId(`route-${Routes.ONBOARDING.CHOOSE_PASSWORD}`);
+    },
+  );
+
+  itForPlatforms(
+    'Account Already Exists shows Log in on Android and Unlock wallet on iOS',
+    async ({ os }) => {
+      const { findByText } = renderAccountAlreadyExists({
+        routeParams: {
+          type: 'found',
+          provider: AuthConnection.Google,
+        },
+      });
+
+      if (os === 'ios') {
+        expect(
+          await findByText(strings('account_status.unlock_wallet')),
+        ).toBeOnTheScreen();
+      } else {
+        expect(
+          await findByText(strings('account_status.log_in')),
+        ).toBeOnTheScreen();
+      }
     },
   );
 });

--- a/app/components/Views/AccountStatus/AccountStatus.view.test.tsx
+++ b/app/components/Views/AccountStatus/AccountStatus.view.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Component View tests for the Account Already Exists screen.
+ *
+ * Mirrors (partial):
+ * - tests/smoke/seedless/apple-login-existing-user.spec.ts
+ * - tests/smoke/seedless/google-login-existing-user.spec.ts
+ *
+ * CV covers Account Already Exists UI and Login navigation after OAuth detects
+ * an existing user. Full E2E still required for OAuth mockttp, onboarding sheet,
+ * and native provider flows — see SocialLoginIosUser.view.test.tsx and E2E specs.
+ *
+ * Run:
+ * yarn jest -c jest.config.view.js AccountStatus.view.test.tsx --runInBand
+ */
+import '../../../../tests/component-view/mocks';
+import { fireEvent } from '@testing-library/react-native';
+import {
+  describeForPlatforms,
+  itEach,
+} from '../../../../tests/component-view/platform';
+import { renderAccountAlreadyExists } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import Routes from '../../../constants/navigation/Routes';
+import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
+import { AccountStatusSelectorIDs } from './AccountStatus.testIds';
+
+const existingUserProviders = [
+  {
+    provider: AuthConnection.Apple,
+    label: 'Apple',
+  },
+  {
+    provider: AuthConnection.Google,
+    label: 'Google',
+  },
+] as const;
+
+describeForPlatforms('AccountStatus — Account Already Exists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  itEach(existingUserProviders)(
+    'existing $label user sees Account Already Exists and navigates to OAuth rehydrate on Login',
+    async ({ provider }) => {
+      const { findByTestId } = renderAccountAlreadyExists({
+        routeParams: {
+          type: 'found',
+          provider,
+          accountName: 'seedless-cv@example.com',
+          oauthLoginSuccess: true,
+        },
+      });
+
+      expect(
+        await findByTestId(AccountStatusSelectorIDs.ACCOUNT_FOUND_CONTAINER),
+      ).toBeOnTheScreen();
+
+      expect(
+        await findByTestId(AccountStatusSelectorIDs.ACCOUNT_FOUND_TITLE),
+      ).toBeOnTheScreen();
+
+      expect(
+        await findByTestId(AccountStatusSelectorIDs.ACCOUNT_FOUND_LOGIN_BUTTON),
+      ).toBeOnTheScreen();
+
+      expect(
+        await findByTestId(
+          AccountStatusSelectorIDs.ACCOUNT_FOUND_DIFFERENT_METHOD_BUTTON,
+        ),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(
+        await findByTestId(AccountStatusSelectorIDs.ACCOUNT_FOUND_LOGIN_BUTTON),
+      );
+
+      await findByTestId(
+        `route-${Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE}`,
+      );
+    },
+  );
+});

--- a/app/components/Views/ChoosePassword/ChoosePassword.view.test.tsx
+++ b/app/components/Views/ChoosePassword/ChoosePassword.view.test.tsx
@@ -53,7 +53,6 @@ function mockAuthenticationForSocialWalletCreation() {
 function mockAuthenticationGetType() {
   return jest.spyOn(Authentication, 'getType').mockResolvedValue({
     currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
-    availableBiometryType: null,
   });
 }
 

--- a/app/components/Views/ChoosePassword/ChoosePassword.view.test.tsx
+++ b/app/components/Views/ChoosePassword/ChoosePassword.view.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Component View tests for ChoosePassword during seedless social-login onboarding.
+ *
+ * Mirrors (partial):
+ * - tests/smoke/seedless/apple-login-new-user.spec.ts
+ * - tests/smoke/seedless/google-login-new-user.spec.ts (Android path skips iOS screen)
+ *
+ * CV covers password validation UX and marketing opt-in auth-server sync (nock).
+ * Full wallet creation, MetaMetrics, and wallet home remain E2E.
+ *
+ * Run: yarn jest -c jest.config.view.js ChoosePassword.view.test.tsx --runInBand
+ */
+import '../../../../tests/component-view/mocks';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { InteractionManager } from 'react-native';
+import {
+  describeForPlatforms,
+  itEach,
+} from '../../../../tests/component-view/platform';
+import {
+  clearSeedlessAuthServerMocks,
+  setupSeedlessAuthServerMocks,
+} from '../../../../tests/component-view/api-mocking/seedless-onboarding';
+import { renderChoosePasswordForSocialLogin } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
+import { ChoosePasswordSelectorsIDs } from './ChoosePassword.testIds';
+import { strings } from '../../../../locales/i18n';
+import { MIN_PASSWORD_LENGTH } from '../../../util/password';
+import { Authentication } from '../../../core';
+import AUTHENTICATION_TYPE from '../../../constants/userProperties';
+import Routes from '../../../constants/navigation/Routes';
+import Engine from '../../../core/Engine';
+import { SEEDLESS_CV_ACCESS_TOKEN } from '../../../../tests/component-view/presets/seedlessOnboarding';
+
+const VALID_PASSWORD = 'Test1234!';
+const socialLoginProviders = [
+  { provider: AuthConnection.Google, label: 'Google' },
+  { provider: AuthConnection.Apple, label: 'Apple' },
+] as const;
+
+function mockAuthenticationForSocialWalletCreation() {
+  jest.spyOn(Authentication, 'componentAuthenticationType').mockResolvedValue({
+    currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
+  });
+  jest
+    .spyOn(Authentication, 'requestBiometricsAccessControlForIOS')
+    .mockImplementation(async (authType) => authType);
+  jest
+    .spyOn(Authentication, 'newWalletAndKeychain')
+    .mockResolvedValue(undefined);
+}
+
+function mockAuthenticationGetType() {
+  return jest.spyOn(Authentication, 'getType').mockResolvedValue({
+    currentAuthType: AUTHENTICATION_TYPE.PASSWORD,
+    availableBiometryType: null,
+  });
+}
+
+beforeAll(() => {
+  jest.spyOn(InteractionManager, 'runAfterInteractions').mockImplementation(
+    jest.fn().mockImplementation((callback) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return {
+        then: (onfulfilled?: () => void) => Promise.resolve(onfulfilled?.()),
+        done: (onfulfilled?: () => void, onrejected?: () => void) =>
+          Promise.resolve().then(onfulfilled, onrejected),
+        cancel: jest.fn(),
+      };
+    }),
+  );
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describeForPlatforms('ChoosePassword — seedless social login', () => {
+  let getTypeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getTypeSpy = mockAuthenticationGetType();
+    if (Engine.context.SeedlessOnboardingController?.state) {
+      Engine.context.SeedlessOnboardingController.state.accessToken =
+        SEEDLESS_CV_ACCESS_TOKEN;
+    }
+  });
+
+  afterEach(() => {
+    clearSeedlessAuthServerMocks();
+    getTypeSpy.mockRestore();
+  });
+
+  itEach(socialLoginProviders)(
+    'keeps submit disabled for $label login until matching passwords meet minimum length',
+    async ({ provider }) => {
+      const { findByTestId } = renderChoosePasswordForSocialLogin({
+        routeParams: {
+          oauthLoginSuccess: true,
+          provider,
+        },
+      });
+
+      const submitButton = await findByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
+
+      expect(submitButton).toBeDisabled();
+
+      fireEvent.changeText(
+        await findByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+        'short',
+      );
+      fireEvent.changeText(
+        await findByTestId(
+          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+        ),
+        'short',
+      );
+
+      await waitFor(() => {
+        expect(submitButton).toBeDisabled();
+      });
+    },
+  );
+
+  itEach(socialLoginProviders)(
+    'shows password mismatch error for $label login when confirm password differs',
+    async ({ provider }) => {
+      const { findByTestId, findByText } = renderChoosePasswordForSocialLogin({
+        routeParams: {
+          oauthLoginSuccess: true,
+          provider,
+        },
+      });
+
+      fireEvent.changeText(
+        await findByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+        VALID_PASSWORD,
+      );
+      fireEvent.changeText(
+        await findByTestId(
+          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+        ),
+        `${VALID_PASSWORD}x`,
+      );
+
+      expect(
+        await findByText(strings('choose_password.password_error')),
+      ).toBeOnTheScreen();
+
+      expect(
+        await findByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+      ).toBeDisabled();
+    },
+  );
+
+  itEach(socialLoginProviders)(
+    'enables submit for $label login when passwords match and meet minimum length',
+    async ({ provider }) => {
+      const { findByTestId } = renderChoosePasswordForSocialLogin({
+        routeParams: {
+          oauthLoginSuccess: true,
+          provider,
+        },
+      });
+
+      fireEvent.changeText(
+        await findByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+        VALID_PASSWORD,
+      );
+      fireEvent.changeText(
+        await findByTestId(
+          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+        ),
+        VALID_PASSWORD,
+      );
+
+      await waitFor(async () => {
+        expect(
+          await findByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+        ).toBeEnabled();
+      });
+
+      expect(VALID_PASSWORD.length).toBeGreaterThanOrEqual(MIN_PASSWORD_LENGTH);
+    },
+  );
+
+  it('posts marketing opt-in to auth server and navigates to onboarding success after wallet creation', async () => {
+    setupSeedlessAuthServerMocks({ marketingOptIn: true });
+    mockAuthenticationForSocialWalletCreation();
+
+    const { findByTestId } = renderChoosePasswordForSocialLogin({
+      routeParams: {
+        oauthLoginSuccess: true,
+        provider: AuthConnection.Google,
+      },
+    });
+
+    fireEvent.changeText(
+      await findByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+      VALID_PASSWORD,
+    );
+    fireEvent.changeText(
+      await findByTestId(ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID),
+      VALID_PASSWORD,
+    );
+
+    await waitFor(async () => {
+      expect(
+        await findByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+      ).toBeEnabled();
+    });
+
+    fireEvent.press(
+      await findByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+    );
+
+    await findByTestId(`route-${Routes.ONBOARDING.SUCCESS_FLOW}`);
+  });
+});

--- a/app/components/Views/SocialLoginIosUser/SocialLoginIosUser.view.test.tsx
+++ b/app/components/Views/SocialLoginIosUser/SocialLoginIosUser.view.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Component View tests for the iOS social-login success screen (new user).
+ *
+ * Mirrors (partial, iOS path only):
+ * - tests/smoke/seedless/apple-login-new-user.spec.ts
+ * - tests/smoke/seedless/google-login-new-user.spec.ts (iOS branch in utils)
+ *
+ * CV covers the iOS post-OAuth PIN setup screen and navigation to ChoosePassword.
+ * Full E2E still required for OAuth mockttp, OnboardingSheet, password creation,
+ * MetaMetrics opt-in, and wallet home — keep those specs active.
+ *
+ * Not migratable to CV (keep E2E):
+ * - google-login-add-srp.spec.ts — full onboarding + wallet + SRP import
+ * - google-login-lock-unlock.spec.ts — native Keychain lock/unlock
+ * - google-login-reset-wallet.spec.ts — native Keychain reset from login
+ *
+ * Run:
+ * yarn jest -c jest.config.view.js SocialLoginIosUser.view.test.tsx --runInBand
+ */
+import '../../../../tests/component-view/mocks';
+import { fireEvent } from '@testing-library/react-native';
+import {
+  describeForPlatforms,
+  itEach,
+} from '../../../../tests/component-view/platform';
+import { renderSocialLoginIosNewUser } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import Routes from '../../../constants/navigation/Routes';
+import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { OnboardingSelectorIDs } from '../Onboarding/Onboarding.testIds';
+
+const iosNewUserProviders = [
+  {
+    provider: AuthConnection.Apple,
+    label: 'Apple',
+  },
+  {
+    provider: AuthConnection.Google,
+    label: 'Google',
+  },
+] as const;
+
+describeForPlatforms(
+  'SocialLoginIosUser — new user (iOS)',
+  () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    itEach(iosNewUserProviders)(
+      'shows iOS new-user screen after $label login and navigates to ChoosePassword on Set PIN',
+      async ({ provider }) => {
+        const { findByTestId } = renderSocialLoginIosNewUser({
+          routeParams: {
+            provider,
+            oauthLoginSuccess: true,
+            accountName: 'seedless-cv@example.com',
+          },
+        });
+
+        expect(
+          await findByTestId(
+            OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_TITLE,
+          ),
+        ).toBeOnTheScreen();
+
+        expect(
+          await findByTestId(
+            OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_BUTTON,
+          ),
+        ).toBeOnTheScreen();
+
+        fireEvent.press(
+          await findByTestId(
+            OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_BUTTON,
+          ),
+        );
+
+        await findByTestId(`route-${Routes.ONBOARDING.CHOOSE_PASSWORD}`);
+      },
+    );
+  },
+  { only: 'ios' },
+);

--- a/app/components/Views/SocialLoginIosUser/SocialLoginIosUser.view.test.tsx
+++ b/app/components/Views/SocialLoginIosUser/SocialLoginIosUser.view.test.tsx
@@ -23,7 +23,10 @@ import {
   describeForPlatforms,
   itEach,
 } from '../../../../tests/component-view/platform';
-import { renderSocialLoginIosNewUser } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import {
+  renderSocialLoginIosNewUser,
+  renderSocialLoginIosExistingUser,
+} from '../../../../tests/component-view/renderers/seedlessOnboarding';
 import Routes from '../../../constants/navigation/Routes';
 import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -77,6 +80,35 @@ describeForPlatforms(
         );
 
         await findByTestId(`route-${Routes.ONBOARDING.CHOOSE_PASSWORD}`);
+      },
+    );
+
+    itEach(iosNewUserProviders)(
+      'shows iOS existing-user screen after $label login and navigates to OAuth rehydrate on Secure wallet',
+      async ({ provider }) => {
+        const { findByTestId } = renderSocialLoginIosExistingUser({
+          routeParams: {
+            provider,
+            oauthLoginSuccess: true,
+            accountName: 'seedless-cv@example.com',
+          },
+        });
+
+        expect(
+          await findByTestId(
+            OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_EXISTING_USER_TITLE,
+          ),
+        ).toBeOnTheScreen();
+
+        fireEvent.press(
+          await findByTestId(
+            OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_EXISTING_USER_BUTTON,
+          ),
+        );
+
+        await findByTestId(
+          `route-${Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE}`,
+        );
       },
     );
   },

--- a/app/components/Views/WalletCreationError/WalletCreationError.view.test.tsx
+++ b/app/components/Views/WalletCreationError/WalletCreationError.view.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Component View tests for social-login wallet creation error UI.
+ *
+ * Negative path coverage for failed seedless onboarding (OAuth / vault errors).
+ * E2E still covers full failure flows from live OAuth and native SDK.
+ *
+ * Run: yarn jest -c jest.config.view.js WalletCreationError.view.test.tsx --runInBand
+ */
+import '../../../../tests/component-view/mocks';
+import { fireEvent } from '@testing-library/react-native';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
+import { renderSocialLoginWalletCreationError } from '../../../../tests/component-view/renderers/seedlessOnboarding';
+import Authentication from '../../../core/Authentication';
+import Routes from '../../../constants/navigation/Routes';
+import { strings } from '../../../../locales/i18n';
+import { AccountType } from '../../../constants/onboarding';
+
+describeForPlatforms('WalletCreationError — social login error sheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the social login error sheet and navigates to onboarding root on Try again', async () => {
+    jest.spyOn(Authentication, 'deleteWallet').mockResolvedValue(undefined);
+
+    const { findByTestId, findByText } = renderSocialLoginWalletCreationError({
+      routeParams: {
+        metricsEnabled: true,
+        error: new Error('OAuth seedless failure'),
+        accountType: AccountType.MetamaskGoogle,
+      },
+    });
+
+    expect(
+      await findByText(strings('wallet_creation_error.title')),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      await findByText(strings('wallet_creation_error.try_again')),
+    );
+
+    await findByTestId(`route-${Routes.ONBOARDING.ROOT_NAV}`);
+  });
+});

--- a/tests/component-view/api-mocking/seedless-onboarding.ts
+++ b/tests/component-view/api-mocking/seedless-onboarding.ts
@@ -1,0 +1,53 @@
+/**
+ * Seedless onboarding auth-server mocks for component view tests.
+ *
+ * Intercepts OAuth marketing opt-in HTTP calls made by OAuthService
+ * (ChoosePassword post-wallet creation, OAuthRehydration post-unlock sync).
+ *
+ * E2E uses mockttp with a broader surface (token, metadata, SSS nodes); CV tests
+ * focus on views that call fetch against the auth server marketing endpoints.
+ */
+
+// eslint-disable-next-line import-x/no-extraneous-dependencies
+import nock from 'nock';
+import { clearAllNockMocks, disableNetConnect } from './nockHelpers';
+
+/** Auth server origins used across dev / UAT / prod OAuth config. */
+export const SEEDLESS_AUTH_SERVER_ORIGINS = [
+  'https://auth-service.dev-api.cx.metamask.io',
+  'https://auth-service.uat-api.cx.metamask.io',
+  'https://auth-service.api.cx.metamask.io',
+] as const;
+
+const MARKETING_OPT_IN_PATH = '/api/v1/oauth/marketing_opt_in_status';
+
+export interface SeedlessAuthServerMockOptions {
+  /** Response body for GET/POST marketing opt-in (default: true). */
+  marketingOptIn?: boolean;
+  /** When true, POST marketing opt-in returns HTTP 500. */
+  marketingPostFails?: boolean;
+}
+
+export function setupSeedlessAuthServerMocks(
+  options: SeedlessAuthServerMockOptions = {},
+): void {
+  clearSeedlessAuthServerMocks();
+  disableNetConnect();
+
+  const marketingOptIn = options.marketingOptIn ?? true;
+  const marketingBody = { is_opt_in: marketingOptIn };
+  const postStatus = options.marketingPostFails ? 500 : 200;
+
+  for (const origin of SEEDLESS_AUTH_SERVER_ORIGINS) {
+    nock(origin).persist().get(MARKETING_OPT_IN_PATH).reply(200, marketingBody);
+
+    nock(origin)
+      .persist()
+      .post(MARKETING_OPT_IN_PATH)
+      .reply(postStatus, marketingBody);
+  }
+}
+
+export function clearSeedlessAuthServerMocks(): void {
+  clearAllNockMocks();
+}

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -197,6 +197,17 @@ jest.mock('../../app/core/Engine', () => {
       AuthenticationController: {
         getBearerToken: jest.fn().mockResolvedValue('mock-bearer-token'),
       },
+      GeolocationController: {
+        state: {
+          location: 'US',
+        },
+        refreshGeolocation: jest.fn().mockResolvedValue('US'),
+      },
+      SeedlessOnboardingController: {
+        state: {
+          accessToken: undefined,
+        },
+      },
       // Notifications: stubbed so notification view + settings flows can call
       // controller methods (enable / disable / toggleFeatureAnnouncements /
       // markMetamaskNotificationsAsRead / fetchAndUpdateMetamaskNotifications

--- a/tests/component-view/presets/seedlessOnboarding.ts
+++ b/tests/component-view/presets/seedlessOnboarding.ts
@@ -1,4 +1,25 @@
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
 import { createStateFixture } from '../stateFixture';
+
+/** Access token for auth-server marketing opt-in API calls in CV tests. */
+export const SEEDLESS_CV_ACCESS_TOKEN = 'cv-seedless-access-token';
+
+/**
+ * Engine + Redux overrides for seedless social-login flows (marketing sync, geolocation).
+ */
+export const seedlessSocialLoginStateOverrides: DeepPartial<RootState> = {
+  engine: {
+    backgroundState: {
+      GeolocationController: {
+        location: 'US',
+      },
+      SeedlessOnboardingController: {
+        accessToken: SEEDLESS_CV_ACCESS_TOKEN,
+      },
+    },
+  },
+} as DeepPartial<RootState>;
 
 /**
  * Baseline Redux state for seedless onboarding component view tests.
@@ -7,4 +28,5 @@ import { createStateFixture } from '../stateFixture';
 export const initialStateSeedlessOnboarding = () =>
   createStateFixture()
     .withRemoteFeatureFlags({})
-    .withMinimalAnalyticsController();
+    .withMinimalAnalyticsController()
+    .withOverrides(seedlessSocialLoginStateOverrides);

--- a/tests/component-view/presets/seedlessOnboarding.ts
+++ b/tests/component-view/presets/seedlessOnboarding.ts
@@ -1,0 +1,10 @@
+import { createStateFixture } from '../stateFixture';
+
+/**
+ * Baseline Redux state for seedless onboarding component view tests.
+ * Screens are route-param driven; no unlocked wallet is required.
+ */
+export const initialStateSeedlessOnboarding = () =>
+  createStateFixture()
+    .withRemoteFeatureFlags({})
+    .withMinimalAnalyticsController();

--- a/tests/component-view/renderers/seedlessOnboarding.tsx
+++ b/tests/component-view/renderers/seedlessOnboarding.tsx
@@ -1,16 +1,29 @@
 import '../mocks';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
 import type { RootState } from '../../../app/reducers';
 import Routes from '../../../app/constants/navigation/Routes';
-import { renderScreenWithRoutes } from '../render';
+import { renderComponentViewScreen, renderScreenWithRoutes } from '../render';
 import AccountStatus from '../../../app/components/Views/AccountStatus';
 import SocialLoginIosUser from '../../../app/components/Views/SocialLoginIosUser';
+import ChoosePassword from '../../../app/components/Views/ChoosePassword';
+import WalletCreationError from '../../../app/components/Views/WalletCreationError';
 import type { AccountStatusParams } from '../../../app/components/Views/AccountStatus/types';
 import { AuthConnection } from '../../../app/core/OAuthService/OAuthInterface';
-import { initialStateSeedlessOnboarding } from '../presets/seedlessOnboarding';
+import { ONBOARDING, PREVIOUS_SCREEN } from '../../../app/constants/navigation';
+import { AccountType } from '../../../app/constants/onboarding';
+import {
+  initialStateSeedlessOnboarding,
+  SEEDLESS_CV_ACCESS_TOKEN,
+} from '../presets/seedlessOnboarding';
+import Engine from '../../../app/core/Engine';
 
 const ACCOUNT_ALREADY_EXISTS_ROUTE = 'AccountAlreadyExists';
+const ACCOUNT_NOT_FOUND_ROUTE = 'AccountNotFound';
+export const ONBOARDING_PREVIOUS_PROBE_ID =
+  'seedless-onboarding-previous-probe';
 
 interface SeedlessOnboardingRendererOptions {
   overrides?: DeepPartial<RootState>;
@@ -27,9 +40,18 @@ function buildSeedlessOnboardingState(
   return builder.build();
 }
 
+function syncSeedlessAccessToken() {
+  if (Engine.context.SeedlessOnboardingController?.state) {
+    Engine.context.SeedlessOnboardingController.state.accessToken =
+      SEEDLESS_CV_ACCESS_TOKEN;
+  }
+}
+
 export function renderAccountAlreadyExists(
   options: SeedlessOnboardingRendererOptions = {},
 ) {
+  syncSeedlessAccessToken();
+
   const defaultParams: AccountStatusParams = {
     type: 'found',
     provider: AuthConnection.Google,
@@ -46,7 +68,84 @@ export function renderAccountAlreadyExists(
   );
 }
 
+function OnboardingPreviousProbe() {
+  return <Text testID={ONBOARDING_PREVIOUS_PROBE_ID}>Onboarding</Text>;
+}
+
+function AccountAlreadyExistsFromOnboardingHarness({
+  routeParams,
+}: {
+  routeParams: AccountStatusParams;
+}) {
+  const navigation = useNavigation();
+  const didNavigate = useRef(false);
+
+  useEffect(() => {
+    if (didNavigate.current) {
+      return;
+    }
+    didNavigate.current = true;
+    navigation.navigate(ACCOUNT_ALREADY_EXISTS_ROUTE, routeParams);
+  }, [navigation, routeParams]);
+
+  return <OnboardingPreviousProbe />;
+}
+
+export function renderAccountAlreadyExistsWithOnboardingHistory(
+  options: SeedlessOnboardingRendererOptions = {},
+) {
+  syncSeedlessAccessToken();
+
+  const defaultParams: AccountStatusParams = {
+    type: 'found',
+    provider: AuthConnection.Google,
+    accountName: 'seedless-cv@example.com',
+    oauthLoginSuccess: true,
+  };
+  const mergedParams = { ...defaultParams, ...options.routeParams };
+
+  function Harness() {
+    return (
+      <AccountAlreadyExistsFromOnboardingHarness routeParams={mergedParams} />
+    );
+  }
+
+  return renderScreenWithRoutes(
+    Harness as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.ONBOARDING },
+    [
+      { name: ACCOUNT_ALREADY_EXISTS_ROUTE, Component: AccountStatus },
+      { name: Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE },
+    ],
+    { state: buildSeedlessOnboardingState(options) },
+  );
+}
+
+export function renderAccountNotFound(
+  options: SeedlessOnboardingRendererOptions = {},
+) {
+  syncSeedlessAccessToken();
+
+  const defaultParams: AccountStatusParams = {
+    type: 'not_exist',
+    provider: AuthConnection.Google,
+    accountName: 'seedless-cv@example.com',
+    oauthLoginSuccess: true,
+  };
+
+  return renderScreenWithRoutes(
+    AccountStatus as unknown as React.ComponentType,
+    { name: ACCOUNT_NOT_FOUND_ROUTE },
+    [{ name: Routes.ONBOARDING.CHOOSE_PASSWORD }],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}
+
 const SocialLoginSuccessNewUser = () => <SocialLoginIosUser type="new" />;
+const SocialLoginSuccessExistingUser = () => (
+  <SocialLoginIosUser type="existing" />
+);
 
 interface SocialLoginIosUserRendererOptions {
   overrides?: DeepPartial<RootState>;
@@ -60,6 +159,8 @@ interface SocialLoginIosUserRendererOptions {
 export function renderSocialLoginIosNewUser(
   options: SocialLoginIosUserRendererOptions = {},
 ) {
+  syncSeedlessAccessToken();
+
   const defaultParams = {
     accountName: 'seedless-cv@example.com',
     oauthLoginSuccess: true,
@@ -72,5 +173,94 @@ export function renderSocialLoginIosNewUser(
     [{ name: Routes.ONBOARDING.CHOOSE_PASSWORD }],
     { state: buildSeedlessOnboardingState(options) },
     { ...defaultParams, ...options.routeParams },
+  );
+}
+
+export function renderSocialLoginIosExistingUser(
+  options: SocialLoginIosUserRendererOptions = {},
+) {
+  syncSeedlessAccessToken();
+
+  const defaultParams = {
+    accountName: 'seedless-cv@example.com',
+    oauthLoginSuccess: true,
+    provider: AuthConnection.Google,
+  };
+
+  return renderScreenWithRoutes(
+    SocialLoginSuccessExistingUser as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.SOCIAL_LOGIN_SUCCESS_EXISTING_USER },
+    [{ name: Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE }],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}
+
+interface ChoosePasswordRendererOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: Record<string, unknown>;
+}
+
+export function renderChoosePasswordForSocialLogin(
+  options: ChoosePasswordRendererOptions = {},
+) {
+  syncSeedlessAccessToken();
+
+  const defaultParams = {
+    [PREVIOUS_SCREEN]: ONBOARDING,
+    oauthLoginSuccess: true,
+    provider: AuthConnection.Google,
+  };
+
+  return renderScreenWithRoutes(
+    ChoosePassword as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.CHOOSE_PASSWORD },
+    [
+      {
+        name: Routes.ONBOARDING.SUCCESS_FLOW,
+      },
+    ],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}
+
+interface WalletCreationErrorRendererOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: {
+    metricsEnabled?: boolean;
+    error?: Error;
+    accountType?: AccountType;
+  };
+}
+
+export function renderSocialLoginWalletCreationError(
+  options: WalletCreationErrorRendererOptions = {},
+) {
+  syncSeedlessAccessToken();
+
+  const defaultParams = {
+    metricsEnabled: true,
+    error: new Error('Seedless wallet creation failed'),
+    accountType: AccountType.MetamaskGoogle,
+  };
+
+  return renderScreenWithRoutes(
+    WalletCreationError as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.WALLET_CREATION_ERROR },
+    [{ name: Routes.ONBOARDING.ROOT_NAV }],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}
+
+export function renderChoosePasswordScreen(
+  options: ChoosePasswordRendererOptions = {},
+) {
+  return renderComponentViewScreen(
+    ChoosePassword as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.CHOOSE_PASSWORD },
+    { state: buildSeedlessOnboardingState(options) },
+    options.routeParams,
   );
 }

--- a/tests/component-view/renderers/seedlessOnboarding.tsx
+++ b/tests/component-view/renderers/seedlessOnboarding.tsx
@@ -25,13 +25,17 @@ const ACCOUNT_NOT_FOUND_ROUTE = 'AccountNotFound';
 export const ONBOARDING_PREVIOUS_PROBE_ID =
   'seedless-onboarding-previous-probe';
 
-interface SeedlessOnboardingRendererOptions {
+interface SeedlessOnboardingStateOptions {
   overrides?: DeepPartial<RootState>;
+}
+
+interface SeedlessOnboardingRendererOptions
+  extends SeedlessOnboardingStateOptions {
   routeParams?: AccountStatusParams;
 }
 
 function buildSeedlessOnboardingState(
-  options: SeedlessOnboardingRendererOptions = {},
+  options: SeedlessOnboardingStateOptions = {},
 ) {
   const builder = initialStateSeedlessOnboarding();
   if (options.overrides) {

--- a/tests/component-view/renderers/seedlessOnboarding.tsx
+++ b/tests/component-view/renderers/seedlessOnboarding.tsx
@@ -1,0 +1,76 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import Routes from '../../../app/constants/navigation/Routes';
+import { renderScreenWithRoutes } from '../render';
+import AccountStatus from '../../../app/components/Views/AccountStatus';
+import SocialLoginIosUser from '../../../app/components/Views/SocialLoginIosUser';
+import type { AccountStatusParams } from '../../../app/components/Views/AccountStatus/types';
+import { AuthConnection } from '../../../app/core/OAuthService/OAuthInterface';
+import { initialStateSeedlessOnboarding } from '../presets/seedlessOnboarding';
+
+const ACCOUNT_ALREADY_EXISTS_ROUTE = 'AccountAlreadyExists';
+
+interface SeedlessOnboardingRendererOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: AccountStatusParams;
+}
+
+function buildSeedlessOnboardingState(
+  options: SeedlessOnboardingRendererOptions = {},
+) {
+  const builder = initialStateSeedlessOnboarding();
+  if (options.overrides) {
+    builder.withOverrides(options.overrides);
+  }
+  return builder.build();
+}
+
+export function renderAccountAlreadyExists(
+  options: SeedlessOnboardingRendererOptions = {},
+) {
+  const defaultParams: AccountStatusParams = {
+    type: 'found',
+    provider: AuthConnection.Google,
+    accountName: 'seedless-cv@example.com',
+    oauthLoginSuccess: true,
+  };
+
+  return renderScreenWithRoutes(
+    AccountStatus as unknown as React.ComponentType,
+    { name: ACCOUNT_ALREADY_EXISTS_ROUTE },
+    [{ name: Routes.ONBOARDING.ONBOARDING_OAUTH_REHYDRATE }],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}
+
+const SocialLoginSuccessNewUser = () => <SocialLoginIosUser type="new" />;
+
+interface SocialLoginIosUserRendererOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: {
+    accountName?: string;
+    oauthLoginSuccess?: boolean;
+    provider?: string;
+  };
+}
+
+export function renderSocialLoginIosNewUser(
+  options: SocialLoginIosUserRendererOptions = {},
+) {
+  const defaultParams = {
+    accountName: 'seedless-cv@example.com',
+    oauthLoginSuccess: true,
+    provider: AuthConnection.Google,
+  };
+
+  return renderScreenWithRoutes(
+    SocialLoginSuccessNewUser as unknown as React.ComponentType,
+    { name: Routes.ONBOARDING.SOCIAL_LOGIN_SUCCESS_NEW_USER },
+    [{ name: Routes.ONBOARDING.CHOOSE_PASSWORD }],
+    { state: buildSeedlessOnboardingState(options) },
+    { ...defaultParams, ...options.routeParams },
+  );
+}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Adds Component View (CV) test coverage for **Seedless (Apple & Google Login)** flows as part of the E2E → CV migration ([MMQA-1768](https://consensyssoftware.atlassian.net/browse/MMQA-1768), epic [MMQA-1723](https://consensyssoftware.atlassian.net/browse/MMQA-1723)).

**This PR adds CV tests only — no E2E specs were skipped or removed.** E2E continues to run for OAuth mockttp, native Apple/Google provider flows, Keychain lock/unlock/reset, and full onboarding journeys until @MetaMask/web3auth sign-off per MMQA-1768.

### CV files added (34 tests)

| CV file | Source E2E spec(s) | Coverage | E2E status |
| --- | --- | --- | --- |
| `AccountStatus.view.test.tsx` | `apple-login-existing-user.spec.ts`, `google-login-existing-user.spec.ts` | Account Already Exists UI, Login → OAuth rehydrate, Use a different login method → onboarding, Account Not Found → ChoosePassword, platform-specific copy (iOS/Android × Apple & Google) | Still active |
| `SocialLoginIosUser.view.test.tsx` | `apple-login-new-user.spec.ts`, `google-login-new-user.spec.ts` (iOS path) | iOS post-OAuth new-user → ChoosePassword; existing-user → OAuth rehydrate (Apple & Google) | Still active |
| `ChoosePassword.view.test.tsx` | `apple-login-new-user.spec.ts`, `google-login-new-user.spec.ts` | Submit disabled until valid matching passwords; mismatch error; wallet creation with mocked `Authentication`; **nock** marketing opt-in POST → success flow | Still active |
| `WalletCreationError.view.test.tsx` | Negative path (failed seedless onboarding) | Social login error sheet; Try again → onboarding root with mocked `deleteWallet` | Still active |

### Shared test infrastructure

| File | Purpose |
| --- | --- |
| `tests/component-view/presets/seedlessOnboarding.ts` | Baseline Redux state, geolocation, `SeedlessOnboardingController` access token |
| `tests/component-view/renderers/seedlessOnboarding.tsx` | Multi-route renderers and onboarding-history harness |
| `tests/component-view/api-mocking/seedless-onboarding.ts` | **nock** mocks for auth-server marketing opt-in GET/POST |
| `tests/component-view/mocks.ts` | Engine CV mocks extended with `GeolocationController` and `SeedlessOnboardingController` |

### Not migrated (keep E2E)

| E2E spec | Reason |
| --- | --- |
| Full new-user onboarding (Apple & Google) | Requires OAuth mockttp, password creation, MetaMetrics opt-in, wallet home |
| `google-login-add-srp.spec.ts` | Full onboarding + wallet identicon + multichain SRP import |
| `google-login-lock-unlock.spec.ts` | Native Keychain lock/unlock |
| `google-login-reset-wallet.spec.ts` | Native vault reset from login screen |
| `OAuthRehydration` unlock / marketing GET sync | Requires deeper auth hook coverage; deferred to follow-up |

### Suggested reviewers (CODEOWNERS)

| Team | Files |
| --- | --- |
| **@MetaMask/web3auth** | `SocialLoginIosUser.view.test.tsx`, `ChoosePassword.view.test.tsx`, `WalletCreationError.view.test.tsx` |
| **@MetaMask/qa** | `tests/component-view/presets/seedlessOnboarding.ts`, `tests/component-view/renderers/seedlessOnboarding.tsx`, `tests/component-view/api-mocking/seedless-onboarding.ts` |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/MMQA-1768

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Seedless component view tests

  Scenario: run all new CV tests
    Given jest.config.view.js is configured
    When yarn jest -c jest.config.view.js AccountStatus.view.test.tsx SocialLoginIosUser.view.test.tsx ChoosePassword.view.test.tsx WalletCreationError.view.test.tsx --runInBand
    Then all 34 CV tests pass

  Scenario: Account Already Exists navigates to OAuth rehydrate
    Given AccountStatus is rendered with type "found" and provider "google" or "apple"
    When user taps the Login button
    Then navigation reaches OnboardingOAuthRehydrate

  Scenario: iOS social-login new-user navigates to ChoosePassword
    Given SocialLoginIosUser is rendered with type "new" on iOS
    When user taps Set MetaMask PIN
    Then navigation reaches ChoosePassword

  Scenario: ChoosePassword posts marketing opt-in after wallet creation
    Given ChoosePassword is rendered after OAuth success with nock auth-server mocks
    When user enters matching valid passwords and submits
    Then marketing opt-in POST is intercepted and navigation reaches success flow

  Scenario: Wallet creation error Try again resets to onboarding
    Given WalletCreationError is rendered with a social-login failure
    When user taps Try again
    Then navigation reaches onboarding root
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - CV tests run on Android via `describeForPlatforms` / `itEach` (AccountStatus, ChoosePassword, WalletCreationError); SocialLoginIosUser is iOS-only by design
- [x] I've tested with a power user scenario
  - N/A — test-only change, no wallet or account flows exercised in the app
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no production code changed

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

[MMQA-1768]: https://consensyssoftware.atlassian.net/browse/MMQA-1768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1723]: https://consensyssoftware.atlassian.net/browse/MMQA-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with mocks and nock; no app behavior or authentication logic modified in production code.
> 
> **Overview**
> Expands **E2E → component view (CV)** coverage for **seedless Apple & Google** onboarding. **No production code** and **no E2E specs removed**—comments in the new tests call out what still needs full E2E (OAuth mockttp, native providers, Keychain, wallet home).
> 
> **New CV suites** (run via `jest.config.view.js`): `AccountStatus` (account found / not found, Login → OAuth rehydrate, different login method → onboarding, platform-specific copy); `SocialLoginIosUser` (iOS-only new/existing user → `ChoosePassword` or rehydrate); `ChoosePassword` (validation, mismatch, submit enablement, mocked wallet creation + **nock** marketing opt-in → success flow); `WalletCreationError` (Try again → onboarding root with mocked `deleteWallet`).
> 
> **Shared test infrastructure:** `seedlessOnboarding` preset (Redux/engine overrides + CV access token), `seedlessOnboarding` renderers (multi-route navigation harnesses), `seedless-onboarding` API mocks for auth-server marketing endpoints, and **Engine** CV mocks extended with `GeolocationController` and `SeedlessOnboardingController` state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1249bdb638cbdc8e05ce700b14986fb73e9b3e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->