### PR TITLE
perf(caip-account-selector): replace initialNumToRender=999 with getItemLayout + scrollToIndex

### DIFF
--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -302,27 +302,37 @@ const CaipAccountSelectorList = ({
     ],
   );
 
+  const getItemLayout = useCallback(
+    (_data: ArrayLike<Account> | null | undefined, index: number) => {
+      const account = accounts[index];
+      const itemHeight = account?.type !== KeyringTypes.hd ? 102 : 78;
+      return { length: itemHeight, offset: account?.yOffset ?? 0, index };
+    },
+    [accounts],
+  );
+
   const onContentSizeChanged = useCallback(() => {
     // Handle auto scroll to account
     if (!accounts.length || !isAutoScrollEnabled) return;
     if (accountsLengthRef.current !== accounts.length) {
-      let selectedAccount: Account | undefined;
+      let selectedIndex = -1;
 
       if (selectedAddresses.length) {
-        const selectedAddress = selectedAddresses[0];
-        selectedAccount = accounts.find(
-          (acc) => acc.caipAccountId === selectedAddress,
+        selectedIndex = accounts.findIndex(
+          (acc) => acc.caipAccountId === selectedAddresses[0],
         );
       }
       // Fall back to the account with isSelected flag if no override or match found
-      if (!selectedAccount) {
-        selectedAccount = accounts.find((acc) => acc.isSelected);
+      if (selectedIndex === -1) {
+        selectedIndex = accounts.findIndex((acc) => acc.isSelected);
       }
 
-      accountListRef?.current?.scrollToOffset({
-        offset: selectedAccount?.yOffset,
-        animated: false,
-      });
+      if (selectedIndex >= 0) {
+        accountListRef?.current?.scrollToIndex({
+          index: selectedIndex,
+          animated: false,
+        });
+      }
 
       accountsLengthRef.current = accounts.length;
     }
@@ -335,8 +345,8 @@ const CaipAccountSelectorList = ({
       data={accounts}
       keyExtractor={getKeyExtractor}
       renderItem={renderAccountItem}
-      // Increasing number of items at initial render fixes scroll issue.
-      initialNumToRender={999}
+      getItemLayout={getItemLayout}
+      initialNumToRender={10}
       testID={ACCOUNT_SELECTOR_LIST_TESTID}
       {...props}
     />


### PR DESCRIPTION
## **Description**

`initialNumToRender={999}` in `CaipAccountSelectorList` forced synchronous rendering of every account row on mount as a workaround for auto-scroll positioning. This blocked the JS thread proportionally to the number of accounts.

The fix adds `getItemLayout` using the pre-computed `yOffset` values already available on each `Account` object (set in `useAccounts.ts`). With exact item dimensions provided upfront, `FlatList` can resolve scroll positions without needing all rows rendered. The auto-scroll in `onContentSizeChanged` is updated from `scrollToOffset` to `scrollToIndex`, and `initialNumToRender` is reduced to 10.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31308

## **Manual testing steps**

```gherkin
Feature: Account selector list performance

  Scenario: Opening account selector with many accounts
    Given a wallet with 20+ accounts
    When the user opens the account selector
    Then the list scrolls to the selected account correctly
    And the initial render does not block for the full account count
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only list scrolling and render tuning in the account selector; incorrect layout heights could mis-scroll but behavior is localized.
> 
> **Overview**
> Improves **CAIP account selector** list performance by dropping the `initialNumToRender={999}` workaround and using normal virtualization with **`initialNumToRender={10}`**.
> 
> Adds **`getItemLayout`** so row height depends on account type (78px for HD, 102px otherwise) and scroll offsets reuse each account’s existing **`yOffset`**.
> 
> When the account list length changes and auto-scroll runs, selection is resolved by **index** (`findIndex` on `selectedAddresses` or `isSelected`) and the list scrolls with **`scrollToIndex`** instead of **`scrollToOffset`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256cb9b1f8262e864553ad008a0c74157f528fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->