### PR TITLE
chore: deprecate AccountTrackerController behind assets-unify-state

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -564,37 +564,33 @@ describe('App', () => {
       });
     }, 30000);
 
-    it(
-      'renders the multichain account share address screen when navigated to',
-      async () => {
-        jest.useRealTimers();
-        try {
-          const routeState = {
-            index: 0,
-            routes: [
-              {
-                name: Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS,
+    it('renders the multichain account share address screen when navigated to', async () => {
+      jest.useRealTimers();
+      try {
+        const routeState = {
+          index: 0,
+          routes: [
+            {
+              name: Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS,
+              params: {
+                screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS,
                 params: {
-                  screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS,
-                  params: {
-                    account: mockAccount,
-                  },
+                  account: mockAccount,
                 },
               },
-            ],
-          };
+            },
+          ],
+        };
 
-          const { getByText } = renderAppWithRouteState(routeState);
+        const { getByText } = renderAppWithRouteState(routeState);
 
-          await waitFor(() => {
-            expect(getByText('Share address')).toBeOnTheScreen();
-          });
-        } finally {
-          jest.useFakeTimers();
-        }
-      },
-      30000,
-    );
+        await waitFor(() => {
+          expect(getByText('Share address')).toBeOnTheScreen();
+        });
+      } finally {
+        jest.useFakeTimers();
+      }
+    }, 30000);
   });
 
   describe('route registration', () => {

--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -564,32 +564,37 @@ describe('App', () => {
       });
     }, 30000);
 
-    it('renders the multichain account share address screen when navigated to', async () => {
-      jest.useRealTimers();
-
-      const routeState = {
-        index: 0,
-        routes: [
-          {
-            name: Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS,
-            params: {
-              screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS,
-              params: {
-                account: mockAccount,
+    it(
+      'renders the multichain account share address screen when navigated to',
+      async () => {
+        jest.useRealTimers();
+        try {
+          const routeState = {
+            index: 0,
+            routes: [
+              {
+                name: Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS,
+                params: {
+                  screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS,
+                  params: {
+                    account: mockAccount,
+                  },
+                },
               },
-            },
-          },
-        ],
-      };
+            ],
+          };
 
-      const { getByText } = renderAppWithRouteState(routeState);
+          const { getByText } = renderAppWithRouteState(routeState);
 
-      await waitFor(() => {
-        expect(getByText('Share address')).toBeOnTheScreen();
-      });
-
-      jest.useFakeTimers();
-    });
+          await waitFor(() => {
+            expect(getByText('Share address')).toBeOnTheScreen();
+          });
+        } finally {
+          jest.useFakeTimers();
+        }
+      },
+      30000,
+    );
   });
 
   describe('route registration', () => {

--- a/app/core/Engine/controllers/account-tracker-controller-init.test.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@metamask/assets-controllers';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { selectAssetsAccountApiBalancesEnabled } from '../../../selectors/featureFlagController/assetsAccountApiBalances';
+import { selectIsAssetsUnifyStateEnabled } from '../../../selectors/featureFlagController/assetsUnifyState';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 
 jest.mock('@metamask/assets-controllers');
@@ -20,6 +21,10 @@ jest.mock(
     selectAssetsAccountApiBalancesEnabled: jest.fn().mockReturnValue([]),
   }),
 );
+
+jest.mock('../../../selectors/featureFlagController/assetsUnifyState', () => ({
+  selectIsAssetsUnifyStateEnabled: jest.fn().mockReturnValue(false),
+}));
 
 jest.mock('../../../selectors/settings', () => ({
   selectBasicFunctionalityEnabled: jest.fn().mockReturnValue(true),
@@ -57,7 +62,7 @@ describe('accountTrackerControllerInit', () => {
     jest.clearAllMocks();
   });
 
-  it('passes the proper arguments to the controller including isHomepageSectionsV1Enabled', () => {
+  it('passes the proper arguments to the controller including deprecation checks', () => {
     accountTrackerControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountTrackerController);
@@ -67,6 +72,7 @@ describe('accountTrackerControllerInit', () => {
         getStakedBalanceForChain: expect.any(Function),
         accountsApiChainIds: expect.any(Function),
         allowExternalServices: expect.any(Function),
+        isDeprecated: expect.any(Function),
         isHomepageSectionsV1Enabled: expect.any(Function),
       }),
     );
@@ -112,5 +118,19 @@ describe('accountTrackerControllerInit', () => {
 
     expect(allowExternalServices()).toBe(false);
     expect(selectBasicFunctionalityEnabled).toHaveBeenCalled();
+  });
+
+  it('reads deprecation state from assets-unify-state flag', () => {
+    accountTrackerControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AccountTrackerController);
+    const { isDeprecated } = controllerMock.mock.calls[0][0] as {
+      isDeprecated: () => boolean;
+    };
+
+    jest.mocked(selectIsAssetsUnifyStateEnabled).mockReturnValue(true);
+
+    expect(isDeprecated()).toBe(true);
+    expect(selectIsAssetsUnifyStateEnabled).toHaveBeenCalled();
   });
 });

--- a/app/core/Engine/controllers/account-tracker-controller-init.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.ts
@@ -4,6 +4,7 @@ import {
   AccountTrackerControllerMessenger,
 } from '@metamask/assets-controllers';
 import { selectAssetsAccountApiBalancesEnabled } from '../../../selectors/featureFlagController/assetsAccountApiBalances';
+import { selectIsAssetsUnifyStateEnabled } from '../../../selectors/featureFlagController/assetsUnifyState';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 /**
  * Initialize the accountTracker controller.
@@ -33,6 +34,7 @@ export const accountTrackerControllerInit: MessengerClientInitFunction<
     accountsApiChainIds: () =>
       selectAssetsAccountApiBalancesEnabled(getState()) as `0x${string}`[],
     allowExternalServices: () => selectBasicFunctionalityEnabled(getState()),
+    isDeprecated: () => selectIsAssetsUnifyStateEnabled(getState()),
     isHomepageSectionsV1Enabled: () => true,
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Wires `AccountTrackerController` deprecation to the `assets-unify-state` feature flag in mobile Engine initialization.

When the flag is enabled, the controller now receives `isDeprecated: () => selectIsAssetsUnifyStateEnabled(getState())`, matching the upstream deprecation pattern and keeping this change behavior-preserving outside the flag.

Also extends the init unit test coverage to assert that:
- the `isDeprecated` callback is passed to the controller constructor, and
- the callback reflects selector state.

Babysit follow-up for CI UT failures:
- Stabilized `app/components/Nav/App/App.test.tsx` (`renders the multichain account share address screen when navigated to`) by adding an explicit `30000` test timeout and wrapping timer mode switching in `try/finally` so fake timers are always restored.

Babysit follow-up for CI format failure:
- Applied Prettier formatting to `app/components/Nav/App/App.test.tsx` so `format:check` passes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3334

## **Manual testing steps**

N/A — behavior-preserving tech-debt change behind existing feature-flag gating.

Automated verification performed:
1. `yarn jest app/core/Engine/controllers/account-tracker-controller-init.test.ts --coverage=false` ✅
2. `yarn eslint app/core/Engine/controllers/account-tracker-controller-init.ts app/core/Engine/controllers/account-tracker-controller-init.test.ts` ✅
3. `yarn eslint app/components/Nav/App/App.test.tsx` ✅ (1 existing deprecation warning)
4. `yarn test:unit --runInBand --runTestsByPath app/components/Nav/App/App.test.tsx -t "renders the multichain account share address screen when navigated to" --coverage=false` ⚠️ local env hits unrelated `react-native-material-textfield` import error when executing the suite by path; CI failure being addressed is the timeout in this same test, and the fix is scoped to that timeout/timer handling.
5. `yarn format:check` ✅

## **Screenshots/Recordings**

### **Before**

N/A (no UI change)

### **After**

N/A (no UI change)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c0dedca-161a-4b28-a5c6-000eddb70178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c0dedca-161a-4b28-a5c6-000eddb70178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

