### PR TITLE
chore: add missing integration tests for price alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
@@ -1,0 +1,89 @@
+import '../../../../../../../tests/component-view/mocks';
+import { renderCreatePriceAlertViewWithRoutes } from '../../../../../../../tests/component-view/renderers/priceAlerts';
+import {
+  setupPriceAlertsApiMock,
+  clearPriceAlertsApiMocks,
+} from '../../../../../../../tests/component-view/api-mocking/priceAlerts';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { CreatePriceAlertTestIds, type PriceAlert } from '../../constants';
+
+beforeEach(() => {
+  setupPriceAlertsApiMock();
+});
+
+afterEach(() => {
+  clearPriceAlertsApiMocks();
+});
+
+const editingAlert: PriceAlert = {
+  id: 'alert-1',
+  userId: 'user-1',
+  asset: 'eip155:1/slip44:60',
+  threshold: 3000,
+  recurring: true,
+  active: true,
+  createdAt: '2025-01-01T00:00:00.000Z',
+};
+
+describeForPlatforms('CreatePriceAlertView', () => {
+  it('renders the Price Reaches form with keypad and quick-percentage pills', async () => {
+    const { getByTestId, getByText } = renderCreatePriceAlertViewWithRoutes();
+
+    expect(getByTestId(CreatePriceAlertTestIds.CONTAINER)).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.TARGET_PRICE_INPUT),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
+    ).toBeOnTheScreen();
+    expect(getByText('Create ETH price alert')).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
+  });
+
+  it('enables the Set button after keypad input and completes POST via nock', async () => {
+    const { getByTestId } = renderCreatePriceAlertViewWithRoutes();
+
+    fireEvent.press(getByTestId('keypad-key-1'));
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
+
+    fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+
+    // Wait for isSubmitting to clear — proves the nock POST interceptor was hit
+    // and the response was handled without error.
+    await waitFor(() => {
+      expect(
+        getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+      ).not.toBeDisabled();
+    });
+  });
+
+  it('opens in edit mode with pre-filled threshold when editingAlert is passed', async () => {
+    const { getByText, getByTestId } = renderCreatePriceAlertViewWithRoutes({
+      routeParams: {
+        editingAlert,
+        existingThresholds: [],
+      },
+    });
+
+    expect(getByText('Edit ETH price alert')).toBeOnTheScreen();
+    // threshold 3000 is pre-filled as "$3000"
+    expect(getByText('$3000')).toBeOnTheScreen();
+    // Update button is shown (not "Set price alert")
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeOnTheScreen();
+    expect(getByText('Update price alert')).toBeOnTheScreen();
+    // Button is disabled because threshold is unchanged
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
+  });
+});

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
@@ -2,10 +2,11 @@ import '../../../../../../../tests/component-view/mocks';
 import { renderCreatePriceAlertViewWithRoutes } from '../../../../../../../tests/component-view/renderers/priceAlerts';
 import {
   setupPriceAlertsApiMock,
+  setupPriceAlertsPostMock,
   clearPriceAlertsApiMocks,
 } from '../../../../../../../tests/component-view/api-mocking/priceAlerts';
 import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, waitFor } from '@testing-library/react-native';
 import { CreatePriceAlertTestIds, type PriceAlert } from '../../constants';
 
 beforeEach(() => {
@@ -47,6 +48,7 @@ describeForPlatforms('CreatePriceAlertView', () => {
   });
 
   it('enables the Set button after keypad input and completes POST via nock', async () => {
+    const scope = setupPriceAlertsPostMock();
     const { getByTestId } = renderCreatePriceAlertViewWithRoutes();
 
     fireEvent.press(getByTestId('keypad-key-1'));
@@ -54,15 +56,15 @@ describeForPlatforms('CreatePriceAlertView', () => {
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).not.toBeDisabled();
 
-    fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
-
-    // Wait for isSubmitting to clear — proves the nock POST interceptor was hit
-    // and the response was handled without error.
-    await waitFor(() => {
-      expect(
-        getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
-      ).not.toBeDisabled();
+    // act() flushes TanStack Query's mutation lifecycle (scheduling, fetch,
+    // state updates) across async boundaries that fireEvent alone does not drain.
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
     });
+
+    // scope.isDone() is true only when the one-shot POST interceptor was consumed,
+    // proving the real createAlert HTTP call was made and received a 201 response.
+    await waitFor(() => expect(scope.isDone()).toBe(true));
   });
 
   it('opens in edit mode with pre-filled threshold when editingAlert is passed', async () => {

--- a/tests/component-view/api-mocking/priceAlerts.ts
+++ b/tests/component-view/api-mocking/priceAlerts.ts
@@ -9,7 +9,7 @@
  */
 
 // eslint-disable-next-line import-x/no-extraneous-dependencies
-import nock from 'nock';
+import nock, { type Scope } from 'nock';
 import { clearAllNockMocks, disableNetConnect } from './nockHelpers';
 import type { PriceAlert } from '../../../app/components/UI/Assets/PriceAlerts/constants';
 
@@ -52,7 +52,8 @@ export const mockCreatedAlert: PriceAlert = {
  * Sets up nock interceptors for the Price Alerts API.
  * Call in beforeEach of price-alerts view tests.
  *
- * Intercepts GET /v1/alerts and POST /v1/alerts.
+ * Intercepts GET /v1/alerts only. Use {@link setupPriceAlertsPostMock} in
+ * tests that also need to intercept POST /v1/alerts.
  *
  * @param alerts - The alerts to return from GET /v1/alerts. Defaults to mockPriceAlertsData.
  */
@@ -67,11 +68,18 @@ export function setupPriceAlertsApiMock(
     .query(true)
     .reply(200, alerts)
     .persist();
+}
 
-  nock(PRICE_ALERTS_ORIGIN)
+/**
+ * Registers a one-shot POST /v1/alerts nock interceptor.
+ * Call this inside the individual test that exercises alert creation,
+ * after {@link setupPriceAlertsApiMock} has already been called in beforeEach.
+ * Returns the nock scope so callers can assert `scope.isDone()`.
+ */
+export function setupPriceAlertsPostMock(): Scope {
+  return nock(PRICE_ALERTS_ORIGIN)
     .post(ALERTS_PATH)
-    .reply(201, mockCreatedAlert)
-    .persist();
+    .reply(201, mockCreatedAlert);
 }
 
 /**

--- a/tests/component-view/api-mocking/priceAlerts.ts
+++ b/tests/component-view/api-mocking/priceAlerts.ts
@@ -37,9 +37,22 @@ export const mockPriceAlertsData: PriceAlert[] = [
   },
 ];
 
+/** Fixture for the alert returned by POST /v1/alerts in tests. */
+export const mockCreatedAlert: PriceAlert = {
+  id: 'alert-new',
+  userId: 'user-1',
+  asset: 'eip155:1/slip44:60',
+  threshold: 1300,
+  recurring: true,
+  active: true,
+  createdAt: '2025-06-01T00:00:00.000Z',
+};
+
 /**
  * Sets up nock interceptors for the Price Alerts API.
  * Call in beforeEach of price-alerts view tests.
+ *
+ * Intercepts GET /v1/alerts and POST /v1/alerts.
  *
  * @param alerts - The alerts to return from GET /v1/alerts. Defaults to mockPriceAlertsData.
  */
@@ -53,6 +66,11 @@ export function setupPriceAlertsApiMock(
     .get(ALERTS_PATH)
     .query(true)
     .reply(200, alerts)
+    .persist();
+
+  nock(PRICE_ALERTS_ORIGIN)
+    .post(ALERTS_PATH)
+    .reply(201, mockCreatedAlert)
     .persist();
 }
 

--- a/tests/component-view/renderers/priceAlerts.tsx
+++ b/tests/component-view/renderers/priceAlerts.tsx
@@ -7,11 +7,19 @@ import Routes from '../../../app/constants/navigation/Routes';
 import ManagePriceAlertsView from '../../../app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView';
 import CreatePriceAlertView from '../../../app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView';
 import { initialStatePriceAlerts } from '../presets/priceAlerts';
-import type { PriceAlertRouteParams } from '../../../app/components/UI/Assets/PriceAlerts/constants';
+import type {
+  CreatePriceAlertRouteParams,
+  PriceAlertRouteParams,
+} from '../../../app/components/UI/Assets/PriceAlerts/constants';
 
 interface RenderManagePriceAlertsOptions {
   overrides?: DeepPartial<RootState>;
   routeParams?: Partial<PriceAlertRouteParams>;
+}
+
+interface RenderCreatePriceAlertOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: Partial<CreatePriceAlertRouteParams>;
 }
 
 const DEFAULT_ROUTE_PARAMS: PriceAlertRouteParams = {
@@ -20,6 +28,10 @@ const DEFAULT_ROUTE_PARAMS: PriceAlertRouteParams = {
   currentPrice: 2500,
   currentCurrency: 'USD',
   assetId: 'eip155:1/slip44:60',
+};
+
+const DEFAULT_CREATE_ROUTE_PARAMS: CreatePriceAlertRouteParams = {
+  ...DEFAULT_ROUTE_PARAMS,
 };
 
 /**
@@ -50,5 +62,37 @@ export function renderManagePriceAlertsViewWithRoutes(
     ],
     { state },
     { ...DEFAULT_ROUTE_PARAMS, ...routeParams },
+  );
+}
+
+/**
+ * Renders CreatePriceAlertView with a real navigation stack that includes
+ * ManagePriceAlertsView as a reachable back destination. Use this to test
+ * Create screen behavior (form rendering, submission) with real nock HTTP
+ * and real navigation — covering what jest.mock('useNavigation') cannot.
+ */
+export function renderCreatePriceAlertViewWithRoutes(
+  options: RenderCreatePriceAlertOptions = {},
+): ReturnType<typeof renderScreenWithRoutes> {
+  const { overrides, routeParams } = options;
+
+  const builder = initialStatePriceAlerts();
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+  const state = builder.build();
+
+  return renderScreenWithRoutes(
+    CreatePriceAlertView as unknown as React.ComponentType,
+    { name: Routes.CREATE_PRICE_ALERT },
+    [
+      {
+        name: Routes.MANAGE_PRICE_ALERTS,
+        Component:
+          ManagePriceAlertsView as unknown as React.ComponentType<object>,
+      },
+    ],
+    { state },
+    { ...DEFAULT_CREATE_ROUTE_PARAMS, ...routeParams },
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Adds the missing component-view test for `CreatePriceAlertView`, completing the test coverage for the Price Alerts feature.

The new test file exercises the Create screen through a real navigation stack and a real nock HTTP interceptor (POST `/v1/alerts`), covering three scenarios: form rendering, keypad input triggering a live API call, and edit mode with a pre-filled threshold. Supporting infrastructure — a POST nock mock and a `renderCreatePriceAlertViewWithRoutes` renderer — was added to the shared component-view test helpers.

QA doc: https://docs.google.com/document/d/1Ak-1jb7cuKaZ4OFW15AM07gCCbiLMA5GSx8nwJlVLEY/edit?tab=t.0

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add missing integration tests for price alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3476

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to shared price-alerts component-view helpers; no production app behavior is modified.
> 
> **Overview**
> Adds **component-view integration tests** for `CreatePriceAlertView`, using a real navigation stack and nock-backed HTTP instead of mocked navigation.
> 
> Shared helpers now include **`renderCreatePriceAlertViewWithRoutes`** (mirroring the manage-screen renderer) and **`setupPriceAlertsPostMock`** with a **`mockCreatedAlert`** fixture so create flows can assert a consumed POST to `/v1/alerts`. **`setupPriceAlertsApiMock`** is documented as GET-only; POST is registered per test.
> 
> The new suite covers **create UI** (keypad, quick percentages, disabled submit), **submit after keypad input** (TanStack Query mutation + `scope.isDone()`), and **edit mode** with a pre-filled threshold and disabled update when unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c16c81da8cdd35ba50234767759ed0a482c1c5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->