### PR TITLE
fix(money): redirect to Money Home after funding the money account (MUSD-1058)

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -488,6 +488,48 @@ describe('useTransactionConfirm', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    it('money home if money account deposit', async () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        type: TransactionType.moneyAccountDeposit,
+      } as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      });
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('money home if money account deposit is a nested batch transaction', async () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        type: TransactionType.batch,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.moneyAccountDeposit },
+        ],
+      } as unknown as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      });
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
     it('skips navigation if perps deposit and order (caller handles navigation)', async () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: transactionIdMock,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -32,7 +32,6 @@ import { useHandleHwSend } from '../../../../UI/HardwareWallet/Swaps/useHandleHw
 const log = createProjectLogger('transaction-confirm');
 
 export const GO_BACK_TYPES = [
-  TransactionType.moneyAccountDeposit,
   TransactionType.moneyAccountWithdraw,
   TransactionType.perpsWithdraw,
   TransactionType.predictClaim,
@@ -179,6 +178,15 @@ export function useTransactionConfirm() {
         }
       } else if (type === TransactionType.musdConversion) {
         musdConversionNavigateOnConfirm();
+      } else if (
+        hasTransactionType(transactionMetadata, [
+          TransactionType.moneyAccountDeposit,
+        ])
+      ) {
+        navigation.navigate(Routes.HOME_TABS, {
+          screen: Routes.MONEY.ROOT,
+          params: { screen: Routes.MONEY.HOME },
+        });
       } else if (
         isFullScreenConfirmation &&
         !hasTransactionType(transactionMetadata, GO_BACK_TYPES)


### PR DESCRIPTION
## **Description**

When a user taps **Add** on the Money card on the mobile **home** screen and completes a deposit (e.g. converting crypto to mUSD), the app navigated them back to the wallet home screen instead of to their Money Account home. A new user had no way to find their funding activity after the deposit.

Root cause: `moneyAccountDeposit` was listed in `GO_BACK_TYPES`, so after the confirmation `useTransactionConfirm.onConfirm` called `navigation.goBack()`, which returns to whatever screen launched the flow (the wallet home when started from the home Money card).

This change removes `moneyAccountDeposit` from `GO_BACK_TYPES` and adds an explicit branch that navigates money account deposit confirmations to Money Home (`HOME_TABS → Money → MoneyHome`), mirroring the existing `perpsDeposit`/`predictDeposit` MoneyAccount branches. It uses `hasTransactionType(...)` so it correctly matches the `moneyAccountDeposit` type nested inside the approve+deposit batch transaction.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where funding the money account from the wallet home screen returned the user to the home screen instead of their Money Account home.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1058

## **Manual testing steps**

```gherkin
Feature: Money account funding redirect

  Scenario: user funds the money account from the wallet home screen
    Given the user is on the wallet home screen with the Money Account feature enabled
    And the user has completed money onboarding

    When the user taps "Add" on the Money card
    And the user completes the deposit/convert confirmation
    Then the user is taken to their Money Account home (not the wallet home screen)

  Scenario: user funds the money account from Money Home
    Given the user is on the Money Account home screen

    When the user taps "Add"
    And the user completes the deposit confirmation
    Then the user remains on their Money Account home

  Scenario: withdraw flow is unchanged
    Given the user initiates a money account withdrawal

    When the user completes the withdraw confirmation
    Then the user is navigated back as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/d9055b13-57cc-4f59-a014-ab5702de6e97



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change in transaction confirm with unit tests; withdraw and other GO_BACK_TYPES behavior unchanged.
> 
> **Overview**
> After confirming a **money account deposit**, users are sent to **Money Home** (`HOME_TABS → Money → MoneyHome`) instead of `goBack()` to wallet home.
> 
> `moneyAccountDeposit` is removed from `GO_BACK_TYPES` in `useTransactionConfirm`. A dedicated post-confirm branch uses `hasTransactionType` so standalone deposits and approve+deposit **batch** flows both match.
> 
> Tests cover direct `moneyAccountDeposit` and nested batch navigation expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e00dce3361b2e4d7ff6e68b0b9e22d3fd536db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->