### PR TITLE
perf: use `createDeepEqualSelector` with narrowed input for `selectOrderedInternalAccountsByLastSelected`

### DIFF
--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -28,6 +28,7 @@ import {
   selectInternalAccountsByScope,
   selectInternalAccountByAddresses,
   selectEvmAddress,
+  selectOrderedInternalAccountsByLastSelected,
 } from './accountsController';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
@@ -801,6 +802,49 @@ describe('selectEvmAddress', () => {
     const result = selectEvmAddress(state);
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('selectOrderedInternalAccountsByLastSelected', () => {
+  const makeState = (lastSelectedMap: Record<string, number>) =>
+    ({
+      engine: {
+        backgroundState: {
+          KeyringController: MOCK_KEYRING_CONTROLLER,
+          AccountsController: {
+            internalAccounts: {
+              accounts: Object.fromEntries(
+                Object.entries(lastSelectedMap).map(([address, ts]) => {
+                  const account = createMockInternalAccount(address, address);
+                  account.metadata.lastSelected = ts;
+                  return [account.id, account];
+                }),
+              ),
+              selectedAccount: '',
+            },
+            accountIdByAddress: {},
+          },
+        },
+      },
+    }) as RootState;
+
+  it('sorts accounts by lastSelected descending', () => {
+    const state = makeState({ '0xaaa': 100, '0xbbb': 300, '0xccc': 200 });
+
+    const result = selectOrderedInternalAccountsByLastSelected(state);
+
+    expect(result[0].metadata.lastSelected).toBe(300);
+    expect(result[1].metadata.lastSelected).toBe(200);
+    expect(result[2].metadata.lastSelected).toBe(100);
+  });
+
+  it('returns the same reference when accounts are unchanged', () => {
+    const state = makeState({ '0xaaa': 100, '0xbbb': 200 });
+
+    const result1 = selectOrderedInternalAccountsByLastSelected(state);
+    const result2 = selectOrderedInternalAccountsByLastSelected(state);
+
+    expect(result1).toBe(result2);
   });
 });
 

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -136,21 +136,13 @@ export const selectSelectedInternalAccountId = createSelector(
 /**
  * A memoized selector that returns the internal accounts sorted by the last selected timestamp
  */
-export const selectOrderedInternalAccountsByLastSelected = createSelector(
-  selectAccountsControllerState,
-  (accountsControllerState) => {
-    const accounts = accountsControllerState.internalAccounts.accounts;
-
-    // Convert accounts object to array and sort by lastSelected timestamp
-    return Object.values(accounts).sort((a, b) => {
-      const aLastSelected = a.metadata?.lastSelected || 0;
-      const bLastSelected = b.metadata?.lastSelected || 0;
-
-      // Sort in descending order (most recent first)
-      return bLastSelected - aLastSelected;
-    });
-  },
-);
+export const selectOrderedInternalAccountsByLastSelected =
+  createDeepEqualSelector(selectInternalAccountsById, (accounts) =>
+    Object.values(accounts).sort(
+      (a, b) =>
+        (b.metadata?.lastSelected || 0) - (a.metadata?.lastSelected || 0),
+    ),
+  );
 
 export const getMemoizedInternalAccountByAddress = createDeepEqualSelector(
   [selectInternalAccounts, (_state, address) => address],


### PR DESCRIPTION
## **Description**

`selectOrderedInternalAccountsByLastSelected` was using `createSelector` with `selectAccountsControllerState` as its input, causing recomputation on any change to the full controller state — not just when account data changed. This meant all downstream consumers (`selectLastSelectedEvmAccount`, `selectLastSelectedSolanaAccount`) re-rendered on unrelated state updates.

Two fixes:
1. Narrows the input selector from `selectAccountsControllerState` to `selectInternalAccountsById` so only changes to the accounts map trigger recomputation.
2. Switches to `createDeepEqualSelector` so the result reference is stable when the sorted output is the same.

Adds sort-order and referential-stability tests.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31351
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1924

## **Manual testing steps**

N/A — pure selector optimization with identical output; covered by new and existing unit tests.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Selector-only memoization change with unchanged sort semantics; covered by new unit tests and existing consumers.
> 
> **Overview**
> **`selectOrderedInternalAccountsByLastSelected`** is refactored so it recomputes less often and returns a stable array reference when the sorted account list is unchanged.
> 
> The input is narrowed from **`selectAccountsControllerState`** to **`selectInternalAccountsById`**, so unrelated AccountsController updates no longer invalidate this selector. Memoization switches from **`createSelector`** to **`createDeepEqualSelector`**, which keeps the same reference when deep-equal sorted output would be identical—reducing unnecessary updates for dependents like **`selectLastSelectedEvmAccount`** and **`selectLastSelectedSolanaAccount`**.
> 
> Unit tests cover descending **`lastSelected`** ordering and referential stability across repeated calls with the same state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb175d3bf7acd0e009ae5950d144b64642b65d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->