### PR TITLE
perf(selectors): use `createDeepEqualSelector` for `selectInternalEvmAccounts`

### DIFF
--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -766,6 +766,24 @@ describe('selectInternalEvmAccounts', () => {
 
     expect(result).toHaveLength(4);
   });
+
+  it('returns the same reference when EVM accounts are unchanged', () => {
+    const mockAccountsController =
+      MOCK_GENERATED_ACCOUNTS_CONTROLLER_REVERSED();
+    const state = {
+      engine: {
+        backgroundState: {
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+          AccountsController: mockAccountsController,
+        },
+      },
+    } as RootState;
+
+    const result1 = selectInternalEvmAccounts(state);
+    const result2 = selectInternalEvmAccounts(state);
+
+    expect(result1).toBe(result2);
+  });
 });
 
 describe('selectEvmAddress', () => {

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -80,7 +80,7 @@ export const selectInternalAccounts = createDeepEqualSelector(
   },
 );
 
-export const selectInternalEvmAccounts = createSelector(
+export const selectInternalEvmAccounts = createDeepEqualSelector(
   selectInternalAccounts,
   (accounts) => accounts.filter((account) => isEvmAccountType(account.type)),
 );


### PR DESCRIPTION
## **Description**

Replaces `createSelector` with `createDeepEqualSelector` for `selectInternalEvmAccounts`. The `.filter()` call was returning a new array reference on every invocation even when the filtered content was unchanged, causing unnecessary re-renders in all downstream consumers (~5 modules including account pickers and balances). `selectInternalAccounts` is already a `createDeepEqualSelector`, so its output is stable — the fix extends that stability through the filter.

Adds a `toBe` referential-stability test to assert the fix holds.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31350
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1921

## **Manual testing steps**

N/A — pure selector memoization change with no behavioral difference; covered by existing and new unit tests.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow selector memoization change with a regression test; output values stay the same, only reference stability improves.
> 
> **Overview**
> **`selectInternalEvmAccounts`** now uses **`createDeepEqualSelector`** instead of Reselect’s default reference-based memoization, so repeated reads with the same underlying EVM account set keep a **stable array reference** even when upstream inputs produce new object references.
> 
> A unit test asserts **`result1 === result2`** when state is unchanged, guarding the intended memoization behavior for consumers that depend on reference equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb87eee4e6fc32f14608c9ae143bb8e3b26adaaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->