### PR TITLE
perf: memoize `nonTestNetworkCaipChainIds` and `testNetworkCaipChainIds`

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -244,11 +244,13 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     [networkConfigurations],
   );
 
-  const nonTestNetworkCaipChainIds = nonTestNetworkConfigurations.map(
-    ({ caipChainId }) => caipChainId,
+  const nonTestNetworkCaipChainIds = useMemo(
+    () => nonTestNetworkConfigurations.map(({ caipChainId }) => caipChainId),
+    [nonTestNetworkConfigurations],
   );
-  const testNetworkCaipChainIds = testNetworkConfigurations.map(
-    ({ caipChainId }) => caipChainId,
+  const testNetworkCaipChainIds = useMemo(
+    () => testNetworkConfigurations.map(({ caipChainId }) => caipChainId),
+    [testNetworkConfigurations],
   );
 
   const alreadyConnectedCaipChainIds = useMemo(


### PR DESCRIPTION
## **Description**

Wraps `nonTestNetworkCaipChainIds` and `testNetworkCaipChainIds` in `useMemo` in `MultichainAccountConnect`. Previously, bare `.map()` calls on already-memoized arrays created fresh references every render, causing the downstream `requestedAndAlreadyConnectedCaipChainIdsOrDefault` memo to invalidate on every render cycle even when network configurations had not changed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31292
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1920

## **Manual testing steps**

N/A — pure memoization change with no behavioral difference; covered by existing unit tests.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.