### PR TITLE
fix(card): handle duplicate onboarding session revocation

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -84,6 +84,7 @@ import type { TokenI } from '../../../Tokens/types';
 import { useCardHomeData } from '../../hooks/useCardHomeData';
 import { useOpenSwaps } from '../../hooks/useOpenSwaps';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { ToastContext } from '../../../../../component-library/components/Toast';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { TOKEN_RATE_UNDEFINED } from '../../../Tokens/constants';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
@@ -94,6 +95,7 @@ import {
 import { selectMetalCardCheckoutFeatureFlag } from '../../../../../selectors/featureFlagController/card';
 import {
   selectIsCardAuthenticated,
+  selectCardLastUnauthenticatedReason,
   selectCardholderAccounts,
   selectCardUserLocation,
   selectCardHomeDataStatus,
@@ -108,7 +110,11 @@ const mockGoBack = jest.fn();
 const mockSetNavigationOptions = jest.fn();
 const mockNavigationDispatch = jest.fn();
 
-import { useFocusEffect, StackActions } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  StackActions,
+  CommonActions,
+} from '@react-navigation/native';
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -125,9 +131,15 @@ jest.mock('@react-navigation/native', () => {
       params: {},
     }),
     StackActions: {
-      replace: jest.fn((routeName) => ({
+      replace: jest.fn((routeName: string) => ({
         type: 'REPLACE',
         routeName,
+      })),
+    },
+    CommonActions: {
+      reset: jest.fn((payload: unknown) => ({
+        type: 'RESET',
+        payload,
       })),
     },
   };
@@ -532,6 +544,7 @@ jest.mock('../../../../../core/Engine', () => ({
         getCapabilities: jest.fn().mockReturnValue(null),
         logout: jest.fn().mockResolvedValue(undefined),
         fetchCardHomeData: jest.fn().mockResolvedValue(undefined),
+        clearLastUnauthenticatedReason: jest.fn(),
       },
     },
   },
@@ -572,10 +585,22 @@ const mockGetCapabilities = Engine.context.CardController
   .getCapabilities as jest.Mock;
 const mockCardControllerLogout = Engine.context.CardController
   .logout as jest.MockedFunction<typeof Engine.context.CardController.logout>;
+const mockClearLastUnauthenticatedReason = Engine.context.CardController
+  .clearLastUnauthenticatedReason as jest.MockedFunction<
+  typeof Engine.context.CardController.clearLastUnauthenticatedReason
+>;
 
 const mockIsSolanaChainId = isSolanaChainId as jest.MockedFunction<
   typeof isSolanaChainId
 >;
+const mockShowToast = jest.fn();
+const mockCloseToast = jest.fn();
+const mockToastRef = {
+  current: {
+    showToast: mockShowToast,
+    closeToast: mockCloseToast,
+  },
+};
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string, params?: Record<string, unknown>) => {
@@ -588,6 +613,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'card.card_home.error_title': 'Unable to load card',
       'card.card_home.error_description': 'Please try again later',
       'card.card_home.try_again': 'Try again',
+      'card.card_home.onboarding_token_revoked':
+        'We couldn’t continue your Card session. Please log in again.',
       'card.card_home.logout': 'Logout',
       'card.card_home.logout_description': 'Logout of your Card account',
       'card.card_home.logout_confirmation_title': 'Confirm Logout',
@@ -712,6 +739,7 @@ function setupMockSelectors(
     cardholderAccounts: string[];
     selectedAccount: typeof mockSelectedInternalAccount;
     isAuthenticated: boolean;
+    lastUnauthenticatedReason: 'onboarding_token_revoked' | null;
     userLocation: 'us' | 'international';
     isMetalCardCheckoutEnabled: boolean;
     cardHomeDataStatus: 'idle' | 'loading' | 'success' | 'error';
@@ -725,6 +753,7 @@ function setupMockSelectors(
     cardholderAccounts: [mockCurrentAddress],
     selectedAccount: mockSelectedInternalAccount,
     isAuthenticated: false,
+    lastUnauthenticatedReason: null,
     userLocation: 'international' as const,
     isMetalCardCheckoutEnabled: true,
     cardHomeDataStatus: 'success' as const,
@@ -741,6 +770,8 @@ function setupMockSelectors(
       return config.depositMinVersion;
     if (selector === selectCardholderAccounts) return config.cardholderAccounts;
     if (selector === selectIsCardAuthenticated) return config.isAuthenticated;
+    if (selector === selectCardLastUnauthenticatedReason)
+      return config.lastUnauthenticatedReason;
     if (selector === selectCardUserLocation) return config.userLocation;
     if (selector === selectCardHomeDataStatus) return config.cardHomeDataStatus;
     if (selector === selectMetalCardCheckoutFeatureFlag)
@@ -1027,10 +1058,16 @@ function overrideCardHomeDataBalance(
   }
 }
 
+const CardHomeWithToast = () => (
+  <ToastContext.Provider value={{ toastRef: mockToastRef }}>
+    <CardHome />
+  </ToastContext.Provider>
+);
+
 // Helper: Render component with proper wrapper
 function render() {
   return renderScreen(
-    withCardSDK(CardHome),
+    withCardSDK(CardHomeWithToast),
     {
       name: Routes.CARD.HOME,
     },
@@ -1246,6 +1283,39 @@ describe('CardHome Component', () => {
     expect(
       screen.queryByTestId(CardHomeSelectors.CARD_WALLET_ADDRESS),
     ).not.toBeOnTheScreen();
+  });
+
+  it('resets to authentication when onboarding token is revoked', async () => {
+    setupMockSelectors({
+      isAuthenticated: false,
+      lastUnauthenticatedReason: 'onboarding_token_revoked',
+    });
+
+    render();
+
+    await waitFor(() => {
+      expect(CommonActions.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: Routes.CARD.AUTHENTICATION }],
+      });
+    });
+    expect(mockNavigationDispatch).toHaveBeenCalledWith({
+      type: 'RESET',
+      payload: {
+        index: 0,
+        routes: [{ name: Routes.CARD.AUTHENTICATION }],
+      },
+    });
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labelOptions: [
+          {
+            label: strings('card.card_home.onboarding_token_revoked'),
+          },
+        ],
+      }),
+    );
+    expect(mockClearLastUnauthenticatedReason).toHaveBeenCalledTimes(1);
   });
 
   it('renders wallet address on the card image when authenticated', () => {

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -24,6 +24,7 @@ import Icon, {
   IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
 import {
+  CommonActions,
   StackActions,
   useFocusEffect,
   useNavigation,
@@ -37,6 +38,7 @@ import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
 import {
   selectIsCardAuthenticated,
+  selectCardLastUnauthenticatedReason,
   selectCardUserLocation,
   selectCardHomeDataStatus,
 } from '../../../../../selectors/cardController';
@@ -91,6 +93,9 @@ const CardHome = () => {
   const { data, isLoading, isError, refetch, primaryToken } = useCardHomeData();
   const capabilities = useCardCapabilities();
   const isAuthenticated = useSelector(selectIsCardAuthenticated);
+  const lastUnauthenticatedReason = useSelector(
+    selectCardLastUnauthenticatedReason,
+  );
   const userLocation = useSelector(selectCardUserLocation);
   const { data: registrationSettings } = useRegistrationSettings();
   const privacyMode = useSelector(selectPrivacyMode);
@@ -196,10 +201,43 @@ const CardHome = () => {
   useEffect(() => {
     const wasAuth = wasAuthenticated.current;
     wasAuthenticated.current = isAuthenticated;
-    if (wasAuth && !isAuthenticated) {
+    if (
+      wasAuth &&
+      !isAuthenticated &&
+      lastUnauthenticatedReason !== 'onboarding_token_revoked'
+    ) {
       navigation.dispatch(StackActions.replace(Routes.CARD.AUTHENTICATION));
     }
-  }, [isAuthenticated, navigation]);
+  }, [isAuthenticated, lastUnauthenticatedReason, navigation]);
+
+  const hasHandledOnboardingTokenRevocation = useRef(false);
+  useEffect(() => {
+    if (
+      lastUnauthenticatedReason !== 'onboarding_token_revoked' ||
+      hasHandledOnboardingTokenRevocation.current
+    ) {
+      return;
+    }
+
+    hasHandledOnboardingTokenRevocation.current = true;
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      labelOptions: [
+        {
+          label: strings('card.card_home.onboarding_token_revoked'),
+        },
+      ],
+      hasNoTimeout: false,
+      iconName: IconName.Warning,
+    });
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: Routes.CARD.AUTHENTICATION }],
+      }),
+    );
+    Engine.context.CardController.clearLastUnauthenticatedReason();
+  }, [lastUnauthenticatedReason, navigation, toastRef]);
 
   // --- Deeplink toast ---
   const hasShownDeeplinkToast = useRef(false);

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -603,6 +603,33 @@ describe('CardController — auth methods', () => {
     });
   });
 
+  describe('clearLastUnauthenticatedReason', () => {
+    it('clears the stored reason when one is set', () => {
+      const provider = buildMockProvider();
+      const controller = buildController(provider, {
+        lastUnauthenticatedReason: 'onboarding_token_revoked',
+      });
+
+      controller.clearLastUnauthenticatedReason();
+
+      expect(controller.state.lastUnauthenticatedReason).toBeNull();
+    });
+
+    it('is a no-op when no reason is set', () => {
+      const provider = buildMockProvider();
+      const controller = buildController(provider);
+      const updateSpy = jest.spyOn(
+        controller as unknown as { update: () => void },
+        'update',
+      );
+
+      controller.clearLastUnauthenticatedReason();
+
+      expect(controller.state.lastUnauthenticatedReason).toBeNull();
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('resetAll', () => {
     function buildMultiProviderController(
       stateOverrides: Partial<typeof defaultCardControllerState> = {},

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -256,6 +256,7 @@ describe('CardController', () => {
       selectedCountry: 'US',
       activeProviderId: 'baanx',
       isAuthenticated: true,
+      lastUnauthenticatedReason: null,
       cardholderAccounts: [],
       providerData: {},
       cardHomeData: null,
@@ -553,6 +554,7 @@ describe('CardController — auth methods', () => {
       expect(provider.logout).toHaveBeenCalledWith(mockTokenSet);
       expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
       expect(controller.state.isAuthenticated).toBe(false);
+      expect(controller.state.lastUnauthenticatedReason).toBeNull();
     });
 
     it('still clears local state when provider.logout throws', async () => {
@@ -568,6 +570,7 @@ describe('CardController — auth methods', () => {
 
       expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
       expect(controller.state.isAuthenticated).toBe(false);
+      expect(controller.state.lastUnauthenticatedReason).toBeNull();
     });
 
     it('skips provider.logout call when no tokens exist', async () => {
@@ -980,6 +983,7 @@ describe('CardController — 401 retry and forced logout', () => {
 
     expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
     expect(controller.state.isAuthenticated).toBe(false);
+    expect(controller.state.lastUnauthenticatedReason).toBeNull();
     expect(controller.state.providerData.baanx).toStrictEqual({});
     expect(controller.state.cardHomeData).toBeNull();
     expect(controller.state.cardHomeDataStatus).toBe('idle');
@@ -1043,6 +1047,33 @@ describe('CardController — 401 retry and forced logout', () => {
     expect(provider.refreshTokens).not.toHaveBeenCalled();
     expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
     expect(controller.state.isAuthenticated).toBe(false);
+    expect(controller.state.lastUnauthenticatedReason).toBe(
+      'onboarding_token_revoked',
+    );
+  });
+
+  it('keeps onboarding token revoked reason after unauthenticated repaint', async () => {
+    wireTokenStorage({ ...mockTokenSet, refreshToken: undefined });
+    const provider = buildAuthedProvider();
+    (provider.getCashbackWallet as jest.Mock).mockRejectedValue(
+      unauthorizedError,
+    );
+    (provider.getOnChainAssets as jest.Mock).mockResolvedValue(
+      mockCardHomeData,
+    );
+    const { controller } = buildControllerWithMockMessenger(provider, {
+      isAuthenticated: true,
+    });
+
+    await expect(controller.getCashbackWallet()).rejects.toBe(
+      unauthorizedError,
+    );
+    await flushPromises(10);
+
+    expect(provider.getOnChainAssets).toHaveBeenCalledWith('0xabc');
+    expect(controller.state.lastUnauthenticatedReason).toBe(
+      'onboarding_token_revoked',
+    );
   });
 
   it('does not attempt a refresh for non-401 errors', async () => {

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -11,6 +11,7 @@ import { getGasFeesSponsoredNetworkEnabled } from '../../../../selectors/feature
 import {
   CARD_CONTROLLER_NAME,
   DEFAULT_CARD_PROVIDER_ID,
+  type CardUnauthenticatedReason,
   type CardControllerMessenger,
   type CardControllerState,
 } from './types';
@@ -86,6 +87,12 @@ const metadata: StateMetadata<CardControllerState> = {
     includeInStateLogs: true,
     usedInUi: true,
   },
+  lastUnauthenticatedReason: {
+    persist: false,
+    includeInDebugSnapshot: true,
+    includeInStateLogs: true,
+    usedInUi: true,
+  },
   cardholderAccounts: {
     persist: true,
     includeInDebugSnapshot: true,
@@ -122,6 +129,7 @@ export const defaultCardControllerState: CardControllerState = {
   selectedCountry: null,
   activeProviderId: DEFAULT_CARD_PROVIDER_ID,
   isAuthenticated: false,
+  lastUnauthenticatedReason: null,
   cardholderAccounts: [],
   providerData: {},
   cardHomeData: null,
@@ -407,9 +415,20 @@ export class CardController extends BaseController<
     return provider;
   }
 
-  private markUnauthenticated(): void {
+  private markUnauthenticated(
+    reason: CardUnauthenticatedReason | null = null,
+  ): void {
     this.update((s) => {
       s.isAuthenticated = false;
+      s.lastUnauthenticatedReason = reason;
+    });
+  }
+
+  clearLastUnauthenticatedReason(): void {
+    if (!this.state.lastUnauthenticatedReason) return;
+
+    this.update((s) => {
+      s.lastUnauthenticatedReason = null;
     });
   }
 
@@ -537,6 +556,7 @@ export class CardController extends BaseController<
       }
       this.update((s) => {
         s.isAuthenticated = true;
+        s.lastUnauthenticatedReason = null;
         s.cardHomeData = null;
         s.cardHomeDataStatus = 'idle';
         (s.providerData as unknown as Record<string, Record<string, string>>)[
@@ -585,13 +605,16 @@ export class CardController extends BaseController<
    * Clears stored tokens, drops in-flight fetches, and resets auth state.
    * Does NOT call the provider's remote logout endpoint.
    */
-  async #clearLocalSession(): Promise<void> {
+  async #clearLocalSession(
+    reason: CardUnauthenticatedReason | null = null,
+  ): Promise<void> {
     const pid = this.state.activeProviderId;
     this.currentSession = null;
     await this.clearTokens();
     this.invalidateFetch();
     this.update((s) => {
       s.isAuthenticated = false;
+      s.lastUnauthenticatedReason = reason;
       s.cardHomeData = null;
       s.cardHomeDataStatus = 'idle';
       if (pid) {
@@ -605,8 +628,10 @@ export class CardController extends BaseController<
   /**
    * Forced logout for an unrecoverable session.
    */
-  async #handleSessionExpired(): Promise<void> {
-    await this.#clearLocalSession();
+  async #handleSessionExpired(
+    reason: CardUnauthenticatedReason | null = null,
+  ): Promise<void> {
+    await this.#clearLocalSession(reason);
     this.#fetchCardHomeDataWithLogging('#handleSessionExpired');
   }
 
@@ -702,7 +727,7 @@ export class CardController extends BaseController<
 
     const tokens = await CardTokenStore.get(pid);
     if (!tokens) {
-      this.markUnauthenticated();
+      this.markUnauthenticated(this.state.lastUnauthenticatedReason);
       return null;
     }
 
@@ -723,7 +748,7 @@ export class CardController extends BaseController<
 
     // expired
     await this.clearTokens();
-    this.markUnauthenticated();
+    this.markUnauthenticated(null);
     return null;
   }
 
@@ -773,7 +798,7 @@ export class CardController extends BaseController<
 
     const tokens = await CardTokenStore.get(pid);
     if (!tokens) {
-      this.markUnauthenticated();
+      this.markUnauthenticated(this.state.lastUnauthenticatedReason);
       return null;
     }
 
@@ -784,7 +809,7 @@ export class CardController extends BaseController<
 
     if (!tokens.refreshToken) {
       // 401 with no refresh token to fall back on — session unrecoverable.
-      await this.#handleSessionExpired();
+      await this.#handleSessionExpired('onboarding_token_revoked');
       return null;
     }
 
@@ -834,6 +859,7 @@ export class CardController extends BaseController<
   #markAuthenticatedWithLocation(pid: string, location: string): void {
     this.update((s) => {
       s.isAuthenticated = true;
+      s.lastUnauthenticatedReason = null;
       (s.providerData as unknown as Record<string, Record<string, string>>)[
         pid
       ] = {

--- a/app/core/Engine/controllers/card-controller/types.ts
+++ b/app/core/Engine/controllers/card-controller/types.ts
@@ -32,6 +32,7 @@ export const CARD_CONTROLLER_NAME = 'CardController';
 export const DEFAULT_CARD_PROVIDER_ID = 'baanx';
 
 export type CardHomeDataStatus = 'idle' | 'loading' | 'error' | 'success';
+export type CardUnauthenticatedReason = 'onboarding_token_revoked';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CardControllerState = {
@@ -41,6 +42,8 @@ export type CardControllerState = {
   activeProviderId: string | null;
   /** Whether the user is authenticated with the active provider. */
   isAuthenticated: boolean;
+  /** Last reason the active provider session became unauthenticated. */
+  lastUnauthenticatedReason: CardUnauthenticatedReason | null;
   /** CAIP-10 account IDs that are card holders. */
   cardholderAccounts: string[];
   /**

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -3,6 +3,7 @@ import {
   selectCardSelectedCountry,
   selectCardActiveProviderId,
   selectIsCardAuthenticated,
+  selectCardLastUnauthenticatedReason,
   selectIsMoneyAccountCardLinkInProgress,
   selectCardholderAccounts,
   selectHasCardholderAccounts,
@@ -189,6 +190,32 @@ describe('CardController selectors', () => {
       const state = createMockRootState({ isAuthenticated: true });
 
       expect(selectIsCardAuthenticated(state)).toBe(true);
+    });
+  });
+
+  describe('selectCardLastUnauthenticatedReason', () => {
+    it('returns null by default', () => {
+      const state = createMockRootState();
+
+      expect(selectCardLastUnauthenticatedReason(state)).toBeNull();
+    });
+
+    it('returns the last unauthenticated reason when set', () => {
+      const state = createMockRootState({
+        lastUnauthenticatedReason: 'onboarding_token_revoked',
+      });
+
+      expect(selectCardLastUnauthenticatedReason(state)).toBe(
+        'onboarding_token_revoked',
+      );
+    });
+
+    it('returns null when CardController state is undefined', () => {
+      const state = {
+        engine: { backgroundState: {} },
+      } as unknown as RootState;
+
+      expect(selectCardLastUnauthenticatedReason(state)).toBeNull();
     });
   });
 

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -3,6 +3,7 @@ import { parseCaipAccountId, isCaipAccountId } from '@metamask/utils';
 import { RootState } from '../reducers';
 import {
   DEFAULT_CARD_PROVIDER_ID,
+  type CardUnauthenticatedReason,
   type CardControllerState,
   type CardHomeDataStatus,
 } from '../core/Engine/controllers/card-controller/types';
@@ -86,6 +87,14 @@ export const selectIsCardAuthenticated = createSelector(
   selectCardControllerState,
   (cardState: CardControllerState | undefined) =>
     cardState?.isAuthenticated ?? false,
+);
+
+export const selectCardLastUnauthenticatedReason = createSelector(
+  selectCardControllerState,
+  (
+    cardState: CardControllerState | undefined,
+  ): CardUnauthenticatedReason | null =>
+    cardState?.lastUnauthenticatedReason ?? null,
 );
 
 export const selectIsMoneyAccountCardLinkInProgress = createSelector(

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -702,7 +702,8 @@
     "isAuthenticated": false,
     "cardholderAccounts": [],
     "providerData": {},
-    "moneyAccountCardLinkInProgress": false
+    "moneyAccountCardLinkInProgress": false,
+    "lastUnauthenticatedReason": null
   },
   "ClientController": {
     "isUiOpen": false

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8674,6 +8674,7 @@
     "card_home": {
       "title": "Card",
       "authentication_error": "Your session has expired. Please log in again.",
+      "onboarding_token_revoked": "We couldn't continue your Card session. Please log in again.",
       "available_balance": "Available balance",
       "error_title": "Can't fetch data",
       "error_description": "It seems that there is an issue preventing you from viewing the content on this page. Please check your connection or try refreshing the page.",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a user completes Card onboarding but Baanx later revokes the access token because the user is duplicated in Baanx, Card Home could fall through the generic unauthenticated state without explaining what happened or clearing the navigation history.

This change records a non-persisted Card unauthenticated reason for the 401/no-refresh-token path, preserves the existing full-session expiry behavior, and has Card Home consume that reason once to show a toast, reset to Card Authentication, and clear the reason. Controller and Card Home tests cover the new branch and the reason-preservation repaint path.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Card onboarding session revocation to return users to login with an explanation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: null

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Card onboarding session revocation

  Background:
    Given I am logged into MetaMask Mobile
    And I have completed Card onboarding
    And my Card access token has been revoked by Baanx with no refresh token available

  Scenario: user is returned to Card Authentication after onboarding session revocation
    Given I am on Card Home

    When Card Home refreshes Card data
    Then I should be redirected to Card Authentication
    And I should not be able to go back to Card Home with the back button
    And I should see a toast explaining that my Card session could not continue
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Card auth/session teardown and navigation reset on Card Home; behavior is scoped to a specific unauthenticated reason with tests, but incorrect reason handling could mis-route users after 401s.
> 
> **Overview**
> When Baanx invalidates a Card session after onboarding (e.g. duplicate user) with **no refresh token**, users no longer land on Card Home with a silent logout.
> 
> **CardController** now tracks a non-persisted `lastUnauthenticatedReason` (`onboarding_token_revoked` on that 401/no-refresh path; cleared on successful auth and explicit `clearLastUnauthenticatedReason`). Other forced logouts (e.g. rejected refresh) still clear the reason to `null`.
> 
> **Card Home** reads that reason once: shows a warning toast, **resets** navigation to Card Authentication (so back cannot return to Home), and skips the usual `StackActions.replace` logout transition for this case.
> 
> Adds selector, i18n copy, and controller/UI tests for the new branch and reason preservation through unauthenticated repaint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0f4c9c98e3fd749be395e29f94bda27456b444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->