### PR TITLE
feat(mwp): show SDK loading sheet while a MetaMask Connect request is pending

### DIFF
--- a/app/core/AgenticCli/AgenticCliMwpConnectionService.test.ts
+++ b/app/core/AgenticCli/AgenticCliMwpConnectionService.test.ts
@@ -219,6 +219,33 @@ describe('AgenticCliMwpConnectionService', () => {
     );
   });
 
+  it('dismisses the loading sheet before showing the OTP sheet so it is not left stacked underneath', async () => {
+    mockConnection.connect.mockImplementation(async () => {
+      clientHandlers.display_otp?.('4892AKJ7', Date.now() + 60_000);
+    });
+
+    await handleAgenticCliConnectDeeplink(agenticCliDeeplink, {
+      relayURL: RELAY_URL,
+      keymanager: mockKeyManager,
+      hostapp: mockHostApp,
+      hasConnection: () => false,
+      cleanupConnection: jest.fn().mockResolvedValue(undefined),
+    });
+
+    expect(mockHostApp.hideConnectionLoading).toHaveBeenCalledWith(
+      expect.objectContaining({ id: mockConnectionInfo.id }),
+    );
+    expect(showAgenticCliOtpCode).toHaveBeenCalled();
+
+    // The loading sheet must be dismissed before the OTP sheet is pushed,
+    // otherwise the loading route is left stacked underneath the OTP sheet.
+    const firstHideOrder = (mockHostApp.hideConnectionLoading as jest.Mock).mock
+      .invocationCallOrder[0];
+    const firstShowOtpOrder = (showAgenticCliOtpCode as jest.Mock).mock
+      .invocationCallOrder[0];
+    expect(firstHideOrder).toBeLessThan(firstShowOtpOrder);
+  });
+
   it('hides the OTP sheet when connect fails after display_otp', async () => {
     mockConnection.connect.mockImplementation(async () => {
       clientHandlers.display_otp?.('4892AKJ7', Date.now() + 60_000);

--- a/app/core/AgenticCli/AgenticCliMwpConnectionService.ts
+++ b/app/core/AgenticCli/AgenticCliMwpConnectionService.ts
@@ -72,8 +72,17 @@ const parseAgenticCliConnectionRequest = (
   return parsed;
 };
 
-const wireAgenticCliClientEvents = (conn: Connection): void => {
+const wireAgenticCliClientEvents = (
+  conn: Connection,
+  hostapp: IHostApplicationAdapter,
+): void => {
   conn.client.on('display_otp', (otp, deadline) => {
+    // The OTP sheet supersedes the connection loading sheet. Dismiss the
+    // loading sheet *before* pushing the OTP sheet so it isn't left stacked
+    // underneath it — otherwise hideConnectionLoading (which only pops when the
+    // loading sheet is the top route) would no-op, and the loading sheet would
+    // re-surface when the OTP sheet is dismissed.
+    hostapp.hideConnectionLoading(conn.info);
     showAgenticCliOtpCode(conn.info, otp, deadline);
   });
 
@@ -146,7 +155,7 @@ export async function handleAgenticCliConnectDeeplink(
       deps.relayURL,
       deps.hostapp,
     );
-    wireAgenticCliClientEvents(conn);
+    wireAgenticCliClientEvents(conn, deps.hostapp);
 
     agenticCliStage = 'mwp-connect';
     await conn.connect({

--- a/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.test.ts
@@ -4,12 +4,24 @@ import { Connection } from '../services/connection';
 import { store } from '../../../store';
 import { setSdkV2Connections } from '../../../actions/sdk';
 import { SDKSessions } from '../../../core/SDKConnect/SDKConnect';
-import {
-  hideNotificationById,
-  showSimpleNotification,
-} from '../../../actions/notification';
+import { showSimpleNotification } from '../../../actions/notification';
 import Engine from '../../Engine';
 import { Caip25EndowmentPermissionName } from '@metamask/chain-agnostic-permission';
+import NavigationService from '../../NavigationService';
+import Routes from '../../../constants/navigation/Routes';
+
+jest.mock('../../NavigationService', () => ({
+  __esModule: true,
+  default: {
+    navigation: {
+      navigate: jest.fn(),
+      goBack: jest.fn(),
+      canGoBack: jest.fn(() => true),
+      getCurrentRoute: jest.fn(() => ({ name: 'Home' })),
+    },
+  },
+}));
+
 jest.mock('../../../store', () => ({
   store: {
     dispatch: jest.fn(),
@@ -66,52 +78,131 @@ describe('HostApplicationAdapter', () => {
     (store.dispatch as jest.Mock).mockClear();
     (setSdkV2Connections as jest.Mock).mockClear();
     (showSimpleNotification as jest.Mock).mockClear();
-    (hideNotificationById as jest.Mock).mockClear();
     (revokePermission as jest.Mock).mockClear();
     adapter = new HostApplicationAdapter();
   });
 
-  describe('showConnectionLoading', () => {
-    it('dispatches a pending notification with connection details', () => {
-      adapter.showConnectionLoading(
-        createMockConnectionInfo('session-123', 'Test DApp'),
-      );
+  describe('connection loading sheet', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nav = (NavigationService as any).navigation as {
+      navigate: jest.Mock;
+      goBack: jest.Mock;
+      canGoBack: jest.Mock;
+      getCurrentRoute: jest.Mock;
+    };
 
-      expect(showSimpleNotification).toHaveBeenCalledTimes(1);
-      expect(showSimpleNotification).toHaveBeenCalledWith({
-        id: 'session-123',
-        autodismiss: 10000,
-        title: 'sdk_connect_v2.show_loading.title',
-        description: 'sdk_connect_v2.show_loading.description',
-        status: 'pending',
+    beforeEach(() => {
+      jest.useFakeTimers();
+      nav.navigate.mockClear();
+      nav.goBack.mockClear();
+      nav.canGoBack.mockReturnValue(true);
+      nav.getCurrentRoute.mockReturnValue({ name: 'Home' });
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    describe('showConnectionLoading', () => {
+      it('navigates to the shared SDK loading sheet', () => {
+        adapter.showConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+        );
+
+        expect(nav.navigate).toHaveBeenCalledTimes(1);
+        expect(nav.navigate).toHaveBeenCalledWith(
+          Routes.MODAL.ROOT_MODAL_FLOW,
+          {
+            screen: Routes.SHEET.SDK_LOADING,
+          },
+        );
       });
-      expect(store.dispatch).toHaveBeenCalledTimes(1);
+
+      it.each([
+        ['lock screen', Routes.LOCK_SCREEN],
+        ['login screen', Routes.ONBOARDING.LOGIN],
+        ['account connect sheet', Routes.SHEET.ACCOUNT_CONNECT],
+      ])('does not show the sheet over the %s', (_label, routeName) => {
+        nav.getCurrentRoute.mockReturnValue({ name: routeName });
+
+        adapter.showConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+        );
+
+        expect(nav.navigate).not.toHaveBeenCalled();
+      });
+
+      it('auto-dismisses the sheet after the timeout as a safety net', () => {
+        adapter.showConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+        );
+
+        // The sheet is now on top; the safety timer should take it down.
+        nav.getCurrentRoute.mockReturnValue({
+          name: Routes.SHEET.SDK_LOADING,
+        });
+        jest.advanceTimersByTime(10000);
+
+        expect(nav.goBack).toHaveBeenCalledTimes(1);
+      });
+
+      it('honors a custom autodismiss timeout', () => {
+        adapter.showConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+          { autodismissMs: 15000 },
+        );
+
+        nav.getCurrentRoute.mockReturnValue({
+          name: Routes.SHEET.SDK_LOADING,
+        });
+
+        jest.advanceTimersByTime(10000);
+        expect(nav.goBack).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(5000);
+        expect(nav.goBack).toHaveBeenCalledTimes(1);
+      });
     });
 
-    it('uses a custom autodismiss timeout when provided', () => {
-      adapter.showConnectionLoading(
-        createMockConnectionInfo('session-123', 'Test DApp'),
-        { autodismissMs: 15000 },
-      );
+    describe('hideConnectionLoading', () => {
+      it('dismisses the sheet when it is the current route', () => {
+        nav.getCurrentRoute.mockReturnValue({
+          name: Routes.SHEET.SDK_LOADING,
+        });
 
-      expect(showSimpleNotification).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'session-123',
-          autodismiss: 15000,
-        }),
-      );
-    });
-  });
+        adapter.hideConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+        );
 
-  describe('hideConnectionLoading', () => {
-    it('dispatches hideNotificationById with the session request ID', () => {
-      adapter.hideConnectionLoading(
-        createMockConnectionInfo('session-123', 'Test DApp'),
-      );
+        expect(nav.goBack).toHaveBeenCalledTimes(1);
+      });
 
-      expect(hideNotificationById).toHaveBeenCalledTimes(1);
-      expect(hideNotificationById).toHaveBeenCalledWith('session-123');
-      expect(store.dispatch).toHaveBeenCalledTimes(1);
+      it('does nothing when the loading sheet is not the current route', () => {
+        nav.getCurrentRoute.mockReturnValue({ name: 'Home' });
+
+        adapter.hideConnectionLoading(
+          createMockConnectionInfo('session-123', 'Test DApp'),
+        );
+
+        expect(nav.goBack).not.toHaveBeenCalled();
+      });
+
+      it('cancels the pending safety auto-dismiss timer', () => {
+        const info = createMockConnectionInfo('session-123', 'Test DApp');
+        adapter.showConnectionLoading(info);
+
+        nav.getCurrentRoute.mockReturnValue({
+          name: Routes.SHEET.SDK_LOADING,
+        });
+        adapter.hideConnectionLoading(info);
+        expect(nav.goBack).toHaveBeenCalledTimes(1);
+
+        // The safety timer should have been cleared, so advancing time must not
+        // trigger a second goBack.
+        jest.advanceTimersByTime(20000);
+        expect(nav.goBack).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/app/core/SDKConnectV2/adapters/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.ts
@@ -7,44 +7,115 @@ import { SDKSessions } from '../../../core/SDKConnect/SDKConnect';
 import { store } from '../../../store';
 import { setSdkV2Connections } from '../../../actions/sdk';
 import { ConnectionProps } from '../../../core/SDKConnect/Connection';
-import {
-  hideNotificationById,
-  showSimpleNotification,
-} from '../../../actions/notification';
+import { showSimpleNotification } from '../../../actions/notification';
 import { strings } from '../../../../locales/i18n';
 import { ConnectionInfo } from '../types/connection-info';
 import Engine from '../../Engine';
 import { Caip25EndowmentPermissionName } from '@metamask/chain-agnostic-permission';
 import logger from '../services/logger';
+import NavigationService from '../../NavigationService';
+import Routes from '../../../constants/navigation/Routes';
 
 const DEFAULT_CONNECTION_LOADING_AUTODISMISS_MS = 10_000;
 
 /** Longer timeout for multi-step agentic CLI connect (MWP → OTP → dashboard). */
 export const AGENTIC_CLI_CONNECTION_LOADING_AUTODISMISS_MS = 15_000;
 
+/**
+ * Routes over which the connection loading sheet must NOT be shown:
+ * - the lock / login screens (it would cover the unlock UI), and
+ * - the account-connect sheet (the approval is already up, so loading is moot).
+ * Mirrors the skip list used by the legacy SDK loading state.
+ */
+const LOADING_SKIP_ROUTES: readonly string[] = [
+  Routes.LOCK_SCREEN,
+  Routes.ONBOARDING.LOGIN,
+  Routes.SHEET.ACCOUNT_CONNECT,
+];
+
 export class HostApplicationAdapter implements IHostApplicationAdapter {
+  /**
+   * Safety auto-dismiss timers per connection id. The loading sheet is normally
+   * dismissed explicitly (when the approval is ready, or on success/failure),
+   * but we keep a timer so it can never linger if a connection stalls without
+   * ever surfacing an approval or error.
+   */
+  private readonly loadingDismissTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
+  /**
+   * Shows the shared SDK loading bottom sheet (the same Lottie "connecting"
+   * sheet used by the legacy SDK) while an incoming MetaMask Connect request is
+   * pending — i.e. while the MWP handshake runs and before the approval appears.
+   */
   showConnectionLoading(
     conninfo: ConnectionInfo,
     options?: ShowConnectionLoadingOptions,
   ): void {
+    const navigation = this.getNavigation();
+    if (!navigation) return;
+
+    const currentRoute = navigation.getCurrentRoute?.()?.name;
+    if (currentRoute && LOADING_SKIP_ROUTES.includes(currentRoute)) {
+      return;
+    }
+
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.SDK_LOADING,
+    });
+
     const autodismiss =
       options?.autodismissMs ?? DEFAULT_CONNECTION_LOADING_AUTODISMISS_MS;
-
-    store.dispatch(
-      showSimpleNotification({
-        id: conninfo.id,
-        autodismiss,
-        title: strings('sdk_connect_v2.show_loading.title'),
-        description: strings('sdk_connect_v2.show_loading.description', {
-          dappName: conninfo.metadata.dapp.name,
-        }),
-        status: 'pending',
-      }),
+    this.clearLoadingTimer(conninfo.id);
+    this.loadingDismissTimers.set(
+      conninfo.id,
+      setTimeout(() => {
+        this.loadingDismissTimers.delete(conninfo.id);
+        this.dismissLoadingSheet();
+      }, autodismiss),
     );
   }
 
   hideConnectionLoading(conninfo: ConnectionInfo): void {
-    store.dispatch(hideNotificationById(conninfo.id));
+    this.clearLoadingTimer(conninfo.id);
+    this.dismissLoadingSheet();
+  }
+
+  /**
+   * Dismisses the SDK loading sheet if it is the route currently on top.
+   * Mirrors the legacy SDK `hideLoadingState`.
+   */
+  private dismissLoadingSheet(): void {
+    const navigation = this.getNavigation();
+    if (!navigation) return;
+
+    const currentRoute = navigation.getCurrentRoute?.()?.name;
+    if (currentRoute === Routes.SHEET.SDK_LOADING && navigation.canGoBack?.()) {
+      navigation.goBack();
+    }
+  }
+
+  private clearLoadingTimer(id: string): void {
+    const timer = this.loadingDismissTimers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.loadingDismissTimers.delete(id);
+    }
+  }
+
+  /**
+   * Safely resolves the global navigation reference. Returns undefined if it
+   * isn't ready yet (e.g. an early cold-start deeplink), in which case the
+   * loading sheet is simply skipped rather than throwing.
+   */
+  private getNavigation() {
+    try {
+      return NavigationService.navigation;
+    } catch {
+      return undefined;
+    }
   }
 
   showConnectionError(conninfo?: ConnectionInfo): void {

--- a/app/core/SDKConnectV2/services/connection.test.ts
+++ b/app/core/SDKConnectV2/services/connection.test.ts
@@ -292,6 +292,52 @@ describe('Connection', () => {
         );
       });
 
+      it('dismisses the connection loading sheet when a wallet_createSession request arrives', async () => {
+        await Connection.create(
+          mockConnectionInfo,
+          mockKeyManager,
+          RELAY_URL,
+          mockHostApp,
+        );
+
+        (
+          Engine.context.ApprovalController.getTotalApprovalCount as jest.Mock
+        ).mockReturnValue(0);
+
+        const walletCreateSessionPayload = {
+          name: 'metamask-multichain-provider',
+          data: {
+            method: 'wallet_createSession',
+            params: {},
+            id: 1,
+          },
+        };
+
+        await onClientMessageCallback(walletCreateSessionPayload);
+
+        expect(mockHostApp.hideConnectionLoading).toHaveBeenCalledWith(
+          mockConnectionInfo,
+        );
+      });
+
+      it('does not dismiss the loading sheet for non-createSession messages', async () => {
+        await Connection.create(
+          mockConnectionInfo,
+          mockKeyManager,
+          RELAY_URL,
+          mockHostApp,
+        );
+
+        const otherPayload = {
+          name: 'metamask-provider',
+          data: { method: 'eth_accounts', params: [], id: 2 },
+        };
+
+        await onClientMessageCallback(otherPayload);
+
+        expect(mockHostApp.hideConnectionLoading).not.toHaveBeenCalled();
+      });
+
       it('does not clear pending approvals or navigate away when there are no pending approval requests', async () => {
         await Connection.create(
           mockConnectionInfo,

--- a/app/core/SDKConnectV2/services/connection.ts
+++ b/app/core/SDKConnectV2/services/connection.ts
@@ -116,6 +116,16 @@ export class Connection {
         'method' in payload.data &&
         payload.data.method === 'wallet_createSession';
 
+      // The connection request is now ready to be shown to the user as an
+      // approval, so take down the "connecting" loading sheet first. For QR
+      // flows the dapp sends wallet_createSession only after the handshake, so
+      // this is the point where the loading sheet is dismissed before the
+      // approval appears (for direct deeplink flows it has usually already been
+      // dismissed by the connection registry).
+      if (isWalletCreateSessionRequest) {
+        this.hostApp.hideConnectionLoading(this.info);
+      }
+
       // If the request is a wallet_createSession request and there are pending approval requests, clear those pending approvals before
       // showing the wallet_createSession approval. We do this to prevent the user from seeing a stale wallet_createSession approval in the
       // scenario where they make a connection request, but leave the wallet before approving or rejecting the request, return to the dapp


### PR DESCRIPTION
## **Description**

When a dapp connects to MetaMask Mobile via **MetaMask Connect (SDKConnectV2)** — e.g. through a deeplink — there's a short window where the MWP relay handshake runs before the approval appears. Today that window shows only a small in-app notification ("toast"). This PR shows the **same loading bottom sheet the legacy SDK uses** (`Routes.SHEET.SDK_LOADING`, the Lottie "connecting" sheet) so an incoming connection request gives clear, prominent feedback while it's pending.

What changed:
- `HostApplicationAdapter.showConnectionLoading` now navigates to the shared `SDK_LOADING` sheet instead of dispatching a toast. It skips the lock/login/account-connect routes (so it never covers the unlock UI or an already-open approval) and arms a safety auto-dismiss timer so the sheet can't linger.
- `HostApplicationAdapter.hideConnectionLoading` dismisses the sheet (and clears the timer).
- `Connection` dismisses the sheet the moment a `wallet_createSession` request arrives — i.e. right before the approval is shown. This covers QR flows (where the dapp sends the request *after* the handshake) and guarantees the loading sheet isn't left underneath the approval sheet.

This reuses the existing legacy SDK loading component/route — no new UI component is introduced.

## **Changelog**

CHANGELOG entry: Added a connecting/loading screen while a MetaMask Connect request is being established

## **Related issues**

Related to: WAPI-1564

## **Manual testing steps**

Feature: MetaMask Connect pending-request loading sheet

  Scenario: user connects to a dapp and a connection request is pending
  Given the user has MetaMask Mobile installed and unlocked
  And the user opens a Connect-SDK dapp (e.g. https://demo-mmc-wagmi.vercel.app/)

  When the user taps "Connect" and the connection request is being established
  Then the SDK loading sheet (Lottie "connecting" animation) is shown while pending
  And it is dismissed right before the connection approval appears
  And after approving/rejecting, the loading sheet is not left on the navigation stack

  Scenario: wallet is locked
  Given the wallet is locked (lock/login screen showing)
  When a connection request arrives
  Then the loading sheet does not cover the unlock UI

## **Screenshots/Recordings**

### **Before**

<!-- Small in-app notification (toast) while connecting. -->

### **After**

<!-- Full SDK loading bottom sheet (Lottie) while the connect request is pending. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation during live wallet-connect flows (loading/approval/OTP stacking); mitigated by route guards, explicit dismiss hooks, and reusing an existing sheet.
> 
> **Overview**
> Replaces the small **pending-connection toast** with the **legacy SDK Lottie loading bottom sheet** (`SDK_LOADING`) while MetaMask Connect (SDKConnectV2) handshakes run, so incoming deeplink/QR connects get clearer feedback before approval.
> 
> **`HostApplicationAdapter`** now **navigates** to the shared loading sheet instead of dispatching a pending notification; it **skips** lock, login, and account-connect routes, arms a **per-connection auto-dismiss** safety timer, and **`hideConnectionLoading`** pops the sheet only when it is the top route (and clears the timer). **`Connection`** calls **`hideConnectionLoading`** when a **`wallet_createSession`** message arrives so QR flows dismiss loading right before the approval sheet. **Agentic CLI** dismisses loading **before** showing the OTP sheet so the loading route is not left stacked underneath (where hide would no-op).
> 
> Tests cover navigation, skip routes, timers, createSession dismissal, and OTP ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3179741c09b6a5072aed25bdbcdd2a5489608e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->