### PR TITLE
feat: update device added screen and add extension cancel error sheet

### DIFF
--- a/app/components/Views/AddDeviceToWallet/DeviceAdded.test.tsx
+++ b/app/components/Views/AddDeviceToWallet/DeviceAdded.test.tsx
@@ -1,14 +1,30 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { strings } from '../../../../locales/i18n';
 import DeviceAdded from './DeviceAdded';
+import {
+  MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS,
+  showExtensionCancelledErrorSheet,
+} from './showExtensionCancelledErrorSheet';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
     style: jest.fn(() => ({})),
   }),
 }));
+
+jest.mock('./showExtensionCancelledErrorSheet', () => {
+  const actual = jest.requireActual('./showExtensionCancelledErrorSheet');
+  return {
+    ...actual,
+    showExtensionCancelledErrorSheet: jest.fn(),
+  };
+});
+
+const mockShowExtensionCancelledErrorSheet = jest.mocked(
+  showExtensionCancelledErrorSheet,
+);
 
 const mockGoBack = jest.fn();
 
@@ -27,15 +43,55 @@ const renderComponent = () => renderWithProvider(<DeviceAdded />);
 describe('DeviceAdded', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('rendering', () => {
-    it('renders the device added confirmation text', () => {
-      const { getByText } = renderComponent();
+    it('renders the waiting for extension screen', () => {
+      const { getByText, getByTestId } = renderComponent();
 
+      expect(getByTestId('device-added-loader')).toBeOnTheScreen();
       expect(
-        getByText(strings('app_settings.add_device.device_added')),
+        getByText(strings('app_settings.add_device.waiting_for_extension')),
       ).toBeOnTheScreen();
+      expect(
+        getByText(
+          strings('app_settings.add_device.waiting_for_extension_description'),
+        ),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('extension cancelled error sheet', () => {
+    it('shows the error sheet after the mock delay', () => {
+      renderComponent();
+
+      act(() => {
+        jest.advanceTimersByTime(MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS);
+      });
+
+      expect(mockShowExtensionCancelledErrorSheet).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show the error sheet again after unmount and remount within the delay', () => {
+      const { unmount } = renderComponent();
+
+      act(() => {
+        jest.advanceTimersByTime(MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS - 1);
+      });
+
+      unmount();
+      renderComponent();
+
+      act(() => {
+        jest.advanceTimersByTime(MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS);
+      });
+
+      expect(mockShowExtensionCancelledErrorSheet).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/Views/AddDeviceToWallet/DeviceAdded.tsx
+++ b/app/components/Views/AddDeviceToWallet/DeviceAdded.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -8,26 +8,107 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
 import { strings } from '../../../../locales/i18n';
 import HeaderCompactStandard from '../../../component-library/components-temp/HeaderCompactStandard';
 import { useNavigation } from '@react-navigation/native';
+import { useTheme } from '../../../util/theme';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import {
+  MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS,
+  showExtensionCancelledErrorSheet,
+} from './showExtensionCancelledErrorSheet';
+
+const LOADER_SIZE = 48;
+const LOADER_BORDER_WIDTH = 4;
+
+const DeviceAddedLoader = () => {
+  const tw = useTailwind();
+  const { colors } = useTheme();
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, {
+        duration: 1000,
+        easing: Easing.linear,
+      }),
+      -1,
+    );
+
+    return () => {
+      cancelAnimation(rotation);
+    };
+  }, [rotation]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  return (
+    <Animated.View
+      testID="device-added-loader"
+      style={[
+        tw.style('rounded-full', {
+          width: LOADER_SIZE,
+          height: LOADER_SIZE,
+          borderWidth: LOADER_BORDER_WIDTH,
+          borderColor: colors.border.muted,
+          borderTopColor: colors.primary.default,
+        }),
+        animatedStyle,
+      ]}
+    />
+  );
+};
 
 const DeviceAdded = () => {
   const tw = useTailwind();
-  const navigation = useNavigation();
+  const navigation = useNavigation<AppNavigationProp>();
+  const hasShownErrorSheetRef = useRef(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (hasShownErrorSheetRef.current) {
+        return;
+      }
+
+      hasShownErrorSheetRef.current = true;
+      showExtensionCancelledErrorSheet(navigation);
+    }, MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [navigation]);
+
   return (
     <SafeAreaView style={tw.style('flex-1 bg-default')}>
       <HeaderCompactStandard
         onBack={() => navigation.goBack()}
         backButtonProps={{ testID: 'device-added-back-button' }}
       />
-      <Box twClassName="flex-1 px-4 justify-center items-center">
+      <Box twClassName="flex-1 px-4 justify-center items-center gap-4">
+        <DeviceAddedLoader />
         <Text
           variant={TextVariant.HeadingLg}
           color={TextColor.TextDefault}
           fontWeight={FontWeight.Bold}
+          twClassName="text-center"
         >
-          {strings('app_settings.add_device.device_added')}
+          {strings('app_settings.add_device.waiting_for_extension')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center px-4"
+        >
+          {strings('app_settings.add_device.waiting_for_extension_description')}
         </Text>
       </Box>
     </SafeAreaView>

--- a/app/components/Views/AddDeviceToWallet/index.test.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.test.tsx
@@ -109,7 +109,7 @@ describe('AddDeviceToWallet', () => {
       const { queryByText } = renderComponent();
 
       expect(
-        queryByText(strings('app_settings.add_device.device_added')),
+        queryByText(strings('app_settings.add_device.waiting_for_extension')),
       ).not.toBeOnTheScreen();
     });
   });
@@ -228,9 +228,33 @@ describe('AddDeviceToWallet', () => {
       });
     });
 
-    it('removes the event listener on unmount', () => {
+    it('returns to the instructions screen when addDeviceResetToInstructions event fires', async () => {
+      const { queryByText } = renderComponent();
+
+      await act(async () => {
+        DeviceEventEmitter.emit('addDeviceVerificationDone');
+      });
+
+      await waitFor(() => {
+        expect(
+          queryByText(strings('app_settings.add_device.add_device_to_wallet')),
+        ).not.toBeOnTheScreen();
+      });
+
+      await act(async () => {
+        DeviceEventEmitter.emit('addDeviceResetToInstructions');
+      });
+
+      await waitFor(() => {
+        expect(
+          queryByText(strings('app_settings.add_device.add_device_to_wallet')),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('removes the event listeners on unmount', () => {
       const removeSpy = jest.fn();
-      jest.spyOn(DeviceEventEmitter, 'addListener').mockReturnValueOnce({
+      jest.spyOn(DeviceEventEmitter, 'addListener').mockReturnValue({
         remove: removeSpy,
       } as unknown as ReturnType<typeof DeviceEventEmitter.addListener>);
 
@@ -238,7 +262,7 @@ describe('AddDeviceToWallet', () => {
 
       unmount();
 
-      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/app/components/Views/AddDeviceToWallet/index.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.tsx
@@ -23,6 +23,7 @@ import {
   // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 } from '../QRTabSwitcher';
 import DeviceAdded from './DeviceAdded';
+import { ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT } from './showExtensionCancelledErrorSheet';
 
 const MOCK_SCAN_DELAY_MS = 2000;
 
@@ -59,11 +60,19 @@ const AddDeviceToWallet = () => {
   const [deviceAdded, setDeviceAdded] = useState(false);
 
   useEffect(() => {
-    const subscription = DeviceEventEmitter.addListener(
+    const verificationDoneSubscription = DeviceEventEmitter.addListener(
       'addDeviceVerificationDone',
       () => setDeviceAdded(true),
     );
-    return () => subscription.remove();
+    const resetSubscription = DeviceEventEmitter.addListener(
+      ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT,
+      () => setDeviceAdded(false),
+    );
+
+    return () => {
+      verificationDoneSubscription.remove();
+      resetSubscription.remove();
+    };
   }, []);
 
   const showVerificationSheet = useCallback(() => {

--- a/app/components/Views/AddDeviceToWallet/showExtensionCancelledErrorSheet.test.ts
+++ b/app/components/Views/AddDeviceToWallet/showExtensionCancelledErrorSheet.test.ts
@@ -1,0 +1,58 @@
+import { DeviceEventEmitter } from 'react-native';
+import { strings } from '../../../../locales/i18n';
+import Routes from '../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import {
+  ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT,
+  showExtensionCancelledErrorSheet,
+} from './showExtensionCancelledErrorSheet';
+
+const mockNavigate = jest.fn();
+const mockNavigation = {
+  navigate: mockNavigate,
+} as unknown as AppNavigationProp;
+
+describe('showExtensionCancelledErrorSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the shared success/error sheet with extension-cancel copy', () => {
+    showExtensionCancelledErrorSheet(mockNavigation);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+      params: expect.objectContaining({
+        type: 'error',
+        title: strings('app_settings.add_device.extension_cancelled_title'),
+        description: strings(
+          'app_settings.add_device.extension_cancelled_description',
+        ),
+        descriptionAlign: 'center',
+        primaryButtonLabel: strings(
+          'app_settings.add_device.extension_cancelled_button',
+        ),
+        closeOnPrimaryButtonPress: true,
+        onPrimaryButtonPress: expect.any(Function),
+      }),
+    });
+  });
+
+  it('returns to the instructions screen when try again is pressed', () => {
+    const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
+
+    showExtensionCancelledErrorSheet(mockNavigation);
+
+    const { params } = mockNavigate.mock.calls[0][1] as {
+      params: { onPrimaryButtonPress?: () => void };
+    };
+
+    params.onPrimaryButtonPress?.();
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT,
+    );
+
+    emitSpy.mockRestore();
+  });
+});

--- a/app/components/Views/AddDeviceToWallet/showExtensionCancelledErrorSheet.ts
+++ b/app/components/Views/AddDeviceToWallet/showExtensionCancelledErrorSheet.ts
@@ -1,0 +1,33 @@
+import { DeviceEventEmitter } from 'react-native';
+import { strings } from '../../../../locales/i18n';
+import Routes from '../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+
+/** Temporary UI demo delay until QrSyncController cancel wiring lands. */
+export const MOCK_EXTENSION_CANCEL_ERROR_DELAY_MS = 3500;
+
+export const ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT =
+  'addDeviceResetToInstructions';
+
+export const showExtensionCancelledErrorSheet = (
+  navigation: AppNavigationProp,
+): void => {
+  navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+    screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+    params: {
+      type: 'error',
+      title: strings('app_settings.add_device.extension_cancelled_title'),
+      description: strings(
+        'app_settings.add_device.extension_cancelled_description',
+      ),
+      descriptionAlign: 'center',
+      primaryButtonLabel: strings(
+        'app_settings.add_device.extension_cancelled_button',
+      ),
+      closeOnPrimaryButtonPress: true,
+      onPrimaryButtonPress: () => {
+        DeviceEventEmitter.emit(ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT);
+      },
+    },
+  });
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4036,7 +4036,11 @@
       "enter_code_on_extension": "Enter code on extension",
       "enter_code_on_extension_desc": "For security, enter the verification code below on your MetaMask extension.",
       "done": "Done",
-      "device_added": "Device added"
+      "waiting_for_extension": "Waiting for extension...",
+      "waiting_for_extension_description": "Finish choosing accounts on your computer to continue.",
+      "extension_cancelled_title": "Import cancelled",
+      "extension_cancelled_description": "The account import was cancelled/failed. Try again.",
+      "extension_cancelled_button": "Try again"
     }
   },
   "aes_crypto_test_form": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
* Replaces the placeholder Device added screen in the add-device-to-wallet flow with the designed Waiting for extension state.
*  Adds an extension-cancel error bottom sheet.
* Jira: https://consensyssoftware.atlassian.net/browse/TO-868
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the add-device flow waiting screen to show a loading state while waiting for the extension, and added an error sheet when the extension import is cancelled or fails.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add device waiting screen and extension cancel error UI

  Scenario: User sees waiting screen after OTP verification
    Given the user is on the "Add this device to wallet" instructions screen
    And the addDeviceSyncEnabled flag is enabled
    When the user taps "Scan QR code" and completes OTP verification
    Then the user sees "Waiting for extension..."
    And a loading spinner is visible
    And the subtitle reads "Finish choosing accounts on your computer to continue."
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="264" height="568" alt="Screenshot 2026-06-29 at 3 31 39 PM" src="https://github.com/user-attachments/assets/1cdfc237-e695-4e35-9d33-eae001bbaa33" />

<!-- [screenshots/recordings] -->

### **After**
<img width="252" height="553" alt="Screenshot 2026-06-29 at 4 00 54 PM" src="https://github.com/user-attachments/assets/adfe2e68-d1a4-4438-b1cf-c60a727e7229" />

https://github.com/user-attachments/assets/1fc0fdbd-55ab-4a69-9c59-4f497458411f


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped add-device UI and navigation with mock timing; no auth, wallet, or data-layer changes.
> 
> **Overview**
> After OTP verification, the post-verification screen is now a **waiting for extension** state with an animated spinner and copy asking the user to finish on the computer, instead of a static “device added” message.
> 
> A new helper opens the shared **success/error** sheet when extension import is cancelled or fails (today triggered by a **temporary mock delay** until real cancel wiring lands). **Try again** emits `addDeviceResetToInstructions`, and the parent flow listens so it returns from the waiting screen back to the QR/instructions view.
> 
> Strings and unit tests were updated for the new UI, timer/error-sheet behavior, reset navigation, and sheet navigation params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbde2e9d5d1b8c452adf7a6ca111b01f938ed7b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->