### PR TITLE
fix(mwp): surface deeplink connection approval in parallel with relay handshake

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -373,9 +373,10 @@ export class ConnectionRegistry {
       //   the same time, and the loading toast would linger after the error
       //   toast auto-dismisses.
       // - On success for direct deeplink flows (initialMessage present), the
-      //   connection request includes the initial RPC, so an approval will
-      //   surface immediately after the MWP handshake — it's safe to dismiss
-      //   the loading toast right away.
+      //   connection request includes the initial RPC, which Connection.connect
+      //   surfaces as an approval eagerly (in parallel with the MWP handshake),
+      //   so the approval is already on its way — it's safe to dismiss the
+      //   loading toast right away.
       // - On success for QR flows (no initialMessage), the dapp sends
       //   wallet_createSession separately after the handshake. There may be
       //   a noticeable delay before the approval appears, so we keep the

--- a/app/core/SDKConnectV2/services/connection.test.ts
+++ b/app/core/SDKConnectV2/services/connection.test.ts
@@ -326,6 +326,143 @@ describe('Connection', () => {
     });
   });
 
+  describe('eager approval for direct deeplink connections', () => {
+    const inlineRpc = {
+      name: 'metamask-multichain-provider',
+      data: { method: 'wallet_createSession', params: {}, id: 1 },
+    };
+    const sessionRequestWithInlineMessage = {
+      ...mockConnectionRequest.sessionRequest,
+      initialMessage: { type: 'message', payload: inlineRpc },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any as SessionRequest;
+
+    it('forwards the inline initialMessage to the bridge immediately, in parallel with the handshake', async () => {
+      const connection = await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      await connection.connect(sessionRequestWithInlineMessage);
+
+      // The approval is driven from the inline payload without waiting on the relay.
+      expect(mockBridgeInstance.send).toHaveBeenCalledWith(inlineRpc);
+    });
+
+    it('strips initialMessage before handing the request to the wallet client to avoid a duplicate approval', async () => {
+      const connection = await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      await connection.connect(sessionRequestWithInlineMessage);
+
+      expect(mockWalletClientInstance.connect).toHaveBeenCalledTimes(1);
+      const callArg = (mockWalletClientInstance.connect as jest.Mock).mock
+        .calls[0][0];
+      expect(callArg.sessionRequest.initialMessage).toBeUndefined();
+      expect(callArg.sessionRequest.id).toBe(
+        sessionRequestWithInlineMessage.id,
+      );
+      expect(callArg.sessionRequest.channel).toBe(
+        sessionRequestWithInlineMessage.channel,
+      );
+    });
+
+    it('does not eagerly forward anything for QR flows (no initialMessage)', async () => {
+      const connection = await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      await connection.connect(mockConnectionRequest.sessionRequest);
+
+      expect(mockBridgeInstance.send).not.toHaveBeenCalled();
+      expect(mockWalletClientInstance.connect).toHaveBeenCalledWith({
+        sessionRequest: mockConnectionRequest.sessionRequest,
+      });
+    });
+
+    it('rejects the eagerly-surfaced approval when the handshake fails', async () => {
+      const connection = await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      mockWalletClientInstance.connect = jest
+        .fn()
+        .mockRejectedValue(new Error('handshake failed'));
+      // First read (eager wallet_createSession handling) sees no pre-existing
+      // approvals; the second read (rejectEagerApproval after the handshake
+      // fails) sees the approval we just surfaced and clears it.
+      (Engine.context.ApprovalController.getTotalApprovalCount as jest.Mock)
+        .mockReturnValueOnce(0)
+        .mockReturnValue(1);
+
+      await expect(
+        connection.connect(sessionRequestWithInlineMessage),
+      ).rejects.toThrow('handshake failed');
+
+      expect(NavigationService.navigation?.goBack).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.ApprovalController.clearRequests,
+      ).toHaveBeenCalledWith(
+        providerErrors.userRejectedRequest({
+          data: { cause: 'connectionFailed' },
+        }),
+      );
+    });
+
+    it('does not send a response until the handshake has completed', async () => {
+      let resolveHandshake: () => void = () => undefined;
+      mockWalletClientInstance.connect = jest.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveHandshake = resolve;
+          }),
+      );
+
+      const connection = await Connection.create(
+        mockConnectionInfo,
+        mockKeyManager,
+        RELAY_URL,
+        mockHostApp,
+      );
+
+      // Kick off the connect but leave the handshake pending.
+      const connectPromise = connection.connect(
+        sessionRequestWithInlineMessage,
+      );
+
+      // Approve before the handshake resolves: response must be held back.
+      const responsePayload = {
+        name: 'metamask-multichain-provider',
+        data: { id: 1, result: { sessionScopes: {} } },
+      };
+      onBridgeResponseCallback(responsePayload);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockWalletClientInstance.sendResponse).not.toHaveBeenCalled();
+
+      // Once the handshake resolves, the held response is delivered.
+      resolveHandshake();
+      await connectPromise;
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockWalletClientInstance.sendResponse).toHaveBeenCalledWith(
+        responsePayload,
+      );
+    });
+  });
+
   describe('resume', () => {
     it('should call resume on its WalletClient with the connection ID', async () => {
       const connection = await Connection.create(

--- a/app/core/SDKConnectV2/services/connection.ts
+++ b/app/core/SDKConnectV2/services/connection.ts
@@ -84,6 +84,22 @@ export class Connection {
    */
   private readonly requestMap: Map<string, unknown> = new Map();
 
+  /**
+   * Resolves once the secure relay session is fully established — i.e. after
+   * the MWP handshake completes via {@link connect} or {@link resume} and the
+   * underlying WalletClient is in the `CONNECTED` state.
+   *
+   * Used to gate outbound responses. With the eager-approval optimization in
+   * {@link connect}, the connection request is surfaced to the user directly
+   * from the deeplink's inline `initialMessage` — potentially before the relay
+   * handshake has finished. Awaiting this before calling
+   * `client.sendResponse()` guarantees we never try to respond while the client
+   * is still `CONNECTING` (which throws `SESSION_INVALID_STATE` and silently
+   * drops the response). In the common case the handshake finishes long before
+   * the user acts, so this resolves instantly.
+   */
+  private clientReady: Promise<void> | null = null;
+
   private constructor(
     connInfo: ConnectionInfo,
     client: WalletClient,
@@ -95,69 +111,11 @@ export class Connection {
     this.hostApp = hostApp;
     this.bridge = new RPCBridgeAdapter(this.info);
 
-    this.client.on('message', async (payload) => {
-      const data =
-        payload && typeof payload === 'object' && 'data' in payload
-          ? (payload.data as Record<string, unknown>)
-          : undefined;
-      logger.debug('Received message:', this.id, {
-        method: data?.method,
-        id: data?.id,
-      });
-
-      const isWalletCreateSessionRequest =
-        payload &&
-        typeof payload === 'object' &&
-        'name' in payload &&
-        payload.name === 'metamask-multichain-provider' &&
-        'data' in payload &&
-        payload.data &&
-        typeof payload.data === 'object' &&
-        'method' in payload.data &&
-        payload.data.method === 'wallet_createSession';
-
-      // If the request is a wallet_createSession request and there are pending approval requests, clear those pending approvals before
-      // showing the wallet_createSession approval. We do this to prevent the user from seeing a stale wallet_createSession approval in the
-      // scenario where they make a connection request, but leave the wallet before approving or rejecting the request, return to the dapp
-      // to make a new connection request, and then finally return to the wallet to approve or reject the new connection request.
-      if (
-        isWalletCreateSessionRequest &&
-        Engine.context.ApprovalController.getTotalApprovalCount() > 0
-      ) {
-        // We must manually navigate away from the currently open approval request, otherwise an approval component may be rendered
-        // with an approval request prop that it cannot handle and cause the wallet to throw an exception.
-        NavigationService.navigation?.goBack();
-        await Engine.context.ApprovalController.clearRequests(
-          providerErrors.userRejectedRequest({
-            data: {
-              cause: 'rejectAllApprovals',
-            },
-          }),
-        );
-      }
-
-      // Record the originating request payload (keyed by multiplex channel
-      // name + JSON-RPC id) so the response handler can look up any of its
-      // fields (e.g. `method`) when the matching response arrives. At runtime
-      // BackgroundBridge wraps payloads with `{ name, data }` via the
-      // json-rpc-middleware-stream multiplex layer, but `payload` is typed as
-      // `unknown` here, so we narrow defensively.
-      const requestId = data?.id;
-      if (
-        (typeof requestId === 'number' || typeof requestId === 'string') &&
-        payload &&
-        typeof payload === 'object' &&
-        'name' in payload &&
-        typeof payload.name === 'string'
-      ) {
-        const key = `${payload.name}:${requestId}`;
-        this.requestMap.set(key, payload);
-      }
-
-      this.bridge.send(payload);
+    this.client.on('message', (payload) => {
+      void this.handleIncomingMessage(payload);
     });
 
-    this.bridge.on('response', (payload) => {
+    this.bridge.on('response', async (payload) => {
       const responseData =
         'data' in payload
           ? (payload.data as Record<string, unknown>)
@@ -232,8 +190,93 @@ export class Connection {
         }
       }
 
+      // Wait for the relay handshake to finish before responding. With the
+      // eager-approval optimization (see {@link connect}) the user can be
+      // shown the connection request before the handshake completes, so a
+      // response could otherwise be emitted while the client is still
+      // `CONNECTING`. If the handshake failed, drop the response — the
+      // connection is being torn down anyway. See {@link clientReady}.
+      if (this.clientReady) {
+        try {
+          await this.clientReady;
+        } catch {
+          return;
+        }
+      }
+
       this.client.sendResponse(payload);
     });
+  }
+
+  /**
+   * Forwards a single inbound message to the RPC bridge.
+   *
+   * Invoked both for messages that arrive over the relay (via the WalletClient
+   * `message` event) and — for direct deeplink connections — for the
+   * `initialMessage` embedded in the connection request, which {@link connect}
+   * processes eagerly so the approval surfaces without waiting for the relay
+   * handshake.
+   */
+  private async handleIncomingMessage(payload: unknown): Promise<void> {
+    const data =
+      payload && typeof payload === 'object' && 'data' in payload
+        ? (payload.data as Record<string, unknown>)
+        : undefined;
+    logger.debug('Received message:', this.id, {
+      method: data?.method,
+      id: data?.id,
+    });
+
+    const isWalletCreateSessionRequest =
+      payload &&
+      typeof payload === 'object' &&
+      'name' in payload &&
+      payload.name === 'metamask-multichain-provider' &&
+      'data' in payload &&
+      payload.data &&
+      typeof payload.data === 'object' &&
+      'method' in payload.data &&
+      payload.data.method === 'wallet_createSession';
+
+    // If the request is a wallet_createSession request and there are pending approval requests, clear those pending approvals before
+    // showing the wallet_createSession approval. We do this to prevent the user from seeing a stale wallet_createSession approval in the
+    // scenario where they make a connection request, but leave the wallet before approving or rejecting the request, return to the dapp
+    // to make a new connection request, and then finally return to the wallet to approve or reject the new connection request.
+    if (
+      isWalletCreateSessionRequest &&
+      Engine.context.ApprovalController.getTotalApprovalCount() > 0
+    ) {
+      // We must manually navigate away from the currently open approval request, otherwise an approval component may be rendered
+      // with an approval request prop that it cannot handle and cause the wallet to throw an exception.
+      NavigationService.navigation?.goBack();
+      await Engine.context.ApprovalController.clearRequests(
+        providerErrors.userRejectedRequest({
+          data: {
+            cause: 'rejectAllApprovals',
+          },
+        }),
+      );
+    }
+
+    // Record the originating request payload (keyed by multiplex channel
+    // name + JSON-RPC id) so the response handler can look up any of its
+    // fields (e.g. `method`) when the matching response arrives. At runtime
+    // BackgroundBridge wraps payloads with `{ name, data }` via the
+    // json-rpc-middleware-stream multiplex layer, but `payload` is typed as
+    // `unknown` here, so we narrow defensively.
+    const requestId = data?.id;
+    if (
+      (typeof requestId === 'number' || typeof requestId === 'string') &&
+      payload &&
+      typeof payload === 'object' &&
+      'name' in payload &&
+      typeof payload.name === 'string'
+    ) {
+      const key = `${payload.name}:${requestId}`;
+      this.requestMap.set(key, payload);
+    }
+
+    this.bridge.send(payload);
   }
 
   /**
@@ -266,16 +309,79 @@ export class Connection {
   /**
    * Connects the connection to the dApp.
    * @param sessionRequest - The session request.
+   *
+   * Direct deeplink connections embed the initial RPC (typically
+   * `wallet_createSession`) in `sessionRequest.initialMessage`. The approval UI
+   * is driven entirely by that inline payload and does NOT need the relay — only
+   * the eventual *response* delivery does. So we surface the approval
+   * immediately, in parallel with the MWP handshake, rather than waiting for the
+   * handshake (WebSocket connect + channel subscribes + handshake-offer publish)
+   * to complete before the user can even see the request. This removes those
+   * relay round-trips from the time-to-prompt critical path, which is the main
+   * source of the perceived "deeplink connection is slow to prompt" latency.
+   *
+   * The inline message is stripped before the request is handed to the wallet
+   * client so the client does not replay it after the handshake (see the wallet
+   * client's `_processInitialMessage`), which would surface a duplicate
+   * approval.
    */
   public async connect(sessionRequest: SessionRequest): Promise<void> {
-    await this.client.connect({ sessionRequest });
+    const { initialMessage } = sessionRequest;
+
+    if (initialMessage) {
+      // Fire-and-forget: drives the approval modal from the inline payload
+      // while the handshake below runs concurrently.
+      void this.handleIncomingMessage(initialMessage.payload);
+    }
+
+    try {
+      this.clientReady = this.client.connect({
+        sessionRequest: initialMessage
+          ? { ...sessionRequest, initialMessage: undefined }
+          : sessionRequest,
+      });
+      await this.clientReady;
+    } catch (error) {
+      // The handshake failed after we eagerly surfaced the approval. Reject the
+      // pending approval so the user isn't left looking at a connection request
+      // whose response can never be delivered.
+      if (initialMessage) {
+        await this.rejectEagerApproval();
+      }
+      throw error;
+    }
   }
 
   /**
    * Resumes a previously established session.
    */
   public async resume(): Promise<void> {
-    await this.client.resume(this.id);
+    this.clientReady = this.client.resume(this.id);
+    await this.clientReady;
+  }
+
+  /**
+   * Rejects an approval that was eagerly surfaced from a deeplink's inline
+   * `initialMessage` when the subsequent relay handshake fails. Mirrors the
+   * superseded-request cleanup in {@link handleIncomingMessage}: navigate away
+   * from the open approval first so a stale approval component isn't left
+   * mounted, then clear the pending request(s).
+   */
+  private async rejectEagerApproval(): Promise<void> {
+    try {
+      if (Engine.context.ApprovalController.getTotalApprovalCount() > 0) {
+        NavigationService.navigation?.goBack();
+        await Engine.context.ApprovalController.clearRequests(
+          providerErrors.userRejectedRequest({
+            data: {
+              cause: 'connectionFailed',
+            },
+          }),
+        );
+      }
+    } catch (error) {
+      logger.error('Failed to reject eager approval', this.id, error);
+    }
   }
 
   /**


### PR DESCRIPTION
## **Description**

Connection requests initiated via **deeplink** take several seconds to surface the connection approval modal in MetaMask Mobile — even though the deeplink already carries the full CAIP-25 `wallet_createSession` request inline (as `sessionRequest.initialMessage`). The wallet therefore has everything it needs to prompt the user immediately, yet the prompt is delayed.

**Root cause (verified from source).** The inline request is parsed right away, but it is not used to drive the approval until the entire MWP relay handshake completes. The wallet client replays `initialMessage` as the *last* step of `TrustedConnectionHandler.execute()` — after `transport.connect()`, two channel `subscribe`s, the `handshake-offer` publish, and session persistence. Those relay round-trips end up on the time-to-prompt critical path, even though the prompt itself does not need the relay. The relay session is only genuinely required to deliver the *response* back to the dapp after the user acts.

**Fix.** `Connection.connect()` now:
1. Forwards the inline `initialMessage` to the RPC bridge **immediately**, in parallel with the handshake, so the approval modal is driven straight from the deeplink data.
2. **Strips** `initialMessage` before handing the request to the wallet client, so the client does not replay it post-handshake (which would surface a duplicate approval).
3. **Gates** outbound responses on handshake completion (`clientReady`) so a response is never sent while the client is still `CONNECTING`.
4. **Rejects** the eagerly-surfaced approval if the handshake ultimately fails, so the user is never left with a prompt whose response can't be delivered.

QR flows (no `initialMessage`) are unchanged.

## **Changelog**

CHANGELOG entry: Fixed slow connection prompt when connecting to a dapp via deeplink

## **Related issues**

Fixes: WAPI-1564

## **Manual testing steps**

Feature: Deeplink dapp connection

  Scenario: user connects to a dapp via deeplink from a mobile browser
  Given the user has MetaMask Mobile installed and unlocked
  And the user opens a Connect-SDK dapp in a mobile browser (e.g. https://demo-mmc-wagmi.vercel.app/)

  When the user taps "Connect" and is deeplinked into MetaMask Mobile
  Then the connection approval modal appears almost immediately (driven by the inline request), instead of after a multi-second relay handshake
  And approving connects the dapp correctly
  And rejecting delivers the rejection to the dapp
  And QR-code connection flows still behave as before

## **Screenshots/Recordings**

### **Before**

<!-- Multi-second delay before the connection modal appears (see WAPI-1564 recording). -->

### **After**

<!-- Connection modal appears near-instantly on deeplink. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of connection approvals and response delivery in SDKConnectV2, but scope is limited to deeplink `initialMessage` paths with explicit gating and failure cleanup; QR flows are untouched.
> 
> **Overview**
> Deeplink MWP connects no longer wait for the full relay handshake before showing the connection approval. **`Connection.connect`** now forwards `sessionRequest.initialMessage` (typically `wallet_createSession`) to the RPC bridge **immediately**, while the wallet client handshake runs in parallel with **`initialMessage` stripped** so the client does not replay it and duplicate the prompt.
> 
> Outbound JSON-RPC responses are **held until `clientReady`** (handshake or resume completes), avoiding `sendResponse` while the client is still `CONNECTING`. If the handshake fails after eager approval, **`rejectEagerApproval`** clears the pending approval with cause `connectionFailed`. **`resume`** also sets `clientReady` for the same gating behavior.
> 
> QR flows without `initialMessage` are unchanged. **`connection-registry`** only updates comments on when the loading toast is dismissed for direct deeplink success. New unit tests cover eager forward, strip, QR, handshake failure cleanup, and response deferral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1825a53d9f08670353cf73b3fe58c0a7f76e5ce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->