### PR TITLE
chore(predict): add wimbledon tab cp-8.0.1

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
@@ -12,25 +12,10 @@ import {
   formatOutcomeCardTitle,
   getDefaultLineIndex,
   getFallbackSportsMarketTypeLabel,
+  getMoneylineButtonEntries,
   getSportsMarketTypeLabel,
   getTranslatedSportsMarketTypeLabel,
-  sortMoneylineOutcomes,
 } from './utils';
-
-const getSimpleOutcomeCardTitle = (
-  outcome: PredictOutcomeGroup['outcomes'][number],
-): string => {
-  const fallbackTitle = formatOutcomeCardTitle(outcome);
-
-  if (
-    !outcome.sportsMarketType ||
-    !isMoneylineLikeMarketType(outcome.sportsMarketType)
-  ) {
-    return fallbackTitle;
-  }
-
-  return getSportsMarketTypeLabel(outcome.sportsMarketType, fallbackTitle);
-};
 
 const SimpleOutcomeCard = memo(
   ({
@@ -155,8 +140,8 @@ const MoneylineCard = memo(
     );
     const tokenIds = useMemo(
       () =>
-        sortMoneylineOutcomes(outcomes, game)
-          .map((outcome) => outcome.tokens[0]?.id)
+        getMoneylineButtonEntries(outcomes, game)
+          .map(({ token }) => token.id)
           .filter((id): id is string => Boolean(id)),
       [outcomes, game],
     );
@@ -208,10 +193,7 @@ const SubgroupCards = memo(
       );
     const testID = `${groupKey}-${subgroup.key}-${index}`;
 
-    if (
-      isMoneylineLikeMarketType(subgroup.key) &&
-      subgroup.outcomes.length > 1
-    ) {
+    if (isMoneylineLikeMarketType(subgroup.key)) {
       return (
         <MoneylineCard
           outcomes={subgroup.outcomes}
@@ -279,11 +261,7 @@ export const OutcomesContent = memo(
     }
 
     const firstType = group.outcomes[0]?.sportsMarketType;
-    if (
-      firstType &&
-      isMoneylineLikeMarketType(firstType) &&
-      group.outcomes.length > 1
-    ) {
+    if (firstType && isMoneylineLikeMarketType(firstType)) {
       return (
         <MoneylineCard
           outcomes={group.outcomes}
@@ -304,7 +282,7 @@ export const OutcomesContent = memo(
           <SimpleOutcomeCard
             key={outcome.id}
             outcome={outcome}
-            title={getSimpleOutcomeCardTitle(outcome)}
+            title={formatOutcomeCardTitle(outcome)}
             onBuyPress={onBuyPress}
             game={game}
             sportsMarketType={outcome.sportsMarketType}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
@@ -17,6 +17,21 @@ import {
   sortMoneylineOutcomes,
 } from './utils';
 
+const getSimpleOutcomeCardTitle = (
+  outcome: PredictOutcomeGroup['outcomes'][number],
+): string => {
+  const fallbackTitle = formatOutcomeCardTitle(outcome);
+
+  if (
+    !outcome.sportsMarketType ||
+    !isMoneylineLikeMarketType(outcome.sportsMarketType)
+  ) {
+    return fallbackTitle;
+  }
+
+  return getSportsMarketTypeLabel(outcome.sportsMarketType, fallbackTitle);
+};
+
 const SimpleOutcomeCard = memo(
   ({
     outcome,
@@ -289,7 +304,7 @@ export const OutcomesContent = memo(
           <SimpleOutcomeCard
             key={outcome.id}
             outcome={outcome}
-            title={formatOutcomeCardTitle(outcome)}
+            title={getSimpleOutcomeCardTitle(outcome)}
             onBuyPress={onBuyPress}
             game={game}
             sportsMarketType={outcome.sportsMarketType}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -282,7 +282,7 @@ describe('PredictGameOutcomesTab', () => {
         />,
       );
 
-      expect(getByTestId('game_lines-outcome-0')).toBeOnTheScreen();
+      expect(getByTestId('game_lines-moneyline')).toBeOnTheScreen();
     });
   });
 
@@ -975,7 +975,7 @@ describe('PredictGameOutcomesTab', () => {
       expect(mockCapturedCards[0].subtitle).toBe('$15k Vol');
     });
 
-    it('renders individual cards when flat group has only one outcome with moneyline type', () => {
+    it('renders MoneylineCard when flat group has only one outcome with moneyline type', () => {
       const outcomes = [
         createOutcome({
           id: 'hr-single',
@@ -996,7 +996,45 @@ describe('PredictGameOutcomesTab', () => {
       );
 
       expect(mockCapturedCards).toHaveLength(1);
-      expect(mockCapturedCards[0].buttonLayout).toBeUndefined();
+      expect(mockCapturedCards[0].buttonLayout).toBe('inlineNoSeparator');
+      expect(mockCapturedCards[0].testID).toBe('halftime-moneyline');
+    });
+
+    it('uses live best ask prices for one-outcome moneyline buttons', () => {
+      mockGetLivePrice.mockImplementation((tokenId: string) => ({
+        tokenId,
+        price: 0,
+        bestBid: 0,
+        bestAsk: tokenId === 'tok-home' ? 0.72 : 0.28,
+      }));
+      const outcomes = [
+        createOutcome({
+          id: 'ml-single',
+          sportsMarketType: 'moneyline',
+          tokens: [
+            createToken({ id: 'tok-home', shortTitle: 'HOME', price: 0.62 }),
+            createToken({ id: 'tok-away', shortTitle: 'AWAY', price: 0.38 }),
+          ],
+        }),
+      ];
+      const groups = [createGroup({ key: 'game_lines', outcomes })];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards).toHaveLength(1);
+      expect(mockCapturedCards[0].title).toBe('Moneyline');
+      expect(mockCapturedCards[0].buttonLayout).toBe('inlineNoSeparator');
+      expect(mockCapturedCards[0].buttons).toEqual([
+        expect.objectContaining({ label: 'HOME', price: 72 }),
+        expect.objectContaining({ label: 'AWAY', price: 28 }),
+      ]);
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -455,6 +455,38 @@ describe('PredictGameOutcomesTab', () => {
       expect(mockCapturedCards[0].lines).toBeUndefined();
     });
 
+    it('renders top-level single moneyline outcome with moneyline title', () => {
+      const groups = [
+        createGroup({
+          key: 'game_lines',
+          outcomes: [
+            createOutcome({
+              id: 'ml-single',
+              title: 'Wimbledon ATP: Player A vs Player B',
+              groupItemTitle: 'Wimbledon ATP: Player A vs Player B',
+              sportsMarketType: 'moneyline',
+            }),
+          ],
+        }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards).toHaveLength(1);
+      expect(mockCapturedCards[0].title).toBe('Moneyline');
+      expect(mockCapturedCards[0].buttons).toEqual([
+        expect.objectContaining({ label: 'TA', price: 65 }),
+        expect.objectContaining({ label: 'TB', price: 35 }),
+      ]);
+    });
+
     it('renders LineOutcomeCard for subgroup with multiple outcomes', () => {
       const subgroups: PredictOutcomeGroup[] = [
         createGroup({

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/utils.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/utils.ts
@@ -276,27 +276,46 @@ export const sortMoneylineOutcomes = (
   return [sorted[0], neutral, ...sorted.slice(1)];
 };
 
+export const getMoneylineButtonEntries = (
+  outcomes: PredictOutcome[],
+  game?: PredictMarketGame,
+): { outcome: PredictOutcome; token: PredictOutcomeToken }[] => {
+  const sortedWithTokens = sortMoneylineOutcomes(outcomes, game).filter(
+    (outcome) => outcome.tokens.length > 0,
+  );
+
+  if (sortedWithTokens.length === 1) {
+    const [outcome] = sortedWithTokens;
+    return sortMoneylineTokensForDisplay(outcome.tokens, game).map((token) => ({
+      outcome,
+      token,
+    }));
+  }
+
+  return sortedWithTokens.flatMap((outcome) => {
+    const token = outcome.tokens[0];
+    return token ? [{ outcome, token }] : [];
+  });
+};
+
 export const buildMoneylineButtons = (
   outcomes: PredictOutcome[],
   onBuyPress: BuyHandler,
   game?: PredictMarketGame,
   getPrice?: LivePriceGetter,
 ): PredictSportOutcomeButton[] => {
-  const sortedWithTokens = sortMoneylineOutcomes(outcomes, game).filter(
-    (outcome) => outcome.tokens[0] !== undefined,
-  );
+  const buttonEntries = getMoneylineButtonEntries(outcomes, game);
 
-  return sortedWithTokens.map((outcome, i) => {
-    const yesToken = outcome.tokens[0];
-    const liveBestAsk = getPrice?.(yesToken.id)?.bestAsk;
-    const price = isValidPrice(liveBestAsk) ? liveBestAsk : yesToken.price;
+  return buttonEntries.map(({ outcome, token }, i) => {
+    const liveBestAsk = getPrice?.(token.id)?.bestAsk;
+    const price = isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
 
     return {
-      label: yesToken.shortTitle ?? yesToken.title,
+      label: token.shortTitle ?? token.title,
       price: Math.round(price * 100),
-      onPress: () => onBuyPress(outcome, yesToken),
-      variant: getButtonVariant(i, sortedWithTokens.length, true),
-      teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
+      onPress: () => onBuyPress(outcome, token),
+      variant: getButtonVariant(i, buttonEntries.length, true),
+      teamColor: getTeamColor(token.shortTitle ?? token.title, game),
     };
   });
 };

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
@@ -290,6 +290,23 @@ describe('PredictSportScoreboard', () => {
       ]);
     });
 
+    it('renders the home team on the left for tennis leagues', () => {
+      const { getAllByTestId } = render(
+        <PredictSportScoreboard
+          game={createGame({ league: 'atp' })}
+          testID="scoreboard"
+        />,
+      );
+
+      const order = getAllByTestId(/-(home|away)-team-logo$/).map(
+        (node) => node.props.testID,
+      );
+      expect(order).toEqual([
+        'scoreboard-home-team-logo',
+        'scoreboard-away-team-logo',
+      ]);
+    });
+
     it('renders the away team on the left for US sports (NFL)', () => {
       const { getAllByTestId } = render(
         <PredictSportScoreboard

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -12,8 +12,8 @@ import React from 'react';
 import I18n from '../../../../../../locales/i18n';
 import { getIntlDateTimeFormatter } from '../../../../../util/intl';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
-import { isSoccerLeague } from '../../constants/sports';
 import { PredictMarketGame, PredictSportTeam } from '../../types';
+import { getLeagueTeamOrder } from '../../utils/gameParser';
 import { getSportLiveStatusText, isGameEnded } from '../../utils/scoreboard';
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import PulsingLiveDot from '../PulsingLiveDot/PulsingLiveDot';
@@ -98,11 +98,9 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
   const teamLogoSize = compact ? COMPACT_TEAM_LOGO_SIZE : TEAM_LOGO_SIZE;
   const showScores = isLive || isEnded;
 
-  // Team display order is sport-dependent: soccer (and other draw-capable
-  // leagues) show the home team on the left, while US sports (e.g. American
-  // football) follow the away-then-home convention. testIDs stay tied to the
-  // team identity (home/away), not the slot.
-  const isHomeFirst = isSoccerLeague(game.league);
+  // Keep visual order aligned with the parser's score/team normalization.
+  // testIDs stay tied to the team identity (home/away), not the slot.
+  const isHomeFirst = getLeagueTeamOrder(game.league) === 'home-away';
   const leftTeam = isHomeFirst ? game.homeTeam : game.awayTeam;
   const rightTeam = isHomeFirst ? game.awayTeam : game.homeTeam;
   const leftScore = isHomeFirst ? gameData.homeScore : gameData.awayScore;

--- a/app/components/UI/Predict/constants/feedTabs.ts
+++ b/app/components/UI/Predict/constants/feedTabs.ts
@@ -27,10 +27,16 @@ export const PREDICT_WORLD_CUP_TAB: PredictTabConfig = {
   labelKey: 'predict.world_cup.title',
 };
 
+export const PREDICT_WIMBLEDON_TAB: PredictTabConfig = {
+  key: 'wimbledon',
+  labelKey: 'predict.category.wimbledon',
+};
+
 export const PREDICT_ALL_TABS: readonly PredictTabConfig[] = [
   ...PREDICT_BASE_TABS,
   PREDICT_HOT_TAB,
   PREDICT_WORLD_CUP_TAB,
+  PREDICT_WIMBLEDON_TAB,
 ];
 
 const PREDICT_TAB_KEYS = PREDICT_ALL_TABS.map((tab) => tab.key);

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -4,6 +4,7 @@ import {
   PredictHotTabFlag,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
+  PredictWimbledonTabFlag,
   PredictWorldCupConfig,
 } from '../types/flags';
 
@@ -44,6 +45,22 @@ export const DEFAULT_HOT_TAB_FLAG: PredictHotTabFlag = {
   queryParams:
     'active=true&archived=false&closed=false&liquidity_min=10000&volume_min=10000&tag_id=1',
   minimumVersion: '7.64.0',
+};
+
+export const PREDICT_WIMBLEDON_DEFAULT_GAMES_TAG_ID = '100639';
+export const PREDICT_WIMBLEDON_DEFAULT_TAG_SLUG = 'tennis';
+export const PREDICT_WIMBLEDON_DEFAULT_SEARCH = 'Wimbledon';
+
+export const PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS =
+  `active=true&archived=false&closed=false&tag_id=${PREDICT_WIMBLEDON_DEFAULT_GAMES_TAG_ID}` +
+  `&tag_slug=${PREDICT_WIMBLEDON_DEFAULT_TAG_SLUG}` +
+  `&title_search=${PREDICT_WIMBLEDON_DEFAULT_SEARCH}` +
+  '&order=volume24hr&ascending=false';
+
+export const DEFAULT_WIMBLEDON_TAB_FLAG: PredictWimbledonTabFlag = {
+  enabled: false,
+  queryParams: PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+  minimumVersion: '',
 };
 
 export const PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG = 'fifa-world-cup';

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -57,11 +57,11 @@ export const PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS =
   `&title_search=${PREDICT_WIMBLEDON_DEFAULT_SEARCH}` +
   '&order=volume24hr&ascending=false';
 
-export const DEFAULT_WIMBLEDON_TAB_FLAG: PredictWimbledonTabFlag = {
+export const DEFAULT_WIMBLEDON_TAB_FLAG = {
   enabled: false,
   queryParams: PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
   minimumVersion: '',
-};
+} satisfies PredictWimbledonTabFlag;
 
 export const PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG = 'fifa-world-cup';
 export const PREDICT_WORLD_CUP_DEFAULT_GAMES_TAG_ID = '100639';

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -52,7 +52,7 @@ export const PREDICT_WIMBLEDON_DEFAULT_TAG_SLUG = 'tennis';
 export const PREDICT_WIMBLEDON_DEFAULT_SEARCH = 'Wimbledon';
 
 export const PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS =
-  `active=true&archived=false&closed=false&tag_id=${PREDICT_WIMBLEDON_DEFAULT_GAMES_TAG_ID}` +
+  `active=true&archived=false&closed=false&ended=false&tag_id=${PREDICT_WIMBLEDON_DEFAULT_GAMES_TAG_ID}` +
   `&tag_slug=${PREDICT_WIMBLEDON_DEFAULT_TAG_SLUG}` +
   `&title_search=${PREDICT_WIMBLEDON_DEFAULT_SEARCH}` +
   '&order=volume24hr&ascending=false';

--- a/app/components/UI/Predict/hooks/usePredictTabs.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, act } from '@testing-library/react-native';
-import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../constants/flags';
+import {
+  DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
+  PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+} from '../constants/flags';
 import { buildPredictWorldCupAllQuery } from '../utils/worldCup';
 import { usePredictTabs } from './usePredictTabs';
 
@@ -15,6 +19,13 @@ const mockHotTabFlag: { enabled: boolean; queryParams: string | undefined } = {
   enabled: false,
   queryParams: undefined,
 };
+const mockWimbledonTabFlag: {
+  enabled: boolean;
+  queryParams: string | undefined;
+} = {
+  enabled: false,
+  queryParams: undefined,
+};
 let mockIsWorldCupMainFeedTabEnabled = false;
 let mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
 
@@ -23,6 +34,8 @@ jest.mock('react-redux', () => ({
     switch (selector) {
       case 'selectPredictHotTabFlag':
         return mockHotTabFlag;
+      case 'selectPredictWimbledonTabFlag':
+        return mockWimbledonTabFlag;
       case 'selectPredictWorldCupMainFeedTabEnabledFlag':
         return mockIsWorldCupMainFeedTabEnabled;
       case 'selectPredictWorldCupConfig':
@@ -35,6 +48,7 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../selectors/featureFlags', () => ({
   selectPredictHotTabFlag: 'selectPredictHotTabFlag',
+  selectPredictWimbledonTabFlag: 'selectPredictWimbledonTabFlag',
   selectPredictWorldCupConfig: 'selectPredictWorldCupConfig',
   selectPredictWorldCupMainFeedTabEnabledFlag:
     'selectPredictWorldCupMainFeedTabEnabledFlag',
@@ -50,6 +64,8 @@ describe('usePredictTabs', () => {
     mockRouteParams.tab = undefined;
     mockHotTabFlag.enabled = false;
     mockHotTabFlag.queryParams = undefined;
+    mockWimbledonTabFlag.enabled = false;
+    mockWimbledonTabFlag.queryParams = undefined;
     mockIsWorldCupMainFeedTabEnabled = false;
     mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
   });
@@ -80,6 +96,14 @@ describe('usePredictTabs', () => {
       );
     });
 
+    it('does not include Wimbledon tab when Wimbledon tab flag is disabled', () => {
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs.map((tab) => tab.key)).not.toContain(
+        'wimbledon',
+      );
+    });
+
     it('includes World Cup tab at beginning when enabled', () => {
       mockIsWorldCupMainFeedTabEnabled = true;
 
@@ -103,6 +127,23 @@ describe('usePredictTabs', () => {
 
       expect(result.current.tabs.map((tab) => tab.key).slice(0, 3)).toEqual([
         'world-cup',
+        'hot',
+        'trending',
+      ]);
+    });
+
+    it('places Wimbledon after World Cup and before Hot when all optional tabs are enabled', () => {
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'test=value';
+      mockWimbledonTabFlag.enabled = true;
+      mockWimbledonTabFlag.queryParams = DEFAULT_WIMBLEDON_TAB_FLAG.queryParams;
+      mockIsWorldCupMainFeedTabEnabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs.map((tab) => tab.key).slice(0, 4)).toEqual([
+        'world-cup',
+        'wimbledon',
         'hot',
         'trending',
       ]);
@@ -150,6 +191,15 @@ describe('usePredictTabs', () => {
       expect(result.current.initialTabKey).toBe('trending');
     });
 
+    it('defaults to trending when Wimbledon tab is requested but disabled', () => {
+      mockRouteParams.tab = 'wimbledon';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.initialTabKey).toBe('trending');
+    });
+
     it('sets active index to requested World Cup tab when enabled', () => {
       mockRouteParams.tab = 'world-cup';
       mockIsWorldCupMainFeedTabEnabled = true;
@@ -158,6 +208,17 @@ describe('usePredictTabs', () => {
 
       expect(result.current.activeIndex).toBe(0);
       expect(result.current.initialTabKey).toBe('world-cup');
+    });
+
+    it('sets active index to requested Wimbledon tab when enabled', () => {
+      mockRouteParams.tab = 'wimbledon';
+      mockWimbledonTabFlag.enabled = true;
+      mockWimbledonTabFlag.queryParams = DEFAULT_WIMBLEDON_TAB_FLAG.queryParams;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.activeIndex).toBe(0);
+      expect(result.current.initialTabKey).toBe('wimbledon');
     });
 
     it('updates when setActiveIndex is called', () => {
@@ -309,6 +370,31 @@ describe('usePredictTabs', () => {
         key: 'world-cup',
         label: 'predict.world_cup.title',
         customQueryParams: buildPredictWorldCupAllQuery(mockWorldCupConfig),
+      });
+    });
+
+    it('adds default Wimbledon query params to the Wimbledon tab when enabled without remote query params', () => {
+      mockWimbledonTabFlag.enabled = true;
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs[0]).toEqual({
+        key: 'wimbledon',
+        label: 'predict.category.wimbledon',
+        customQueryParams: PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+      });
+    });
+
+    it('uses remote Wimbledon query params when provided', () => {
+      mockWimbledonTabFlag.enabled = true;
+      mockWimbledonTabFlag.queryParams = 'tag_slug=wimbledon&order=volume24hr';
+
+      const { result } = renderHook(() => usePredictTabs());
+
+      expect(result.current.tabs[0]).toEqual({
+        key: 'wimbledon',
+        label: 'predict.category.wimbledon',
+        customQueryParams: 'tag_slug=wimbledon&order=volume24hr',
       });
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictTabs.ts
+++ b/app/components/UI/Predict/hooks/usePredictTabs.ts
@@ -4,16 +4,19 @@ import { useRoute, RouteProp } from '@react-navigation/native';
 import { strings } from '../../../../../locales/i18n';
 import {
   selectPredictHotTabFlag,
+  selectPredictWimbledonTabFlag,
   selectPredictWorldCupConfig,
   selectPredictWorldCupMainFeedTabEnabledFlag,
 } from '../selectors/featureFlags';
 import {
   PREDICT_BASE_TABS,
   PREDICT_HOT_TAB,
+  PREDICT_WIMBLEDON_TAB,
   PREDICT_WORLD_CUP_TAB,
   isPredictTabKey,
   type PredictTabKey,
 } from '../constants/feedTabs';
+import { PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS } from '../constants/flags';
 import type { PredictNavigationParamList } from '../types/navigation';
 import { buildPredictWorldCupAllQuery } from '../utils/worldCup';
 
@@ -34,6 +37,7 @@ export const usePredictTabs = (): UsePredictTabsResult => {
   const route =
     useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
   const hotTabFlag = useSelector(selectPredictHotTabFlag);
+  const wimbledonTabFlag = useSelector(selectPredictWimbledonTabFlag);
   const isWorldCupMainFeedTabEnabled = useSelector(
     selectPredictWorldCupMainFeedTabEnabledFlag,
   );
@@ -45,27 +49,41 @@ export const usePredictTabs = (): UsePredictTabsResult => {
       label: strings(tab.labelKey),
     }));
 
-    if (hotTabFlag.enabled) {
-      baseTabs.unshift({
-        key: PREDICT_HOT_TAB.key,
-        label: strings(PREDICT_HOT_TAB.labelKey),
-        customQueryParams: hotTabFlag.queryParams,
-      });
-    }
+    const optionalTabs: FeedTab[] = [];
 
     if (isWorldCupMainFeedTabEnabled) {
-      baseTabs.unshift({
+      optionalTabs.push({
         key: PREDICT_WORLD_CUP_TAB.key,
         label: strings(PREDICT_WORLD_CUP_TAB.labelKey),
         customQueryParams: buildPredictWorldCupAllQuery(worldCupConfig),
       });
     }
 
-    return baseTabs;
+    if (wimbledonTabFlag.enabled) {
+      optionalTabs.push({
+        key: PREDICT_WIMBLEDON_TAB.key,
+        label: strings(PREDICT_WIMBLEDON_TAB.labelKey),
+        customQueryParams:
+          wimbledonTabFlag.queryParams ??
+          PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+      });
+    }
+
+    if (hotTabFlag.enabled) {
+      optionalTabs.push({
+        key: PREDICT_HOT_TAB.key,
+        label: strings(PREDICT_HOT_TAB.labelKey),
+        customQueryParams: hotTabFlag.queryParams,
+      });
+    }
+
+    return [...optionalTabs, ...baseTabs];
   }, [
     hotTabFlag.enabled,
     hotTabFlag.queryParams,
     isWorldCupMainFeedTabEnabled,
+    wimbledonTabFlag.enabled,
+    wimbledonTabFlag.queryParams,
     worldCupConfig,
   ]);
 

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -10,6 +10,7 @@ import { UserProfileProperty } from '../../../../../util/metrics/UserSettingsAna
 import {
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../../constants/flags';
 import type { OrderPreview } from '../types';
 import { Side, type PredictActivity, type PredictPosition } from '../../types';
@@ -365,6 +366,7 @@ const defaultFeatureFlags: PredictFeatureFlags = {
   predictHomeRedesignEnabled: false,
   predictSportCardLivePricesEnabled: true,
   predictWorldCup: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  predictWimbledonTab: DEFAULT_WIMBLEDON_TAB_FLAG,
 };
 
 function createProvider(featureFlags?: Partial<PredictFeatureFlags>) {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1059,6 +1059,7 @@ describe('polymarket utils', () => {
       expect(requestedUrl).toContain('tag_id=100639');
       expect(requestedUrl).toContain('tag_slug=tennis');
       expect(requestedUrl).toContain('title_search=Wimbledon');
+      expect(requestedUrl).toContain('ended=false');
       expect(requestedUrl).toContain('order=volume24hr');
       expect(requestedUrl).not.toContain('liquidity_min');
       expect(requestedUrl).not.toContain('volume_min');

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -5,6 +5,7 @@ import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
 import { Side, type OrderPreview, type PredictOutcome } from '../../types';
 import { PREDICT_ERROR_CODES } from '../../constants/errors';
+import { PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS } from '../../constants/flags';
 import {
   DEFAULT_CLOB_BASE_URL,
   MATIC_CONTRACTS_V2,
@@ -1024,6 +1025,41 @@ describe('polymarket utils', () => {
         'https://gamma-api.polymarket.com/events/keyset?limit=10&active=true&archived=false&closed=false&tag_slug=fifa-world-cup&order=volume24hr&ascending=false',
       );
       const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).not.toContain('liquidity_min');
+      expect(requestedUrl).not.toContain('volume_min');
+      expect(requestedUrl).not.toContain('offset=');
+    });
+
+    it('uses exact Wimbledon custom query params without normal feed filters', async () => {
+      await fetchEventsFromPolymarketApi({
+        category: 'wimbledon',
+        limit: 20,
+        customQueryParams: 'tag_slug=wimbledon&order=volume24hr',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gamma-api.polymarket.com/events/keyset?limit=20&tag_slug=wimbledon&order=volume24hr',
+      );
+      const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).not.toContain('liquidity_min');
+      expect(requestedUrl).not.toContain('volume_min');
+      expect(requestedUrl).not.toContain('offset=');
+    });
+
+    it('falls back to default Wimbledon query params without normal feed filters', async () => {
+      await fetchEventsFromPolymarketApi({
+        category: 'wimbledon',
+        limit: 10,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://gamma-api.polymarket.com/events/keyset?limit=10&${PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS}`,
+      );
+      const requestedUrl = String(mockFetch.mock.calls[0][0]);
+      expect(requestedUrl).toContain('tag_id=100639');
+      expect(requestedUrl).toContain('tag_slug=tennis');
+      expect(requestedUrl).toContain('title_search=Wimbledon');
+      expect(requestedUrl).toContain('order=volume24hr');
       expect(requestedUrl).not.toContain('liquidity_min');
       expect(requestedUrl).not.toContain('volume_min');
       expect(requestedUrl).not.toContain('offset=');

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -79,7 +79,10 @@ import {
   OrderBook,
 } from './types';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../../constants/errors';
-import { PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG } from '../../constants/flags';
+import {
+  PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+  PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG,
+} from '../../constants/flags';
 import { PredictFeeCollection } from '../../types/flags';
 import { roundToFiveDecimals } from '../../utils/orders';
 import { getMinAmountReceivedWithSlippage } from './protocol/slippage';
@@ -1175,6 +1178,7 @@ export interface FetchEventsResult {
 const EXACT_QUERY_PARAM_CATEGORIES: readonly PredictCategory[] = [
   'hot',
   'world-cup',
+  'wimbledon',
 ];
 
 const appendCustomQueryParams = (
@@ -1230,6 +1234,11 @@ export const fetchEventsFromPolymarketApi = async (
     queryParams.set('order', 'volume24hr');
     queryParams.set('ascending', 'false');
     queryParamsEvents = queryParams.toString();
+  } else if (category === 'wimbledon') {
+    queryParamsEvents = appendCustomQueryParams(
+      queryParams,
+      PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+    );
   } else {
     queryParams.set('active', 'true');
     queryParams.set('archived', 'false');
@@ -1240,7 +1249,7 @@ export const fetchEventsFromPolymarketApi = async (
     queryParams.set('volume_min', String(10000.0));
 
     const categoryParamMap: Record<
-      Exclude<PredictCategory, 'world-cup'>,
+      Exclude<PredictCategory, 'world-cup' | 'wimbledon'>,
       Record<string, string>
     > = {
       trending: { order: 'volume24hr' },

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1178,7 +1178,6 @@ export interface FetchEventsResult {
 const EXACT_QUERY_PARAM_CATEGORIES: readonly PredictCategory[] = [
   'hot',
   'world-cup',
-  'wimbledon',
 ];
 
 const appendCustomQueryParams = (
@@ -1237,7 +1236,7 @@ export const fetchEventsFromPolymarketApi = async (
   } else if (category === 'wimbledon') {
     queryParamsEvents = appendCustomQueryParams(
       queryParams,
-      PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+      customQueryParams ?? PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
     );
   } else {
     queryParams.set('active', 'true');

--- a/app/components/UI/Predict/schemas/flags.ts
+++ b/app/components/UI/Predict/schemas/flags.ts
@@ -12,6 +12,8 @@ import { HexSchema } from './common';
 import {
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
+  PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
 } from '../constants/flags';
 
 export const PredictFeeCollectionSchema = defaulted(
@@ -100,4 +102,19 @@ export const PredictWorldCupSchema = defaulted(
     stages: defaulted(array(PredictWorldCupStageSchema), () => []),
   }),
   () => DEFAULT_PREDICT_WORLD_CUP_FLAG,
+);
+
+export const PredictWimbledonTabSchema = defaulted(
+  type({
+    enabled: defaulted(boolean(), () => DEFAULT_WIMBLEDON_TAB_FLAG.enabled),
+    minimumVersion: defaulted(
+      string(),
+      () => DEFAULT_WIMBLEDON_TAB_FLAG.minimumVersion,
+    ),
+    queryParams: defaulted(
+      string(),
+      () => PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+    ),
+  }),
+  () => DEFAULT_WIMBLEDON_TAB_FLAG,
 );

--- a/app/components/UI/Predict/schemas/index.ts
+++ b/app/components/UI/Predict/schemas/index.ts
@@ -3,6 +3,7 @@ export { parse } from './utils';
 export { HexSchema } from './common';
 export {
   PredictFeeCollectionSchema,
+  PredictWimbledonTabSchema,
   PredictWorldCupSchema,
   PredictWorldCupStageSchema,
 } from './flags';

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -14,6 +14,7 @@ import {
   selectPredictSportCardLivePricesEnabledFlag,
   selectPredictUpDownEnabledFlag,
   selectPredictWithAnyTokenEnabledFlag,
+  selectPredictWimbledonTabFlag,
   selectPredictWorldCupConfig,
   selectPredictWorldCupHubBannerEnabledFlag,
   selectPredictWorldCupHubV2EnabledFlag,
@@ -32,7 +33,10 @@ import {
 } from '../../../../../util/remoteFeatureFlag';
 // eslint-disable-next-line import-x/no-namespace
 import * as remoteFeatureFlagModule from '../../../../../util/remoteFeatureFlag';
-import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../../constants/flags';
+import {
+  DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
+} from '../../constants/flags';
 
 jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn().mockReturnValue('1.0.0'),
@@ -539,6 +543,89 @@ describe('Predict Feature Flag Selectors', () => {
           minimumVersion: '7.64.0',
         });
       });
+    });
+  });
+
+  describe('selectPredictWimbledonTabFlag', () => {
+    it('returns default flag when remote flag is missing', () => {
+      expect(selectPredictWimbledonTabFlag(mockedEmptyFlagsState)).toEqual(
+        DEFAULT_WIMBLEDON_TAB_FLAG,
+      );
+    });
+
+    it('returns enabled flag with default query params when remote query params are omitted', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const stateWithWimbledonTabFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictWimbledon: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      expect(selectPredictWimbledonTabFlag(stateWithWimbledonTabFlag)).toEqual({
+        ...DEFAULT_WIMBLEDON_TAB_FLAG,
+        enabled: true,
+        minimumVersion: '1.0.0',
+      });
+    });
+
+    it('returns enabled flag with remote query params when provided', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const stateWithWimbledonTabFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictWimbledon: {
+                  enabled: true,
+                  queryParams: 'tag_slug=wimbledon&order=volume24hr',
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      expect(selectPredictWimbledonTabFlag(stateWithWimbledonTabFlag)).toEqual({
+        enabled: true,
+        queryParams: 'tag_slug=wimbledon&order=volume24hr',
+        minimumVersion: '1.0.0',
+      });
+    });
+
+    it('returns default flag when query params are invalid', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const stateWithInvalidQueryParams = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictWimbledon: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                  queryParams: 12345,
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      expect(
+        selectPredictWimbledonTabFlag(stateWithInvalidQueryParams),
+      ).toEqual(DEFAULT_WIMBLEDON_TAB_FLAG);
     });
   });
 

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -152,6 +152,11 @@ export const selectPredictWorldCupConfig = createSelector(
   (flags) => flags.predictWorldCup,
 );
 
+export const selectPredictWimbledonTabFlag = createSelector(
+  selectPredictFeatureFlags,
+  (flags) => flags.predictWimbledonTab,
+);
+
 export const selectPredictWorldCupEnabledFlag = createSelector(
   selectPredictWorldCupConfig,
   (config) => config.enabled,

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -59,6 +59,7 @@ export interface PredictFeatureFlags {
   predictWithAnyTokenEnabled: boolean;
   predictUpDownEnabled: boolean;
   predictWorldCup: PredictWorldCupConfig;
+  predictWimbledonTab: PredictWimbledonTabFlag;
   predictPortfolioEnabled: boolean;
   predictHomeRedesignEnabled: boolean;
   predictSportCardLivePricesEnabled: boolean;
@@ -66,4 +67,8 @@ export interface PredictFeatureFlags {
 
 export interface PredictHotTabFlag extends VersionGatedFeatureFlag {
   queryParams?: string; // Raw query params WITHOUT leading &: "tag_id=149&tag_id=100995&order=volume24hr"
+}
+
+export interface PredictWimbledonTabFlag extends VersionGatedFeatureFlag {
+  queryParams?: string; // Raw query params WITHOUT leading &: "tag_id=100639&tag_slug=tennis&order=volume24hr"
 }

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -70,5 +70,5 @@ export interface PredictHotTabFlag extends VersionGatedFeatureFlag {
 }
 
 export interface PredictWimbledonTabFlag extends VersionGatedFeatureFlag {
-  queryParams: string; // Raw query params WITHOUT leading &: "tag_id=100639&tag_slug=tennis&order=volume24hr"
+  queryParams?: string; // Raw query params WITHOUT leading &: "tag_id=100639&tag_slug=tennis&order=volume24hr"
 }

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -70,5 +70,5 @@ export interface PredictHotTabFlag extends VersionGatedFeatureFlag {
 }
 
 export interface PredictWimbledonTabFlag extends VersionGatedFeatureFlag {
-  queryParams?: string; // Raw query params WITHOUT leading &: "tag_id=100639&tag_slug=tennis&order=volume24hr"
+  queryParams: string; // Raw query params WITHOUT leading &: "tag_id=100639&tag_slug=tennis&order=volume24hr"
 }

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -153,7 +153,8 @@ export type PredictCategory =
   | 'crypto'
   | 'politics'
   | 'hot'
-  | 'world-cup';
+  | 'world-cup'
+  | 'wimbledon';
 
 // Sports league types
 export type PredictSportsLeague =

--- a/app/components/UI/Predict/utils/gameParser.test.ts
+++ b/app/components/UI/Predict/utils/gameParser.test.ts
@@ -580,6 +580,61 @@ describe('gameParser', () => {
       expect(result?.awayTeam).toEqual(awayTeam);
     });
 
+    it('builds ATP game scores from completed sets won', () => {
+      const homeTeam: PredictSportTeam = {
+        id: 'team-home',
+        name: 'Yibing Wu',
+        logo: 'https://example.com/wu.png',
+        abbreviation: 'wu',
+        color: TEST_HEX_COLORS.PURE_RED,
+        alias: 'Y. Wu',
+      };
+
+      const awayTeam: PredictSportTeam = {
+        id: 'team-away',
+        name: 'Novak Djokovic',
+        logo: 'https://example.com/djokovic.png',
+        abbreviation: 'djokovi',
+        color: TEST_HEX_COLORS.PURE_BLUE,
+        alias: 'N. Djokovic',
+      };
+
+      const atpTeamLookup = (
+        league: PredictSportsLeague,
+        abbr: string,
+      ): PredictSportTeam | undefined => {
+        if (league !== 'atp') return undefined;
+        const teams: Record<string, PredictSportTeam> = {
+          wu: homeTeam,
+          djokovi: awayTeam,
+        };
+        return teams[abbr.toLowerCase()];
+      };
+
+      const event = createMockEvent({
+        gameId: 'game-atp-123',
+        slug: 'atp-wu-djokovi-2026-06-29',
+        title: 'Yibing Wu vs Novak Djokovic',
+        tags: [
+          { id: '1', label: 'ATP', slug: 'atp' },
+          { id: '2', label: 'Games', slug: 'games' },
+        ],
+        score: '4-6, 7-5, 4-6, 3-2',
+        period: 'S4',
+        live: true,
+      });
+
+      const result = buildGameData(event, 'atp', atpTeamLookup);
+
+      expect(result?.score).toEqual({
+        away: 2,
+        home: 1,
+        raw: '4-6, 7-5, 4-6, 3-2',
+      });
+      expect(result?.homeTeam).toEqual(homeTeam);
+      expect(result?.awayTeam).toEqual(awayTeam);
+    });
+
     it('returns null when gameId is missing', () => {
       const event = createMockEvent({ gameId: undefined });
 
@@ -708,6 +763,46 @@ describe('gameParser', () => {
       const result = parseScore('42-35');
 
       expect(result).toEqual({ away: 42, home: 35, raw: '42-35' });
+    });
+
+    it('parses ATP scores as completed sets won', () => {
+      const result = parseScore('4-6, 7-5, 4-6, 3-2', 'atp');
+
+      expect(result).toEqual({
+        away: 2,
+        home: 1,
+        raw: '4-6, 7-5, 4-6, 3-2',
+      });
+    });
+
+    it('ignores incomplete ATP sets when counting sets won', () => {
+      const result = parseScore('6-4, 2-3', 'atp');
+
+      expect(result).toEqual({
+        away: 0,
+        home: 1,
+        raw: '6-4, 2-3',
+      });
+    });
+
+    it('parses WTA scores as completed sets won', () => {
+      const result = parseScore('6-3, 4-6, 2-1', 'wta');
+
+      expect(result).toEqual({
+        away: 1,
+        home: 1,
+        raw: '6-3, 4-6, 2-1',
+      });
+    });
+
+    it('counts completed ATP tiebreak sets toward sets won', () => {
+      const result = parseScore('7-6(7-4), 3-6, 3-5', 'atp');
+
+      expect(result).toEqual({
+        away: 1,
+        home: 1,
+        raw: '7-6(7-4), 3-6, 3-5',
+      });
     });
   });
 

--- a/app/components/UI/Predict/utils/gameParser.test.ts
+++ b/app/components/UI/Predict/utils/gameParser.test.ts
@@ -9,6 +9,7 @@ import {
   mapApiTeamToPredictTeam,
   buildGameData,
   extractNeededTeamsFromEvents,
+  getLeagueTeamOrder,
 } from './gameParser';
 import {
   PolymarketApiEvent,
@@ -49,6 +50,18 @@ const createMockEvent = (
 });
 
 describe('gameParser', () => {
+  describe('getLeagueTeamOrder', () => {
+    it('returns home-away for tennis leagues', () => {
+      expect(getLeagueTeamOrder('atp')).toBe('home-away');
+      expect(getLeagueTeamOrder('wta')).toBe('home-away');
+      expect(getLeagueTeamOrder('itf')).toBe('home-away');
+    });
+
+    it('returns away-home for US sports leagues', () => {
+      expect(getLeagueTeamOrder('nfl')).toBe('away-home');
+    });
+  });
+
   describe('getEventLeague', () => {
     it('returns "nfl" for event with nfl tag, games tag, and valid slug', () => {
       const event = createMockEvent();

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -12,6 +12,12 @@ import {
 
 type LeagueTeamOrder = 'away-home' | 'home-away';
 
+const TENNIS_LEAGUES: ReadonlySet<PredictSportsLeague> = new Set([
+  'atp',
+  'wta',
+  'itf',
+]);
+
 interface LeagueSlugConfig {
   pattern: RegExp;
   teamOrder: LeagueTeamOrder;
@@ -403,12 +409,85 @@ export function getLeagueTeamOrder(
   return LEAGUE_SLUG_CONFIGS[league].teamOrder;
 }
 
+const isTennisGame = (league?: PredictSportsLeague): boolean =>
+  Boolean(league && TENNIS_LEAGUES.has(league));
+
+const parseTennisSetSegment = (
+  segment: string,
+): { first: number; second: number } | null => {
+  const match = segment.trim().match(/^(\d+)-(\d+)(?:\(\d+-\d+\))?$/u);
+  if (!match) {
+    return null;
+  }
+
+  const firstScore = parseInt(match[1], 10);
+  const secondScore = parseInt(match[2], 10);
+
+  if (isNaN(firstScore) || isNaN(secondScore)) {
+    return null;
+  }
+
+  return { first: firstScore, second: secondScore };
+};
+
+const isCompletedTennisSet = (
+  firstScore: number,
+  secondScore: number,
+): boolean => {
+  const maxScore = Math.max(firstScore, secondScore);
+  const minScore = Math.min(firstScore, secondScore);
+  const lead = maxScore - minScore;
+
+  return (maxScore >= 6 && lead >= 2) || (maxScore === 7 && minScore >= 5);
+};
+
+const parseTennisSetsWonScore = (
+  scoreString: string,
+): PredictGameScore | null => {
+  const setSegments = scoreString
+    .split(',')
+    .map((segment) => parseTennisSetSegment(segment))
+    .filter(
+      (segment): segment is { first: number; second: number } =>
+        segment !== null,
+    );
+
+  if (setSegments.length === 0) {
+    return null;
+  }
+
+  let firstSetsWon = 0;
+  let secondSetsWon = 0;
+
+  setSegments.forEach(({ first, second }) => {
+    if (!isCompletedTennisSet(first, second)) {
+      return;
+    }
+
+    if (first > second) {
+      firstSetsWon += 1;
+    } else if (second > first) {
+      secondSetsWon += 1;
+    }
+  });
+
+  return {
+    away: secondSetsWon,
+    home: firstSetsWon,
+    raw: scoreString,
+  };
+};
+
 export function parseScore(
   scoreString?: string,
   league?: PredictSportsLeague,
 ): PredictGameScore | null {
   if (!scoreString || scoreString === '0-0') {
     return null;
+  }
+
+  if (isTennisGame(league)) {
+    return parseTennisSetsWonScore(scoreString);
   }
 
   const parts = scoreString.split('-');
@@ -453,7 +532,7 @@ export function buildGameData(
     return null;
   }
 
-  return {
+  const gameData = {
     id: String(event.gameId),
     startTime:
       event.startTime ?? event.endDate ?? `${parsedSlug.dateString}T00:00:00Z`,
@@ -466,6 +545,8 @@ export function buildGameData(
     homeTeam,
     awayTeam,
   };
+
+  return gameData;
 }
 
 /**

--- a/app/components/UI/Predict/utils/gameParser.ts
+++ b/app/components/UI/Predict/utils/gameParser.ts
@@ -393,7 +393,9 @@ export function mapApiTeamToPredictTeam(
   };
 }
 
-function getLeagueTeamOrder(league?: PredictSportsLeague): LeagueTeamOrder {
+export function getLeagueTeamOrder(
+  league?: PredictSportsLeague,
+): LeagueTeamOrder {
   if (!league) {
     return 'away-home';
   }

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../constants/flags';
 import { resolvePredictFeatureFlags } from './resolvePredictFeatureFlags';
 
@@ -37,6 +38,7 @@ describe('resolvePredictFeatureFlags', () => {
       predictHomeRedesignEnabled: false,
       predictSportCardLivePricesEnabled: true,
       predictWorldCup: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      predictWimbledonTab: DEFAULT_WIMBLEDON_TAB_FLAG,
     });
   });
 
@@ -348,6 +350,81 @@ describe('resolvePredictFeatureFlags', () => {
       });
 
       expect(result.predictWorldCup).toEqual(DEFAULT_PREDICT_WORLD_CUP_FLAG);
+    });
+  });
+
+  describe('predictWimbledonTab', () => {
+    it('returns default disabled flag when flag is missing', () => {
+      const result = resolvePredictFeatureFlags({});
+
+      expect(result.predictWimbledonTab).toEqual(DEFAULT_WIMBLEDON_TAB_FLAG);
+    });
+
+    it('uses default query params when enabled flag omits query params', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) =>
+        Boolean(
+          flag &&
+            typeof flag === 'object' &&
+            'enabled' in flag &&
+            (flag as { enabled: boolean }).enabled,
+        ),
+      );
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictWimbledon: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+          },
+        },
+      });
+
+      expect(result.predictWimbledonTab).toEqual({
+        ...DEFAULT_WIMBLEDON_TAB_FLAG,
+        enabled: true,
+        minimumVersion: '1.0.0',
+      });
+    });
+
+    it('uses remote query params when provided', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) =>
+        Boolean(
+          flag &&
+            typeof flag === 'object' &&
+            'enabled' in flag &&
+            (flag as { enabled: boolean }).enabled,
+        ),
+      );
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictWimbledon: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            queryParams: 'tag_slug=wimbledon&order=volume24hr',
+          },
+        },
+      });
+
+      expect(result.predictWimbledonTab).toEqual({
+        enabled: true,
+        minimumVersion: '1.0.0',
+        queryParams: 'tag_slug=wimbledon&order=volume24hr',
+      });
+    });
+
+    it('falls back to default when schema parsing fails', () => {
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictWimbledon: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            queryParams: 12345,
+          },
+        },
+      });
+
+      expect(result.predictWimbledonTab).toEqual(DEFAULT_WIMBLEDON_TAB_FLAG);
     });
   });
 

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
@@ -8,12 +8,14 @@ import {
   DEFAULT_LIVE_SPORTS_FLAG,
   DEFAULT_MARKET_HIGHLIGHTS_FLAG,
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../constants/flags';
 import { filterSupportedLeagues } from '../constants/sports';
 import { normalizeEnabledSportsMarketTypes } from '../providers/polymarket/outcomeGrouping';
 import {
   parse,
   PredictFeeCollectionSchema,
+  PredictWimbledonTabSchema,
   PredictWorldCupSchema,
 } from '../schemas';
 import {
@@ -21,6 +23,7 @@ import {
   PredictFeatureFlags,
   PredictLiveSportsFlag,
   PredictMarketHighlightsFlag,
+  PredictWimbledonTabFlag,
 } from '../types/flags';
 import { unwrapRemoteFeatureFlag } from './flags';
 
@@ -127,6 +130,16 @@ export function resolvePredictFeatureFlags(
   )
     ? parsedPredictWorldCup
     : DEFAULT_PREDICT_WORLD_CUP_FLAG;
+  const parsedPredictWimbledonTab = parse(
+    unwrapRemoteFeatureFlag<PredictWimbledonTabFlag>(flags.predictWimbledon),
+    PredictWimbledonTabSchema,
+    DEFAULT_WIMBLEDON_TAB_FLAG,
+  );
+  const predictWimbledonTab = validatedVersionGatedFeatureFlag(
+    parsedPredictWimbledonTab,
+  )
+    ? parsedPredictWimbledonTab
+    : DEFAULT_WIMBLEDON_TAB_FLAG;
 
   return {
     feeCollection,
@@ -141,5 +154,6 @@ export function resolvePredictFeatureFlags(
     predictHomeRedesignEnabled,
     predictSportCardLivePricesEnabled,
     predictWorldCup,
+    predictWimbledonTab,
   };
 }

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -10,7 +10,10 @@ import {
   getPredictFeedSelector,
   getPredictFeedMockSelector,
 } from '../../Predict.testIds';
-import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../../constants/flags';
+import {
+  DEFAULT_PREDICT_WORLD_CUP_FLAG,
+  PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+} from '../../constants/flags';
 import { buildPredictWorldCupAllQuery } from '../../utils/worldCup';
 
 jest.mock('react-native-reanimated', () => {
@@ -107,6 +110,11 @@ const mockHotTabFlag: { enabled: boolean; queryParams?: string } = {
 };
 let mockIsWorldCupMainFeedTabEnabled = false;
 let mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
+let mockWimbledonTabFlag = {
+  enabled: false,
+  queryParams: PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+  minimumVersion: '',
+};
 let mockIsFeaturedCarouselEnabled = false;
 let mockIsUpDownEnabled = false;
 let mockIsPredictPortfolioEnabled = false;
@@ -125,6 +133,7 @@ jest.mock('../../selectors/featureFlags', () => ({
   selectPredictHotTabFlag: 'selectPredictHotTabFlag',
   selectPredictPortfolioEnabledFlag: 'selectPredictPortfolioEnabledFlag',
   selectPredictUpDownEnabledFlag: 'selectPredictUpDownEnabledFlag',
+  selectPredictWimbledonTabFlag: 'selectPredictWimbledonTabFlag',
   selectPredictWorldCupConfig: 'selectPredictWorldCupConfig',
   selectPredictWorldCupMainFeedTabEnabledFlag:
     'selectPredictWorldCupMainFeedTabEnabledFlag',
@@ -328,6 +337,11 @@ describe('PredictFeed', () => {
     mockHotTabFlag.queryParams = undefined;
     mockIsWorldCupMainFeedTabEnabled = false;
     mockWorldCupConfig = DEFAULT_PREDICT_WORLD_CUP_FLAG;
+    mockWimbledonTabFlag = {
+      enabled: false,
+      queryParams: PREDICT_WIMBLEDON_DEFAULT_QUERY_PARAMS,
+      minimumVersion: '',
+    };
     mockIsFeaturedCarouselEnabled = false;
     mockIsUpDownEnabled = false;
     mockIsPredictPortfolioEnabled = false;
@@ -341,6 +355,8 @@ describe('PredictFeed', () => {
           return mockIsPredictPortfolioEnabled;
         case 'selectPredictUpDownEnabledFlag':
           return mockIsUpDownEnabled;
+        case 'selectPredictWimbledonTabFlag':
+          return mockWimbledonTabFlag;
         case 'selectPredictWorldCupConfig':
           return mockWorldCupConfig;
         case 'selectPredictWorldCupMainFeedTabEnabledFlag':

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
@@ -231,6 +231,18 @@ describe('handlePredictUrl', () => {
       });
     });
 
+    it('navigates to market list with Wimbledon tab parameter', async () => {
+      await handlePredictUrl({ predictPath: '?tab=wimbledon' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+          tab: 'wimbledon',
+        },
+      });
+    });
+
     it('normalizes uppercase tab parameter to lowercase', async () => {
       await handlePredictUrl({ predictPath: '?tab=CRYPTO' });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2571,7 +2571,8 @@
       "sports": "Sports",
       "crypto": "Crypto",
       "politics": "Politics",
-      "hot": "Hot"
+      "hot": "Hot",
+      "wimbledon": "Wimbledon"
     },
     "feed": {
       "live": "Live",


### PR DESCRIPTION
## **Description**

This PR adds Wimbledon support to the Predict main feed behind feature flags while preserving existing feed behavior and tab ordering rules. It introduces the new `wimbledon` category across tab config, typed feature-flag resolution/schema/selectors, and deeplink handling, and wires dedicated Wimbledon query params through the Polymarket fetch path (including `ended=false`) so it does not inherit generic feed filters.

This PR also fixes home/away ordering consistency in sports scoreboards by reusing league team-order logic from the game parser, and updates moneyline rendering so single-outcome moneyline groups still render as `MoneylineCard` with consistent live-price token mapping. Tests were added/updated across tabs, feature flags, parser/scoreboard ordering, Polymarket query behavior, deeplink handling, and game outcomes rendering.

## **Changelog**

CHANGELOG entry: Added a Wimbledon tab to Predict and fixed sports home/away ordering consistency in scoreboards.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1063

## **Manual testing steps**

```gherkin
Feature: Predict Wimbledon tab and sports ordering behavior

  Scenario: User views the Predict feed with Wimbledon support enabled
    Given Predict is opened and Wimbledon feature flag is enabled
    When user navigates to the market list tabs
    Then Wimbledon appears as an available tab with Wimbledon-specific market results

  Scenario: User opens a tennis market scoreboard
    Given a tennis game market (ATP/WTA/ITF) is displayed
    When scoreboard renders teams and scores
    Then home team is shown on the left and score mapping is consistent with parsed game data

  Scenario: User views moneyline outcomes with single-outcome grouping
    Given a moneyline-like market with one grouped outcome entry is displayed
    When outcome cards render and live prices update
    Then a Moneyline card layout is shown and button prices/labels map to the correct tokens
```

Also validated with targeted unit tests:

- `npx jest app/components/UI/Predict/utils/gameParser.test.ts --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx --coverage=false`
- `npx jest app/components/UI/Predict/hooks/usePredictTabs.test.ts --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx --coverage=false`
- `npx jest app/components/UI/Predict/providers/polymarket/utils.test.ts --coverage=false`

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches feed tab composition, remote flags, and Polymarket query behavior plus live price mapping for moneyline buttons; changes are gated by flags but affect how users browse and trade on sports markets.
> 
> **Overview**
> Adds a **feature-flagged Wimbledon tab** to the Predict feed (`wimbledon` category, remote `predictWimbledon` flag, schema/selectors, deeplink `?tab=wimbledon`, and Polymarket fetch that uses Wimbledon-specific query params—including `ended=false`—without the generic feed liquidity/volume filters). Optional tabs are ordered **World Cup → Wimbledon → Hot** before base tabs.
> 
> **Sports UX fixes:** scoreboards use **`getLeagueTeamOrder`** from the game parser (tennis/ATP shows home on the left; US sports stay away-home). **Tennis scores** are parsed as **sets won** from set strings (completed sets only, tiebreak notation supported).
> 
> **Moneyline cards** no longer require multiple outcomes: single-outcome moneyline groups render as **`MoneylineCard`** via **`getMoneylineButtonEntries`**, mapping both player tokens from one outcome with live best-ask prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699577cf4a21ac85945491011f0eb2de1b602497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->