### PR TITLE
fix: cap redundant accounts spans

### DIFF
--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -146,7 +146,7 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
 
   // Tracing for the account list: start at layout flush, end after paint (the
   // `useEffect` below). The `useLayoutEffect` cleanup is a leak-safety fallback
-  // that ends the span if the sheet unmounts before the passive effect runs;
+  // that ends the span if the view unmounts before the passive effect runs;
   // `endTrace` is idempotent, so the normal path only records one span.
   useLayoutEffect(() => {
     if (!isAccountSelector) {

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -144,16 +144,24 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     }
   }, [dispatch, reloadAccounts]);
 
-  // Tracing for the account list: start at layout flush, end after paint (useEffect).
+  // Tracing for the account list: start at layout flush, end after paint (the
+  // `useEffect` below). The `useLayoutEffect` cleanup is a leak-safety fallback
+  // that ends the span if the sheet unmounts before the passive effect runs;
+  // `endTrace` is idempotent, so the normal path only records one span.
   useLayoutEffect(() => {
     if (!isAccountSelector) {
-      return;
+      return undefined;
     }
     trace({
       name: TraceName.ShowAccountList,
       op: TraceOperation.AccountUi,
       tags: getTraceTags(store.getState()),
     });
+    return () => {
+      endTrace({
+        name: TraceName.ShowAccountList,
+      });
+    };
   }, [isAccountSelector]);
 
   useEffect(() => {

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -147,18 +147,13 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
   // Tracing for the account list: start at layout flush, end after paint (useEffect).
   useLayoutEffect(() => {
     if (!isAccountSelector) {
-      return undefined;
+      return;
     }
     trace({
       name: TraceName.ShowAccountList,
       op: TraceOperation.AccountUi,
       tags: getTraceTags(store.getState()),
     });
-    return () => {
-      endTrace({
-        name: TraceName.ShowAccountList,
-      });
-    };
   }, [isAccountSelector]);
 
   useEffect(() => {

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -60,7 +60,6 @@ import Badge, {
 } from '../../../../component-library/components/Badges/Badge';
 import AvatarFavicon from '../../../../component-library/components/Avatars/Avatar/variants/AvatarFavicon';
 import AvatarToken from '../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
-import { endTrace, trace, TraceName } from '../../../../util/trace';
 import { NetworkAvatarProps } from '../../MultichainAccounts/shared/AccountConnect.types';
 import MultichainAccountsConnectedList from '../MultichainAccountsConnectedList/MultichainAccountsConnectedList';
 import { AccountGroupId } from '@metamask/account-api';
@@ -300,7 +299,6 @@ const MultichainPermissionsSummary = ({
   }, [onRevokeAll, hostname, navigation]);
 
   const toggleRevokeAllPermissionsModal = useCallback(() => {
-    trace({ name: TraceName.DisconnectAllAccountPermissions });
     navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.REVOKE_ALL_ACCOUNT_PERMISSIONS,
       params: {
@@ -312,7 +310,6 @@ const MultichainPermissionsSummary = ({
         onRevokeAll: onRevokeAllHandler,
       },
     });
-    endTrace({ name: TraceName.DisconnectAllAccountPermissions });
   }, [onRevokeAllHandler, hostname, navigate]);
 
   const getNetworkLabel = useCallback(() => {

--- a/app/core/SnapKeyring/SnapKeyring.ts
+++ b/app/core/SnapKeyring/SnapKeyring.ts
@@ -15,7 +15,6 @@ import {
   isMultichainWalletSnap,
   isSnapPreinstalled,
 } from './utils/snaps';
-import { endTrace, TraceName } from '../../util/trace';
 import { store } from '../../store';
 import { MetaMetricsEvents } from '../../core/Analytics/MetaMetrics.events';
 import { trackSnapAccountEvent } from '../../util/analytics/helpers/snapKeyring/trackSnapAccountEvent';
@@ -178,10 +177,6 @@ export class SnapKeyringImpl implements SnapKeyringCallbacks {
           snapId,
           snapName,
         );
-
-        endTrace({
-          name: TraceName.CreateSnapAccount,
-        });
 
         store.dispatch(
           endPerformanceTrace({

--- a/app/multichain-accounts/discovery.test.ts
+++ b/app/multichain-accounts/discovery.test.ts
@@ -1,4 +1,5 @@
 import { discoverAccounts } from './discovery';
+import { endTrace, trace, TraceName, TraceOperation } from '../util/trace';
 
 const mockDiscoverAccounts = jest.fn();
 const mockSyncWithUserStorageAtLeastOnce = jest.fn();
@@ -20,15 +21,27 @@ jest.mock('../core/Engine', () => ({
   },
 }));
 
+jest.mock('../util/trace', () => ({
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+  TraceName: { DiscoverAccounts: 'Discover Accounts' },
+  TraceOperation: { AccountDiscover: 'account.discover' },
+}));
+
+const mockTrace = jest.mocked(trace);
+const mockEndTrace = jest.mocked(endTrace);
+
 const mockEntropySource = 'mock-entropy-source';
 
 describe('discoverAccounts', () => {
   beforeEach(() => {
     mockDiscoverAccounts.mockReset();
+    mockTrace.mockClear();
+    mockEndTrace.mockClear();
   });
 
   it('ensures account syncing is triggered at least once before discovery', async () => {
-    mockDiscoverAccounts.mockResolvedValue({}); // Nothing got discovered.
+    mockDiscoverAccounts.mockResolvedValue([]); // Nothing got discovered.
 
     await discoverAccounts(mockEntropySource);
 
@@ -45,5 +58,37 @@ describe('discoverAccounts', () => {
     expect(result).toBe(discoveredAccounts);
 
     expect(mockDiscoverAccounts).toHaveBeenCalled();
+  });
+
+  it('emits a backdated trace only when accounts were discovered', async () => {
+    const discoveredAccounts = 3;
+    mockDiscoverAccounts.mockResolvedValue(
+      Array.from({ length: discoveredAccounts }),
+    );
+
+    await discoverAccounts(mockEntropySource);
+
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.DiscoverAccounts,
+        op: TraceOperation.AccountDiscover,
+        startTime: expect.any(Number),
+      }),
+    );
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.DiscoverAccounts,
+      data: { discovered: discoveredAccounts },
+    });
+  });
+
+  it('does not emit a trace when nothing was discovered', async () => {
+    mockDiscoverAccounts.mockResolvedValue([]);
+
+    await discoverAccounts(mockEntropySource);
+
+    expect(mockTrace).not.toHaveBeenCalled();
+    expect(mockEndTrace).not.toHaveBeenCalled();
   });
 });

--- a/app/multichain-accounts/discovery.ts
+++ b/app/multichain-accounts/discovery.ts
@@ -2,7 +2,7 @@ import { Bip44Account } from '@metamask/account-api';
 import { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { MultichainAccountWallet } from '@metamask/multichain-account-service';
 import Engine from '../core/Engine';
-import { trace, TraceOperation, TraceName } from '../util/trace';
+import { endTrace, trace, TraceOperation, TraceName } from '../util/trace';
 
 /**
  * Discover and create accounts.
@@ -37,17 +37,35 @@ async function _discoverAccounts(
 /**
  * Discover and create accounts.
  *
+ * A trace is only emitted when discovery actually created accounts. The common
+ * no-op login discovery (which fires on every login, per entropy source, but
+ * creates nothing) is intentionally not traced to avoid disproportionate span
+ * volume. The emitted span still covers the full discovery duration via a
+ * backdated start time, so timing for meaningful runs is unchanged.
+ *
  * @param entropySource - Entropy source ID to use for account discovery
  * @returns The number of discovered and created accounts.
  */
 export async function discoverAccounts(
   entropySource: EntropySourceId,
 ): Promise<number> {
-  return trace(
-    {
+  // Capture the start up-front (same instant the callback trace form would have
+  // stamped) so we can backdate the span if discovery turns out to do real work.
+  const startTime = Date.now();
+
+  const discovered = await _discoverAccounts(entropySource);
+
+  if (discovered > 0) {
+    trace({
       name: TraceName.DiscoverAccounts,
       op: TraceOperation.AccountDiscover,
-    },
-    () => _discoverAccounts(entropySource),
-  );
+      startTime,
+    });
+    endTrace({
+      name: TraceName.DiscoverAccounts,
+      data: { discovered },
+    });
+  }
+
+  return discovered;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This PR caps redundant spans related to the accounts area

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1940

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes that skip or remove redundant spans; snap account success is still tracked via the existing performance trace dispatch.
> 
> **Overview**
> Reduces **accounts-area Sentry span noise** without changing user-facing behavior.
> 
> **`discoverAccounts`** no longer wraps every login discovery in a span. It records `DiscoverAccounts` only when at least one account is created, using a **backdated `startTime`** so duration still reflects the full run; `endTrace` includes `{ discovered }`. Tests cover trace-on-success vs no trace on empty discovery.
> 
> **`MultichainPermissionsSummary`** drops the immediate `trace`/`endTrace` around opening the revoke-all sheet (navigation-only, not a meaningful operation boundary).
> 
> **`SnapKeyring`** stops calling `endTrace` for `CreateSnapAccount` on success; **`AddSnapAccount`** performance tracing remains.
> 
> **`AccountSelector`** tracing behavior is unchanged; comments clarify the layout-effect cleanup vs passive `endTrace` and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3032ab0f5c146075bc2cf28c1bf1a0ac1b21782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->