### PR TITLE
prototype: Refine trade sheet animation

### DIFF
--- a/app/component-library/components/Overlay/Overlay.constants.ts
+++ b/app/component-library/components/Overlay/Overlay.constants.ts
@@ -1,7 +1,12 @@
 /* eslint-disable import-x/prefer-default-export */
 
+// Third party dependencies.
+import { Easing } from 'react-native';
+
 // External dependencies.
 import { AnimationDuration } from '../../constants/animation.constants';
 
-// Defaults
-export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Fast;
+/** Matches UIKit `curveEaseInOut` for a native modal scrim fade-in. */
+export const DEFAULT_OVERLAY_ANIMATION_EASING = Easing.bezier(0.42, 0, 0.58, 1);
+
+export const DEFAULT_OVERLAY_ANIMATION_DURATION = AnimationDuration.Regularly;

--- a/app/component-library/components/Overlay/Overlay.tsx
+++ b/app/component-library/components/Overlay/Overlay.tsx
@@ -1,48 +1,76 @@
 /* eslint-disable react/prop-types */
 
 // Third party dependencies.
-import React from 'react';
-import { TouchableOpacity } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { Animated, TouchableOpacity } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
 
 // Internal dependencies.
 import styleSheet from './Overlay.styles';
-import { OverlayProps } from './Overlay.types';
-import { DEFAULT_OVERLAY_ANIMATION_DURATION } from './Overlay.constants';
+import {
+  DEFAULT_OVERLAY_ANIMATION_DURATION,
+  DEFAULT_OVERLAY_ANIMATION_EASING,
+} from './Overlay.constants';
+import { OverlayProps, OverlayRef } from './Overlay.types';
 
-const Overlay: React.FC<OverlayProps> = ({
-  style,
-  onPress,
-  color,
-  duration,
-}) => {
-  const { styles } = useStyles(styleSheet, { style, color });
-  const opacityVal = useSharedValue(0);
-  const animatedStyles = useAnimatedStyle(
-    () => ({
-      opacity: opacityVal.value,
-    }),
-    [opacityVal.value],
-  );
+const Overlay = forwardRef<OverlayRef, OverlayProps>(
+  ({ style, onPress, color, duration, ...touchableProps }, ref) => {
+    const { styles } = useStyles(styleSheet, { style, color });
+    const opacityVal = useRef(new Animated.Value(0)).current;
 
-  opacityVal.value = withTiming(1, {
-    duration: duration ?? DEFAULT_OVERLAY_ANIMATION_DURATION,
-    easing: Easing.linear,
-  });
+    const fadeIn = useCallback(() => {
+      Animated.timing(opacityVal, {
+        toValue: 1,
+        duration: duration ?? DEFAULT_OVERLAY_ANIMATION_DURATION,
+        easing: DEFAULT_OVERLAY_ANIMATION_EASING,
+        useNativeDriver: true,
+      }).start();
+    }, [duration, opacityVal]);
 
-  return (
-    <Animated.View style={[styles.base, animatedStyles]}>
-      {onPress && <TouchableOpacity onPress={onPress} style={styles.fill} />}
-    </Animated.View>
-  );
-};
+    const fadeOut = useCallback(
+      (callback?: () => void) => {
+        Animated.timing(opacityVal, {
+          toValue: 0,
+          duration: duration ?? DEFAULT_OVERLAY_ANIMATION_DURATION,
+          easing: DEFAULT_OVERLAY_ANIMATION_EASING,
+          useNativeDriver: true,
+        }).start(({ finished }) => {
+          if (finished) {
+            callback?.();
+          }
+        });
+      },
+      [duration, opacityVal],
+    );
+
+    useImperativeHandle(ref, () => ({ fadeIn, fadeOut }), [fadeIn, fadeOut]);
+
+    useEffect(() => {
+      fadeIn();
+    }, [fadeIn]);
+
+    return (
+      <Animated.View style={[styles.base, { opacity: opacityVal }]}>
+        {onPress && (
+          <TouchableOpacity
+            onPress={onPress}
+            style={styles.fill}
+            {...touchableProps}
+          />
+        )}
+      </Animated.View>
+    );
+  },
+);
+
+Overlay.displayName = 'Overlay';
 
 export default Overlay;

--- a/app/component-library/components/Overlay/Overlay.types.ts
+++ b/app/component-library/components/Overlay/Overlay.types.ts
@@ -21,3 +21,13 @@ export interface OverlayProps extends TouchableOpacityProps {
  * Style sheet Overlay parameters.
  */
 export type OverlayStyleSheetVars = Pick<OverlayProps, 'style' | 'color'>;
+
+/**
+ * Ref handle for imperative control of overlay fade animations.
+ */
+export interface OverlayRef {
+  /** Fade the overlay in. */
+  fadeIn: () => void;
+  /** Fade the overlay out with an optional callback after animation completes. */
+  fadeOut: (callback?: () => void) => void;
+}

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -1,6 +1,6 @@
 import MaskedView from '@react-native-masked-view/masked-view';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   BackHandler,
   Platform,
@@ -10,11 +10,14 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import Animated, {
-  FadeInDown,
-  FadeOutDown,
   runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  type WithSpringConfig,
 } from 'react-native-reanimated';
 import Overlay from '../../../component-library/components/Overlay';
+import type { OverlayRef } from '../../../component-library/components/Overlay/Overlay.types';
 import { useParams } from '../../../util/navigation/navUtils';
 import { Box } from '../../UI/Box/Box';
 
@@ -37,7 +40,6 @@ import { useSelector } from 'react-redux';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletActionsBottomSheetSelectorsIDs } from '../WalletActions/WalletActionsBottomSheet.testIds';
 import { strings } from '../../../../locales/i18n';
-import { AnimationDuration } from '../../../component-library/constants/animation.constants';
 import { selectBatchSellEnabled } from '../../../selectors/featureFlagController/batchSell';
 import Routes from '../../../constants/navigation/Routes';
 import AppConstants from '../../../core/AppConstants';
@@ -74,7 +76,15 @@ import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsContro
 import useStakingEligibility from '../../UI/Stake/hooks/useStakingEligibility';
 
 const bottomMaskHeight = 35;
-const animationDuration = AnimationDuration.Fast;
+
+/** iOS-like sheet spring: natural deceleration with minimal overshoot on open. */
+const TRADE_WALLET_ACTIONS_SHEET_SPRING_CONFIG = {
+  damping: 28,
+  stiffness: 320,
+  mass: 0.9,
+  overshootClamping: true,
+} as const satisfies WithSpringConfig;
+
 const batchSellIconStyle = {
   transform: [{ rotate: '180deg' }],
 } satisfies ViewStyle;
@@ -95,9 +105,11 @@ function TradeWalletActions() {
   const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
 
   const postCallback = useRef<(() => void) | undefined>(undefined);
-  const [visible, setIsVisible] = useState(true);
+  const overlayRef = useRef<OverlayRef>(null);
+  const isClosingRef = useRef(false);
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const { height: screenHeight } = useSafeAreaFrame();
+  const sheetOffset = useSharedValue(screenHeight);
   const insets = useSafeAreaInsets();
   const insetsTop = Platform.OS === 'android' ? insets.top : 0;
 
@@ -158,10 +170,52 @@ function TradeWalletActions() {
     navigation.goBack();
   }, [navigation]);
 
+  const finishDismiss = useCallback(() => {
+    const callback = postCallback.current;
+    postCallback.current = undefined;
+
+    dismissRootModalFlow();
+
+    if (callback) {
+      // Defer navigation until RootModalFlow is fully dismissed so screens
+      // on MainNavigator (e.g. StakeModals) are not opened underneath it.
+      requestAnimationFrame(() => {
+        callback();
+      });
+    }
+  }, [dismissRootModalFlow]);
+
+  const dismissSheet = useCallback(() => {
+    if (isClosingRef.current) {
+      return;
+    }
+    isClosingRef.current = true;
+    overlayRef.current?.fadeOut();
+    sheetOffset.value = withSpring(
+      screenHeight,
+      TRADE_WALLET_ACTIONS_SHEET_SPRING_CONFIG,
+      (finished) => {
+        if (finished) {
+          runOnJS(finishDismiss)();
+        }
+      },
+    );
+  }, [finishDismiss, screenHeight, sheetOffset]);
+
   const handleNavigateBack = useCallback(() => {
     onDismiss?.();
-    setIsVisible(false);
-  }, [onDismiss]);
+    dismissSheet();
+  }, [dismissSheet, onDismiss]);
+
+  useEffect(() => {
+    isClosingRef.current = false;
+    sheetOffset.value = screenHeight;
+    sheetOffset.value = withSpring(0, TRADE_WALLET_ACTIONS_SHEET_SPRING_CONFIG);
+  }, [screenHeight, sheetOffset]);
+
+  const sheetAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: sheetOffset.value }],
+  }));
 
   const goToSwaps = useCallback(() => {
     postCallback.current = () => {
@@ -248,33 +302,6 @@ function TradeWalletActions() {
     }, [handleNavigateBack]),
   );
 
-  const exitingAnimationWithCallback = useCallback(
-    (callback: () => void) =>
-      FadeOutDown.duration(animationDuration).withCallback(
-        (finished) => finished && runOnJS(callback)(),
-      ),
-    [],
-  );
-
-  const exitingWithNavigateBack = useMemo(
-    () =>
-      exitingAnimationWithCallback(() => {
-        const callback = postCallback.current;
-        postCallback.current = undefined;
-
-        dismissRootModalFlow();
-
-        if (callback) {
-          // Defer navigation until RootModalFlow is fully dismissed so screens
-          // on MainNavigator (e.g. StakeModals) are not opened underneath it.
-          requestAnimationFrame(() => {
-            callback();
-          });
-        }
-      }),
-    [dismissRootModalFlow, exitingAnimationWithCallback],
-  );
-
   return (
     <View style={tw.style('flex-1 justify-end')}>
       <MaskedView
@@ -289,128 +316,111 @@ function TradeWalletActions() {
           />
         }
       >
-        <Overlay
-          onPress={handleNavigateBack}
-          duration={animationDuration}
-        ></Overlay>
+        <Overlay ref={overlayRef} onPress={handleNavigateBack} />
       </MaskedView>
 
-      {visible && (
-        <Animated.View exiting={exitingWithNavigateBack}>
-          <MaskedView
-            // iOS: MaskedView otherwise intercepts touches and ActionListItem onPress never fires (Android is unaffected).
-            pointerEvents="box-none"
-            maskElement={
-              <View style={tw.style('flex-1 bg-transparent px-4')}>
-                <View style={tw.style('flex-1 bg-black')} />
-                <View style={tw.style('flex-row mt-[-1px]')}>
-                  <View style={tw.style('bg-black flex-1 rounded-bl-2xl')} />
-                  <BottomShape
-                    width={buttonLayout.width * 4}
-                    height={bottomMaskHeight}
-                    peakHeight={16}
-                    peakBezierLength={25}
-                    baseBezierLength={55}
-                    fill="black"
-                  />
-                  <View style={tw.style('bg-black flex-1 rounded-br-2xl')} />
-                </View>
+      <Animated.View style={sheetAnimatedStyle}>
+        <MaskedView
+          // iOS: MaskedView otherwise intercepts touches and ActionListItem onPress never fires (Android is unaffected).
+          pointerEvents="box-none"
+          maskElement={
+            <View style={tw.style('flex-1 bg-transparent px-4')}>
+              <View style={tw.style('flex-1 bg-black')} />
+              <View style={tw.style('flex-row mt-[-1px]')}>
+                <View style={tw.style('bg-black flex-1 rounded-bl-2xl')} />
+                <BottomShape
+                  width={buttonLayout.width * 4}
+                  height={bottomMaskHeight}
+                  peakHeight={16}
+                  peakBezierLength={25}
+                  baseBezierLength={55}
+                  fill="black"
+                />
+                <View style={tw.style('bg-black flex-1 rounded-br-2xl')} />
               </View>
-            }
+            </View>
+          }
+        >
+          <Box
+            style={tw.style(
+              `${surfaceClass} p-4 rounded-2xl mx-4`,
+              `pb-[${bottomMaskHeight - 12}px]`,
+              `px-0`,
+            )}
           >
-            <Animated.View
-              entering={FadeInDown.duration(
-                animationDuration,
-              ).withInitialValues({
-                transform: [{ translateY: 50 }],
-              })}
-            >
-              <Box
-                style={tw.style(
-                  `${surfaceClass} p-4 rounded-2xl mx-4`,
-                  `pb-[${bottomMaskHeight - 12}px]`,
-                  `px-0`,
-                )}
-              >
-                {shouldRenderBatchSell && (
-                  <ActionListItem
-                    label={
-                      <View style={tw.style('flex-row items-center gap-2')}>
-                        <Text
-                          variant={TextVariant.BodyMd}
-                          fontWeight={FontWeight.Medium}
-                        >
-                          {strings('asset_overview.batch_sell')}
-                        </Text>
-                        <Tag severity={TagSeverity.Info}>
-                          {strings('asset_overview.batch_sell_new_label')}
-                        </Tag>
-                      </View>
-                    }
-                    description={strings(
-                      'asset_overview.batch_sell_description',
-                    )}
-                    iconName={IconName.Merge}
-                    iconProps={{
-                      style: batchSellIconStyle,
-                    }}
-                    onPress={onBatchSell}
-                    testID={
-                      WalletActionsBottomSheetSelectorsIDs.BATCH_SELL_BUTTON
-                    }
-                    isDisabled={!isSwapsEnabled}
-                    style={tw.style('bg-transparent')}
-                  />
-                )}
-                {AppConstants.SWAPS.ACTIVE && (
-                  <ActionListItem
-                    label={strings('asset_overview.swap')}
-                    description={strings('asset_overview.swap_description')}
-                    iconName={IconName.SwapVertical}
-                    onPress={goToSwaps}
-                    testID={WalletActionsBottomSheetSelectorsIDs.SWAP_BUTTON}
-                    isDisabled={!isSwapsEnabled}
-                    style={tw.style('bg-transparent')}
-                  />
-                )}
-                {isPerpsEnabled && (
-                  <ActionListItem
-                    label={strings('asset_overview.perps_button')}
-                    description={strings('asset_overview.perps_description')}
-                    iconName={IconName.Candlestick}
-                    onPress={onPerps}
-                    testID={WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON}
-                    isDisabled={!canSignTransactions}
-                    style={tw.style('bg-transparent')}
-                  />
-                )}
-                {isPredictEnabled && (
-                  <ActionListItem
-                    label={strings('asset_overview.predict_button')}
-                    description={strings('asset_overview.predict_description')}
-                    iconName={IconName.Speedometer}
-                    onPress={onPredict}
-                    testID={WalletActionsBottomSheetSelectorsIDs.PREDICT_BUTTON}
-                    isDisabled={!canSignTransactions}
-                    style={tw.style('bg-transparent')}
-                  />
-                )}
-                {isEarnWalletActionEnabled && isEarnEligible && (
-                  <ActionListItem
-                    label={strings('asset_overview.earn_button')}
-                    description={strings('asset_overview.earn_description')}
-                    iconName={IconName.Stake}
-                    onPress={onEarn}
-                    testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
-                    isDisabled={!canSignTransactions}
-                    style={tw.style('bg-transparent')}
-                  />
-                )}
-              </Box>
-            </Animated.View>
-          </MaskedView>
-        </Animated.View>
-      )}
+            {shouldRenderBatchSell && (
+              <ActionListItem
+                label={
+                  <View style={tw.style('flex-row items-center gap-2')}>
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {strings('asset_overview.batch_sell')}
+                    </Text>
+                    <Tag severity={TagSeverity.Info}>
+                      {strings('asset_overview.batch_sell_new_label')}
+                    </Tag>
+                  </View>
+                }
+                description={strings('asset_overview.batch_sell_description')}
+                iconName={IconName.Merge}
+                iconProps={{
+                  style: batchSellIconStyle,
+                }}
+                onPress={onBatchSell}
+                testID={WalletActionsBottomSheetSelectorsIDs.BATCH_SELL_BUTTON}
+                isDisabled={!isSwapsEnabled}
+                style={tw.style('bg-transparent')}
+              />
+            )}
+            {AppConstants.SWAPS.ACTIVE && (
+              <ActionListItem
+                label={strings('asset_overview.swap')}
+                description={strings('asset_overview.swap_description')}
+                iconName={IconName.SwapVertical}
+                onPress={goToSwaps}
+                testID={WalletActionsBottomSheetSelectorsIDs.SWAP_BUTTON}
+                isDisabled={!isSwapsEnabled}
+                style={tw.style('bg-transparent')}
+              />
+            )}
+            {isPerpsEnabled && (
+              <ActionListItem
+                label={strings('asset_overview.perps_button')}
+                description={strings('asset_overview.perps_description')}
+                iconName={IconName.Candlestick}
+                onPress={onPerps}
+                testID={WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON}
+                isDisabled={!canSignTransactions}
+                style={tw.style('bg-transparent')}
+              />
+            )}
+            {isPredictEnabled && (
+              <ActionListItem
+                label={strings('asset_overview.predict_button')}
+                description={strings('asset_overview.predict_description')}
+                iconName={IconName.Speedometer}
+                onPress={onPredict}
+                testID={WalletActionsBottomSheetSelectorsIDs.PREDICT_BUTTON}
+                isDisabled={!canSignTransactions}
+                style={tw.style('bg-transparent')}
+              />
+            )}
+            {isEarnWalletActionEnabled && isEarnEligible && (
+              <ActionListItem
+                label={strings('asset_overview.earn_button')}
+                description={strings('asset_overview.earn_description')}
+                iconName={IconName.Stake}
+                onPress={onEarn}
+                testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
+                isDisabled={!canSignTransactions}
+                style={tw.style('bg-transparent')}
+              />
+            )}
+          </Box>
+        </MaskedView>
+      </Animated.View>
       <View
         style={tw.style('pointer-events-none', {
           height: screenHeight - buttonLayout.y - insetsTop,

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -208,7 +208,9 @@ function TradeWalletActions() {
   }, [dismissSheet, onDismiss]);
 
   useEffect(() => {
-    isClosingRef.current = false;
+    if (isClosingRef.current) {
+      return;
+    }
     sheetOffset.value = screenHeight;
     sheetOffset.value = withSpring(0, TRADE_WALLET_ACTIONS_SHEET_SPRING_CONFIG);
   }, [screenHeight, sheetOffset]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

### What issues does this PR address?
Bottom sheet open and close transitions felt glitchy and performance-related, but the root cause may have been animation timing. This PR updates easing and spring configuration so enter/exit motion matches native iOS behavior.

### What are the key improvements?
Smoother, more natural animations throughout the bottom sheet lifecycle:

- Overlay: UIKit-style ease-in-out fade (replacing linear timing)
- Sheet: Spring-based open, close, and snap-back animations
- Dismiss: Overlay fade-out runs in parallel with sheet close on all dismiss paths (overlay tap, swipe, back button, imperative close)

The animation style matches the DS component:

<img width="550" height="233" alt="Screenshot 2026-06-27 at 6 37 49 PM" src="https://github.com/user-attachments/assets/b8e8da9d-b98d-4efe-a044-d55919273e06" />




## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: refine trade sheet animation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-design-system/pull/1296

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bottom sheet and overlay animation

  Scenario: user dismisses the Trade wallet actions sheet by tapping the overlay
    Given I am logged into MetaMask Mobile on the Wallet home screen
    And the Trade wallet actions sheet is open with a visible scrim overlay

    When I tap the scrim overlay outside the sheet
    Then the scrim overlay fades out in parallel with the sheet springing down off the screen
    And I return to the Wallet home screen
```

### TestFlight build
Test that animation works as expected:
Field | Value
-- | --
Source branch | overlay/trade-sheet
Build name | main-rc
Build commit SHA | 87fda8df44ab6690b30fa1649255469a436b729d
Build version | 8.2.0
Build number | 5792
TestFlight group | MetaMask BETA & Release Candidates
Workflow branch ref | main




## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f5d2138a-79f5-4234-a1ff-b2197e2fc0af




### **After**

Simulator

https://github.com/user-attachments/assets/94c39c3b-4dd7-4078-ab3b-7499285db1ac



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overlay is a shared component (including bottom-sheet overlay wrappers), and dismiss/navigation timing changed; regressions could affect any screen using Overlay or trade-sheet dismissal paths.
> 
> **Overview**
> Refines **Trade wallet actions** open/close motion and updates the shared **Overlay** so scrim and sheet animate together in a more iOS-native way.
> 
> **Overlay** moves from Reanimated to React Native `Animated` with the native driver, exposes a ref with **`fadeIn` / `fadeOut`** (optional callback after fade-out), and changes defaults to UIKit-style **ease-in-out** easing and a **longer** default duration. Touchable overlay props can be forwarded to the press target.
> 
> **TradeWalletActions** drops `visible` plus Reanimated enter/exit (`FadeInDown` / `FadeOutDown`) in favor of a **spring-driven `translateY`** sheet. On dismiss, **overlay fade-out runs in parallel** with the sheet springing off-screen; navigation and post-dismiss callbacks still run only after the sheet animation finishes, with the same deferred `requestAnimationFrame` behavior for follow-up routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0776a4a8a2b1cb5b841c7f31054d2b0708f5744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->