### PR TITLE
perf(mwp): defer session resume/reconnect while a new connect is in flight

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -1855,4 +1855,126 @@ describe('ConnectionRegistry', () => {
       await reconnectPromise;
     });
   });
+
+  describe('defers background work while a new connect is in flight (H2)', () => {
+    const makeDeferred = <T = void>() => {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    };
+
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('defers foreground reconnect until the in-flight connect finishes', async () => {
+      mockStore.list.mockResolvedValue([
+        createPersistedConnection('existing-1'),
+      ]);
+      const mockExisting = createMockConnection('existing-1');
+      const connectDeferred = makeDeferred();
+      const mockNew = createMockConnection('new-1', {
+        connect: jest.fn(() => connectDeferred.promise),
+      });
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockExisting)
+        .mockResolvedValueOnce(mockNew);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      await tick();
+      mockExisting.client.reconnect.mockClear();
+
+      // Start a new connect that stays in flight (its connect() hasn't resolved).
+      const connectPromise = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+
+      // reconnectAll must not reconnect the existing connection while the new
+      // connect is still being established.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reconnectPromise = (registry as any).reconnectAll();
+      await tick();
+      expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
+
+      // Once the connect finishes, the deferred reconnect proceeds.
+      connectDeferred.resolve(undefined);
+      await connectPromise;
+      await tick();
+      expect(mockExisting.client.reconnect).toHaveBeenCalledTimes(1);
+      await reconnectPromise;
+    });
+
+    it('defers cold-start resume until the in-flight connect finishes', async () => {
+      const listDeferred = makeDeferred<ConnectionInfo[]>();
+      mockStore.list.mockReturnValue(listDeferred.promise);
+
+      const connectDeferred = makeDeferred();
+      const mockNew = createMockConnection('new-1', {
+        connect: jest.fn(() => connectDeferred.promise),
+      });
+      const mockExisting = createMockConnection('existing-1');
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockNew) // the new connect (happens first)
+        .mockResolvedValueOnce(mockExisting); // the deferred resume
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      // initialize() is now paused awaiting store.list().
+      await tick();
+
+      // Fire a new connect that stays in flight.
+      const connectPromise = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+      expect(Connection.create).toHaveBeenCalledTimes(1); // only the new connect
+
+      // Let initialize() proceed to its resume loop; it must wait for the
+      // in-flight connect rather than resuming immediately.
+      listDeferred.resolve([createPersistedConnection('existing-1')]);
+      await tick();
+      expect(Connection.create).toHaveBeenCalledTimes(1); // resume still deferred
+      expect(mockExisting.resume).not.toHaveBeenCalled();
+
+      // Finish the connect; the deferred resume now runs.
+      connectDeferred.resolve(undefined);
+      await connectPromise;
+      await tick();
+      expect(Connection.create).toHaveBeenCalledTimes(2);
+      expect(mockExisting.resume).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not defer when no connect is in flight', async () => {
+      mockStore.list.mockResolvedValue([
+        createPersistedConnection('existing-1'),
+      ]);
+      const mockExisting = createMockConnection('existing-1');
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValue(mockExisting);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      await tick();
+      mockExisting.client.reconnect.mockClear();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (registry as any).reconnectAll();
+      expect(mockExisting.client.reconnect).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -167,7 +167,15 @@ describe('ConnectionRegistry', () => {
     mockStore.list = jest.fn().mockResolvedValue([]);
     mockStore.save = jest.fn().mockResolvedValue(undefined);
     mockStore.delete = jest.fn().mockResolvedValue(undefined);
-    mockStore.get = jest.fn().mockResolvedValue(null);
+    // Consistent with list() by default: ids in the (last) listed set
+    // resolve to their info, others to null. Reads list's prior result
+    // rather than calling it, to keep list call-count assertions intact.
+    mockStore.get = jest.fn().mockImplementation(async (id: string) => {
+      const lastList = mockStore.list.mock.results.at(-1);
+      const infos: ConnectionInfo[] =
+        lastList && lastList.type === 'return' ? await lastList.value : [];
+      return infos.find((info) => info.id === id) ?? null;
+    });
 
     mockConnection = {
       id: mockConnectionRequest.sessionRequest.id,
@@ -2106,6 +2114,59 @@ describe('ConnectionRegistry', () => {
       // The stale snapshot entry must be skipped, not reconnected.
       expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
       await reconnectPromise;
+    });
+
+    it('skips resuming a persisted session that was disconnected while deferred', async () => {
+      const listDeferred = makeDeferred<ConnectionInfo[]>();
+      mockStore.list.mockReturnValue(listDeferred.promise);
+
+      const connectDeferred = makeDeferred();
+      const mockNew = createMockConnection('new-1', {
+        connect: jest.fn(() => connectDeferred.promise),
+      });
+      const mockExisting = createMockConnection('existing-1');
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockNew) // the new connect (happens first)
+        .mockResolvedValueOnce(mockExisting); // would-be resume (must not run)
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      // initialize() is now paused awaiting store.list().
+      await tick();
+
+      // Fire a new connect that stays in flight.
+      const connectPromise = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+
+      // Let initialize() reach its resume loop; it parks at the barrier.
+      listDeferred.resolve([createPersistedConnection('existing-1')]);
+      await tick();
+      expect(mockExisting.resume).not.toHaveBeenCalled();
+
+      // While parked, the user disconnects the not-yet-resumed session:
+      // its store entry is deleted.
+      await registry.disconnect('existing-1');
+      mockStore.get.mockResolvedValue(null);
+
+      connectDeferred.resolve(undefined);
+      await connectPromise;
+      await tick();
+
+      // The disconnected session must NOT be resurrected by the stale
+      // snapshot — only the new connect's Connection was created.
+      expect(mockExisting.resume).not.toHaveBeenCalled();
+      expect(Connection.create).toHaveBeenCalledTimes(1);
+      expect(
+        mockHostApp.syncConnectionList.mock.calls.at(-1)?.[0],
+      ).not.toContainEqual(
+        expect.objectContaining({ id: 'existing-1' }),
+      );
     });
 
     it('does not defer when no connect is in flight', async () => {

--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -1954,6 +1954,160 @@ describe('ConnectionRegistry', () => {
       expect(mockExisting.resume).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps deferring when a second connect begins as the first one ends', async () => {
+      mockStore.list.mockResolvedValue([
+        createPersistedConnection('existing-1'),
+      ]);
+      const mockExisting = createMockConnection('existing-1');
+      const connectDeferredA = makeDeferred();
+      const connectDeferredB = makeDeferred();
+      const mockNewA = createMockConnection('new-a', {
+        connect: jest.fn(() => connectDeferredA.promise),
+      });
+      const mockNewB = createMockConnection('new-b', {
+        connect: jest.fn(() => connectDeferredB.promise),
+      });
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockExisting)
+        .mockResolvedValueOnce(mockNewA)
+        .mockResolvedValueOnce(mockNewB);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      await tick();
+      mockExisting.client.reconnect.mockClear();
+
+      // Connect A in flight; reconnect parks at the barrier.
+      const connectPromiseA = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reconnectPromise = (registry as any).reconnectAll();
+      await tick();
+      expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
+
+      // Connect B starts while A is still in flight (distinct deeplink URL).
+      const secondDeeplink = `metamask://connect/mwp?p=${encodeURIComponent(
+        JSON.stringify({
+          ...mockConnectionRequest,
+          sessionRequest: {
+            ...mockConnectionRequest.sessionRequest,
+            id: '99999999-8888-7777-6666-555555555555',
+          },
+        }),
+      )}`;
+      const connectPromiseB = registry.handleConnectDeeplink(secondDeeplink);
+      await tick();
+
+      // A finishes, but B is still in flight: the waiter must re-check and
+      // keep deferring rather than proceeding on A's wake-up.
+      connectDeferredA.resolve(undefined);
+      await connectPromiseA;
+      await tick();
+      expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
+
+      // Only once B also finishes does the deferred reconnect run.
+      connectDeferredB.resolve(undefined);
+      await connectPromiseB;
+      await tick();
+      expect(mockExisting.client.reconnect).toHaveBeenCalledTimes(1);
+      await reconnectPromise;
+    });
+
+    it('releases the barrier when the in-flight connect fails', async () => {
+      mockStore.list.mockResolvedValue([
+        createPersistedConnection('existing-1'),
+      ]);
+      const mockExisting = createMockConnection('existing-1');
+      let rejectConnect!: (error: Error) => void;
+      const connectPromiseInner = new Promise<void>((_resolve, reject) => {
+        rejectConnect = reject;
+      });
+      const mockNew = createMockConnection('new-1', {
+        connect: jest.fn(() => connectPromiseInner),
+        disconnect: jest.fn().mockResolvedValue(undefined),
+      });
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockExisting)
+        .mockResolvedValueOnce(mockNew);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      await tick();
+      mockExisting.client.reconnect.mockClear();
+
+      const connectPromise = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reconnectPromise = (registry as any).reconnectAll();
+      await tick();
+      expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
+
+      // The handshake fails; handleConnectDeeplink's finally must still
+      // release the barrier so background work is not deferred forever.
+      rejectConnect(new Error('handshake failed'));
+      await connectPromise; // handleConnectDeeplink catches internally
+      await tick();
+      expect(mockExisting.client.reconnect).toHaveBeenCalledTimes(1);
+      await reconnectPromise;
+    });
+
+    it('skips reconnecting a connection that was removed while deferred', async () => {
+      mockStore.list.mockResolvedValue([
+        createPersistedConnection('existing-1'),
+      ]);
+      const mockExisting = createMockConnection('existing-1');
+      const connectDeferred = makeDeferred();
+      const mockNew = createMockConnection('new-1', {
+        connect: jest.fn(() => connectDeferred.promise),
+      });
+
+      (Connection.create as jest.Mock)
+        .mockReset()
+        .mockResolvedValueOnce(mockExisting)
+        .mockResolvedValueOnce(mockNew);
+
+      registry = new ConnectionRegistry(
+        RELAY_URL,
+        mockKeyManager,
+        mockHostApp,
+        mockStore,
+      );
+      await tick();
+      mockExisting.client.reconnect.mockClear();
+
+      const connectPromise = registry.handleConnectDeeplink(validDeeplink);
+      await tick();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reconnectPromise = (registry as any).reconnectAll();
+      await tick();
+
+      // While reconnect is deferred, the existing connection is disconnected
+      // (e.g. user disconnect or capacity eviction).
+      await registry.disconnect('existing-1');
+
+      connectDeferred.resolve(undefined);
+      await connectPromise;
+      await tick();
+
+      // The stale snapshot entry must be skipped, not reconnected.
+      expect(mockExisting.client.reconnect).not.toHaveBeenCalled();
+      await reconnectPromise;
+    });
+
     it('does not defer when no connect is in flight', async () => {
       mockStore.list.mockResolvedValue([
         createPersistedConnection('existing-1'),

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -62,6 +62,18 @@ export class ConnectionRegistry {
   private deeplinks = new Set<string>();
   private appStateSubscription: NativeEventSubscription | null = null;
 
+  /**
+   * Number of new incoming connect deeplinks currently being established, plus
+   * the resolvers waiting for that count to reach zero.
+   *
+   * Background work (cold-start resume in {@link initialize} and foreground
+   * reconnect in {@link reconnectAll}) yields to in-flight connects via
+   * {@link waitForConnectIdle} so a fresh incoming connection isn't slowed by
+   * resume/reconnect traffic contending with it on the shared relay socket.
+   */
+  private activeConnectCount = 0;
+  private connectIdleResolvers: (() => void)[] = [];
+
   constructor(
     relayURL: string,
     keymanager: IKeyManager,
@@ -90,6 +102,10 @@ export class ConnectionRegistry {
     const persisted = await this.store.list().catch(() => []);
 
     for (const connInfo of persisted) {
+      // Defer resuming a persisted connection while a new connect is being
+      // established, so cold-start resume doesn't contend with the fresh
+      // incoming connection on the shared relay socket.
+      await this.waitForConnectIdle();
       try {
         const conn = await Connection.create(
           connInfo,
@@ -258,6 +274,9 @@ export class ConnectionRegistry {
   public async handleConnectDeeplink(url: string): Promise<void> {
     if (this.deeplinks.has(url)) return;
     this.deeplinks.add(url);
+    // Mark this as an in-flight connect so background resume/reconnect work
+    // yields to it (see waitForConnectIdle).
+    this.beginNewConnect();
 
     logger.debug('Handling connect deeplink:', redactUrl(url));
 
@@ -366,6 +385,7 @@ export class ConnectionRegistry {
 
       if (conn) await this.cleanupConnection(conn);
     } finally {
+      this.endNewConnect();
       this.deeplinks.delete(url);
       // Loading-toast dismissal rules:
       // - On failure, always dismiss the loading toast. Otherwise the user
@@ -434,6 +454,7 @@ export class ConnectionRegistry {
   ): Promise<void> {
     if (this.deeplinks.has(url)) return;
     this.deeplinks.add(url);
+    this.beginNewConnect();
 
     try {
       await handleAgenticCliConnectDeeplink(
@@ -448,6 +469,7 @@ export class ConnectionRegistry {
         connReq,
       );
     } finally {
+      this.endNewConnect();
       this.deeplinks.delete(url);
     }
   }
@@ -540,10 +562,48 @@ export class ConnectionRegistry {
    * A single failure is logged and does not stop subsequent connections from
    * being processed.
    */
+  /**
+   * Marks the start of a new incoming connect so background resume/reconnect
+   * work defers to it. Must be paired with {@link endNewConnect}.
+   */
+  private beginNewConnect(): void {
+    this.activeConnectCount += 1;
+  }
+
+  /**
+   * Marks the end of a new incoming connect, releasing any background work that
+   * is waiting in {@link waitForConnectIdle} once no connects remain in flight.
+   */
+  private endNewConnect(): void {
+    this.activeConnectCount = Math.max(0, this.activeConnectCount - 1);
+    if (this.activeConnectCount === 0 && this.connectIdleResolvers.length > 0) {
+      const resolvers = this.connectIdleResolvers;
+      this.connectIdleResolvers = [];
+      for (const resolve of resolvers) {
+        resolve();
+      }
+    }
+  }
+
+  /**
+   * Resolves immediately when no new connect is in flight, otherwise waits
+   * until the in-flight connect(s) finish. Used to keep cold-start resume and
+   * foreground reconnect off the critical path of a fresh incoming connect.
+   */
+  private async waitForConnectIdle(): Promise<void> {
+    if (this.activeConnectCount === 0) return;
+    await new Promise<void>((resolve) => {
+      this.connectIdleResolvers.push(resolve);
+    });
+  }
+
   private async reconnectAll(): Promise<void> {
     const connections = Array.from(this.connections.values());
 
     for (const conn of connections) {
+      // Defer reconnecting an existing connection while a new connect is being
+      // established, so background reconnect traffic doesn't contend with it.
+      await this.waitForConnectIdle();
       try {
         await conn.client.reconnect();
         logger.debug('Connection reconnected:', conn.id);

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -554,15 +554,6 @@ export class ConnectionRegistry {
   }
 
   /**
-   * Proactively refreshes all active connections. This is the primary mechanism
-   * for preventing stale/zombie connections after the app was put in the background.
-   *
-   * Reconnections are processed sequentially so a user with N active sessions
-   * does not trigger N concurrent relay handshakes on every foreground event.
-   * A single failure is logged and does not stop subsequent connections from
-   * being processed.
-   */
-  /**
    * Marks the start of a new incoming connect so background resume/reconnect
    * work defers to it. Must be paired with {@link endNewConnect}.
    */
@@ -589,14 +580,33 @@ export class ConnectionRegistry {
    * Resolves immediately when no new connect is in flight, otherwise waits
    * until the in-flight connect(s) finish. Used to keep cold-start resume and
    * foreground reconnect off the critical path of a fresh incoming connect.
+   *
+   * Re-checks the count in a loop: the wake-up from {@link endNewConnect}
+   * lands on a later microtask, so another connect may have already begun by
+   * the time a waiter resumes. Without the loop, background work could slip
+   * through and run alongside that new in-flight connect.
+   *
+   * Note the barrier only gates loop *iterations* — a resume/reconnect that
+   * has already started is never preempted mid-operation (an in-flight relay
+   * handshake cannot be cancelled).
    */
   private async waitForConnectIdle(): Promise<void> {
-    if (this.activeConnectCount === 0) return;
-    await new Promise<void>((resolve) => {
-      this.connectIdleResolvers.push(resolve);
-    });
+    while (this.activeConnectCount > 0) {
+      await new Promise<void>((resolve) => {
+        this.connectIdleResolvers.push(resolve);
+      });
+    }
   }
 
+  /**
+   * Proactively refreshes all active connections. This is the primary mechanism
+   * for preventing stale/zombie connections after the app was put in the background.
+   *
+   * Reconnections are processed sequentially so a user with N active sessions
+   * does not trigger N concurrent relay handshakes on every foreground event.
+   * A single failure is logged and does not stop subsequent connections from
+   * being processed.
+   */
   private async reconnectAll(): Promise<void> {
     const connections = Array.from(this.connections.values());
 
@@ -604,6 +614,14 @@ export class ConnectionRegistry {
       // Defer reconnecting an existing connection while a new connect is being
       // established, so background reconnect traffic doesn't contend with it.
       await this.waitForConnectIdle();
+
+      // The connection may have been disconnected/evicted while we were
+      // deferring (e.g. the in-flight connect triggered capacity eviction),
+      // so skip anything no longer in the registry.
+      if (!this.connections.has(conn.id)) {
+        continue;
+      }
+
       try {
         await conn.client.reconnect();
         logger.debug('Connection reconnected:', conn.id);

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -106,6 +106,19 @@ export class ConnectionRegistry {
       // established, so cold-start resume doesn't contend with the fresh
       // incoming connection on the shared relay socket.
       await this.waitForConnectIdle();
+
+      // The barrier may have parked this loop for a while. If this
+      // not-yet-resumed session was disconnected in the meantime, its store
+      // entry is gone — resuming it anyway would resurrect a session the
+      // user just removed. On a store read failure, err on resuming (the
+      // pre-barrier behavior).
+      const stillPersisted = await this.store
+        .get(connInfo.id)
+        .catch(() => connInfo);
+      if (!stillPersisted) {
+        continue;
+      }
+
       try {
         const conn = await Connection.create(
           connInfo,


### PR DESCRIPTION
## **Description**

On cold start, `ConnectionRegistry.initialize()` resumes every persisted MWP session **sequentially**, and on every foreground `reconnectAll()` reconnects them **sequentially**. All connections share a single relay WebSocket (`useSharedConnection: true`), so this background resume/reconnect traffic can contend with a brand-new incoming connect deeplink and slow its handshake — i.e. the time until the approval appears.

This adds a lightweight **in-flight-connect barrier**:
- `handleConnectDeeplink` and the agentic-CLI connect mark a connect as active for their full duration (`beginNewConnect` / `endNewConnect`).
- The cold-start resume loop and the foreground reconnect loop `await waitForConnectIdle()` between iterations, so they yield to any in-flight connect.

Net effect: a fresh incoming connect runs without resume/reconnect contention on the shared relay; the deferred background work resumes the instant the connect finishes. When nothing is connecting, behavior is unchanged (the barrier resolves immediately).

This is a focused, low-risk slice. A larger follow-up (lazy/on-demand resume instead of eager cold-start resume) is noted in WAPI-1566 as a future option.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: WAPI-1566
Related to: WAPI-1564

## **Manual testing steps**

Feature: Deeplink connect is not slowed by background session resume

  Scenario: connect on cold start with many persisted sessions
  Given the wallet has several persisted MetaMask Connect sessions
  And the app is cold-started

  When the user connects to a dapp via deeplink while sessions are still resuming
  Then the new connection's handshake/approval is not delayed behind the resume work
  And the previously persisted sessions still resume/reconnect afterwards

## **Screenshots/Recordings**

### **Before**

<!-- New connect handshake contends with cold-start/foreground resume on the shared relay. -->

### **After**

<!-- Resume/reconnect yields to the in-flight connect, then continues. -->

## **Benchmark results**

Measured with a cold-start A/B harness ([`mwp-connect-bench`](https://github.com/MetaMask/connect-monorepo/tree/main/playground/mwp-connect-bench)): iPhone 16 Pro simulator, **Release** build (embedded bundle, no Metro), 20 seeded persisted MWP sessions, 8 cold-start connect-deeplink trials per arm. Timer runs from deeplink receipt (`connect_start`) to handshake completion (`connect_end`); both arms carry identical instrumentation, differing only in `connection-registry.ts`.

| Arm | median | p75 | min | max | resume events inside connect window |
|---|---|---|---|---|---|
| `main` (control) | 1015 ms | 1047 ms | 964 ms | 1097 ms | 30 |
| this PR | **924 ms** | **958 ms** | 824 ms | 994 ms | 8 |

- **−91 ms median (−9%), −89 ms p75** on an unthrottled local network, with a tighter distribution.
- Resume contention inside the connect window dropped 30 → 8. The remaining 8 (exactly 1 per trial) are the resume already in flight when the deeplink lands — the barrier defers subsequent iterations but can't preempt one that already started, as designed.
- All 160 background resumes per arm still completed successfully afterwards (no starvation).

A throttled run (+150 ms egress delay to the relay) was started to simulate realistic mobile RTTs: control came in at median **1923 ms** (each of the handshake's relay round-trips absorbs the added delay, and contending resume traffic gets proportionally more expensive), so the absolute win should grow with RTT. The throttled PR arm wasn't completed due to local machine constraints; happy to finish that pass if reviewers want it.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted scheduling change in SDK connect lifecycle with no auth/data-model changes; behavior when idle is unchanged and failures still release the barrier.
> 
> **Overview**
> Adds an **in-flight connect barrier** in `ConnectionRegistry` so cold-start session resume and foreground `reconnectAll` **yield** while a connect deeplink (or agentic CLI connect) is establishing, reducing contention on the shared relay WebSocket.
> 
> Connect flows call `beginNewConnect` / `endNewConnect` (including on failure in `finally`). Background loops `await waitForConnectIdle()` between iterations, with a **re-check loop** when multiple connects overlap. After deferral, resume/reconnect **skip** sessions removed from the store or registry (disconnect/eviction).
> 
> Tests cover deferral, overlapping connects, failed connect release, stale snapshots, and the no-defer idle path; `mockStore.get` aligns with `list()` for barrier re-checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38bced927f0b812ace69906851c51d354cb6b5bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


