### PR TITLE
feat(predict): emit outcome metrics for key flows

### DIFF
--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -128,6 +128,8 @@ export const PredictEventValues = {
     MM_PREDICT_DEPOSIT: 'mm_predict_deposit',
     MM_PREDICT_WITHDRAW: 'mm_predict_withdraw',
     MM_PREDICT_CLAIM: 'mm_predict_claim',
+    MM_PREDICT_TRANSACTION_SUBMISSION: 'mm_predict_transaction_submission',
+    MM_PREDICT_WALLET_CREATION: 'mm_predict_wallet_creation',
   },
   CLAIM_FAILURE_REASON: {
     PENDING_RESOLUTION: 'pending_resolution',
@@ -192,6 +194,7 @@ export const PredictTradeStatus = {
   SUBMITTED: 'submitted',
   SUCCEEDED: 'succeeded',
   FAILED: 'failed',
+  CANCELLED: 'cancelled',
   SWAP_INITIATED: 'swap_initiated',
   SWAP_SUCCESS: 'swap_success',
   SWAP_FAILED: 'swap_failed',

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4927,6 +4927,108 @@ describe('PredictController', () => {
         await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           'Value must be a hexadecimal string.',
         );
+        expect(addTransactionBatch).not.toHaveBeenCalled();
+
+        const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type ===
+              'mm_predict_transaction_submission',
+          );
+        expect(submissionEvent).toBeUndefined();
+      });
+    });
+
+    it('does not track deposit failure when local bookkeeping fails after submission', async () => {
+      mockPolymarketProvider.prepareDeposit.mockResolvedValue({
+        transactions: [
+          {
+            params: {
+              to: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174' as `0x${string}`,
+              data: '0x095ea7b3000000000000000000000000' as `0x${string}`,
+            },
+          },
+        ],
+        chainId: '0x89',
+      });
+
+      let batchSubmitted = false;
+      (addTransactionBatch as jest.Mock).mockImplementation(async () => {
+        batchSubmitted = true;
+        return {
+          batchId: 'batch-123',
+        };
+      });
+
+      await withController(async ({ controller }) => {
+        type ControllerWithUpdate = PredictController & {
+          update: (updater: (state: PredictControllerState) => void) => void;
+        };
+
+        const signerAddress = '0x1234567890123456789012345678901234567890';
+        const controllerWithUpdate = controller as ControllerWithUpdate;
+        const originalUpdate = controllerWithUpdate.update.bind(controller);
+        let updateFailedAfterSubmission = false;
+
+        controllerWithUpdate.update = (updater) => {
+          const submissionSucceeded = (
+            analytics.trackEvent as jest.Mock
+          ).mock.calls
+            .map((call) => call[0])
+            .some(
+              (arg) =>
+                arg?.properties?.transaction_type ===
+                  'mm_predict_transaction_submission' &&
+                arg?.properties?.status === 'succeeded',
+            );
+
+          if (
+            batchSubmitted &&
+            submissionSucceeded &&
+            !updateFailedAfterSubmission
+          ) {
+            updateFailedAfterSubmission = true;
+            throw new Error('state update failed after submission');
+          }
+
+          originalUpdate(updater);
+        };
+
+        try {
+          (analytics.trackEvent as jest.Mock).mockClear();
+
+          await expect(controller.depositWithConfirmation({})).rejects.toThrow(
+            'state update failed after submission',
+          );
+
+          const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type ===
+                  'mm_predict_transaction_submission' &&
+                arg?.properties?.status === 'succeeded',
+            );
+          const depositFailureEvent = (
+            analytics.trackEvent as jest.Mock
+          ).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+                arg?.properties?.status === 'failed',
+            );
+
+          expect(updateFailedAfterSubmission).toBe(true);
+          expect(submissionEvent).toBeDefined();
+          expect(depositFailureEvent).toBeUndefined();
+          expect(controller.state.pendingDeposits[signerAddress]).toBe(
+            'pending',
+          );
+        } finally {
+          controllerWithUpdate.update = originalUpdate;
+        }
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -540,6 +540,40 @@ describe('PredictController', () => {
     return fn({ controller, messenger: rootMessenger });
   }
 
+  function installOneTimeUpdateFailure({
+    controller,
+    shouldFail,
+    errorMessage,
+  }: {
+    controller: PredictController;
+    shouldFail: () => boolean;
+    errorMessage: string;
+  }): { didFail: () => boolean; restore: () => void } {
+    type ControllerWithUpdate = PredictController & {
+      update: (updater: (state: PredictControllerState) => void) => void;
+    };
+
+    const controllerWithUpdate = controller as ControllerWithUpdate;
+    const originalUpdate = controllerWithUpdate.update;
+    let updateFailed = false;
+
+    controllerWithUpdate.update = (updater) => {
+      if (shouldFail() && !updateFailed) {
+        updateFailed = true;
+        throw new Error(errorMessage);
+      }
+
+      originalUpdate.call(controller, updater);
+    };
+
+    return {
+      didFail: () => updateFailed,
+      restore: () => {
+        controllerWithUpdate.update = originalUpdate;
+      },
+    };
+  }
+
   describe('constructor', () => {
     it('initializes with default state', () => {
       withController(({ controller }) => {
@@ -4962,38 +4996,21 @@ describe('PredictController', () => {
       });
 
       await withController(async ({ controller }) => {
-        type ControllerWithUpdate = PredictController & {
-          update: (updater: (state: PredictControllerState) => void) => void;
-        };
-
         const signerAddress = '0x1234567890123456789012345678901234567890';
-        const controllerWithUpdate = controller as ControllerWithUpdate;
-        const originalUpdate = controllerWithUpdate.update.bind(controller);
-        let updateFailedAfterSubmission = false;
-
-        controllerWithUpdate.update = (updater) => {
-          const submissionSucceeded = (
-            analytics.trackEvent as jest.Mock
-          ).mock.calls
-            .map((call) => call[0])
-            .some(
-              (arg) =>
-                arg?.properties?.transaction_type ===
-                  'mm_predict_transaction_submission' &&
-                arg?.properties?.status === 'succeeded',
-            );
-
-          if (
+        const updateFailure = installOneTimeUpdateFailure({
+          controller,
+          errorMessage: 'state update failed after submission',
+          shouldFail: () =>
             batchSubmitted &&
-            submissionSucceeded &&
-            !updateFailedAfterSubmission
-          ) {
-            updateFailedAfterSubmission = true;
-            throw new Error('state update failed after submission');
-          }
-
-          originalUpdate(updater);
-        };
+            (analytics.trackEvent as jest.Mock).mock.calls
+              .map((call) => call[0])
+              .some(
+                (arg) =>
+                  arg?.properties?.transaction_type ===
+                    'mm_predict_transaction_submission' &&
+                  arg?.properties?.status === 'succeeded',
+              ),
+        });
 
         try {
           (analytics.trackEvent as jest.Mock).mockClear();
@@ -5020,14 +5037,14 @@ describe('PredictController', () => {
                 arg?.properties?.status === 'failed',
             );
 
-          expect(updateFailedAfterSubmission).toBe(true);
+          expect(updateFailure.didFail()).toBe(true);
           expect(submissionEvent).toBeDefined();
           expect(depositFailureEvent).toBeUndefined();
           expect(controller.state.pendingDeposits[signerAddress]).toBe(
             'pending',
           );
         } finally {
-          controllerWithUpdate.update = originalUpdate;
+          updateFailure.restore();
         }
       });
     });
@@ -5938,6 +5955,74 @@ describe('PredictController', () => {
         expect(
           controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
         ).toBeUndefined();
+      });
+    });
+
+    it('does not track deposit failure when local bookkeeping fails after pay-with-any-token submission', async () => {
+      let batchSubmitted = false;
+      (addTransactionBatch as jest.Mock).mockImplementation(async () => {
+        batchSubmitted = true;
+        return {
+          batchId: 'batch-pay-with-any-token',
+        };
+      });
+
+      await withController(async ({ controller }) => {
+        controller.updateStateForTesting((state) => {
+          state.activeBuyOrders[MOCK_ADDRESS] = {
+            state: ActiveOrderState.PREVIEW,
+            error: 'previous-error',
+          };
+        });
+
+        const updateFailure = installOneTimeUpdateFailure({
+          controller,
+          errorMessage:
+            'state update failed after pay-with-any-token submission',
+          shouldFail: () =>
+            batchSubmitted &&
+            (analytics.trackEvent as jest.Mock).mock.calls
+              .map((call) => call[0])
+              .some(
+                (arg) =>
+                  arg?.properties?.transaction_type ===
+                    'mm_predict_transaction_submission' &&
+                  arg?.properties?.status === 'succeeded',
+              ),
+        });
+
+        try {
+          (analytics.trackEvent as jest.Mock).mockClear();
+
+          await expect(controller.initPayWithAnyToken()).resolves.toEqual({
+            success: false,
+            error: 'state update failed after pay-with-any-token submission',
+          });
+
+          const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type ===
+                  'mm_predict_transaction_submission' &&
+                arg?.properties?.status === 'succeeded',
+            );
+          const depositFailureEvent = (
+            analytics.trackEvent as jest.Mock
+          ).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+                arg?.properties?.status === 'failed',
+            );
+
+          expect(updateFailure.didFail()).toBe(true);
+          expect(submissionEvent).toBeDefined();
+          expect(depositFailureEvent).toBeUndefined();
+        } finally {
+          updateFailure.restore();
+        }
       });
     });
   });
@@ -7735,6 +7820,68 @@ describe('PredictController', () => {
         expect(controller.state.withdrawTransaction?.transactionId).toBe(
           mockBatchId,
         );
+      });
+    });
+
+    it('does not track withdraw failure when local bookkeeping fails after submission', async () => {
+      mockPolymarketProvider.prepareWithdraw.mockResolvedValue(
+        mockWithdrawResponse,
+      );
+      let batchSubmitted = false;
+      (addTransactionBatch as jest.Mock).mockImplementation(async () => {
+        batchSubmitted = true;
+        return {
+          batchId: 'batch-withdraw',
+        };
+      });
+
+      await withController(async ({ controller }) => {
+        const updateFailure = installOneTimeUpdateFailure({
+          controller,
+          errorMessage: 'state update failed after withdraw submission',
+          shouldFail: () =>
+            batchSubmitted &&
+            (analytics.trackEvent as jest.Mock).mock.calls
+              .map((call) => call[0])
+              .some(
+                (arg) =>
+                  arg?.properties?.transaction_type ===
+                    'mm_predict_transaction_submission' &&
+                  arg?.properties?.status === 'succeeded',
+              ),
+        });
+
+        try {
+          (analytics.trackEvent as jest.Mock).mockClear();
+
+          await expect(controller.prepareWithdraw({})).rejects.toThrow(
+            'state update failed after withdraw submission',
+          );
+
+          const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type ===
+                  'mm_predict_transaction_submission' &&
+                arg?.properties?.status === 'succeeded',
+            );
+          const withdrawFailureEvent = (
+            analytics.trackEvent as jest.Mock
+          ).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type === 'mm_predict_withdraw' &&
+                arg?.properties?.status === 'failed',
+            );
+
+          expect(updateFailure.didFail()).toBe(true);
+          expect(submissionEvent).toBeDefined();
+          expect(withdrawFailureEvent).toBeUndefined();
+        } finally {
+          updateFailure.restore();
+        }
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4293,13 +4293,11 @@ describe('PredictController', () => {
             balance: '100',
           },
         ]);
-        mockPolymarketProvider.prepareClaim = jest
-          .fn()
-          .mockRejectedValue(
-            Object.assign(new Error('Some upstream wording change'), {
-              code: 4001,
-            }),
-          );
+        mockPolymarketProvider.prepareClaim = jest.fn().mockRejectedValue(
+          Object.assign(new Error('Some upstream wording change'), {
+            code: 4001,
+          }),
+        );
         await controller.getPositions({ claimable: true });
         (analytics.trackEvent as jest.Mock).mockClear();
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -549,11 +549,11 @@ describe('PredictController', () => {
     shouldFail: () => boolean;
     errorMessage: string;
   }): { didFail: () => boolean; restore: () => void } {
-    type ControllerWithUpdate = PredictController & {
-      update: (updater: (state: PredictControllerState) => void) => void;
-    };
+    type UpdateFn = (
+      updater: (state: PredictControllerState) => void,
+    ) => unknown;
 
-    const controllerWithUpdate = controller as ControllerWithUpdate;
+    const controllerWithUpdate = controller as unknown as { update: UpdateFn };
     const originalUpdate = controllerWithUpdate.update;
     let updateFailed = false;
 
@@ -563,7 +563,7 @@ describe('PredictController', () => {
         throw new Error(errorMessage);
       }
 
-      originalUpdate.call(controller, updater);
+      return originalUpdate.call(controller, updater);
     };
 
     return {
@@ -4283,6 +4283,100 @@ describe('PredictController', () => {
         expect(controller.state.pendingClaims[signerAddress]).toBeUndefined();
       });
     });
+
+    it('treats an error with EIP-1193 code 4001 as user cancellation regardless of message', async () => {
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
+          {
+            marketId: 'test-market',
+            outcomeId: 'test-outcome',
+            balance: '100',
+          },
+        ]);
+        mockPolymarketProvider.prepareClaim = jest
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error('Some upstream wording change'), {
+              code: 4001,
+            }),
+          );
+        await controller.getPositions({ claimable: true });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        // Act
+        const result = await controller.claimWithConfirmation({});
+
+        // Assert
+        expect(result.status).toBe(PredictClaimStatus.CANCELLED);
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find((arg) => arg?.properties?.status === 'cancelled');
+        expect(event).toBeDefined();
+        expect(event.properties.transaction_type).toBe('mm_predict_claim');
+      });
+    });
+
+    it('does not record a failed claim when local bookkeeping fails after submission', async () => {
+      const signerAddress = '0x1234567890123456789012345678901234567890';
+      const mockBatchId = 'claim-batch-post-submit';
+      let batchSubmitted = false;
+
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
+          {
+            marketId: 'test-market',
+            outcomeId: 'test-outcome',
+            balance: '100',
+          },
+        ]);
+        mockPolymarketProvider.prepareClaim = jest
+          .fn()
+          .mockResolvedValue(mockClaim);
+        (addTransactionBatch as jest.Mock).mockImplementation(async () => {
+          batchSubmitted = true;
+          return { batchId: mockBatchId };
+        });
+        await controller.getPositions({ claimable: true });
+
+        const updateFailure = installOneTimeUpdateFailure({
+          controller,
+          errorMessage: 'state update failed after claim submission',
+          shouldFail: () => batchSubmitted,
+        });
+
+        try {
+          (analytics.trackEvent as jest.Mock).mockClear();
+
+          // Act — should resolve with the pending claim rather than throwing,
+          // so the calling hook does not record a false claim failure.
+          const result = await controller.claimWithConfirmation({});
+
+          // Assert
+          expect(result).toEqual({
+            batchId: mockBatchId,
+            chainId: mockClaim.chainId,
+            status: PredictClaimStatus.PENDING,
+          });
+          expect(updateFailure.didFail()).toBe(true);
+          // The pending-claim lock is preserved while the claim is in flight.
+          expect(controller.state.pendingClaims[signerAddress]).toBe('pending');
+
+          const failedOrCancelledEvent = (
+            analytics.trackEvent as jest.Mock
+          ).mock.calls
+            .map((call) => call[0])
+            .find(
+              (arg) =>
+                arg?.properties?.transaction_type === 'mm_predict_claim' &&
+                (arg?.properties?.status === 'failed' ||
+                  arg?.properties?.status === 'cancelled'),
+            );
+          expect(failedOrCancelledEvent).toBeUndefined();
+        } finally {
+          updateFailure.restore();
+        }
+      });
+    });
   });
 
   describe('getUnrealizedPnL', () => {
@@ -5015,8 +5109,11 @@ describe('PredictController', () => {
         try {
           (analytics.trackEvent as jest.Mock).mockClear();
 
-          await expect(controller.depositWithConfirmation({})).rejects.toThrow(
-            'state update failed after submission',
+          await expect(controller.depositWithConfirmation({})).resolves.toEqual(
+            {
+              success: true,
+              response: { batchId: 'batch-123' },
+            },
           );
 
           const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
@@ -5995,8 +6092,8 @@ describe('PredictController', () => {
           (analytics.trackEvent as jest.Mock).mockClear();
 
           await expect(controller.initPayWithAnyToken()).resolves.toEqual({
-            success: false,
-            error: 'state update failed after pay-with-any-token submission',
+            success: true,
+            response: { batchId: 'batch-pay-with-any-token' },
           });
 
           const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
@@ -7854,9 +7951,10 @@ describe('PredictController', () => {
         try {
           (analytics.trackEvent as jest.Mock).mockClear();
 
-          await expect(controller.prepareWithdraw({})).rejects.toThrow(
-            'state update failed after withdraw submission',
-          );
+          await expect(controller.prepareWithdraw({})).resolves.toEqual({
+            success: true,
+            response: 'batch-withdraw',
+          });
 
           const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
             .map((call) => call[0])

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4186,7 +4186,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('tracks a user_rejected mm_predict_claim failure when signing is cancelled', async () => {
+    it('tracks a cancelled mm_predict_claim transaction when signing is cancelled', async () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
           {
@@ -4212,10 +4212,10 @@ describe('PredictController', () => {
         expect(result.status).toBe(PredictClaimStatus.CANCELLED);
         const event = (analytics.trackEvent as jest.Mock).mock.calls
           .map((call) => call[0])
-          .find((arg) => arg?.properties?.status === 'failed');
+          .find((arg) => arg?.properties?.status === 'cancelled');
         expect(event).toBeDefined();
         expect(event.properties.transaction_type).toBe('mm_predict_claim');
-        expect(event.properties.failure_reason).toBe('user_rejected');
+        expect(event.properties.failure_reason).toBeUndefined();
         expect(event.properties.entry_point).toBe('predict_market_details');
       });
     });
@@ -4549,6 +4549,16 @@ describe('PredictController', () => {
           skipInitialGasEstimate: true,
           transactions: mockTransactions,
         });
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type ===
+                'mm_predict_transaction_submission' &&
+              arg?.properties?.status === 'succeeded',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.entry_point).toBe('background');
       });
     });
 
@@ -4565,6 +4575,15 @@ describe('PredictController', () => {
         await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           errorMessage,
         );
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+              arg?.properties?.status === 'failed',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.failure_reason).toBe(errorMessage);
       });
     });
 
@@ -4593,6 +4612,25 @@ describe('PredictController', () => {
         await expect(controller.depositWithConfirmation({})).rejects.toThrow(
           errorMessage,
         );
+        const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type ===
+                'mm_predict_transaction_submission' &&
+              arg?.properties?.status === 'failed',
+          );
+        const depositEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+              arg?.properties?.status === 'failed',
+          );
+        expect(submissionEvent).toBeDefined();
+        expect(submissionEvent.properties.failure_reason).toBe(errorMessage);
+        expect(depositEvent).toBeDefined();
+        expect(depositEvent.properties.failure_reason).toBe(errorMessage);
       });
     });
 
@@ -4698,6 +4736,23 @@ describe('PredictController', () => {
         // Then it should return success with NA batchId instead of throwing
         expect(result.success).toBe(true);
         expect(result.response?.batchId).toBe('NA');
+        const cancelledEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .filter((arg) => arg?.properties?.status === 'cancelled');
+        expect(cancelledEvents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                transaction_type: 'mm_predict_transaction_submission',
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                transaction_type: 'mm_predict_deposit',
+              }),
+            }),
+          ]),
+        );
       });
     });
 
@@ -6175,7 +6230,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('tracks a failed mm_predict_claim transaction with user_rejected when rejected', () => {
+    it('tracks a cancelled mm_predict_claim transaction when rejected', () => {
       withController(({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
           nestedType: TransactionType.predictClaim,
@@ -6198,9 +6253,10 @@ describe('PredictController', () => {
           transactionMeta,
         } as unknown as { transactionMeta: TransactionMeta });
 
-        const event = findPredictTradeEvent('failed');
+        const event = findPredictTradeEvent('cancelled');
         expect(event).toBeDefined();
-        expect(event.properties.failure_reason).toBe('user_rejected');
+        expect(event.properties.transaction_type).toBe('mm_predict_claim');
+        expect(event.properties.failure_reason).toBeUndefined();
       });
     });
 
@@ -6369,6 +6425,33 @@ describe('PredictController', () => {
             transactionId: 'tx-1',
           }),
         );
+      });
+    });
+
+    it('tracks failed mm_predict_withdraw when withdraw transaction fails', () => {
+      withController(({ messenger }) => {
+        const transactionMeta = {
+          ...createPredictTransactionMeta({
+            nestedType: TransactionType.predictWithdraw,
+            status: TransactionStatus.failed,
+          }),
+          error: { message: 'Withdraw reverted' },
+        };
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as { transactionMeta: TransactionMeta });
+
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_withdraw' &&
+              arg?.properties?.status === 'failed',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.failure_reason).toBe('Withdraw reverted');
       });
     });
 
@@ -6544,6 +6627,45 @@ describe('PredictController', () => {
       });
     });
 
+    it('tracks succeeded mm_predict_deposit when pending deposit confirms', () => {
+      withController(({ controller, messenger }) => {
+        const transactionMeta = {
+          ...createPredictTransactionMeta({
+            nestedType: TransactionType.predictDeposit,
+            status: TransactionStatus.confirmed,
+            batchId: 'batch-1',
+          }),
+          metamaskPay: {
+            totalFiat: '105',
+            bridgeFeeFiat: '3',
+            networkFeeFiat: '2',
+          },
+        };
+
+        controller.updateStateForTesting((state) => {
+          state.pendingDeposits = {
+            [accountAddress]: 'batch-1',
+          };
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as { transactionMeta: TransactionMeta });
+
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+              arg?.properties?.status === 'succeeded',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.entry_point).toBe('background');
+        expect(event.sensitiveProperties.amount_usd).toBe(100);
+      });
+    });
+
     it('clears pending deposit when deposit transaction is rejected', () => {
       withController(({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
@@ -6667,6 +6789,36 @@ describe('PredictController', () => {
         expect(
           controller.state.activeBuyOrders[MOCK_ADDRESS]?.transactionId,
         ).toBeUndefined();
+      });
+    });
+
+    it('tracks cancelled mm_predict_deposit when deposit-and-order is rejected', () => {
+      withController(({ controller, messenger }) => {
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictDepositAndOrder,
+          status: TransactionStatus.rejected,
+          batchId: 'batch-1',
+        });
+
+        setActiveOrderForTest(controller, {
+          transactionId: 'tx-1',
+          state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as { transactionMeta: TransactionMeta });
+
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_deposit' &&
+              arg?.properties?.status === 'cancelled',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.failure_reason).toBeUndefined();
       });
     });
 
@@ -7314,6 +7466,15 @@ describe('PredictController', () => {
           transactionId: mockBatchId,
           amount: 0,
         });
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type ===
+                'mm_predict_transaction_submission' &&
+              arg?.properties?.status === 'succeeded',
+          );
+        expect(event).toBeDefined();
       });
     });
 
@@ -7330,6 +7491,15 @@ describe('PredictController', () => {
         expect(controller.state.lastError).toBe('Provider error');
         expect(controller.state.lastUpdateTimestamp).toBeGreaterThan(0);
         expect(controller.state.withdrawTransaction).toBeNull();
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_withdraw' &&
+              arg?.properties?.status === 'failed',
+          );
+        expect(event).toBeDefined();
+        expect(event.properties.failure_reason).toBe('Provider error');
       });
     });
 
@@ -7482,6 +7652,23 @@ describe('PredictController', () => {
         expect(controller.state.lastError).toBe(
           'Transaction batch submission failed',
         );
+        const submissionEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type ===
+                'mm_predict_transaction_submission' &&
+              arg?.properties?.status === 'failed',
+          );
+        const withdrawEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_withdraw' &&
+              arg?.properties?.status === 'failed',
+          );
+        expect(submissionEvent).toBeDefined();
+        expect(withdrawEvent).toBeDefined();
       });
     });
 
@@ -7533,6 +7720,15 @@ describe('PredictController', () => {
 
         expect(result.success).toBe(true);
         expect(result.response).toBe('User cancelled transaction');
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find(
+            (arg) =>
+              arg?.properties?.transaction_type === 'mm_predict_withdraw' &&
+              arg?.properties?.status === 'cancelled',
+          );
+        expect(event).toBeDefined();
+        expect(addTransactionBatch).not.toHaveBeenCalled();
       });
     });
 
@@ -7551,6 +7747,23 @@ describe('PredictController', () => {
 
         expect(result.success).toBe(true);
         expect(result.response).toBe('User cancelled transaction');
+        const cancelledEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .filter((arg) => arg?.properties?.status === 'cancelled');
+        expect(cancelledEvents).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                transaction_type: 'mm_predict_transaction_submission',
+              }),
+            }),
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                transaction_type: 'mm_predict_withdraw',
+              }),
+            }),
+          ]),
+        );
       });
     });
 
@@ -11079,7 +11292,7 @@ describe('PredictController', () => {
       });
     });
 
-    it('fires swap_failed analytics event when depositAndOrder transaction is rejected', () => {
+    it('fires cancelled analytics event when depositAndOrder transaction is rejected', () => {
       withController(({ controller, messenger }) => {
         const trackSpy = jest.spyOn(controller, 'trackPredictOrderEvent');
 
@@ -11121,8 +11334,7 @@ describe('PredictController', () => {
 
         expect(trackSpy).toHaveBeenCalledWith(
           expect.objectContaining({
-            status: 'swap_failed',
-            failureReason: 'user_rejected',
+            status: 'cancelled',
           }),
         );
       });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1288,6 +1288,51 @@ export class PredictController extends BaseController<
     });
   }
 
+  /**
+   * Logs an error that occurred after a transaction batch was already
+   * submitted. At that point the flow is genuinely in flight, so callers
+   * swallow the error (keeping any pending-state locks for the
+   * terminal-status handler) instead of surfacing a false failure.
+   */
+  private logPostSubmissionBookkeepingError(
+    method: string,
+    error: Error,
+  ): void {
+    Logger.error(
+      error,
+      this.getErrorContext(method, {
+        providerId: POLYMARKET_PROVIDER_ID,
+        operation: 'post_submission_bookkeeping',
+      }),
+    );
+  }
+
+  /**
+   * Tracks the terminal flow metric for an error thrown before the
+   * transaction batch was submitted, classifying user cancellations.
+   *
+   * @returns whether the error was a user cancellation
+   */
+  private trackFlowSubmissionFailureMetric({
+    transactionType,
+    error,
+  }: {
+    transactionType: PredictTransactionMetricType;
+    error: unknown;
+  }): boolean {
+    const isUserCancelled = this.isUserCancelledTransactionError(error);
+
+    this.trackPredictFlowMetric({
+      transactionType,
+      status: isUserCancelled
+        ? PredictTradeStatus.CANCELLED
+        : PredictTradeStatus.FAILED,
+      failureReason: ensureError(error).message,
+    });
+
+    return isUserCancelled;
+  }
+
   private isUserCancelledTransactionError(error: unknown): boolean {
     // Prefer the language-independent EIP-1193 code (4001) emitted by
     // `providerErrors.userRejectedRequest()` over message matching, which can
@@ -1993,18 +2038,11 @@ export class PredictController extends BaseController<
       const e = ensureError(error);
 
       if (submittedClaim) {
-        // The batch was submitted, so the claim is genuinely in flight: keep
-        // the pending-claim lock and analytics stash for the terminal-status
-        // handler, and return the pending claim so the caller does not record
-        // a false failure for a local bookkeeping error.
+        // Keep the pending-claim lock and analytics stash for the
+        // terminal-status handler, and return the pending claim so the caller
+        // does not record a false failure for a local bookkeeping error.
         traceData = { success: true, error: e.message };
-        Logger.error(
-          e,
-          this.getErrorContext('claimWithConfirmation', {
-            providerId: POLYMARKET_PROVIDER_ID,
-            operation: 'post_submission_bookkeeping',
-          }),
-        );
+        this.logPostSubmissionBookkeepingError('claimWithConfirmation', e);
         return submittedClaim;
       }
 
@@ -2685,31 +2723,19 @@ export class PredictController extends BaseController<
       const e = ensureError(error);
 
       if (submittedBatchId !== undefined) {
-        // The batch was submitted, so the deposit is genuinely in flight: keep
-        // the pending-deposit entry (the terminal-status handler clears it by
-        // address) and return the batchId so the caller does not surface a
-        // false deposit failure for a local bookkeeping error.
-        Logger.error(
-          e,
-          this.getErrorContext('depositWithConfirmation', {
-            providerId: POLYMARKET_PROVIDER_ID,
-            operation: 'post_submission_bookkeeping',
-          }),
-        );
+        // Keep the pending-deposit entry (the terminal-status handler clears
+        // it by address) and return the batchId so the caller does not
+        // surface a false deposit failure for a local bookkeeping error.
+        this.logPostSubmissionBookkeepingError('depositWithConfirmation', e);
         return {
           success: true,
           response: { batchId: submittedBatchId },
         };
       }
 
-      const isUserCancelled = this.isUserCancelledTransactionError(error);
-
-      this.trackPredictFlowMetric({
+      const isUserCancelled = this.trackFlowSubmissionFailureMetric({
         transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
+        error,
       });
 
       if (isUserCancelled) {
@@ -2856,29 +2882,18 @@ export class PredictController extends BaseController<
       const e = ensureError(error);
 
       if (submittedBatchId !== undefined) {
-        // The batch was submitted, so the deposit-and-order flow is genuinely
-        // in flight: report success so a local bookkeeping error does not get
-        // treated as a deposit failure.
-        Logger.error(
-          e,
-          this.getErrorContext('initPayWithAnyToken', {
-            providerId: POLYMARKET_PROVIDER_ID,
-            operation: 'post_submission_bookkeeping',
-          }),
-        );
+        // Report success so a local bookkeeping error does not get treated as
+        // a failure of the in-flight deposit-and-order batch.
+        this.logPostSubmissionBookkeepingError('initPayWithAnyToken', e);
         return {
           success: true,
           response: { batchId: submittedBatchId },
         };
       }
 
-      const isUserCancelled = this.isUserCancelledTransactionError(error);
-      this.trackPredictFlowMetric({
+      this.trackFlowSubmissionFailureMetric({
         transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
+        error,
       });
 
       Logger.error(
@@ -3553,31 +3568,20 @@ export class PredictController extends BaseController<
       const e = ensureError(error);
 
       if (submittedBatchId !== undefined) {
-        // The batch was submitted, so the withdraw is genuinely in flight:
-        // keep `withdrawTransaction` (the terminal-status handler clears it)
+        // Keep `withdrawTransaction` (the terminal-status handler clears it)
         // and report success so a local bookkeeping error does not surface a
-        // false withdraw failure.
-        Logger.error(
-          e,
-          this.getErrorContext('prepareWithdraw', {
-            providerId: POLYMARKET_PROVIDER_ID,
-            operation: 'post_submission_bookkeeping',
-          }),
-        );
+        // false failure for the in-flight withdraw.
+        this.logPostSubmissionBookkeepingError('prepareWithdraw', e);
         return {
           success: true,
           response: submittedBatchId,
         };
       }
 
-      const isUserCancelled = this.isUserCancelledTransactionError(error);
-      this.trackPredictFlowMetric({
+      const isUserCancelled = this.trackFlowSubmissionFailureMetric({
         transactionType:
           PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
+        error,
       });
 
       if (isUserCancelled) {

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -25,6 +25,7 @@ import {
   RemoteFeatureFlagControllerGetStateAction,
   RemoteFeatureFlagControllerStateChangeEvent,
 } from '@metamask/remote-feature-flag-controller';
+import { errorCodes } from '@metamask/rpc-errors';
 import {
   TransactionControllerEstimateGasAction,
   TransactionControllerTransactionConfirmedEvent,
@@ -1287,8 +1288,16 @@ export class PredictController extends BaseController<
     });
   }
 
-  private isUserCancelledTransactionError(error: Error): boolean {
-    const message = error.message.toLowerCase();
+  private isUserCancelledTransactionError(error: unknown): boolean {
+    // Prefer the language-independent EIP-1193 code (4001) emitted by
+    // `providerErrors.userRejectedRequest()` over message matching, which can
+    // silently flip cancelled/failed if upstream error wording changes.
+    const errorCode = (error as { code?: unknown } | null | undefined)?.code;
+    if (errorCode === errorCodes.provider.userRejectedRequest) {
+      return true;
+    }
+
+    const message = ensureError(error).message.toLowerCase();
     return (
       message.includes('user denied transaction signature') ||
       message.includes('user rejected') ||
@@ -1318,7 +1327,7 @@ export class PredictController extends BaseController<
       return batchResult.batchId;
     } catch (error) {
       const e = ensureError(error);
-      const isUserCancelled = this.isUserCancelledTransactionError(e);
+      const isUserCancelled = this.isUserCancelledTransactionError(error);
 
       this.trackTransactionSubmissionMetric({
         status: isUserCancelled
@@ -1873,6 +1882,7 @@ export class PredictController extends BaseController<
     });
 
     const signer = this.getSigner();
+    let submittedClaim: PredictClaim | undefined;
 
     try {
       const provider = this.provider;
@@ -1961,17 +1971,16 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from claim transaction submission',
       });
+      submittedClaim = {
+        batchId,
+        chainId,
+        status: PredictClaimStatus.PENDING,
+      };
 
       // Store the real batchId for pending claim tracking
       this.update((state) => {
         state.pendingClaims[signer.address] = batchId;
       });
-
-      const predictClaim: PredictClaim = {
-        batchId,
-        chainId,
-        status: PredictClaimStatus.PENDING,
-      };
 
       this.update((state) => {
         state.lastError = null; // Clear any previous errors
@@ -1979,12 +1988,29 @@ export class PredictController extends BaseController<
       });
 
       traceData = { success: true, positionCount: claimablePositions.length };
-      return predictClaim;
+      return submittedClaim;
     } catch (error) {
+      const e = ensureError(error);
+
+      if (submittedClaim) {
+        // The batch was submitted, so the claim is genuinely in flight: keep
+        // the pending-claim lock and analytics stash for the terminal-status
+        // handler, and return the pending claim so the caller does not record
+        // a false failure for a local bookkeeping error.
+        traceData = { success: true, error: e.message };
+        Logger.error(
+          e,
+          this.getErrorContext('claimWithConfirmation', {
+            providerId: POLYMARKET_PROVIDER_ID,
+            operation: 'post_submission_bookkeeping',
+          }),
+        );
+        return submittedClaim;
+      }
+
       this.clearPendingClaimForAddress({ address: signer.address });
 
-      const e = ensureError(error);
-      if (this.isUserCancelledTransactionError(e)) {
+      if (this.isUserCancelledTransactionError(error)) {
         traceData = { success: false, reason: 'user_cancelled' };
 
         const claimAnalytics =
@@ -2567,7 +2593,7 @@ export class PredictController extends BaseController<
     _params: PrepareDepositParams = {},
   ): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
-    let transactionSubmitted = false;
+    let submittedBatchId: string | undefined;
 
     try {
       const signer = this.getSigner();
@@ -2643,7 +2669,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
-      transactionSubmitted = true;
+      submittedBatchId = batchId;
 
       this.update((state) => {
         state.pendingDeposits[signer.address] = batchId;
@@ -2657,24 +2683,38 @@ export class PredictController extends BaseController<
       };
     } catch (error) {
       const e = ensureError(error);
-      const isUserCancelled = this.isUserCancelledTransactionError(e);
 
-      if (!transactionSubmitted) {
-        this.trackPredictFlowMetric({
-          transactionType:
-            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-          status: isUserCancelled
-            ? PredictTradeStatus.CANCELLED
-            : PredictTradeStatus.FAILED,
-          failureReason: e.message,
-        });
+      if (submittedBatchId !== undefined) {
+        // The batch was submitted, so the deposit is genuinely in flight: keep
+        // the pending-deposit entry (the terminal-status handler clears it by
+        // address) and return the batchId so the caller does not surface a
+        // false deposit failure for a local bookkeeping error.
+        Logger.error(
+          e,
+          this.getErrorContext('depositWithConfirmation', {
+            providerId: POLYMARKET_PROVIDER_ID,
+            operation: 'post_submission_bookkeeping',
+          }),
+        );
+        return {
+          success: true,
+          response: { batchId: submittedBatchId },
+        };
       }
+
+      const isUserCancelled = this.isUserCancelledTransactionError(error);
+
+      this.trackPredictFlowMetric({
+        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
 
       if (isUserCancelled) {
         // Clear pending state before returning
-        if (!transactionSubmitted) {
-          this.clearPendingDeposit();
-        }
+        this.clearPendingDeposit();
         // ignore error, as the user cancelled the tx
         return {
           success: true,
@@ -2689,9 +2729,7 @@ export class PredictController extends BaseController<
         }),
       );
 
-      if (!transactionSubmitted) {
-        this.clearPendingDeposit();
-      }
+      this.clearPendingDeposit();
 
       throw new Error(
         error instanceof Error
@@ -2714,7 +2752,7 @@ export class PredictController extends BaseController<
   public async initPayWithAnyToken(): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
     const address = this.requireEvmAccountAddress();
-    let transactionSubmitted = false;
+    let submittedBatchId: string | undefined;
 
     if (!this.state.activeBuyOrders[address]) {
       this.update((state) => {
@@ -2800,7 +2838,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
-      transactionSubmitted = true;
+      submittedBatchId = batchId;
 
       this.update((state) => {
         if (state.activeBuyOrders[address]) {
@@ -2816,17 +2854,32 @@ export class PredictController extends BaseController<
       };
     } catch (error) {
       const e = ensureError(error);
-      const isUserCancelled = this.isUserCancelledTransactionError(e);
-      if (!transactionSubmitted) {
-        this.trackPredictFlowMetric({
-          transactionType:
-            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-          status: isUserCancelled
-            ? PredictTradeStatus.CANCELLED
-            : PredictTradeStatus.FAILED,
-          failureReason: e.message,
-        });
+
+      if (submittedBatchId !== undefined) {
+        // The batch was submitted, so the deposit-and-order flow is genuinely
+        // in flight: report success so a local bookkeeping error does not get
+        // treated as a deposit failure.
+        Logger.error(
+          e,
+          this.getErrorContext('initPayWithAnyToken', {
+            providerId: POLYMARKET_PROVIDER_ID,
+            operation: 'post_submission_bookkeeping',
+          }),
+        );
+        return {
+          success: true,
+          response: { batchId: submittedBatchId },
+        };
       }
+
+      const isUserCancelled = this.isUserCancelledTransactionError(error);
+      this.trackPredictFlowMetric({
+        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
 
       Logger.error(
         e,
@@ -3428,7 +3481,7 @@ export class PredictController extends BaseController<
   public async prepareWithdraw(
     _params: PrepareWithdrawParams = {},
   ): Promise<Result<string>> {
-    let transactionSubmitted = false;
+    let submittedBatchId: string | undefined;
 
     try {
       const provider = this.provider;
@@ -3479,7 +3532,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
-      transactionSubmitted = true;
+      submittedBatchId = batchId;
 
       this.update((state) => {
         if (state.withdrawTransaction) {
@@ -3498,17 +3551,34 @@ export class PredictController extends BaseController<
           : PREDICT_ERROR_CODES.WITHDRAW_FAILED;
 
       const e = ensureError(error);
-      const isUserCancelled = this.isUserCancelledTransactionError(e);
-      if (!transactionSubmitted) {
-        this.trackPredictFlowMetric({
-          transactionType:
-            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
-          status: isUserCancelled
-            ? PredictTradeStatus.CANCELLED
-            : PredictTradeStatus.FAILED,
-          failureReason: e.message,
-        });
+
+      if (submittedBatchId !== undefined) {
+        // The batch was submitted, so the withdraw is genuinely in flight:
+        // keep `withdrawTransaction` (the terminal-status handler clears it)
+        // and report success so a local bookkeeping error does not surface a
+        // false withdraw failure.
+        Logger.error(
+          e,
+          this.getErrorContext('prepareWithdraw', {
+            providerId: POLYMARKET_PROVIDER_ID,
+            operation: 'post_submission_bookkeeping',
+          }),
+        );
+        return {
+          success: true,
+          response: submittedBatchId,
+        };
       }
+
+      const isUserCancelled = this.isUserCancelledTransactionError(error);
+      this.trackPredictFlowMetric({
+        transactionType:
+          PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
 
       if (isUserCancelled) {
         // ignore error, as the user cancelled the tx

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -2567,6 +2567,7 @@ export class PredictController extends BaseController<
     _params: PrepareDepositParams = {},
   ): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
+    let transactionSubmitted = false;
 
     try {
       const signer = this.getSigner();
@@ -2594,6 +2595,11 @@ export class PredictController extends BaseController<
 
       if (!chainId) {
         throw new Error('Chain ID not provided by deposit preparation');
+      }
+
+      const parsedChainId = hexToNumber(chainId);
+      if (isNaN(parsedChainId)) {
+        throw new Error(`Invalid chain ID format: ${chainId}`);
       }
 
       DevLogger.log('PredictController: depositWithConfirmation transactions', {
@@ -2637,12 +2643,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
-
-      // Validate chainId format before parsing
-      const parsedChainId = hexToNumber(chainId);
-      if (isNaN(parsedChainId)) {
-        throw new Error(`Invalid chain ID format: ${chainId}`);
-      }
+      transactionSubmitted = true;
 
       this.update((state) => {
         state.pendingDeposits[signer.address] = batchId;
@@ -2657,17 +2658,23 @@ export class PredictController extends BaseController<
     } catch (error) {
       const e = ensureError(error);
       const isUserCancelled = this.isUserCancelledTransactionError(e);
-      this.trackPredictFlowMetric({
-        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
-      });
+
+      if (!transactionSubmitted) {
+        this.trackPredictFlowMetric({
+          transactionType:
+            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+          status: isUserCancelled
+            ? PredictTradeStatus.CANCELLED
+            : PredictTradeStatus.FAILED,
+          failureReason: e.message,
+        });
+      }
 
       if (isUserCancelled) {
         // Clear pending state before returning
-        this.clearPendingDeposit();
+        if (!transactionSubmitted) {
+          this.clearPendingDeposit();
+        }
         // ignore error, as the user cancelled the tx
         return {
           success: true,
@@ -2682,7 +2689,9 @@ export class PredictController extends BaseController<
         }),
       );
 
-      this.clearPendingDeposit();
+      if (!transactionSubmitted) {
+        this.clearPendingDeposit();
+      }
 
       throw new Error(
         error instanceof Error

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -2714,6 +2714,7 @@ export class PredictController extends BaseController<
   public async initPayWithAnyToken(): Promise<Result<{ batchId: string }>> {
     const provider = this.provider;
     const address = this.requireEvmAccountAddress();
+    let transactionSubmitted = false;
 
     if (!this.state.activeBuyOrders[address]) {
       this.update((state) => {
@@ -2799,6 +2800,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
+      transactionSubmitted = true;
 
       this.update((state) => {
         if (state.activeBuyOrders[address]) {
@@ -2815,13 +2817,16 @@ export class PredictController extends BaseController<
     } catch (error) {
       const e = ensureError(error);
       const isUserCancelled = this.isUserCancelledTransactionError(e);
-      this.trackPredictFlowMetric({
-        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
-      });
+      if (!transactionSubmitted) {
+        this.trackPredictFlowMetric({
+          transactionType:
+            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+          status: isUserCancelled
+            ? PredictTradeStatus.CANCELLED
+            : PredictTradeStatus.FAILED,
+          failureReason: e.message,
+        });
+      }
 
       Logger.error(
         e,
@@ -3423,6 +3428,8 @@ export class PredictController extends BaseController<
   public async prepareWithdraw(
     _params: PrepareWithdrawParams = {},
   ): Promise<Result<string>> {
+    let transactionSubmitted = false;
+
     try {
       const provider = this.provider;
 
@@ -3472,6 +3479,7 @@ export class PredictController extends BaseController<
         missingBatchIdError:
           'Failed to get batch ID from transaction submission',
       });
+      transactionSubmitted = true;
 
       this.update((state) => {
         if (state.withdrawTransaction) {
@@ -3491,14 +3499,16 @@ export class PredictController extends BaseController<
 
       const e = ensureError(error);
       const isUserCancelled = this.isUserCancelledTransactionError(e);
-      this.trackPredictFlowMetric({
-        transactionType:
-          PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
-        status: isUserCancelled
-          ? PredictTradeStatus.CANCELLED
-          : PredictTradeStatus.FAILED,
-        failureReason: e.message,
-      });
+      if (!transactionSubmitted) {
+        this.trackPredictFlowMetric({
+          transactionType:
+            PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
+          status: isUserCancelled
+            ? PredictTradeStatus.CANCELLED
+            : PredictTradeStatus.FAILED,
+          failureReason: e.message,
+        });
+      }
 
       if (isUserCancelled) {
         // ignore error, as the user cancelled the tx

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -53,6 +53,7 @@ import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import {
   PredictEventValues,
   PredictTradeStatus,
+  type PredictTradeStatusValue,
 } from '../constants/eventNames';
 
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
@@ -288,6 +289,9 @@ export type PredictTransactionEventStatus =
   | 'rejected'
   | 'depositing';
 
+type PredictTransactionMetricType =
+  (typeof PredictEventValues.TRANSACTION_TYPE)[keyof typeof PredictEventValues.TRANSACTION_TYPE];
+
 export interface PredictControllerTransactionStatusChangedEvent {
   type: 'PredictController:transactionStatusChanged';
   payload: [
@@ -481,6 +485,8 @@ export class PredictController extends BaseController<
    * Each claim creates a unique transaction id, so no per-attempt reset is needed.
    */
   private claimTerminalEmitted = new Set<string>();
+
+  private flowTerminalMetricEmitted = new Set<string>();
 
   private readonly traceable: TraceableController = {
     update: (updater) => this.update(updater),
@@ -1232,6 +1238,99 @@ export class PredictController extends BaseController<
     return this.analytics.trackPredictOrderEvent(args);
   }
 
+  private trackPredictFlowMetric({
+    transactionType,
+    status,
+    amountUsd,
+    analyticsProperties,
+    failureReason,
+  }: {
+    transactionType: PredictTransactionMetricType;
+    status: PredictTradeStatusValue;
+    amountUsd?: number;
+    analyticsProperties?: PredictTradeAnalyticsProperties;
+    failureReason?: string;
+  }): void {
+    const flowAnalyticsProperties: PredictTradeAnalyticsProperties = {
+      entryPoint: PredictEventValues.ENTRY_POINT.BACKGROUND,
+      ...(analyticsProperties ?? {}),
+      transactionType,
+    };
+
+    this.trackPredictOrderEvent({
+      status,
+      analyticsProperties: flowAnalyticsProperties,
+      ...(amountUsd !== undefined && {
+        amountUsd,
+      }),
+      ...(status === PredictTradeStatus.FAILED &&
+        failureReason && {
+          failureReason,
+        }),
+    });
+  }
+
+  private trackTransactionSubmissionMetric({
+    status,
+    failureReason,
+  }: {
+    status: PredictTradeStatusValue;
+    failureReason?: string;
+  }): void {
+    this.trackPredictFlowMetric({
+      transactionType:
+        PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_TRANSACTION_SUBMISSION,
+      status,
+      ...(failureReason && {
+        failureReason,
+      }),
+    });
+  }
+
+  private isUserCancelledTransactionError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('user denied transaction signature') ||
+      message.includes('user rejected') ||
+      message.includes('user cancelled') ||
+      message.includes('user canceled')
+    );
+  }
+
+  private async submitPredictTransactionBatch({
+    params,
+    missingBatchIdError,
+  }: {
+    params: Parameters<typeof addTransactionBatch>[0];
+    missingBatchIdError: string;
+  }): Promise<string> {
+    try {
+      const batchResult = await addTransactionBatch(params);
+
+      if (!batchResult?.batchId) {
+        throw new Error(missingBatchIdError);
+      }
+
+      this.trackTransactionSubmissionMetric({
+        status: PredictTradeStatus.SUCCEEDED,
+      });
+
+      return batchResult.batchId;
+    } catch (error) {
+      const e = ensureError(error);
+      const isUserCancelled = this.isUserCancelledTransactionError(e);
+
+      this.trackTransactionSubmissionMetric({
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
+
+      throw error;
+    }
+  }
+
   public trackMarketDetailsOpened(
     args: Parameters<PredictAnalytics['trackMarketDetailsOpened']>[0],
   ): void {
@@ -1846,26 +1945,22 @@ export class PredictController extends BaseController<
       }
 
       // Add transaction batch - can fail if transaction submission fails
-      const batchResult = await addTransactionBatch({
-        from: signer.address as Hex,
-        origin: ORIGIN_METAMASK,
-        isInternal: true,
-        networkClientId,
-        disableHook: true,
-        disableSequential: true,
-        skipInitialGasEstimate: true,
-        // Temporarily breaking abstraction, can instead be abstracted via provider.
-        gasFeeToken: MATIC_CONTRACTS_V2.collateral as Hex,
-        transactions,
-      });
-
-      if (!batchResult?.batchId) {
-        throw new Error(
+      const batchId = await this.submitPredictTransactionBatch({
+        params: {
+          from: signer.address as Hex,
+          origin: ORIGIN_METAMASK,
+          isInternal: true,
+          networkClientId,
+          disableHook: true,
+          disableSequential: true,
+          skipInitialGasEstimate: true,
+          // Temporarily breaking abstraction, can instead be abstracted via provider.
+          gasFeeToken: MATIC_CONTRACTS_V2.collateral as Hex,
+          transactions,
+        },
+        missingBatchIdError:
           'Failed to get batch ID from claim transaction submission',
-        );
-      }
-
-      const { batchId } = batchResult;
+      });
 
       // Store the real batchId for pending claim tracking
       this.update((state) => {
@@ -1889,21 +1984,15 @@ export class PredictController extends BaseController<
       this.clearPendingClaimForAddress({ address: signer.address });
 
       const e = ensureError(error);
-      if (e.message.includes('User denied transaction signature')) {
+      if (this.isUserCancelledTransactionError(e)) {
         traceData = { success: false, reason: 'user_cancelled' };
 
-        // This branch returns without throwing and before any on-chain
-        // transaction exists, so neither the hook catch nor the terminal-status
-        // handler fires. Track the user rejection here so it stays measurable.
         const claimAnalytics =
           this.pendingClaimAnalytics[signer.address.toLowerCase()] ??
           this.buildClaimAnalyticsProperties(analyticsContext);
-        // Signing was denied before any transaction was created, so there is no
-        // terminal `transactionStatusUpdated` to dedupe against (no guard entry).
         this.trackPredictOrderEvent({
-          status: PredictTradeStatus.FAILED,
+          status: PredictTradeStatus.CANCELLED,
           analyticsProperties: claimAnalytics,
-          failureReason: PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED,
         });
         delete this.pendingClaimAnalytics[signer.address.toLowerCase()];
 
@@ -2029,16 +2118,18 @@ export class PredictController extends BaseController<
         amountUsd: amount,
         analyticsProperties,
       });
+    } else if (status === 'rejected') {
+      this.trackPredictOrderEvent({
+        status: PredictTradeStatus.CANCELLED,
+        amountUsd: amount,
+        analyticsProperties,
+      });
     } else {
-      const failureReason =
-        status === 'rejected'
-          ? PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED
-          : mapClaimFailureReason(transactionMeta.error?.message);
       this.trackPredictOrderEvent({
         status: PredictTradeStatus.FAILED,
         amountUsd: amount,
         analyticsProperties,
-        failureReason,
+        failureReason: mapClaimFailureReason(transactionMeta.error?.message),
       });
     }
 
@@ -2052,7 +2143,7 @@ export class PredictController extends BaseController<
    * footer (Sentry 5JA7). Participates in the same per-transaction idempotency
    * guard as {@link trackClaimTransactionOutcome} (keyed by `transactionId`), so
    * the eventual `rejected` status update for the same transaction does not emit
-   * a duplicate (mislabeled `user_rejected`) terminal event.
+   * a duplicate terminal event.
    */
   public trackClaimResolutionLagFailure({
     transactionId,
@@ -2083,6 +2174,99 @@ export class PredictController extends BaseController<
       this.claimTerminalEmitted.add(transactionId);
     }
     delete this.pendingClaimAnalytics[normalizedAddress];
+  }
+
+  private getTerminalFlowTransactionType(
+    type: PredictTransactionEventType,
+  ): PredictTransactionMetricType | null {
+    switch (type) {
+      case 'deposit':
+      case 'depositAndOrder':
+        return PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT;
+      case 'withdraw':
+        return PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW;
+      case 'claim':
+      case 'order':
+        return null;
+    }
+  }
+
+  private getTerminalFlowStatus(
+    status: PredictTransactionEventStatus,
+  ): PredictTradeStatusValue | null {
+    switch (status) {
+      case 'confirmed':
+        return PredictTradeStatus.SUCCEEDED;
+      case 'failed':
+        return PredictTradeStatus.FAILED;
+      case 'rejected':
+        return PredictTradeStatus.CANCELLED;
+      case 'approved':
+      case 'depositing':
+        return null;
+    }
+  }
+
+  private getTerminalFlowFailureReason({
+    type,
+    transactionMeta,
+  }: {
+    type: PredictTransactionEventType;
+    transactionMeta: TransactionMeta;
+  }): string {
+    if (transactionMeta.error?.message) {
+      return transactionMeta.error.message;
+    }
+
+    switch (type) {
+      case 'withdraw':
+        return PREDICT_ERROR_CODES.WITHDRAW_FAILED;
+      case 'deposit':
+      case 'depositAndOrder':
+        return PREDICT_ERROR_CODES.DEPOSIT_FAILED;
+      case 'claim':
+      case 'order':
+        return PREDICT_ERROR_CODES.UNKNOWN_ERROR;
+    }
+  }
+
+  private trackTerminalFlowOutcomeMetric({
+    type,
+    status,
+    amount,
+    transactionMeta,
+  }: {
+    type: PredictTransactionEventType;
+    status: PredictTransactionEventStatus;
+    amount?: number;
+    transactionMeta: TransactionMeta;
+  }): void {
+    const transactionType = this.getTerminalFlowTransactionType(type);
+    const tradeStatus = this.getTerminalFlowStatus(status);
+
+    if (!transactionType || !tradeStatus) {
+      return;
+    }
+
+    const metricKey = `${transactionMeta.id}:${transactionType}`;
+    if (this.flowTerminalMetricEmitted.has(metricKey)) {
+      return;
+    }
+
+    this.trackPredictFlowMetric({
+      transactionType,
+      status: tradeStatus,
+      ...(amount !== undefined && {
+        amountUsd: amount,
+      }),
+      ...(tradeStatus === PredictTradeStatus.FAILED && {
+        failureReason: this.getTerminalFlowFailureReason({
+          type,
+          transactionMeta,
+        }),
+      }),
+    });
+    this.flowTerminalMetricEmitted.add(metricKey);
   }
 
   public confirmClaim({ address }: { address?: string }): void {
@@ -2439,22 +2623,20 @@ export class PredictController extends BaseController<
         state.pendingDeposits[signer.address] = 'pending';
       });
 
-      const batchResult = await addTransactionBatch({
-        from: signer.address as Hex,
-        origin: ORIGIN_METAMASK,
-        isInternal: true,
-        networkClientId,
-        disableHook: true,
-        disableSequential: true,
-        skipInitialGasEstimate: true,
-        transactions,
+      const batchId = await this.submitPredictTransactionBatch({
+        params: {
+          from: signer.address as Hex,
+          origin: ORIGIN_METAMASK,
+          isInternal: true,
+          networkClientId,
+          disableHook: true,
+          disableSequential: true,
+          skipInitialGasEstimate: true,
+          transactions,
+        },
+        missingBatchIdError:
+          'Failed to get batch ID from transaction submission',
       });
-
-      if (!batchResult?.batchId) {
-        throw new Error('Failed to get batch ID from transaction submission');
-      }
-
-      const { batchId } = batchResult;
 
       // Validate chainId format before parsing
       const parsedChainId = hexToNumber(chainId);
@@ -2474,7 +2656,16 @@ export class PredictController extends BaseController<
       };
     } catch (error) {
       const e = ensureError(error);
-      if (e.message.includes('User denied transaction signature')) {
+      const isUserCancelled = this.isUserCancelledTransactionError(e);
+      this.trackPredictFlowMetric({
+        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
+
+      if (isUserCancelled) {
         // Clear pending state before returning
         this.clearPendingDeposit();
         // ignore error, as the user cancelled the tx
@@ -2585,22 +2776,20 @@ export class PredictController extends BaseController<
         throw new Error(`Network client not found for chain ID: ${chainId}`);
       }
 
-      const batchResult = await addTransactionBatch({
-        from: signer.address as Hex,
-        origin: ORIGIN_METAMASK,
-        isInternal: true,
-        networkClientId,
-        disableHook: true,
-        disableSequential: true,
-        skipInitialGasEstimate: true,
-        transactions: depositAndOrderTransactions,
+      const batchId = await this.submitPredictTransactionBatch({
+        params: {
+          from: signer.address as Hex,
+          origin: ORIGIN_METAMASK,
+          isInternal: true,
+          networkClientId,
+          disableHook: true,
+          disableSequential: true,
+          skipInitialGasEstimate: true,
+          transactions: depositAndOrderTransactions,
+        },
+        missingBatchIdError:
+          'Failed to get batch ID from transaction submission',
       });
-
-      if (!batchResult?.batchId) {
-        throw new Error('Failed to get batch ID from transaction submission');
-      }
-
-      const { batchId } = batchResult;
 
       this.update((state) => {
         if (state.activeBuyOrders[address]) {
@@ -2616,6 +2805,15 @@ export class PredictController extends BaseController<
       };
     } catch (error) {
       const e = ensureError(error);
+      const isUserCancelled = this.isUserCancelledTransactionError(e);
+      this.trackPredictFlowMetric({
+        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
+
       Logger.error(
         e,
         this.getErrorContext('initPayWithAnyToken', {
@@ -2751,6 +2949,13 @@ export class PredictController extends BaseController<
       senderAddress: address,
       ...(transactionId ? { transactionId } : {}),
       ...(amount !== undefined ? { amount } : {}),
+    });
+
+    this.trackTerminalFlowOutcomeMetric({
+      type,
+      status,
+      amount,
+      transactionMeta,
     });
 
     // Track terminal claim outcome on PREDICT_TRADE_TRANSACTION. `amount` is
@@ -2969,15 +3174,13 @@ export class PredictController extends BaseController<
       }
 
       if (this.state.activeBuyOrders[address]) {
-        // Track swap_failed — user rejected the deposit/swap approval
         this.trackPredictOrderEvent({
-          status: PredictTradeStatus.SWAP_FAILED,
+          status: PredictTradeStatus.CANCELLED,
           analyticsProperties: rejectedPendingOrder?.analyticsProperties,
           paymentTokenAddress:
             this.state.activeBuyOrders[address]?.paymentTokenAddress,
           paymentTokenSymbol:
             this.state.activeBuyOrders[address]?.paymentTokenSymbol,
-          failureReason: 'user_rejected',
           activeAbTests: rejectedPendingOrder?.activeAbTests,
         });
 
@@ -3066,7 +3269,10 @@ export class PredictController extends BaseController<
     transactionMeta: TransactionMeta;
     address: string;
   }): number | undefined {
-    if (type === 'deposit' && status === 'confirmed') {
+    if (
+      (type === 'deposit' || type === 'depositAndOrder') &&
+      status === 'confirmed'
+    ) {
       const totalFiat = Number(transactionMeta.metamaskPay?.totalFiat ?? 0);
       const bridgeFeeFiat = Number(
         transactionMeta.metamaskPay?.bridgeFeeFiat ?? 0,
@@ -3239,19 +3445,23 @@ export class PredictController extends BaseController<
         };
       });
 
-      const { batchId } = await addTransactionBatch({
-        from: signer.address as Hex,
-        origin: ORIGIN_METAMASK,
-        isInternal: true,
-        networkClientId: this.messenger.call(
-          'NetworkController:findNetworkClientIdByChainId',
-          chainId,
-        ),
-        disableHook: true,
-        disableSequential: true,
-        requireApproval: true,
-        transactions: [transaction],
-        gasFeeToken,
+      const batchId = await this.submitPredictTransactionBatch({
+        params: {
+          from: signer.address as Hex,
+          origin: ORIGIN_METAMASK,
+          isInternal: true,
+          networkClientId: this.messenger.call(
+            'NetworkController:findNetworkClientIdByChainId',
+            chainId,
+          ),
+          disableHook: true,
+          disableSequential: true,
+          requireApproval: true,
+          transactions: [transaction],
+          gasFeeToken,
+        },
+        missingBatchIdError:
+          'Failed to get batch ID from transaction submission',
       });
 
       this.update((state) => {
@@ -3271,7 +3481,17 @@ export class PredictController extends BaseController<
           : PREDICT_ERROR_CODES.WITHDRAW_FAILED;
 
       const e = ensureError(error);
-      if (e.message.includes('User denied transaction signature')) {
+      const isUserCancelled = this.isUserCancelledTransactionError(e);
+      this.trackPredictFlowMetric({
+        transactionType:
+          PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WITHDRAW,
+        status: isUserCancelled
+          ? PredictTradeStatus.CANCELLED
+          : PredictTradeStatus.FAILED,
+        failureReason: e.message,
+      });
+
+      if (isUserCancelled) {
         // ignore error, as the user cancelled the tx
         return {
           success: true,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1379,7 +1379,7 @@ describe('PolymarketProvider', () => {
     });
   });
 
-  it('tracks failed wallet creation when deposit-wallet deployment fails', async () => {
+  it('tracks failed wallet creation when the relayer create request fails', async () => {
     const provider = createProvider();
     mockIsSmartContractAddress.mockResolvedValueOnce(false);
     mockRequestDepositWalletCreate.mockRejectedValueOnce(
@@ -1407,6 +1407,34 @@ describe('PolymarketProvider', () => {
     expect(walletCreationEvent?.properties?.failure_reason).toBe(
       'relayer unavailable',
     );
+  });
+
+  it('does not track failed wallet creation when waiting fails after the relayer accepted', async () => {
+    const provider = createProvider();
+    mockIsSmartContractAddress.mockResolvedValueOnce(false);
+    // The relayer accepted the create request, but local polling failed
+    // afterwards — the wallet may still have been created remotely.
+    mockWaitForDepositWalletTransaction.mockRejectedValueOnce(
+      new Error('polling timed out'),
+    );
+
+    await expect(
+      provider.beforePublishDepositWalletDeposit({
+        transactionMeta: createDepositTransactionMeta({
+          recipient: depositWalletAddress,
+        }),
+        getSigner: () => signer,
+      }),
+    ).rejects.toThrow('polling timed out');
+
+    const walletCreationEvents = mockAnalyticsTrackEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (event) =>
+          event?.properties?.transaction_type === 'mm_predict_wallet_creation',
+      );
+    expect(walletCreationEvents).toHaveLength(1);
+    expect(walletCreationEvents[0]?.properties?.status).toBe('succeeded');
   });
 
   it('waits for WALLET-CREATE polling before submitting allowance batch', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -82,7 +82,7 @@ jest.mock('../../../../../util/Logger', () => ({
 }));
 
 jest.mock('../../../../../util/analytics/analytics', () => ({
-  analytics: { identify: jest.fn() },
+  analytics: { identify: jest.fn(), trackEvent: jest.fn() },
 }));
 
 jest.mock('../../../../../util/transactions', () => ({
@@ -196,6 +196,7 @@ jest.mock('./preflight/withdraw', () => ({
 }));
 
 const mockAnalyticsIdentify = jest.mocked(analytics.identify);
+const mockAnalyticsTrackEvent = jest.mocked(analytics.trackEvent);
 const mockComputeProxyAddress = jest.mocked(computeProxyAddress);
 const mockCreateApiKey = jest.mocked(createApiKey);
 const mockDeriveDepositWalletAddress = jest.mocked(deriveDepositWalletAddress);
@@ -1344,6 +1345,16 @@ describe('PolymarketProvider', () => {
     expect(mockAnalyticsIdentify).toHaveBeenCalledWith({
       [UserProfileProperty.CREATED_POLYMARKET_ACCOUNT_VIA_MM]: true,
     });
+    const walletCreationEvent = mockAnalyticsTrackEvent.mock.calls
+      .map((call) => call[0])
+      .find(
+        (event) =>
+          event?.properties?.transaction_type ===
+            'mm_predict_wallet_creation' &&
+          event?.properties?.status === 'succeeded',
+      );
+    expect(walletCreationEvent).toBeDefined();
+    expect(walletCreationEvent?.properties?.entry_point).toBe('background');
     expect(
       mockSyncDepositWalletCollateralBalanceAllowance,
     ).not.toHaveBeenCalled();
@@ -1366,6 +1377,36 @@ describe('PolymarketProvider', () => {
       transactionID: 'batch-1',
       requireCompletion: true,
     });
+  });
+
+  it('tracks failed wallet creation when deposit-wallet deployment fails', async () => {
+    const provider = createProvider();
+    mockIsSmartContractAddress.mockResolvedValueOnce(false);
+    mockRequestDepositWalletCreate.mockRejectedValueOnce(
+      new Error('relayer unavailable'),
+    );
+
+    await expect(
+      provider.beforePublishDepositWalletDeposit({
+        transactionMeta: createDepositTransactionMeta({
+          recipient: depositWalletAddress,
+        }),
+        getSigner: () => signer,
+      }),
+    ).rejects.toThrow('relayer unavailable');
+
+    const walletCreationEvent = mockAnalyticsTrackEvent.mock.calls
+      .map((call) => call[0])
+      .find(
+        (event) =>
+          event?.properties?.transaction_type ===
+            'mm_predict_wallet_creation' &&
+          event?.properties?.status === 'failed',
+      );
+    expect(walletCreationEvent).toBeDefined();
+    expect(walletCreationEvent?.properties?.failure_reason).toBe(
+      'relayer unavailable',
+    );
   });
 
   it('waits for WALLET-CREATE polling before submitting allowance batch', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -2955,12 +2955,17 @@ export class PolymarketProvider implements PredictProvider {
     );
 
     if (!depositWalletIsDeployed) {
+      // The wallet-creation metric only covers the relayer create request.
+      // Once the relayer accepts the request the wallet may be created
+      // remotely even if local waiting/polling fails afterwards, and a retry
+      // would skip this branch entirely, so reporting a post-acceptance
+      // failure would misclassify creations that actually succeeded.
+      let transactionID: string | undefined;
       try {
         const createResponse = await requestDepositWalletCreate({
           ownerAddress,
         });
-        const transactionID =
-          getDepositWalletRelayerTransactionId(createResponse);
+        transactionID = getDepositWalletRelayerTransactionId(createResponse);
 
         if (!transactionID) {
           throw new Error(
@@ -2968,41 +2973,6 @@ export class PolymarketProvider implements PredictProvider {
           );
         }
 
-        DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
-          operation: 'deposit_wallet_create',
-          walletType: 'deposit-wallet',
-          transactionID,
-          from: ownerAddress,
-          depositWalletAddress,
-        });
-
-        await waitForDepositWalletTransaction({
-          transactionID,
-          requireCompletion: true,
-        });
-
-        DevLogger.log(
-          'PolymarketProvider: Waiting for deposit wallet relayer registry',
-          {
-            operation: 'deposit_wallet_relayer_registry',
-            walletType: 'deposit-wallet',
-            from: ownerAddress,
-            depositWalletAddress,
-          },
-        );
-
-        await waitForDepositWalletDeployed({
-          walletAddress: depositWalletAddress,
-        });
-        depositWalletDeploymentConfirmed = true;
-
-        this.#setCachedAccountState(ownerAddress, {
-          address: depositWalletAddress,
-          isDeployed: true,
-          walletType: 'deposit-wallet',
-        });
-        this.setPolymarketAccountCreatedTrait();
-        updatedState = true;
         this.trackDepositWalletCreationMetric({
           status: PredictTradeStatus.SUCCEEDED,
         });
@@ -3016,6 +2986,42 @@ export class PolymarketProvider implements PredictProvider {
         });
         throw error;
       }
+
+      DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
+        operation: 'deposit_wallet_create',
+        walletType: 'deposit-wallet',
+        transactionID,
+        from: ownerAddress,
+        depositWalletAddress,
+      });
+
+      await waitForDepositWalletTransaction({
+        transactionID,
+        requireCompletion: true,
+      });
+
+      DevLogger.log(
+        'PolymarketProvider: Waiting for deposit wallet relayer registry',
+        {
+          operation: 'deposit_wallet_relayer_registry',
+          walletType: 'deposit-wallet',
+          from: ownerAddress,
+          depositWalletAddress,
+        },
+      );
+
+      await waitForDepositWalletDeployed({
+        walletAddress: depositWalletAddress,
+      });
+      depositWalletDeploymentConfirmed = true;
+
+      this.#setCachedAccountState(ownerAddress, {
+        address: depositWalletAddress,
+        isDeployed: true,
+        walletType: 'deposit-wallet',
+      });
+      this.setPolymarketAccountCreatedTrait();
+      updatedState = true;
     }
 
     const preflightPlan = await planDepositWalletPreflight({

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -9,8 +9,10 @@ import {
 } from '@metamask/transaction-controller';
 import { Hex, numberToHex } from '@metamask/utils';
 import { getAddress, Interface, parseUnits } from 'ethers/lib/utils';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import Logger, { type LoggerErrorOptions } from '../../../../../util/Logger';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { UserProfileProperty } from '../../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import {
@@ -18,6 +20,12 @@ import {
   isSmartContractAddress,
 } from '../../../../../util/transactions';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../../constants/errors';
+import {
+  PredictEventProperties,
+  PredictEventValues,
+  PredictTradeStatus,
+  type PredictTradeStatusValue,
+} from '../../constants/eventNames';
 import { filterSupportedLeagues } from '../../constants/sports';
 import { PREDICT_ACTIVITY_PAGE_SIZE } from '../../constants/transactions';
 import { SERIES_MAX_EVENTS } from '../../utils/series';
@@ -2538,6 +2546,34 @@ export class PolymarketProvider implements PredictProvider {
     });
   }
 
+  private trackDepositWalletCreationMetric({
+    status,
+    failureReason,
+  }: {
+    status: PredictTradeStatusValue;
+    failureReason?: string;
+  }): void {
+    const properties = {
+      [PredictEventProperties.STATUS]: status,
+      [PredictEventProperties.TRANSACTION_TYPE]:
+        PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_WALLET_CREATION,
+      [PredictEventProperties.ENTRY_POINT]:
+        PredictEventValues.ENTRY_POINT.BACKGROUND,
+      ...(status === PredictTradeStatus.FAILED &&
+        failureReason && {
+          [PredictEventProperties.FAILURE_REASON]: failureReason,
+        }),
+    };
+
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.PREDICT_TRADE_TRANSACTION,
+      )
+        .addProperties(properties)
+        .build(),
+    );
+  }
+
   public async prepareDeposit(
     params: PrepareDepositParams,
   ): Promise<PrepareDepositResponse> {
@@ -2919,53 +2955,67 @@ export class PolymarketProvider implements PredictProvider {
     );
 
     if (!depositWalletIsDeployed) {
-      const createResponse = await requestDepositWalletCreate({
-        ownerAddress,
-      });
-      const transactionID =
-        getDepositWalletRelayerTransactionId(createResponse);
+      try {
+        const createResponse = await requestDepositWalletCreate({
+          ownerAddress,
+        });
+        const transactionID =
+          getDepositWalletRelayerTransactionId(createResponse);
 
-      if (!transactionID) {
-        throw new Error(
-          'Polymarket deposit wallet creation response missing transactionID',
-        );
-      }
+        if (!transactionID) {
+          throw new Error(
+            'Polymarket deposit wallet creation response missing transactionID',
+          );
+        }
 
-      DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
-        operation: 'deposit_wallet_create',
-        walletType: 'deposit-wallet',
-        transactionID,
-        from: ownerAddress,
-        depositWalletAddress,
-      });
-
-      await waitForDepositWalletTransaction({
-        transactionID,
-        requireCompletion: true,
-      });
-
-      DevLogger.log(
-        'PolymarketProvider: Waiting for deposit wallet relayer registry',
-        {
-          operation: 'deposit_wallet_relayer_registry',
+        DevLogger.log('PolymarketProvider: Waiting for deposit wallet create', {
+          operation: 'deposit_wallet_create',
           walletType: 'deposit-wallet',
+          transactionID,
           from: ownerAddress,
           depositWalletAddress,
-        },
-      );
+        });
 
-      await waitForDepositWalletDeployed({
-        walletAddress: depositWalletAddress,
-      });
-      depositWalletDeploymentConfirmed = true;
+        await waitForDepositWalletTransaction({
+          transactionID,
+          requireCompletion: true,
+        });
 
-      this.#setCachedAccountState(ownerAddress, {
-        address: depositWalletAddress,
-        isDeployed: true,
-        walletType: 'deposit-wallet',
-      });
-      this.setPolymarketAccountCreatedTrait();
-      updatedState = true;
+        DevLogger.log(
+          'PolymarketProvider: Waiting for deposit wallet relayer registry',
+          {
+            operation: 'deposit_wallet_relayer_registry',
+            walletType: 'deposit-wallet',
+            from: ownerAddress,
+            depositWalletAddress,
+          },
+        );
+
+        await waitForDepositWalletDeployed({
+          walletAddress: depositWalletAddress,
+        });
+        depositWalletDeploymentConfirmed = true;
+
+        this.#setCachedAccountState(ownerAddress, {
+          address: depositWalletAddress,
+          isDeployed: true,
+          walletType: 'deposit-wallet',
+        });
+        this.setPolymarketAccountCreatedTrait();
+        updatedState = true;
+        this.trackDepositWalletCreationMetric({
+          status: PredictTradeStatus.SUCCEEDED,
+        });
+      } catch (error) {
+        this.trackDepositWalletCreationMetric({
+          status: PredictTradeStatus.FAILED,
+          failureReason:
+            error instanceof Error
+              ? error.message
+              : PREDICT_ERROR_CODES.UNKNOWN_ERROR,
+        });
+        throw error;
+      }
     }
 
     const preflightPlan = await planDepositWalletPreflight({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This implements PRED-946 by adding outcome telemetry for key Predict flows on the existing `Predict Trade Transaction` event.

- Emits `cancelled` rather than `failed` for user-rejected claim/deposit/PWAT confirmation paths.
- Tracks transaction batch submission outcomes with `transaction_type: mm_predict_transaction_submission`.
- Tracks deposit outcomes for both regular deposit and pay-with-any-token deposit-and-order flows.
- Tracks withdraw outcomes and deposit-wallet creation success/failure.
- Keeps Segment schema aligned in Consensys/segment-schema#643.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-946
## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - no visual/manual UI behavior changed. Verification was automated:

- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/Predict/controllers/PredictController.test.ts --runInBand --forceExit`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts --runInBand --forceExit`
- `yarn prettier --check app/components/UI/Predict/constants/eventNames.ts app/components/UI/Predict/controllers/PredictController.ts app/components/UI/Predict/controllers/PredictController.test.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn eslint app/components/UI/Predict/constants/eventNames.ts app/components/UI/Predict/controllers/PredictController.ts app/components/UI/Predict/controllers/PredictController.test.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts`

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A - no UI changes; telemetry and schema-only update.

### **Before**

N/A - telemetry-only change; no visual before state.

<!-- [screenshots/recordings] -->

### **After**

N/A - telemetry-only change; no visual after state.

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how failures vs cancellations are classified and when success is returned after submission; incorrect handling could skew analytics or leave pending locks, but scope is telemetry and error-handling around existing transaction flows with broad test coverage.
> 
> **Overview**
> Adds **outcome telemetry** on the existing Predict Trade Transaction event for deposit, withdraw, claim, batch submission, and Polymarket deposit-wallet creation.
> 
> **Status semantics:** User dismissals/rejections are tracked as **`cancelled`** (including EIP-1193 `4001`), not **`failed`** with `user_rejected`. Pay-with-any-token deposit-and-order rejections use **`cancelled`** instead of **`swap_failed`**.
> 
> **New event dimensions:** `mm_predict_transaction_submission` wraps all `addTransactionBatch` calls; terminal **deposit** / **withdraw** outcomes fire on transaction status updates (with deduping). **Wallet creation** is success/failed only when the relayer **accepts** the create request—not when local polling fails afterward.
> 
> **Reliability:** After a batch is already submitted, local state update failures are logged and callers still return success/pending so analytics and UI do not report a false failure while the tx is in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a536febcfe1136e40078129d0ac2d259c11f1e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->