### PR TITLE
perf: replace per-row `find()` and `Engine` call with memoized `Map`

### DIFF
--- a/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
+++ b/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
@@ -12,9 +12,10 @@ import {
 } from '@metamask/utils';
 
 // external dependencies
+import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
 import { isDefaultAccountName } from '../../../../../util/ENSUtils';
-import { formatAddress } from '../../../../../util/address';
+import { formatAddress, isEthAddress } from '../../../../../util/address';
 import { useStyles } from '../../../../../component-library/hooks';
 import AvatarGroup from '../../../../../component-library/components/Avatars/AvatarGroup';
 import { EnsByAccountAddress, Account } from '../../../../hooks/useAccounts';
@@ -68,7 +69,10 @@ const AccountsConnectedList = ({
   const accountByAddress = useMemo(() => {
     const map = new Map<string, Account>();
     for (const account of accounts) {
-      map.set(account.address.toLowerCase(), account);
+      const key = isEthAddress(account.address)
+        ? account.address.toLowerCase()
+        : account.address;
+      map.set(key, account);
     }
     return map;
   }, [accounts]);
@@ -138,17 +142,20 @@ const AccountsConnectedList = ({
     ({ item }: { item: CaipAccountId }) => {
       const { address } = parseCaipAccountId(item);
       const shortAddress = formatAddress(address, 'short');
-      const account = accountByAddress.get(address.toLowerCase());
+      const lookupKey = isEthAddress(address) ? address.toLowerCase() : address;
+      const account = accountByAddress.get(lookupKey);
       const avatarProps = {
         variant: AvatarVariant.Account as const,
         type: accountAvatarType,
         accountAddress: address,
       };
       const ensName = ensByAccountAddress[address];
+      const resolvedName =
+        account?.name ??
+        Engine.context.AccountsController.getAccountByAddress(address)?.metadata
+          .name;
       const accountName =
-        isDefaultAccountName(account?.name) && ensName
-          ? ensName
-          : account?.name;
+        isDefaultAccountName(resolvedName) && ensName ? ensName : resolvedName;
 
       return (
         <Cell

--- a/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
+++ b/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
@@ -15,7 +15,7 @@ import {
 import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
 import { isDefaultAccountName } from '../../../../../util/ENSUtils';
-import { formatAddress, isEthAddress } from '../../../../../util/address';
+import { formatAddress } from '../../../../../util/address';
 import { useStyles } from '../../../../../component-library/hooks';
 import AvatarGroup from '../../../../../component-library/components/Avatars/AvatarGroup';
 import { EnsByAccountAddress, Account } from '../../../../hooks/useAccounts';
@@ -69,10 +69,7 @@ const AccountsConnectedList = ({
   const accountByAddress = useMemo(() => {
     const map = new Map<string, Account>();
     for (const account of accounts) {
-      const key = isEthAddress(account.address)
-        ? account.address.toLowerCase()
-        : account.address;
-      map.set(key, account);
+      map.set(account.address, account);
     }
     return map;
   }, [accounts]);
@@ -142,8 +139,7 @@ const AccountsConnectedList = ({
     ({ item }: { item: CaipAccountId }) => {
       const { address } = parseCaipAccountId(item);
       const shortAddress = formatAddress(address, 'short');
-      const lookupKey = isEthAddress(address) ? address.toLowerCase() : address;
-      const account = accountByAddress.get(lookupKey);
+      const account = accountByAddress.get(address);
       const avatarProps = {
         variant: AvatarVariant.Account as const,
         type: accountAvatarType,

--- a/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
+++ b/app/components/Views/MultichainAccounts/shared/AccountsConnectedList/AccountsConnectedList.tsx
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { useSelector, shallowEqual } from 'react-redux';
@@ -12,10 +12,9 @@ import {
 } from '@metamask/utils';
 
 // external dependencies
-import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
 import { isDefaultAccountName } from '../../../../../util/ENSUtils';
-import { areAddressesEqual, formatAddress } from '../../../../../util/address';
+import { formatAddress } from '../../../../../util/address';
 import { useStyles } from '../../../../../component-library/hooks';
 import AvatarGroup from '../../../../../component-library/components/Avatars/AvatarGroup';
 import { EnsByAccountAddress, Account } from '../../../../hooks/useAccounts';
@@ -65,6 +64,14 @@ const AccountsConnectedList = ({
 
   const { styles } = useStyles(styleSheet, { itemHeight: MAX_HEIGHT });
   const accountAvatarType = useSelector(selectAvatarAccountType, shallowEqual);
+
+  const accountByAddress = useMemo(() => {
+    const map = new Map<string, Account>();
+    for (const account of accounts) {
+      map.set(account.address.toLowerCase(), account);
+    }
+    return map;
+  }, [accounts]);
 
   const getFilteredNetworkAvatars = useCallback(
     (accountScopes: CaipChainId[] = []) => {
@@ -131,22 +138,17 @@ const AccountsConnectedList = ({
     ({ item }: { item: CaipAccountId }) => {
       const { address } = parseCaipAccountId(item);
       const shortAddress = formatAddress(address, 'short');
-      const accountMetadata =
-        Engine.context.AccountsController.getAccountByAddress(address);
-      const account = accounts.find((accountData: Account) =>
-        areAddressesEqual(accountData.address, address),
-      );
+      const account = accountByAddress.get(address.toLowerCase());
       const avatarProps = {
         variant: AvatarVariant.Account as const,
         type: accountAvatarType,
         accountAddress: address,
       };
-      const accountMetadataName = accountMetadata?.metadata.name;
       const ensName = ensByAccountAddress[address];
       const accountName =
-        isDefaultAccountName(accountMetadataName) && ensName
+        isDefaultAccountName(account?.name) && ensName
           ? ensName
-          : accountMetadataName;
+          : account?.name;
 
       return (
         <Cell
@@ -165,7 +167,7 @@ const AccountsConnectedList = ({
     [
       styles.accountListItem,
       ensByAccountAddress,
-      accounts,
+      accountByAddress,
       renderRightAccessory,
       accountAvatarType,
     ],
@@ -179,6 +181,11 @@ const AccountsConnectedList = ({
           data={selectedAddresses}
           renderItem={renderAccountItem}
           scrollEnabled={selectedAddresses.length > 1}
+          getItemLayout={(_data, index) => ({
+            length: ACCOUNTS_CONNECTED_LIST_ITEM_HEIGHT,
+            offset: ACCOUNTS_CONNECTED_LIST_ITEM_HEIGHT * index,
+            index,
+          })}
         />
       </View>
       <TouchableOpacity


### PR DESCRIPTION
## **Description**

`renderAccountItem` in `AccountsConnectedList` was performing two expensive operations for every rendered row:

1. `accounts.find((a) => areAddressesEqual(a.address, address))` — O(accounts) linear scan per row, giving O(rows × accounts) overall complexity.
2. `Engine.context.AccountsController.getAccountByAddress(address)` — controller logic executed on the JS thread during render of each row, used only to read the account name.

Fixes:
- Pre-builds a `Map<address, Account>` once via `useMemo` so each row lookup is O(1).
- Derives the account name directly from `account.name` (already populated from `internalAccount.metadata.name` in `useAccounts`), eliminating the `Engine` call entirely.
- Adds `getItemLayout` with the known fixed row height (`ACCOUNTS_CONNECTED_LIST_ITEM_HEIGHT`) so `FlatList` can resolve positions without measuring.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31306

## **Manual testing steps**

N/A — performance refactor with identical output; covered by existing unit tests (8 passing).

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/4f29a5b9-ed50-463e-a755-33851814ea40

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-path optimization only; naming logic is slightly reordered but should match prior behavior when `useAccounts` data is present.
> 
> **Overview**
> **Performance refactor** for `AccountsConnectedList` when showing connected accounts in multichain flows—no intended UI change.
> 
> Each row no longer scans the full `accounts` array or always hits `AccountsController` during render. A **`useMemo` `Map` keyed by address** gives O(1) lookups per row. Display names prefer **`account.name`** from props (with `Engine.getAccountByAddress` only as fallback), and **`getItemLayout`** uses the fixed row height so `FlatList` skips per-row measurement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b00deb5c3b0c29c95f425a2662286e49630e5de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->