### PR TITLE
docs: add Headless Buy all-providers support plan

### DIFF
--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -3,7 +3,7 @@
 Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support in two shippable phases:
 
 - **Phase 1** widens quoting to in-app WebView providers only, filtered at the quote layer, behind one scoped flag set to `in-app`. It needs none of the Phase 2 checkout work because external and custom-action quotes are filtered out.
-- **Phase 2** makes the external-browser and custom-action checkout paths headless-aware, then widens the SAME flag to `all`.
+- **Phase 2** makes the external-browser and custom-action checkout paths headless-aware, then widens the same flag to `all`.
 
 Native-only is never broken: the flag's `off` state falls back to native-only.
 
@@ -11,7 +11,7 @@ Companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan).
 
 ## Phases checklist
 
-**Phase 1 - Quick-win MVP (in-app WebView providers only):**
+**Phase 1 - MVP (in-app WebView providers only):**
 
 - [ ] **P1.M0** - `failSession`-terminal must-fix
 - [ ] **P1.M1** - In-app-only quoting capability (in-app filter, reliability-then-price selection in `RampsController`, WebView fail-safe, per-provider smoke check, analytics tagging, limits decision)
@@ -37,7 +37,7 @@ P1.M0 is a precondition for everything else: the terminal-callback contract fix 
 
 ## Background
 
-In-app vs external is knowable at the quote layer (before `getBuyWidgetData`), so widening can be staged by provider class rather than deferred wholesale. The risk being avoided: widening live quoting to providers whose checkout is not headless-aware would land users in the broken external-browser branch (silent BuildQuote reset, no terminal callback), making "user backed out" indistinguishable from "provider broke".
+In-app vs external is knowable at the quote layer (before `getBuyWidgetData`), so widening can be staged by provider class rather than deferred wholesale. The risk this avoids: widening live quoting to providers whose checkout is not headless-aware would land users in the broken external-browser branch (silent BuildQuote reset, no terminal callback), making "user backed out" indistinguishable from "provider broke".
 
 Context for the phasing decisions:
 
@@ -75,9 +75,9 @@ These facts make the in-app filter and the phase split possible.
 
 - **One `getQuotes` call, no client fan-out.** `RampsController.getQuotes()` returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal (lands in `error[]`); other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
 - **Custom actions ride inside `success[]`**, flagged by `quote.isCustomAction` (reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts:43-45`). The separate `customActions[]` array is empty in UB2 usage. UB2 already excludes `isCustomAction` entries from provider/payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx:262-274`). Phase 1 filters them out the same way; Phase 2 brings them into scope.
-- **Partial vs full failure** is computed over non-customAction `success[]` entries. Full failure (no usable entry) maps to `NO_QUOTES`; it is NOT `success.length === 0 && customActions.length === 0`.
+- **Partial vs full failure** is computed over non-customAction `success[]` entries. Full failure (no usable entry) maps to `NO_QUOTES`; it is not `success.length === 0 && customActions.length === 0`.
 - **In-app vs external is decided at the quote layer.** `getAggregatorRedirectConfig` reads `quote.quote?.buyWidget?.browser` and `isCustomAction` off the quote (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts:35-71`) and is called at `useContinueWithQuote.ts:249`, before `getBuyWidgetData` at `:257`. Custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. So Phase 1 can pre-filter to in-app: keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`.
-- **`buyWidget.browser` is optional.** Mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote missing `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from TWO layers together: (1) the multi-value scoped flag (`off | in-app | all`), and (2) the in-app filter plus selection in the shared `RampsController` selection (`getSmartSelectedQuote`) that `getRampsQuote` consumes, backed by the mandatory in-app `Checkout` WebView fail-safe.
+- **`buyWidget.browser` is optional.** Mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote missing `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from two layers together: (1) the multi-value scoped flag (`off | in-app | all`), and (2) the in-app filter and selection in the shared `RampsController` (`getSmartSelectedQuote`) that `getRampsQuote` consumes, backed by the mandatory in-app `Checkout` WebView fail-safe.
 
 ### Selection (ordering like UB2)
 
@@ -138,7 +138,7 @@ In Phase 1 only the `native` and `in-app widget` branches are reachable for prod
 
 ---
 
-## Phase 1 - Quick-win MVP: in-app WebView providers only
+## Phase 1 - MVP: in-app WebView providers only
 
 Ships to production behind one scoped flag set to `in-app`; external-browser and custom-action providers are filtered out.
 
@@ -155,7 +155,7 @@ Tests: `failSession` fires exactly one `onError` and no `onClose`; the session i
 - **Selection.** Reliability-then-price off `sorted[]`; the order-history rung is cut from Phase 1 (added back in P2.M6).
 - **Selection ownership.** Put the in-app filter plus reliability-then-price selection in `RampsController` (`getSmartSelectedQuote`), consumed by both `transaction-pay-controller` `getRampsQuote` and the mobile headless path.
 - **WebView fail-safe.** A quote omitting `buyWidget.browser` is classified in-app and routes to the in-app `Checkout` WebView, so the real safety net is the WebView's terminal-failure path: confirm `Checkout`'s `onHttpError` / load-failure routes through `failHeadlessCheckout` -> `failSession` (`app/components/UI/Ramp/Views/Checkout/Checkout.tsx` ~241) for the newly-enabled in-app providers, producing a clean terminal `onError` rather than a stranded session.
-- **Per-provider WebView smoke check.** The SET of providers hitting the in-app `Checkout` WebView is new. Add a smoke check per newly-enabled in-app provider, including `getQuoteBuyUserAgent` custom-user-agent needs (`app/components/UI/Ramp/types/index.ts` ~81-87).
+- **Per-provider WebView smoke check.** The set of providers hitting the in-app `Checkout` WebView is new. Add a smoke check per newly-enabled in-app provider, including `getQuoteBuyUserAgent` custom-user-agent needs (`app/components/UI/Ramp/types/index.ts` ~81-87).
 - **Analytics tagging.** Confirm the existing `RAMPS_CHECKOUT_CLOSED` / `RAMPS_ORDER_FAILED` instrumentation in `Checkout.tsx` already tags `ramp_type: 'HEADLESS'` for the new providers (full external-browser parity stays Phase 2).
 - **Min/max limits decision.** `useRampsBuyLimits` reads limits from the native preferred provider and breaks once non-native providers are in scope (`app/components/UI/Ramp/hooks/useRampsBuyLimits.ts` ~15-20, 42-50). For MM Pay the amount is deposit-driven, so decide explicitly: enforce per-provider limits up front, or accept provider-side mid-checkout rejection and ensure that rejection is a clean terminal callback (ties to the fail-safe).
 
@@ -174,13 +174,13 @@ Tests: with the flag `in-app`, in-app non-native quotes reach the consumer and c
 
 ## Phase 2 - External-browser and custom-action providers (Coinbase, PayPal, etc.)
 
-Makes the external/custom checkout paths headless-aware, then widens the SAME flag to `all`.
+Makes the external/custom checkout paths headless-aware, then widens the same flag to `all`.
 
 ### P2.M1 - Make `continueWidget`'s external-browser branch headless-aware
 
 Thread `ctx.headlessSessionId` into the external-browser branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts:289-335`) so it routes to terminal callbacks instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`app/components/UI/Ramp/utils/rampsNavigation.ts:50-75`):
 
-- iOS `InAppBrowser.openAuth` success (today calls `navigateAfterExternalBrowser({ returnDestination: 'order', ... })`, lines 325-330): resolve into `onOrderCreated`. This is NOT headless-aware today; iOS external success is not "already handled".
+- iOS `InAppBrowser.openAuth` success (today calls `navigateAfterExternalBrowser({ returnDestination: 'order', ... })`, lines 325-330): resolve into `onOrderCreated`. This is not headless-aware today; iOS external success is not "already handled".
 - Cancel: `onClose({ reason: 'user_dismissed' })`.
 - Error / open-rejection: `failSession`.
 
@@ -238,9 +238,9 @@ Tests: ladder order with and without preferred provider ids; deterministic outpu
 
 - Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open). Depends on the P1.M0 terminal-callback contract.
 - Route user exits to `onClose` per the callback-routing rule. Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit: `Checkout.tsx:386-393` already treats it as `closeSession({ reason: 'user_dismissed' })`.
-- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, and HTTP / load failures, tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`. Note: today MM Pay / TPC detects an order's terminal state by POLLING `RampsController:getOrder` (in `transaction-pay-controller` `strategy/fiat/fiat-submit.ts`), NOT via a `RampsController:orderStatusChanged` subscription. The headless session ends at `onOrderCreated` (order CREATED); the order's terminal state is observed afterward by that TPC polling. So hanging Phase 2 analytics off `orderStatusChanged` would be NEW subscription work, not existing behavior.
-- **Export reality check.** On core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but NOT `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). A consumer that must branch on those first needs a core sub-task to export them; otherwise depend only on the already-exported helpers plus `RAMPS_ERROR_CODES`. Re-verify against `origin/main` before relying on it.
-- **Scope the taxonomy.** Granular provider codes (e.g. `KYC_REQUIRED`) are implement-on-demand: add a code when a consumer actually needs to branch on it.
+- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, and HTTP / load failures, tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`. Note: today MM Pay / TPC detects an order's terminal state by polling `RampsController:getOrder` (in `transaction-pay-controller` `strategy/fiat/fiat-submit.ts`), not via a `RampsController:orderStatusChanged` subscription. The headless session ends at `onOrderCreated` (order created); the order's terminal state is observed afterward by that TPC polling. So hanging Phase 2 analytics off `orderStatusChanged` would be new subscription work, not existing behavior.
+- **Export reality check.** On core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but not `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). A consumer that must branch on those first needs a core sub-task to export them; otherwise depend only on the already-exported helpers plus `RAMPS_ERROR_CODES`. Re-verify against `origin/main` before relying on it.
+- **Scope the taxonomy.** Granular provider codes (e.g. `KYC_REQUIRED`) are implement-on-demand: add a code when a consumer needs to branch on it.
 
 ---
 

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -1,18 +1,21 @@
 # Headless Buy: All Providers Support Plan
 
-> Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support in two checkpointable phases. Phase 1 ships a quick-win MVP for in-app WebView providers only, filtered at the quote layer, behind one scoped flag. Phase 2 adds external-browser and custom-action providers (headless-aware checkout, deeplink reconciliation, custom actions), then widens the same flag. Each phase is shippable on its own: Phase 1 needs none of the Phase 2 checkout work because external/custom quotes are filtered out.
+Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support in two shippable phases:
 
-This is a companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan) and follows its style.
+- **Phase 1** widens quoting to in-app WebView providers only, filtered at the quote layer, behind one scoped flag set to `in-app`. It needs none of the Phase 2 checkout work because external and custom-action quotes are filtered out.
+- **Phase 2** makes the external-browser and custom-action checkout paths headless-aware, then widens the SAME flag to `all`.
+
+Native-only is never broken: the flag's `off` state falls back to native-only.
+
+Companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan).
 
 ## Phases checklist
 
-The work is split into two phases plus a deferred tail. Phase 1 is shippable on its own: it widens quoting to in-app WebView providers, filters out everything that needs external-browser or custom-action handling, and activates behind a multi-value scoped flag set to `in-app`. Phase 2 makes the external/custom checkout paths headless-aware and then widens the SAME flag to `all`. The native-only flow is never broken in either phase: the flag's `off` state falls back to native-only.
-
 **Phase 1 - Quick-win MVP (in-app WebView providers only):**
 
-- [ ] **P1.M0** - `failSession`-terminal must-fix (OTP typed-code de-scoped as native-only / optional)
-- [ ] **P1.M1** - In-app-only quoting capability (in-app filter, reliability-then-price selection in `RampsController`, re-specified WebView fail-safe, per-provider WebView smoke check, analytics tagging, limits decision)
-- [ ] **P1.M2** - Activation behind a multi-value scoped flag (`off | in-app | all`), with MM Pay passing allowed `providerIds`
+- [ ] **P1.M0** - `failSession`-terminal must-fix
+- [ ] **P1.M1** - In-app-only quoting capability (in-app filter, reliability-then-price selection in `RampsController`, WebView fail-safe, per-provider smoke check, analytics tagging, limits decision)
+- [ ] **P1.M2** - Activation behind a multi-value scoped flag (`off | in-app | all`), MM Pay passing allowed `providerIds`
 
 **Phase 2 - External-browser + custom-action providers (Coinbase, PayPal, etc.):**
 
@@ -26,30 +29,30 @@ The work is split into two phases plus a deferred tail. Phase 1 is shippable on 
 
 **Deferred (after Phase 2):**
 
-- [ ] TPC multi-provider wiring; DRY cleanup ("UB2 becomes dumb"); broad typed-error taxonomy on demand
+- [ ] TPC multi-provider wiring; DRY cleanup (UB2 becomes a dumb consumer); broad typed-error taxonomy on demand
 
-P1.M0 is a precondition for everything else: the terminal-callback contract fix (see Must-fix preconditions) must land before typed errors expand or before any consumer relies on terminal outcomes. The OTP typed-code fix is native-flow-only and is de-scoped (optional) for the in-app MVP.
-
----
-
-## Scope (confirmed: full cross-repo)
-
-Enabling all providers spans three layers. Phase 1 touches only the subset needed for in-app WebView providers; Phase 2 finishes the rest.
-
-- **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` (line ~113) + `restrictToKnownOrNativeProviders: true` (line ~116) and takes only `quotes.success?.[0]` (line ~124) (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, the `getRampsQuote` function around lines 95 to 131 on `origin/main`). This is the native-only gate's quote-side enforcement.
-- **`@metamask/ramps-controller`** - home for the shared smart selection (the deferred `getSmartSelectedQuote`). Phase 1 puts the in-app filter plus reliability-then-price selection here so that BOTH `transaction-pay-controller` `getRampsQuote` and the mobile headless path call one implementation instead of forking selection between core and a separate mobile `recommendQuotes` util (drift hazard). Pure callback parsing / status helpers extract here only once 2+ consumers justify it.
-- **`metamask-mobile`** - relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26); consume the shared selection; own the in-app `Checkout` WebView fail-safe (Phase 1); make `useContinueWithQuote`'s external-browser branch headless-aware, plus typed errors, analytics, and all navigation/session and redirect/deeplink policy (Phase 2).
+P1.M0 is a precondition for everything else: the terminal-callback contract fix must land before typed errors expand or any consumer relies on terminal outcomes. The OTP typed-code fix is native-flow-only and de-scoped (optional) for the in-app MVP.
 
 ---
 
-## Sequencing and safety: capability vs activation
+## Background
 
-**Risk:** widening live MM Pay / HeadlessBuy quoting to providers whose checkout path is not headless-aware would land users in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
+In-app vs external is knowable at the quote layer (before `getBuyWidgetData`), so widening can be staged by provider class rather than deferred wholesale. The risk being avoided: widening live quoting to providers whose checkout is not headless-aware would land users in the broken external-browser branch (silent BuildQuote reset, no terminal callback), making "user backed out" indistinguishable from "provider broke".
 
-**Rule:** widening is staged by provider class, not deferred wholesale. In-app vs external is knowable at the quote layer (see the B1 finding and the "In-app WebView vs external-browser providers" concern), so Phase 1 can safely ship in-app WebView providers in production behind a flag while the external/custom checkout work is still pending.
+Context for the phasing decisions:
 
-- **Phase 1 ships in-app behind the flag.** The in-app filter (`!isCustomAction(quote)` and `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`) is the safety boundary: external-browser and custom-action quotes are filtered out before continuation, so the broken external branch is never reached. Three layers make this safe together (B1): MM Pay passes allowed `providerIds`, the in-app filter, and a mandatory in-app `Checkout` WebView fail-safe.
-- **Phase 2 makes external/custom safe, then widens the SAME flag.** Only after `continueWidget`'s external-browser branch and the headless deeplink path emit terminal callbacks does the flag move from `in-app` to `all`. Because it is a flag VALUE flip (not a deploy-time filter removal), it is staged and roll-back-able independently of the Phase 2 deploy.
+- The earlier "native-only for v0, disable aggregators" decision was time-boxed to the Money Account launch. Money Account has launched, so enabling in-app aggregators is in scope.
+- Provider gating happens at the distribution layer (MM Pay passes allowed `providerIds`). Core also applies the in-app filter as defense-in-depth.
+- Smart selection lives in `RampsController` (the deferred `getSmartSelectedQuote`), consumed by both `transaction-pay-controller` and the mobile headless path, so selection is not forked between core and a separate mobile `recommendQuotes` util.
+- PayPal and Robinhood are "checkout outside of MetaMask" (Phase 2). MoonPay and Revolut are top in-app providers in Phase 1 scope.
+
+## Scope (full cross-repo)
+
+Three layers. Phase 1 touches only the in-app WebView subset; Phase 2 finishes the rest.
+
+- **`@metamask/core` - `TransactionPayController`** (MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` and `restrictToKnownOrNativeProviders: true`, taking only `quotes.success?.[0]` (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, `getRampsQuote` ~lines 95-131). This is the native-only gate's quote-side enforcement.
+- **`@metamask/ramps-controller`** - home for the shared selection (`getSmartSelectedQuote`). Phase 1 puts the in-app filter plus reliability-then-price selection here.
+- **`metamask-mobile`** - relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts:19-23`; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts:23-26`); consume the shared selection; own the in-app `Checkout` WebView fail-safe (Phase 1); make `useContinueWithQuote`'s external-browser branch headless-aware plus typed errors, analytics, and navigation/session/deeplink policy (Phase 2).
 
 ---
 
@@ -57,94 +60,59 @@ Enabling all providers spans three layers. Phase 1 touches only the subset neede
 
 Inherited from [PLAN.md](./PLAN.md), with one addition:
 
-1. **Callbacks-only, three terminal events.** A session ends in exactly one of `onOrderCreated`, `onError`, `onClose`. No intermediate progress callbacks. KYC stays terminal-only for consumers: native Transak may surface auth/limit/KYC-specific typed errors, but non-native provider KYC stays inside the provider checkout unless it produces a terminal callback, cancellation, or load failure.
+1. **Callbacks-only, three terminal events.** A session ends in exactly one of `onOrderCreated`, `onError`, `onClose`. No intermediate progress callbacks. Native Transak may surface auth/limit/KYC-specific typed errors, but non-native provider KYC stays inside the provider checkout unless it produces a terminal callback, cancellation, or load failure.
 2. **The consumer renders all visible UI.** `useHeadlessBuy` is a behavior provider, not a UI provider.
-3. **Callback-routing rule (new).** `onError` is reserved for technical / provider failures only. User-driven and consumer-driven exits terminate via `onClose`, not `onError`:
+3. **Callback-routing rule (new).** `onError` is reserved for technical / provider failures only. User-driven and consumer-driven exits terminate via `onClose`:
    - User in-flow exit (browser cancel, WebView close, back-press, inferred abandonment): `onClose({ reason: 'user_dismissed' })`.
    - Consumer programmatic cancel (`cancel()` / session replacement): `onClose({ reason: 'consumer_cancelled' })`.
-   - The `USER_CANCELLED` error code is retired for in-session exits. If retained at all, it is reserved only for a pre-session cancellation error and never emitted for in-flow user closes. Otherwise MM Pay cannot distinguish "user backed out" from "provider broke".
+   - `USER_CANCELLED` is retired for in-session exits (at most reserved for a pre-session cancellation error). Otherwise MM Pay cannot distinguish "user backed out" from "provider broke".
 
 ---
 
-## Must-fix preconditions (before expanding errors)
+## Quote-layer behavior (the foundation for filtering)
 
-**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 264). MM Pay's `onClose` currently clears the error set by `onError` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, the `onClose` handler at lines 129 to 132 calls `setHeadlessBuyError(undefined)`), so the error is lost.
+These facts make the in-app filter and the phase split possible.
 
-**Decision (chosen contract):** `onError` is terminal on its own. `failSession` fires `onError` and then ends the session WITHOUT a trailing `onClose`. A session ends in exactly one of `onOrderCreated`, `onError`, or `onClose`, with no pairing. This keeps "provider broke" (`onError`) cleanly separable from "user/consumer exited" (`onClose`).
+- **One `getQuotes` call, no client fan-out.** `RampsController.getQuotes()` returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal (lands in `error[]`); other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
+- **Custom actions ride inside `success[]`**, flagged by `quote.isCustomAction` (reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts:43-45`). The separate `customActions[]` array is empty in UB2 usage. UB2 already excludes `isCustomAction` entries from provider/payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx:262-274`). Phase 1 filters them out the same way; Phase 2 brings them into scope.
+- **Partial vs full failure** is computed over non-customAction `success[]` entries. Full failure (no usable entry) maps to `NO_QUOTES`; it is NOT `success.length === 0 && customActions.length === 0`.
+- **In-app vs external is decided at the quote layer.** `getAggregatorRedirectConfig` reads `quote.quote?.buyWidget?.browser` and `isCustomAction` off the quote (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts:35-71`) and is called at `useContinueWithQuote.ts:249`, before `getBuyWidgetData` at `:257`. Custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. So Phase 1 can pre-filter to in-app: keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`.
+- **`buyWidget.browser` is optional.** Mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote missing `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from THREE layers together: MM Pay passes allowed `providerIds`, the in-app filter, and the mandatory in-app `Checkout` WebView fail-safe.
 
-Implementation: `failSession` stops calling `closeSession`; it sets the terminal status (`failed`) and removes the session from the registry directly, without invoking `onClose`. `onClose` remains the terminal event only for `user_dismissed` / `consumer_cancelled` / `completed` paths.
+### Selection (ordering like UB2)
 
-Caveat to confirm with MM Pay before building broad typed errors: if MM Pay relies on a single cleanup hook regardless of outcome, we instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract above unless MM Pay asks for the cleanup variant.
+Two existing UB2 behaviors:
 
-This is a precondition for the typed-error work, not an afterthought, and is implemented as P1.M0. The companion OTP typed-code fix is native-flow-only and is de-scoped (optional) for the in-app MVP.
+- **Modal ordering** (`ProviderSelection.tsx:205-228`): reliability-only sort of providers-with-quotes.
+- **Recommendation ladder** (legacy `app/components/UI/Ramp/Aggregator/hooks/useSortedQuotes.ts:43-69`): previously-used provider, then reliability, then price.
+
+Phase 1 needs only reliability-then-price to pick one quote for the MM Pay MVP, so the order-history rung is cut from Phase 1. That rung exists in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`) but is `#private` and runs only in the single-provider auto-select branch; the all-provider path never invokes it. Phase 2 adds it back when there is a real returning-user requirement (P2.M6).
+
+### Routing and KYC, native vs non-native
+
+`useContinueWithQuote` branches on `isNativeProvider(quote)` (`app/components/UI/Ramp/types/index.ts:33-35`). Native uses the Transak auth/KYC loop (`useTransakRouting`); KYC is fully in-app (NativeFlow screens plus Transak APIs). Non-native fetches `getBuyWidgetData` then opens either an in-app `Checkout` WebView or an external browser; KYC happens inside the provider WebView/browser and MetaMask only learns the outcome at callback / deeplink time.
+
+In-app success is detected via `getOrderFromCallback` on the callback URL. External success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`), both handled in Phase 2.
 
 ---
 
 ## UB2 behavior to preserve
 
-- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`. (In practice custom actions ride inside `success[]` flagged by `isCustomAction`; the separate `customActions[]` array is empty in UB2 usage, and custom actions are out of scope in Phase 1, see the "Getting multiple quotes" concern.)
-- Provider-level quote errors are non-terminal: they are surfaced as partial errors and only become terminal when every provider fails or no usable quote can be selected.
-- Existing UB2 quote ordering, recommended-quote selection, WebView retry behavior, and OrderDetails routing must remain unchanged (regression-tested).
+- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`.
+- Provider-level quote errors are non-terminal: surfaced as partial errors, terminal only when every provider fails or no usable quote can be selected.
+- Existing UB2 quote ordering, recommended-quote selection, WebView retry behavior, and OrderDetails routing remain unchanged (regression-tested).
 
 ---
 
-## Concerns addressed
+## Must-fix precondition: terminal-callback contract (P1.M0)
 
-A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the phases below.
+`failSession` currently fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts:235-264`). MM Pay's `onClose` clears the error set by `onError` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts:129-132` calls `setHeadlessBuyError(undefined)`), so the error is lost.
 
-### Getting multiple quotes; partial vs full failure
+**Contract:** `onError` is terminal on its own. `failSession` sets the terminal status (`failed`) and removes the session from the registry directly, without invoking `onClose`. A session ends in exactly one of `onOrderCreated`, `onError`, or `onClose`, with no pairing. `onClose` remains terminal only for `user_dismissed` / `consumer_cancelled` / `completed`.
 
-UB2 does not fan out to providers with `Promise.all`. One `RampsController.getQuotes()` call returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal: its message lands in `error[]` while other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
+Confirm with MM Pay before building broad typed errors: if MM Pay relies on a single cleanup hook regardless of outcome, instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract unless MM Pay asks for the cleanup variant.
 
-Custom actions are NOT a separate candidate array in practice. UB2 carries custom actions INSIDE `success[]`, flagged by `quote.isCustomAction` (`isCustomAction()` reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). The separate `customActions[]` array is empty in UB2 usage and tests. UB2 already EXCLUDES `isCustomAction` entries from provider / payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx`, lines 262 to 274). In Phase 1 custom-action entries are OUT of scope: headless candidate selection must filter them out of `success[]` the same way, so that removing `restrictToKnownOrNativeProviders` cannot surface an unhandled custom-action path. Phase 2 brings custom actions into scope.
-
-- Partial failure: at least one usable non-customAction `success[]` entry exists. Keep it.
-- Full failure: no usable non-customAction `success[]` entry. This is NOT `success.length === 0 && customActions.length === 0`. Map to `NO_QUOTES`.
-
-Decision: there is no union candidate model. Selection, "no quotes", and continuation operate over `success[]` with `isCustomAction` entries filtered out (in Phase 1).
-
-### Sorting / ordering quotes like UB2
-
-There are two existing UB2 behaviors:
-
-- **Modal ordering** in `app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx` (lines 205 to 228): reliability-only sort of providers-with-quotes.
-- **Recommendation ladder** in legacy `app/components/UI/Ramp/Aggregator/hooks/useSortedQuotes.ts` (lines 43 to 69): previously-used provider, then reliability, then price.
-
-Phase 1 needs only reliability-then-price to pick one quote for the MM Pay MVP, so the previously-used-provider (order-history) rung is CUT from Phase 1. The order-history rung DOES exist in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`) but is `#private` and runs only in the single-provider auto-select branch; the all-provider path never invokes it (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`: the `else if (autoSelectProvider || restrictToKnownOrNativeProviders)` branch, lines 1003 to 1024, versus the all-provider `else` branch that quotes `state.providers.data`, line 1026). Phase 2 adds the preferred-provider rung back when there is a real returning-user requirement (P2.M6).
-
-### Routing for native vs non-native
-
-`useContinueWithQuote` branches on `isNativeProvider(quote)` (`app/components/UI/Ramp/types/index.ts`, lines 33 to 35). Native uses the Transak auth/KYC loop via `useTransakRouting`. Non-native fetches `getBuyWidgetData` then opens either an in-app `Checkout` WebView or an external browser.
-
-### KYC for native vs non-native
-
-Native KYC is fully in-app (NativeFlow screens plus Transak APIs: email, OTP, BasicInfo, KycWebview, KycProcessing, AdditionalVerification). Non-native KYC happens inside the provider's WebView or external browser; MetaMask only learns the outcome at callback / deeplink time.
-
-### In-app WebView providers vs external-browser providers
-
-The decision is made at the QUOTE LAYER, before `getBuyWidgetData`. `getWidgetRedirectConfig` / `getAggregatorRedirectConfig` read `quote.quote?.buyWidget?.browser === 'IN_APP_OS_BROWSER'` and `isCustomAction` directly off the quote (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the redirect-config helpers around lines 35 to 71), and `getAggregatorRedirectConfig` is called at `useContinueWithQuote.ts:249` BEFORE `getBuyWidgetData` at `:257`. So whether a quote is in-app or external is knowable at selection time, not only after `getBuyWidgetData`. Custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. This is why Phase 1 can pre-filter to in-app providers at the quote layer: keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`. In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`), both handled in Phase 2.
-
-Caveat (B1): this is the right MECHANISM, but `buyWidget.browser` is optional, mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote MISSING `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from THREE layers together, not from the field alone (see the B1 finding).
-
-### Load failure handling and notifying MM Pay
-
-In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). This is the Phase 1 fail-safe for newly-enabled in-app providers. The external-browser path has no load-failure handling and no headless notification today; Phase 2 routes external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit) so MM Pay always receives a terminal callback.
-
-### Analytics abandon vs failed
-
-Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. Phase 1 confirms the existing in-app `Checkout` instrumentation already tags the new in-app providers; external-browser abandon is currently untracked and is brought to parity in Phase 2 (P2.M7).
-
-### Gaps in the external-browser branch of `useContinueWithQuote`
-
-The branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) ignores `ctx.headlessSessionId`: cancel, Android `Linking.openURL`, and iOS success all call `navigateAfterExternalBrowser({ returnDestination: 'buildQuote' | 'order' })` (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75), landing on BuildQuote / OrderDetails with no `onOrderCreated` / `onError` / `onClose`. `addPrecreatedOrder` is conditional, and OrderDetails has no headless path. This is Phase 2 work; Phase 1 never reaches this branch because external quotes are filtered out.
-
-### Specific non-native errors UB2 handles that Headless does not
-
-Missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `getOrderFromCallback` throw, terminal HTTP error, `getBuyWidgetData` failure, static min/max limits, and no-quotes. Most map to a coarse `UNKNOWN` in headless today; `NO_QUOTES` / `QUOTE_FAILED` are defined but unemitted; and the OTP `nativeFlowError` string path force-maps post-auth failures (including limit / KYC) to `AUTH_FAILED`. (An empty callback query is NOT in this technical-error set: `app/components/UI/Ramp/Views/Checkout/Checkout.tsx`, lines 386 to 393, already treats an empty query as `closeSession({ reason: 'user_dismissed' })`, so it stays a user-exit via `onClose`.)
-
-### DRY: logic to move out of UB2 UI
-
-Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Deferred for the precise core-vs-mobile split.
+The OTP typed-code fix (stop force-mapping `nativeFlowError` to `AUTH_FAILED` in `HeadlessHost.tsx:136-147`) is native-flow-only and de-scoped (optional) for the in-app MVP.
 
 ---
 
@@ -170,183 +138,144 @@ In Phase 1 only the `native` and `in-app widget` branches are reachable for prod
 
 ---
 
-## Conflicts resolved
-
-Reconciliations that shaped the phasing; capturing them so we do not re-litigate during implementation:
-
-- **In-app widening can ship in Phase 1; only external/custom widening waits for Phase 2.** Earlier framing claimed gate removal "must be LAST" because external-vs-in-app was thought to be decided only AFTER `getBuyWidgetData`. That is corrected: `getAggregatorRedirectConfig` reads `quote.quote?.buyWidget?.browser` and `isCustomAction` off the quote BEFORE `getBuyWidgetData` (`buildQuoteWithRedirectUrl.ts:39-65`, `useContinueWithQuote.ts:249` vs `:257`). So the quote layer CAN pre-filter to in-app-WebView providers, and Phase 1 widens in-app in production behind a flag. Phase 2 makes external/custom checkout headless-aware first, then widens the same flag to `all`.
-- **Shared smart selection lives in `RampsController`.** MM Pay's single-quote pick is core-side (`transaction-pay-controller` `getRampsQuote` returns `success?.[0]`). Rather than embedding the in-app filter + reliability-then-price logic into `transaction-pay-controller` and forking a separate mobile `recommendQuotes` util (drift hazard), the shared selection goes in `RampsController` (the team's deferred `getSmartSelectedQuote`, per Goktug / Matthew Walsh, #confirmations-ramps-collab 2026-05-27) so BOTH `getRampsQuote` and the mobile headless path call one implementation.
-- **A distinct multi-value scoped flag is required.** The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat), so activation needs a new scoped flag whose "off" state falls back to native-only, not "no fiat" (P1.M2). It is multi-value (`off | in-app | all`) so the Phase 2 widening is a controlled flag flip, not a deploy-time jump.
-
----
-
-## Verified findings (B1-B3)
-
-These three findings were verified against code history plus Slack, and they unlock the phase split. They replace the earlier "open blockers" framing.
-
-- **B1 - Mechanism sound; residual risk handled by the gate, NOT by assuming the field is always present** (downgraded from "resolved" after verification). The quote-layer read is real: `getAggregatorRedirectConfig` reads `quote.quote.buyWidget?.browser` and `isCustomAction` before `getBuyWidgetData` (`buildQuoteWithRedirectUrl.ts:39-65`, `useContinueWithQuote.ts:249` vs `:257`). Core commit `6e0a31c9a` documents the V2 API embedding `buyWidget` on quotes. BUT this is not a safe "always embedded" invariant: `buyWidget.browser` is optional (`RampsService.d.mts:193-206`), mobile still fetches the URL via the deprecated `buyURL` + `getBuyWidgetData` path (`buildQuoteWithRedirectUrl.ts:13-14`, `useContinueWithQuote.ts:257,271`), and custom actions arrive in a separate `customActions[]` array with no `buyWidget` (caught by the `isCustomAction` prong). So an aggregator quote missing `buyWidget.browser` would be classed in-app. This is made safe by the gating decision below (MM Pay passes allowed provider IDs) PLUS the in-app filter PLUS the mandatory WebView fail-safe - not by the field alone.
-- **B2 - Provider-agnostic headless, gate at the distribution layer** (confirmed: Lorenzo DM 2026-05-26 "gate providers at the distribution layer (i.e., MM Pay)... deprecate [the provider field] later to avoid sister teams overfitting"). DECISION (Shane): use BOTH gates - MM Pay PASSES allowed provider IDs (the team's documented mechanism: `providerIds` via feature flag, so only known in-app providers are quoted) AND core applies the in-app filter as defense-in-depth. This supersedes the earlier "dynamic filter, no allowlist" framing. Categorization: PayPal + Robinhood = "checkout outside of MetaMask" -> Phase 2; MoonPay / Revolut = top in-app providers in Phase 1 scope.
-- **B3 - (a) and (b) confirmed in code; framing corrected.** (a) An empty catalog in the no-restriction path does NOT throw: `RampsController.getQuotes` omits the provider filter and quotes every provider server-side (`RampsController.mjs:1039-1046`; only the `restrictToKnownOrNativeProviders` path returns empty). (b) MM Pay's single-quote pick is core-side: `transaction-pay-controller` `getRampsQuote` returns `quotes.success?.[0]` (`strategy/fiat/utils.ts:124`). Correction: do NOT cite the Apr 28 thread as support - it DEFERRED "fetch all providers and pick best" as too complex. Ownership: align with the team's stated intent (Goktug / Matthew Walsh, #confirmations-ramps-collab 2026-05-27) to put smart selection in `RampsController` (the deferred `getSmartSelectedQuote`) consumed by BOTH `transaction-pay-controller` and the mobile headless path, rather than embedding ramp business logic in `transaction-pay-controller` and forking a separate mobile `recommendQuotes` (drift hazard). Direction unblock: the Jun 7 #money-movement-sca-collab decision ("native-only for v0, disable aggregators on all flows until after Money Account launch") was time-boxed to the launch and is now SUPERSEDED (Money Account has launched), so enabling in-app aggregators is in scope.
-
----
-
 ## Phase 1 - Quick-win MVP: in-app WebView providers only
 
-Ships to production behind one scoped flag set to `in-app`; external-browser and custom-action providers are filtered out, so none of the Phase 2 checkout work is required to ship.
+Ships to production behind one scoped flag set to `in-app`; external-browser and custom-action providers are filtered out.
 
-### P1.M0 - Must-fix: `failSession` terminal
+### P1.M0 - `failSession` terminal
 
-`onError` fires, the session is removed, and there is NO trailing `onClose`. See the Must-fix preconditions section for the full contract. `failSession` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 264) currently calls `closeSession({ reason: 'unknown' }, { terminalStatus: 'failed' })` after `onError`, and the MM Pay consumer (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 123 to 132) clears the error in its `onClose` handler. Fix: `failSession` sets the terminal status and removes the session directly, without invoking `onClose`.
-
-The OTP typed-code fix (stop force-mapping `nativeFlowError` to `AUTH_FAILED` in `HeadlessHost.tsx`, lines 136 to 147) is native-flow-only and therefore de-scoped (optional) for the in-app MVP; it can ride along with the broad typed-error work later.
+`failSession` (`sessionRegistry.ts:235-264`) currently calls `closeSession({ reason: 'unknown' }, { terminalStatus: 'failed' })` after `onError`, and MM Pay (`useFiatConfirm.ts:123-132`) clears the error in its `onClose` handler. Fix: `failSession` sets the terminal status and removes the session directly, without invoking `onClose`. See the must-fix precondition section for the full contract.
 
 Tests: `failSession` fires exactly one `onError` and no `onClose`; the session is removed from the registry; the MM Pay consumer retains the error after a failure.
 
 ### P1.M1 - In-app-only quoting capability
 
-Build everything needed to request, filter, and recommend in-app WebView quotes, and consume it through one shared selection.
+- **Widen `getRampsQuote`.** Drop both `autoSelectProvider` and `restrictToKnownOrNativeProviders` so `getQuotes` falls back to `state.providers.data` and quotes every provider server-side; switch the pick off `success?.[0]`. Verify the provider catalog is hydrated in the TPC context (or pass an explicit `providers` list), otherwise all-provider quoting could return zero providers.
+- **In-app filter.** Keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'` (the same predicate the routing uses).
+- **Selection.** Reliability-then-price off `sorted[]`; the order-history rung is cut from Phase 1 (added back in P2.M6).
+- **Selection ownership.** Put the in-app filter plus reliability-then-price selection in `RampsController` (`getSmartSelectedQuote`), consumed by both `transaction-pay-controller` `getRampsQuote` and the mobile headless path.
+- **WebView fail-safe.** A quote omitting `buyWidget.browser` is classified in-app and routes to the in-app `Checkout` WebView, so the real safety net is the WebView's terminal-failure path: confirm `Checkout`'s `onHttpError` / load-failure routes through `failHeadlessCheckout` -> `failSession` (`app/components/UI/Ramp/Views/Checkout/Checkout.tsx` ~241) for the newly-enabled in-app providers, producing a clean terminal `onError` rather than a stranded session.
+- **Per-provider WebView smoke check.** The SET of providers hitting the in-app `Checkout` WebView is new. Add a smoke check per newly-enabled in-app provider, including `getQuoteBuyUserAgent` custom-user-agent needs (`app/components/UI/Ramp/types/index.ts` ~81-87).
+- **Analytics tagging.** Confirm the existing `RAMPS_CHECKOUT_CLOSED` / `RAMPS_ORDER_FAILED` instrumentation in `Checkout.tsx` already tags `ramp_type: 'HEADLESS'` for the new providers (full external-browser parity stays Phase 2).
+- **Min/max limits decision.** `useRampsBuyLimits` reads limits from the native preferred provider and breaks once non-native providers are in scope (`app/components/UI/Ramp/hooks/useRampsBuyLimits.ts` ~15-20, 42-50). For MM Pay the amount is deposit-driven, so decide explicitly: enforce per-provider limits up front, or accept provider-side mid-checkout rejection and ensure that rejection is a clean terminal callback (ties to the fail-safe).
 
-- **Widen `getRampsQuote`.** Drop both `autoSelectProvider` and `restrictToKnownOrNativeProviders` so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026) and quotes every provider server-side; switch the pick off `success?.[0]`. Gated by B3 catalog hydration (verify the provider catalog is hydrated in the TPC context, or pass an explicit `providers` list, otherwise all-provider quoting could return zero providers).
-- **In-app filter.** Keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'` (the same predicate the routing uses). This removes external-browser and custom-action quotes before continuation.
-- **Selection: reliability-then-price off `sorted[]` only.** CUT the preferred-provider (order-history) rung from Phase 1 - it is not needed to pick one quote for the MM Pay MVP. It is added back in Phase 2 (P2.M6) when there is a real returning-user requirement.
-- **Selection ownership in `RampsController`.** Put the in-app filter + reliability-then-price selection in `RampsController` (the team's deferred `getSmartSelectedQuote`), consumed by BOTH `transaction-pay-controller` `getRampsQuote` and the mobile headless path, rather than embedding ramp business logic in `transaction-pay-controller` and forking a separate mobile `recommendQuotes` util (drift hazard, per Goktug / Matthew Walsh). Gating per B2: MM Pay passes allowed `providerIds`, and the selection applies the in-app filter as defense-in-depth.
-- **Re-specified WebView fail-safe** (the original was aimed at the wrong branch): a quote that OMITS `buyWidget.browser` is classified in-app and routes to the in-app `Checkout` WebView, NOT the external branch. So the real Phase 1 safety net is the WebView's existing terminal-failure path: confirm `Checkout`'s `onHttpError` / load-failure routes through `failHeadlessCheckout` -> `failSession` (`app/components/UI/Ramp/Views/Checkout/Checkout.tsx`, ~241) for the newly-enabled in-app providers, so a provider that fails to load in the WebView produces a clean terminal `onError` rather than a stranded session.
-- **Per-provider WebView smoke check.** "Regression-test only" understates this: the SET of providers hitting the in-app `Checkout` WebView is new. Add a smoke check per newly-enabled in-app provider, including `getQuoteBuyUserAgent` (`app/components/UI/Ramp/types/index.ts`, ~81-87) custom-user-agent needs.
-- **Analytics tagging confirmation.** Confirm the existing `RAMPS_CHECKOUT_CLOSED` / `RAMPS_ORDER_FAILED` instrumentation in `Checkout.tsx` already tags `ramp_type: 'HEADLESS'` for the new providers, so Phase 1 does not ship a production flow with an observability blind spot (full external-browser analytics parity stays Phase 2).
-- **Min/max limits decision.** `useRampsBuyLimits` reads limits from the native preferred provider and its own doc warns this breaks once non-native providers are in scope (`app/components/UI/Ramp/hooks/useRampsBuyLimits.ts`, ~15-20, 42-50). For MM Pay the amount is deposit-driven, so decide explicitly: enforce per-provider limits up front, or accept provider-side mid-checkout rejection, and ensure that rejection is a clean terminal callback (ties to the fail-safe above), not a stranded WebView.
-
-Tests: multi-provider request returns multiple non-customAction in-app candidates; the in-app filter drops external/custom quotes; reliability-then-price picks one quote; partial failure keeps usable candidates plus `error[]`; full failure (no usable in-app `success[]` entry) maps to `NO_QUOTES`; a quote missing `buyWidget.browser` routes to the in-app WebView and a load failure fires `failSession`; per-provider WebView smoke check for each newly-enabled in-app provider.
+Tests: multi-provider request returns multiple non-customAction in-app candidates; the in-app filter drops external/custom quotes; reliability-then-price picks one quote; partial failure keeps usable candidates plus `error[]`; full failure maps to `NO_QUOTES`; a quote missing `buyWidget.browser` routes to the in-app WebView and a load failure fires `failSession`; per-provider WebView smoke check.
 
 ### P1.M2 - Activation behind a multi-value scoped flag
 
-- **Add one scoped flag whose `off` state falls back to native-only**, not "no fiat" (existing `MetaMaskPayFiatFlags` cannot scope this, `app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90).
-- **Make it multi-value (`off | in-app | all`), NOT a boolean.** Phase 1 ships the `in-app` value (filter on). This keeps "one flag" while making the Phase 2 widening a controlled, staged, roll-back-able flip to `all` rather than an implicit deploy-time behavior change.
-- **Gate composition (per B2 "both").** The flag enables non-native and sets scope; within that, MM Pay passes the allowed `providerIds` (the team's distribution-layer mechanism), and the shared selection applies the in-app filter as defense-in-depth. The flag and the passed provider IDs are complementary, not redundant: the flag is the kill switch / scope, the provider IDs are the per-feature allowlist.
-- **Relax the mobile gates behind the flag.** Relax `useHasNativeFiatProvider` / `useIsFiatPaymentAvailable` (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26) and activate the widened + filtered quote path.
-- Safe to activate once the fail-safe is verified; the Jun 7 native-only gate is superseded (Money Account launched), so direction is unblocked.
+- **Add one scoped flag whose `off` state falls back to native-only**, not "no fiat". The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat; `app/selectors/featureFlagController/confirmations/index.ts:87-90`).
+- **Make it multi-value (`off | in-app | all`), not a boolean.** Phase 1 ships `in-app` (filter on); Phase 2 widening is a controlled flag flip to `all`, not a deploy-time behavior change.
+- **Gate composition.** The flag is the kill switch / scope; within that, MM Pay passes the allowed `providerIds` (per-feature allowlist) and the shared selection applies the in-app filter as defense-in-depth. Complementary, not redundant.
+- **Relax the mobile gates behind the flag.** `useHasNativeFiatProvider` (`:23-26`) and `useIsFiatPaymentAvailable` (`:19-23`), then activate the widened + filtered quote path.
 
-Tests: with the flag set to `in-app`, in-app non-native quotes reach the consumer and complete via the in-app `Checkout` WebView callbacks; external/custom quotes are filtered out; with the flag `off`, behavior is identical to today's native-only (native fiat still available).
+Tests: with the flag `in-app`, in-app non-native quotes reach the consumer and complete via the in-app `Checkout` WebView callbacks, and external/custom quotes are filtered out; with the flag `off`, behavior is identical to today's native-only.
 
 ---
 
 ## Phase 2 - External-browser and custom-action providers (Coinbase, PayPal, etc.)
 
-Makes the external/custom checkout paths headless-aware, then widens the SAME flag to its `all` value (one flag, controlled widening; no second product flag).
+Makes the external/custom checkout paths headless-aware, then widens the SAME flag to `all`.
 
 ### P2.M1 - Make `continueWidget`'s external-browser branch headless-aware
 
-Thread `ctx.headlessSessionId` into the external-browser branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) so it routes to `onOrderCreated` / `onClose` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75):
+Thread `ctx.headlessSessionId` into the external-browser branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts:289-335`) so it routes to terminal callbacks instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`app/components/UI/Ramp/utils/rampsNavigation.ts:50-75`):
 
-- iOS `InAppBrowser.openAuth` success: today the success path calls `navigateAfterExternalBrowser({ returnDestination: 'order', callbackUrl, ... })` (lines 325 to 330), landing on `RAMPS_ORDER_DETAILS` with no headless path. Headless: resolve `openAuth` success into `onOrderCreated`.
+- iOS `InAppBrowser.openAuth` success (today calls `navigateAfterExternalBrowser({ returnDestination: 'order', ... })`, lines 325-330): resolve into `onOrderCreated`. This is NOT headless-aware today; iOS external success is not "already handled".
 - Cancel: `onClose({ reason: 'user_dismissed' })`.
 - Error / open-rejection: `failSession`.
 
-**Redirect URL: name one source of truth.** Today `getQuotes` accepts a `redirectUrl` override, but `HeadlessHost` does not pass `HeadlessBuyParams.redirectUrl` into `useContinueWithQuote`, and `continueWidget` recomputes the redirect URL via the mobile redirect-policy util. Decision: the mobile redirect-policy util (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig`) is the source of truth at checkout continuation. `HeadlessBuyParams.redirectUrl` is an optional override that must be threaded from the session onto `ContinueWithQuoteContext` and honored by `continueWidget` when present; when absent, the policy util computes it. The quote-fetch `redirectUrl` and the continuation `redirectUrl` must resolve from this same rule so they cannot diverge.
+**Redirect URL source of truth.** `getQuotes` accepts a `redirectUrl` override, but `HeadlessHost` does not pass `HeadlessBuyParams.redirectUrl` into `useContinueWithQuote`, and `continueWidget` recomputes the redirect via the mobile redirect-policy util. Decision: the mobile redirect-policy util (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig`) is the source of truth at continuation; `HeadlessBuyParams.redirectUrl` is an optional override that must be threaded from the session onto `ContinueWithQuoteContext` and honored when present. The quote-fetch and continuation redirect URLs resolve from this same rule so they cannot diverge.
 
-Observability is only partial; document the three cases explicitly:
+Observability is only partial:
 
-- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously, but is NOT headless-aware today and iOS external success is NOT "already handled". Must be resolved into the headless callbacks above.
-- **`Linking.openURL` (Android / no InAppBrowser)**: we can only catch the OPEN failure (promise rejection, which fires `failSession`). We cannot observe provider page load.
-- **Android / system browser**: provider-side load failure is unknowable. Success arrives via deeplink return. Abandonment is inferred by the existing dismissal machinery (below), not guaranteed.
+- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously; must be resolved into the headless callbacks above.
+- **`Linking.openURL` (Android / no InAppBrowser)**: only the OPEN failure is catchable (promise rejection fires `failSession`); provider page load is unobservable.
+- **Android / system browser**: provider-side load failure is unknowable; success arrives via deeplink; abandonment is inferred via the existing dismissal machinery.
 
 Tests: each branch routes to the correct terminal callback; iOS `openAuth` success fires `onOrderCreated`; cancel fires `onClose({ reason: 'user_dismissed' })`; open-rejection fires `failSession`.
 
 ### P2.M2 - Give `handleRampReturnUrl.ts` a headless path
 
-Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the `getProviderDeeplinkRedirectUrl` helper around lines 27 to 28), so the deeplink DOES carry the provider code in its path. It does NOT carry the wallet address, chainId, or session id.
+Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`buildQuoteWithRedirectUrl.ts`, `getProviderDeeplinkRedirectUrl` ~lines 27-28), so the deeplink carries the provider code in its path but not the wallet address, chainId, or session id.
 
-Concrete design:
+1. At external-browser launch (P2.M1), record a pending correlation in the session registry: `{ sessionId, walletAddress, chainId }`. The session registry holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
+2. On deeplink return, `handleRampReturnUrl` checks for an active headless session. If one exists and is `continued`, take the headless path: resolve the order via the shared callback resolver using the `providerCode` from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the query), then fire `onOrderCreated` and end the session. No active session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
+3. Build on the cached / internal order-id resolution (mobile #32372 `app/components/UI/Ramp/hooks/useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
 
-1. At external-browser launch (P2.M1), record a pending external-order correlation in the session registry: `{ sessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
-2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: resolve the order via the shared callback resolver using the `providerCode` parsed from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fire `onOrderCreated` and end the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
-3. Build on the just-landed cached / internal order-id resolution (mobile #32372 `app/components/UI/Ramp/hooks/useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
-
-Core-vs-mobile split: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the focus-dismissal pre-emption stay mobile-side.
+Core-vs-mobile split: core may own only the pure parsing/status helpers. The correlation record, deeplink routing, and focus-dismissal pre-emption stay mobile-side.
 
 Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; a deeplink return with a live `continued` session fires `onOrderCreated`; a no-order deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
 
 ### P2.M3 - E1/E2/E3 reconciliation (money-losing if skipped)
 
-Three hazards must be reconciled, all reusing the EXISTING dismissal machinery `HeadlessHost` already wires (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx`, lines 86 to 99: `useHeadlessSessionDismissal`, `useHeadlessSessionFocusDismissal`, and the `beforeRemove` listener), NOT a parallel new grace timer, so there are not two competing dismissal paths.
+All three reuse the EXISTING dismissal machinery `HeadlessHost` wires (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx:86-99`: `useHeadlessSessionDismissal`, `useHeadlessSessionFocusDismissal`, the `beforeRemove` listener), not a parallel grace timer.
 
-- **E1 - iOS `openAuth` success resolves into the headless callback.** The iOS success path must terminate via `onOrderCreated` (covered by P2.M1), never silently land on `RAMPS_ORDER_DETAILS`.
-- **E2 - A SUCCESS deeplink must WIN even if the session was already dismissed or GC'd.** Because MM Pay's two-step intent transaction is gated on `onOrderCreated` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 112 to 122), a real fiat order can complete (the user paid) while the intent leg never fires if the focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `app/components/UI/Ramp/headless/sessionRegistry.ts`, line 110) terminated the session first. Reconciliation rule: a success deeplink must still complete the order through the consumer's `onOrderCreated` (re-opening or directly completing the dismissed session) rather than being silently dropped to `RAMPS_ORDER_DETAILS`. Only a deeplink with no order / no recoverable success and no live session falls back to `RAMPS_ORDER_DETAILS` so the order is still recoverable manually.
-- **E3 - Pre-empt the existing zero-delay focus-dismissal timer, do not add a parallel grace timer.** On re-focus, `useHeadlessSessionFocusDismissal` schedules dismissal via `setTimeout(..., 0)` (`app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts`, line 51) and bails if the session is already gone or the focus / session id changed. The only addition is to ensure a real deeplink callback can PRE-EMPT this existing path: a deeplink-success must terminate the session before, or take precedence over, focus-dismissal. It does NOT emit `onError`, and the consumer's `cancel()` and the registry's stale-session GC remain as backstops. The remaining product / MM Pay decision is whether the existing zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
+- **E1 - iOS `openAuth` success resolves into `onOrderCreated`** (covered by P2.M1), never silently lands on `RAMPS_ORDER_DETAILS`.
+- **E2 - A success deeplink must win even if the session was already dismissed or GC'd.** MM Pay's two-step intent transaction is gated on `onOrderCreated` (`useFiatConfirm.ts:112-122`), so a real fiat order can complete (the user paid) while the intent leg never fires if focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `sessionRegistry.ts:110`) terminated the session first. Rule: a success deeplink completes the order through `onOrderCreated` (re-opening or directly completing the dismissed session). Only a deeplink with no recoverable success and no live session falls back to `RAMPS_ORDER_DETAILS`.
+- **E3 - Pre-empt the existing zero-delay focus-dismissal timer.** On re-focus, `useHeadlessSessionFocusDismissal` schedules dismissal via `setTimeout(..., 0)` (`useHeadlessSessionFocusDismissal.ts:51`) and bails if the session is gone or the focus / session id changed. Ensure a real deeplink-success terminates the session before, or takes precedence over, focus-dismissal; it does not emit `onError`, and `cancel()` plus stale-session GC remain backstops. Open product decision: whether the zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
 
-Tests: iOS `openAuth` success completes via `onOrderCreated` (E1); a success deeplink arriving AFTER the session was dismissed still completes via `onOrderCreated` and is not dropped to `RAMPS_ORDER_DETAILS` (E2); a deeplink-success pre-empts the existing focus-dismissal so a slow-but-successful return is not closed as `user_dismissed` (E3).
+Tests: E1 iOS `openAuth` success completes via `onOrderCreated`; E2 a success deeplink after dismissal still completes via `onOrderCreated`; E3 a deeplink-success pre-empts focus-dismissal so a slow-but-successful return is not closed as `user_dismissed`.
 
 ### P2.M4 - Custom-action (PayPal) support
 
-Bring `isCustomAction` quotes into scope with their external CTA path: remove them from the Phase 1 filter exclusion and route their continuation through the now-headless-aware external/custom path (custom-action flows always use the system / in-app browser, per Patrick Kowalski, #money-movement-core 2026-04-17). Typed errors and analytics for these flows are covered by P2.M7.
+Bring `isCustomAction` quotes into scope: remove them from the Phase 1 filter exclusion and route their continuation through the now-headless-aware external/custom path (custom-action flows always use the system / in-app browser). Typed errors and analytics are covered by P2.M7.
 
 Tests: a custom-action quote is selectable, continues through the external CTA path, and terminates via `onOrderCreated` / `onClose` / `failSession`.
 
 ### P2.M5 - Widen via the flag's `all` value
 
-When the flag reads `all`, relax the in-app filter so external / custom quotes flow. Because it is a flag VALUE flip (not a deploy-time filter removal), it can be staged and rolled back independently of the Phase 2 deploy. Lands after P2.M1-P2.M4 are proven.
+When the flag reads `all`, relax the in-app filter so external / custom quotes flow. Because it is a flag value flip (not a deploy-time filter removal), it can be staged and rolled back independently of the Phase 2 deploy. Lands after P2.M1-P2.M4 are proven.
 
-Tests: with the flag set to `all`, external and custom quotes reach the consumer and complete via headless callbacks; with it `in-app`, only in-app quotes flow; with it `off`, native-only.
+Tests: with the flag `all`, external and custom quotes complete via headless callbacks; with `in-app`, only in-app quotes flow; with `off`, native-only.
 
 ### P2.M6 - Add back the preferred-provider recommendation rung
 
-Add back the previously-used-provider (order-history) recommendation rung deferred from Phase 1, if a returning-user requirement exists. The order-history rung is `#private` in `RampsController` and runs only in the single-provider auto-select branch, so it must be re-derived and supplied as an explicit input to the shared selection, then layered ahead of reliability-then-price.
+Add back the order-history rung deferred from Phase 1, if a returning-user requirement exists. The rung is `#private` in `RampsController` and runs only in the single-provider auto-select branch, so it must be re-derived and supplied as an explicit input to the shared selection, layered ahead of reliability-then-price.
 
 Tests: ladder order with and without preferred provider ids; deterministic output for UB2 and MM Pay callers.
 
 ### P2.M7 - Typed errors + analytics parity for external-browser
 
-- Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures). Depends on the P1.M0 terminal-callback contract.
-- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit, not a typed error: `Checkout.tsx` (lines 386 to 393) already treats it as `closeSession({ reason: 'user_dismissed' })`.
-- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), all tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
-- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). So a consumer that must branch on `TRANSAK_ERROR_CODES` / `TransakErrorCode` first needs a core sub-task to export them from the package; otherwise depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until that export lands. Re-verify against `origin/main` / the published package before relying on it.
-- Scope the taxonomy. The broader typed-code taxonomy (e.g. `KYC_REQUIRED` and other granular provider codes) is implement-on-demand: add a code when a consumer actually needs to branch on it, not up front.
+- Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open). Depends on the P1.M0 terminal-callback contract.
+- Route user exits to `onClose` per the callback-routing rule. Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit: `Checkout.tsx:386-393` already treats it as `closeSession({ reason: 'user_dismissed' })`.
+- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
+- **Export reality check.** On core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but NOT `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). A consumer that must branch on those first needs a core sub-task to export them; otherwise depend only on the already-exported helpers plus `RAMPS_ERROR_CODES`. Re-verify against `origin/main` before relying on it.
+- **Scope the taxonomy.** Granular provider codes (e.g. `KYC_REQUIRED`) are implement-on-demand: add a code when a consumer actually needs to branch on it.
 
 ---
 
 ## Deferred (after Phase 2)
 
-These are intentionally deferred. They are not required to ship all-provider support behind the scoped flag, and several refactor working code with regression risk.
+Not required to ship all-provider support behind the scoped flag; several refactor working code with regression risk.
 
 ### Wire TPC to consume multi-provider quotes
 
-Wire core (`TransactionPayController`) to consume multi-provider quotes via the shared `RampsController` selection instead of `success[0]`, and keep the MM Pay terminal-callback contract. This depends ONLY on the P1.M0 terminal-callback contract; there is no upstream wait, because the `transaction-pay-controller` fiat second-leg hardening PRs are merged and published (see Upstream context).
+Wire `TransactionPayController` to consume multi-provider quotes via the shared `RampsController` selection instead of `success[0]`, keeping the MM Pay terminal-callback contract. Depends only on the P1.M0 contract; the `transaction-pay-controller` fiat second-leg hardening PRs are merged and published.
 
 ### DRY cleanup (UB2 UI becomes "dumb")
 
-Deferred until AFTER Phase 2 activation is stable. This refactors working UB2 code (regression risk) with no production benefit before all-providers ships.
+Deferred until after Phase 2 activation is stable; refactors working UB2 code (regression risk) with no production benefit before all-providers ships.
 
-- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (already shared via `getSmartSelectedQuote`); pure callback parsing and status classification; bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
-- **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes. The only exception: if the controller API is extended to accept redirect / browser options as inputs, the browser-mode decision can move down; otherwise it stays mobile-side.
-- Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers. ("UB2 becomes dumb.")
+- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (already shared via `getSmartSelectedQuote`); pure callback parsing and status classification; bailed-status checks; min/max validation as a pure `validateBuyAmount()`.
+- **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes (unless the controller API is extended to accept redirect / browser options, in which case the browser-mode decision can move down).
+- Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers.
 
-Tests: UB2 regression proves ordering, recommended selection, WebView retry, and OrderDetails routing are unchanged after the extraction.
+Tests: UB2 regression proves ordering, recommended selection, WebView retry, and OrderDetails routing are unchanged after extraction.
 
 ### Broad typed-error taxonomy on demand
 
-Beyond the external-browser typed errors in P2.M7, the broader provider-code taxonomy stays implement-on-demand: add a code when a consumer actually needs to branch on it. The native-flow OTP typed-code fix (de-scoped from P1.M0) rides along here.
+Beyond P2.M7, the broader provider-code taxonomy stays implement-on-demand. The native-flow OTP typed-code fix (de-scoped from P1.M0) rides along here.
 
 ---
 
 ## Test plan (consolidated)
 
-- ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared `getSmartSelectedQuote` selection (in-app filter + reliability-then-price) consumed by both `getRampsQuote` and the mobile headless path.
+- ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared `getSmartSelectedQuote` selection consumed by both `getRampsQuote` and the mobile headless path.
 - Transaction Pay: the widened selector picking the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds.
-- Phase 1 mobile: `useHeadlessBuy` in-app filter and selection, in-app `Checkout` WebView fail-safe (`failHeadlessCheckout` -> `failSession`), per-provider WebView smoke check, analytics tagging confirmation, limits decision.
+- Phase 1 mobile: `useHeadlessBuy` in-app filter and selection, in-app `Checkout` WebView fail-safe (`failHeadlessCheckout` -> `failSession`), per-provider WebView smoke check, analytics tagging, limits decision.
 - Phase 2 mobile: `useContinueWithQuote` external-browser branch, `HeadlessHost`, external-browser deeplink return, E1/E2/E3 reconciliation, custom-action continuation.
 - UB2 regression: quote ordering, recommended quote selection, WebView retry behavior, and order-details routing unchanged.
 - Analytics: `RAMPS_CHECKOUT_CLOSED`, `RAMPS_ORDER_FAILED`, provider cancellation, checkout HTTP / load failures, and order terminal failed / cancelled events.
-
----
-
-## Upstream context
-
-Time-sensitive references that informed sequencing; verify before relying on them.
-
-- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic for the request itself.
-- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES` / `RampsErrorCode`), confirmed on `origin/main`. Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are NOT re-exported from `index.ts` on `main`; the typed-error export sub-task (P2.M7) must add that export before depending on it from mobile.
-- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform P2.M2.
-- The MM Pay fiat second-leg hardening PRs (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay, plus #9159 and #9135) are MERGED and published (core ~release 1082.0.0). There is no upstream wait: the MM Pay integration (Deferred TPC wiring) now depends only on the P1.M0 terminal-callback contract, not on an in-flight upstream sequence.
-- A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
 
 ---
 
@@ -354,17 +283,17 @@ Time-sensitive references that informed sequencing; verify before relying on the
 
 Assumptions:
 
-- Ship behind a multi-value scoped flag (`off | in-app | all`) whose `off` state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (P1.M2). Phase 1 ships `in-app`; Phase 2 flips to `all`. No new product flag beyond this kill switch unless product asks.
+- Ship behind a multi-value scoped flag (`off | in-app | all`) whose `off` state keeps native-only working. A distinct scoped flag is required (P1.M2); no new product flag beyond this kill switch unless product asks.
 - Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
 - System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the existing focus-dismissal machinery for inferred cancellation (Phase 2).
-- Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.
+- Provider quote failures are surfaced as partial errors, terminal only when every provider fails or no quote can be selected.
 
 Risks:
 
-- `buyWidget.browser` is optional, so an aggregator quote missing it would be classed in-app; Phase 1 safety relies on the THREE layers together (MM Pay allowed `providerIds`, the in-app filter, the WebView fail-safe), not on the field alone (B1).
+- `buyWidget.browser` is optional, so an aggregator quote missing it would be classed in-app; Phase 1 safety relies on the three layers together (B1).
 - Cross-repo sequencing (core publish before mobile bump) for the shared `RampsController` selection.
 - Android foreground-without-callback heuristic reliability (built on the existing focus-dismissal) and whether it needs a deliberate grace delay (Phase 2).
-- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (P2.M3, E2) is implemented.
+- Slow-but-successful deeplink returning after the session was dismissed: the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins rule (P2.M3, E2) is implemented.
 
 ---
 

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -1,42 +1,55 @@
 # Headless Buy: All Providers Support Plan
 
-> Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support: multi-provider quoting, headless-aware non-native checkout (in-app WebView and external-browser providers), typed error outcomes, analytics parity, and DRY shared logic between Unified Buy v2 (UB2) and Headless Buy. The native-only gate stays closed in production the entire time we build; widening to all providers happens last, behind a flag.
+> Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support in two checkpointable phases. Phase 1 ships a quick-win MVP for in-app WebView providers only, filtered at the quote layer, behind one scoped flag. Phase 2 adds external-browser and custom-action providers (headless-aware checkout, deeplink reconciliation, custom actions), then widens the same flag. Each phase is shippable on its own: Phase 1 needs none of the Phase 2 checkout work because external/custom quotes are filtered out.
 
 This is a companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan) and follows its style.
 
-## Milestones checklist
+## Phases checklist
 
-Milestones 0 to 2 are capability work, built behind the still-closed native-only gate and exercised only via the dev playground plus unit/integration tests. Milestone 3 is the only production-widening milestone, flag-gated, landing last. Milestone 4+ is deferred follow-up.
+The work is split into two phases plus a deferred tail. Phase 1 is shippable on its own: it widens quoting to in-app WebView providers, filters out everything that needs external-browser or custom-action handling, and activates behind a multi-value scoped flag set to `in-app`. Phase 2 makes the external/custom checkout paths headless-aware and then widens the SAME flag to `all`. The native-only flow is never broken in either phase: the flag's `off` state falls back to native-only.
 
-- [ ] **Milestone 0** - Must-fix preconditions (no production behavior change)
-- [ ] **Milestone 1** - All-provider quoting capability (built but gated OFF)
-- [ ] **Milestone 2** - Headless checkout for non-native providers (makes widening safe)
-- [ ] **Milestone 3** - Activation behind a required scoped flag
-- [ ] **Milestone 4+** - Deferred (broad typed errors, analytics parity, TPC multi-provider wiring, DRY cleanup)
+**Phase 1 - Quick-win MVP (in-app WebView providers only):**
 
-Milestone 0 is a precondition for everything else: the terminal-callback contract fix (see Must-fix preconditions) and the OTP typed-code fix must land before typed errors expand or before any consumer relies on terminal outcomes.
+- [ ] **P1.M0** - `failSession`-terminal must-fix (OTP typed-code de-scoped as native-only / optional)
+- [ ] **P1.M1** - In-app-only quoting capability (in-app filter, reliability-then-price selection in `RampsController`, re-specified WebView fail-safe, per-provider WebView smoke check, analytics tagging, limits decision)
+- [ ] **P1.M2** - Activation behind a multi-value scoped flag (`off | in-app | all`), with MM Pay passing allowed `providerIds`
+
+**Phase 2 - External-browser + custom-action providers (Coinbase, PayPal, etc.):**
+
+- [ ] **P2.M1** - Headless-aware `continueWidget` external-browser branch
+- [ ] **P2.M2** - Headless deeplink path in `handleRampReturnUrl` + correlation record `{sessionId, walletAddress, chainId}`
+- [ ] **P2.M3** - E1/E2/E3 reconciliation
+- [ ] **P2.M4** - Custom-action (PayPal) support
+- [ ] **P2.M5** - Widen the flag to `all`
+- [ ] **P2.M6** - Add back the preferred-provider (order-history) recommendation rung
+- [ ] **P2.M7** - Typed errors + analytics parity for external-browser
+
+**Deferred (after Phase 2):**
+
+- [ ] TPC multi-provider wiring; DRY cleanup ("UB2 becomes dumb"); broad typed-error taxonomy on demand
+
+P1.M0 is a precondition for everything else: the terminal-callback contract fix (see Must-fix preconditions) must land before typed errors expand or before any consumer relies on terminal outcomes. The OTP typed-code fix is native-flow-only and is de-scoped (optional) for the in-app MVP.
 
 ---
 
 ## Scope (confirmed: full cross-repo)
 
-Enabling all providers spans three layers, and this plan documents all three as coordinated milestones:
+Enabling all providers spans three layers. Phase 1 touches only the subset needed for in-app WebView providers; Phase 2 finishes the rest.
 
 - **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` (line ~113) + `restrictToKnownOrNativeProviders: true` (line ~116) and takes only `quotes.success?.[0]` (line ~124) (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, the `getRampsQuote` function around lines 95 to 131 on `origin/main`). This is the native-only gate's quote-side enforcement.
-- **`@metamask/ramps-controller`** - eventual home for the PURE quote filter/sort/recommend helper and pure callback parsing/status helpers, but only once 2+ consumers justify extraction. The selection / recommendation util starts mobile-side (see Milestone 1.2), since the order-history rung cannot be reused from core and there is one real consumer today.
-- **`metamask-mobile`** - relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26); make `useContinueWithQuote`'s external-browser branch headless-aware; typed errors; analytics; DRY; and own all navigation/session and redirect/deeplink policy.
+- **`@metamask/ramps-controller`** - home for the shared smart selection (the deferred `getSmartSelectedQuote`). Phase 1 puts the in-app filter plus reliability-then-price selection here so that BOTH `transaction-pay-controller` `getRampsQuote` and the mobile headless path call one implementation instead of forking selection between core and a separate mobile `recommendQuotes` util (drift hazard). Pure callback parsing / status helpers extract here only once 2+ consumers justify it.
+- **`metamask-mobile`** - relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26); consume the shared selection; own the in-app `Checkout` WebView fail-safe (Phase 1); make `useContinueWithQuote`'s external-browser branch headless-aware, plus typed errors, analytics, and all navigation/session and redirect/deeplink policy (Phase 2).
 
 ---
 
 ## Sequencing and safety: capability vs activation
 
-**Risk:** removing the native-only gate early would route live MM Pay / HeadlessBuy users to aggregator / external-browser quotes before the logic to handle them (Milestone 2, and the typed-error / analytics follow-ups) exists, landing them in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
+**Risk:** widening live MM Pay / HeadlessBuy quoting to providers whose checkout path is not headless-aware would land users in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
 
-**Rule:** the native-only gate stays CLOSED for production the entire time we build capability. We never widen what real users get until the supporting logic is in and verified.
+**Rule:** widening is staged by provider class, not deferred wholesale. In-app vs external is knowable at the quote layer (see the B1 finding and the "In-app WebView vs external-browser providers" concern), so Phase 1 can safely ship in-app WebView providers in production behind a flag while the external/custom checkout work is still pending.
 
-- **Capability milestones (0 to 2)** add all-provider quoting, selection, external-browser headless support, and the headless deeplink path, but are exercised only via the dev playground and unit/integration tests. The live MM Pay path keeps `restrictToKnownOrNativeProviders: true`, and `useHasNativeFiatProvider` keeps gating.
-- **Activation milestone (3, flag-gated)** is the only milestone that widens production. It flips `getRampsQuote` and relaxes the mobile gate, behind a distinct scoped flag, and lands last, after Milestone 2 is proven.
-- Within the capability milestones, land external-browser headless support and the headless deeplink path (Milestone 2) before any wiring that could surface non-native quotes to a consumer.
+- **Phase 1 ships in-app behind the flag.** The in-app filter (`!isCustomAction(quote)` and `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`) is the safety boundary: external-browser and custom-action quotes are filtered out before continuation, so the broken external branch is never reached. Three layers make this safe together (B1): MM Pay passes allowed `providerIds`, the in-app filter, and a mandatory in-app `Checkout` WebView fail-safe.
+- **Phase 2 makes external/custom safe, then widens the SAME flag.** Only after `continueWidget`'s external-browser branch and the headless deeplink path emit terminal callbacks does the flag move from `in-app` to `all`. Because it is a flag VALUE flip (not a deploy-time filter removal), it is staged and roll-back-able independently of the Phase 2 deploy.
 
 ---
 
@@ -63,13 +76,13 @@ Implementation: `failSession` stops calling `closeSession`; it sets the terminal
 
 Caveat to confirm with MM Pay before building broad typed errors: if MM Pay relies on a single cleanup hook regardless of outcome, we instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract above unless MM Pay asks for the cleanup variant.
 
-This is a precondition for the typed-error work (Milestone 4), not an afterthought, and is implemented as Milestone 0.1.
+This is a precondition for the typed-error work, not an afterthought, and is implemented as P1.M0. The companion OTP typed-code fix is native-flow-only and is de-scoped (optional) for the in-app MVP.
 
 ---
 
 ## UB2 behavior to preserve
 
-- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`. (In practice custom actions ride inside `success[]` flagged by `isCustomAction`; the separate `customActions[]` array is empty in UB2 usage, and custom actions are out of scope here, see the "Getting multiple quotes" concern.)
+- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`. (In practice custom actions ride inside `success[]` flagged by `isCustomAction`; the separate `customActions[]` array is empty in UB2 usage, and custom actions are out of scope in Phase 1, see the "Getting multiple quotes" concern.)
 - Provider-level quote errors are non-terminal: they are surfaced as partial errors and only become terminal when every provider fails or no usable quote can be selected.
 - Existing UB2 quote ordering, recommended-quote selection, WebView retry behavior, and OrderDetails routing must remain unchanged (regression-tested).
 
@@ -77,18 +90,18 @@ This is a precondition for the typed-error work (Milestone 4), not an afterthoug
 
 ## Concerns addressed
 
-A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the milestones below.
+A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the phases below.
 
 ### Getting multiple quotes; partial vs full failure
 
 UB2 does not fan out to providers with `Promise.all`. One `RampsController.getQuotes()` call returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal: its message lands in `error[]` while other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
 
-Custom actions are NOT a separate candidate array in practice. UB2 carries custom actions INSIDE `success[]`, flagged by `quote.isCustomAction` (`isCustomAction()` reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). The separate `customActions[]` array is empty in UB2 usage and tests. UB2 already EXCLUDES `isCustomAction` entries from provider / payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx`, lines 262 to 274). For this effort custom-action entries are OUT of scope: headless candidate selection must filter them out of `success[]` the same way, so that removing `restrictToKnownOrNativeProviders` cannot surface an unhandled custom-action path.
+Custom actions are NOT a separate candidate array in practice. UB2 carries custom actions INSIDE `success[]`, flagged by `quote.isCustomAction` (`isCustomAction()` reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). The separate `customActions[]` array is empty in UB2 usage and tests. UB2 already EXCLUDES `isCustomAction` entries from provider / payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx`, lines 262 to 274). In Phase 1 custom-action entries are OUT of scope: headless candidate selection must filter them out of `success[]` the same way, so that removing `restrictToKnownOrNativeProviders` cannot surface an unhandled custom-action path. Phase 2 brings custom actions into scope.
 
 - Partial failure: at least one usable non-customAction `success[]` entry exists. Keep it.
 - Full failure: no usable non-customAction `success[]` entry. This is NOT `success.length === 0 && customActions.length === 0`. Map to `NO_QUOTES`.
 
-Decision: there is no union candidate model. Selection, "no quotes", and continuation operate over `success[]` with `isCustomAction` entries filtered out.
+Decision: there is no union candidate model. Selection, "no quotes", and continuation operate over `success[]` with `isCustomAction` entries filtered out (in Phase 1).
 
 ### Sorting / ordering quotes like UB2
 
@@ -97,7 +110,7 @@ There are two existing UB2 behaviors:
 - **Modal ordering** in `app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx` (lines 205 to 228): reliability-only sort of providers-with-quotes.
 - **Recommendation ladder** in legacy `app/components/UI/Ramp/Aggregator/hooks/useSortedQuotes.ts` (lines 43 to 69): previously-used provider, then reliability, then price.
 
-Headless / MM Pay need the recommendation ladder (to replace core's current `success[0]` pick), not just modal ordering. Provider preference-from-order-history DOES exist in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`), but those are `#private` and run only in the single-provider auto-select branch; the all-provider path never invokes them (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`: the `else if (autoSelectProvider || restrictToKnownOrNativeProviders)` branch, lines 1003 to 1024, versus the all-provider `else` branch that quotes `state.providers.data`, line 1026). So that order-history rung CANNOT be reused by a pure / mobile helper: the previously-used-provider rung must be re-derived mobile-side. The new build is that re-derived preference rung plus the reliability-then-price recommendation among the returned `success[]`.
+Phase 1 needs only reliability-then-price to pick one quote for the MM Pay MVP, so the previously-used-provider (order-history) rung is CUT from Phase 1. The order-history rung DOES exist in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`) but is `#private` and runs only in the single-provider auto-select branch; the all-provider path never invokes it (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`: the `else if (autoSelectProvider || restrictToKnownOrNativeProviders)` branch, lines 1003 to 1024, versus the all-provider `else` branch that quotes `state.providers.data`, line 1026). Phase 2 adds the preferred-provider rung back when there is a real returning-user requirement (P2.M6).
 
 ### Routing for native vs non-native
 
@@ -109,19 +122,21 @@ Native KYC is fully in-app (NativeFlow screens plus Transak APIs: email, OTP, Ba
 
 ### In-app WebView providers vs external-browser providers
 
-The decision lives in `getWidgetRedirectConfig` / `getAggregatorRedirectConfig` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the redirect-config helpers around lines 35 to 71): custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. This is the reason the gate removal must be LAST: external-vs-in-app is decided per-quote AFTER `getBuyWidgetData`, so you cannot limit quote-widening to only in-app-WebView providers at the quote layer (see "Conflicts resolved"). In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`).
+The decision is made at the QUOTE LAYER, before `getBuyWidgetData`. `getWidgetRedirectConfig` / `getAggregatorRedirectConfig` read `quote.quote?.buyWidget?.browser === 'IN_APP_OS_BROWSER'` and `isCustomAction` directly off the quote (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the redirect-config helpers around lines 35 to 71), and `getAggregatorRedirectConfig` is called at `useContinueWithQuote.ts:249` BEFORE `getBuyWidgetData` at `:257`. So whether a quote is in-app or external is knowable at selection time, not only after `getBuyWidgetData`. Custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. This is why Phase 1 can pre-filter to in-app providers at the quote layer: keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`. In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`), both handled in Phase 2.
+
+Caveat (B1): this is the right MECHANISM, but `buyWidget.browser` is optional, mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote MISSING `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from THREE layers together, not from the field alone (see the B1 finding).
 
 ### Load failure handling and notifying MM Pay
 
-In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). The external-browser path has no load-failure handling and no headless notification today. Decision: route external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit), so MM Pay always receives a terminal callback. See the observability policy in Milestone 2.
+In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). This is the Phase 1 fail-safe for newly-enabled in-app providers. The external-browser path has no load-failure handling and no headless notification today; Phase 2 routes external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit) so MM Pay always receives a terminal callback.
 
 ### Analytics abandon vs failed
 
-Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. External-browser abandon is currently untracked (Milestone 5).
+Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. Phase 1 confirms the existing in-app `Checkout` instrumentation already tags the new in-app providers; external-browser abandon is currently untracked and is brought to parity in Phase 2 (P2.M7).
 
 ### Gaps in the external-browser branch of `useContinueWithQuote`
 
-The branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) ignores `ctx.headlessSessionId`: cancel, Android `Linking.openURL`, and iOS success all call `navigateAfterExternalBrowser({ returnDestination: 'buildQuote' | 'order' })` (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75), landing on BuildQuote / OrderDetails with no `onOrderCreated` / `onError` / `onClose`. `addPrecreatedOrder` is conditional, and OrderDetails has no headless path.
+The branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) ignores `ctx.headlessSessionId`: cancel, Android `Linking.openURL`, and iOS success all call `navigateAfterExternalBrowser({ returnDestination: 'buildQuote' | 'order' })` (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75), landing on BuildQuote / OrderDetails with no `onOrderCreated` / `onError` / `onClose`. `addPrecreatedOrder` is conditional, and OrderDetails has no headless path. This is Phase 2 work; Phase 1 never reaches this branch because external quotes are filtered out.
 
 ### Specific non-native errors UB2 handles that Headless does not
 
@@ -129,7 +144,7 @@ Missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `ge
 
 ### DRY: logic to move out of UB2 UI
 
-Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Milestone 7 for the precise core-vs-mobile split.
+Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Deferred for the precise core-vs-mobile split.
 
 ---
 
@@ -151,84 +166,74 @@ flowchart LR
   Terminal --> Consumer
 ```
 
+In Phase 1 only the `native` and `in-app widget` branches are reachable for production traffic; the `external` branch is filtered out at the quote layer and made headless-aware in Phase 2.
+
 ---
 
 ## Conflicts resolved
 
-Three reconciliations that shaped this milestone ordering; capturing them so we do not re-litigate during implementation:
+Reconciliations that shaped the phasing; capturing them so we do not re-litigate during implementation:
 
-- **Gate removal is LAST.** You cannot limit quote-widening to only in-app-WebView providers at the quote layer, because external-vs-in-app is decided PER-QUOTE by `buyWidget.browser === 'IN_APP_OS_BROWSER'` only AFTER `getBuyWidgetData` runs at continuation (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig` in `app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`). So the quote layer cannot pre-filter to "safe" providers; the only safe ordering is to make external-browser checkout headless-aware first (Milestone 2), then widen quoting in production (Milestone 3).
-- **The recommendation ladder is mobile-side.** The order-history preference rung is `#private` in `RampsController` and only runs in the single-provider auto-select branch, so it cannot be reused from core. The selection util is built mobile-side first (Milestone 1.2); extraction to `@metamask/ramps-controller` waits for a second consumer (Milestone 6).
-- **A distinct scoped flag is required.** The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat), so activation needs a new scoped flag whose "off" state falls back to native-only, not "no fiat" (Milestone 3.1).
+- **In-app widening can ship in Phase 1; only external/custom widening waits for Phase 2.** Earlier framing claimed gate removal "must be LAST" because external-vs-in-app was thought to be decided only AFTER `getBuyWidgetData`. That is corrected: `getAggregatorRedirectConfig` reads `quote.quote?.buyWidget?.browser` and `isCustomAction` off the quote BEFORE `getBuyWidgetData` (`buildQuoteWithRedirectUrl.ts:39-65`, `useContinueWithQuote.ts:249` vs `:257`). So the quote layer CAN pre-filter to in-app-WebView providers, and Phase 1 widens in-app in production behind a flag. Phase 2 makes external/custom checkout headless-aware first, then widens the same flag to `all`.
+- **Shared smart selection lives in `RampsController`.** MM Pay's single-quote pick is core-side (`transaction-pay-controller` `getRampsQuote` returns `success?.[0]`). Rather than embedding the in-app filter + reliability-then-price logic into `transaction-pay-controller` and forking a separate mobile `recommendQuotes` util (drift hazard), the shared selection goes in `RampsController` (the team's deferred `getSmartSelectedQuote`, per Goktug / Matthew Walsh, #confirmations-ramps-collab 2026-05-27) so BOTH `getRampsQuote` and the mobile headless path call one implementation.
+- **A distinct multi-value scoped flag is required.** The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat), so activation needs a new scoped flag whose "off" state falls back to native-only, not "no fiat" (P1.M2). It is multi-value (`off | in-app | all`) so the Phase 2 widening is a controlled flag flip, not a deploy-time jump.
 
 ---
 
-## Milestone 0 - Must-fix preconditions (no production behavior change)
+## Verified findings (B1-B3)
 
-Goal: fix the two correctness bugs that any downstream typed-error / terminal-callback work depends on. Neither changes production behavior for today's native-only flow.
+These three findings were verified against code history plus Slack, and they unlock the phase split. They replace the earlier "open blockers" framing.
 
-### M0.1 - Make `failSession` terminal
+- **B1 - Mechanism sound; residual risk handled by the gate, NOT by assuming the field is always present** (downgraded from "resolved" after verification). The quote-layer read is real: `getAggregatorRedirectConfig` reads `quote.quote.buyWidget?.browser` and `isCustomAction` before `getBuyWidgetData` (`buildQuoteWithRedirectUrl.ts:39-65`, `useContinueWithQuote.ts:249` vs `:257`). Core commit `6e0a31c9a` documents the V2 API embedding `buyWidget` on quotes. BUT this is not a safe "always embedded" invariant: `buyWidget.browser` is optional (`RampsService.d.mts:193-206`), mobile still fetches the URL via the deprecated `buyURL` + `getBuyWidgetData` path (`buildQuoteWithRedirectUrl.ts:13-14`, `useContinueWithQuote.ts:257,271`), and custom actions arrive in a separate `customActions[]` array with no `buyWidget` (caught by the `isCustomAction` prong). So an aggregator quote missing `buyWidget.browser` would be classed in-app. This is made safe by the gating decision below (MM Pay passes allowed provider IDs) PLUS the in-app filter PLUS the mandatory WebView fail-safe - not by the field alone.
+- **B2 - Provider-agnostic headless, gate at the distribution layer** (confirmed: Lorenzo DM 2026-05-26 "gate providers at the distribution layer (i.e., MM Pay)... deprecate [the provider field] later to avoid sister teams overfitting"). DECISION (Shane): use BOTH gates - MM Pay PASSES allowed provider IDs (the team's documented mechanism: `providerIds` via feature flag, so only known in-app providers are quoted) AND core applies the in-app filter as defense-in-depth. This supersedes the earlier "dynamic filter, no allowlist" framing. Categorization: PayPal + Robinhood = "checkout outside of MetaMask" -> Phase 2; MoonPay / Revolut = top in-app providers in Phase 1 scope.
+- **B3 - (a) and (b) confirmed in code; framing corrected.** (a) An empty catalog in the no-restriction path does NOT throw: `RampsController.getQuotes` omits the provider filter and quotes every provider server-side (`RampsController.mjs:1039-1046`; only the `restrictToKnownOrNativeProviders` path returns empty). (b) MM Pay's single-quote pick is core-side: `transaction-pay-controller` `getRampsQuote` returns `quotes.success?.[0]` (`strategy/fiat/utils.ts:124`). Correction: do NOT cite the Apr 28 thread as support - it DEFERRED "fetch all providers and pick best" as too complex. Ownership: align with the team's stated intent (Goktug / Matthew Walsh, #confirmations-ramps-collab 2026-05-27) to put smart selection in `RampsController` (the deferred `getSmartSelectedQuote`) consumed by BOTH `transaction-pay-controller` and the mobile headless path, rather than embedding ramp business logic in `transaction-pay-controller` and forking a separate mobile `recommendQuotes` (drift hazard). Direction unblock: the Jun 7 #money-movement-sca-collab decision ("native-only for v0, disable aggregators on all flows until after Money Account launch") was time-boxed to the launch and is now SUPERSEDED (Money Account has launched), so enabling in-app aggregators is in scope.
+
+---
+
+## Phase 1 - Quick-win MVP: in-app WebView providers only
+
+Ships to production behind one scoped flag set to `in-app`; external-browser and custom-action providers are filtered out, so none of the Phase 2 checkout work is required to ship.
+
+### P1.M0 - Must-fix: `failSession` terminal
 
 `onError` fires, the session is removed, and there is NO trailing `onClose`. See the Must-fix preconditions section for the full contract. `failSession` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 264) currently calls `closeSession({ reason: 'unknown' }, { terminalStatus: 'failed' })` after `onError`, and the MM Pay consumer (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 123 to 132) clears the error in its `onClose` handler. Fix: `failSession` sets the terminal status and removes the session directly, without invoking `onClose`.
 
+The OTP typed-code fix (stop force-mapping `nativeFlowError` to `AUTH_FAILED` in `HeadlessHost.tsx`, lines 136 to 147) is native-flow-only and therefore de-scoped (optional) for the in-app MVP; it can ride along with the broad typed-error work later.
+
 Tests: `failSession` fires exactly one `onError` and no `onClose`; the session is removed from the registry; the MM Pay consumer retains the error after a failure.
 
-### M0.2 - OTP typed-code fix
+### P1.M1 - In-app-only quoting capability
 
-Stop force-mapping `nativeFlowError` to `AUTH_FAILED`. `HeadlessHost.tsx` (the `nativeFlowError` effect at lines 136 to 147) hard-codes `code: 'AUTH_FAILED'` and the `'AUTH_FAILED'` fallback for any `nativeFlowError` string. The OTP path (`OtpCode`) hands back a bare `nativeFlowError` string, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled as `AUTH_FAILED`. (Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` via the `error.name` check.) Fix: thread a typed code (not a string) through the native route-back param so post-auth failures keep their real code.
+Build everything needed to request, filter, and recommend in-app WebView quotes, and consume it through one shared selection.
 
-Tests: a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`; a genuine auth failure still surfaces `AUTH_FAILED`.
+- **Widen `getRampsQuote`.** Drop both `autoSelectProvider` and `restrictToKnownOrNativeProviders` so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026) and quotes every provider server-side; switch the pick off `success?.[0]`. Gated by B3 catalog hydration (verify the provider catalog is hydrated in the TPC context, or pass an explicit `providers` list, otherwise all-provider quoting could return zero providers).
+- **In-app filter.** Keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'` (the same predicate the routing uses). This removes external-browser and custom-action quotes before continuation.
+- **Selection: reliability-then-price off `sorted[]` only.** CUT the preferred-provider (order-history) rung from Phase 1 - it is not needed to pick one quote for the MM Pay MVP. It is added back in Phase 2 (P2.M6) when there is a real returning-user requirement.
+- **Selection ownership in `RampsController`.** Put the in-app filter + reliability-then-price selection in `RampsController` (the team's deferred `getSmartSelectedQuote`), consumed by BOTH `transaction-pay-controller` `getRampsQuote` and the mobile headless path, rather than embedding ramp business logic in `transaction-pay-controller` and forking a separate mobile `recommendQuotes` util (drift hazard, per Goktug / Matthew Walsh). Gating per B2: MM Pay passes allowed `providerIds`, and the selection applies the in-app filter as defense-in-depth.
+- **Re-specified WebView fail-safe** (the original was aimed at the wrong branch): a quote that OMITS `buyWidget.browser` is classified in-app and routes to the in-app `Checkout` WebView, NOT the external branch. So the real Phase 1 safety net is the WebView's existing terminal-failure path: confirm `Checkout`'s `onHttpError` / load-failure routes through `failHeadlessCheckout` -> `failSession` (`app/components/UI/Ramp/Views/Checkout/Checkout.tsx`, ~241) for the newly-enabled in-app providers, so a provider that fails to load in the WebView produces a clean terminal `onError` rather than a stranded session.
+- **Per-provider WebView smoke check.** "Regression-test only" understates this: the SET of providers hitting the in-app `Checkout` WebView is new. Add a smoke check per newly-enabled in-app provider, including `getQuoteBuyUserAgent` (`app/components/UI/Ramp/types/index.ts`, ~81-87) custom-user-agent needs.
+- **Analytics tagging confirmation.** Confirm the existing `RAMPS_CHECKOUT_CLOSED` / `RAMPS_ORDER_FAILED` instrumentation in `Checkout.tsx` already tags `ramp_type: 'HEADLESS'` for the new providers, so Phase 1 does not ship a production flow with an observability blind spot (full external-browser analytics parity stays Phase 2).
+- **Min/max limits decision.** `useRampsBuyLimits` reads limits from the native preferred provider and its own doc warns this breaks once non-native providers are in scope (`app/components/UI/Ramp/hooks/useRampsBuyLimits.ts`, ~15-20, 42-50). For MM Pay the amount is deposit-driven, so decide explicitly: enforce per-provider limits up front, or accept provider-side mid-checkout rejection, and ensure that rejection is a clean terminal callback (ties to the fail-safe above), not a stranded WebView.
 
----
+Tests: multi-provider request returns multiple non-customAction in-app candidates; the in-app filter drops external/custom quotes; reliability-then-price picks one quote; partial failure keeps usable candidates plus `error[]`; full failure (no usable in-app `success[]` entry) maps to `NO_QUOTES`; a quote missing `buyWidget.browser` routes to the in-app WebView and a load failure fires `failSession`; per-provider WebView smoke check for each newly-enabled in-app provider.
 
-## Milestone 1 - All-provider quoting capability (built but gated OFF)
+### P1.M2 - Activation behind a multi-value scoped flag
 
-Goal: build everything needed to request, filter, and recommend multi-provider quotes, plus the core widening, but DO NOT activate any of it in production. The live MM Pay path keeps both gating flags; `useHasNativeFiatProvider` keeps gating. Exercised only via the dev playground and unit/integration tests.
+- **Add one scoped flag whose `off` state falls back to native-only**, not "no fiat" (existing `MetaMaskPayFiatFlags` cannot scope this, `app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90).
+- **Make it multi-value (`off | in-app | all`), NOT a boolean.** Phase 1 ships the `in-app` value (filter on). This keeps "one flag" while making the Phase 2 widening a controlled, staged, roll-back-able flip to `all` rather than an implicit deploy-time behavior change.
+- **Gate composition (per B2 "both").** The flag enables non-native and sets scope; within that, MM Pay passes the allowed `providerIds` (the team's distribution-layer mechanism), and the shared selection applies the in-app filter as defense-in-depth. The flag and the passed provider IDs are complementary, not redundant: the flag is the kill switch / scope, the provider IDs are the per-feature allowlist.
+- **Relax the mobile gates behind the flag.** Relax `useHasNativeFiatProvider` / `useIsFiatPaymentAvailable` (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26) and activate the widened + filtered quote path.
+- Safe to activate once the fail-safe is verified; the Jun 7 native-only gate is superseded (Money Account launched), so direction is unblocked.
 
-### M1.1 - Filter `isCustomAction` out of headless candidate selection
-
-`RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller logic is required for the request itself. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`. Candidate selection operates over `success[]` only, with `isCustomAction` entries filtered out (`isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). Custom actions are OUT of scope (see the "Getting multiple quotes" concern): there is no union candidate model. Full failure is "no usable non-customAction `success[]` entry", which maps to `NO_QUOTES`. Filtering custom actions out is what keeps removing `restrictToKnownOrNativeProviders` from surfacing an unhandled custom-action path.
-
-Tests: multi-provider request returns multiple non-customAction candidates; partial failure keeps usable candidates plus `error[]`; `isCustomAction` `success[]` entries are filtered out of candidate selection; full failure (no usable non-customAction `success[]` entry) maps to `NO_QUOTES`; playground renders all non-custom providers.
-
-### M1.2 - Build a mobile-side `recommendQuotes` util
-
-Build the selection / recommendation ladder as a PURE mobile-side util. Do NOT extract a shared helper into `@metamask/ramps-controller` up front: there is a single real consumer today (headless / MM Pay), and the order-history rung cannot be pulled from core (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote` are `#private` and run only in the single-provider auto-select branch, `node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, lines 1003 to 1024; the all-provider path takes the `else` branch and quotes `state.providers.data`, line 1026). The previously-used-provider rung must be re-derived mobile-side and supplied as an explicit input. Extract to core only once 2+ confirmed consumers justify it (Milestone 6).
-
-The util must be PURE, with explicit inputs (it cannot read controller-private order history or mobile Redux). Proposed signature:
-
-```ts
-recommendQuotes(input: {
-  response: QuotesResponse;           // success[], sorted[], error[]
-  preferredProviderIds?: string[];    // caller derives order-history / preference, in priority order
-}): { ordered: Quote[]; recommended?: Quote };
-```
-
-Defined behavior the util must specify:
-
-- Ladder: first a quote whose provider id is in `preferredProviderIds` (in order), then `sorted` with `sortBy === 'reliability'`, then `sorted` with `sortBy === 'price'`.
-- Custom actions: filter out `isCustomAction` entries before ranking (out of scope this effort).
-- `sorted` handling: map provider ids to `success[]` entries; ids missing from `sorted` are appended after sorted ones in a stable, documented order (original `success[]` order).
-- Price fallback: when no `reliability` sort entry exists, fall back to the `price` sort entry; when neither exists, preserve input order.
-- Provider id normalization: match on normalized provider code so `/providers/x` and `x` are equivalent.
-
-Tests: ladder order with and without `preferredProviderIds`; missing `sorted` entries; price fallback; `isCustomAction` entries excluded; deterministic output for UB2 and MM Pay callers.
-
-### M1.3 - Core `getRampsQuote` widening (built but NOT activated)
-
-Build the core widening but leave it gated behind the Milestone 3 flag; do not flip it here. In `getRampsQuote` (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 95 to 131), the production call passes `autoSelectProvider: true` (line ~113) and `restrictToKnownOrNativeProviders: true` (line ~116) and takes `quotes.success?.[0]` (line ~124). True all-provider quoting requires dropping BOTH flags so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026). Dropping ONLY the restriction is not enough: `#resolveProviderIdsForQuote` returns a SINGLE provider id even when `restrictToKnownOrNative` is false, so the auto-select branch still yields one provider. So the widened path must drop both flags and switch the pick from `success?.[0]` to the Milestone 1.2 selection logic.
-
-- **Catalog hydration (must verify).** Falling back to `state.providers.data` presumes the controller provider catalog is hydrated in the `TransactionPayController` context. TPC currently relies on auto-select, not on `state.providers.data`, so verify catalog hydration in the TPC context or pass an explicit `providers` list; otherwise all-provider quoting could return zero providers.
-
-Tests: the widened selector (off the production flag) picks the recommended successful quote and ignores provider-level failures when another quote succeeds; the dormant path is proven by tests while production stays native-only.
+Tests: with the flag set to `in-app`, in-app non-native quotes reach the consumer and complete via the in-app `Checkout` WebView callbacks; external/custom quotes are filtered out; with the flag `off`, behavior is identical to today's native-only (native fiat still available).
 
 ---
 
-## Milestone 2 - Headless checkout for non-native providers (makes widening safe)
+## Phase 2 - External-browser and custom-action providers (Coinbase, PayPal, etc.)
 
-Goal: make the non-native checkout paths (in-app WebView and external browser) emit terminal headless callbacks, so that widening quoting in Milestone 3 cannot strand a user in a callback-less branch. This is the milestone that must land before any production widening.
+Makes the external/custom checkout paths headless-aware, then widens the SAME flag to its `all` value (one flag, controlled widening; no second product flag).
 
-### M2.1 - Make `continueWidget`'s external-browser branch headless-aware
+### P2.M1 - Make `continueWidget`'s external-browser branch headless-aware
 
 Thread `ctx.headlessSessionId` into the external-browser branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) so it routes to `onOrderCreated` / `onClose` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75):
 
@@ -246,13 +251,13 @@ Observability is only partial; document the three cases explicitly:
 
 Tests: each branch routes to the correct terminal callback; iOS `openAuth` success fires `onOrderCreated`; cancel fires `onClose({ reason: 'user_dismissed' })`; open-rejection fires `failSession`.
 
-### M2.2 - Give `handleRampReturnUrl.ts` a headless path
+### P2.M2 - Give `handleRampReturnUrl.ts` a headless path
 
 Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the `getProviderDeeplinkRedirectUrl` helper around lines 27 to 28), so the deeplink DOES carry the provider code in its path. It does NOT carry the wallet address, chainId, or session id.
 
 Concrete design:
 
-1. At external-browser launch (Milestone 2.1), record a pending external-order correlation in the session registry: `{ sessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
+1. At external-browser launch (P2.M1), record a pending external-order correlation in the session registry: `{ sessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
 2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: resolve the order via the shared callback resolver using the `providerCode` parsed from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fire `onOrderCreated` and end the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
 3. Build on the just-landed cached / internal order-id resolution (mobile #32372 `app/components/UI/Ramp/hooks/useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
 
@@ -260,75 +265,74 @@ Core-vs-mobile split: core may own only the pure parsing/status helpers (parse c
 
 Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; a deeplink return with a live `continued` session fires `onOrderCreated`; a no-order deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
 
-### M2.3 - E1/E2/E3 reconciliation (money-losing if skipped)
+### P2.M3 - E1/E2/E3 reconciliation (money-losing if skipped)
 
 Three hazards must be reconciled, all reusing the EXISTING dismissal machinery `HeadlessHost` already wires (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx`, lines 86 to 99: `useHeadlessSessionDismissal`, `useHeadlessSessionFocusDismissal`, and the `beforeRemove` listener), NOT a parallel new grace timer, so there are not two competing dismissal paths.
 
-- **E1 - iOS `openAuth` success resolves into the headless callback.** The iOS success path must terminate via `onOrderCreated` (covered by Milestone 2.1), never silently land on `RAMPS_ORDER_DETAILS`.
+- **E1 - iOS `openAuth` success resolves into the headless callback.** The iOS success path must terminate via `onOrderCreated` (covered by P2.M1), never silently land on `RAMPS_ORDER_DETAILS`.
 - **E2 - A SUCCESS deeplink must WIN even if the session was already dismissed or GC'd.** Because MM Pay's two-step intent transaction is gated on `onOrderCreated` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 112 to 122), a real fiat order can complete (the user paid) while the intent leg never fires if the focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `app/components/UI/Ramp/headless/sessionRegistry.ts`, line 110) terminated the session first. Reconciliation rule: a success deeplink must still complete the order through the consumer's `onOrderCreated` (re-opening or directly completing the dismissed session) rather than being silently dropped to `RAMPS_ORDER_DETAILS`. Only a deeplink with no order / no recoverable success and no live session falls back to `RAMPS_ORDER_DETAILS` so the order is still recoverable manually.
 - **E3 - Pre-empt the existing zero-delay focus-dismissal timer, do not add a parallel grace timer.** On re-focus, `useHeadlessSessionFocusDismissal` schedules dismissal via `setTimeout(..., 0)` (`app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts`, line 51) and bails if the session is already gone or the focus / session id changed. The only addition is to ensure a real deeplink callback can PRE-EMPT this existing path: a deeplink-success must terminate the session before, or take precedence over, focus-dismissal. It does NOT emit `onError`, and the consumer's `cancel()` and the registry's stale-session GC remain as backstops. The remaining product / MM Pay decision is whether the existing zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
 
 Tests: iOS `openAuth` success completes via `onOrderCreated` (E1); a success deeplink arriving AFTER the session was dismissed still completes via `onOrderCreated` and is not dropped to `RAMPS_ORDER_DETAILS` (E2); a deeplink-success pre-empts the existing focus-dismissal so a slow-but-successful return is not closed as `user_dismissed` (E3).
 
----
+### P2.M4 - Custom-action (PayPal) support
 
-## Milestone 3 - Activation behind a required scoped flag
+Bring `isCustomAction` quotes into scope with their external CTA path: remove them from the Phase 1 filter exclusion and route their continuation through the now-headless-aware external/custom path (custom-action flows always use the system / in-app browser, per Patrick Kowalski, #money-movement-core 2026-04-17). Typed errors and analytics for these flows are covered by P2.M7.
 
-Goal: the only production-widening milestone. Lands last, after Milestone 2 is proven. Flip the gate behind a distinct scoped flag for staged rollout.
+Tests: a custom-action quote is selectable, continues through the external CTA path, and terminates via `onOrderCreated` / `onClose` / `failSession`.
 
-### M3.1 - Add a distinct scoped flag / config bit
+### P2.M5 - Widen via the flag's `all` value
 
-**A distinct scoped flag is REQUIRED; the existing flag cannot scope provider-widening.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing `MetaMaskPayFiatFlags` only carries `enabledTransactionTypes` and `maxDelayMinutesForPaymentMethods` (`app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90); there is NO native-vs-all-providers bit, and setting `enabledTransactionTypes: []` disables ALL fiat. So a distinct scoped flag / config bit (e.g. `allProvidersEnabled` / a non-native provider scope) is REQUIRED so that "off" falls back to native-only rather than killing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond it unless product asks.
+When the flag reads `all`, relax the in-app filter so external / custom quotes flow. Because it is a flag VALUE flip (not a deploy-time filter removal), it can be staged and rolled back independently of the Phase 2 deploy. Lands after P2.M1-P2.M4 are proven.
 
-### M3.2 - Flip the two gates and activate Milestone 1.3 behind the flag
+Tests: with the flag set to `all`, external and custom quotes reach the consumer and complete via headless callbacks; with it `in-app`, only in-app quotes flow; with it `off`, native-only.
 
-Lands after Milestone 2 is proven. Behind the scoped flag from Milestone 3.1:
+### P2.M6 - Add back the preferred-provider recommendation rung
 
-- Mobile: relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26).
-- Core: activate the Milestone 1.3 widening in `getRampsQuote` (drop both flags, switch the pick to the selection util), gated on the same scoped rollout.
+Add back the previously-used-provider (order-history) recommendation rung deferred from Phase 1, if a returning-user requirement exists. The order-history rung is `#private` in `RampsController` and runs only in the single-provider auto-select branch, so it must be re-derived and supplied as an explicit input to the shared selection, then layered ahead of reliability-then-price.
 
-Tests: with the scoped flag on, non-native quotes reach the consumer and complete via headless callbacks; with it off, behavior is identical to today's native-only (native fiat still available).
+Tests: ladder order with and without preferred provider ids; deterministic output for UB2 and MM Pay callers.
 
----
+### P2.M7 - Typed errors + analytics parity for external-browser
 
-## Milestone 4+ - Deferred follow-up
-
-These are intentionally deferred. They are not required to ship all-provider support behind the Milestone 3 flag, and several refactor working code with regression risk.
-
-### M4 - Broad typed errors
-
-Depends on Milestone 0.1 (terminal-callback contract). The Milestone 0.2 OTP typed-code fix is already in scope at Milestone 0. Then, on demand:
-
-- Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures).
+- Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures). Depends on the P1.M0 terminal-callback contract.
 - Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit, not a typed error: `Checkout.tsx` (lines 386 to 393) already treats it as `closeSession({ reason: 'user_dismissed' })`.
+- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), all tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
 - Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). So a consumer that must branch on `TRANSAK_ERROR_CODES` / `TransakErrorCode` first needs a core sub-task to export them from the package; otherwise depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until that export lands. Re-verify against `origin/main` / the published package before relying on it.
 - Scope the taxonomy. The broader typed-code taxonomy (e.g. `KYC_REQUIRED` and other granular provider codes) is implement-on-demand: add a code when a consumer actually needs to branch on it, not up front.
 
-### M5 - Analytics parity for external-browser providers
+---
 
-Bring external-browser providers to parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), all tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
+## Deferred (after Phase 2)
 
-### M6 - Wire TPC to consume multi-provider quotes
+These are intentionally deferred. They are not required to ship all-provider support behind the scoped flag, and several refactor working code with regression risk.
 
-Wire core (`TransactionPayController`) to consume multi-provider quotes via the Milestone 1.2 selection logic instead of `success[0]`, and keep the MM Pay terminal-callback contract. This depends ONLY on the Milestone 0.1 terminal-callback contract; there is no upstream wait, because the `transaction-pay-controller` fiat second-leg hardening PRs are merged and published (see Upstream context). Extract a shared helper into `@metamask/ramps-controller` only once there are 2+ confirmed consumers to justify the cross-repo publish / version coupling cost.
+### Wire TPC to consume multi-provider quotes
 
-### M7 - DRY cleanup (UB2 UI becomes "dumb")
+Wire core (`TransactionPayController`) to consume multi-provider quotes via the shared `RampsController` selection instead of `success[0]`, and keep the MM Pay terminal-callback contract. This depends ONLY on the P1.M0 terminal-callback contract; there is no upstream wait, because the `transaction-pay-controller` fiat second-leg hardening PRs are merged and published (see Upstream context).
 
-Deferred until AFTER Milestone 3 activation is stable. This refactors working UB2 code (regression risk) with no production benefit before all-providers ships.
+### DRY cleanup (UB2 UI becomes "dumb")
 
-- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (once 2+ consumers justify extraction); pure callback parsing and status classification; bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
+Deferred until AFTER Phase 2 activation is stable. This refactors working UB2 code (regression risk) with no production benefit before all-providers ships.
+
+- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (already shared via `getSmartSelectedQuote`); pure callback parsing and status classification; bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
 - **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes. The only exception: if the controller API is extended to accept redirect / browser options as inputs, the browser-mode decision can move down; otherwise it stays mobile-side.
-- Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers.
+- Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers. ("UB2 becomes dumb.")
 
 Tests: UB2 regression proves ordering, recommended selection, WebView retry, and OrderDetails routing are unchanged after the extraction.
+
+### Broad typed-error taxonomy on demand
+
+Beyond the external-browser typed errors in P2.M7, the broader provider-code taxonomy stays implement-on-demand: add a code when a consumer actually needs to branch on it. The native-flow OTP typed-code fix (de-scoped from P1.M0) rides along here.
 
 ---
 
 ## Test plan (consolidated)
 
-- ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared recommendation order.
-- Transaction Pay: the widened selector picking the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds; dormant-path coverage before activation.
-- Mobile hooks: `useHeadlessBuy`, `useContinueWithQuote`, `HeadlessHost`, `Checkout`, and external-browser deeplink return.
+- ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared `getSmartSelectedQuote` selection (in-app filter + reliability-then-price) consumed by both `getRampsQuote` and the mobile headless path.
+- Transaction Pay: the widened selector picking the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds.
+- Phase 1 mobile: `useHeadlessBuy` in-app filter and selection, in-app `Checkout` WebView fail-safe (`failHeadlessCheckout` -> `failSession`), per-provider WebView smoke check, analytics tagging confirmation, limits decision.
+- Phase 2 mobile: `useContinueWithQuote` external-browser branch, `HeadlessHost`, external-browser deeplink return, E1/E2/E3 reconciliation, custom-action continuation.
 - UB2 regression: quote ordering, recommended quote selection, WebView retry behavior, and order-details routing unchanged.
 - Analytics: `RAMPS_CHECKOUT_CLOSED`, `RAMPS_ORDER_FAILED`, provider cancellation, checkout HTTP / load failures, and order terminal failed / cancelled events.
 
@@ -338,10 +342,10 @@ Tests: UB2 regression proves ordering, recommended selection, WebView retry, and
 
 Time-sensitive references that informed sequencing; verify before relying on them.
 
-- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Milestone 1 adds no new controller logic.
-- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES` / `RampsErrorCode`), confirmed on `origin/main`. Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are NOT re-exported from `index.ts` on `main`; the typed-error export sub-task (Milestone 4) must add that export before depending on it from mobile.
-- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Milestone 2.2.
-- The MM Pay fiat second-leg hardening PRs (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay, plus #9159 and #9135) are MERGED and published (core ~release 1082.0.0). There is no upstream wait: the MM Pay integration (Milestone 6) now depends only on the Milestone 0.1 terminal-callback contract, not on an in-flight upstream sequence.
+- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic for the request itself.
+- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES` / `RampsErrorCode`), confirmed on `origin/main`. Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are NOT re-exported from `index.ts` on `main`; the typed-error export sub-task (P2.M7) must add that export before depending on it from mobile.
+- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform P2.M2.
+- The MM Pay fiat second-leg hardening PRs (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay, plus #9159 and #9135) are MERGED and published (core ~release 1082.0.0). There is no upstream wait: the MM Pay integration (Deferred TPC wiring) now depends only on the P1.M0 terminal-callback contract, not on an in-flight upstream sequence.
 - A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
 
 ---
@@ -350,17 +354,17 @@ Time-sensitive references that informed sequencing; verify before relying on the
 
 Assumptions:
 
-- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (Milestone 3.1). No new product flag beyond the kill switch unless product asks.
+- Ship behind a multi-value scoped flag (`off | in-app | all`) whose `off` state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (P1.M2). Phase 1 ships `in-app`; Phase 2 flips to `all`. No new product flag beyond this kill switch unless product asks.
 - Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
-- System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the existing focus-dismissal machinery for inferred cancellation.
+- System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the existing focus-dismissal machinery for inferred cancellation (Phase 2).
 - Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.
 
 Risks:
 
-- Cross-repo sequencing (core publish before mobile bump) for the eventual core extraction.
-- Android foreground-without-callback heuristic reliability (built on the existing focus-dismissal) and whether it needs a deliberate grace delay.
-- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (Milestone 2.3, E2) is implemented.
-- Migrating pure helpers into core without dragging platform policy along (and the cross-repo publish / version coupling cost of doing it before a second consumer exists).
+- `buyWidget.browser` is optional, so an aggregator quote missing it would be classed in-app; Phase 1 safety relies on the THREE layers together (MM Pay allowed `providerIds`, the in-app filter, the WebView fail-safe), not on the field alone (B1).
+- Cross-repo sequencing (core publish before mobile bump) for the shared `RampsController` selection.
+- Android foreground-without-callback heuristic reliability (built on the existing focus-dismissal) and whether it needs a deliberate grace delay (Phase 2).
+- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (P2.M3, E2) is implemented.
 
 ---
 

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -15,7 +15,7 @@ Companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan).
 
 - [ ] **P1.M0** - `failSession`-terminal must-fix
 - [ ] **P1.M1** - In-app-only quoting capability (in-app filter, reliability-then-price selection in `RampsController`, WebView fail-safe, per-provider smoke check, analytics tagging, limits decision)
-- [ ] **P1.M2** - Activation behind a multi-value scoped flag (`off | in-app | all`), MM Pay passing allowed `providerIds`
+- [ ] **P1.M2** - Activation behind a multi-value scoped flag (`off | in-app | all`)
 
 **Phase 2 - External-browser + custom-action providers (Coinbase, PayPal, etc.):**
 
@@ -42,7 +42,7 @@ In-app vs external is knowable at the quote layer (before `getBuyWidgetData`), s
 Context for the phasing decisions:
 
 - The earlier "native-only for v0, disable aggregators" decision was time-boxed to the Money Account launch. Money Account has launched, so enabling in-app aggregators is in scope.
-- Provider gating happens at the distribution layer (MM Pay passes allowed `providerIds`). Core also applies the in-app filter as defense-in-depth.
+- Provider gating happens in the shared `RampsController` selection (the in-app filter plus `getSmartSelectedQuote`) that `getRampsQuote` consumes; the scoped flag is the distribution-layer control. MM Pay itself forwards no `providerIds` today (see the P1.M2 gate-composition note), so gating is not relied on there.
 - Smart selection lives in `RampsController` (the deferred `getSmartSelectedQuote`), consumed by both `transaction-pay-controller` and the mobile headless path, so selection is not forked between core and a separate mobile `recommendQuotes` util.
 - PayPal and Robinhood are "checkout outside of MetaMask" (Phase 2). MoonPay and Revolut are top in-app providers in Phase 1 scope.
 
@@ -77,7 +77,7 @@ These facts make the in-app filter and the phase split possible.
 - **Custom actions ride inside `success[]`**, flagged by `quote.isCustomAction` (reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts:43-45`). The separate `customActions[]` array is empty in UB2 usage. UB2 already excludes `isCustomAction` entries from provider/payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx:262-274`). Phase 1 filters them out the same way; Phase 2 brings them into scope.
 - **Partial vs full failure** is computed over non-customAction `success[]` entries. Full failure (no usable entry) maps to `NO_QUOTES`; it is NOT `success.length === 0 && customActions.length === 0`.
 - **In-app vs external is decided at the quote layer.** `getAggregatorRedirectConfig` reads `quote.quote?.buyWidget?.browser` and `isCustomAction` off the quote (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts:35-71`) and is called at `useContinueWithQuote.ts:249`, before `getBuyWidgetData` at `:257`. Custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. So Phase 1 can pre-filter to in-app: keep a quote only if `!isCustomAction(quote)` AND `quote.quote?.buyWidget?.browser !== 'IN_APP_OS_BROWSER'`.
-- **`buyWidget.browser` is optional.** Mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote missing `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from THREE layers together: MM Pay passes allowed `providerIds`, the in-app filter, and the mandatory in-app `Checkout` WebView fail-safe.
+- **`buyWidget.browser` is optional.** Mobile still fetches the widget URL via the deprecated `buyURL` + `getBuyWidgetData` path, and an aggregator quote missing `buyWidget.browser` would be classified in-app. So Phase 1 safety comes from TWO layers together: (1) the multi-value scoped flag (`off | in-app | all`), and (2) the in-app filter plus selection in the shared `RampsController` selection (`getSmartSelectedQuote`) that `getRampsQuote` consumes, backed by the mandatory in-app `Checkout` WebView fail-safe.
 
 ### Selection (ordering like UB2)
 
@@ -165,7 +165,7 @@ Tests: multi-provider request returns multiple non-customAction in-app candidate
 
 - **Add one scoped flag whose `off` state falls back to native-only**, not "no fiat". The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat; `app/selectors/featureFlagController/confirmations/index.ts:87-90`).
 - **Make it multi-value (`off | in-app | all`), not a boolean.** Phase 1 ships `in-app` (filter on); Phase 2 widening is a controlled flag flip to `all`, not a deploy-time behavior change.
-- **Gate composition.** The flag is the kill switch / scope; within that, MM Pay passes the allowed `providerIds` (per-feature allowlist) and the shared selection applies the in-app filter as defense-in-depth. Complementary, not redundant.
+- **Gate composition.** The flag is the kill switch / scope; within that, the shared `RampsController` selection applies the in-app filter plus `getSmartSelectedQuote` (which `getRampsQuote` consumes) as the quote-side enforcement. Note: MM Pay CAN pass `providerIds` but does not today (leftover artifact; consumers have no provider preferences). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` + `restrictToKnownOrNativeProviders: true` and forwards no `providers` / `providerIds`; the headless `getQuotes` facade CAN take `providerIds`, but MM Pay calls `startHeadlessBuy` (whose `HeadlessBuyParams` has no `providerIds`), so it never reaches that facade. Turning `providerIds` into a real gate would need net-new plumbing: either `getRampsQuote` forwards a `providers` allowlist, or MM Pay routes through the headless `getQuotes`.
 - **Relax the mobile gates behind the flag.** `useHasNativeFiatProvider` (`:23-26`) and `useIsFiatPaymentAvailable` (`:19-23`), then activate the widened + filtered quote path.
 
 Tests: with the flag `in-app`, in-app non-native quotes reach the consumer and complete via the in-app `Checkout` WebView callbacks, and external/custom quotes are filtered out; with the flag `off`, behavior is identical to today's native-only.
@@ -238,7 +238,7 @@ Tests: ladder order with and without preferred provider ids; deterministic outpu
 
 - Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open). Depends on the P1.M0 terminal-callback contract.
 - Route user exits to `onClose` per the callback-routing rule. Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit: `Checkout.tsx:386-393` already treats it as `closeSession({ reason: 'user_dismissed' })`.
-- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
+- Bring external-browser providers to analytics parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, and HTTP / load failures, tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`. Note: today MM Pay / TPC detects an order's terminal state by POLLING `RampsController:getOrder` (in `transaction-pay-controller` `strategy/fiat/fiat-submit.ts`), NOT via a `RampsController:orderStatusChanged` subscription. The headless session ends at `onOrderCreated` (order CREATED); the order's terminal state is observed afterward by that TPC polling. So hanging Phase 2 analytics off `orderStatusChanged` would be NEW subscription work, not existing behavior.
 - **Export reality check.** On core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but NOT `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). A consumer that must branch on those first needs a core sub-task to export them; otherwise depend only on the already-exported helpers plus `RAMPS_ERROR_CODES`. Re-verify against `origin/main` before relying on it.
 - **Scope the taxonomy.** Granular provider codes (e.g. `KYC_REQUIRED`) are implement-on-demand: add a code when a consumer actually needs to branch on it.
 

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -9,13 +9,13 @@ This is a companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan) and
 Phases 1 to 8 are capability work, built behind the still-closed native-only gate and exercised only via the dev playground plus unit/integration tests. Phase 9 is the only production-widening phase, flag-gated, landing last.
 
 - [ ] **Phase 1** - All-provider quoting capability (gated, NOT activated)
-- [ ] **Phase 2** - Shared quote selection / recommendation helper
+- [ ] **Phase 2** - Quote selection / recommendation util (mobile-side first; core extraction DEFERRED)
 - [ ] **Phase 3** - WebView + external-browser headless support (pulled early)
 - [ ] **Phase 4** - Native and non-native routing alignment
 - [ ] **Phase 5** - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
 - [ ] **Phase 6** - Typed error handling
 - [ ] **Phase 7** - Analytics parity
-- [ ] **Phase 8** - DRY cleanup (UB2 UI becomes "dumb")
+- [ ] **Phase 8** - DRY cleanup (UB2 UI becomes "dumb") (DEFERRED until after Phase 9)
 - [ ] **Phase 9** - Activation / rollout (flag-gated gate-flip)
 
 Pre-phase: a terminal-callback contract fix (see Must-fix preconditions) must land before typed errors expand.
@@ -27,7 +27,7 @@ Pre-phase: a terminal-callback contract fix (see Must-fix preconditions) must la
 Enabling all providers spans three layers, and this plan documents all three as coordinated phases:
 
 - **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` + `restrictToKnownOrNativeProviders: true` and takes only `quotes.success?.[0]` (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, around lines 61 to 78). This is the native-only gate's quote-side enforcement.
-- **`@metamask/ramps-controller`** - home for the shared, PURE quote filter/sort/recommend helper and pure callback parsing/status helpers.
+- **`@metamask/ramps-controller`** - eventual home for the PURE quote filter/sort/recommend helper and pure callback parsing/status helpers, but only once 2+ consumers justify extraction. The selection / recommendation util starts mobile-side (see Phase 2, DEFERRED), since the order-history rung cannot be reused from core and there is one real consumer today.
 - **`metamask-mobile`** - relax the native-only availability gate (`useIsFiatPaymentAvailable`, lines 19 to 23; `useHasNativeFiatProvider`, lines 23 to 26); make `useContinueWithQuote`'s external-browser branch headless-aware; typed errors; analytics; DRY; and own all navigation/session and redirect/deeplink policy.
 
 ---
@@ -73,7 +73,7 @@ This is a precondition for Phase 6, not an afterthought.
 
 ## UB2 behavior to preserve
 
-- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`.
+- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`. (In practice custom actions ride inside `success[]` flagged by `isCustomAction`; the separate `customActions[]` array is empty in UB2 usage, and custom actions are out of scope here, see the "Getting multiple quotes" concern.)
 - Provider-level quote errors are non-terminal: they are surfaced as partial errors and only become terminal when every provider fails or no usable quote can be selected.
 - Existing UB2 quote ordering, recommended-quote selection, WebView retry behavior, and OrderDetails routing must remain unchanged (regression-tested).
 
@@ -87,12 +87,12 @@ A direct answer to each open question that motivated this plan. Findings are UB2
 
 UB2 does not fan out to providers with `Promise.all`. One `RampsController.getQuotes()` call returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal: its message lands in `error[]` while other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
 
-`customActions[]` matters here: UB2 can still render `customActions` (e.g. PayPal-style providers) even when `success[]` is empty, and those use a separate CTA / external-browser path rather than a normal `Quote`. So "no quotes" is NOT just `success.length === 0`.
+Custom actions are NOT a separate candidate array in practice. UB2 carries custom actions INSIDE `success[]`, flagged by `quote.isCustomAction` (`isCustomAction()` reads `quote.quote.isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). The separate `customActions[]` array is empty in UB2 usage and tests. UB2 already EXCLUDES `isCustomAction` entries from provider / payment matching (`app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx`, lines 262 to 274). For this effort custom-action entries are OUT of scope: headless candidate selection must filter them out of `success[]` the same way, so that removing `restrictToKnownOrNativeProviders` cannot surface an unhandled custom-action path.
 
-- Partial failure: at least one usable candidate exists. Keep it.
-- Full failure: `success.length === 0 && customActions.length === 0`. Map to `NO_QUOTES`.
+- Partial failure: at least one usable non-customAction `success[]` entry exists. Keep it.
+- Full failure: no usable non-customAction `success[]` entry. This is NOT `success.length === 0 && customActions.length === 0`. Map to `NO_QUOTES`.
 
-Decision: custom-action providers are IN scope for all-providers. The candidate set is a union of `success[]` (`Quote`) and `customActions[]` (custom-action), so selection, "no quotes", and continuation must operate over a unified candidate model, not over `success[]` alone.
+Decision: there is no union candidate model. Selection, "no quotes", and continuation operate over `success[]` with `isCustomAction` entries filtered out.
 
 ### Sorting / ordering quotes like UB2
 
@@ -101,7 +101,7 @@ There are two existing UB2 behaviors:
 - **Modal ordering** in `app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx` (lines 205 to 228): reliability-only sort of providers-with-quotes.
 - **Recommendation ladder** in legacy `app/components/UI/Ramp/Aggregator/hooks/useSortedQuotes.ts` (lines 43 to 69): previously-used provider, then reliability, then price.
 
-Headless / MM Pay need the recommendation ladder (to replace core's current `success[0]` pick), not just modal ordering. Provider preference-from-order-history already exists in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`), so the new build is the reliability-then-price recommendation among the returned `success[]`.
+Headless / MM Pay need the recommendation ladder (to replace core's current `success[0]` pick), not just modal ordering. Provider preference-from-order-history DOES exist in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`), but those are `#private` and run only in the single-provider auto-select branch; the all-provider path never invokes them (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`: the `else if (autoSelectProvider || restrictToKnownOrNativeProviders)` branch, lines 1003 to 1024, versus the all-provider `else` branch that quotes `state.providers.data`, line 1026). So that order-history rung CANNOT be reused by a pure / mobile helper: the previously-used-provider rung must be re-derived mobile-side. The new build is that re-derived preference rung plus the reliability-then-price recommendation among the returned `success[]`.
 
 ### Routing for native vs non-native
 
@@ -129,7 +129,7 @@ The branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to
 
 ### Specific non-native errors UB2 handles that Headless does not
 
-Empty callback query, missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `getOrderFromCallback` throw, terminal HTTP error, `getBuyWidgetData` failure, static min/max limits, and no-quotes. Most map to a coarse `UNKNOWN` in headless today; `NO_QUOTES` / `QUOTE_FAILED` are defined but unemitted; and the OTP `nativeFlowError` string path force-maps post-auth failures (including limit / KYC) to `AUTH_FAILED`.
+Missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `getOrderFromCallback` throw, terminal HTTP error, `getBuyWidgetData` failure, static min/max limits, and no-quotes. Most map to a coarse `UNKNOWN` in headless today; `NO_QUOTES` / `QUOTE_FAILED` are defined but unemitted; and the OTP `nativeFlowError` string path force-maps post-auth failures (including limit / KYC) to `AUTH_FAILED`. (An empty callback query is NOT in this technical-error set: `app/components/UI/Ramp/Views/Checkout/Checkout.tsx`, lines 386 to 393, already treats an empty query as `closeSession({ reason: 'user_dismissed' })`, so it stays a user-exit via `onClose`.)
 
 ### DRY: logic to move out of UB2 UI
 
@@ -161,37 +161,40 @@ flowchart LR
 
 Build the capability without widening production. `RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller work is required. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`, exercised in the dev playground only. Preserve `QuotesResponse`.
 
-Define a **candidate model** up front: a discriminated union over `success[]` (`Quote`, normal checkout path) and `customActions[]` (custom-action, separate CTA / external-browser path). Selection and "no quotes" operate over candidates, not over `success[]` alone. Full failure is `success.length === 0 && customActions.length === 0`, which maps to `NO_QUOTES`.
+Candidate selection operates over `success[]` only, with `isCustomAction` entries filtered out. Custom actions are OUT of scope for this effort (see the "Getting multiple quotes" concern): there is no union candidate model. Full failure is "no usable non-customAction `success[]` entry", which maps to `NO_QUOTES`. Filtering custom actions out of headless candidate selection is what keeps removing `restrictToKnownOrNativeProviders` from surfacing an unhandled custom-action path.
 
 Do not touch the live MM Pay path here: `getRampsQuote` keeps `autoSelectProvider` / `restrictToKnownOrNativeProviders`, and `useHasNativeFiatProvider` keeps gating until Phase 9.
 
-Tests: multi-provider request returns multiple candidates; partial failure keeps usable candidates plus `error[]`; a `customActions`-only response is NOT `NO_QUOTES`; full failure (no success, no custom actions) maps to `NO_QUOTES`; playground renders all providers including custom actions.
+Tests: multi-provider request returns multiple non-customAction candidates; partial failure keeps usable candidates plus `error[]`; `isCustomAction` `success[]` entries are filtered out of candidate selection; full failure (no usable non-customAction `success[]` entry) maps to `NO_QUOTES`; playground renders all non-custom providers.
 
 ---
 
-## Phase 2 - Shared quote selection / recommendation helper
+## Phase 2 - Shared quote selection / recommendation helper (DEFERRED: build as a mobile-side util first)
 
-Extract a pure quote filter/sort/recommend helper into `@metamask/ramps-controller`, consumed by UB2, headless, and MM Pay so ordering and recommendation never diverge. The new build is the reliability-then-price recommendation among candidates (the provider preference-from-order-history rung already exists in the controller's `getQuotes` provider resolution).
+**Scope: DEFERRED.** Do NOT extract a shared helper into `@metamask/ramps-controller` up front. Build it as a mobile-side util first. There is a single real consumer today (headless / MM Pay), and the order-history rung cannot be pulled from core (see below), so a cross-repo extraction now buys publish / version coupling cost (core must publish, then mobile must bump) with no second consumer to justify it. Extract to `@metamask/ramps-controller` only once there are 2+ confirmed consumers.
 
-The helper must be PURE, with explicit inputs (it cannot read controller-private order history or mobile Redux). Proposed signature:
+Build the reliability-then-price recommendation among the non-customAction `success[]` entries (custom actions are filtered out; see Phase 1).
+
+**The previously-used-provider rung must be re-derived mobile-side; it cannot be reused from core.** `#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote` are `#private` and run only in the single-provider auto-select branch (`else if (autoSelectProvider || restrictToKnownOrNativeProviders)`, `node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, lines 1003 to 1024). In the all-provider path (gating flags omitted) `getQuotes` takes the `else` branch and quotes `state.providers.data` (line 1026), so that order-history rung is NOT invoked and cannot be reused by a pure / mobile helper. The mobile util derives the preferred-provider list from order history itself and supplies it as an explicit input.
+
+The util must be PURE, with explicit inputs (it cannot read controller-private order history or mobile Redux). Proposed signature:
 
 ```ts
 recommendQuotes(input: {
-  response: QuotesResponse;           // success[], sorted[], error[], customActions[]
-  preferredProviderIds?: string[];    // caller supplies order-history / preference, in priority order
-}): { ordered: Candidate[]; recommended?: Candidate };
+  response: QuotesResponse;           // success[], sorted[], error[]
+  preferredProviderIds?: string[];    // caller derives order-history / preference, in priority order
+}): { ordered: Quote[]; recommended?: Quote };
 ```
 
-Defined behavior the helper must specify:
+Defined behavior the util must specify:
 
-- Ladder: first a candidate whose provider id is in `preferredProviderIds` (in order), then `sorted` with `sortBy === 'reliability'`, then `sorted` with `sortBy === 'price'`.
-- `sorted` handling: map provider ids to candidates; ids missing from `sorted` are appended after sorted ones in a stable, documented order (e.g. original `success[]` order, then `customActions[]`).
+- Ladder: first a quote whose provider id is in `preferredProviderIds` (in order), then `sorted` with `sortBy === 'reliability'`, then `sorted` with `sortBy === 'price'`.
+- Custom actions: filter out `isCustomAction` entries before ranking (out of scope this effort).
+- `sorted` handling: map provider ids to `success[]` entries; ids missing from `sorted` are appended after sorted ones in a stable, documented order (original `success[]` order).
 - Price fallback: when no `reliability` sort entry exists, fall back to the `price` sort entry; when neither exists, preserve input order.
 - Provider id normalization: match on normalized provider code so `/providers/x` and `x` are equivalent.
 
-Scope guard: only this pure selection / order resolution moves to core. No mobile deeplink schemes or redirect policy (Phase 8).
-
-Tests: ladder order with and without `preferredProviderIds`; missing `sorted` entries; price fallback; custom-action candidates included; identical output for UB2 and MM Pay callers.
+Tests: ladder order with and without `preferredProviderIds`; missing `sorted` entries; price fallback; `isCustomAction` entries excluded; deterministic output for UB2 and MM Pay callers.
 
 ---
 
@@ -203,22 +206,23 @@ Make `continueWidget` fully headless-aware: thread `ctx.headlessSessionId` into 
 
 Observability is only partial; document the three cases explicitly:
 
-- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously. Success resolves the order; cancel fires `onClose({ reason: 'user_dismissed' })`; error fires `failSession`.
+- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously, but is NOT headless-aware today and iOS external success is NOT "already handled". The success path currently calls `navigateAfterExternalBrowser({ returnDestination: 'order', callbackUrl, ... })` (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 325 to 330), landing on `RAMPS_ORDER_DETAILS` with no headless path. Phase 3 must explicitly resolve `openAuth` success into the headless `onOrderCreated` callback; cancel fires `onClose({ reason: 'user_dismissed' })`; error fires `failSession`.
 - **`Linking.openURL` (Android / no InAppBrowser)**: we can only catch the OPEN failure (promise rejection, which fires `failSession`). We cannot observe provider page load.
 - **Android / system browser**: provider-side load failure is unknowable. Success arrives via deeplink return. Abandonment is inferred by a named policy (below), not guaranteed.
 
-### Android foreground-without-callback policy (named, must be decided)
+### Android foreground-without-callback policy (reuse the EXISTING dismissal machinery)
 
-A concrete policy is required, not a vague "timeout":
+This policy must be defined in terms of the dismissal mechanisms `HeadlessHost` already wires, NOT as a parallel new grace timer, so there are not two competing dismissal paths (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx`, lines 86 to 99):
 
-- **Trigger:** app returns to foreground (`AppState` transition from `background`/`inactive` to `active`) while a headless session is still `continued` and no deeplink callback has arrived.
-- **Grace window:** wait a defined duration after foreground (proposed default 2000 ms) for a late deeplink before deciding, to avoid racing a real callback.
-- **Outcome:** after the grace window with no callback, fire `onClose({ reason: 'user_dismissed' })` and end the session. It does NOT emit `onError`, and it does NOT leave MM Pay pending indefinitely.
-- **Escape hatch:** the consumer's `cancel()` and the registry's stale-session GC remain as backstops.
+- `useHeadlessSessionDismissal(headlessSessionId)`.
+- `useHeadlessSessionFocusDismissal(headlessSessionId, isFocused, ...)`, which on re-focus schedules the dismissal via `setTimeout(..., 0)` (`app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts`, line 51) and bails if the session is already gone or the focus / session id changed.
+- A `beforeRemove` navigation listener that closes the session as `user_dismissed` on back-out (lines 91 to 99).
 
-The exact grace duration and whether to auto-dismiss vs leave pending is a product/MM Pay decision; the doc must record the chosen values before implementation.
+Policy: when the external browser hands control back and the app re-focuses `HeadlessHost` with the session still `continued` and no deeplink callback observed, the EXISTING focus-dismissal path is what fires `onClose({ reason: 'user_dismissed' })`. There is no second grace timer. The only Phase 3 / Phase 4 addition is to ensure a real deeplink callback can pre-empt this existing path (see the deeplink reconciliation in Phase 4 and the slow-deeplink risk below): a deeplink-success must terminate the session before, or take precedence over, focus-dismissal. It does NOT emit `onError`, and the consumer's `cancel()` and the registry's stale-session GC remain as backstops.
 
-Tests: each of the three cases routes to the correct terminal callback; the Android policy fires `user_dismissed` only after the grace window and never pre-empts a real deeplink callback.
+The remaining product / MM Pay decision is whether the existing zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
+
+Tests: each of the three cases routes to the correct terminal callback; a deeplink-success callback pre-empts the existing focus-dismissal so a slow-but-successful return is not closed as `user_dismissed`.
 
 ---
 
@@ -226,21 +230,23 @@ Tests: each of the three cases routes to the correct terminal callback; the Andr
 
 Unify callback order resolution shared by `Checkout` and `OrderDetails` (`getOrderFromCallback`, `isBailedOrderStatus`); give the Android deeplink return (`app/components/UI/Ramp/deeplink/handleRampReturnUrl.ts`) a headless path; keep the native Transak auth/KYC loop unchanged via the existing `useTransakRouting` base-route param.
 
-**Android deeplink correlation (concrete design).** Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`; the provider deeplink carries provider path plus query, not the session id, providerCode, or wallet. The return must map back to the active headless session without racing the Phase 3 foreground-dismiss policy:
+**Android deeplink correlation (concrete design).** Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, lines 27 to 28), so the deeplink DOES carry the provider code in its path. It does NOT carry the wallet address, chainId, or session id. The return must map back to the active headless session without racing the Phase 3 focus-dismissal:
 
-1. At external-browser launch (Phase 3), record a pending external-order correlation in the session registry: `{ headlessSessionId, providerCode, walletAddress, chainId }`. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
-2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: it CANCELS the foreground-dismiss grace timer (correlation wins over the abandonment heuristic), resolves the order via the shared callback resolver using `providerCode` / `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fires `onOrderCreated` and ends the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
-3. Ambiguity guard: because only one headless session is active at a time, there is no multi-session matching. If the deeplink arrives with no live session (already dismissed/GC'd), fall back to the non-headless `RAMPS_ORDER_DETAILS` path so the order is still recoverable.
+1. At external-browser launch (Phase 3), record a pending external-order correlation in the session registry: `{ headlessSessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
+2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: it PRE-EMPTS the existing focus-dismissal (correlation wins over the abandonment heuristic), resolves the order via the shared callback resolver using the `providerCode` parsed from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fires `onOrderCreated` and ends the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
+3. Slow-deeplink reconciliation (not just an ambiguity guard): because only one headless session is active at a time, there is no multi-session matching. A SUCCESS deeplink must WIN even if the session was already dismissed or GC'd (see the slow-deeplink money-losing risk below): it must still complete the order through the consumer's `onOrderCreated` (re-opening or directly completing the dismissed session), not be silently dropped to `RAMPS_ORDER_DETAILS`. Only a deeplink with no order / no recoverable success and no live session falls back to the non-headless `RAMPS_ORDER_DETAILS` path so the order is still recoverable manually.
 
-Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the grace-timer cancel stay mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
+**Slow-deeplink money-losing risk (must reconcile).** If the existing focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `app/components/UI/Ramp/headless/sessionRegistry.ts`, line 110) terminates the session BEFORE a slow-but-successful deeplink returns, the session closes as `user_dismissed`, the deeplink falls back to `RAMPS_ORDER_DETAILS`, and the consumer never gets `onOrderCreated`. Because MM Pay's two-step intent transaction is gated on `onOrderCreated` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 112 to 122), a real fiat order completes (the user paid) but the intent leg never fires. Reconciliation rule: a success deeplink must WIN even if the session was already dismissed, re-opening or directly completing the order via `onOrderCreated` rather than being silently dropped.
 
-Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return with a live session fires `onOrderCreated` and cancels the grace timer; deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
+Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the focus-dismissal pre-emption stay mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
+
+Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return with a live session fires `onOrderCreated` and pre-empts focus-dismissal; a success deeplink arriving AFTER the session was dismissed still completes via `onOrderCreated` and is not dropped to `RAMPS_ORDER_DETAILS`; a no-order deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
 
 ---
 
 ## Phase 5 - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
 
-Wire core to consume multi-provider quotes via the Phase 2 shared selector instead of `success[0]`, but keep this path dormant behind the still-closed native-only gate (the gate relaxation itself is Phase 9). Keep the MM Pay terminal-callback contract.
+Wire core to consume multi-provider quotes via the Phase 2 selection util instead of `success[0]`, but keep this path dormant behind the still-closed native-only gate (the gate relaxation itself is Phase 9). Keep the MM Pay terminal-callback contract. Per Phase 2, that util starts mobile-side; core consumes it (or its extracted equivalent) only once 2+ consumers justify extraction.
 
 To prevent the dormant path from rotting, tests must exercise the new core selector directly (selecting the recommended successful quote, ignoring provider-level failures when another quote succeeds) without production activation.
 
@@ -255,9 +261,10 @@ Tests: core selector picks the recommended quote and ignores partial failures; d
 Depends on the Must-fix terminal-callback contract. Then:
 
 - Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures).
-- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits.
-- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param.
-- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `transakErrorCodes.ts` but are unexported). So Phase 6 must either (a) add a core sub-task to export `TRANSAK_ERROR_CODES` / `TransakErrorCode` from the package, or (b) depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until (a) lands.
+- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit, not a typed error: `Checkout.tsx` (lines 386 to 393) already treats it as `closeSession({ reason: 'user_dismissed' })`, so it is excluded from the typed-error list and surfaces via `onClose`.
+- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param. This OTP typed-code fix is confirmed real and in scope now.
+- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `transakErrorCodes.ts` but are unexported). So Phase 6 must either (a) add a core sub-task to export `TRANSAK_ERROR_CODES` / `TransakErrorCode` from the package, or (b) depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until (a) lands. Verify the export against `origin/main` / the published package, NOT against the local checkout: the local core at `/Users/saustrie/github/repos/core/packages/ramps-controller` is STALE (it lacks the Transak error helpers present in the published artifact), so the published package / `origin/main` is the source of truth for the Transak error exports.
+- Scope the taxonomy. The terminal-callback contract must-fix (Must-fix section) and the OTP typed-code fix above are both confirmed real and in scope now. The broader typed-code taxonomy (e.g. `KYC_REQUIRED` and other granular provider codes) is implement-on-demand: add a code when a consumer actually needs to branch on it, not up front.
 
 Tests: each technical failure maps to its typed code; user exits never emit error codes; a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`.
 
@@ -271,9 +278,11 @@ Tests: external-browser abandon and failure emit the expected events with headle
 
 ---
 
-## Phase 8 - DRY cleanup (UB2 UI becomes "dumb")
+## Phase 8 - DRY cleanup (UB2 UI becomes "dumb") (DEFERRED until AFTER Phase 9 activation)
 
-- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (Phase 2); pure callback parsing and status classification (Phase 4); bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
+**Scope: DEFERRED until AFTER Phase 9 activation.** This refactors working UB2 code (regression risk) with no production benefit before all-providers ships. Do it once activation has landed and is stable, not before.
+
+- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (Phase 2, once 2+ consumers justify extraction); pure callback parsing and status classification (Phase 4); bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
 - **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes. The only exception: if the controller API is extended to accept redirect / browser options as inputs, the browser-mode decision can move down; otherwise it stays mobile-side.
 - Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers.
 
@@ -283,12 +292,13 @@ Tests: UB2 regression proves ordering, recommended selection, WebView retry, and
 
 ## Phase 9 - Activation / rollout (the only production-widening phase)
 
-Lands last, after Phases 3, 4, 6, 7 are proven. Flip the gate behind the existing MM Pay fiat feature flags for staged rollout:
+Lands last, after Phases 3, 4, 6, 7 are proven. Flip the gate behind a scoped MM Pay fiat rollout flag for staged rollout:
 
-- Core: remove `restrictToKnownOrNativeProviders` / `autoSelectProvider` from `getRampsQuote` (or make them all-provider) and switch the pick to the Phase 2 shared selector (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 61 to 78).
+- Core: true all-provider quoting requires omitting BOTH `autoSelectProvider` and `providers` so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026). Dropping ONLY `restrictToKnownOrNativeProviders` while keeping `autoSelectProvider: true` is NOT enough: `#resolveProviderIdsForQuote` returns a SINGLE provider id even when `restrictToKnownOrNative` is false, so the auto-select branch still yields one provider. So `getRampsQuote` must drop both flags (not just the restriction) and switch the pick to the Phase 2 selection util (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 61 to 78).
+  - **Catalog hydration (must verify).** Falling back to `state.providers.data` presumes the controller provider catalog is hydrated in the `TransactionPayController` context. TPC currently relies on auto-select, not on `state.providers.data`, so Phase 9 must verify catalog hydration in the TPC context or pass an explicit `providers` list; otherwise all-provider quoting could return zero providers.
 - Mobile: relax the native-only availability gate (`useIsFiatPaymentAvailable` / `useHasNativeFiatProvider`).
 
-**Validate the kill switch before assuming the existing flag works.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing MM Pay fiat flag may do the latter. First task of Phase 9: confirm what `useMMPayFiatConfig` / the existing fiat flags actually gate. If toggling them off disables native fiat too, introduce a distinct config bit or provider-scope flag (e.g. `allProvidersEnabled` / a non-native provider scope) so that "off" falls back to native-only rather than removing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond the kill switch unless product asks.
+**A distinct scoped flag is REQUIRED; the existing flag cannot scope provider-widening.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing `MetaMaskPayFiatFlags` only carries `enabledTransactionTypes` and `maxDelayMinutesForPaymentMethods` (`app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90); there is NO native-vs-all-providers bit, and setting `enabledTransactionTypes: []` disables ALL fiat. So a distinct scoped flag / config bit (e.g. `allProvidersEnabled` / a non-native provider scope) is REQUIRED so that "off" falls back to native-only rather than killing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond it unless product asks. This kill-switch validation is confirmed-correct and stays.
 
 Tests: with the scoped flag on, non-native quotes reach the consumer and complete via headless callbacks; with it off, behavior is identical to today's native-only (native fiat still available).
 
@@ -309,7 +319,7 @@ Tests: with the scoped flag on, non-native quotes reach the consumer and complet
 Time-sensitive references that informed sequencing; verify before relying on them.
 
 - Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic.
-- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES`). Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `transakErrorCodes.ts` but are NOT re-exported from `index.ts`; Phase 6 must add that export before depending on it from mobile.
+- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES`). Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `transakErrorCodes.ts` but are NOT re-exported from `index.ts`; Phase 6 must add that export before depending on it from mobile. Verify against `origin/main` / the published package, not the local checkout: the local core at `/Users/saustrie/github/repos/core/packages/ramps-controller` is STALE and lacks the Transak error helpers present in the published artifact.
 - Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Phase 4.
 - In-flight MM Pay fiat second-leg hardening (core #9267, #9279, #9250, #9216) is coordinated by Phase 5.
 - A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
@@ -320,7 +330,7 @@ Time-sensitive references that informed sequencing; verify before relying on the
 
 Assumptions:
 
-- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). Reuse an existing MM Pay fiat flag only if it has that scope; otherwise add a non-native provider-scope flag (validated in Phase 9). No new product flag beyond the kill switch unless product asks.
+- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (validated in Phase 9). No new product flag beyond the kill switch unless product asks.
 - Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
 - System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the named Android foreground policy for cancellation.
 - Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.
@@ -328,8 +338,9 @@ Assumptions:
 Risks:
 
 - Cross-repo sequencing (core publish before mobile bump).
-- Android foreground-without-callback heuristic reliability and the chosen grace duration.
-- Migrating pure helpers into core without dragging platform policy along.
+- Android foreground-without-callback heuristic reliability (built on the existing focus-dismissal) and whether it needs a deliberate grace delay.
+- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (Phase 4) is implemented.
+- Migrating pure helpers into core without dragging platform policy along (and the cross-repo publish / version coupling cost of doing it before a second consumer exists).
 
 ---
 

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -1,0 +1,308 @@
+# Headless Buy: All Providers Support Plan
+
+> Take Headless Buy (and its MM Pay / Money Account consumer) from native-only to all-provider support: multi-provider quoting, headless-aware non-native checkout (in-app WebView and external-browser providers), typed error outcomes, analytics parity, and DRY shared logic between Unified Buy v2 (UB2) and Headless Buy. The native-only gate stays closed in production the entire time we build; widening to all providers happens last, behind a flag.
+
+This is a companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan) and follows its style.
+
+## Phases checklist
+
+Phases 1 to 8 are capability work, built behind the still-closed native-only gate and exercised only via the dev playground plus unit/integration tests. Phase 9 is the only production-widening phase, flag-gated, landing last.
+
+- [ ] **Phase 1** - All-provider quoting capability (gated, NOT activated)
+- [ ] **Phase 2** - Shared quote selection / recommendation helper
+- [ ] **Phase 3** - WebView + external-browser headless support (pulled early)
+- [ ] **Phase 4** - Native and non-native routing alignment
+- [ ] **Phase 5** - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
+- [ ] **Phase 6** - Typed error handling
+- [ ] **Phase 7** - Analytics parity
+- [ ] **Phase 8** - DRY cleanup (UB2 UI becomes "dumb")
+- [ ] **Phase 9** - Activation / rollout (flag-gated gate-flip)
+
+Pre-phase: a terminal-callback contract fix (see Must-fix preconditions) must land before typed errors expand.
+
+---
+
+## Scope (confirmed: full cross-repo)
+
+Enabling all providers spans three layers, and this plan documents all three as coordinated phases:
+
+- **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` + `restrictToKnownOrNativeProviders: true` and takes only `quotes.success?.[0]` (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, around lines 61 to 78). This is the native-only gate's quote-side enforcement.
+- **`@metamask/ramps-controller`** - home for the shared, PURE quote filter/sort/recommend helper and pure callback parsing/status helpers.
+- **`metamask-mobile`** - relax the native-only availability gate (`useIsFiatPaymentAvailable`, lines 19 to 23; `useHasNativeFiatProvider`, lines 23 to 26); make `useContinueWithQuote`'s external-browser branch headless-aware; typed errors; analytics; DRY; and own all navigation/session and redirect/deeplink policy.
+
+---
+
+## Sequencing and safety: capability vs activation
+
+**Risk:** removing the native-only gate early would route live MM Pay / HeadlessBuy users to aggregator / external-browser quotes before the logic to handle them (Phases 3, 4, 6, 7) exists, landing them in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
+
+**Rule:** the native-only gate stays CLOSED for production the entire time we build capability. We never widen what real users get until the supporting logic is in and verified.
+
+- **Capability phases (1 to 8)** add all-provider quoting, selection, external-browser headless support, typed errors, and analytics, but are exercised only via the dev playground and unit/integration tests. The live MM Pay path keeps `restrictToKnownOrNativeProviders: true`, and `useHasNativeFiatProvider` keeps gating.
+- **Activation phase (9, flag-gated)** is the only phase that widens production. It flips `getRampsQuote` and relaxes the mobile gate, behind the existing MM Pay fiat feature flags, and lands last, after Phases 3, 4, 6, 7 are proven.
+- Within the capability phases, land external-browser headless support (Phase 3) and typed errors (Phase 6) before any wiring that could surface non-native quotes to a consumer.
+
+---
+
+## Design principles
+
+Inherited from [PLAN.md](./PLAN.md), with one addition:
+
+1. **Callbacks-only, three terminal events.** A session ends in exactly one of `onOrderCreated`, `onError`, `onClose`. No intermediate progress callbacks. KYC stays terminal-only for consumers: native Transak may surface auth/limit/KYC-specific typed errors, but non-native provider KYC stays inside the provider checkout unless it produces a terminal callback, cancellation, or load failure.
+2. **The consumer renders all visible UI.** `useHeadlessBuy` is a behavior provider, not a UI provider.
+3. **Callback-routing rule (new).** `onError` is reserved for technical / provider failures only. User-driven and consumer-driven exits terminate via `onClose`, not `onError`:
+   - User in-flow exit (browser cancel, WebView close, back-press, inferred abandonment): `onClose({ reason: 'user_dismissed' })`.
+   - Consumer programmatic cancel (`cancel()` / session replacement): `onClose({ reason: 'consumer_cancelled' })`.
+   - The `USER_CANCELLED` error code is retired for in-session exits. If retained at all, it is reserved only for a pre-session cancellation error and never emitted for in-flow user closes. Otherwise MM Pay cannot distinguish "user backed out" from "provider broke".
+
+---
+
+## Must-fix preconditions (before expanding errors)
+
+**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 263). MM Pay's `onClose` currently clears the error set by `onError`, so the error is lost. This must be fixed or explicitly defined before we expand error codes. Options:
+
+- Signal "already errored" on the trailing `onClose` (a distinct reason, or carry the `HeadlessBuyError` on the close info) so the consumer does not wipe the error; or
+- Do not auto-fire `onClose` after `onError` and document `onError` as terminal on its own.
+
+This is a precondition for Phase 6, not an afterthought.
+
+---
+
+## UB2 behavior to preserve
+
+- The `QuotesResponse` contract `{ success, error, sorted, customActions }` from `@metamask/ramps-controller`. No client-side `Promise.all` fan-out is needed: the existing single `getQuotes` call already models partial failure via `success[]` plus per-provider `error[]`.
+- Provider-level quote errors are non-terminal: they are surfaced as partial errors and only become terminal when every provider fails or no usable quote can be selected.
+- Existing UB2 quote ordering, recommended-quote selection, WebView retry behavior, and OrderDetails routing must remain unchanged (regression-tested).
+
+---
+
+## Concerns addressed
+
+A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the phases below.
+
+### Getting multiple quotes; partial vs full failure
+
+UB2 does not fan out to providers with `Promise.all`. One `RampsController.getQuotes()` call returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal: its message lands in `error[]` while other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
+
+- Partial failure: `success.length > 0 && error.length > 0`. Keep the successes.
+- Full failure: `success.length === 0`. Map to `NO_QUOTES`.
+
+Decision: Headless keeps successes, exposes `error[]`, and never treats a single provider failure as terminal.
+
+### Sorting / ordering quotes like UB2
+
+There are two existing UB2 behaviors:
+
+- **Modal ordering** in `app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx` (lines 205 to 228): reliability-only sort of providers-with-quotes.
+- **Recommendation ladder** in legacy `app/components/UI/Ramp/Aggregator/hooks/useSortedQuotes.ts` (lines 43 to 69): previously-used provider, then reliability, then price.
+
+Headless / MM Pay need the recommendation ladder (to replace core's current `success[0]` pick), not just modal ordering. Provider preference-from-order-history already exists in the controller (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote`), so the new build is the reliability-then-price recommendation among the returned `success[]`.
+
+### Routing for native vs non-native
+
+`useContinueWithQuote` branches on `isNativeProvider(quote)` (`app/components/UI/Ramp/types/index.ts`, lines 33 to 35). Native uses the Transak auth/KYC loop via `useTransakRouting`. Non-native fetches `getBuyWidgetData` then opens either an in-app `Checkout` WebView or an external browser.
+
+### KYC for native vs non-native
+
+Native KYC is fully in-app (NativeFlow screens plus Transak APIs: email, OTP, BasicInfo, KycWebview, KycProcessing, AdditionalVerification). Non-native KYC happens inside the provider's WebView or external browser; MetaMask only learns the outcome at callback / deeplink time.
+
+### In-app WebView providers vs external-browser providers
+
+The decision lives in `getWidgetRedirectConfig` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, lines 35 to 65): custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`).
+
+### Load failure handling and notifying MM Pay
+
+In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). The external-browser path has no load-failure handling and no headless notification today. Decision: route external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit), so MM Pay always receives a terminal callback. See the named observability policy in Phase 3.
+
+### Analytics abandon vs failed
+
+Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. External-browser abandon is currently untracked (Phase 7).
+
+### Gaps in the external-browser branch of `useContinueWithQuote`
+
+The branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) ignores `ctx.headlessSessionId`: cancel, Android `Linking.openURL`, and iOS success all call `navigateAfterExternalBrowser({ returnDestination: 'buildQuote' | 'order' })` (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75), landing on BuildQuote / OrderDetails with no `onOrderCreated` / `onError` / `onClose`. `addPrecreatedOrder` is conditional, and OrderDetails has no headless path.
+
+### Specific non-native errors UB2 handles that Headless does not
+
+Empty callback query, missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `getOrderFromCallback` throw, terminal HTTP error, `getBuyWidgetData` failure, static min/max limits, and no-quotes. Most map to a coarse `UNKNOWN` in headless today; `NO_QUOTES` / `QUOTE_FAILED` are defined but unemitted; and the OTP `nativeFlowError` string path force-maps post-auth failures (including limit / KYC) to `AUTH_FAILED`.
+
+### DRY: logic to move out of UB2 UI
+
+Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Phase 8 for the precise core-vs-mobile split.
+
+---
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+  Consumer["MM Pay / Playground"] --> Hook["useHeadlessBuy()"]
+  Hook -->|getQuotes multi-provider| Ctrl["RampsController.getQuotes"]
+  Ctrl -->|"success[] / error[] / sorted[]"| Hook
+  Consumer -->|"startHeadlessBuy(quote)"| Host["HeadlessHost"]
+  Host --> Continue["useContinueWithQuote"]
+  Continue -->|native| Native["Transak auth / KYC loop"]
+  Continue -->|in-app widget| Checkout["in-app Checkout WebView"]
+  Continue -->|external| Browser["InAppBrowser / system browser + deeplink"]
+  Native --> Terminal["onOrderCreated / onError / onClose"]
+  Checkout --> Terminal
+  Browser --> Terminal
+  Terminal --> Consumer
+```
+
+---
+
+## Phase 1 - All-provider quoting capability (gated, NOT activated)
+
+Build the capability without widening production. `RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller work is required. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`, exercised in the dev playground only. Preserve `QuotesResponse`; classify partial vs full failure; map full failure to `NO_QUOTES`.
+
+Do not touch the live MM Pay path here: `getRampsQuote` keeps `autoSelectProvider` / `restrictToKnownOrNativeProviders`, and `useHasNativeFiatProvider` keeps gating until Phase 9.
+
+Tests: multi-provider request returns multiple `success[]`; partial failure keeps successes plus `error[]`; full failure maps to `NO_QUOTES`; playground renders all providers.
+
+---
+
+## Phase 2 - Shared quote selection / recommendation helper
+
+Extract a pure quote filter/sort/recommend helper into `@metamask/ramps-controller`, consumed by UB2, headless, and MM Pay so ordering and recommendation never diverge. The new build is the reliability-then-price recommendation among `success[]` (the provider preference-from-order-history rung already exists in the controller). The helper operates on the UB2 `QuotesResponse` shape.
+
+Scope guard: only pure quote selection / order resolution moves to core. No mobile deeplink schemes or redirect policy (Phase 8).
+
+Tests: helper unit tests for ladder order (previously-used, then reliability, then price); UB2 and MM Pay both consume it and produce identical ordering.
+
+---
+
+## Phase 3 - WebView + external-browser headless support (pulled early)
+
+Make `continueWidget` fully headless-aware: thread `ctx.headlessSessionId` into the external-browser branch so it routes to `onOrderCreated` / `closeSession` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`useContinueWithQuote.ts`, lines 289 to 335; `rampsNavigation.ts`, lines 50 to 75).
+
+Observability is only partial; document the three cases explicitly:
+
+- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously. Success resolves the order; cancel fires `onClose({ reason: 'user_dismissed' })`; error fires `failSession`.
+- **`Linking.openURL` (Android / no InAppBrowser)**: we can only catch the OPEN failure (promise rejection, which fires `failSession`). We cannot observe provider page load.
+- **Android / system browser**: provider-side load failure is unknowable. Success arrives via deeplink return. Abandonment is inferred by a named policy (below), not guaranteed.
+
+### Android foreground-without-callback policy (named, must be decided)
+
+A concrete policy is required, not a vague "timeout":
+
+- **Trigger:** app returns to foreground (`AppState` transition from `background`/`inactive` to `active`) while a headless session is still `continued` and no deeplink callback has arrived.
+- **Grace window:** wait a defined duration after foreground (proposed default 2000 ms) for a late deeplink before deciding, to avoid racing a real callback.
+- **Outcome:** after the grace window with no callback, fire `onClose({ reason: 'user_dismissed' })` and end the session. It does NOT emit `onError`, and it does NOT leave MM Pay pending indefinitely.
+- **Escape hatch:** the consumer's `cancel()` and the registry's stale-session GC remain as backstops.
+
+The exact grace duration and whether to auto-dismiss vs leave pending is a product/MM Pay decision; the doc must record the chosen values before implementation.
+
+Tests: each of the three cases routes to the correct terminal callback; the Android policy fires `user_dismissed` only after the grace window and never pre-empts a real deeplink callback.
+
+---
+
+## Phase 4 - Native and non-native routing alignment
+
+Unify callback order resolution shared by `Checkout` and `OrderDetails` (`getOrderFromCallback`, `isBailedOrderStatus`); give the Android deeplink return (`app/components/UI/Ramp/deeplink/handleRampReturnUrl.ts`) a headless path; keep the native Transak auth/KYC loop unchanged via the existing `useTransakRouting` base-route param.
+
+Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). Anything that needs mobile navigation or session behavior stays mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
+
+Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return fires headless callbacks; native loop unchanged (regression).
+
+---
+
+## Phase 5 - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
+
+Wire core to consume multi-provider quotes via the Phase 2 shared selector instead of `success[0]`, but keep this path dormant behind the still-closed native-only gate (the gate relaxation itself is Phase 9). Keep the MM Pay terminal-callback contract.
+
+To prevent the dormant path from rotting, tests must exercise the new core selector directly (selecting the recommended successful quote, ignoring provider-level failures when another quote succeeds) without production activation.
+
+Upstream coordination: sequence against the in-flight `transaction-pay-controller` fiat second-leg hardening (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay). That two-step fiat-to-intent flow depends on the terminal-callback contract fixed in the Must-fix section, so Phase 5 lands after the Must-fix and after those changes are merged and published.
+
+Tests: core selector picks the recommended quote and ignores partial failures; dormant path proven by tests while production stays native-only.
+
+---
+
+## Phase 6 - Typed error handling
+
+Depends on the Must-fix terminal-callback contract. Then:
+
+- Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures).
+- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits.
+- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param, mapping the now-exported `TRANSAK_ERROR_CODES` plus `getTransakApiMessage` / `isTransakPhoneRegisteredError` (core #9135) into `HeadlessBuyError` codes.
+
+Tests: each technical failure maps to its typed code; user exits never emit error codes; a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`.
+
+---
+
+## Phase 7 - Analytics parity
+
+Bring external-browser providers to parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), all tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
+
+Tests: external-browser abandon and failure emit the expected events with headless tags; terminal failed / cancelled events fire once.
+
+---
+
+## Phase 8 - DRY cleanup (UB2 UI becomes "dumb")
+
+- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (Phase 2); pure callback parsing and status classification (Phase 4); bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
+- **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes. The only exception: if the controller API is extended to accept redirect / browser options as inputs, the browser-mode decision can move down; otherwise it stays mobile-side.
+- Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers.
+
+Tests: UB2 regression proves ordering, recommended selection, WebView retry, and OrderDetails routing are unchanged after the extraction.
+
+---
+
+## Phase 9 - Activation / rollout (the only production-widening phase)
+
+Lands last, after Phases 3, 4, 6, 7 are proven. Flip the gate behind the existing MM Pay fiat feature flags for staged rollout:
+
+- Core: remove `restrictToKnownOrNativeProviders` / `autoSelectProvider` from `getRampsQuote` (or make them all-provider) and switch the pick to the Phase 2 shared selector (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 61 to 78).
+- Mobile: relax the native-only availability gate (`useIsFiatPaymentAvailable` / `useHasNativeFiatProvider`).
+- Roll out incrementally via the existing flags; no new product flag unless product asks. Verify the kill-switch path (flag off returns to native-only) before wide release.
+
+Tests: with the flag on, non-native quotes reach the consumer and complete via headless callbacks; with the flag off, behavior is identical to today's native-only.
+
+---
+
+## Test plan (consolidated)
+
+- ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared recommendation order.
+- Transaction Pay: selecting the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds; dormant-path coverage before activation.
+- Mobile hooks: `useHeadlessBuy`, `useContinueWithQuote`, `HeadlessHost`, `Checkout`, and external-browser deeplink return.
+- UB2 regression: quote ordering, recommended quote selection, WebView retry behavior, and order-details routing unchanged.
+- Analytics: `RAMPS_CHECKOUT_CLOSED`, `RAMPS_ORDER_FAILED`, provider cancellation, checkout HTTP / load failures, and order terminal failed / cancelled events.
+
+---
+
+## Upstream context
+
+Time-sensitive references that informed sequencing; verify before relying on them.
+
+- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic.
+- Transak typed errors are now exported (core #9135): `TRANSAK_ERROR_CODES`, `getTransakApiMessage`, `isTransakPhoneRegisteredError` (used by Phase 6).
+- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Phase 4.
+- In-flight MM Pay fiat second-leg hardening (core #9267, #9279, #9250, #9216) is coordinated by Phase 5.
+- A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
+
+---
+
+## Open risks and assumptions
+
+Assumptions:
+
+- Ship behind the existing MM Pay fiat feature flags; do not introduce a new product flag unless product asks for staged rollout.
+- Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
+- System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the named Android foreground policy for cancellation.
+- Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.
+
+Risks:
+
+- Cross-repo sequencing (core publish before mobile bump).
+- Android foreground-without-callback heuristic reliability and the chosen grace duration.
+- Migrating pure helpers into core without dragging platform policy along.
+
+---
+
+## Out of scope
+
+- Sell flow parity (headless Sell is a follow-up).
+- Non-React / imperative global consumers.
+- Wholesale migration of BuildQuote to the headless primitives.
+- Exporting `useHeadlessBuy` outside of Ramp.

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -59,10 +59,13 @@ Inherited from [PLAN.md](./PLAN.md), with one addition:
 
 ## Must-fix preconditions (before expanding errors)
 
-**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 263). MM Pay's `onClose` currently clears the error set by `onError`, so the error is lost. This must be fixed or explicitly defined before we expand error codes. Options:
+**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 263). MM Pay's `onClose` currently clears the error set by `onError`, so the error is lost.
 
-- Signal "already errored" on the trailing `onClose` (a distinct reason, or carry the `HeadlessBuyError` on the close info) so the consumer does not wipe the error; or
-- Do not auto-fire `onClose` after `onError` and document `onError` as terminal on its own.
+**Decision (chosen contract):** `onError` is terminal on its own. `failSession` fires `onError` and then ends the session WITHOUT a trailing `onClose`. A session ends in exactly one of `onOrderCreated`, `onError`, or `onClose`, with no pairing. This keeps "provider broke" (`onError`) cleanly separable from "user/consumer exited" (`onClose`).
+
+Implementation: `failSession` stops calling `closeSession`; it sets the terminal status (`failed`) and removes the session from the registry directly, without invoking `onClose`. `onClose` remains the terminal event only for `user_dismissed` / `consumer_cancelled` / `completed` paths.
+
+Caveat to confirm with MM Pay before building Phase 6: if MM Pay relies on a single cleanup hook regardless of outcome, we instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract above unless MM Pay asks for the cleanup variant.
 
 This is a precondition for Phase 6, not an afterthought.
 
@@ -84,10 +87,12 @@ A direct answer to each open question that motivated this plan. Findings are UB2
 
 UB2 does not fan out to providers with `Promise.all`. One `RampsController.getQuotes()` call returns `{ success[], sorted[], error[], customActions[] }`; multi-provider parallelism is server-side. A single provider failing is non-terminal: its message lands in `error[]` while other providers stay in `success[]`. Only HTTP / validation / malformed-shape failures reject the promise.
 
-- Partial failure: `success.length > 0 && error.length > 0`. Keep the successes.
-- Full failure: `success.length === 0`. Map to `NO_QUOTES`.
+`customActions[]` matters here: UB2 can still render `customActions` (e.g. PayPal-style providers) even when `success[]` is empty, and those use a separate CTA / external-browser path rather than a normal `Quote`. So "no quotes" is NOT just `success.length === 0`.
 
-Decision: Headless keeps successes, exposes `error[]`, and never treats a single provider failure as terminal.
+- Partial failure: at least one usable candidate exists. Keep it.
+- Full failure: `success.length === 0 && customActions.length === 0`. Map to `NO_QUOTES`.
+
+Decision: custom-action providers are IN scope for all-providers. The candidate set is a union of `success[]` (`Quote`) and `customActions[]` (custom-action), so selection, "no quotes", and continuation must operate over a unified candidate model, not over `success[]` alone.
 
 ### Sorting / ordering quotes like UB2
 
@@ -154,27 +159,47 @@ flowchart LR
 
 ## Phase 1 - All-provider quoting capability (gated, NOT activated)
 
-Build the capability without widening production. `RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller work is required. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`, exercised in the dev playground only. Preserve `QuotesResponse`; classify partial vs full failure; map full failure to `NO_QUOTES`.
+Build the capability without widening production. `RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller work is required. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`, exercised in the dev playground only. Preserve `QuotesResponse`.
+
+Define a **candidate model** up front: a discriminated union over `success[]` (`Quote`, normal checkout path) and `customActions[]` (custom-action, separate CTA / external-browser path). Selection and "no quotes" operate over candidates, not over `success[]` alone. Full failure is `success.length === 0 && customActions.length === 0`, which maps to `NO_QUOTES`.
 
 Do not touch the live MM Pay path here: `getRampsQuote` keeps `autoSelectProvider` / `restrictToKnownOrNativeProviders`, and `useHasNativeFiatProvider` keeps gating until Phase 9.
 
-Tests: multi-provider request returns multiple `success[]`; partial failure keeps successes plus `error[]`; full failure maps to `NO_QUOTES`; playground renders all providers.
+Tests: multi-provider request returns multiple candidates; partial failure keeps usable candidates plus `error[]`; a `customActions`-only response is NOT `NO_QUOTES`; full failure (no success, no custom actions) maps to `NO_QUOTES`; playground renders all providers including custom actions.
 
 ---
 
 ## Phase 2 - Shared quote selection / recommendation helper
 
-Extract a pure quote filter/sort/recommend helper into `@metamask/ramps-controller`, consumed by UB2, headless, and MM Pay so ordering and recommendation never diverge. The new build is the reliability-then-price recommendation among `success[]` (the provider preference-from-order-history rung already exists in the controller). The helper operates on the UB2 `QuotesResponse` shape.
+Extract a pure quote filter/sort/recommend helper into `@metamask/ramps-controller`, consumed by UB2, headless, and MM Pay so ordering and recommendation never diverge. The new build is the reliability-then-price recommendation among candidates (the provider preference-from-order-history rung already exists in the controller's `getQuotes` provider resolution).
 
-Scope guard: only pure quote selection / order resolution moves to core. No mobile deeplink schemes or redirect policy (Phase 8).
+The helper must be PURE, with explicit inputs (it cannot read controller-private order history or mobile Redux). Proposed signature:
 
-Tests: helper unit tests for ladder order (previously-used, then reliability, then price); UB2 and MM Pay both consume it and produce identical ordering.
+```ts
+recommendQuotes(input: {
+  response: QuotesResponse;           // success[], sorted[], error[], customActions[]
+  preferredProviderIds?: string[];    // caller supplies order-history / preference, in priority order
+}): { ordered: Candidate[]; recommended?: Candidate };
+```
+
+Defined behavior the helper must specify:
+
+- Ladder: first a candidate whose provider id is in `preferredProviderIds` (in order), then `sorted` with `sortBy === 'reliability'`, then `sorted` with `sortBy === 'price'`.
+- `sorted` handling: map provider ids to candidates; ids missing from `sorted` are appended after sorted ones in a stable, documented order (e.g. original `success[]` order, then `customActions[]`).
+- Price fallback: when no `reliability` sort entry exists, fall back to the `price` sort entry; when neither exists, preserve input order.
+- Provider id normalization: match on normalized provider code so `/providers/x` and `x` are equivalent.
+
+Scope guard: only this pure selection / order resolution moves to core. No mobile deeplink schemes or redirect policy (Phase 8).
+
+Tests: ladder order with and without `preferredProviderIds`; missing `sorted` entries; price fallback; custom-action candidates included; identical output for UB2 and MM Pay callers.
 
 ---
 
 ## Phase 3 - WebView + external-browser headless support (pulled early)
 
 Make `continueWidget` fully headless-aware: thread `ctx.headlessSessionId` into the external-browser branch so it routes to `onOrderCreated` / `closeSession` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`useContinueWithQuote.ts`, lines 289 to 335; `rampsNavigation.ts`, lines 50 to 75).
+
+**Redirect URL: name one source of truth.** Today `getQuotes` accepts a `redirectUrl` override, but `HeadlessHost` does not pass `HeadlessBuyParams.redirectUrl` into `useContinueWithQuote`, and `continueWidget` recomputes the redirect URL via the mobile redirect-policy util. Decision: the mobile redirect-policy util (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig`) is the source of truth at checkout continuation. `HeadlessBuyParams.redirectUrl` is an optional override that must be threaded from the session onto `ContinueWithQuoteContext` and honored by `continueWidget` when present; when absent, the policy util computes it. The quote-fetch `redirectUrl` and the continuation `redirectUrl` must resolve from this same rule so they cannot diverge.
 
 Observability is only partial; document the three cases explicitly:
 
@@ -201,9 +226,15 @@ Tests: each of the three cases routes to the correct terminal callback; the Andr
 
 Unify callback order resolution shared by `Checkout` and `OrderDetails` (`getOrderFromCallback`, `isBailedOrderStatus`); give the Android deeplink return (`app/components/UI/Ramp/deeplink/handleRampReturnUrl.ts`) a headless path; keep the native Transak auth/KYC loop unchanged via the existing `useTransakRouting` base-route param.
 
-Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). Anything that needs mobile navigation or session behavior stays mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
+**Android deeplink correlation (concrete design).** Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`; the provider deeplink carries provider path plus query, not the session id, providerCode, or wallet. The return must map back to the active headless session without racing the Phase 3 foreground-dismiss policy:
 
-Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return fires headless callbacks; native loop unchanged (regression).
+1. At external-browser launch (Phase 3), record a pending external-order correlation in the session registry: `{ headlessSessionId, providerCode, walletAddress, chainId }`. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
+2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: it CANCELS the foreground-dismiss grace timer (correlation wins over the abandonment heuristic), resolves the order via the shared callback resolver using `providerCode` / `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fires `onOrderCreated` and ends the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
+3. Ambiguity guard: because only one headless session is active at a time, there is no multi-session matching. If the deeplink arrives with no live session (already dismissed/GC'd), fall back to the non-headless `RAMPS_ORDER_DETAILS` path so the order is still recoverable.
+
+Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the grace-timer cancel stay mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
+
+Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return with a live session fires `onOrderCreated` and cancels the grace timer; deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
 
 ---
 
@@ -225,7 +256,8 @@ Depends on the Must-fix terminal-callback contract. Then:
 
 - Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures).
 - Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits.
-- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param, mapping the now-exported `TRANSAK_ERROR_CODES` plus `getTransakApiMessage` / `isTransakPhoneRegisteredError` (core #9135) into `HeadlessBuyError` codes.
+- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param.
+- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `transakErrorCodes.ts` but are unexported). So Phase 6 must either (a) add a core sub-task to export `TRANSAK_ERROR_CODES` / `TransakErrorCode` from the package, or (b) depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until (a) lands.
 
 Tests: each technical failure maps to its typed code; user exits never emit error codes; a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`.
 
@@ -255,9 +287,10 @@ Lands last, after Phases 3, 4, 6, 7 are proven. Flip the gate behind the existin
 
 - Core: remove `restrictToKnownOrNativeProviders` / `autoSelectProvider` from `getRampsQuote` (or make them all-provider) and switch the pick to the Phase 2 shared selector (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 61 to 78).
 - Mobile: relax the native-only availability gate (`useIsFiatPaymentAvailable` / `useHasNativeFiatProvider`).
-- Roll out incrementally via the existing flags; no new product flag unless product asks. Verify the kill-switch path (flag off returns to native-only) before wide release.
 
-Tests: with the flag on, non-native quotes reach the consumer and complete via headless callbacks; with the flag off, behavior is identical to today's native-only.
+**Validate the kill switch before assuming the existing flag works.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing MM Pay fiat flag may do the latter. First task of Phase 9: confirm what `useMMPayFiatConfig` / the existing fiat flags actually gate. If toggling them off disables native fiat too, introduce a distinct config bit or provider-scope flag (e.g. `allProvidersEnabled` / a non-native provider scope) so that "off" falls back to native-only rather than removing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond the kill switch unless product asks.
+
+Tests: with the scoped flag on, non-native quotes reach the consumer and complete via headless callbacks; with it off, behavior is identical to today's native-only (native fiat still available).
 
 ---
 
@@ -276,7 +309,7 @@ Tests: with the flag on, non-native quotes reach the consumer and complete via h
 Time-sensitive references that informed sequencing; verify before relying on them.
 
 - Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic.
-- Transak typed errors are now exported (core #9135): `TRANSAK_ERROR_CODES`, `getTransakApiMessage`, `isTransakPhoneRegisteredError` (used by Phase 6).
+- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES`). Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `transakErrorCodes.ts` but are NOT re-exported from `index.ts`; Phase 6 must add that export before depending on it from mobile.
 - Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Phase 4.
 - In-flight MM Pay fiat second-leg hardening (core #9267, #9279, #9250, #9216) is coordinated by Phase 5.
 - A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
@@ -287,7 +320,7 @@ Time-sensitive references that informed sequencing; verify before relying on the
 
 Assumptions:
 
-- Ship behind the existing MM Pay fiat feature flags; do not introduce a new product flag unless product asks for staged rollout.
+- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). Reuse an existing MM Pay fiat flag only if it has that scope; otherwise add a non-native provider-scope flag (validated in Phase 9). No new product flag beyond the kill switch unless product asks.
 - Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
 - System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the named Android foreground policy for cancellation.
 - Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.

--- a/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
+++ b/app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md
@@ -4,43 +4,39 @@
 
 This is a companion to [PLAN.md](./PLAN.md) (the original Headless Buy plan) and follows its style.
 
-## Phases checklist
+## Milestones checklist
 
-Phases 1 to 8 are capability work, built behind the still-closed native-only gate and exercised only via the dev playground plus unit/integration tests. Phase 9 is the only production-widening phase, flag-gated, landing last.
+Milestones 0 to 2 are capability work, built behind the still-closed native-only gate and exercised only via the dev playground plus unit/integration tests. Milestone 3 is the only production-widening milestone, flag-gated, landing last. Milestone 4+ is deferred follow-up.
 
-- [ ] **Phase 1** - All-provider quoting capability (gated, NOT activated)
-- [ ] **Phase 2** - Quote selection / recommendation util (mobile-side first; core extraction DEFERRED)
-- [ ] **Phase 3** - WebView + external-browser headless support (pulled early)
-- [ ] **Phase 4** - Native and non-native routing alignment
-- [ ] **Phase 5** - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
-- [ ] **Phase 6** - Typed error handling
-- [ ] **Phase 7** - Analytics parity
-- [ ] **Phase 8** - DRY cleanup (UB2 UI becomes "dumb") (DEFERRED until after Phase 9)
-- [ ] **Phase 9** - Activation / rollout (flag-gated gate-flip)
+- [ ] **Milestone 0** - Must-fix preconditions (no production behavior change)
+- [ ] **Milestone 1** - All-provider quoting capability (built but gated OFF)
+- [ ] **Milestone 2** - Headless checkout for non-native providers (makes widening safe)
+- [ ] **Milestone 3** - Activation behind a required scoped flag
+- [ ] **Milestone 4+** - Deferred (broad typed errors, analytics parity, TPC multi-provider wiring, DRY cleanup)
 
-Pre-phase: a terminal-callback contract fix (see Must-fix preconditions) must land before typed errors expand.
+Milestone 0 is a precondition for everything else: the terminal-callback contract fix (see Must-fix preconditions) and the OTP typed-code fix must land before typed errors expand or before any consumer relies on terminal outcomes.
 
 ---
 
 ## Scope (confirmed: full cross-repo)
 
-Enabling all providers spans three layers, and this plan documents all three as coordinated phases:
+Enabling all providers spans three layers, and this plan documents all three as coordinated milestones:
 
-- **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` + `restrictToKnownOrNativeProviders: true` and takes only `quotes.success?.[0]` (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, around lines 61 to 78). This is the native-only gate's quote-side enforcement.
-- **`@metamask/ramps-controller`** - eventual home for the PURE quote filter/sort/recommend helper and pure callback parsing/status helpers, but only once 2+ consumers justify extraction. The selection / recommendation util starts mobile-side (see Phase 2, DEFERRED), since the order-history rung cannot be reused from core and there is one real consumer today.
-- **`metamask-mobile`** - relax the native-only availability gate (`useIsFiatPaymentAvailable`, lines 19 to 23; `useHasNativeFiatProvider`, lines 23 to 26); make `useContinueWithQuote`'s external-browser branch headless-aware; typed errors; analytics; DRY; and own all navigation/session and redirect/deeplink policy.
+- **`@metamask/core` - `TransactionPayController`** (the MM Pay fiat quote path). `getRampsQuote` calls `RampsController:getQuotes` with `autoSelectProvider: true` (line ~113) + `restrictToKnownOrNativeProviders: true` (line ~116) and takes only `quotes.success?.[0]` (line ~124) (source: `packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, the `getRampsQuote` function around lines 95 to 131 on `origin/main`). This is the native-only gate's quote-side enforcement.
+- **`@metamask/ramps-controller`** - eventual home for the PURE quote filter/sort/recommend helper and pure callback parsing/status helpers, but only once 2+ consumers justify extraction. The selection / recommendation util starts mobile-side (see Milestone 1.2), since the order-history rung cannot be reused from core and there is one real consumer today.
+- **`metamask-mobile`** - relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26); make `useContinueWithQuote`'s external-browser branch headless-aware; typed errors; analytics; DRY; and own all navigation/session and redirect/deeplink policy.
 
 ---
 
 ## Sequencing and safety: capability vs activation
 
-**Risk:** removing the native-only gate early would route live MM Pay / HeadlessBuy users to aggregator / external-browser quotes before the logic to handle them (Phases 3, 4, 6, 7) exists, landing them in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
+**Risk:** removing the native-only gate early would route live MM Pay / HeadlessBuy users to aggregator / external-browser quotes before the logic to handle them (Milestone 2, and the typed-error / analytics follow-ups) exists, landing them in the broken external-browser branch (silent BuildQuote reset, no terminal callback). That is the "user backed out vs provider broke" confusion we must avoid.
 
 **Rule:** the native-only gate stays CLOSED for production the entire time we build capability. We never widen what real users get until the supporting logic is in and verified.
 
-- **Capability phases (1 to 8)** add all-provider quoting, selection, external-browser headless support, typed errors, and analytics, but are exercised only via the dev playground and unit/integration tests. The live MM Pay path keeps `restrictToKnownOrNativeProviders: true`, and `useHasNativeFiatProvider` keeps gating.
-- **Activation phase (9, flag-gated)** is the only phase that widens production. It flips `getRampsQuote` and relaxes the mobile gate, behind the existing MM Pay fiat feature flags, and lands last, after Phases 3, 4, 6, 7 are proven.
-- Within the capability phases, land external-browser headless support (Phase 3) and typed errors (Phase 6) before any wiring that could surface non-native quotes to a consumer.
+- **Capability milestones (0 to 2)** add all-provider quoting, selection, external-browser headless support, and the headless deeplink path, but are exercised only via the dev playground and unit/integration tests. The live MM Pay path keeps `restrictToKnownOrNativeProviders: true`, and `useHasNativeFiatProvider` keeps gating.
+- **Activation milestone (3, flag-gated)** is the only milestone that widens production. It flips `getRampsQuote` and relaxes the mobile gate, behind a distinct scoped flag, and lands last, after Milestone 2 is proven.
+- Within the capability milestones, land external-browser headless support and the headless deeplink path (Milestone 2) before any wiring that could surface non-native quotes to a consumer.
 
 ---
 
@@ -59,15 +55,15 @@ Inherited from [PLAN.md](./PLAN.md), with one addition:
 
 ## Must-fix preconditions (before expanding errors)
 
-**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 263). MM Pay's `onClose` currently clears the error set by `onError`, so the error is lost.
+**Terminal-callback contract bug.** `failSession` fires `onError(...)` then `closeSession({ reason: 'unknown' })`, which fires `onClose(...)` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 264). MM Pay's `onClose` currently clears the error set by `onError` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, the `onClose` handler at lines 129 to 132 calls `setHeadlessBuyError(undefined)`), so the error is lost.
 
 **Decision (chosen contract):** `onError` is terminal on its own. `failSession` fires `onError` and then ends the session WITHOUT a trailing `onClose`. A session ends in exactly one of `onOrderCreated`, `onError`, or `onClose`, with no pairing. This keeps "provider broke" (`onError`) cleanly separable from "user/consumer exited" (`onClose`).
 
 Implementation: `failSession` stops calling `closeSession`; it sets the terminal status (`failed`) and removes the session from the registry directly, without invoking `onClose`. `onClose` remains the terminal event only for `user_dismissed` / `consumer_cancelled` / `completed` paths.
 
-Caveat to confirm with MM Pay before building Phase 6: if MM Pay relies on a single cleanup hook regardless of outcome, we instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract above unless MM Pay asks for the cleanup variant.
+Caveat to confirm with MM Pay before building broad typed errors: if MM Pay relies on a single cleanup hook regardless of outcome, we instead carry the `HeadlessBuyError` on the close info and fire one `onClose({ reason: 'errored', error })` after `onError`. Default is the no-trailing-`onClose` contract above unless MM Pay asks for the cleanup variant.
 
-This is a precondition for Phase 6, not an afterthought.
+This is a precondition for the typed-error work (Milestone 4), not an afterthought, and is implemented as Milestone 0.1.
 
 ---
 
@@ -81,7 +77,7 @@ This is a precondition for Phase 6, not an afterthought.
 
 ## Concerns addressed
 
-A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the phases below.
+A direct answer to each open question that motivated this plan. Findings are UB2-vs-Headless; decisions feed the milestones below.
 
 ### Getting multiple quotes; partial vs full failure
 
@@ -113,15 +109,15 @@ Native KYC is fully in-app (NativeFlow screens plus Transak APIs: email, OTP, Ba
 
 ### In-app WebView providers vs external-browser providers
 
-The decision lives in `getWidgetRedirectConfig` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, lines 35 to 65): custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`).
+The decision lives in `getWidgetRedirectConfig` / `getAggregatorRedirectConfig` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the redirect-config helpers around lines 35 to 71): custom actions and `buyWidget.browser === 'IN_APP_OS_BROWSER'` go to an external browser with a deeplink redirect; otherwise an in-app `Checkout` WebView with a callback-base redirect. This is the reason the gate removal must be LAST: external-vs-in-app is decided per-quote AFTER `getBuyWidgetData`, so you cannot limit quote-widening to only in-app-WebView providers at the quote layer (see "Conflicts resolved"). In-app success is detected via `getOrderFromCallback` on the callback URL; external success returns via iOS `InAppBrowser.openAuth` result or an Android deeplink (`handleRampReturnUrl`).
 
 ### Load failure handling and notifying MM Pay
 
-In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). The external-browser path has no load-failure handling and no headless notification today. Decision: route external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit), so MM Pay always receives a terminal callback. See the named observability policy in Phase 3.
+In-app `Checkout` handles `onHttpError` (terminal failure routes to `failHeadlessCheckout`, which fires `RAMPS_ORDER_FAILED` and `failSession`). The external-browser path has no load-failure handling and no headless notification today. Decision: route external-browser open / load / cancel / bail outcomes through `failSession` (technical) or `closeSession` (user exit), so MM Pay always receives a terminal callback. See the observability policy in Milestone 2.
 
 ### Analytics abandon vs failed
 
-Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. External-browser abandon is currently untracked (Phase 7).
+Abandon is tracked via `RAMPS_CHECKOUT_CLOSED.close_source` plus the headless `onClose` reason. Failure is tracked via terminal `RampsController:orderStatusChanged` (`RAMPS_TRANSACTION_FAILED`) and in-flow headless `RAMPS_ORDER_FAILED`. External-browser abandon is currently untracked (Milestone 5).
 
 ### Gaps in the external-browser branch of `useContinueWithQuote`
 
@@ -133,7 +129,7 @@ Missing wallet / providerCode, null or bailed order (`isBailedOrderStatus`), `ge
 
 ### DRY: logic to move out of UB2 UI
 
-Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Phase 8 for the precise core-vs-mobile split.
+Quote selection / recommendation, min/max validation, callback parsing/status, and bailed-status checks are pure and should be shared. Redirect / browser-mode decision and deeplink-scheme construction are platform policy and stay mobile-side. See Milestone 7 for the precise core-vs-mobile split.
 
 ---
 
@@ -157,25 +153,47 @@ flowchart LR
 
 ---
 
-## Phase 1 - All-provider quoting capability (gated, NOT activated)
+## Conflicts resolved
 
-Build the capability without widening production. `RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller work is required. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`, exercised in the dev playground only. Preserve `QuotesResponse`.
+Three reconciliations that shaped this milestone ordering; capturing them so we do not re-litigate during implementation:
 
-Candidate selection operates over `success[]` only, with `isCustomAction` entries filtered out. Custom actions are OUT of scope for this effort (see the "Getting multiple quotes" concern): there is no union candidate model. Full failure is "no usable non-customAction `success[]` entry", which maps to `NO_QUOTES`. Filtering custom actions out of headless candidate selection is what keeps removing `restrictToKnownOrNativeProviders` from surfacing an unhandled custom-action path.
-
-Do not touch the live MM Pay path here: `getRampsQuote` keeps `autoSelectProvider` / `restrictToKnownOrNativeProviders`, and `useHasNativeFiatProvider` keeps gating until Phase 9.
-
-Tests: multi-provider request returns multiple non-customAction candidates; partial failure keeps usable candidates plus `error[]`; `isCustomAction` `success[]` entries are filtered out of candidate selection; full failure (no usable non-customAction `success[]` entry) maps to `NO_QUOTES`; playground renders all non-custom providers.
+- **Gate removal is LAST.** You cannot limit quote-widening to only in-app-WebView providers at the quote layer, because external-vs-in-app is decided PER-QUOTE by `buyWidget.browser === 'IN_APP_OS_BROWSER'` only AFTER `getBuyWidgetData` runs at continuation (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig` in `app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`). So the quote layer cannot pre-filter to "safe" providers; the only safe ordering is to make external-browser checkout headless-aware first (Milestone 2), then widen quoting in production (Milestone 3).
+- **The recommendation ladder is mobile-side.** The order-history preference rung is `#private` in `RampsController` and only runs in the single-provider auto-select branch, so it cannot be reused from core. The selection util is built mobile-side first (Milestone 1.2); extraction to `@metamask/ramps-controller` waits for a second consumer (Milestone 6).
+- **A distinct scoped flag is required.** The existing `MetaMaskPayFiatFlags` cannot scope provider-widening (`enabledTransactionTypes: []` kills all fiat), so activation needs a new scoped flag whose "off" state falls back to native-only, not "no fiat" (Milestone 3.1).
 
 ---
 
-## Phase 2 - Shared quote selection / recommendation helper (DEFERRED: build as a mobile-side util first)
+## Milestone 0 - Must-fix preconditions (no production behavior change)
 
-**Scope: DEFERRED.** Do NOT extract a shared helper into `@metamask/ramps-controller` up front. Build it as a mobile-side util first. There is a single real consumer today (headless / MM Pay), and the order-history rung cannot be pulled from core (see below), so a cross-repo extraction now buys publish / version coupling cost (core must publish, then mobile must bump) with no second consumer to justify it. Extract to `@metamask/ramps-controller` only once there are 2+ confirmed consumers.
+Goal: fix the two correctness bugs that any downstream typed-error / terminal-callback work depends on. Neither changes production behavior for today's native-only flow.
 
-Build the reliability-then-price recommendation among the non-customAction `success[]` entries (custom actions are filtered out; see Phase 1).
+### M0.1 - Make `failSession` terminal
 
-**The previously-used-provider rung must be re-derived mobile-side; it cannot be reused from core.** `#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote` are `#private` and run only in the single-provider auto-select branch (`else if (autoSelectProvider || restrictToKnownOrNativeProviders)`, `node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, lines 1003 to 1024). In the all-provider path (gating flags omitted) `getQuotes` takes the `else` branch and quotes `state.providers.data` (line 1026), so that order-history rung is NOT invoked and cannot be reused by a pure / mobile helper. The mobile util derives the preferred-provider list from order history itself and supplies it as an explicit input.
+`onError` fires, the session is removed, and there is NO trailing `onClose`. See the Must-fix preconditions section for the full contract. `failSession` (`app/components/UI/Ramp/headless/sessionRegistry.ts`, lines 235 to 264) currently calls `closeSession({ reason: 'unknown' }, { terminalStatus: 'failed' })` after `onError`, and the MM Pay consumer (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 123 to 132) clears the error in its `onClose` handler. Fix: `failSession` sets the terminal status and removes the session directly, without invoking `onClose`.
+
+Tests: `failSession` fires exactly one `onError` and no `onClose`; the session is removed from the registry; the MM Pay consumer retains the error after a failure.
+
+### M0.2 - OTP typed-code fix
+
+Stop force-mapping `nativeFlowError` to `AUTH_FAILED`. `HeadlessHost.tsx` (the `nativeFlowError` effect at lines 136 to 147) hard-codes `code: 'AUTH_FAILED'` and the `'AUTH_FAILED'` fallback for any `nativeFlowError` string. The OTP path (`OtpCode`) hands back a bare `nativeFlowError` string, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled as `AUTH_FAILED`. (Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` via the `error.name` check.) Fix: thread a typed code (not a string) through the native route-back param so post-auth failures keep their real code.
+
+Tests: a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`; a genuine auth failure still surfaces `AUTH_FAILED`.
+
+---
+
+## Milestone 1 - All-provider quoting capability (built but gated OFF)
+
+Goal: build everything needed to request, filter, and recommend multi-provider quotes, plus the core widening, but DO NOT activate any of it in production. The live MM Pay path keeps both gating flags; `useHasNativeFiatProvider` keeps gating. Exercised only via the dev playground and unit/integration tests.
+
+### M1.1 - Filter `isCustomAction` out of headless candidate selection
+
+`RampsController.getQuotes` already supports all-provider quoting by omitting the gating flags (auto-selection internals are already on core main and published), so no new controller logic is required for the request itself. Mobile: confirm `useHeadlessBuy.getQuotes` can pass no restriction and supports multi-provider `providerIds`. Candidate selection operates over `success[]` only, with `isCustomAction` entries filtered out (`isCustomAction`, `app/components/UI/Ramp/types/index.ts`, lines 43 to 45). Custom actions are OUT of scope (see the "Getting multiple quotes" concern): there is no union candidate model. Full failure is "no usable non-customAction `success[]` entry", which maps to `NO_QUOTES`. Filtering custom actions out is what keeps removing `restrictToKnownOrNativeProviders` from surfacing an unhandled custom-action path.
+
+Tests: multi-provider request returns multiple non-customAction candidates; partial failure keeps usable candidates plus `error[]`; `isCustomAction` `success[]` entries are filtered out of candidate selection; full failure (no usable non-customAction `success[]` entry) maps to `NO_QUOTES`; playground renders all non-custom providers.
+
+### M1.2 - Build a mobile-side `recommendQuotes` util
+
+Build the selection / recommendation ladder as a PURE mobile-side util. Do NOT extract a shared helper into `@metamask/ramps-controller` up front: there is a single real consumer today (headless / MM Pay), and the order-history rung cannot be pulled from core (`#getPreferredProviderIdsFromOrders` / `#resolveProviderIdsForQuote` are `#private` and run only in the single-provider auto-select branch, `node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, lines 1003 to 1024; the all-provider path takes the `else` branch and quotes `state.providers.data`, line 1026). The previously-used-provider rung must be re-derived mobile-side and supplied as an explicit input. Extract to core only once 2+ confirmed consumers justify it (Milestone 6).
 
 The util must be PURE, with explicit inputs (it cannot read controller-private order history or mobile Redux). Proposed signature:
 
@@ -196,93 +214,109 @@ Defined behavior the util must specify:
 
 Tests: ladder order with and without `preferredProviderIds`; missing `sorted` entries; price fallback; `isCustomAction` entries excluded; deterministic output for UB2 and MM Pay callers.
 
+### M1.3 - Core `getRampsQuote` widening (built but NOT activated)
+
+Build the core widening but leave it gated behind the Milestone 3 flag; do not flip it here. In `getRampsQuote` (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 95 to 131), the production call passes `autoSelectProvider: true` (line ~113) and `restrictToKnownOrNativeProviders: true` (line ~116) and takes `quotes.success?.[0]` (line ~124). True all-provider quoting requires dropping BOTH flags so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026). Dropping ONLY the restriction is not enough: `#resolveProviderIdsForQuote` returns a SINGLE provider id even when `restrictToKnownOrNative` is false, so the auto-select branch still yields one provider. So the widened path must drop both flags and switch the pick from `success?.[0]` to the Milestone 1.2 selection logic.
+
+- **Catalog hydration (must verify).** Falling back to `state.providers.data` presumes the controller provider catalog is hydrated in the `TransactionPayController` context. TPC currently relies on auto-select, not on `state.providers.data`, so verify catalog hydration in the TPC context or pass an explicit `providers` list; otherwise all-provider quoting could return zero providers.
+
+Tests: the widened selector (off the production flag) picks the recommended successful quote and ignores provider-level failures when another quote succeeds; the dormant path is proven by tests while production stays native-only.
+
 ---
 
-## Phase 3 - WebView + external-browser headless support (pulled early)
+## Milestone 2 - Headless checkout for non-native providers (makes widening safe)
 
-Make `continueWidget` fully headless-aware: thread `ctx.headlessSessionId` into the external-browser branch so it routes to `onOrderCreated` / `closeSession` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`useContinueWithQuote.ts`, lines 289 to 335; `rampsNavigation.ts`, lines 50 to 75).
+Goal: make the non-native checkout paths (in-app WebView and external browser) emit terminal headless callbacks, so that widening quoting in Milestone 3 cannot strand a user in a callback-less branch. This is the milestone that must land before any production widening.
+
+### M2.1 - Make `continueWidget`'s external-browser branch headless-aware
+
+Thread `ctx.headlessSessionId` into the external-browser branch (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 289 to 335) so it routes to `onOrderCreated` / `onClose` / `failSession` instead of `navigateAfterExternalBrowser` to BuildQuote / OrderDetails (`app/components/UI/Ramp/utils/rampsNavigation.ts`, lines 50 to 75):
+
+- iOS `InAppBrowser.openAuth` success: today the success path calls `navigateAfterExternalBrowser({ returnDestination: 'order', callbackUrl, ... })` (lines 325 to 330), landing on `RAMPS_ORDER_DETAILS` with no headless path. Headless: resolve `openAuth` success into `onOrderCreated`.
+- Cancel: `onClose({ reason: 'user_dismissed' })`.
+- Error / open-rejection: `failSession`.
 
 **Redirect URL: name one source of truth.** Today `getQuotes` accepts a `redirectUrl` override, but `HeadlessHost` does not pass `HeadlessBuyParams.redirectUrl` into `useContinueWithQuote`, and `continueWidget` recomputes the redirect URL via the mobile redirect-policy util. Decision: the mobile redirect-policy util (`getWidgetRedirectConfig` / `getAggregatorRedirectConfig`) is the source of truth at checkout continuation. `HeadlessBuyParams.redirectUrl` is an optional override that must be threaded from the session onto `ContinueWithQuoteContext` and honored by `continueWidget` when present; when absent, the policy util computes it. The quote-fetch `redirectUrl` and the continuation `redirectUrl` must resolve from this same rule so they cannot diverge.
 
 Observability is only partial; document the three cases explicitly:
 
-- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously, but is NOT headless-aware today and iOS external success is NOT "already handled". The success path currently calls `navigateAfterExternalBrowser({ returnDestination: 'order', callbackUrl, ... })` (`app/components/UI/Ramp/hooks/useContinueWithQuote.ts`, lines 325 to 330), landing on `RAMPS_ORDER_DETAILS` with no headless path. Phase 3 must explicitly resolve `openAuth` success into the headless `onOrderCreated` callback; cancel fires `onClose({ reason: 'user_dismissed' })`; error fires `failSession`.
+- **iOS `InAppBrowser.openAuth`**: returns success / cancel / error synchronously, but is NOT headless-aware today and iOS external success is NOT "already handled". Must be resolved into the headless callbacks above.
 - **`Linking.openURL` (Android / no InAppBrowser)**: we can only catch the OPEN failure (promise rejection, which fires `failSession`). We cannot observe provider page load.
-- **Android / system browser**: provider-side load failure is unknowable. Success arrives via deeplink return. Abandonment is inferred by a named policy (below), not guaranteed.
+- **Android / system browser**: provider-side load failure is unknowable. Success arrives via deeplink return. Abandonment is inferred by the existing dismissal machinery (below), not guaranteed.
 
-### Android foreground-without-callback policy (reuse the EXISTING dismissal machinery)
+Tests: each branch routes to the correct terminal callback; iOS `openAuth` success fires `onOrderCreated`; cancel fires `onClose({ reason: 'user_dismissed' })`; open-rejection fires `failSession`.
 
-This policy must be defined in terms of the dismissal mechanisms `HeadlessHost` already wires, NOT as a parallel new grace timer, so there are not two competing dismissal paths (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx`, lines 86 to 99):
+### M2.2 - Give `handleRampReturnUrl.ts` a headless path
 
-- `useHeadlessSessionDismissal(headlessSessionId)`.
-- `useHeadlessSessionFocusDismissal(headlessSessionId, isFocused, ...)`, which on re-focus schedules the dismissal via `setTimeout(..., 0)` (`app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts`, line 51) and bails if the session is already gone or the focus / session id changed.
-- A `beforeRemove` navigation listener that closes the session as `user_dismissed` on back-out (lines 91 to 99).
+Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, the `getProviderDeeplinkRedirectUrl` helper around lines 27 to 28), so the deeplink DOES carry the provider code in its path. It does NOT carry the wallet address, chainId, or session id.
 
-Policy: when the external browser hands control back and the app re-focuses `HeadlessHost` with the session still `continued` and no deeplink callback observed, the EXISTING focus-dismissal path is what fires `onClose({ reason: 'user_dismissed' })`. There is no second grace timer. The only Phase 3 / Phase 4 addition is to ensure a real deeplink callback can pre-empt this existing path (see the deeplink reconciliation in Phase 4 and the slow-deeplink risk below): a deeplink-success must terminate the session before, or take precedence over, focus-dismissal. It does NOT emit `onError`, and the consumer's `cancel()` and the registry's stale-session GC remain as backstops.
+Concrete design:
 
-The remaining product / MM Pay decision is whether the existing zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
+1. At external-browser launch (Milestone 2.1), record a pending external-order correlation in the session registry: `{ sessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
+2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: resolve the order via the shared callback resolver using the `providerCode` parsed from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fire `onOrderCreated` and end the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
+3. Build on the just-landed cached / internal order-id resolution (mobile #32372 `app/components/UI/Ramp/hooks/useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
 
-Tests: each of the three cases routes to the correct terminal callback; a deeplink-success callback pre-empts the existing focus-dismissal so a slow-but-successful return is not closed as `user_dismissed`.
+Core-vs-mobile split: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the focus-dismissal pre-emption stay mobile-side.
 
----
+Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; a deeplink return with a live `continued` session fires `onOrderCreated`; a no-order deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
 
-## Phase 4 - Native and non-native routing alignment
+### M2.3 - E1/E2/E3 reconciliation (money-losing if skipped)
 
-Unify callback order resolution shared by `Checkout` and `OrderDetails` (`getOrderFromCallback`, `isBailedOrderStatus`); give the Android deeplink return (`app/components/UI/Ramp/deeplink/handleRampReturnUrl.ts`) a headless path; keep the native Transak auth/KYC loop unchanged via the existing `useTransakRouting` base-route param.
+Three hazards must be reconciled, all reusing the EXISTING dismissal machinery `HeadlessHost` already wires (`app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx`, lines 86 to 99: `useHeadlessSessionDismissal`, `useHeadlessSessionFocusDismissal`, and the `beforeRemove` listener), NOT a parallel new grace timer, so there are not two competing dismissal paths.
 
-**Android deeplink correlation (concrete design).** Today `handleRampReturnUrl` only parses `orderId` and navigates to `RAMPS_ORDER_DETAILS`. The redirect URL is `metamask://on-ramp/providers/${providerCode}` (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`, lines 27 to 28), so the deeplink DOES carry the provider code in its path. It does NOT carry the wallet address, chainId, or session id. The return must map back to the active headless session without racing the Phase 3 focus-dismissal:
+- **E1 - iOS `openAuth` success resolves into the headless callback.** The iOS success path must terminate via `onOrderCreated` (covered by Milestone 2.1), never silently land on `RAMPS_ORDER_DETAILS`.
+- **E2 - A SUCCESS deeplink must WIN even if the session was already dismissed or GC'd.** Because MM Pay's two-step intent transaction is gated on `onOrderCreated` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 112 to 122), a real fiat order can complete (the user paid) while the intent leg never fires if the focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `app/components/UI/Ramp/headless/sessionRegistry.ts`, line 110) terminated the session first. Reconciliation rule: a success deeplink must still complete the order through the consumer's `onOrderCreated` (re-opening or directly completing the dismissed session) rather than being silently dropped to `RAMPS_ORDER_DETAILS`. Only a deeplink with no order / no recoverable success and no live session falls back to `RAMPS_ORDER_DETAILS` so the order is still recoverable manually.
+- **E3 - Pre-empt the existing zero-delay focus-dismissal timer, do not add a parallel grace timer.** On re-focus, `useHeadlessSessionFocusDismissal` schedules dismissal via `setTimeout(..., 0)` (`app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts`, line 51) and bails if the session is already gone or the focus / session id changed. The only addition is to ensure a real deeplink callback can PRE-EMPT this existing path: a deeplink-success must terminate the session before, or take precedence over, focus-dismissal. It does NOT emit `onError`, and the consumer's `cancel()` and the registry's stale-session GC remain as backstops. The remaining product / MM Pay decision is whether the existing zero-delay focus dismissal needs a deliberate grace delay to avoid racing a slow-but-successful deeplink; record the chosen behavior before implementation.
 
-1. At external-browser launch (Phase 3), record a pending external-order correlation in the session registry: `{ headlessSessionId, walletAddress, chainId }`. The provider code is recoverable from the deeplink path, so it need not be stored. The session registry already holds the single active session, so the active session id is the correlation key; do not rely on the deeplink to carry it.
-2. On deeplink return, `handleRampReturnUrl` first checks for an active headless session. If one exists and is `continued`, it takes the headless path: it PRE-EMPTS the existing focus-dismissal (correlation wins over the abandonment heuristic), resolves the order via the shared callback resolver using the `providerCode` parsed from the deeplink path plus `walletAddress` from the correlation record (plus any `orderId` from the deeplink query), then fires `onOrderCreated` and ends the session. No active headless session means today's behavior (navigate to `RAMPS_ORDER_DETAILS`).
-3. Slow-deeplink reconciliation (not just an ambiguity guard): because only one headless session is active at a time, there is no multi-session matching. A SUCCESS deeplink must WIN even if the session was already dismissed or GC'd (see the slow-deeplink money-losing risk below): it must still complete the order through the consumer's `onOrderCreated` (re-opening or directly completing the dismissed session), not be silently dropped to `RAMPS_ORDER_DETAILS`. Only a deeplink with no order / no recoverable success and no live session falls back to the non-headless `RAMPS_ORDER_DETAILS` path so the order is still recoverable manually.
-
-**Slow-deeplink money-losing risk (must reconcile).** If the existing focus-dismissal, the `beforeRemove` listener, or the 1-hour stale GC (`STALE_SESSION_TTL_MS`, `app/components/UI/Ramp/headless/sessionRegistry.ts`, line 110) terminates the session BEFORE a slow-but-successful deeplink returns, the session closes as `user_dismissed`, the deeplink falls back to `RAMPS_ORDER_DETAILS`, and the consumer never gets `onOrderCreated`. Because MM Pay's two-step intent transaction is gated on `onOrderCreated` (`app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts`, lines 112 to 122), a real fiat order completes (the user paid) but the intent leg never fires. Reconciliation rule: a success deeplink must WIN even if the session was already dismissed, re-opening or directly completing the order via `onOrderCreated` rather than being silently dropped.
-
-Core-vs-mobile split for the unification: core may own only the pure parsing/status helpers (parse callback URL, classify bailed/terminal status). The correlation record, deeplink routing, and the focus-dismissal pre-emption stay mobile-side. Build on the just-landed cached / internal order-id matching (mobile #32372 `useRampsOrders.ts`, core #9159) rather than re-deriving order lookup.
-
-Tests: shared callback resolver returns identical results for `Checkout` and `OrderDetails`; Android deeplink return with a live session fires `onOrderCreated` and pre-empts focus-dismissal; a success deeplink arriving AFTER the session was dismissed still completes via `onOrderCreated` and is not dropped to `RAMPS_ORDER_DETAILS`; a no-order deeplink with no live session falls back to `RAMPS_ORDER_DETAILS`; native loop unchanged (regression).
+Tests: iOS `openAuth` success completes via `onOrderCreated` (E1); a success deeplink arriving AFTER the session was dismissed still completes via `onOrderCreated` and is not dropped to `RAMPS_ORDER_DETAILS` (E2); a deeplink-success pre-empts the existing focus-dismissal so a slow-but-successful return is not closed as `user_dismissed` (E3).
 
 ---
 
-## Phase 5 - MM Pay (`TransactionPayController`) integration (dormant behind the gate)
+## Milestone 3 - Activation behind a required scoped flag
 
-Wire core to consume multi-provider quotes via the Phase 2 selection util instead of `success[0]`, but keep this path dormant behind the still-closed native-only gate (the gate relaxation itself is Phase 9). Keep the MM Pay terminal-callback contract. Per Phase 2, that util starts mobile-side; core consumes it (or its extracted equivalent) only once 2+ consumers justify extraction.
+Goal: the only production-widening milestone. Lands last, after Milestone 2 is proven. Flip the gate behind a distinct scoped flag for staged rollout.
 
-To prevent the dormant path from rotting, tests must exercise the new core selector directly (selecting the recommended successful quote, ignoring provider-level failures when another quote succeeds) without production activation.
+### M3.1 - Add a distinct scoped flag / config bit
 
-Upstream coordination: sequence against the in-flight `transaction-pay-controller` fiat second-leg hardening (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay). That two-step fiat-to-intent flow depends on the terminal-callback contract fixed in the Must-fix section, so Phase 5 lands after the Must-fix and after those changes are merged and published.
+**A distinct scoped flag is REQUIRED; the existing flag cannot scope provider-widening.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing `MetaMaskPayFiatFlags` only carries `enabledTransactionTypes` and `maxDelayMinutesForPaymentMethods` (`app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90); there is NO native-vs-all-providers bit, and setting `enabledTransactionTypes: []` disables ALL fiat. So a distinct scoped flag / config bit (e.g. `allProvidersEnabled` / a non-native provider scope) is REQUIRED so that "off" falls back to native-only rather than killing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond it unless product asks.
 
-Tests: core selector picks the recommended quote and ignores partial failures; dormant path proven by tests while production stays native-only.
+### M3.2 - Flip the two gates and activate Milestone 1.3 behind the flag
+
+Lands after Milestone 2 is proven. Behind the scoped flag from Milestone 3.1:
+
+- Mobile: relax the native-only availability gate (`app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts`, lines 19 to 23; `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts`, lines 23 to 26).
+- Core: activate the Milestone 1.3 widening in `getRampsQuote` (drop both flags, switch the pick to the selection util), gated on the same scoped rollout.
+
+Tests: with the scoped flag on, non-native quotes reach the consumer and complete via headless callbacks; with it off, behavior is identical to today's native-only (native fiat still available).
 
 ---
 
-## Phase 6 - Typed error handling
+## Milestone 4+ - Deferred follow-up
 
-Depends on the Must-fix terminal-callback contract. Then:
+These are intentionally deferred. They are not required to ship all-provider support behind the Milestone 3 flag, and several refactor working code with regression risk.
+
+### M4 - Broad typed errors
+
+Depends on Milestone 0.1 (terminal-callback contract). The Milestone 0.2 OTP typed-code fix is already in scope at Milestone 0. Then, on demand:
 
 - Emit `NO_QUOTES` and `QUOTE_FAILED` for technical / quote failures (widget-URL, load, callback-parse, order-lookup, external-open failures).
-- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit, not a typed error: `Checkout.tsx` (lines 386 to 393) already treats it as `closeSession({ reason: 'user_dismissed' })`, so it is excluded from the typed-error list and surfaces via `onClose`.
-- Carry typed native route errors; do not stringify all post-auth failures into `AUTH_FAILED`. Direct `LimitExceededError` is already mapped correctly by `toHeadlessBuyError` (the `error.name` check). The actual bug is the OTP path: `OtpCode` hands back a bare `nativeFlowError` string and `HeadlessHost.tsx` (lines 139 to 147) forces it to `AUTH_FAILED`, so a post-auth `LIMIT_EXCEEDED` / `KYC_REQUIRED` is mislabeled. Fix by threading a typed code (not a string) through the native route-back param. This OTP typed-code fix is confirmed real and in scope now.
-- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `transakErrorCodes.ts` but are unexported). So Phase 6 must either (a) add a core sub-task to export `TRANSAK_ERROR_CODES` / `TransakErrorCode` from the package, or (b) depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until (a) lands. Verify the export against `origin/main` / the published package, NOT against the local checkout: the local core at `/Users/saustrie/github/repos/core/packages/ramps-controller` is STALE (it lacks the Transak error helpers present in the published artifact), so the published package / `origin/main` is the source of truth for the Transak error exports.
-- Scope the taxonomy. The terminal-callback contract must-fix (Must-fix section) and the OTP typed-code fix above are both confirmed real and in scope now. The broader typed-code taxonomy (e.g. `KYC_REQUIRED` and other granular provider codes) is implement-on-demand: add a code when a consumer actually needs to branch on it, not up front.
+- Route user exits to `onClose` per the callback-routing rule (`user_dismissed` for in-flow user closes, `consumer_cancelled` for programmatic cancel). Do not emit `USER_CANCELLED` for in-flow exits. An empty callback query is a user-exit, not a typed error: `Checkout.tsx` (lines 386 to 393) already treats it as `closeSession({ reason: 'user_dismissed' })`.
+- Export reality check (must-do, not assume): on core `origin/main`, `@metamask/ramps-controller`'s `index.ts` exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and `RAMPS_ERROR_CODES` / `RampsErrorCode`, but it does NOT export `TRANSAK_ERROR_CODES` / `TransakErrorCode` (they exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are unexported). So a consumer that must branch on `TRANSAK_ERROR_CODES` / `TransakErrorCode` first needs a core sub-task to export them from the package; otherwise depend only on the already-exported helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`) plus `RAMPS_ERROR_CODES`. Do not import `TRANSAK_ERROR_CODES` from mobile until that export lands. Re-verify against `origin/main` / the published package before relying on it.
+- Scope the taxonomy. The broader typed-code taxonomy (e.g. `KYC_REQUIRED` and other granular provider codes) is implement-on-demand: add a code when a consumer actually needs to branch on it, not up front.
 
-Tests: each technical failure maps to its typed code; user exits never emit error codes; a post-auth limit failure surfaces `LIMIT_EXCEEDED`, not `AUTH_FAILED`.
-
----
-
-## Phase 7 - Analytics parity
+### M5 - Analytics parity for external-browser providers
 
 Bring external-browser providers to parity: `RAMPS_CHECKOUT_CLOSED` (abandon), `RAMPS_ORDER_FAILED` (in-flow), provider cancellation, HTTP / load failures, and terminal `RampsController:orderStatusChanged` (failed / cancelled), all tagged `ramp_type: 'HEADLESS'` plus `ramp_surface`.
 
-Tests: external-browser abandon and failure emit the expected events with headless tags; terminal failed / cancelled events fire once.
+### M6 - Wire TPC to consume multi-provider quotes
 
----
+Wire core (`TransactionPayController`) to consume multi-provider quotes via the Milestone 1.2 selection logic instead of `success[0]`, and keep the MM Pay terminal-callback contract. This depends ONLY on the Milestone 0.1 terminal-callback contract; there is no upstream wait, because the `transaction-pay-controller` fiat second-leg hardening PRs are merged and published (see Upstream context). Extract a shared helper into `@metamask/ramps-controller` only once there are 2+ confirmed consumers to justify the cross-repo publish / version coupling cost.
 
-## Phase 8 - DRY cleanup (UB2 UI becomes "dumb") (DEFERRED until AFTER Phase 9 activation)
+### M7 - DRY cleanup (UB2 UI becomes "dumb")
 
-**Scope: DEFERRED until AFTER Phase 9 activation.** This refactors working UB2 code (regression risk) with no production benefit before all-providers ships. Do it once activation has landed and is stable, not before.
+Deferred until AFTER Milestone 3 activation is stable. This refactors working UB2 code (regression risk) with no production benefit before all-providers ships.
 
-- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (Phase 2, once 2+ consumers justify extraction); pure callback parsing and status classification (Phase 4); bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
+- **Move to core (`@metamask/ramps-controller`), pure only:** quote selection / recommendation ladder (once 2+ consumers justify extraction); pure callback parsing and status classification; bailed-status checks; min/max amount validation as a pure `validateBuyAmount()`.
 - **Keep in shared mobile Ramp utils:** platform redirect policy and deeplink-scheme construction (`app/components/UI/Ramp/utils/buildQuoteWithRedirectUrl.ts`); all navigation / session behavior. Core must not learn mobile deeplink schemes. The only exception: if the controller API is extended to accept redirect / browser options as inputs, the browser-mode decision can move down; otherwise it stays mobile-side.
 - Refactor BuildQuote / ProviderSelection into dumb consumers of the shared helpers.
 
@@ -290,24 +324,10 @@ Tests: UB2 regression proves ordering, recommended selection, WebView retry, and
 
 ---
 
-## Phase 9 - Activation / rollout (the only production-widening phase)
-
-Lands last, after Phases 3, 4, 6, 7 are proven. Flip the gate behind a scoped MM Pay fiat rollout flag for staged rollout:
-
-- Core: true all-provider quoting requires omitting BOTH `autoSelectProvider` and `providers` so `getQuotes` falls back to `state.providers.data` (`node_modules/@metamask/ramps-controller/dist/RampsController.mjs`, line 1026). Dropping ONLY `restrictToKnownOrNativeProviders` while keeping `autoSelectProvider: true` is NOT enough: `#resolveProviderIdsForQuote` returns a SINGLE provider id even when `restrictToKnownOrNative` is false, so the auto-select branch still yields one provider. So `getRampsQuote` must drop both flags (not just the restriction) and switch the pick to the Phase 2 selection util (`packages/transaction-pay-controller/src/strategy/fiat/utils.ts`, lines 61 to 78).
-  - **Catalog hydration (must verify).** Falling back to `state.providers.data` presumes the controller provider catalog is hydrated in the `TransactionPayController` context. TPC currently relies on auto-select, not on `state.providers.data`, so Phase 9 must verify catalog hydration in the TPC context or pass an explicit `providers` list; otherwise all-provider quoting could return zero providers.
-- Mobile: relax the native-only availability gate (`useIsFiatPaymentAvailable` / `useHasNativeFiatProvider`).
-
-**A distinct scoped flag is REQUIRED; the existing flag cannot scope provider-widening.** The required kill switch is "keep native-only working, disable only non-native widening", NOT "disable the whole fiat path". The existing `MetaMaskPayFiatFlags` only carries `enabledTransactionTypes` and `maxDelayMinutesForPaymentMethods` (`app/selectors/featureFlagController/confirmations/index.ts`, lines 87 to 90); there is NO native-vs-all-providers bit, and setting `enabledTransactionTypes: []` disables ALL fiat. So a distinct scoped flag / config bit (e.g. `allProvidersEnabled` / a non-native provider scope) is REQUIRED so that "off" falls back to native-only rather than killing fiat entirely. Roll out incrementally via that scoped flag; no new product flag beyond it unless product asks. This kill-switch validation is confirmed-correct and stays.
-
-Tests: with the scoped flag on, non-native quotes reach the consumer and complete via headless callbacks; with it off, behavior is identical to today's native-only (native fiat still available).
-
----
-
 ## Test plan (consolidated)
 
 - ramps-controller / core: all-provider quote requests, partial failures, all-provider failures, and shared recommendation order.
-- Transaction Pay: selecting the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds; dormant-path coverage before activation.
+- Transaction Pay: the widened selector picking the recommended successful ramps quote and ignoring provider-level failures when another quote succeeds; dormant-path coverage before activation.
 - Mobile hooks: `useHeadlessBuy`, `useContinueWithQuote`, `HeadlessHost`, `Checkout`, and external-browser deeplink return.
 - UB2 regression: quote ordering, recommended quote selection, WebView retry behavior, and order-details routing unchanged.
 - Analytics: `RAMPS_CHECKOUT_CLOSED`, `RAMPS_ORDER_FAILED`, provider cancellation, checkout HTTP / load failures, and order terminal failed / cancelled events.
@@ -318,10 +338,10 @@ Tests: with the scoped flag on, non-native quotes reach the consumer and complet
 
 Time-sensitive references that informed sequencing; verify before relying on them.
 
-- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Phase 1 adds no new controller logic.
-- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES`). Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `transakErrorCodes.ts` but are NOT re-exported from `index.ts`; Phase 6 must add that export before depending on it from mobile. Verify against `origin/main` / the published package, not the local checkout: the local core at `/Users/saustrie/github/repos/core/packages/ramps-controller` is STALE and lacks the Transak error helpers present in the published artifact.
-- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Phase 4.
-- In-flight MM Pay fiat second-leg hardening (core #9267, #9279, #9250, #9216) is coordinated by Phase 5.
+- Auto-selection internals are already on core main and published (`#resolveProviderIdsForQuote`, `autoSelectProvider` / `preferredProviderIds` / `restrictToKnownOrNativeProviders`), so Milestone 1 adds no new controller logic.
+- Transak error helpers are exported (core #9135): `getTransakApiMessage` and `isTransakPhoneRegisteredError` (plus `RAMPS_ERROR_CODES` / `RampsErrorCode`), confirmed on `origin/main`. Note: `TRANSAK_ERROR_CODES` / `TransakErrorCode` exist in `packages/ramps-controller/src/transakErrorCodes.ts` but are NOT re-exported from `index.ts` on `main`; the typed-error export sub-task (Milestone 4) must add that export before depending on it from mobile.
+- Order-id resolution refinements: mobile #32372 (resolve order details by cached order id) and core #9159 (compare internal order ids) inform Milestone 2.2.
+- The MM Pay fiat second-leg hardening PRs (core #9267 locked-keyring / CHOMP race guard, #9279 preserve isExternalSign when no quotes, #9250 / #9216 EIP-7702 / relay, plus #9159 and #9135) are MERGED and published (core ~release 1082.0.0). There is no upstream wait: the MM Pay integration (Milestone 6) now depends only on the Milestone 0.1 terminal-callback contract, not on an in-flight upstream sequence.
 - A stale-branch caveat: the core branch `headless-buy-ramps-auto-selection` is unmerged and far behind main, yet main already carries equivalent auto-selection logic; verify it is not redundant before building on it.
 
 ---
@@ -330,16 +350,16 @@ Time-sensitive references that informed sequencing; verify before relying on the
 
 Assumptions:
 
-- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (validated in Phase 9). No new product flag beyond the kill switch unless product asks.
+- Ship behind a flag whose "off" state keeps native-only working (not one that disables the whole fiat path). A distinct scoped flag / config bit is REQUIRED: the existing `MetaMaskPayFiatFlags` cannot scope provider-widening (it only has `enabledTransactionTypes` / `maxDelayMinutesForPaymentMethods`, and `enabledTransactionTypes: []` kills all fiat), so a non-native provider-scope flag must be added (Milestone 3.1). No new product flag beyond the kill switch unless product asks.
 - Headless consumers still receive only terminal callbacks: `onOrderCreated`, `onError`, `onClose`.
-- System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the named Android foreground policy for cancellation.
+- System-browser external checkout cannot be observed synchronously; rely on deeplink return for success, `Linking.openURL` rejection for open failure, and the existing focus-dismissal machinery for inferred cancellation.
 - Provider quote failures are logged and surfaced as partial errors, becoming terminal only when every provider fails or no quote can be selected.
 
 Risks:
 
-- Cross-repo sequencing (core publish before mobile bump).
+- Cross-repo sequencing (core publish before mobile bump) for the eventual core extraction.
 - Android foreground-without-callback heuristic reliability (built on the existing focus-dismissal) and whether it needs a deliberate grace delay.
-- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (Phase 4) is implemented.
+- Slow-but-successful deeplink returning AFTER the session was dismissed (focus-dismissal / `beforeRemove` / 1-hour stale GC): the fiat order completes but `onOrderCreated` never fires and MM Pay's gated two-step intent leg never runs, losing money unless the success-deeplink-wins reconciliation rule (Milestone 2.3, E2) is implemented.
 - Migrating pure helpers into core without dragging platform policy along (and the cross-repo publish / version coupling cost of doing it before a second consumer exists).
 
 ---


### PR DESCRIPTION
## **Description**

Adds `app/components/UI/Ramp/headless/PLAN_-_ALL_PROVIDERS_SUPPORT.md`, a planning document (companion to the existing headless `PLAN.md`) for taking Headless Buy, and its MM Pay / Money Account consumer, from native-only to all-provider support.

What it covers, as a cross-repo phased plan (`@metamask/core` `TransactionPayController`, `@metamask/ramps-controller`, and `metamask-mobile`):

- Multi-provider quoting that preserves the `QuotesResponse` `{ success, error, sorted, customActions }` contract, with partial provider failures kept non-terminal, and `customActions` (PayPal-style providers) modeled as first-class purchase candidates.
- Headless-aware non-native checkout for both in-app WebView and external-browser providers, including a named Android foreground-without-callback policy and a concrete deeplink-to-session correlation design.
- A single terminal-callback contract (`onError` is terminal, no trailing `onClose`) and typed error outcomes, plus the callback-routing rule (technical failures to `onError`, user/consumer exits to `onClose`).
- Analytics parity (abandon vs failed) and DRY extraction of pure logic into the controller while keeping platform redirect/navigation policy mobile-side.

Why it is structured this way: the plan separates capability from activation. The native-only gate stays closed in production through all capability phases (1 to 8) and is only widened in a final, flag-gated activation phase (9), so non-native providers cannot reach real users before the logic to handle them exists.

This PR adds documentation only. No production code changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: companion to `app/components/UI/Ramp/headless/PLAN.md`. This is a team planning artifact for the Headless Buy all-providers effort; there is no single end-user-facing tracking issue for the document itself.

## **Manual testing steps**

N/A. Documentation-only change (a new Markdown planning file); there is no runtime behavior to exercise.

## **Screenshots/Recordings**

N/A. Documentation-only change; no UI is affected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The planning doc is non-runtime; the Transak routing change is a narrow pre-OTT cleanup with `Promise.allSettled` and only affects the non–manual-bank payment path.
> 
> **Overview**
> Adds **`PLAN_-_ALL_PROVIDERS_SUPPORT.md`**, a phased cross-repo plan (core `TransactionPayController`, `@metamask/ramps-controller`, mobile Ramp) to widen Headless Buy / MM Pay from native-only to all providers: Phase 1 in-app WebView quoting behind an `off | in-app | all` flag, Phase 2 external-browser and custom-action checkout with deeplink correlation and terminal-callback rules (companion to existing `PLAN.md`).
> 
> **`useTransakRouting`** now cancels locally persisted **`RampsOrderStatus.Failed`** orders via `cancelOrder` before `requestOtt()` when opening the Transak payment widget, so stale failed orders do not block the widget with Transak’s “Oops” error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b14d24ee3c0df42408a45569a5f1eeaf45c1e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->