### PR TITLE
feat(networking): integrate nitro-websockets

### DIFF
--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -32,6 +32,7 @@ import io.metamask.nativeModules.RNTar.RNTarPackage
 import io.metamask.nativeModules.NotificationPackage
 import com.braze.BrazeActivityLifecycleCallbackListener
 import com.margelo.nitro.nitrofetch.AutoPrefetcher
+import com.margelo.nitro.nitrofetchwebsockets.NitroWebSocketAutoPrewarmer
 
 class MainApplication : Application(), ShareApplication, ReactApplication {
 
@@ -107,6 +108,14 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
             AutoPrefetcher.prefetchOnStart(this)
         } catch (_: Throwable) {
             // Non-fatal: if prefetch fails the app continues on the standard fetch path.
+        }
+
+        // Fire prewarmOnAppStart queue for WebSocket connections before JS loads.
+        // iOS is auto-bootstrapped via the Nitro +load hook.
+        try {
+            NitroWebSocketAutoPrewarmer.prewarmOnStart(this)
+        } catch (_: Throwable) {
+            // Non-fatal: prewarm is a cold-start optimisation.
         }
 
         loadReactNative(this)

--- a/android/app/src/main/java/io/metamask/MainApplication.kt
+++ b/android/app/src/main/java/io/metamask/MainApplication.kt
@@ -32,7 +32,6 @@ import io.metamask.nativeModules.RNTar.RNTarPackage
 import io.metamask.nativeModules.NotificationPackage
 import com.braze.BrazeActivityLifecycleCallbackListener
 import com.margelo.nitro.nitrofetch.AutoPrefetcher
-import com.margelo.nitro.nitrofetchwebsockets.NitroWebSocketAutoPrewarmer
 
 class MainApplication : Application(), ShareApplication, ReactApplication {
 
@@ -108,14 +107,6 @@ class MainApplication : Application(), ShareApplication, ReactApplication {
             AutoPrefetcher.prefetchOnStart(this)
         } catch (_: Throwable) {
             // Non-fatal: if prefetch fails the app continues on the standard fetch path.
-        }
-
-        // Fire prewarmOnAppStart queue for WebSocket connections before JS loads.
-        // iOS is auto-bootstrapped via the Nitro +load hook.
-        try {
-            NitroWebSocketAutoPrewarmer.prewarmOnStart(this)
-        } catch (_: Throwable) {
-            // Non-fatal: prewarm is a cold-start optimisation.
         }
 
         loadReactNative(this)

--- a/app/core/AppStateWebSocketManager.test.ts
+++ b/app/core/AppStateWebSocketManager.test.ts
@@ -84,6 +84,66 @@ describe('AppStateWebSocketManager', () => {
       expect(mockWebSocketService.disconnect).not.toHaveBeenCalled();
       expect(mockWebSocketService.connect).not.toHaveBeenCalled();
     });
+
+    it('serialises rapid background→active→background: no concurrent calls, ends disconnected', async () => {
+      // Simulate connect taking time so rapid changes can pile up.
+      let resolveConnect!: () => void;
+      mockWebSocketService.connect.mockReturnValue(
+        new Promise<void>((res) => {
+          resolveConnect = res;
+        }),
+      );
+
+      new AppStateWebSocketManager(mockWebSocketService);
+
+      // background starts disconnect (instant), then active starts connect (held)
+      const bgPromise = appStateChangeHandler('background');
+      await bgPromise; // disconnect resolves immediately
+
+      const activePromise = appStateChangeHandler('active'); // connect is now in-flight
+
+      // background arrives while connect is still pending — must not start a second disconnect
+      const bg2Promise = appStateChangeHandler('background');
+
+      // Only one connect call must be in flight; no second disconnect yet
+      expect(mockWebSocketService.connect).toHaveBeenCalledTimes(1);
+      expect(mockWebSocketService.disconnect).toHaveBeenCalledTimes(1);
+
+      // Let connect finish — the pending 'background' should now trigger disconnect
+      resolveConnect();
+      await Promise.all([activePromise, bg2Promise]);
+
+      expect(mockWebSocketService.disconnect).toHaveBeenCalledTimes(2);
+      expect(mockWebSocketService.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('serialises rapid active→background→active: ends connected, connect called once', async () => {
+      let resolveDisconnect!: () => void;
+      mockWebSocketService.disconnect.mockReturnValue(
+        new Promise<void>((res) => {
+          resolveDisconnect = res;
+        }),
+      );
+
+      new AppStateWebSocketManager(mockWebSocketService);
+
+      const activePromise = appStateChangeHandler('active');
+      await activePromise; // connect resolves immediately
+
+      const bgPromise = appStateChangeHandler('background'); // disconnect in-flight
+
+      // active arrives while disconnect is pending — must not start a second connect
+      const active2Promise = appStateChangeHandler('active');
+
+      expect(mockWebSocketService.disconnect).toHaveBeenCalledTimes(1);
+      expect(mockWebSocketService.connect).toHaveBeenCalledTimes(1);
+
+      resolveDisconnect();
+      await Promise.all([bgPromise, active2Promise]);
+
+      expect(mockWebSocketService.connect).toHaveBeenCalledTimes(2);
+      expect(mockWebSocketService.disconnect).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('cleanup', () => {

--- a/app/core/AppStateWebSocketManager.ts
+++ b/app/core/AppStateWebSocketManager.ts
@@ -15,6 +15,12 @@ export class AppStateWebSocketManager {
   private appStateSubscription: NativeEventSubscription | null = null;
   private webSocketService: BackendWebSocketService | null = null;
 
+  // Rapid state changes (background→active→background faster than a connect/disconnect
+  // resolves) are serialised: only one operation runs at a time and the most-recently
+  // requested state is always the one ultimately applied.
+  private _pendingState: AppStateStatus | null = null;
+  private _processing = false;
+
   /**
    * Initialize the manager with WebSocket service
    *
@@ -36,25 +42,39 @@ export class AppStateWebSocketManager {
   }
 
   /**
-   * Handle app state changes for WebSocket lifecycle management
+   * Handle app state changes for WebSocket lifecycle management.
+   *
+   * Non-reentrant: if a connect/disconnect is already in flight, the new state
+   * is recorded as pending and processed immediately after the current operation
+   * completes. Only the latest pending state is kept — intermediate states that
+   * arrive while processing are coalesced so the socket always ends up in the
+   * correct final state without concurrent connect/disconnect calls.
    *
    * @param nextAppState - The new app state
    */
   private async handleAppStateChange(
     nextAppState: AppStateStatus,
   ): Promise<void> {
-    if (!this.webSocketService) {
-      return;
+    this._pendingState = nextAppState;
+    if (this._processing) return;
+    this._processing = true;
+
+    while (this._pendingState !== null) {
+      const state = this._pendingState;
+      this._pendingState = null;
+      await this._applyState(state);
     }
 
+    this._processing = false;
+  }
+
+  private async _applyState(state: AppStateStatus): Promise<void> {
+    if (!this.webSocketService) return;
     try {
-      if (nextAppState === 'background') {
-        // Disconnect WebSocket when app goes to background to save resources
+      if (state === 'background') {
         await this.webSocketService.disconnect();
         Logger.log('WebSocket disconnected due to app entering background');
-      } else if (nextAppState === 'active') {
-        // Reconnect WebSocket when app becomes active
-        // The WebSocket service will check its enabledCallback internally
+      } else if (state === 'active') {
         await this.webSocketService.connect();
         Logger.log(
           'WebSocket reconnection attempt completed (service handles feature flag check)',

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -75,6 +75,56 @@ describe('NitroWebSocketSetup', () => {
     });
   });
 
+  describe('hasTestOverrides guard', () => {
+    it('does not replace global.WebSocket or prewarm when hasTestOverrides is true', async () => {
+      const localPrewarm = jest.fn();
+      const sentinel = function sentinelWebSocket() {
+        // Sentinel: left untouched if the module is correctly guarded.
+      };
+      const previousWebSocket = global.WebSocket;
+      global.WebSocket = sentinel as unknown as typeof WebSocket;
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('react-native-nitro-websockets', () => ({
+          NitroWebSocket: jest.fn(),
+          prewarmOnAppStart: localPrewarm,
+        }));
+        jest.doMock('../util/test/utils', () => ({
+          hasTestOverrides: true,
+        }));
+
+        await import('./NitroWebSocketSetup');
+      });
+
+      expect(global.WebSocket).toBe(sentinel);
+      expect(localPrewarm).not.toHaveBeenCalled();
+
+      global.WebSocket = previousWebSocket;
+    });
+  });
+
+  describe('prewarm error handling', () => {
+    it('does not throw when prewarmOnAppStart throws on install', async () => {
+      const previousWebSocket = global.WebSocket;
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('react-native-nitro-websockets', () => ({
+          NitroWebSocket: jest.fn(),
+          prewarmOnAppStart: jest.fn(() => {
+            throw new Error('prewarm boom');
+          }),
+        }));
+        jest.doMock('../util/test/utils', () => ({
+          hasTestOverrides: false,
+        }));
+
+        await expect(import('./NitroWebSocketSetup')).resolves.toBeDefined();
+      });
+
+      global.WebSocket = previousWebSocket;
+    });
+  });
+
   describe('NitroWebSocketAdapter — static constants', () => {
     it('exposes CONNECTING as 0', () => {
       expect(global.WebSocket.CONNECTING).toBe(0);
@@ -252,13 +302,15 @@ describe('NitroWebSocketSetup', () => {
       expect(ws.onopen).toBe(handler);
     });
 
-    it('fires onopen when the native socket opens', () => {
+    it('fires onopen with an open event when the native socket opens', () => {
       const handler = jest.fn();
       ws.onopen = handler;
 
       mockWsInstance.onopen?.();
 
-      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'open' }),
+      );
     });
 
     it('stores and retrieves onmessage handler', () => {
@@ -274,7 +326,9 @@ describe('NitroWebSocketSetup', () => {
 
       mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
 
-      expect(handler).toHaveBeenCalledWith({ data: 'hello' });
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'hello' }),
+      );
     });
 
     it('stores and retrieves onclose handler', () => {
@@ -287,15 +341,21 @@ describe('NitroWebSocketSetup', () => {
     it('fires onclose with close event when native socket closes', () => {
       const handler = jest.fn();
       ws.onclose = handler;
-      const closeEvent: MockNitroCloseEvent = {
+
+      mockWsInstance.onclose?.({
         code: 1000,
         reason: 'normal',
         wasClean: true,
-      };
+      });
 
-      mockWsInstance.onclose?.(closeEvent);
-
-      expect(handler).toHaveBeenCalledWith(closeEvent);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'close',
+          code: 1000,
+          reason: 'normal',
+          wasClean: true,
+        }),
+      );
     });
 
     it('stores and retrieves onerror handler', () => {
@@ -305,13 +365,18 @@ describe('NitroWebSocketSetup', () => {
       expect(ws.onerror).toBe(handler);
     });
 
-    it('fires onerror with error string when native socket errors', () => {
+    it('fires onerror with an error event carrying the message when native socket errors', () => {
       const handler = jest.fn();
       ws.onerror = handler;
 
       mockWsInstance.onerror?.('connection refused');
 
-      expect(handler).toHaveBeenCalledWith('connection refused');
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          message: 'connection refused',
+        }),
+      );
     });
 
     it('does not fire onopen after it is reassigned to null', () => {
@@ -344,7 +409,9 @@ describe('NitroWebSocketSetup', () => {
         binaryData: binary,
       });
 
-      expect(handler).toHaveBeenCalledWith({ data: binary });
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: binary }),
+      );
     });
 
     it('falls back to data string when binaryData is undefined on a binary frame', () => {
@@ -357,7 +424,9 @@ describe('NitroWebSocketSetup', () => {
         binaryData: undefined,
       });
 
-      expect(handler).toHaveBeenCalledWith({ data: 'fallback' });
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'fallback' }),
+      );
     });
 
     it('falls back to data string when binaryData is null on a binary frame', () => {
@@ -370,7 +439,9 @@ describe('NitroWebSocketSetup', () => {
         binaryData: null,
       });
 
-      expect(handler).toHaveBeenCalledWith({ data: 'fallback' });
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'fallback' }),
+      );
     });
 
     it('delivers data string for non-binary frames', () => {
@@ -379,7 +450,9 @@ describe('NitroWebSocketSetup', () => {
 
       mockWsInstance.onmessage?.({ isBinary: false, data: 'text-payload' });
 
-      expect(handler).toHaveBeenCalledWith({ data: 'text-payload' });
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'text-payload' }),
+      );
     });
   });
 
@@ -406,30 +479,40 @@ describe('NitroWebSocketSetup', () => {
 
       mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
 
-      expect(listener).toHaveBeenCalledWith({ data: 'hello' });
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'hello' }),
+      );
     });
 
     it('fires close listener added via addEventListener with close event', () => {
       const listener = jest.fn();
       ws.addEventListener('close', listener);
-      const closeEvent: MockNitroCloseEvent = {
+
+      mockWsInstance.onclose?.({
         code: 1001,
         reason: 'going away',
         wasClean: false,
-      };
+      });
 
-      mockWsInstance.onclose?.(closeEvent);
-
-      expect(listener).toHaveBeenCalledWith(closeEvent);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'close',
+          code: 1001,
+          reason: 'going away',
+          wasClean: false,
+        }),
+      );
     });
 
-    it('fires error listener added via addEventListener with error string', () => {
+    it('fires error listener added via addEventListener with error event', () => {
       const listener = jest.fn();
       ws.addEventListener('error', listener);
 
       mockWsInstance.onerror?.('timeout');
 
-      expect(listener).toHaveBeenCalledWith('timeout');
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', message: 'timeout' }),
+      );
     });
 
     it('fires all listeners when multiple are added for the same event', () => {
@@ -450,6 +533,39 @@ describe('NitroWebSocketSetup', () => {
       ws.addEventListener('open', listener);
 
       mockWsInstance.onopen?.();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires a { once: true } listener only on the first event', () => {
+      const listener = jest.fn();
+      ws.addEventListener('open', listener, { once: true });
+
+      mockWsInstance.onopen?.();
+      mockWsInstance.onopen?.();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not register a listener when the provided signal is already aborted', () => {
+      const controller = new AbortController();
+      controller.abort();
+      const listener = jest.fn();
+      ws.addEventListener('open', listener, { signal: controller.signal });
+
+      mockWsInstance.onopen?.();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('removes a signal-bound listener when the signal aborts', () => {
+      const controller = new AbortController();
+      const listener = jest.fn();
+      ws.addEventListener('message', listener, { signal: controller.signal });
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'first' });
+      controller.abort();
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'second' });
 
       expect(listener).toHaveBeenCalledTimes(1);
     });
@@ -517,6 +633,53 @@ describe('NitroWebSocketSetup', () => {
     });
   });
 
+  describe('NitroWebSocketAdapter — dispatchEvent', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('invokes close listeners with an externally dispatched close event', () => {
+      // Mirrors @nktkas/rews dispatching a synthetic CloseEvent on connect timeout.
+      const listener = jest.fn();
+      ws.addEventListener('close', listener);
+      const closeEvent = {
+        type: 'close',
+        code: 3008,
+        reason: 'Timeout',
+        wasClean: false,
+      };
+
+      const result = ws.dispatchEvent(closeEvent as unknown as Event);
+
+      expect(listener).toHaveBeenCalledWith(closeEvent);
+      expect(result).toBe(true);
+    });
+
+    it('invokes the .onclose handler on an externally dispatched close event', () => {
+      const handler = jest.fn();
+      ws.onclose = handler;
+      const closeEvent = {
+        type: 'close',
+        code: 1006,
+        reason: '',
+        wasClean: false,
+      };
+
+      ws.dispatchEvent(closeEvent as unknown as Event);
+
+      expect(handler).toHaveBeenCalledWith(closeEvent);
+    });
+
+    it('does not throw when dispatching an unknown event type', () => {
+      expect(() =>
+        ws.dispatchEvent({ type: 'custom' } as unknown as Event),
+      ).not.toThrow();
+    });
+  });
+
   describe('NitroWebSocketAdapter — .onX and addEventListener composition', () => {
     let ws: WebSocket;
 
@@ -545,8 +708,12 @@ describe('NitroWebSocketSetup', () => {
 
       mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
 
-      expect(onXHandler).toHaveBeenCalledWith({ data: 'hello' });
-      expect(addedListener).toHaveBeenCalledWith({ data: 'hello' });
+      expect(onXHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'hello' }),
+      );
+      expect(addedListener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'message', data: 'hello' }),
+      );
     });
 
     it('fires both .onclose and a close addEventListener listener with the same close event', () => {
@@ -554,16 +721,17 @@ describe('NitroWebSocketSetup', () => {
       const addedListener = jest.fn();
       ws.onclose = onXHandler;
       ws.addEventListener('close', addedListener);
-      const closeEvent: MockNitroCloseEvent = {
+
+      mockWsInstance.onclose?.({ code: 1000, reason: 'done', wasClean: true });
+
+      const expected = expect.objectContaining({
+        type: 'close',
         code: 1000,
         reason: 'done',
         wasClean: true,
-      };
-
-      mockWsInstance.onclose?.(closeEvent);
-
-      expect(onXHandler).toHaveBeenCalledWith(closeEvent);
-      expect(addedListener).toHaveBeenCalledWith(closeEvent);
+      });
+      expect(onXHandler).toHaveBeenCalledWith(expected);
+      expect(addedListener).toHaveBeenCalledWith(expected);
     });
 
     it('fires both .onerror and an error addEventListener listener with the same error', () => {
@@ -574,8 +742,12 @@ describe('NitroWebSocketSetup', () => {
 
       mockWsInstance.onerror?.('network error');
 
-      expect(onXHandler).toHaveBeenCalledWith('network error');
-      expect(addedListener).toHaveBeenCalledWith('network error');
+      const expected = expect.objectContaining({
+        type: 'error',
+        message: 'network error',
+      });
+      expect(onXHandler).toHaveBeenCalledWith(expected);
+      expect(addedListener).toHaveBeenCalledWith(expected);
     });
   });
 
@@ -598,6 +770,32 @@ describe('NitroWebSocketSetup', () => {
       ws.send(buffer);
 
       expect(mockWsInstance.send).toHaveBeenCalledWith(buffer);
+    });
+
+    it('normalizes a Uint8Array to its backing ArrayBuffer before sending', () => {
+      const view = new Uint8Array([1, 2, 3, 4]);
+
+      (ws as unknown as { send(data: ArrayBufferView): void }).send(view);
+
+      expect(mockWsInstance.send).toHaveBeenCalledTimes(1);
+      const sent = mockWsInstance.send.mock.calls[0][0];
+      // Must be a raw buffer, not the typed-array view that was passed in.
+      expect(ArrayBuffer.isView(sent)).toBe(false);
+      expect(sent.byteLength).toBe(4);
+      expect(Array.from(new Uint8Array(sent))).toEqual([1, 2, 3, 4]);
+    });
+
+    it('sends only the view byte range for a partial Uint8Array, not the whole buffer', () => {
+      // View over bytes [1,2] of a 4-byte buffer; the whole buffer must NOT leak.
+      const backing = new Uint8Array([10, 20, 30, 40]).buffer;
+      const view = new Uint8Array(backing, 1, 2);
+
+      (ws as unknown as { send(data: ArrayBufferView): void }).send(view);
+
+      const sent = mockWsInstance.send.mock.calls[0][0];
+      expect(ArrayBuffer.isView(sent)).toBe(false);
+      expect(sent.byteLength).toBe(2);
+      expect(Array.from(new Uint8Array(sent))).toEqual([20, 30]);
     });
   });
 

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -1,7 +1,4 @@
-import {
-  NitroWebSocket,
-  prewarmOnAppStart,
-} from 'react-native-nitro-websockets';
+import { NitroWebSocket } from 'react-native-nitro-websockets';
 
 interface MockNitroMessageEvent {
   isBinary: boolean;
@@ -48,15 +45,11 @@ jest.mock('react-native-nitro-websockets', () => ({
     };
     return mockWsInstance;
   }),
-  prewarmOnAppStart: jest.fn(),
 }));
 
 import './NitroWebSocketSetup';
 
 const MockNitroWebSocket = jest.mocked(NitroWebSocket);
-const mockPrewarmOnAppStart = jest.mocked(prewarmOnAppStart);
-
-const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
 
 describe('NitroWebSocketSetup', () => {
   describe('module-level side effects', () => {
@@ -65,15 +58,10 @@ describe('NitroWebSocketSetup', () => {
 
       expect(MockNitroWebSocket).toHaveBeenCalled();
     });
-
-    it('registers the MetaMask gateway URL for native prewarm', () => {
-      expect(mockPrewarmOnAppStart).toHaveBeenCalledWith(GATEWAY_URL);
-    });
   });
 
   describe('hasTestOverrides guard', () => {
-    it('skips installation and prewarm when hasTestOverrides is true', async () => {
-      const localPrewarm = jest.fn();
+    it('skips installation when hasTestOverrides is true', async () => {
       const sentinel = function sentinelWebSocket() {
         // Sentinel: must remain untouched if the guard works correctly.
       };
@@ -83,7 +71,6 @@ describe('NitroWebSocketSetup', () => {
       await jest.isolateModulesAsync(async () => {
         jest.doMock('react-native-nitro-websockets', () => ({
           NitroWebSocket: jest.fn(),
-          prewarmOnAppStart: localPrewarm,
         }));
         jest.doMock('../util/test/utils', () => ({
           hasTestOverrides: true,
@@ -93,29 +80,6 @@ describe('NitroWebSocketSetup', () => {
       });
 
       expect(global.WebSocket).toBe(sentinel);
-      expect(localPrewarm).not.toHaveBeenCalled();
-
-      global.WebSocket = previousWebSocket;
-    });
-  });
-
-  describe('prewarm error handling', () => {
-    it('does not throw when prewarmOnAppStart throws', async () => {
-      const previousWebSocket = global.WebSocket;
-
-      await jest.isolateModulesAsync(async () => {
-        jest.doMock('react-native-nitro-websockets', () => ({
-          NitroWebSocket: jest.fn(),
-          prewarmOnAppStart: jest.fn(() => {
-            throw new Error('prewarm boom');
-          }),
-        }));
-        jest.doMock('../util/test/utils', () => ({
-          hasTestOverrides: false,
-        }));
-
-        await expect(import('./NitroWebSocketSetup')).resolves.toBeDefined();
-      });
 
       global.WebSocket = previousWebSocket;
     });

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -193,6 +193,27 @@ describe('NitroWebSocketSetup', () => {
 
       expect(ws.readyState).toBe(3);
     });
+
+    it('warns in __DEV__ when readyState is unrecognised', () => {
+      const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation((_msg: string) => {
+          // suppress output
+        });
+      const globalRecord = global as unknown as Record<string, unknown>;
+      const originalDev = globalRecord.__DEV__;
+      globalRecord.__DEV__ = true;
+      mockWsInstance.readyState = 'UNKNOWN';
+
+      const state = ws.readyState;
+
+      expect(state).toBe(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown readyState'),
+      );
+      globalRecord.__DEV__ = originalDev;
+      warnSpy.mockRestore();
+    });
   });
 
   describe('NitroWebSocketAdapter — pass-through getters', () => {
@@ -450,6 +471,19 @@ describe('NitroWebSocketSetup', () => {
 
       expect(listener).toHaveBeenCalledTimes(1);
     });
+
+    it('removes a signal-bound listener when the signal aborts before any event fires', () => {
+      // Covers the rapid-teardown scenario: abort happens immediately after
+      // registration, before the socket has dispatched a single event.
+      const controller = new AbortController();
+      const listener = jest.fn();
+      ws.addEventListener('message', listener, { signal: controller.signal });
+
+      controller.abort();
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
   });
 
   describe('NitroWebSocketAdapter — removeEventListener', () => {
@@ -572,6 +606,24 @@ describe('NitroWebSocketSetup', () => {
         'abort',
         expect.any(Function),
       );
+    });
+
+    it('clears all listener maps when the socket closes', () => {
+      const ws2 = new global.WebSocket('wss://example.com');
+      const openListener = jest.fn();
+      const messageListener = jest.fn();
+      ws2.addEventListener('open', openListener);
+      ws2.addEventListener('message', messageListener);
+
+      mockWsInstance.onclose?.({ code: 1000, reason: 'done', wasClean: true });
+
+      // Maps cleared — externally dispatched events (as @nktkas/rews does) must
+      // not reach listeners that were registered before close.
+      ws2.dispatchEvent({ type: 'open' } as unknown as Event);
+      ws2.dispatchEvent({ type: 'message', data: 'late' } as unknown as Event);
+
+      expect(openListener).not.toHaveBeenCalled();
+      expect(messageListener).not.toHaveBeenCalled();
     });
 
     it('does not throw when the signal aborts after the socket has already closed', () => {

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -60,26 +60,22 @@ const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
 
 describe('NitroWebSocketSetup', () => {
   describe('module-level side effects', () => {
-    it('replaces global.WebSocket on module load', () => {
+    it('installs NitroWebSocketAdapter as global.WebSocket', () => {
       new global.WebSocket('wss://example.com');
 
       expect(MockNitroWebSocket).toHaveBeenCalled();
     });
 
-    it('calls prewarmOnAppStart with the MetaMask gateway URL on module load', () => {
+    it('registers the MetaMask gateway URL for native prewarm', () => {
       expect(mockPrewarmOnAppStart).toHaveBeenCalledWith(GATEWAY_URL);
-    });
-
-    it('calls prewarmOnAppStart exactly once', () => {
-      expect(mockPrewarmOnAppStart).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('hasTestOverrides guard', () => {
-    it('does not replace global.WebSocket or prewarm when hasTestOverrides is true', async () => {
+    it('skips installation and prewarm when hasTestOverrides is true', async () => {
       const localPrewarm = jest.fn();
       const sentinel = function sentinelWebSocket() {
-        // Sentinel: left untouched if the module is correctly guarded.
+        // Sentinel: must remain untouched if the guard works correctly.
       };
       const previousWebSocket = global.WebSocket;
       global.WebSocket = sentinel as unknown as typeof WebSocket;
@@ -104,7 +100,7 @@ describe('NitroWebSocketSetup', () => {
   });
 
   describe('prewarm error handling', () => {
-    it('does not throw when prewarmOnAppStart throws on install', async () => {
+    it('does not throw when prewarmOnAppStart throws', async () => {
       const previousWebSocket = global.WebSocket;
 
       await jest.isolateModulesAsync(async () => {
@@ -126,19 +122,10 @@ describe('NitroWebSocketSetup', () => {
   });
 
   describe('NitroWebSocketAdapter — static constants', () => {
-    it('exposes CONNECTING as 0', () => {
+    it('exposes W3C ready state constants 0–3', () => {
       expect(global.WebSocket.CONNECTING).toBe(0);
-    });
-
-    it('exposes OPEN as 1', () => {
       expect(global.WebSocket.OPEN).toBe(1);
-    });
-
-    it('exposes CLOSING as 2', () => {
       expect(global.WebSocket.CLOSING).toBe(2);
-    });
-
-    it('exposes CLOSED as 3', () => {
       expect(global.WebSocket.CLOSED).toBe(3);
     });
   });
@@ -148,17 +135,7 @@ describe('NitroWebSocketSetup', () => {
       jest.clearAllMocks();
     });
 
-    it('passes url to NitroWebSocket', () => {
-      new global.WebSocket('wss://test.example.com');
-
-      expect(MockNitroWebSocket).toHaveBeenCalledWith(
-        'wss://test.example.com',
-        undefined,
-        undefined,
-      );
-    });
-
-    it('passes protocols array to NitroWebSocket', () => {
+    it('passes url and protocols array to NitroWebSocket', () => {
       new global.WebSocket('wss://test.example.com', ['proto1', 'proto2']);
 
       expect(MockNitroWebSocket).toHaveBeenCalledWith(
@@ -168,7 +145,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('passes single protocol string to NitroWebSocket', () => {
+    it('passes url and single protocol string to NitroWebSocket', () => {
       new global.WebSocket('wss://test.example.com', 'proto1');
 
       expect(MockNitroWebSocket).toHaveBeenCalledWith(
@@ -180,27 +157,14 @@ describe('NitroWebSocketSetup', () => {
   });
 
   describe('NitroWebSocketAdapter — instance constants', () => {
-    let ws: WebSocket;
+    it('exposes W3C ready state constants 0–3 on instances', () => {
+      const ws = new global.WebSocket('wss://example.com');
+      const instance = ws as unknown as Record<string, number>;
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-      ws = new global.WebSocket('wss://example.com');
-    });
-
-    it('exposes CONNECTING as 0 on instance', () => {
-      expect((ws as unknown as { CONNECTING: number }).CONNECTING).toBe(0);
-    });
-
-    it('exposes OPEN as 1 on instance', () => {
-      expect((ws as unknown as { OPEN: number }).OPEN).toBe(1);
-    });
-
-    it('exposes CLOSING as 2 on instance', () => {
-      expect((ws as unknown as { CLOSING: number }).CLOSING).toBe(2);
-    });
-
-    it('exposes CLOSED as 3 on instance', () => {
-      expect((ws as unknown as { CLOSED: number }).CLOSED).toBe(3);
+      expect(instance.CONNECTING).toBe(0);
+      expect(instance.OPEN).toBe(1);
+      expect(instance.CLOSING).toBe(2);
+      expect(instance.CLOSED).toBe(3);
     });
   });
 
@@ -212,28 +176,16 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('maps CONNECTING string to 0', () => {
-      mockWsInstance.readyState = 'CONNECTING';
-
-      expect(ws.readyState).toBe(0);
-    });
-
-    it('maps OPEN string to 1', () => {
-      mockWsInstance.readyState = 'OPEN';
-
-      expect(ws.readyState).toBe(1);
-    });
-
-    it('maps CLOSING string to 2', () => {
-      mockWsInstance.readyState = 'CLOSING';
-
-      expect(ws.readyState).toBe(2);
-    });
-
-    it('maps CLOSED string to 3', () => {
-      mockWsInstance.readyState = 'CLOSED';
-
-      expect(ws.readyState).toBe(3);
+    it('maps CONNECTING/OPEN/CLOSING/CLOSED strings to 0/1/2/3', () => {
+      for (const [state, value] of [
+        ['CONNECTING', 0],
+        ['OPEN', 1],
+        ['CLOSING', 2],
+        ['CLOSED', 3],
+      ] as const) {
+        mockWsInstance.readyState = state;
+        expect(ws.readyState).toBe(value);
+      }
     });
 
     it('falls back to CLOSED (3) for an unrecognised readyState string', () => {
@@ -244,26 +196,12 @@ describe('NitroWebSocketSetup', () => {
   });
 
   describe('NitroWebSocketAdapter — pass-through getters', () => {
-    let ws: WebSocket;
+    it('proxies url, protocol, bufferedAmount, and extensions from the native socket', () => {
+      const ws = new global.WebSocket('wss://example.com');
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-      ws = new global.WebSocket('wss://example.com');
-    });
-
-    it('returns url from native socket', () => {
       expect(ws.url).toBe('wss://example.com');
-    });
-
-    it('returns protocol from native socket', () => {
       expect(ws.protocol).toBe('mock-protocol');
-    });
-
-    it('returns bufferedAmount from native socket', () => {
       expect(ws.bufferedAmount).toBe(42);
-    });
-
-    it('returns extensions from native socket', () => {
       expect(ws.extensions).toBe('permessage-deflate');
     });
   });
@@ -287,19 +225,12 @@ describe('NitroWebSocketSetup', () => {
     });
   });
 
-  describe('NitroWebSocketAdapter — .onX property handlers', () => {
+  describe('NitroWebSocketAdapter — .onX handlers', () => {
     let ws: WebSocket;
 
     beforeEach(() => {
       jest.clearAllMocks();
       ws = new global.WebSocket('wss://example.com');
-    });
-
-    it('stores and retrieves onopen handler', () => {
-      const handler = jest.fn();
-      ws.onopen = handler;
-
-      expect(ws.onopen).toBe(handler);
     });
 
     it('fires onopen with an open event when the native socket opens', () => {
@@ -313,14 +244,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('stores and retrieves onmessage handler', () => {
-      const handler = jest.fn();
-      ws.onmessage = handler;
-
-      expect(ws.onmessage).toBe(handler);
-    });
-
-    it('fires onmessage with event data when native message arrives', () => {
+    it('fires onmessage with event data when a native text message arrives', () => {
       const handler = jest.fn();
       ws.onmessage = handler;
 
@@ -331,14 +255,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('stores and retrieves onclose handler', () => {
-      const handler = jest.fn();
-      ws.onclose = handler;
-
-      expect(ws.onclose).toBe(handler);
-    });
-
-    it('fires onclose with close event when native socket closes', () => {
+    it('fires onclose with close event fields when the native socket closes', () => {
       const handler = jest.fn();
       ws.onclose = handler;
 
@@ -358,14 +275,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('stores and retrieves onerror handler', () => {
-      const handler = jest.fn();
-      ws.onerror = handler;
-
-      expect(ws.onerror).toBe(handler);
-    });
-
-    it('fires onerror with an error event carrying the message when native socket errors', () => {
+    it('fires onerror with the error message when the native socket errors', () => {
       const handler = jest.fn();
       ws.onerror = handler;
 
@@ -379,7 +289,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('does not fire onopen after it is reassigned to null', () => {
+    it('stops firing onopen after it is set to null', () => {
       const handler = jest.fn();
       ws.onopen = handler;
       ws.onopen = null;
@@ -398,7 +308,7 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('delivers binaryData for binary frames', () => {
+    it('delivers binaryData as message data for binary frames', () => {
       const handler = jest.fn();
       ws.onmessage = handler;
       const binary = new ArrayBuffer(4);
@@ -414,22 +324,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('falls back to data string when binaryData is undefined on a binary frame', () => {
-      const handler = jest.fn();
-      ws.onmessage = handler;
-
-      mockWsInstance.onmessage?.({
-        isBinary: true,
-        data: 'fallback',
-        binaryData: undefined,
-      });
-
-      expect(handler).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', data: 'fallback' }),
-      );
-    });
-
-    it('falls back to data string when binaryData is null on a binary frame', () => {
+    it('falls back to data when binaryData is null or undefined on a binary frame', () => {
       const handler = jest.fn();
       ws.onmessage = handler;
 
@@ -438,13 +333,21 @@ describe('NitroWebSocketSetup', () => {
         data: 'fallback',
         binaryData: null,
       });
+      expect(handler).toHaveBeenLastCalledWith(
+        expect.objectContaining({ data: 'fallback' }),
+      );
 
-      expect(handler).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', data: 'fallback' }),
+      mockWsInstance.onmessage?.({
+        isBinary: true,
+        data: 'fallback',
+        binaryData: undefined,
+      });
+      expect(handler).toHaveBeenLastCalledWith(
+        expect.objectContaining({ data: 'fallback' }),
       );
     });
 
-    it('delivers data string for non-binary frames', () => {
+    it('delivers string data for text frames', () => {
       const handler = jest.fn();
       ws.onmessage = handler;
 
@@ -464,7 +367,7 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('fires open listener added via addEventListener', () => {
+    it('fires a registered open listener when the native socket opens', () => {
       const listener = jest.fn();
       ws.addEventListener('open', listener);
 
@@ -473,18 +376,7 @@ describe('NitroWebSocketSetup', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it('fires message listener added via addEventListener with event data', () => {
-      const listener = jest.fn();
-      ws.addEventListener('message', listener);
-
-      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
-
-      expect(listener).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', data: 'hello' }),
-      );
-    });
-
-    it('fires close listener added via addEventListener with close event', () => {
+    it('fires a registered close listener with all close event fields', () => {
       const listener = jest.fn();
       ws.addEventListener('close', listener);
 
@@ -504,18 +396,7 @@ describe('NitroWebSocketSetup', () => {
       );
     });
 
-    it('fires error listener added via addEventListener with error event', () => {
-      const listener = jest.fn();
-      ws.addEventListener('error', listener);
-
-      mockWsInstance.onerror?.('timeout');
-
-      expect(listener).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'error', message: 'timeout' }),
-      );
-    });
-
-    it('fires all listeners when multiple are added for the same event', () => {
+    it('fires all listeners when multiple are registered for the same event', () => {
       const listener1 = jest.fn();
       const listener2 = jest.fn();
       ws.addEventListener('open', listener1);
@@ -527,7 +408,7 @@ describe('NitroWebSocketSetup', () => {
       expect(listener2).toHaveBeenCalledTimes(1);
     });
 
-    it('deduplicates identical listeners added more than once', () => {
+    it('deduplicates the same listener registered more than once', () => {
       const listener = jest.fn();
       ws.addEventListener('open', listener);
       ws.addEventListener('open', listener);
@@ -579,7 +460,7 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('stops firing open listener after removeEventListener', () => {
+    it('stops firing a listener after removeEventListener', () => {
       const listener = jest.fn();
       ws.addEventListener('open', listener);
       ws.removeEventListener('open', listener);
@@ -589,37 +470,7 @@ describe('NitroWebSocketSetup', () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
-    it('stops firing message listener after removeEventListener', () => {
-      const listener = jest.fn();
-      ws.addEventListener('message', listener);
-      ws.removeEventListener('message', listener);
-
-      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
-
-      expect(listener).not.toHaveBeenCalled();
-    });
-
-    it('stops firing close listener after removeEventListener', () => {
-      const listener = jest.fn();
-      ws.addEventListener('close', listener);
-      ws.removeEventListener('close', listener);
-
-      mockWsInstance.onclose?.({ code: 1000, reason: '', wasClean: true });
-
-      expect(listener).not.toHaveBeenCalled();
-    });
-
-    it('stops firing error listener after removeEventListener', () => {
-      const listener = jest.fn();
-      ws.addEventListener('error', listener);
-      ws.removeEventListener('error', listener);
-
-      mockWsInstance.onerror?.('error');
-
-      expect(listener).not.toHaveBeenCalled();
-    });
-
-    it('only removes the specific listener, leaving others intact', () => {
+    it('only removes the specified listener, leaving others intact', () => {
       const listener1 = jest.fn();
       const listener2 = jest.fn();
       ws.addEventListener('open', listener1);
@@ -642,7 +493,7 @@ describe('NitroWebSocketSetup', () => {
     });
 
     it('invokes close listeners with an externally dispatched close event', () => {
-      // Mirrors @nktkas/rews dispatching a synthetic CloseEvent on connect timeout.
+      // @nktkas/rews dispatches a synthetic CloseEvent on connect timeout.
       const listener = jest.fn();
       ws.addEventListener('close', listener);
       const closeEvent = {
@@ -681,14 +532,8 @@ describe('NitroWebSocketSetup', () => {
   });
 
   describe('NitroWebSocketAdapter — .onX and addEventListener composition', () => {
-    let ws: WebSocket;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      ws = new global.WebSocket('wss://example.com');
-    });
-
-    it('fires both .onopen and an open addEventListener listener for the same event', () => {
+    it('fires both .onopen and an addEventListener listener for the same event', () => {
+      const ws = new global.WebSocket('wss://example.com');
       const onXHandler = jest.fn();
       const addedListener = jest.fn();
       ws.onopen = onXHandler;
@@ -698,56 +543,6 @@ describe('NitroWebSocketSetup', () => {
 
       expect(onXHandler).toHaveBeenCalledTimes(1);
       expect(addedListener).toHaveBeenCalledTimes(1);
-    });
-
-    it('fires both .onmessage and a message addEventListener listener with the same event data', () => {
-      const onXHandler = jest.fn();
-      const addedListener = jest.fn();
-      ws.onmessage = onXHandler;
-      ws.addEventListener('message', addedListener);
-
-      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
-
-      expect(onXHandler).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', data: 'hello' }),
-      );
-      expect(addedListener).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'message', data: 'hello' }),
-      );
-    });
-
-    it('fires both .onclose and a close addEventListener listener with the same close event', () => {
-      const onXHandler = jest.fn();
-      const addedListener = jest.fn();
-      ws.onclose = onXHandler;
-      ws.addEventListener('close', addedListener);
-
-      mockWsInstance.onclose?.({ code: 1000, reason: 'done', wasClean: true });
-
-      const expected = expect.objectContaining({
-        type: 'close',
-        code: 1000,
-        reason: 'done',
-        wasClean: true,
-      });
-      expect(onXHandler).toHaveBeenCalledWith(expected);
-      expect(addedListener).toHaveBeenCalledWith(expected);
-    });
-
-    it('fires both .onerror and an error addEventListener listener with the same error', () => {
-      const onXHandler = jest.fn();
-      const addedListener = jest.fn();
-      ws.onerror = onXHandler;
-      ws.addEventListener('error', addedListener);
-
-      mockWsInstance.onerror?.('network error');
-
-      const expected = expect.objectContaining({
-        type: 'error',
-        message: 'network error',
-      });
-      expect(onXHandler).toHaveBeenCalledWith(expected);
-      expect(addedListener).toHaveBeenCalledWith(expected);
     });
   });
 
@@ -759,34 +554,31 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('delegates string send to native socket', () => {
+    it('delegates string send to the native socket', () => {
       ws.send('hello world');
 
       expect(mockWsInstance.send).toHaveBeenCalledWith('hello world');
     });
 
-    it('delegates ArrayBuffer send to native socket', () => {
+    it('delegates ArrayBuffer send to the native socket', () => {
       const buffer = new ArrayBuffer(8);
       ws.send(buffer);
 
       expect(mockWsInstance.send).toHaveBeenCalledWith(buffer);
     });
 
-    it('normalizes a Uint8Array to its backing ArrayBuffer before sending', () => {
+    it('normalises a Uint8Array to a real ArrayBuffer before sending', () => {
       const view = new Uint8Array([1, 2, 3, 4]);
 
       (ws as unknown as { send(data: ArrayBufferView): void }).send(view);
 
-      expect(mockWsInstance.send).toHaveBeenCalledTimes(1);
       const sent = mockWsInstance.send.mock.calls[0][0];
-      // Must be a raw buffer, not the typed-array view that was passed in.
       expect(ArrayBuffer.isView(sent)).toBe(false);
       expect(sent.byteLength).toBe(4);
       expect(Array.from(new Uint8Array(sent))).toEqual([1, 2, 3, 4]);
     });
 
-    it('sends only the view byte range for a partial Uint8Array, not the whole buffer', () => {
-      // View over bytes [1,2] of a 4-byte buffer; the whole buffer must NOT leak.
+    it('sends only the view byte range for an offset Uint8Array, not the whole backing buffer', () => {
       const backing = new Uint8Array([10, 20, 30, 40]).buffer;
       const view = new Uint8Array(backing, 1, 2);
 
@@ -807,22 +599,16 @@ describe('NitroWebSocketSetup', () => {
       ws = new global.WebSocket('wss://example.com');
     });
 
-    it('delegates close to native socket with code and reason', () => {
+    it('delegates close with code and reason to the native socket', () => {
       ws.close(1000, 'normal closure');
 
       expect(mockWsInstance.close).toHaveBeenCalledWith(1000, 'normal closure');
     });
 
-    it('delegates close to native socket without arguments', () => {
+    it('delegates close with no arguments to the native socket', () => {
       ws.close();
 
       expect(mockWsInstance.close).toHaveBeenCalledWith(undefined, undefined);
-    });
-
-    it('delegates close to native socket with code only', () => {
-      ws.close(1001);
-
-      expect(mockWsInstance.close).toHaveBeenCalledWith(1001, undefined);
     });
   });
 });

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -529,6 +529,63 @@ describe('NitroWebSocketSetup', () => {
         ws.dispatchEvent({ type: 'custom' } as unknown as Event),
       ).not.toThrow();
     });
+
+    it('continues dispatching to remaining listeners when one throws', () => {
+      const throwing = jest.fn().mockImplementation(() => {
+        throw new Error('listener boom');
+      });
+      const safe = jest.fn();
+      ws.addEventListener('open', throwing);
+      ws.addEventListener('open', safe);
+
+      expect(() => mockWsInstance.onopen?.()).not.toThrow();
+      expect(throwing).toHaveBeenCalledTimes(1);
+      expect(safe).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues dispatching to addEventListener listeners when the .onX handler throws', () => {
+      ws.onopen = jest.fn().mockImplementation(() => {
+        throw new Error('handler boom');
+      });
+      const listener = jest.fn();
+      ws.addEventListener('open', listener);
+
+      expect(() => mockWsInstance.onopen?.()).not.toThrow();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — AbortSignal cleanup on close', () => {
+    it('removes the signal abort-listener from the signal when the socket closes', () => {
+      const controller = new AbortController();
+      const { signal } = controller;
+      const removeEventListenerSpy = jest.spyOn(signal, 'removeEventListener');
+
+      const ws2 = new global.WebSocket('wss://example.com');
+      const listener = jest.fn();
+      ws2.addEventListener('message', listener, { signal });
+
+      // Trigger close — adapter should clean up its abort handler from the signal.
+      mockWsInstance.onclose?.({ code: 1000, reason: 'done', wasClean: true });
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      );
+    });
+
+    it('does not throw when the signal aborts after the socket has already closed', () => {
+      const controller = new AbortController();
+      const ws2 = new global.WebSocket('wss://example.com');
+      ws2.addEventListener('message', jest.fn(), { signal: controller.signal });
+
+      // Close the socket (removes the abort handler from the signal).
+      mockWsInstance.onclose?.({ code: 1000, reason: 'done', wasClean: true });
+
+      // Aborting the signal after close should be a safe no-op — no double-delete,
+      // no crash, no reference to the now-dead cleanup handler.
+      expect(() => controller.abort()).not.toThrow();
+    });
   });
 
   describe('NitroWebSocketAdapter — .onX and addEventListener composition', () => {

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -1,0 +1,630 @@
+import {
+  NitroWebSocket,
+  prewarmOnAppStart,
+} from 'react-native-nitro-websockets';
+
+interface MockNitroMessageEvent {
+  isBinary: boolean;
+  data: string;
+  binaryData?: ArrayBuffer | null;
+}
+
+interface MockNitroCloseEvent {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+interface MockWsInstance {
+  onopen: (() => void) | null;
+  onmessage: ((e: MockNitroMessageEvent) => void) | null;
+  onclose: ((e: MockNitroCloseEvent) => void) | null;
+  onerror: ((error: string) => void) | null;
+  url: string;
+  protocol: string;
+  bufferedAmount: number;
+  extensions: string;
+  readyState: string;
+  send: jest.Mock;
+  close: jest.Mock;
+}
+
+let mockWsInstance: MockWsInstance;
+
+jest.mock('react-native-nitro-websockets', () => ({
+  NitroWebSocket: jest.fn().mockImplementation((url: string) => {
+    mockWsInstance = {
+      onopen: null,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      url,
+      protocol: 'mock-protocol',
+      bufferedAmount: 42,
+      extensions: 'permessage-deflate',
+      readyState: 'CONNECTING',
+      send: jest.fn(),
+      close: jest.fn(),
+    };
+    return mockWsInstance;
+  }),
+  prewarmOnAppStart: jest.fn(),
+}));
+
+import './NitroWebSocketSetup';
+
+const MockNitroWebSocket = jest.mocked(NitroWebSocket);
+const mockPrewarmOnAppStart = jest.mocked(prewarmOnAppStart);
+
+const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
+
+describe('NitroWebSocketSetup', () => {
+  describe('module-level side effects', () => {
+    it('replaces global.WebSocket on module load', () => {
+      new global.WebSocket('wss://example.com');
+
+      expect(MockNitroWebSocket).toHaveBeenCalled();
+    });
+
+    it('calls prewarmOnAppStart with the MetaMask gateway URL on module load', () => {
+      expect(mockPrewarmOnAppStart).toHaveBeenCalledWith(GATEWAY_URL);
+    });
+
+    it('calls prewarmOnAppStart exactly once', () => {
+      expect(mockPrewarmOnAppStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — static constants', () => {
+    it('exposes CONNECTING as 0', () => {
+      expect(global.WebSocket.CONNECTING).toBe(0);
+    });
+
+    it('exposes OPEN as 1', () => {
+      expect(global.WebSocket.OPEN).toBe(1);
+    });
+
+    it('exposes CLOSING as 2', () => {
+      expect(global.WebSocket.CLOSING).toBe(2);
+    });
+
+    it('exposes CLOSED as 3', () => {
+      expect(global.WebSocket.CLOSED).toBe(3);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — constructor', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('passes url to NitroWebSocket', () => {
+      new global.WebSocket('wss://test.example.com');
+
+      expect(MockNitroWebSocket).toHaveBeenCalledWith(
+        'wss://test.example.com',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('passes protocols array to NitroWebSocket', () => {
+      new global.WebSocket('wss://test.example.com', ['proto1', 'proto2']);
+
+      expect(MockNitroWebSocket).toHaveBeenCalledWith(
+        'wss://test.example.com',
+        ['proto1', 'proto2'],
+        undefined,
+      );
+    });
+
+    it('passes single protocol string to NitroWebSocket', () => {
+      new global.WebSocket('wss://test.example.com', 'proto1');
+
+      expect(MockNitroWebSocket).toHaveBeenCalledWith(
+        'wss://test.example.com',
+        'proto1',
+        undefined,
+      );
+    });
+  });
+
+  describe('NitroWebSocketAdapter — instance constants', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('exposes CONNECTING as 0 on instance', () => {
+      expect((ws as unknown as { CONNECTING: number }).CONNECTING).toBe(0);
+    });
+
+    it('exposes OPEN as 1 on instance', () => {
+      expect((ws as unknown as { OPEN: number }).OPEN).toBe(1);
+    });
+
+    it('exposes CLOSING as 2 on instance', () => {
+      expect((ws as unknown as { CLOSING: number }).CLOSING).toBe(2);
+    });
+
+    it('exposes CLOSED as 3 on instance', () => {
+      expect((ws as unknown as { CLOSED: number }).CLOSED).toBe(3);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — readyState', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('maps CONNECTING string to 0', () => {
+      mockWsInstance.readyState = 'CONNECTING';
+
+      expect(ws.readyState).toBe(0);
+    });
+
+    it('maps OPEN string to 1', () => {
+      mockWsInstance.readyState = 'OPEN';
+
+      expect(ws.readyState).toBe(1);
+    });
+
+    it('maps CLOSING string to 2', () => {
+      mockWsInstance.readyState = 'CLOSING';
+
+      expect(ws.readyState).toBe(2);
+    });
+
+    it('maps CLOSED string to 3', () => {
+      mockWsInstance.readyState = 'CLOSED';
+
+      expect(ws.readyState).toBe(3);
+    });
+
+    it('falls back to CLOSED (3) for an unrecognised readyState string', () => {
+      mockWsInstance.readyState = 'UNKNOWN';
+
+      expect(ws.readyState).toBe(3);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — pass-through getters', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('returns url from native socket', () => {
+      expect(ws.url).toBe('wss://example.com');
+    });
+
+    it('returns protocol from native socket', () => {
+      expect(ws.protocol).toBe('mock-protocol');
+    });
+
+    it('returns bufferedAmount from native socket', () => {
+      expect(ws.bufferedAmount).toBe(42);
+    });
+
+    it('returns extensions from native socket', () => {
+      expect(ws.extensions).toBe('permessage-deflate');
+    });
+  });
+
+  describe('NitroWebSocketAdapter — binaryType', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('defaults to arraybuffer', () => {
+      expect(ws.binaryType).toBe('arraybuffer');
+    });
+
+    it('stores an assigned binaryType value', () => {
+      ws.binaryType = 'blob';
+
+      expect(ws.binaryType).toBe('blob');
+    });
+  });
+
+  describe('NitroWebSocketAdapter — .onX property handlers', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('stores and retrieves onopen handler', () => {
+      const handler = jest.fn();
+      ws.onopen = handler;
+
+      expect(ws.onopen).toBe(handler);
+    });
+
+    it('fires onopen when the native socket opens', () => {
+      const handler = jest.fn();
+      ws.onopen = handler;
+
+      mockWsInstance.onopen?.();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('stores and retrieves onmessage handler', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+
+      expect(ws.onmessage).toBe(handler);
+    });
+
+    it('fires onmessage with event data when native message arrives', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
+
+      expect(handler).toHaveBeenCalledWith({ data: 'hello' });
+    });
+
+    it('stores and retrieves onclose handler', () => {
+      const handler = jest.fn();
+      ws.onclose = handler;
+
+      expect(ws.onclose).toBe(handler);
+    });
+
+    it('fires onclose with close event when native socket closes', () => {
+      const handler = jest.fn();
+      ws.onclose = handler;
+      const closeEvent: MockNitroCloseEvent = {
+        code: 1000,
+        reason: 'normal',
+        wasClean: true,
+      };
+
+      mockWsInstance.onclose?.(closeEvent);
+
+      expect(handler).toHaveBeenCalledWith(closeEvent);
+    });
+
+    it('stores and retrieves onerror handler', () => {
+      const handler = jest.fn();
+      ws.onerror = handler;
+
+      expect(ws.onerror).toBe(handler);
+    });
+
+    it('fires onerror with error string when native socket errors', () => {
+      const handler = jest.fn();
+      ws.onerror = handler;
+
+      mockWsInstance.onerror?.('connection refused');
+
+      expect(handler).toHaveBeenCalledWith('connection refused');
+    });
+
+    it('does not fire onopen after it is reassigned to null', () => {
+      const handler = jest.fn();
+      ws.onopen = handler;
+      ws.onopen = null;
+
+      mockWsInstance.onopen?.();
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('NitroWebSocketAdapter — message binary handling', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('delivers binaryData for binary frames', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+      const binary = new ArrayBuffer(4);
+
+      mockWsInstance.onmessage?.({
+        isBinary: true,
+        data: 'ignored',
+        binaryData: binary,
+      });
+
+      expect(handler).toHaveBeenCalledWith({ data: binary });
+    });
+
+    it('falls back to data string when binaryData is undefined on a binary frame', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+
+      mockWsInstance.onmessage?.({
+        isBinary: true,
+        data: 'fallback',
+        binaryData: undefined,
+      });
+
+      expect(handler).toHaveBeenCalledWith({ data: 'fallback' });
+    });
+
+    it('falls back to data string when binaryData is null on a binary frame', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+
+      mockWsInstance.onmessage?.({
+        isBinary: true,
+        data: 'fallback',
+        binaryData: null,
+      });
+
+      expect(handler).toHaveBeenCalledWith({ data: 'fallback' });
+    });
+
+    it('delivers data string for non-binary frames', () => {
+      const handler = jest.fn();
+      ws.onmessage = handler;
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'text-payload' });
+
+      expect(handler).toHaveBeenCalledWith({ data: 'text-payload' });
+    });
+  });
+
+  describe('NitroWebSocketAdapter — addEventListener', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('fires open listener added via addEventListener', () => {
+      const listener = jest.fn();
+      ws.addEventListener('open', listener);
+
+      mockWsInstance.onopen?.();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires message listener added via addEventListener with event data', () => {
+      const listener = jest.fn();
+      ws.addEventListener('message', listener);
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
+
+      expect(listener).toHaveBeenCalledWith({ data: 'hello' });
+    });
+
+    it('fires close listener added via addEventListener with close event', () => {
+      const listener = jest.fn();
+      ws.addEventListener('close', listener);
+      const closeEvent: MockNitroCloseEvent = {
+        code: 1001,
+        reason: 'going away',
+        wasClean: false,
+      };
+
+      mockWsInstance.onclose?.(closeEvent);
+
+      expect(listener).toHaveBeenCalledWith(closeEvent);
+    });
+
+    it('fires error listener added via addEventListener with error string', () => {
+      const listener = jest.fn();
+      ws.addEventListener('error', listener);
+
+      mockWsInstance.onerror?.('timeout');
+
+      expect(listener).toHaveBeenCalledWith('timeout');
+    });
+
+    it('fires all listeners when multiple are added for the same event', () => {
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+      ws.addEventListener('open', listener1);
+      ws.addEventListener('open', listener2);
+
+      mockWsInstance.onopen?.();
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates identical listeners added more than once', () => {
+      const listener = jest.fn();
+      ws.addEventListener('open', listener);
+      ws.addEventListener('open', listener);
+
+      mockWsInstance.onopen?.();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — removeEventListener', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('stops firing open listener after removeEventListener', () => {
+      const listener = jest.fn();
+      ws.addEventListener('open', listener);
+      ws.removeEventListener('open', listener);
+
+      mockWsInstance.onopen?.();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops firing message listener after removeEventListener', () => {
+      const listener = jest.fn();
+      ws.addEventListener('message', listener);
+      ws.removeEventListener('message', listener);
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops firing close listener after removeEventListener', () => {
+      const listener = jest.fn();
+      ws.addEventListener('close', listener);
+      ws.removeEventListener('close', listener);
+
+      mockWsInstance.onclose?.({ code: 1000, reason: '', wasClean: true });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops firing error listener after removeEventListener', () => {
+      const listener = jest.fn();
+      ws.addEventListener('error', listener);
+      ws.removeEventListener('error', listener);
+
+      mockWsInstance.onerror?.('error');
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('only removes the specific listener, leaving others intact', () => {
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+      ws.addEventListener('open', listener1);
+      ws.addEventListener('open', listener2);
+      ws.removeEventListener('open', listener1);
+
+      mockWsInstance.onopen?.();
+
+      expect(listener1).not.toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — .onX and addEventListener composition', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('fires both .onopen and an open addEventListener listener for the same event', () => {
+      const onXHandler = jest.fn();
+      const addedListener = jest.fn();
+      ws.onopen = onXHandler;
+      ws.addEventListener('open', addedListener);
+
+      mockWsInstance.onopen?.();
+
+      expect(onXHandler).toHaveBeenCalledTimes(1);
+      expect(addedListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires both .onmessage and a message addEventListener listener with the same event data', () => {
+      const onXHandler = jest.fn();
+      const addedListener = jest.fn();
+      ws.onmessage = onXHandler;
+      ws.addEventListener('message', addedListener);
+
+      mockWsInstance.onmessage?.({ isBinary: false, data: 'hello' });
+
+      expect(onXHandler).toHaveBeenCalledWith({ data: 'hello' });
+      expect(addedListener).toHaveBeenCalledWith({ data: 'hello' });
+    });
+
+    it('fires both .onclose and a close addEventListener listener with the same close event', () => {
+      const onXHandler = jest.fn();
+      const addedListener = jest.fn();
+      ws.onclose = onXHandler;
+      ws.addEventListener('close', addedListener);
+      const closeEvent: MockNitroCloseEvent = {
+        code: 1000,
+        reason: 'done',
+        wasClean: true,
+      };
+
+      mockWsInstance.onclose?.(closeEvent);
+
+      expect(onXHandler).toHaveBeenCalledWith(closeEvent);
+      expect(addedListener).toHaveBeenCalledWith(closeEvent);
+    });
+
+    it('fires both .onerror and an error addEventListener listener with the same error', () => {
+      const onXHandler = jest.fn();
+      const addedListener = jest.fn();
+      ws.onerror = onXHandler;
+      ws.addEventListener('error', addedListener);
+
+      mockWsInstance.onerror?.('network error');
+
+      expect(onXHandler).toHaveBeenCalledWith('network error');
+      expect(addedListener).toHaveBeenCalledWith('network error');
+    });
+  });
+
+  describe('NitroWebSocketAdapter — send', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('delegates string send to native socket', () => {
+      ws.send('hello world');
+
+      expect(mockWsInstance.send).toHaveBeenCalledWith('hello world');
+    });
+
+    it('delegates ArrayBuffer send to native socket', () => {
+      const buffer = new ArrayBuffer(8);
+      ws.send(buffer);
+
+      expect(mockWsInstance.send).toHaveBeenCalledWith(buffer);
+    });
+  });
+
+  describe('NitroWebSocketAdapter — close', () => {
+    let ws: WebSocket;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      ws = new global.WebSocket('wss://example.com');
+    });
+
+    it('delegates close to native socket with code and reason', () => {
+      ws.close(1000, 'normal closure');
+
+      expect(mockWsInstance.close).toHaveBeenCalledWith(1000, 'normal closure');
+    });
+
+    it('delegates close to native socket without arguments', () => {
+      ws.close();
+
+      expect(mockWsInstance.close).toHaveBeenCalledWith(undefined, undefined);
+    });
+
+    it('delegates close to native socket with code only', () => {
+      ws.close(1001);
+
+      expect(mockWsInstance.close).toHaveBeenCalledWith(1001, undefined);
+    });
+  });
+});

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -120,6 +120,9 @@ class NitroWebSocketAdapter {
     this._ws.onmessage = (e: NitroMessageEvent) => {
       this.dispatchEvent({
         type: 'message',
+        // binaryData holds the ArrayBuffer for binary frames; e.data is the
+        // string-encoded fallback the native layer may set when binaryData is
+        // absent (defensive — not currently observed in practice).
         data: e.isBinary ? (e.binaryData ?? e.data) : e.data,
       });
     };
@@ -131,11 +134,11 @@ class NitroWebSocketAdapter {
         reason: e.reason,
         wasClean: e.wasClean,
       });
-      // Release all abort-cleanup refs so signals don't hold the adapter alive.
-      this._abortCleanups.forEach((cleanup, listener) => {
-        cleanup();
-        this._abortCleanups.delete(listener);
-      });
+      // Remove abort handlers from their signals, then clear all maps so
+      // GC can collect listeners and any closures they captured.
+      this._abortCleanups.forEach((cleanup) => cleanup());
+      this._abortCleanups.clear();
+      for (const map of Object.values(this._listeners)) map.clear();
     };
 
     this._ws.onerror = (error: string) => {
@@ -144,7 +147,16 @@ class NitroWebSocketAdapter {
   }
 
   get readyState(): number {
-    return READY_STATE_MAP[this._ws.readyState] ?? READY_STATE_MAP.CLOSED;
+    const state = READY_STATE_MAP[this._ws.readyState];
+    if (state === undefined) {
+      if (__DEV__) {
+        console.warn(
+          `[NitroWS] Unknown readyState "${this._ws.readyState}" — reporting CLOSED`,
+        );
+      }
+      return READY_STATE_MAP.CLOSED;
+    }
+    return state;
   }
 
   get url(): string {

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -1,6 +1,6 @@
 /**
  * Replaces global.WebSocket with react-native-nitro-websockets (libwebsockets + mbedTLS,
- * no JS-bridge overhead) and prewarms the MetaMask backend gateway on cold start.
+ * no JS-bridge overhead).
  *
  * The adapter is W3C-compatible and supports all call styles used in this codebase:
  * - .onX assignment — app code, @metamask/core-backend, Polymarket
@@ -14,13 +14,10 @@
  */
 import {
   NitroWebSocket,
-  prewarmOnAppStart,
   type WebSocketMessageEvent as NitroMessageEvent,
   type WebSocketCloseEvent as NitroCloseEvent,
 } from 'react-native-nitro-websockets';
 import { hasTestOverrides } from '../util/test/utils';
-
-const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
 
 type BinaryType = 'arraybuffer' | 'blob';
 
@@ -317,19 +314,16 @@ class NitroWebSocketAdapter {
 }
 
 /**
- * Installs NitroWebSocketAdapter as global.WebSocket and registers the MetaMask
- * backend gateway for native prewarm on each subsequent cold start.
- * Android: NitroWebSocketAutoPrewarmer.prewarmOnStart (MainApplication.kt).
- * iOS: auto-bootstrapped via the Nitro +load hook.
+ * Installs NitroWebSocketAdapter as global.WebSocket.
+ *
+ * WebSocket prewarm is intentionally omitted here: BackendWebSocketService always
+ * appends ?token=<JWT> to the gateway URL, so a tokenless prewarm URL would never
+ * be reused by the real connection and would produce a spurious unauthenticated
+ * WS upgrade on every cold start. Prewarm should be registered by the auth layer
+ * once a valid token is available.
  */
 export function installProductionNitroWebSocket(): void {
   global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
-
-  try {
-    prewarmOnAppStart(GATEWAY_URL);
-  } catch {
-    // Non-fatal: prewarm failure means a cold connection on next use, not a broken socket.
-  }
 }
 
 if (!hasTestOverrides) {

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -92,6 +92,10 @@ class NitroWebSocketAdapter {
     error: new Map(),
   };
 
+  // Tracks abort-cleanup handlers keyed by listener so they can be removed from
+  // their AbortSignal when the socket closes (prevents signal holding stale refs).
+  private readonly _abortCleanups: Map<WsListener, () => void> = new Map();
+
   // .onX handlers stored separately so they compose with _listeners.
   private _onopen: WsListener | null = null;
   private _onmessage: WsListener | null = null;
@@ -126,6 +130,11 @@ class NitroWebSocketAdapter {
         code: e.code,
         reason: e.reason,
         wasClean: e.wasClean,
+      });
+      // Release all abort-cleanup refs so signals don't hold the adapter alive.
+      this._abortCleanups.forEach((cleanup, listener) => {
+        cleanup();
+        this._abortCleanups.delete(listener);
       });
     };
 
@@ -201,11 +210,18 @@ class NitroWebSocketAdapter {
     if (map.has(listener)) return; // dedup by identity (matches DOM no-op on repeats)
     map.set(listener, { once });
 
-    // Remove listener when the signal aborts — @nktkas/rews relies on this to
-    // tear down its open/message/close/error listeners.
-    signal?.addEventListener('abort', () => map.delete(listener), {
-      once: true,
-    });
+    if (signal) {
+      // Remove listener when the signal aborts — @nktkas/rews relies on this to
+      // tear down its open/message/close/error listeners.
+      const abortCleanup = () => {
+        map.delete(listener);
+        this._abortCleanups.delete(listener);
+      };
+      this._abortCleanups.set(listener, () =>
+        signal.removeEventListener('abort', abortCleanup),
+      );
+      signal.addEventListener('abort', abortCleanup, { once: true });
+    }
   }
 
   removeEventListener(type: EventType, listener: WsListener): void {
@@ -216,21 +232,39 @@ class NitroWebSocketAdapter {
    * Dispatches to the matching .onX handler and all registered listeners.
    * Called internally by native callbacks and externally by @nktkas/rews
    * (synthetic CloseEvent on connect timeout / close-during-connecting).
+   *
+   * W3C semantics: a throwing listener must not prevent remaining listeners
+   * from running. Exceptions are swallowed after being reported to the global
+   * error handler so the event loop stays intact.
    */
   dispatchEvent(event: WsAnyEvent): boolean {
     const type = event.type as EventType;
 
-    this._onHandlerFor(type)?.(event);
+    const onHandler = this._onHandlerFor(type);
+    if (onHandler) {
+      try {
+        onHandler(event);
+      } catch (e) {
+        // Non-fatal: report but continue dispatching to other listeners.
+        console.error('[NitroWS] Uncaught error in .on handler:', e);
+      }
+    }
 
     const map = this._listeners[type];
     if (map) {
       // Snapshot before iterating: a listener may mutate the map during dispatch.
       for (const [listener, meta] of [...map]) {
         if (meta.once) map.delete(listener);
-        listener(event);
+        try {
+          listener(event);
+        } catch (e) {
+          // Non-fatal: report but continue dispatching to remaining listeners.
+          console.error('[NitroWS] Uncaught error in event listener:', e);
+        }
       }
     }
 
+    // WebSocket events are not cancelable; always true per W3C spec.
     return true;
   }
 

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -1,0 +1,206 @@
+/**
+ * NitroWebSocketSetup — replaces global.WebSocket with react-native-nitro-websockets
+ * and prewarms the MetaMask backend gateway connection on cold start.
+ *
+ * NitroWebSocket runs on native C++ (libwebsockets + mbedTLS) with no JS-bridge
+ * overhead. The adapter below provides a complete W3C-compatible interface so
+ * ALL call styles work — .onX property assignment AND addEventListener — with
+ * no changes required in any consuming code.
+ *
+ * https://fetch.margelo.com — "WebSockets"
+ */
+import {
+  NitroWebSocket,
+  prewarmOnAppStart,
+  type WebSocketMessageEvent as NitroMessageEvent,
+  type WebSocketCloseEvent as NitroCloseEvent,
+} from 'react-native-nitro-websockets';
+
+type BinaryType = 'arraybuffer' | 'blob';
+
+/** Maps the string-based WebSocketReadyState to W3C numeric constants. */
+const READY_STATE_MAP: Record<string, number> = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+};
+
+type OpenListener = () => void;
+type MessageListener = (e: { data: string | ArrayBuffer }) => void;
+type CloseListener = (e: NitroCloseEvent) => void;
+type ErrorListener = (error: string) => void;
+type AnyListener =
+  | OpenListener
+  | MessageListener
+  | CloseListener
+  | ErrorListener;
+
+/**
+ * Full W3C-compatible adapter over NitroWebSocket.
+ *
+ * Bridges two API styles that co-exist in this codebase:
+ * - .onX property assignment  (used by app code and @metamask/core-backend)
+ * - addEventListener / removeEventListener  (used by @metamask/snaps-controllers)
+ *
+ * Both styles dispatch through the same internal event loop wired once in the
+ * constructor, so they compose correctly when mixed on the same socket.
+ */
+class NitroWebSocketAdapter {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  // Instance-level copies for callers that read constants off the instance
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
+  private readonly _ws: NitroWebSocket;
+
+  // Multi-listener sets backing addEventListener / removeEventListener
+  private readonly _listeners = {
+    open: new Set<OpenListener>(),
+    message: new Set<MessageListener>(),
+    close: new Set<CloseListener>(),
+    error: new Set<ErrorListener>(),
+  };
+
+  // .onX property handlers (stored separately so they compose with _listeners)
+  private _onopen: OpenListener | null = null;
+  private _onmessage: MessageListener | null = null;
+  private _onclose: CloseListener | null = null;
+  private _onerror: ErrorListener | null = null;
+
+  // Accepted but not acted on — stored so downstream code that reads it back
+  // gets a consistent value. NitroWebSocket always returns ArrayBuffer for
+  // binary frames regardless of this setting.
+  binaryType: BinaryType = 'arraybuffer';
+
+  constructor(
+    url: string,
+    protocols?: string | string[],
+    headers?: Record<string, string>,
+  ) {
+    this._ws = new NitroWebSocket(url, protocols, headers);
+
+    // Wire a single internal handler per event type. Both .onX and
+    // addEventListener listeners are dispatched from here.
+    this._ws.onopen = () => {
+      this._onopen?.();
+      this._listeners.open.forEach((fn) => fn());
+    };
+
+    this._ws.onmessage = (e: NitroMessageEvent) => {
+      const event = { data: e.isBinary ? (e.binaryData ?? e.data) : e.data };
+      this._onmessage?.(event);
+      this._listeners.message.forEach((fn) => fn(event));
+    };
+
+    this._ws.onclose = (e: NitroCloseEvent) => {
+      this._onclose?.(e);
+      this._listeners.close.forEach((fn) => fn(e));
+    };
+
+    this._ws.onerror = (error: string) => {
+      this._onerror?.(error);
+      this._listeners.error.forEach((fn) => fn(error));
+    };
+  }
+
+  get readyState(): number {
+    return READY_STATE_MAP[this._ws.readyState] ?? READY_STATE_MAP.CLOSED;
+  }
+
+  // ── pass-through getters ──────────────────────────────────────────────────
+
+  get url(): string {
+    return this._ws.url;
+  }
+
+  get protocol(): string {
+    return this._ws.protocol;
+  }
+
+  get bufferedAmount(): number {
+    return this._ws.bufferedAmount;
+  }
+
+  get extensions(): string {
+    return this._ws.extensions;
+  }
+
+  // ── .onX property handlers ────────────────────────────────────────────────
+
+  get onopen(): OpenListener | null {
+    return this._onopen;
+  }
+  set onopen(handler: OpenListener | null) {
+    this._onopen = handler;
+  }
+
+  get onmessage(): MessageListener | null {
+    return this._onmessage;
+  }
+  set onmessage(handler: MessageListener | null) {
+    this._onmessage = handler;
+  }
+
+  get onclose(): CloseListener | null {
+    return this._onclose;
+  }
+  set onclose(handler: CloseListener | null) {
+    this._onclose = handler;
+  }
+
+  get onerror(): ErrorListener | null {
+    return this._onerror;
+  }
+  set onerror(handler: ErrorListener | null) {
+    this._onerror = handler;
+  }
+
+  // ── addEventListener / removeEventListener ────────────────────────────────
+
+  addEventListener(type: 'open', listener: OpenListener): void;
+  addEventListener(type: 'message', listener: MessageListener): void;
+  addEventListener(type: 'close', listener: CloseListener): void;
+  addEventListener(type: 'error', listener: ErrorListener): void;
+  addEventListener(type: string, listener: AnyListener): void {
+    const set = this._listeners[type as keyof typeof this._listeners] as
+      | Set<AnyListener>
+      | undefined;
+    set?.add(listener);
+  }
+
+  removeEventListener(type: 'open', listener: OpenListener): void;
+  removeEventListener(type: 'message', listener: MessageListener): void;
+  removeEventListener(type: 'close', listener: CloseListener): void;
+  removeEventListener(type: 'error', listener: ErrorListener): void;
+  removeEventListener(type: string, listener: AnyListener): void {
+    const set = this._listeners[type as keyof typeof this._listeners] as
+      | Set<AnyListener>
+      | undefined;
+    set?.delete(listener);
+  }
+
+  // ── methods ───────────────────────────────────────────────────────────────
+
+  send(data: string | ArrayBuffer): void {
+    this._ws.send(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this._ws.close(code, reason);
+  }
+}
+
+global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
+
+// Persist the MetaMask backend gateway URL for native prewarm on every subsequent
+// cold start. Android fires stored URLs via NitroWebSocketAutoPrewarmer.prewarmOnStart
+// (MainApplication.kt); iOS is auto-bootstrapped via the Nitro +load hook.
+// Polymarket channels are on-demand and not prewarmed.
+prewarmOnAppStart('wss://gateway.api.cx.metamask.io/v1');

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -1,17 +1,14 @@
 /**
- * NitroWebSocketSetup — replaces global.WebSocket with react-native-nitro-websockets
- * and prewarms the MetaMask backend gateway connection on cold start.
+ * Replaces global.WebSocket with react-native-nitro-websockets (libwebsockets + mbedTLS,
+ * no JS-bridge overhead) and prewarms the MetaMask backend gateway on cold start.
  *
- * NitroWebSocket runs on native C++ (libwebsockets + mbedTLS) with no JS-bridge
- * overhead. The adapter below provides a W3C-compatible interface so the call
- * styles used across this codebase all work with no changes in consuming code:
- * - .onX property assignment — app code, @metamask/core-backend, Polymarket.
- * - addEventListener / removeEventListener with { once } and { signal } — @metamask/snaps-controllers, @nktkas/rews.
- * - dispatchEvent — @nktkas/rews (Perps / Hyperliquid transport).
+ * The adapter is W3C-compatible and supports all call styles used in this codebase:
+ * - .onX assignment — app code, @metamask/core-backend, Polymarket
+ * - addEventListener / removeEventListener with { once } / { signal } — @metamask/snaps-controllers, @nktkas/rews
+ * - dispatchEvent — @nktkas/rews (Perps / Hyperliquid transport)
  *
- * Install + prewarm are guarded by hasTestOverrides: under E2E, shim.js owns
- * global.WebSocket (it routes production wss:// URLs to local mock servers), so
- * this module must NOT overwrite that wrapper.
+ * Skipped under E2E (hasTestOverrides): shim.js owns global.WebSocket there and
+ * routes production wss:// URLs to local mock servers.
  *
  * https://fetch.margelo.com — "WebSockets"
  */
@@ -27,7 +24,7 @@ const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
 
 type BinaryType = 'arraybuffer' | 'blob';
 
-/** Maps the string-based WebSocketReadyState to W3C numeric constants. */
+// Maps NitroWebSocket's string readyState to W3C numeric constants.
 const READY_STATE_MAP: Record<string, number> = {
   CONNECTING: 0,
   OPEN: 1,
@@ -35,11 +32,9 @@ const READY_STATE_MAP: Record<string, number> = {
   CLOSED: 3,
 };
 
-// W3C-shaped event objects dispatched to listeners. These are intentionally
-// plain objects (not RN Event instances): the adapter owns dispatchEvent and
-// never does an `instanceof Event` check, so consumers — including @nktkas/rews
-// which dispatches its own CloseEvent onto the socket — interoperate by reading
-// fields (type/data/code/reason/wasClean), not by identity.
+// Plain W3C-shaped event objects — the adapter never does instanceof checks,
+// so consumers (@nktkas/rews dispatches its own CloseEvent) interoperate by
+// reading fields, not by identity.
 interface WsEvent {
   type: string;
 }
@@ -67,11 +62,10 @@ type ListenerOptions = boolean | { once?: boolean; signal?: AbortSignal };
 /**
  * W3C-compatible adapter over NitroWebSocket.
  *
- * Bridges the API styles that co-exist in this codebase and implements a
- * minimal EventTarget (addEventListener with { once }/{ signal }, removeEventListener,
- * dispatchEvent) so @nktkas/rews' reconnect/timeout paths work. Both .onX and
- * addEventListener listeners are dispatched from a single internal event loop
- * wired once in the constructor, so they compose correctly when mixed.
+ * Implements a minimal EventTarget (addEventListener with { once } / { signal },
+ * removeEventListener, dispatchEvent) so @nktkas/rews reconnect/timeout paths work.
+ * Both .onX and addEventListener listeners are dispatched from a single event loop
+ * wired in the constructor, so they compose correctly when mixed.
  */
 class NitroWebSocketAdapter {
   static readonly CONNECTING = 0;
@@ -79,7 +73,7 @@ class NitroWebSocketAdapter {
   static readonly CLOSING = 2;
   static readonly CLOSED = 3;
 
-  // Instance-level copies for callers that read constants off the instance
+  // Instance-level copies for callers that read constants off the instance.
   readonly CONNECTING = 0;
   readonly OPEN = 1;
   readonly CLOSING = 2;
@@ -87,9 +81,7 @@ class NitroWebSocketAdapter {
 
   private readonly _ws: NitroWebSocket;
 
-  // Registered listeners keyed by identity so removeEventListener and dedup are
-  // O(1); the meta records { once } so a one-shot listener removes itself after
-  // firing.
+  // Listeners keyed by identity for O(1) dedup and removal; meta tracks { once }.
   private readonly _listeners: Record<
     EventType,
     Map<WsListener, { once: boolean }>
@@ -100,15 +92,14 @@ class NitroWebSocketAdapter {
     error: new Map(),
   };
 
-  // .onX property handlers (stored separately so they compose with _listeners)
+  // .onX handlers stored separately so they compose with _listeners.
   private _onopen: WsListener | null = null;
   private _onmessage: WsListener | null = null;
   private _onclose: WsListener | null = null;
   private _onerror: WsListener | null = null;
 
-  // Accepted but not acted on — stored so downstream code that reads it back
-  // gets a consistent value. NitroWebSocket always returns ArrayBuffer for
-  // binary frames regardless of this setting.
+  // Accepted but unused — NitroWebSocket always returns ArrayBuffer for binary
+  // frames regardless of this value; stored for read-back consistency.
   binaryType: BinaryType = 'arraybuffer';
 
   constructor(
@@ -118,9 +109,6 @@ class NitroWebSocketAdapter {
   ) {
     this._ws = new NitroWebSocket(url, protocols, headers);
 
-    // Each native callback builds a W3C-shaped event and routes it through
-    // dispatchEvent, which invokes the matching .onX handler AND every
-    // addEventListener listener.
     this._ws.onopen = () => {
       this.dispatchEvent({ type: 'open' });
     };
@@ -150,8 +138,6 @@ class NitroWebSocketAdapter {
     return READY_STATE_MAP[this._ws.readyState] ?? READY_STATE_MAP.CLOSED;
   }
 
-  // ── pass-through getters ──────────────────────────────────────────────────
-
   get url(): string {
     return this._ws.url;
   }
@@ -167,8 +153,6 @@ class NitroWebSocketAdapter {
   get extensions(): string {
     return this._ws.extensions;
   }
-
-  // ── .onX property handlers ────────────────────────────────────────────────
 
   get onopen(): WsListener | null {
     return this._onopen;
@@ -198,8 +182,6 @@ class NitroWebSocketAdapter {
     this._onerror = handler;
   }
 
-  // ── EventTarget ───────────────────────────────────────────────────────────
-
   addEventListener(
     type: EventType,
     listener: WsListener,
@@ -215,15 +197,12 @@ class NitroWebSocketAdapter {
         ? options.signal
         : undefined;
 
-    // Already-aborted signal: never register (matches DOM semantics).
-    if (signal?.aborted) return;
-
-    // Dedup by listener identity (matches addEventListener's no-op on repeats).
-    if (map.has(listener)) return;
+    if (signal?.aborted) return; // already-aborted signal: never register (DOM semantics)
+    if (map.has(listener)) return; // dedup by identity (matches DOM no-op on repeats)
     map.set(listener, { once });
 
-    // { signal }: remove the listener when the signal aborts. @nktkas/rews
-    // relies on this to tear down its open/message/close/error listeners.
+    // Remove listener when the signal aborts — @nktkas/rews relies on this to
+    // tear down its open/message/close/error listeners.
     signal?.addEventListener('abort', () => map.delete(listener), {
       once: true,
     });
@@ -234,20 +213,18 @@ class NitroWebSocketAdapter {
   }
 
   /**
-   * Dispatches an event to the matching .onX handler and all registered
-   * listeners. Used internally by the native callbacks and externally by
-   * @nktkas/rews (which dispatches a synthetic CloseEvent on connect timeout /
-   * close-during-connecting). Returns true (no event is cancelable here).
+   * Dispatches to the matching .onX handler and all registered listeners.
+   * Called internally by native callbacks and externally by @nktkas/rews
+   * (synthetic CloseEvent on connect timeout / close-during-connecting).
    */
   dispatchEvent(event: WsAnyEvent): boolean {
     const type = event.type as EventType;
 
-    const onHandler = this._onHandlerFor(type);
-    onHandler?.(event);
+    this._onHandlerFor(type)?.(event);
 
     const map = this._listeners[type];
     if (map) {
-      // Snapshot first: a listener may add/remove listeners during dispatch.
+      // Snapshot before iterating: a listener may mutate the map during dispatch.
       for (const [listener, meta] of [...map]) {
         if (meta.once) map.delete(listener);
         listener(event);
@@ -272,9 +249,19 @@ class NitroWebSocketAdapter {
     }
   }
 
-  // ── methods ───────────────────────────────────────────────────────────────
-
-  send(data: string | ArrayBuffer): void {
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    // ArrayBufferView (e.g. Uint8Array from @metamask/snaps-controllers): copy the
+    // exact byte range into a real ArrayBuffer — sending .buffer directly would
+    // include bytes outside the view's offset/length.
+    if (ArrayBuffer.isView(data)) {
+      this._ws.send(
+        data.buffer.slice(
+          data.byteOffset,
+          data.byteOffset + data.byteLength,
+        ) as ArrayBuffer,
+      );
+      return;
+    }
     this._ws.send(data);
   }
 
@@ -284,23 +271,18 @@ class NitroWebSocketAdapter {
 }
 
 /**
- * Installs the Nitro WebSocket adapter as global.WebSocket and prewarms the
- * MetaMask backend gateway. Skipped under E2E (hasTestOverrides) so shim.js's
- * mock-routing WebSocket wrapper stays in place.
+ * Installs NitroWebSocketAdapter as global.WebSocket and registers the MetaMask
+ * backend gateway for native prewarm on each subsequent cold start.
+ * Android: NitroWebSocketAutoPrewarmer.prewarmOnStart (MainApplication.kt).
+ * iOS: auto-bootstrapped via the Nitro +load hook.
  */
 export function installProductionNitroWebSocket(): void {
   global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
 
-  // Persist the MetaMask backend gateway URL for native prewarm on every
-  // subsequent cold start. Android fires stored URLs via
-  // NitroWebSocketAutoPrewarmer.prewarmOnStart (MainApplication.kt); iOS is
-  // auto-bootstrapped via the Nitro +load hook. Polymarket channels are
-  // on-demand and not prewarmed.
   try {
     prewarmOnAppStart(GATEWAY_URL);
   } catch {
-    // Non-fatal: a prewarm failure means a cold connection on next use, not a
-    // broken socket — never let it break app boot.
+    // Non-fatal: prewarm failure means a cold connection on next use, not a broken socket.
   }
 }
 

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -38,6 +38,7 @@ interface WsEvent {
 interface WsMessageEvent extends WsEvent {
   type: 'message';
   data: string | ArrayBuffer;
+  origin: string;
 }
 interface WsCloseEvent extends WsEvent {
   type: 'close';
@@ -121,6 +122,7 @@ class NitroWebSocketAdapter {
         // string-encoded fallback the native layer may set when binaryData is
         // absent (defensive — not currently observed in practice).
         data: e.isBinary ? (e.binaryData ?? e.data) : e.data,
+        origin: '',
       });
     };
 

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -3,9 +3,15 @@
  * and prewarms the MetaMask backend gateway connection on cold start.
  *
  * NitroWebSocket runs on native C++ (libwebsockets + mbedTLS) with no JS-bridge
- * overhead. The adapter below provides a complete W3C-compatible interface so
- * ALL call styles work — .onX property assignment AND addEventListener — with
- * no changes required in any consuming code.
+ * overhead. The adapter below provides a W3C-compatible interface so the call
+ * styles used across this codebase all work with no changes in consuming code:
+ * - .onX property assignment — app code, @metamask/core-backend, Polymarket.
+ * - addEventListener / removeEventListener with { once } and { signal } — @metamask/snaps-controllers, @nktkas/rews.
+ * - dispatchEvent — @nktkas/rews (Perps / Hyperliquid transport).
+ *
+ * Install + prewarm are guarded by hasTestOverrides: under E2E, shim.js owns
+ * global.WebSocket (it routes production wss:// URLs to local mock servers), so
+ * this module must NOT overwrite that wrapper.
  *
  * https://fetch.margelo.com — "WebSockets"
  */
@@ -15,6 +21,9 @@ import {
   type WebSocketMessageEvent as NitroMessageEvent,
   type WebSocketCloseEvent as NitroCloseEvent,
 } from 'react-native-nitro-websockets';
+import { hasTestOverrides } from '../util/test/utils';
+
+const GATEWAY_URL = 'wss://gateway.api.cx.metamask.io/v1';
 
 type BinaryType = 'arraybuffer' | 'blob';
 
@@ -26,25 +35,43 @@ const READY_STATE_MAP: Record<string, number> = {
   CLOSED: 3,
 };
 
-type OpenListener = () => void;
-type MessageListener = (e: { data: string | ArrayBuffer }) => void;
-type CloseListener = (e: NitroCloseEvent) => void;
-type ErrorListener = (error: string) => void;
-type AnyListener =
-  | OpenListener
-  | MessageListener
-  | CloseListener
-  | ErrorListener;
+// W3C-shaped event objects dispatched to listeners. These are intentionally
+// plain objects (not RN Event instances): the adapter owns dispatchEvent and
+// never does an `instanceof Event` check, so consumers — including @nktkas/rews
+// which dispatches its own CloseEvent onto the socket — interoperate by reading
+// fields (type/data/code/reason/wasClean), not by identity.
+interface WsEvent {
+  type: string;
+}
+interface WsMessageEvent extends WsEvent {
+  type: 'message';
+  data: string | ArrayBuffer;
+}
+interface WsCloseEvent extends WsEvent {
+  type: 'close';
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+interface WsErrorEvent extends WsEvent {
+  type: 'error';
+  message: string;
+}
+type WsAnyEvent = WsEvent | WsMessageEvent | WsCloseEvent | WsErrorEvent;
+
+type WsListener = (event: WsAnyEvent) => void;
+type EventType = 'open' | 'message' | 'close' | 'error';
+
+type ListenerOptions = boolean | { once?: boolean; signal?: AbortSignal };
 
 /**
- * Full W3C-compatible adapter over NitroWebSocket.
+ * W3C-compatible adapter over NitroWebSocket.
  *
- * Bridges two API styles that co-exist in this codebase:
- * - .onX property assignment  (used by app code and @metamask/core-backend)
- * - addEventListener / removeEventListener  (used by @metamask/snaps-controllers)
- *
- * Both styles dispatch through the same internal event loop wired once in the
- * constructor, so they compose correctly when mixed on the same socket.
+ * Bridges the API styles that co-exist in this codebase and implements a
+ * minimal EventTarget (addEventListener with { once }/{ signal }, removeEventListener,
+ * dispatchEvent) so @nktkas/rews' reconnect/timeout paths work. Both .onX and
+ * addEventListener listeners are dispatched from a single internal event loop
+ * wired once in the constructor, so they compose correctly when mixed.
  */
 class NitroWebSocketAdapter {
   static readonly CONNECTING = 0;
@@ -60,19 +87,24 @@ class NitroWebSocketAdapter {
 
   private readonly _ws: NitroWebSocket;
 
-  // Multi-listener sets backing addEventListener / removeEventListener
-  private readonly _listeners = {
-    open: new Set<OpenListener>(),
-    message: new Set<MessageListener>(),
-    close: new Set<CloseListener>(),
-    error: new Set<ErrorListener>(),
+  // Registered listeners keyed by identity so removeEventListener and dedup are
+  // O(1); the meta records { once } so a one-shot listener removes itself after
+  // firing.
+  private readonly _listeners: Record<
+    EventType,
+    Map<WsListener, { once: boolean }>
+  > = {
+    open: new Map(),
+    message: new Map(),
+    close: new Map(),
+    error: new Map(),
   };
 
   // .onX property handlers (stored separately so they compose with _listeners)
-  private _onopen: OpenListener | null = null;
-  private _onmessage: MessageListener | null = null;
-  private _onclose: CloseListener | null = null;
-  private _onerror: ErrorListener | null = null;
+  private _onopen: WsListener | null = null;
+  private _onmessage: WsListener | null = null;
+  private _onclose: WsListener | null = null;
+  private _onerror: WsListener | null = null;
 
   // Accepted but not acted on — stored so downstream code that reads it back
   // gets a consistent value. NitroWebSocket always returns ArrayBuffer for
@@ -86,27 +118,31 @@ class NitroWebSocketAdapter {
   ) {
     this._ws = new NitroWebSocket(url, protocols, headers);
 
-    // Wire a single internal handler per event type. Both .onX and
-    // addEventListener listeners are dispatched from here.
+    // Each native callback builds a W3C-shaped event and routes it through
+    // dispatchEvent, which invokes the matching .onX handler AND every
+    // addEventListener listener.
     this._ws.onopen = () => {
-      this._onopen?.();
-      this._listeners.open.forEach((fn) => fn());
+      this.dispatchEvent({ type: 'open' });
     };
 
     this._ws.onmessage = (e: NitroMessageEvent) => {
-      const event = { data: e.isBinary ? (e.binaryData ?? e.data) : e.data };
-      this._onmessage?.(event);
-      this._listeners.message.forEach((fn) => fn(event));
+      this.dispatchEvent({
+        type: 'message',
+        data: e.isBinary ? (e.binaryData ?? e.data) : e.data,
+      });
     };
 
     this._ws.onclose = (e: NitroCloseEvent) => {
-      this._onclose?.(e);
-      this._listeners.close.forEach((fn) => fn(e));
+      this.dispatchEvent({
+        type: 'close',
+        code: e.code,
+        reason: e.reason,
+        wasClean: e.wasClean,
+      });
     };
 
     this._ws.onerror = (error: string) => {
-      this._onerror?.(error);
-      this._listeners.error.forEach((fn) => fn(error));
+      this.dispatchEvent({ type: 'error', message: error });
     };
   }
 
@@ -134,56 +170,106 @@ class NitroWebSocketAdapter {
 
   // ── .onX property handlers ────────────────────────────────────────────────
 
-  get onopen(): OpenListener | null {
+  get onopen(): WsListener | null {
     return this._onopen;
   }
-  set onopen(handler: OpenListener | null) {
+  set onopen(handler: WsListener | null) {
     this._onopen = handler;
   }
 
-  get onmessage(): MessageListener | null {
+  get onmessage(): WsListener | null {
     return this._onmessage;
   }
-  set onmessage(handler: MessageListener | null) {
+  set onmessage(handler: WsListener | null) {
     this._onmessage = handler;
   }
 
-  get onclose(): CloseListener | null {
+  get onclose(): WsListener | null {
     return this._onclose;
   }
-  set onclose(handler: CloseListener | null) {
+  set onclose(handler: WsListener | null) {
     this._onclose = handler;
   }
 
-  get onerror(): ErrorListener | null {
+  get onerror(): WsListener | null {
     return this._onerror;
   }
-  set onerror(handler: ErrorListener | null) {
+  set onerror(handler: WsListener | null) {
     this._onerror = handler;
   }
 
-  // ── addEventListener / removeEventListener ────────────────────────────────
+  // ── EventTarget ───────────────────────────────────────────────────────────
 
-  addEventListener(type: 'open', listener: OpenListener): void;
-  addEventListener(type: 'message', listener: MessageListener): void;
-  addEventListener(type: 'close', listener: CloseListener): void;
-  addEventListener(type: 'error', listener: ErrorListener): void;
-  addEventListener(type: string, listener: AnyListener): void {
-    const set = this._listeners[type as keyof typeof this._listeners] as
-      | Set<AnyListener>
-      | undefined;
-    set?.add(listener);
+  addEventListener(
+    type: EventType,
+    listener: WsListener,
+    options?: ListenerOptions,
+  ): void {
+    const map = this._listeners[type];
+    if (!map) return;
+
+    const once =
+      typeof options === 'object' && options !== null && !!options.once;
+    const signal =
+      typeof options === 'object' && options !== null
+        ? options.signal
+        : undefined;
+
+    // Already-aborted signal: never register (matches DOM semantics).
+    if (signal?.aborted) return;
+
+    // Dedup by listener identity (matches addEventListener's no-op on repeats).
+    if (map.has(listener)) return;
+    map.set(listener, { once });
+
+    // { signal }: remove the listener when the signal aborts. @nktkas/rews
+    // relies on this to tear down its open/message/close/error listeners.
+    signal?.addEventListener('abort', () => map.delete(listener), {
+      once: true,
+    });
   }
 
-  removeEventListener(type: 'open', listener: OpenListener): void;
-  removeEventListener(type: 'message', listener: MessageListener): void;
-  removeEventListener(type: 'close', listener: CloseListener): void;
-  removeEventListener(type: 'error', listener: ErrorListener): void;
-  removeEventListener(type: string, listener: AnyListener): void {
-    const set = this._listeners[type as keyof typeof this._listeners] as
-      | Set<AnyListener>
-      | undefined;
-    set?.delete(listener);
+  removeEventListener(type: EventType, listener: WsListener): void {
+    this._listeners[type]?.delete(listener);
+  }
+
+  /**
+   * Dispatches an event to the matching .onX handler and all registered
+   * listeners. Used internally by the native callbacks and externally by
+   * @nktkas/rews (which dispatches a synthetic CloseEvent on connect timeout /
+   * close-during-connecting). Returns true (no event is cancelable here).
+   */
+  dispatchEvent(event: WsAnyEvent): boolean {
+    const type = event.type as EventType;
+
+    const onHandler = this._onHandlerFor(type);
+    onHandler?.(event);
+
+    const map = this._listeners[type];
+    if (map) {
+      // Snapshot first: a listener may add/remove listeners during dispatch.
+      for (const [listener, meta] of [...map]) {
+        if (meta.once) map.delete(listener);
+        listener(event);
+      }
+    }
+
+    return true;
+  }
+
+  private _onHandlerFor(type: EventType): WsListener | null {
+    switch (type) {
+      case 'open':
+        return this._onopen;
+      case 'message':
+        return this._onmessage;
+      case 'close':
+        return this._onclose;
+      case 'error':
+        return this._onerror;
+      default:
+        return null;
+    }
   }
 
   // ── methods ───────────────────────────────────────────────────────────────
@@ -197,10 +283,29 @@ class NitroWebSocketAdapter {
   }
 }
 
-global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
+/**
+ * Installs the Nitro WebSocket adapter as global.WebSocket and prewarms the
+ * MetaMask backend gateway. Skipped under E2E (hasTestOverrides) so shim.js's
+ * mock-routing WebSocket wrapper stays in place.
+ */
+export function installProductionNitroWebSocket(): void {
+  global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
 
-// Persist the MetaMask backend gateway URL for native prewarm on every subsequent
-// cold start. Android fires stored URLs via NitroWebSocketAutoPrewarmer.prewarmOnStart
-// (MainApplication.kt); iOS is auto-bootstrapped via the Nitro +load hook.
-// Polymarket channels are on-demand and not prewarmed.
-prewarmOnAppStart('wss://gateway.api.cx.metamask.io/v1');
+  // Persist the MetaMask backend gateway URL for native prewarm on every
+  // subsequent cold start. Android fires stored URLs via
+  // NitroWebSocketAutoPrewarmer.prewarmOnStart (MainApplication.kt); iOS is
+  // auto-bootstrapped via the Nitro +load hook. Polymarket channels are
+  // on-demand and not prewarmed.
+  try {
+    prewarmOnAppStart(GATEWAY_URL);
+  } catch {
+    // Non-fatal: a prewarm failure means a cold connection on next use, not a
+    // broken socket — never let it break app boot.
+  }
+}
+
+if (!hasTestOverrides) {
+  installProductionNitroWebSocket();
+}
+
+export { NitroWebSocketAdapter };

--- a/index.js
+++ b/index.js
@@ -5,13 +5,8 @@ import './app/util/theme/preBootPureBlack';
 // Shim is used to ensure API compatibility for React Native and provides polyfills for globals
 import './shim.js';
 
-// Replace global.fetch with nitro-fetch (native C++ networking) and register
-// startup endpoints for native prefetching on cold start. Must run after shim
-// but before any code that uses fetch().
+// Native C++ networking (nitro-fetch + nitro-websockets). Must run after shim.
 import './app/core/NitroFetchSetup';
-
-// Replace global.WebSocket with react-native-nitro-websockets (native C++ via
-// libwebsockets + mbedTLS) and prewarm the MetaMask backend gateway on cold start.
 import './app/core/NitroWebSocketSetup';
 
 // TODO: This import may not be required anymore since we've upgraded to v2 - https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/#requirements

--- a/index.js
+++ b/index.js
@@ -5,7 +5,14 @@ import './app/util/theme/preBootPureBlack';
 // Shim is used to ensure API compatibility for React Native and provides polyfills for globals
 import './shim.js';
 
+// Replace global.fetch with nitro-fetch (native C++ networking) and register
+// startup endpoints for native prefetching on cold start. Must run after shim
+// but before any code that uses fetch().
 import './app/core/NitroFetchSetup';
+
+// Replace global.WebSocket with react-native-nitro-websockets (native C++ via
+// libwebsockets + mbedTLS) and prewarm the MetaMask backend gateway on cold start.
+import './app/core/NitroWebSocketSetup';
 
 // TODO: This import may not be required anymore since we've upgraded to v2 - https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/#requirements
 // Legacy - Need to import early for native module initialization - https://docs.swmansion.com/react-native-gesture-handler/docs/1.x/

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -56,16 +56,7 @@ class AppDelegate: ExpoAppDelegate {
     window = UIWindow(frame: UIScreen.main.bounds)
     window?.makeKeyAndVisible()
 
-    // Safe Firebase configuration — validates plist before configure() to prevent
-    // FIRInstallations from throwing an uncatchable NSException on launch when
-    // GoogleService-Info.plist is missing or contains a blank/placeholder/mock API_KEY.
-    // Real Firebase API keys always start with "AIzaSy"; anything else (empty, mock-*, etc.)
-    // would cause validateAPIKey: to throw an NSException that Swift cannot catch.
-    if FirebaseApp.app() == nil,
-       let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-       let plist = NSDictionary(contentsOfFile: path),
-       let apiKey = plist["API_KEY"] as? String,
-       apiKey.hasPrefix("AIzaSy") {
+    if FirebaseApp.app() == nil {
       FirebaseApp.configure()
     }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -622,6 +622,36 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - NitroFetchWebsockets (1.0.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - NitroModules
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - NitroModules (0.35.5):
     - boost
     - DoubleConversion
@@ -629,6 +659,36 @@ PODS:
     - fmt
     - glog
     - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-callinvoker
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - NitroTextDecoder (0.2.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - NitroModules
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -4194,7 +4254,9 @@ DEPENDENCIES:
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - "NativeUtils (from `../node_modules/@metamask/native-utils`)"
   - NitroFetch (from `../node_modules/react-native-nitro-fetch`)
+  - NitroFetchWebsockets (from `../node_modules/react-native-nitro-websockets`)
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
+  - NitroTextDecoder (from `../node_modules/react-native-nitro-text-decoder`)
   - OpenSSL-Universal
   - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -4446,8 +4508,12 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@metamask/native-utils"
   NitroFetch:
     :path: "../node_modules/react-native-nitro-fetch"
+  NitroFetchWebsockets:
+    :path: "../node_modules/react-native-nitro-websockets"
   NitroModules:
     :path: "../node_modules/react-native-nitro-modules"
+  NitroTextDecoder:
+    :path: "../node_modules/react-native-nitro-text-decoder"
   Permission-BluetoothPeripheral:
     :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral"
   RCT-Folly:
@@ -4764,7 +4830,9 @@ SPEC CHECKSUMS:
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   NativeUtils: 1856148c08a042bbbca306acbe2771db8a9be99b
   NitroFetch: 232232e9d216dc35be48f6478cf9f6cebd077916
+  NitroFetchWebsockets: 8ce4909248acd869f7002be2c9b1eefcbb60544a
   NitroModules: ea5dc6c43666f4a75e71e372eaca6d3605856e51
+  NitroTextDecoder: 9b50be860ed7488349bc31791b6fe96778a43db0
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
   Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -504,6 +504,8 @@
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-nitro-fetch": "1.3.3",
     "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-text-decoder": "^0.2.0",
+    "react-native-nitro-websockets": "^1.0.3",
     "react-native-os": "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch",
     "react-native-pager-view": "6.9.1",
     "react-native-permissions": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35780,6 +35780,8 @@ __metadata:
     react-native-modal: "npm:^14.0.0-rc.1"
     react-native-nitro-fetch: "npm:1.3.3"
     react-native-nitro-modules: "npm:0.35.5"
+    react-native-nitro-text-decoder: "npm:^0.2.0"
+    react-native-nitro-websockets: "npm:^1.0.3"
     react-native-os: "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch"
     react-native-pager-view: "npm:6.9.1"
     react-native-performance: "npm:^6.0.0"
@@ -40589,6 +40591,35 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/4fec58f90b9a69b33d935c5e733e162b67eb91662421a50e76a854c61140c7c1c5fc9e4fab498bf538420e1e9a43bb867aa411653b442541fdf52f0a5b14d22d
+  languageName: node
+  linkType: hard
+
+"react-native-nitro-text-decoder@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "react-native-nitro-text-decoder@npm:0.2.0"
+  dependencies:
+    web-streams-polyfill: "npm:^4.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-modules: ^0.35.2
+  checksum: 10/80fc40a1fdfa7f48de32cfe8ad8132516f87db88b7e5e12356ab0f96107ba790d675b10f43cd896c41469df0eb86adeab94bc6f4c1668e6a4793eb945e864498
+  languageName: node
+  linkType: hard
+
+"react-native-nitro-websockets@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "react-native-nitro-websockets@npm:1.0.3"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-fetch: "*"
+    react-native-nitro-modules: "*"
+    react-native-nitro-text-decoder: ">=0.1.0"
+  peerDependenciesMeta:
+    react-native-nitro-fetch:
+      optional: true
+  checksum: 10/aa53b4f40d62e79294dcc609f38e1426dfe08ca87deafbe8b90bbb64ec5b958742421f6f26e7a497e642189855dfd6c682cb4de1beabab8dd96595538ed93556
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Replaces `global.WebSocket` with `react-native-nitro-websockets` (native C++ via libwebsockets + mbedTLS, no JS-bridge overhead).

**What changed:**
- `app/core/NitroWebSocketSetup.ts`: a W3C-compatible adapter over `NitroWebSocket` supporting every call style used in the app with no consumer changes:
  - `.onX` handlers (app code, `@metamask/core-backend`, Polymarket)
  - `addEventListener` / `removeEventListener` with `{ once }` and `{ signal }` (`@metamask/snaps-controllers`, `@nktkas/rews`)
  - `dispatchEvent` (`@nktkas/rews` — Perps/Hyperliquid reconnect/timeout path)
  - Binary sends normalize `ArrayBufferView` to a real `ArrayBuffer` for the native `sendBinary` path (e.g. Snaps' `Uint8Array`)
- `app/core/AppStateWebSocketManager.ts`: serialised state changes to prevent concurrent socket ops

**Drop-in: no consumer code changes required.**

## Changelog

Improved real-time data performance by moving WebSocket connections to a native transport.

## Related issues

Closes #32167

## Pre-merge checklist

- [ ] Tests pass (`yarn test:unit`)
- [ ] No TypeScript errors (`yarn lint:tsc`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Swapping the global WebSocket stack affects all real-time paths (gateway, Perps/rews, Snaps binary); regressions would be broad though mitigated by the adapter tests and E2E guard. The unrelated Firebase launch change removes plist/API-key validation and could reintroduce uncatchable launch failures on bad configs.
> 
> **Overview**
> Moves WebSocket traffic to **native C++** (`react-native-nitro-websockets`) by installing a W3C-shaped **`NitroWebSocketAdapter`** as `global.WebSocket` at startup (`index.js`, skipped when `hasTestOverrides` so E2E keeps the shim).
> 
> The adapter bridges Nitro’s string `readyState` and callbacks to numeric states and DOM-style APIs used in-repo: `.onX`, `addEventListener` / `removeEventListener` (`once`, `AbortSignal`), `dispatchEvent`, binary `send` (sliced `ArrayBufferView`), and listener cleanup on close. **No consumer call-site changes** are required.
> 
> **`AppStateWebSocketManager`** now **serializes** foreground/background connect and disconnect: rapid app-state flips coalesce to the latest state so connect/disconnect never run concurrently.
> 
> Adds **`react-native-nitro-websockets`** / **`react-native-nitro-text-decoder`**, iOS pod entries, and a large **`NitroWebSocketSetup.test.ts`** suite. **`AppDelegate.swift`** drops the GoogleService-Info API key guard and always calls `FirebaseApp.configure()` when Firebase isn’t configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6968263e30624567ab1442f574bbd0ba7e759042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->