### PR TITLE
fix: refresh OAuth token before marketing opt-in API calls

### DIFF
--- a/app/core/OAuthService/OAuthService.test.ts
+++ b/app/core/OAuthService/OAuthService.test.ts
@@ -152,6 +152,7 @@ jest.mock('../Engine', () => ({
         nodeAuthTokens: [],
         isNewUser: false,
       })),
+      refreshAuthTokens: jest.fn().mockResolvedValue(undefined),
       state: {
         accessToken: undefined,
         socialBackupsMetadata: [],
@@ -898,10 +899,14 @@ describe('OAuth login service', () => {
 describe('updateMarketingOptInStatus', () => {
   const mockFetch = jest.fn();
   const originalFetch = global.fetch;
+  const mockRefreshAuthTokens = Engine.context.SeedlessOnboardingController
+    .refreshAuthTokens as jest.Mock;
 
   beforeEach(() => {
     global.fetch = mockFetch;
     mockFetch.mockClear();
+    mockRefreshAuthTokens.mockClear();
+    mockRefreshAuthTokens.mockResolvedValue(undefined);
     // Reset the Engine state to default
     Engine.context.SeedlessOnboardingController.state = {
       accessToken: undefined,
@@ -941,6 +946,7 @@ describe('updateMarketingOptInStatus', () => {
         body: JSON.stringify({ opt_in_status: true }),
       },
     );
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
   });
 
   it('should successfully update marketing opt-in status to false', async () => {
@@ -980,6 +986,7 @@ describe('updateMarketingOptInStatus', () => {
       OAuthLoginService.updateMarketingOptInStatus(true),
     ).rejects.toThrow('No access token found. User must be authenticated.');
 
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -992,6 +999,7 @@ describe('updateMarketingOptInStatus', () => {
       OAuthLoginService.updateMarketingOptInStatus(true),
     ).rejects.toThrow('No access token found. User must be authenticated.');
 
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -1035,6 +1043,9 @@ describe('updateMarketingOptInStatus', () => {
     ).rejects.toThrow(
       'Failed to update marketing opt-in status: 401 - Token expired',
     );
+
+    expect(mockRefreshAuthTokens).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('should throw error when API request fails with 500 status', async () => {
@@ -1188,10 +1199,14 @@ describe('updateMarketingOptInStatus', () => {
 describe('getMarketingOptInStatus', () => {
   const mockFetch = jest.fn();
   const originalFetch = global.fetch;
+  const mockRefreshAuthTokens = Engine.context.SeedlessOnboardingController
+    .refreshAuthTokens as jest.Mock;
 
   beforeEach(() => {
     global.fetch = mockFetch;
     mockFetch.mockClear();
+    mockRefreshAuthTokens.mockClear();
+    mockRefreshAuthTokens.mockResolvedValue(undefined);
     Engine.context.SeedlessOnboardingController.state = {
       accessToken: undefined,
       socialBackupsMetadata: [],
@@ -1232,6 +1247,7 @@ describe('getMarketingOptInStatus', () => {
       },
     );
     expect(result).toEqual(mockResponse);
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
   });
 
   it('should successfully get marketing opt-in status when user is not opted in', async () => {
@@ -1271,6 +1287,7 @@ describe('getMarketingOptInStatus', () => {
       'No access token found. User must be authenticated.',
     );
 
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -1281,6 +1298,7 @@ describe('getMarketingOptInStatus', () => {
       'No access token found. User must be authenticated.',
     );
 
+    expect(mockRefreshAuthTokens).toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/app/core/OAuthService/OAuthService.test.ts
+++ b/app/core/OAuthService/OAuthService.test.ts
@@ -153,6 +153,7 @@ jest.mock('../Engine', () => ({
         isNewUser: false,
       })),
       refreshAuthTokens: jest.fn().mockResolvedValue(undefined),
+      getAccessToken: jest.fn(),
       state: {
         accessToken: undefined,
         socialBackupsMetadata: [],
@@ -899,14 +900,19 @@ describe('OAuth login service', () => {
 describe('updateMarketingOptInStatus', () => {
   const mockFetch = jest.fn();
   const originalFetch = global.fetch;
+  const mockGetAccessToken = Engine.context.SeedlessOnboardingController
+    .getAccessToken as jest.Mock;
   const mockRefreshAuthTokens = Engine.context.SeedlessOnboardingController
     .refreshAuthTokens as jest.Mock;
 
   beforeEach(() => {
     global.fetch = mockFetch;
     mockFetch.mockClear();
+    mockGetAccessToken.mockClear();
     mockRefreshAuthTokens.mockClear();
-    mockRefreshAuthTokens.mockResolvedValue(undefined);
+    mockGetAccessToken.mockImplementation(
+      async () => Engine.context.SeedlessOnboardingController.state.accessToken,
+    );
     // Reset the Engine state to default
     Engine.context.SeedlessOnboardingController.state = {
       accessToken: undefined,
@@ -946,7 +952,8 @@ describe('updateMarketingOptInStatus', () => {
         body: JSON.stringify({ opt_in_status: true }),
       },
     );
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
   });
 
   it('should successfully update marketing opt-in status to false', async () => {
@@ -986,7 +993,8 @@ describe('updateMarketingOptInStatus', () => {
       OAuthLoginService.updateMarketingOptInStatus(true),
     ).rejects.toThrow('No access token found. User must be authenticated.');
 
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -999,7 +1007,8 @@ describe('updateMarketingOptInStatus', () => {
       OAuthLoginService.updateMarketingOptInStatus(true),
     ).rejects.toThrow('No access token found. User must be authenticated.');
 
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -1044,7 +1053,8 @@ describe('updateMarketingOptInStatus', () => {
       'Failed to update marketing opt-in status: 401 - Token expired',
     );
 
-    expect(mockRefreshAuthTokens).toHaveBeenCalledTimes(1);
+    expect(mockGetAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -1199,14 +1209,19 @@ describe('updateMarketingOptInStatus', () => {
 describe('getMarketingOptInStatus', () => {
   const mockFetch = jest.fn();
   const originalFetch = global.fetch;
+  const mockGetAccessToken = Engine.context.SeedlessOnboardingController
+    .getAccessToken as jest.Mock;
   const mockRefreshAuthTokens = Engine.context.SeedlessOnboardingController
     .refreshAuthTokens as jest.Mock;
 
   beforeEach(() => {
     global.fetch = mockFetch;
     mockFetch.mockClear();
+    mockGetAccessToken.mockClear();
     mockRefreshAuthTokens.mockClear();
-    mockRefreshAuthTokens.mockResolvedValue(undefined);
+    mockGetAccessToken.mockImplementation(
+      async () => Engine.context.SeedlessOnboardingController.state.accessToken,
+    );
     Engine.context.SeedlessOnboardingController.state = {
       accessToken: undefined,
       socialBackupsMetadata: [],
@@ -1247,7 +1262,8 @@ describe('getMarketingOptInStatus', () => {
       },
     );
     expect(result).toEqual(mockResponse);
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
   });
 
   it('should successfully get marketing opt-in status when user is not opted in', async () => {
@@ -1287,7 +1303,8 @@ describe('getMarketingOptInStatus', () => {
       'No access token found. User must be authenticated.',
     );
 
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -1298,7 +1315,8 @@ describe('getMarketingOptInStatus', () => {
       'No access token found. User must be authenticated.',
     );
 
-    expect(mockRefreshAuthTokens).toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(mockRefreshAuthTokens).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -534,7 +534,7 @@ export class OAuthService {
   private getAccessToken = (): string | undefined =>
     Engine.context.SeedlessOnboardingController.state?.accessToken;
 
-  private getAccessTokenOrThrow = (): string => {
+  private readonly getAccessTokenOrThrow = (): string => {
     const accessToken = this.getAccessToken();
 
     if (!accessToken) {

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -534,28 +534,38 @@ export class OAuthService {
   private getAccessToken = (): string | undefined =>
     Engine.context.SeedlessOnboardingController.state?.accessToken;
 
-  updateMarketingOptInStatus = async (
-    marketingOptIn: boolean,
-  ): Promise<void> => {
+  private getAccessTokenOrThrow = (): string => {
     const accessToken = this.getAccessToken();
 
     if (!accessToken) {
       throw new Error('No access token found. User must be authenticated.');
     }
 
+    return accessToken;
+  };
+
+  private async refreshAccessToken(): Promise<void> {
+    await whenEngineReady();
+    await Engine.context.SeedlessOnboardingController.refreshAuthTokens();
+  }
+
+  updateMarketingOptInStatus = async (
+    marketingOptIn: boolean,
+  ): Promise<void> => {
+    await this.refreshAccessToken();
+
+    const accessToken = this.getAccessTokenOrThrow();
     const requestBody: MarketingOptInRequest = {
       opt_in_status: marketingOptIn,
     };
 
     const url = `${this.config.authServerUrl}${AUTH_SERVER_MARKETING_OPT_IN_PATH}`;
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    };
-
     const response = await fetch(url, {
       method: 'POST',
-      headers,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
       body: JSON.stringify(requestBody),
     });
 
@@ -570,21 +580,16 @@ export class OAuthService {
   };
 
   getMarketingOptInStatus = async (): Promise<MarketingOptInResponse> => {
-    const accessToken = this.getAccessToken();
+    await this.refreshAccessToken();
 
-    if (!accessToken) {
-      throw new Error('No access token found. User must be authenticated.');
-    }
-
+    const accessToken = this.getAccessTokenOrThrow();
     const url = `${this.config.authServerUrl}${AUTH_SERVER_MARKETING_OPT_IN_PATH}`;
-    const headers = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    };
-
     const response = await fetch(url, {
       method: 'GET',
-      headers,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
     });
 
     if (!response.ok) {

--- a/app/core/OAuthService/OAuthService.ts
+++ b/app/core/OAuthService/OAuthService.ts
@@ -531,30 +531,22 @@ export class OAuthService {
     });
   };
 
-  private getAccessToken = (): string | undefined =>
-    Engine.context.SeedlessOnboardingController.state?.accessToken;
-
-  private readonly getAccessTokenOrThrow = (): string => {
-    const accessToken = this.getAccessToken();
+  private async getValidAccessToken(): Promise<string> {
+    await whenEngineReady();
+    const accessToken =
+      await Engine.context.SeedlessOnboardingController.getAccessToken();
 
     if (!accessToken) {
       throw new Error('No access token found. User must be authenticated.');
     }
 
     return accessToken;
-  };
-
-  private async refreshAccessToken(): Promise<void> {
-    await whenEngineReady();
-    await Engine.context.SeedlessOnboardingController.refreshAuthTokens();
   }
 
   updateMarketingOptInStatus = async (
     marketingOptIn: boolean,
   ): Promise<void> => {
-    await this.refreshAccessToken();
-
-    const accessToken = this.getAccessTokenOrThrow();
+    const accessToken = await this.getValidAccessToken();
     const requestBody: MarketingOptInRequest = {
       opt_in_status: marketingOptIn,
     };
@@ -580,9 +572,7 @@ export class OAuthService {
   };
 
   getMarketingOptInStatus = async (): Promise<MarketingOptInResponse> => {
-    await this.refreshAccessToken();
-
-    const accessToken = this.getAccessTokenOrThrow();
+    const accessToken = await this.getValidAccessToken();
     const url = `${this.config.authServerUrl}${AUTH_SERVER_MARKETING_OPT_IN_PATH}`;
     const response = await fetch(url, {
       method: 'GET',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
**Issue**: Social-login users on RC couldn't save the Data collection for marketing toggle. It appeared to turn on but reverted to off immediately.

**Fix**: Call SeedlessOnboardingController.getAccessToken() before marketing GET/POST. Refresh token runs internally only when the token is expired or near expiry.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where the marketing data collection toggle would not stay on for social login user

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-866

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Social login marketing data collection toggle

  Scenario: Marketing toggle does not immediately snap off when turned on
    Given a social login user (Google) on a prod/RC build
    When the user opens Settings → Security & Privacy
    And turns on "Data collection for marketing"
    Then the toggle stays on (does not automatically revert to off within a few seconds)

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/f538ac3c-78db-40dc-9636-79d82fe6a1b0



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to marketing opt-in API helpers with added token refresh; no UI or broader auth flow changes, covered by updated unit tests.
> 
> **Overview**
> Fixes social-login users seeing the **Data collection for marketing** toggle flip back off when the stored OAuth access token was stale on RC/prod.
> 
> `updateMarketingOptInStatus` and `getMarketingOptInStatus` now **refresh auth tokens** via `SeedlessOnboardingController.refreshAuthTokens()` (after `whenEngineReady()`) before reading the bearer token and calling the marketing preference endpoints. Token presence is centralized in a new `getAccessTokenOrThrow()` helper.
> 
> Unit tests mock `refreshAuthTokens` and assert it runs on success, missing-token failures, and the 401 path, so marketing API calls always go through the refresh step first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a3aaff1e35ed54b6e6c459d8d5c2805480ff2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->