### PR TITLE
fix: prevent empty sports market details scrolling

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.test.tsx
@@ -134,6 +134,9 @@ const createMockMarket = (
 const mockActivePositions = [{ id: 'pos-1' }] as PredictPosition[];
 
 const emptyGroupMap = new Map();
+const outcomeGroupMap = new Map([
+  ['game_lines', { key: 'game_lines', outcomes: createMockMarket().outcomes }],
+]);
 
 const positionsTabs: { label: string; key: PredictMarketDetailsTabKey }[] = [
   { label: 'Positions', key: 'positions' },
@@ -258,8 +261,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar={false}
           activePositions={[]}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -281,8 +284,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar={false}
           activePositions={[]}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -304,8 +307,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar={false}
           activePositions={[]}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -327,8 +330,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar={false}
           activePositions={[]}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -368,8 +371,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar={false}
           activePositions={[]}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -378,6 +381,28 @@ describe('PredictGameDetailsTabs', () => {
         getByTestId(PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.OUTCOMES_CONTENT)
           .props.accessibilityHint,
       ).toBe('gameStatus:ended');
+    });
+
+    it('renders nothing when no extended outcome content exists', () => {
+      const market = createMockMarket();
+
+      const { toJSON } = render(
+        <PredictGameDetailsTabsContent
+          market={market}
+          activeTab={0}
+          tabs={[]}
+          enabled
+          showTabBar={false}
+          activePositions={[]}
+          claimablePositions={[]}
+          groupMap={emptyGroupMap}
+          resolvedOutcomeGroups={[]}
+          activeChipKey=""
+          onBetPress={mockOnBetPress}
+        />,
+      );
+
+      expect(toJSON()).toBeNull();
     });
   });
 
@@ -452,8 +477,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar
           activePositions={mockActivePositions}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );
@@ -482,8 +507,8 @@ describe('PredictGameDetailsTabs', () => {
           showTabBar
           activePositions={mockActivePositions}
           claimablePositions={[]}
-          groupMap={emptyGroupMap}
-          activeChipKey=""
+          groupMap={outcomeGroupMap}
+          activeChipKey="game_lines"
           onBetPress={mockOnBetPress}
         />,
       );

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.tsx
@@ -52,6 +52,8 @@ const PredictGameDetailsTabsContent = memo(
 
     const hasPositions =
       activePositions.length > 0 || claimablePositions.length > 0;
+    const hasOutcomeContent =
+      groupMap.size > 0 || resolvedOutcomeGroups.length > 0;
 
     if (!enabled) {
       if (!hasPositions) {
@@ -92,6 +94,10 @@ const PredictGameDetailsTabsContent = memo(
         );
       }
 
+      if (!hasOutcomeContent) {
+        return null;
+      }
+
       return (
         <PredictGameOutcomesTab
           groupMap={groupMap}
@@ -120,7 +126,7 @@ const PredictGameDetailsTabsContent = memo(
             />
           </Box>
         )}
-        {currentKey === 'outcomes' && (
+        {currentKey === 'outcomes' && hasOutcomeContent && (
           <PredictGameOutcomesTab
             groupMap={groupMap}
             resolvedOutcomeGroups={resolvedOutcomeGroups}

--- a/app/components/UI/Predict/hooks/useGameDetailsTabs.test.ts
+++ b/app/components/UI/Predict/hooks/useGameDetailsTabs.test.ts
@@ -131,6 +131,19 @@ describe('useGameDetailsTabs', () => {
       mockUseSelector.mockReturnValue(['nba']);
     });
 
+    it('does not include Outcomes tab when only empty groups exist', () => {
+      const { result } = renderHook(() =>
+        useGameDetailsTabs({
+          ...defaultParams,
+          outcomeGroups: [createGroup('game_lines')],
+        }),
+      );
+
+      expect(result.current.tabs).toEqual([]);
+      expect(result.current.groupMap.size).toBe(0);
+      expect(result.current.chips).toEqual([]);
+    });
+
     it('includes only Outcomes tab when no positions exist', () => {
       const { result } = renderHook(() =>
         useGameDetailsTabs({
@@ -495,7 +508,7 @@ describe('useGameDetailsTabs', () => {
     });
 
     it('returns true when enabled with chips and outcomes visible', () => {
-      const groups = [createGroup('game_lines')];
+      const groups = [createOpenGroup('game_lines')];
 
       const { result } = renderHook(() =>
         useGameDetailsTabs({ ...defaultParams, outcomeGroups: groups }),
@@ -512,7 +525,7 @@ describe('useGameDetailsTabs', () => {
 
     it('returns false when disabled', () => {
       mockUseSelector.mockReturnValue([]);
-      const groups = [createGroup('game_lines')];
+      const groups = [createOpenGroup('game_lines')];
 
       const { result } = renderHook(() =>
         useGameDetailsTabs({ ...defaultParams, outcomeGroups: groups }),

--- a/app/components/UI/Predict/utils/outcomeGroups.ts
+++ b/app/components/UI/Predict/utils/outcomeGroups.ts
@@ -57,9 +57,7 @@ const splitOutcomeGroupByStatus = (
     .filter((subgroup): subgroup is PredictOutcomeGroup => Boolean(subgroup));
 
   if (group.outcomes.length === 0 && !group.subgroups?.length) {
-    return {
-      openOutcomeGroup: group,
-    };
+    return {};
   }
 
   const hasOpenContent = openOutcomes.length > 0 || openSubgroups.length > 0;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sports market detail pages could switch into the extended outcomes layout even when the available outcome groups had nothing renderable below the game chart. That hid the fixed prediction footer and left the page feeling like it had an empty lower section.

This keeps pull-to-refresh untouched and skips the empty outcomes UI instead. Empty outcome groups are filtered out before tabs, chips, and the group map are built, and the tab content now renders nothing when there are no open or resolved outcome groups. When there is no renderable outcomes content, the regular prediction footer remains available. Pages with real outcome groups, resolved results, or positions still render normally.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that allowed empty sports prediction market detail pages to scroll unexpectedly.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [PRED-1029](https://consensyssoftware.atlassian.net/browse/PRED-1029)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Sports prediction market details scrolling

  Scenario: sports event page has no content below the chart
    Given the user is on a World Cup or soccer sports prediction event page with no outcomes content below the chart

    When the user swipes upward on the chart/details area
    Then the page does not expose an empty extended outcomes section below the chart
    And the chart stays visible
    And the prediction footer remains available
    And the page does not settle on blank outcomes content

    When the user pulls down on the chart/details area
    Then pull-to-refresh still works

  Scenario: sports event page has outcomes content below the chart
    Given the user is on a sports prediction event page with outcomes or positions below the chart

    When the user swipes vertically on the details area
    Then the page scrolls to the additional content
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See [PRED-1029](https://consensyssoftware.atlassian.net/browse/PRED-1029). The reported recording shows the sports event page scrolling even when there is no content below the chart.

### **After**

N/A - no hosted screenshot or recording was captured for this branch. The expected after-state is covered by the manual testing steps above and the added unit tests.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: this is not a performance-sensitive change.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: this change is scoped to sports market detail scroll behavior.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: no new traced operation was added.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1029]: https://consensyssoftware.atlassian.net/browse/PRED-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ