### PR TITLE
feat(ci): Team onboarding PR Slack notification bot

### DIFF
--- a/.github/scripts/team-onboarding-pr-slack.mjs
+++ b/.github/scripts/team-onboarding-pr-slack.mjs
@@ -1,0 +1,827 @@
+#!/usr/bin/env node
+
+/**
+ * Team Onboarding PR Slack Bot
+ *
+ * Posts and updates a Slack thread in #metamask-onboarding-mobile-internal for
+ * team-onboarding PRs once they are ready for review.
+ *
+ * Required env:
+ *   GITHUB_TOKEN, SLACK_BOT_TOKEN, GITHUB_REPOSITORY, ACTION
+ *
+ * Optional env:
+ *   TEAM_ONBOARDING_SLACK_CHANNEL (default: metamask-onboarding-mobile-internal)
+ *   GITHUB_EVENT_PATH, GITHUB_EVENT_NAME, DRY_RUN=true
+ */
+
+import fs from 'fs';
+
+export const TEAM_LABEL = 'team-onboarding';
+export const MARKER_PREFIX = 'team-onboarding-pr-slack:';
+export const MARKER_REGEX = new RegExp(
+  `<!--\\s*${MARKER_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([\\s\\S]*?)\\s*-->`,
+);
+
+export const CURSOR_BOT_LOGINS = new Set([
+  'cursor[bot]',
+  'cursorbot',
+  'cursoragent',
+]);
+
+export const IGNORED_COMMENT_BOT_LOGINS = new Set([
+  'github-actions[bot]',
+  'dependabot[bot]',
+  'metamaskbot',
+  'metamaskbotv2[bot]',
+  'crowdin-bot',
+  'runway-github[bot]',
+]);
+
+const DEFAULT_CHANNEL = 'metamask-onboarding-mobile-internal';
+
+/**
+ * @param {string} channel
+ * @returns {string}
+ */
+export function normalizeChannelName(channel) {
+  return channel.replace(/^#/, '').trim();
+}
+
+/**
+ * @param {Array<{ name: string }>} labels
+ * @returns {boolean}
+ */
+export function hasTeamOnboardingLabel(labels) {
+  return labels.some((label) => label.name === TEAM_LABEL);
+}
+
+/**
+ * @param {string} body
+ * @returns {Record<string, unknown> | null}
+ */
+export function parseThreadMarker(body) {
+  const match = body.match(MARKER_REGEX);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(match[1].trim());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {Record<string, unknown>} meta
+ * @returns {string}
+ */
+export function buildMarkerComment(meta) {
+  return `<!-- ${MARKER_PREFIX}${JSON.stringify(meta)} -->\n_Slack thread tracked for team onboarding review._`;
+}
+
+/**
+ * @param {string | undefined | null} login
+ * @returns {boolean}
+ */
+export function isCursorBot(login) {
+  return Boolean(login && CURSOR_BOT_LOGINS.has(login));
+}
+
+/**
+ * @param {string | undefined | null} login
+ * @returns {boolean}
+ */
+export function isIgnoredCommentBot(login) {
+  return Boolean(login && IGNORED_COMMENT_BOT_LOGINS.has(login));
+}
+
+/**
+ * @param {string} login
+ * @returns {string}
+ */
+export function formatGithubAuthorMention(login) {
+  return `<https://github.com/${login}|@${login}>`;
+}
+
+/**
+ * @param {string} conclusion
+ * @returns {'success' | 'failure' | 'other'}
+ */
+export function normalizeCiConclusion(conclusion) {
+  if (conclusion === 'success') {
+    return 'success';
+  }
+  if (['failure', 'cancelled', 'timed_out', 'action_required'].includes(conclusion)) {
+    return 'failure';
+  }
+  return 'other';
+}
+
+/**
+ * @param {Object} options
+ * @param {import('@octokit/rest').Octokit} options.octokit
+ * @param {string} options.owner
+ * @param {string} options.repo
+ * @param {number} options.prNumber
+ * @returns {Promise<Record<string, unknown> | null>}
+ */
+export async function readThreadMeta({ octokit, owner, repo, prNumber }) {
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+
+  for (const comment of comments) {
+    const meta = parseThreadMarker(comment.body ?? '');
+    if (meta?.threadTs && meta?.channelId) {
+      return {
+        ...meta,
+        commentId: comment.id,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * @param {Object} options
+ * @param {import('@octokit/rest').Octokit} options.octokit
+ * @param {string} options.owner
+ * @param {string} options.repo
+ * @param {number} options.prNumber
+ * @param {Record<string, unknown>} options.meta
+ * @returns {Promise<void>}
+ */
+export async function writeThreadMeta({ octokit, owner, repo, prNumber, meta }) {
+  const body = buildMarkerComment(meta);
+  const existing = await readThreadMeta({ octokit, owner, repo, prNumber });
+
+  if (existing?.commentId) {
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: Number(existing.commentId),
+      body,
+    });
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body,
+  });
+}
+
+class SlackClient {
+  /**
+   * @param {string} token
+   */
+  constructor(token) {
+    this.token = token;
+    this.channelCache = new Map();
+  }
+
+  /**
+   * @param {string} method
+   * @param {Record<string, unknown>} body
+   * @returns {Promise<Record<string, unknown>>}
+   */
+  async api(method, body) {
+    const response = await fetch(`https://slack.com/api/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const payload = await response.json();
+    if (!payload.ok) {
+      throw new Error(`Slack API ${method} failed: ${payload.error ?? 'unknown_error'}`);
+    }
+
+    return payload;
+  }
+
+  /**
+   * @param {string} channelName
+   * @returns {Promise<string>}
+   */
+  async resolveChannelId(channelName) {
+    const normalized = normalizeChannelName(channelName);
+    if (this.channelCache.has(normalized)) {
+      return this.channelCache.get(normalized);
+    }
+
+    let cursor;
+    do {
+      const payload = await this.api('conversations.list', {
+        types: 'public_channel,private_channel',
+        limit: 200,
+        cursor,
+      });
+
+      const match = (payload.channels ?? []).find((channel) => channel.name === normalized);
+      if (match?.id) {
+        this.channelCache.set(normalized, match.id);
+        return match.id;
+      }
+
+      cursor = payload.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+
+    throw new Error(`Slack channel not found: ${normalized}`);
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.channelId
+   * @param {string} options.text
+   * @param {string} [options.threadTs]
+   * @returns {Promise<string>}
+   */
+  async postMessage({ channelId, text, threadTs }) {
+    const payload = await this.api('chat.postMessage', {
+      channel: channelId,
+      text,
+      thread_ts: threadTs,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+
+    const ts = threadTs ?? payload.ts;
+    if (!ts || typeof ts !== 'string') {
+      throw new Error('Slack postMessage did not return a timestamp');
+    }
+
+    return ts;
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.channelId
+   * @param {string} options.timestamp
+   * @param {string} options.emoji
+   * @returns {Promise<void>}
+   */
+  async addReaction({ channelId, timestamp, emoji }) {
+    try {
+      await this.api('reactions.add', {
+        channel: channelId,
+        timestamp,
+        name: emoji,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already_reacted')) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.channelId
+   * @param {string} options.timestamp
+   * @param {string} options.emoji
+   * @returns {Promise<void>}
+   */
+  async removeReaction({ channelId, timestamp, emoji }) {
+    try {
+      await this.api('reactions.remove', {
+        channel: channelId,
+        timestamp,
+        name: emoji,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('no_reaction')) {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
+/**
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} login
+ * @returns {Promise<string>}
+ */
+async function resolveAuthorSlackMention(octokit, login) {
+  try {
+    const { data } = await octokit.rest.users.getByUsername({ username: login });
+    if (data.email) {
+      return formatGithubAuthorMention(login);
+    }
+  } catch {
+    // Fall through to GitHub profile mention.
+  }
+
+  return formatGithubAuthorMention(login);
+}
+
+/**
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} prNumber
+ * @returns {Promise<import('@octokit/openapi-types').components['schemas']['pull-request']>}
+ */
+async function getPullRequest(octokit, owner, repo, prNumber) {
+  const { data } = await octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+  return data;
+}
+
+/**
+ * @param {Object} context
+ * @param {import('@octokit/rest').Octokit} context.octokit
+ * @param {string} context.owner
+ * @param {string} context.repo
+ * @param {SlackClient} context.slack
+ * @param {number} context.prNumber
+ * @param {boolean} context.dryRun
+ * @returns {Promise<void>}
+ */
+async function createThread({ octokit, owner, repo, slack, prNumber, dryRun }) {
+  const pr = await getPullRequest(octokit, owner, repo, prNumber);
+
+  if (pr.draft || pr.head.repo?.fork) {
+    return;
+  }
+
+  if (!hasTeamOnboardingLabel(pr.labels)) {
+    return;
+  }
+
+  const existing = await readThreadMeta({ octokit, owner, repo, prNumber });
+  if (existing?.threadTs) {
+    return;
+  }
+
+  const channelName = process.env.TEAM_ONBOARDING_SLACK_CHANNEL || DEFAULT_CHANNEL;
+  const channelId = dryRun ? 'DRY_RUN_CHANNEL' : await slack.resolveChannelId(channelName);
+  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const prUrl = pr.html_url;
+  const text = [
+    `:eyes: *PR ready for review* — ${authorMention}`,
+    `*${pr.title}*`,
+    prUrl,
+  ].join('\n');
+
+  if (dryRun) {
+    console.log('[dry-run] create-thread', { channelName, text });
+    return;
+  }
+
+  const threadTs = await slack.postMessage({ channelId, text });
+  await writeThreadMeta({
+    octokit,
+    owner,
+    repo,
+    prNumber,
+    meta: {
+      threadTs,
+      channelId,
+      lastCiConclusion: null,
+    },
+  });
+}
+
+/**
+ * @param {Object} context
+ * @param {import('@octokit/rest').Octokit} context.octokit
+ * @param {string} context.owner
+ * @param {string} context.repo
+ * @param {SlackClient} context.slack
+ * @param {number} context.prNumber
+ * @param {string} context.conclusion
+ * @param {string} context.workflowUrl
+ * @param {boolean} context.dryRun
+ * @returns {Promise<void>}
+ */
+async function notifyCiStatus({
+  octokit,
+  owner,
+  repo,
+  slack,
+  prNumber,
+  conclusion,
+  workflowUrl,
+  dryRun,
+}) {
+  const pr = await getPullRequest(octokit, owner, repo, prNumber);
+  if (!hasTeamOnboardingLabel(pr.labels)) {
+    return;
+  }
+
+  const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
+  if (!meta?.threadTs || !meta?.channelId) {
+    return;
+  }
+
+  const normalized = normalizeCiConclusion(conclusion);
+  if (normalized === 'other') {
+    return;
+  }
+
+  if (meta.lastCiConclusion === normalized) {
+    return;
+  }
+
+  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const statusText =
+    normalized === 'success'
+      ? ':white_check_mark: CI passed'
+      : ':x: CI failed';
+  const text = `${statusText} for <${pr.html_url}|PR #${prNumber}> — ${authorMention}\n<${workflowUrl}|View workflow run>`;
+
+  if (dryRun) {
+    console.log('[dry-run] ci-status', { normalized, text });
+    return;
+  }
+
+  await slack.postMessage({
+    channelId: String(meta.channelId),
+    threadTs: String(meta.threadTs),
+    text,
+  });
+
+  if (normalized === 'failure') {
+    await slack.addReaction({
+      channelId: String(meta.channelId),
+      timestamp: String(meta.threadTs),
+      emoji: 'alert',
+    });
+  } else {
+    await slack.removeReaction({
+      channelId: String(meta.channelId),
+      timestamp: String(meta.threadTs),
+      emoji: 'alert',
+    });
+  }
+
+  await writeThreadMeta({
+    octokit,
+    owner,
+    repo,
+    prNumber,
+    meta: {
+      ...meta,
+      lastCiConclusion: normalized,
+    },
+  });
+}
+
+/**
+ * @param {Object} context
+ * @param {import('@octokit/rest').Octokit} context.octokit
+ * @param {string} context.owner
+ * @param {string} context.repo
+ * @param {SlackClient} context.slack
+ * @param {number} context.prNumber
+ * @param {string} context.actorLogin
+ * @param {string} context.message
+ * @param {string} context.kind
+ * @param {boolean} context.dryRun
+ * @returns {Promise<void>}
+ */
+async function notifyThreadReply({
+  octokit,
+  owner,
+  repo,
+  slack,
+  prNumber,
+  actorLogin,
+  message,
+  kind,
+  dryRun,
+}) {
+  const pr = await getPullRequest(octokit, owner, repo, prNumber);
+  if (!hasTeamOnboardingLabel(pr.labels)) {
+    return;
+  }
+
+  const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
+  if (!meta?.threadTs || !meta?.channelId) {
+    return;
+  }
+
+  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const actorMention = formatGithubAuthorMention(actorLogin);
+  const trimmedMessage = message.trim().slice(0, 500);
+  const text = [
+    kind === 'cursor-bot'
+      ? `:robot_face: Cursor Bug Bot commented on <${pr.html_url}|PR #${prNumber}> — ${authorMention}`
+      : `:speech_balloon: Review comment on <${pr.html_url}|PR #${prNumber}> from ${actorMention} — ${authorMention}`,
+    trimmedMessage || '_No comment body provided._',
+  ].join('\n');
+
+  if (dryRun) {
+    console.log('[dry-run] thread-reply', { kind, text });
+    return;
+  }
+
+  await slack.postMessage({
+    channelId: String(meta.channelId),
+    threadTs: String(meta.threadTs),
+    text,
+  });
+}
+
+/**
+ * @param {Object} context
+ * @param {import('@octokit/rest').Octokit} context.octokit
+ * @param {string} context.owner
+ * @param {string} context.repo
+ * @param {SlackClient} context.slack
+ * @param {number} context.prNumber
+ * @param {boolean} context.dryRun
+ * @returns {Promise<void>}
+ */
+async function notifyMerged({ octokit, owner, repo, slack, prNumber, dryRun }) {
+  const pr = await getPullRequest(octokit, owner, repo, prNumber);
+  if (!hasTeamOnboardingLabel(pr.labels)) {
+    return;
+  }
+
+  const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
+  if (!meta?.threadTs || !meta?.channelId) {
+    return;
+  }
+
+  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const text = `:tada: <${pr.html_url}|PR #${prNumber}> merged — ${authorMention}`;
+
+  if (dryRun) {
+    console.log('[dry-run] merged', { text });
+    return;
+  }
+
+  await slack.postMessage({
+    channelId: String(meta.channelId),
+    threadTs: String(meta.threadTs),
+    text,
+  });
+
+  await slack.addReaction({
+    channelId: String(meta.channelId),
+    timestamp: String(meta.threadTs),
+    emoji: 'white_check_mark',
+  });
+}
+
+/**
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} headSha
+ * @returns {Promise<number[]>}
+ */
+async function findOpenPrNumbersForSha(octokit, owner, repo, headSha) {
+  const { data } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+    owner,
+    repo,
+    commit_sha: headSha,
+  });
+
+  return data
+    .filter((pr) => pr.state === 'open')
+    .map((pr) => pr.number);
+}
+
+/**
+ * @returns {Record<string, unknown>}
+ */
+function readEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    throw new Error('GITHUB_EVENT_PATH is missing or unreadable');
+  }
+
+  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function main() {
+  const action = process.env.ACTION;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  const slackToken = process.env.SLACK_BOT_TOKEN;
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  if (!action || !repository || !token) {
+    throw new Error('ACTION, GITHUB_REPOSITORY, and GITHUB_TOKEN are required');
+  }
+
+  if (!slackToken && !dryRun) {
+    throw new Error('SLACK_BOT_TOKEN is required unless DRY_RUN=true');
+  }
+
+  const [owner, repo] = repository.split('/');
+  const event = readEventPayload();
+  const eventName = process.env.GITHUB_EVENT_NAME ?? 'unknown';
+
+  const { Octokit } = await import('@octokit/rest');
+  const octokit = new Octokit({ auth: token });
+  const slack = new SlackClient(slackToken ?? 'dry-run-token');
+
+  switch (action) {
+    case 'create-thread': {
+      const pr = event.pull_request;
+      if (!pr?.number) {
+        return;
+      }
+
+      const isReady =
+        eventName === 'pull_request' &&
+        (event.action === 'ready_for_review' ||
+          (event.action === 'opened' && !pr.draft) ||
+          (event.action === 'labeled' && event.label?.name === TEAM_LABEL));
+
+      if (!isReady) {
+        return;
+      }
+
+      await createThread({
+        octokit,
+        owner,
+        repo,
+        slack,
+        prNumber: pr.number,
+        dryRun,
+      });
+      return;
+    }
+
+    case 'ci-status': {
+      const workflowRun = event.workflow_run;
+      if (!workflowRun || workflowRun.event !== 'pull_request') {
+        return;
+      }
+
+      const prNumbers = new Set(
+        (workflowRun.pull_requests ?? []).map((pr) => pr.number).filter(Boolean),
+      );
+
+      if (prNumbers.size === 0 && workflowRun.head_sha) {
+        const associated = await findOpenPrNumbersForSha(
+          octokit,
+          owner,
+          repo,
+          workflowRun.head_sha,
+        );
+        associated.forEach((number) => prNumbers.add(number));
+      }
+
+      for (const prNumber of prNumbers) {
+        await notifyCiStatus({
+          octokit,
+          owner,
+          repo,
+          slack,
+          prNumber,
+          conclusion: workflowRun.conclusion ?? 'unknown',
+          workflowUrl: workflowRun.html_url,
+          dryRun,
+        });
+      }
+      return;
+    }
+
+    case 'review-comment': {
+      const review = event.review;
+      const pr = event.pull_request;
+      if (!review || !pr?.number || review.user?.type === 'Bot') {
+        return;
+      }
+
+      if (isCursorBot(review.user?.login)) {
+        await notifyThreadReply({
+          octokit,
+          owner,
+          repo,
+          slack,
+          prNumber: pr.number,
+          actorLogin: review.user.login,
+          message: review.body ?? '',
+          kind: 'cursor-bot',
+          dryRun,
+        });
+        return;
+      }
+
+      if (isIgnoredCommentBot(review.user?.login)) {
+        return;
+      }
+
+      await notifyThreadReply({
+        octokit,
+        owner,
+        repo,
+        slack,
+        prNumber: pr.number,
+        actorLogin: review.user.login,
+        message: review.body ?? '',
+        kind: 'reviewer',
+        dryRun,
+      });
+      return;
+    }
+
+    case 'inline-review-comment': {
+      const comment = event.comment;
+      const pr = event.pull_request;
+      if (!comment || !pr?.number || comment.user?.type === 'Bot') {
+        return;
+      }
+
+      if (isIgnoredCommentBot(comment.user?.login)) {
+        return;
+      }
+
+      const kind = isCursorBot(comment.user?.login) ? 'cursor-bot' : 'reviewer';
+      await notifyThreadReply({
+        octokit,
+        owner,
+        repo,
+        slack,
+        prNumber: pr.number,
+        actorLogin: comment.user.login,
+        message: comment.body ?? '',
+        kind,
+        dryRun,
+      });
+      return;
+    }
+
+    case 'issue-comment': {
+      const comment = event.comment;
+      const issue = event.issue;
+      if (!comment || !issue?.number || !issue.pull_request) {
+        return;
+      }
+
+      if (parseThreadMarker(comment.body ?? '')) {
+        return;
+      }
+
+      const login = comment.user?.login;
+      if (!isCursorBot(login)) {
+        return;
+      }
+
+      await notifyThreadReply({
+        octokit,
+        owner,
+        repo,
+        slack,
+        prNumber: issue.number,
+        actorLogin: login,
+        message: comment.body ?? '',
+        kind: 'cursor-bot',
+        dryRun,
+      });
+      return;
+    }
+
+    case 'merged': {
+      const pr = event.pull_request;
+      if (!pr?.number || !pr.merged) {
+        return;
+      }
+
+      await notifyMerged({
+        octokit,
+        owner,
+        repo,
+        slack,
+        prNumber: pr.number,
+        dryRun,
+      });
+      return;
+    }
+
+    default:
+      throw new Error(`Unsupported ACTION: ${action}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/team-onboarding-pr-slack.mjs
+++ b/.github/scripts/team-onboarding-pr-slack.mjs
@@ -1,33 +1,17 @@
 #!/usr/bin/env node
 
-/**
- * Team Onboarding PR Slack Bot
- *
- * Posts and updates a Slack thread in #metamask-onboarding-mobile-internal for
- * team-onboarding PRs once they are ready for review.
- *
- * Required env:
- *   GITHUB_TOKEN, SLACK_BOT_TOKEN, GITHUB_REPOSITORY, ACTION
- *
- * Optional env:
- *   TEAM_ONBOARDING_SLACK_CHANNEL (default: metamask-onboarding-mobile-internal)
- *   GITHUB_EVENT_PATH, GITHUB_EVENT_NAME, DRY_RUN=true
- */
+/** Team onboarding PR Slack bot — see .github/workflows/team-onboarding-pr-slack.yml */
 
 import fs from 'fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const TEAM_LABEL = 'team-onboarding';
 export const MARKER_PREFIX = 'team-onboarding-pr-slack:';
 export const MARKER_REGEX = new RegExp(
   `<!--\\s*${MARKER_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([\\s\\S]*?)\\s*-->`,
 );
-
-export const CURSOR_BOT_LOGINS = new Set([
-  'cursor[bot]',
-  'cursorbot',
-  'cursoragent',
-]);
-
+export const CURSOR_BOT_LOGINS = new Set(['cursor[bot]', 'cursorbot', 'cursoragent']);
 export const IGNORED_COMMENT_BOT_LOGINS = new Set([
   'github-actions[bot]',
   'dependabot[bot]',
@@ -39,32 +23,17 @@ export const IGNORED_COMMENT_BOT_LOGINS = new Set([
 
 const DEFAULT_CHANNEL = 'metamask-onboarding-mobile-internal';
 
-/**
- * @param {string} channel
- * @returns {string}
- */
 export function normalizeChannelName(channel) {
   return channel.replace(/^#/, '').trim();
 }
 
-/**
- * @param {Array<{ name: string }>} labels
- * @returns {boolean}
- */
 export function hasTeamOnboardingLabel(labels) {
   return labels.some((label) => label.name === TEAM_LABEL);
 }
 
-/**
- * @param {string} body
- * @returns {Record<string, unknown> | null}
- */
 export function parseThreadMarker(body) {
   const match = body.match(MARKER_REGEX);
-  if (!match?.[1]) {
-    return null;
-  }
-
+  if (!match?.[1]) return null;
   try {
     return JSON.parse(match[1].trim());
   } catch {
@@ -72,60 +41,55 @@ export function parseThreadMarker(body) {
   }
 }
 
-/**
- * @param {Record<string, unknown>} meta
- * @returns {string}
- */
 export function buildMarkerComment(meta) {
   return `<!-- ${MARKER_PREFIX}${JSON.stringify(meta)} -->\n_Slack thread tracked for team onboarding review._`;
 }
 
-/**
- * @param {string | undefined | null} login
- * @returns {boolean}
- */
 export function isCursorBot(login) {
   return Boolean(login && CURSOR_BOT_LOGINS.has(login));
 }
 
-/**
- * @param {string | undefined | null} login
- * @returns {boolean}
- */
 export function isIgnoredCommentBot(login) {
   return Boolean(login && IGNORED_COMMENT_BOT_LOGINS.has(login));
 }
 
-/**
- * @param {string} login
- * @returns {string}
- */
+export function isNotifiableCommenter(login, userType) {
+  if (!login) return false;
+  if (isCursorBot(login)) return true;
+  if (isIgnoredCommentBot(login)) return false;
+  return userType !== 'Bot';
+}
+
 export function formatGithubAuthorMention(login) {
   return `<https://github.com/${login}|@${login}>`;
 }
 
-/**
- * @param {string} conclusion
- * @returns {'success' | 'failure' | 'other'}
- */
 export function normalizeCiConclusion(conclusion) {
-  if (conclusion === 'success') {
-    return 'success';
-  }
+  if (conclusion === 'success') return 'success';
   if (['failure', 'cancelled', 'timed_out', 'action_required'].includes(conclusion)) {
     return 'failure';
   }
   return 'other';
 }
 
-/**
- * @param {Object} options
- * @param {import('@octokit/rest').Octokit} options.octokit
- * @param {string} options.owner
- * @param {string} options.repo
- * @param {number} options.prNumber
- * @returns {Promise<Record<string, unknown> | null>}
- */
+export function resolveAction(eventName, event) {
+  if (eventName === 'workflow_run') return 'ci-status';
+  if (eventName === 'pull_request_review') return 'review-comment';
+  if (eventName === 'pull_request_review_comment') return 'inline-review-comment';
+  if (eventName === 'issue_comment') return 'issue-comment';
+  if (eventName === 'pull_request') {
+    if (event.action === 'closed' && event.pull_request?.merged) return 'merged';
+    if (
+      event.action === 'ready_for_review' ||
+      (event.action === 'opened' && !event.pull_request?.draft) ||
+      (event.action === 'labeled' && event.label?.name === TEAM_LABEL)
+    ) {
+      return 'create-thread';
+    }
+  }
+  return null;
+}
+
 export async function readThreadMeta({ octokit, owner, repo, prNumber }) {
   const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner,
@@ -133,33 +97,18 @@ export async function readThreadMeta({ octokit, owner, repo, prNumber }) {
     issue_number: prNumber,
     per_page: 100,
   });
-
   for (const comment of comments) {
     const meta = parseThreadMarker(comment.body ?? '');
     if (meta?.threadTs && meta?.channelId) {
-      return {
-        ...meta,
-        commentId: comment.id,
-      };
+      return { ...meta, commentId: comment.id };
     }
   }
-
   return null;
 }
 
-/**
- * @param {Object} options
- * @param {import('@octokit/rest').Octokit} options.octokit
- * @param {string} options.owner
- * @param {string} options.repo
- * @param {number} options.prNumber
- * @param {Record<string, unknown>} options.meta
- * @returns {Promise<void>}
- */
 export async function writeThreadMeta({ octokit, owner, repo, prNumber, meta }) {
   const body = buildMarkerComment(meta);
   const existing = await readThreadMeta({ octokit, owner, repo, prNumber });
-
   if (existing?.commentId) {
     await octokit.rest.issues.updateComment({
       owner,
@@ -169,29 +118,15 @@ export async function writeThreadMeta({ octokit, owner, repo, prNumber, meta }) 
     });
     return;
   }
-
-  await octokit.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: prNumber,
-    body,
-  });
+  await octokit.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
 }
 
 class SlackClient {
-  /**
-   * @param {string} token
-   */
   constructor(token) {
     this.token = token;
     this.channelCache = new Map();
   }
 
-  /**
-   * @param {string} method
-   * @param {Record<string, unknown>} body
-   * @returns {Promise<Record<string, unknown>>}
-   */
   async api(method, body) {
     const response = await fetch(`https://slack.com/api/${method}`, {
       method: 'POST',
@@ -201,25 +136,16 @@ class SlackClient {
       },
       body: JSON.stringify(body),
     });
-
     const payload = await response.json();
     if (!payload.ok) {
       throw new Error(`Slack API ${method} failed: ${payload.error ?? 'unknown_error'}`);
     }
-
     return payload;
   }
 
-  /**
-   * @param {string} channelName
-   * @returns {Promise<string>}
-   */
   async resolveChannelId(channelName) {
     const normalized = normalizeChannelName(channelName);
-    if (this.channelCache.has(normalized)) {
-      return this.channelCache.get(normalized);
-    }
-
+    if (this.channelCache.has(normalized)) return this.channelCache.get(normalized);
     let cursor;
     do {
       const payload = await this.api('conversations.list', {
@@ -227,26 +153,16 @@ class SlackClient {
         limit: 200,
         cursor,
       });
-
       const match = (payload.channels ?? []).find((channel) => channel.name === normalized);
       if (match?.id) {
         this.channelCache.set(normalized, match.id);
         return match.id;
       }
-
       cursor = payload.response_metadata?.next_cursor || undefined;
     } while (cursor);
-
     throw new Error(`Slack channel not found: ${normalized}`);
   }
 
-  /**
-   * @param {Object} options
-   * @param {string} options.channelId
-   * @param {string} options.text
-   * @param {string} [options.threadTs]
-   * @returns {Promise<string>}
-   */
   async postMessage({ channelId, text, threadTs }) {
     const payload = await this.api('chat.postMessage', {
       channel: channelId,
@@ -255,129 +171,61 @@ class SlackClient {
       unfurl_links: false,
       unfurl_media: false,
     });
-
     const ts = threadTs ?? payload.ts;
     if (!ts || typeof ts !== 'string') {
       throw new Error('Slack postMessage did not return a timestamp');
     }
-
     return ts;
   }
 
-  /**
-   * @param {Object} options
-   * @param {string} options.channelId
-   * @param {string} options.timestamp
-   * @param {string} options.emoji
-   * @returns {Promise<void>}
-   */
   async addReaction({ channelId, timestamp, emoji }) {
     try {
-      await this.api('reactions.add', {
-        channel: channelId,
-        timestamp,
-        name: emoji,
-      });
+      await this.api('reactions.add', { channel: channelId, timestamp, name: emoji });
     } catch (error) {
-      if (error instanceof Error && error.message.includes('already_reacted')) {
-        return;
-      }
-      throw error;
+      if (!(error instanceof Error && error.message.includes('already_reacted'))) throw error;
     }
   }
 
-  /**
-   * @param {Object} options
-   * @param {string} options.channelId
-   * @param {string} options.timestamp
-   * @param {string} options.emoji
-   * @returns {Promise<void>}
-   */
   async removeReaction({ channelId, timestamp, emoji }) {
     try {
-      await this.api('reactions.remove', {
-        channel: channelId,
-        timestamp,
-        name: emoji,
-      });
+      await this.api('reactions.remove', { channel: channelId, timestamp, name: emoji });
     } catch (error) {
-      if (error instanceof Error && error.message.includes('no_reaction')) {
-        return;
-      }
-      throw error;
+      if (!(error instanceof Error && error.message.includes('no_reaction'))) throw error;
     }
   }
 }
 
-/**
- * @param {import('@octokit/rest').Octokit} octokit
- * @param {string} login
- * @returns {Promise<string>}
- */
-async function resolveAuthorSlackMention(octokit, login) {
-  try {
-    const { data } = await octokit.rest.users.getByUsername({ username: login });
-    if (data.email) {
-      return formatGithubAuthorMention(login);
-    }
-  } catch {
-    // Fall through to GitHub profile mention.
-  }
-
-  return formatGithubAuthorMention(login);
-}
-
-/**
- * @param {import('@octokit/rest').Octokit} octokit
- * @param {string} owner
- * @param {string} repo
- * @param {number} prNumber
- * @returns {Promise<import('@octokit/openapi-types').components['schemas']['pull-request']>}
- */
 async function getPullRequest(octokit, owner, repo, prNumber) {
-  const { data } = await octokit.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: prNumber,
-  });
+  const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
   return data;
 }
 
-/**
- * @param {Object} context
- * @param {import('@octokit/rest').Octokit} context.octokit
- * @param {string} context.owner
- * @param {string} context.repo
- * @param {SlackClient} context.slack
- * @param {number} context.prNumber
- * @param {boolean} context.dryRun
- * @returns {Promise<void>}
- */
+async function findOpenPrNumbersForSha(octokit, owner, repo, headSha) {
+  const { data } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+    owner,
+    repo,
+    commit_sha: headSha,
+  });
+  return data.filter((pr) => pr.state === 'open').map((pr) => pr.number);
+}
+
+function readEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    throw new Error('GITHUB_EVENT_PATH is missing or unreadable');
+  }
+  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
 async function createThread({ octokit, owner, repo, slack, prNumber, dryRun }) {
   const pr = await getPullRequest(octokit, owner, repo, prNumber);
-
-  if (pr.draft || pr.head.repo?.fork) {
-    return;
-  }
-
-  if (!hasTeamOnboardingLabel(pr.labels)) {
-    return;
-  }
-
-  const existing = await readThreadMeta({ octokit, owner, repo, prNumber });
-  if (existing?.threadTs) {
-    return;
-  }
+  if (pr.draft || pr.head.repo?.fork || !hasTeamOnboardingLabel(pr.labels)) return;
+  if ((await readThreadMeta({ octokit, owner, repo, prNumber }))?.threadTs) return;
 
   const channelName = process.env.TEAM_ONBOARDING_SLACK_CHANNEL || DEFAULT_CHANNEL;
   const channelId = dryRun ? 'DRY_RUN_CHANNEL' : await slack.resolveChannelId(channelName);
-  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
-  const prUrl = pr.html_url;
-  const text = [
-    `:eyes: *PR ready for review* — ${authorMention}`,
-    `*${pr.title}*`,
-    prUrl,
-  ].join('\n');
+  const authorMention = formatGithubAuthorMention(pr.user.login);
+  const text = `:eyes: *PR ready for review* — ${authorMention}\n*${pr.title}*\n${pr.html_url}`;
 
   if (dryRun) {
     console.log('[dry-run] create-thread', { channelName, text });
@@ -390,26 +238,10 @@ async function createThread({ octokit, owner, repo, slack, prNumber, dryRun }) {
     owner,
     repo,
     prNumber,
-    meta: {
-      threadTs,
-      channelId,
-      lastCiConclusion: null,
-    },
+    meta: { threadTs, channelId, lastCiConclusion: null },
   });
 }
 
-/**
- * @param {Object} context
- * @param {import('@octokit/rest').Octokit} context.octokit
- * @param {string} context.owner
- * @param {string} context.repo
- * @param {SlackClient} context.slack
- * @param {number} context.prNumber
- * @param {string} context.conclusion
- * @param {string} context.workflowUrl
- * @param {boolean} context.dryRun
- * @returns {Promise<void>}
- */
 async function notifyCiStatus({
   octokit,
   owner,
@@ -421,29 +253,16 @@ async function notifyCiStatus({
   dryRun,
 }) {
   const pr = await getPullRequest(octokit, owner, repo, prNumber);
-  if (!hasTeamOnboardingLabel(pr.labels)) {
-    return;
-  }
+  if (!hasTeamOnboardingLabel(pr.labels)) return;
 
   const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
-  if (!meta?.threadTs || !meta?.channelId) {
-    return;
-  }
+  if (!meta?.threadTs || !meta?.channelId) return;
 
   const normalized = normalizeCiConclusion(conclusion);
-  if (normalized === 'other') {
-    return;
-  }
+  if (normalized === 'other' || meta.lastCiConclusion === normalized) return;
 
-  if (meta.lastCiConclusion === normalized) {
-    return;
-  }
-
-  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
-  const statusText =
-    normalized === 'success'
-      ? ':white_check_mark: CI passed'
-      : ':x: CI failed';
+  const authorMention = formatGithubAuthorMention(pr.user.login);
+  const statusText = normalized === 'success' ? ':white_check_mark: CI passed' : ':x: CI failed';
   const text = `${statusText} for <${pr.html_url}|PR #${prNumber}> — ${authorMention}\n<${workflowUrl}|View workflow run>`;
 
   if (dryRun) {
@@ -476,26 +295,10 @@ async function notifyCiStatus({
     owner,
     repo,
     prNumber,
-    meta: {
-      ...meta,
-      lastCiConclusion: normalized,
-    },
+    meta: { ...meta, lastCiConclusion: normalized },
   });
 }
 
-/**
- * @param {Object} context
- * @param {import('@octokit/rest').Octokit} context.octokit
- * @param {string} context.owner
- * @param {string} context.repo
- * @param {SlackClient} context.slack
- * @param {number} context.prNumber
- * @param {string} context.actorLogin
- * @param {string} context.message
- * @param {string} context.kind
- * @param {boolean} context.dryRun
- * @returns {Promise<void>}
- */
 async function notifyThreadReply({
   octokit,
   owner,
@@ -508,16 +311,12 @@ async function notifyThreadReply({
   dryRun,
 }) {
   const pr = await getPullRequest(octokit, owner, repo, prNumber);
-  if (!hasTeamOnboardingLabel(pr.labels)) {
-    return;
-  }
+  if (!hasTeamOnboardingLabel(pr.labels)) return;
 
   const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
-  if (!meta?.threadTs || !meta?.channelId) {
-    return;
-  }
+  if (!meta?.threadTs || !meta?.channelId) return;
 
-  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const authorMention = formatGithubAuthorMention(pr.user.login);
   const actorMention = formatGithubAuthorMention(actorLogin);
   const trimmedMessage = message.trim().slice(0, 500);
   const text = [
@@ -539,28 +338,14 @@ async function notifyThreadReply({
   });
 }
 
-/**
- * @param {Object} context
- * @param {import('@octokit/rest').Octokit} context.octokit
- * @param {string} context.owner
- * @param {string} context.repo
- * @param {SlackClient} context.slack
- * @param {number} context.prNumber
- * @param {boolean} context.dryRun
- * @returns {Promise<void>}
- */
 async function notifyMerged({ octokit, owner, repo, slack, prNumber, dryRun }) {
   const pr = await getPullRequest(octokit, owner, repo, prNumber);
-  if (!hasTeamOnboardingLabel(pr.labels)) {
-    return;
-  }
+  if (!hasTeamOnboardingLabel(pr.labels)) return;
 
   const meta = await readThreadMeta({ octokit, owner, repo, prNumber });
-  if (!meta?.threadTs || !meta?.channelId) {
-    return;
-  }
+  if (!meta?.threadTs || !meta?.channelId) return;
 
-  const authorMention = await resolveAuthorSlackMention(octokit, pr.user.login);
+  const authorMention = formatGithubAuthorMention(pr.user.login);
   const text = `:tada: <${pr.html_url}|PR #${prNumber}> merged — ${authorMention}`;
 
   if (dryRun) {
@@ -573,7 +358,6 @@ async function notifyMerged({ octokit, owner, repo, slack, prNumber, dryRun }) {
     threadTs: String(meta.threadTs),
     text,
   });
-
   await slack.addReaction({
     channelId: String(meta.channelId),
     timestamp: String(meta.threadTs),
@@ -581,51 +365,14 @@ async function notifyMerged({ octokit, owner, repo, slack, prNumber, dryRun }) {
   });
 }
 
-/**
- * @param {import('@octokit/rest').Octokit} octokit
- * @param {string} owner
- * @param {string} repo
- * @param {string} headSha
- * @returns {Promise<number[]>}
- */
-async function findOpenPrNumbersForSha(octokit, owner, repo, headSha) {
-  const { data } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-    owner,
-    repo,
-    commit_sha: headSha,
-  });
-
-  return data
-    .filter((pr) => pr.state === 'open')
-    .map((pr) => pr.number);
-}
-
-/**
- * @returns {Record<string, unknown>}
- */
-function readEventPayload() {
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath || !fs.existsSync(eventPath)) {
-    throw new Error('GITHUB_EVENT_PATH is missing or unreadable');
-  }
-
-  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
-}
-
-/**
- * @returns {Promise<void>}
- */
 export async function main() {
-  const action = process.env.ACTION;
   const repository = process.env.GITHUB_REPOSITORY;
   const token = process.env.GITHUB_TOKEN;
   const slackToken = process.env.SLACK_BOT_TOKEN;
   const dryRun = process.env.DRY_RUN === 'true';
-
-  if (!action || !repository || !token) {
-    throw new Error('ACTION, GITHUB_REPOSITORY, and GITHUB_TOKEN are required');
+  if (!repository || !token) {
+    throw new Error('GITHUB_REPOSITORY and GITHUB_TOKEN are required');
   }
-
   if (!slackToken && !dryRun) {
     throw new Error('SLACK_BOT_TOKEN is required unless DRY_RUN=true');
   }
@@ -633,6 +380,8 @@ export async function main() {
   const [owner, repo] = repository.split('/');
   const event = readEventPayload();
   const eventName = process.env.GITHUB_EVENT_NAME ?? 'unknown';
+  const action = process.env.ACTION ?? resolveAction(eventName, event);
+  if (!action) return;
 
   const { Octokit } = await import('@octokit/rest');
   const octokit = new Octokit({ auth: token });
@@ -641,41 +390,16 @@ export async function main() {
   switch (action) {
     case 'create-thread': {
       const pr = event.pull_request;
-      if (!pr?.number) {
-        return;
-      }
-
-      const isReady =
-        eventName === 'pull_request' &&
-        (event.action === 'ready_for_review' ||
-          (event.action === 'opened' && !pr.draft) ||
-          (event.action === 'labeled' && event.label?.name === TEAM_LABEL));
-
-      if (!isReady) {
-        return;
-      }
-
-      await createThread({
-        octokit,
-        owner,
-        repo,
-        slack,
-        prNumber: pr.number,
-        dryRun,
-      });
+      if (!pr?.number) return;
+      await createThread({ octokit, owner, repo, slack, prNumber: pr.number, dryRun });
       return;
     }
-
     case 'ci-status': {
       const workflowRun = event.workflow_run;
-      if (!workflowRun || workflowRun.event !== 'pull_request') {
-        return;
-      }
-
+      if (!workflowRun || workflowRun.event !== 'pull_request') return;
       const prNumbers = new Set(
         (workflowRun.pull_requests ?? []).map((pr) => pr.number).filter(Boolean),
       );
-
       if (prNumbers.size === 0 && workflowRun.head_sha) {
         const associated = await findOpenPrNumbersForSha(
           octokit,
@@ -685,7 +409,6 @@ export async function main() {
         );
         associated.forEach((number) => prNumbers.add(number));
       }
-
       for (const prNumber of prNumbers) {
         await notifyCiStatus({
           octokit,
@@ -700,33 +423,11 @@ export async function main() {
       }
       return;
     }
-
     case 'review-comment': {
       const review = event.review;
       const pr = event.pull_request;
-      if (!review || !pr?.number || review.user?.type === 'Bot') {
-        return;
-      }
-
-      if (isCursorBot(review.user?.login)) {
-        await notifyThreadReply({
-          octokit,
-          owner,
-          repo,
-          slack,
-          prNumber: pr.number,
-          actorLogin: review.user.login,
-          message: review.body ?? '',
-          kind: 'cursor-bot',
-          dryRun,
-        });
-        return;
-      }
-
-      if (isIgnoredCommentBot(review.user?.login)) {
-        return;
-      }
-
+      if (!review || !pr?.number) return;
+      if (!isNotifiableCommenter(review.user?.login, review.user?.type)) return;
       await notifyThreadReply({
         octokit,
         owner,
@@ -735,24 +436,16 @@ export async function main() {
         prNumber: pr.number,
         actorLogin: review.user.login,
         message: review.body ?? '',
-        kind: 'reviewer',
+        kind: isCursorBot(review.user.login) ? 'cursor-bot' : 'reviewer',
         dryRun,
       });
       return;
     }
-
     case 'inline-review-comment': {
       const comment = event.comment;
       const pr = event.pull_request;
-      if (!comment || !pr?.number || comment.user?.type === 'Bot') {
-        return;
-      }
-
-      if (isIgnoredCommentBot(comment.user?.login)) {
-        return;
-      }
-
-      const kind = isCursorBot(comment.user?.login) ? 'cursor-bot' : 'reviewer';
+      if (!comment || !pr?.number) return;
+      if (!isNotifiableCommenter(comment.user?.login, comment.user?.type)) return;
       await notifyThreadReply({
         octokit,
         owner,
@@ -761,65 +454,48 @@ export async function main() {
         prNumber: pr.number,
         actorLogin: comment.user.login,
         message: comment.body ?? '',
-        kind,
+        kind: isCursorBot(comment.user.login) ? 'cursor-bot' : 'reviewer',
         dryRun,
       });
       return;
     }
-
     case 'issue-comment': {
       const comment = event.comment;
       const issue = event.issue;
-      if (!comment || !issue?.number || !issue.pull_request) {
-        return;
-      }
-
-      if (parseThreadMarker(comment.body ?? '')) {
-        return;
-      }
-
-      const login = comment.user?.login;
-      if (!isCursorBot(login)) {
-        return;
-      }
-
+      if (!comment || !issue?.number || !issue.pull_request) return;
+      if (parseThreadMarker(comment.body ?? '')) return;
+      if (!isCursorBot(comment.user?.login)) return;
       await notifyThreadReply({
         octokit,
         owner,
         repo,
         slack,
         prNumber: issue.number,
-        actorLogin: login,
+        actorLogin: comment.user.login,
         message: comment.body ?? '',
         kind: 'cursor-bot',
         dryRun,
       });
       return;
     }
-
     case 'merged': {
       const pr = event.pull_request;
-      if (!pr?.number || !pr.merged) {
-        return;
-      }
-
-      await notifyMerged({
-        octokit,
-        owner,
-        repo,
-        slack,
-        prNumber: pr.number,
-        dryRun,
-      });
+      if (!pr?.number || !pr.merged || pr.head?.repo?.fork) return;
+      await notifyMerged({ octokit, owner, repo, slack, prNumber: pr.number, dryRun });
       return;
     }
-
     default:
       throw new Error(`Unsupported ACTION: ${action}`);
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+function isRunningAsCli() {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+  return scriptPath === invokedPath;
+}
+
+if (isRunningAsCli()) {
   main().catch((error) => {
     console.error(error);
     process.exitCode = 1;

--- a/.github/scripts/team-onboarding-pr-slack.test.mjs
+++ b/.github/scripts/team-onboarding-pr-slack.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  TEAM_LABEL,
+  buildMarkerComment,
+  formatGithubAuthorMention,
+  hasTeamOnboardingLabel,
+  isCursorBot,
+  isIgnoredCommentBot,
+  normalizeChannelName,
+  normalizeCiConclusion,
+  parseThreadMarker,
+} from './team-onboarding-pr-slack.mjs';
+
+test('normalizeChannelName strips leading hash', () => {
+  assert.equal(
+    normalizeChannelName('#metamask-onboarding-mobile-internal'),
+    'metamask-onboarding-mobile-internal',
+  );
+});
+
+test('hasTeamOnboardingLabel matches team-onboarding label', () => {
+  assert.equal(hasTeamOnboardingLabel([{ name: TEAM_LABEL }]), true);
+  assert.equal(hasTeamOnboardingLabel([{ name: 'team-mobile-platform' }]), false);
+});
+
+test('parseThreadMarker reads embedded JSON metadata', () => {
+  const body = buildMarkerComment({
+    threadTs: '1718000000.000000',
+    channelId: 'C123',
+  });
+
+  assert.deepEqual(parseThreadMarker(body), {
+    threadTs: '1718000000.000000',
+    channelId: 'C123',
+  });
+});
+
+test('isCursorBot identifies cursor bot logins', () => {
+  assert.equal(isCursorBot('cursor[bot]'), true);
+  assert.equal(isCursorBot('cursorbot'), true);
+  assert.equal(isCursorBot('cw-lee'), false);
+});
+
+test('isIgnoredCommentBot ignores automation accounts', () => {
+  assert.equal(isIgnoredCommentBot('github-actions[bot]'), true);
+  assert.equal(isIgnoredCommentBot('cw-lee'), false);
+});
+
+test('normalizeCiConclusion maps workflow conclusions', () => {
+  assert.equal(normalizeCiConclusion('success'), 'success');
+  assert.equal(normalizeCiConclusion('failure'), 'failure');
+  assert.equal(normalizeCiConclusion('skipped'), 'other');
+});
+
+test('formatGithubAuthorMention links to GitHub profile', () => {
+  assert.equal(
+    formatGithubAuthorMention('cw-lee'),
+    '<https://github.com/cw-lee|@cw-lee>',
+  );
+});

--- a/.github/scripts/team-onboarding-pr-slack.test.mjs
+++ b/.github/scripts/team-onboarding-pr-slack.test.mjs
@@ -8,9 +8,11 @@ import {
   hasTeamOnboardingLabel,
   isCursorBot,
   isIgnoredCommentBot,
+  isNotifiableCommenter,
   normalizeChannelName,
   normalizeCiConclusion,
   parseThreadMarker,
+  resolveAction,
 } from './team-onboarding-pr-slack.mjs';
 
 test('normalizeChannelName strips leading hash', () => {
@@ -26,26 +28,32 @@ test('hasTeamOnboardingLabel matches team-onboarding label', () => {
 });
 
 test('parseThreadMarker reads embedded JSON metadata', () => {
-  const body = buildMarkerComment({
-    threadTs: '1718000000.000000',
-    channelId: 'C123',
-  });
-
+  const body = buildMarkerComment({ threadTs: '1718000000.000000', channelId: 'C123' });
   assert.deepEqual(parseThreadMarker(body), {
     threadTs: '1718000000.000000',
     channelId: 'C123',
   });
 });
 
-test('isCursorBot identifies cursor bot logins', () => {
-  assert.equal(isCursorBot('cursor[bot]'), true);
-  assert.equal(isCursorBot('cursorbot'), true);
-  assert.equal(isCursorBot('cw-lee'), false);
+test('isNotifiableCommenter allows cursor bots and human reviewers', () => {
+  assert.equal(isNotifiableCommenter('cursor[bot]', 'Bot'), true);
+  assert.equal(isNotifiableCommenter('cw-lee', 'User'), true);
+  assert.equal(isNotifiableCommenter('github-actions[bot]', 'Bot'), false);
 });
 
-test('isIgnoredCommentBot ignores automation accounts', () => {
-  assert.equal(isIgnoredCommentBot('github-actions[bot]'), true);
-  assert.equal(isIgnoredCommentBot('cw-lee'), false);
+test('resolveAction maps GitHub events to bot actions', () => {
+  assert.equal(
+    resolveAction('pull_request', { action: 'ready_for_review', pull_request: { draft: false } }),
+    'create-thread',
+  );
+  assert.equal(
+    resolveAction('pull_request', {
+      action: 'closed',
+      pull_request: { merged: true },
+    }),
+    'merged',
+  );
+  assert.equal(resolveAction('workflow_run', {}), 'ci-status');
 });
 
 test('normalizeCiConclusion maps workflow conclusions', () => {
@@ -55,8 +63,10 @@ test('normalizeCiConclusion maps workflow conclusions', () => {
 });
 
 test('formatGithubAuthorMention links to GitHub profile', () => {
-  assert.equal(
-    formatGithubAuthorMention('cw-lee'),
-    '<https://github.com/cw-lee|@cw-lee>',
-  );
+  assert.equal(formatGithubAuthorMention('cw-lee'), '<https://github.com/cw-lee|@cw-lee>');
+});
+
+test('isCursorBot identifies cursor bot logins', () => {
+  assert.equal(isCursorBot('cursor[bot]'), true);
+  assert.equal(isIgnoredCommentBot('github-actions[bot]'), true);
 });

--- a/.github/workflows/team-onboarding-pr-slack.yml
+++ b/.github/workflows/team-onboarding-pr-slack.yml
@@ -1,214 +1,39 @@
 ##############################################################################################
-#
-# Team Onboarding PR Slack Bot
-#
-# Posts a Slack thread in #metamask-onboarding-mobile-internal when a team-onboarding PR
-# is ready for review, then replies on the thread for CI updates, reviews, and bot comments.
-#
-# Required secret: SLACK_BOT_TOKEN (bot needs chat:write, reactions:write, channels:read)
-# Optional repo variable: TEAM_ONBOARDING_SLACK_CHANNEL (default: metamask-onboarding-mobile-internal)
-#
+# Team Onboarding PR Slack Bot — posts threads in #metamask-onboarding-mobile-internal for
+# team-onboarding PRs. Requires SLACK_BOT_TOKEN with chat:write, reactions:write, channels:read.
 ##############################################################################################
 name: Team Onboarding PR Slack Bot
 
 on:
   pull_request:
-    types:
-      - opened
-      - ready_for_review
-      - labeled
-      - closed
+    types: [opened, ready_for_review, labeled, closed]
   pull_request_review:
-    types:
-      - submitted
+    types: [submitted]
   pull_request_review_comment:
-    types:
-      - created
+    types: [created]
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_run:
-    workflows:
-      - ci
-    types:
-      - completed
+    workflows: [ci]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  create-thread:
-    name: Create Slack thread
-    if: >-
-      ${{
-        github.event_name == 'pull_request' &&
-        !github.event.pull_request.head.repo.fork &&
-        !github.event.pull_request.draft &&
-        (
-          github.event.action == 'ready_for_review' ||
-          (github.event.action == 'opened' && !github.event.pull_request.draft) ||
-          (github.event.action == 'labeled' && github.event.label.name == 'team-onboarding')
-        )
-      }}
+  notify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
+      - run: yarn install --immutable
       - name: Notify Slack
         continue-on-error: true
         env:
-          ACTION: create-thread
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
-        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
-
-  ci-status:
-    name: Notify CI status
-    if: >-
-      ${{
-        github.event_name == 'workflow_run' &&
-        github.event.workflow_run.event == 'pull_request'
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Notify Slack
-        continue-on-error: true
-        env:
-          ACTION: ci-status
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
-        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
-
-  review-comment:
-    name: Notify review comment
-    if: >-
-      ${{
-        github.event_name == 'pull_request_review' &&
-        !github.event.pull_request.head.repo.fork
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Notify Slack
-        continue-on-error: true
-        env:
-          ACTION: review-comment
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
-        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
-
-  inline-review-comment:
-    name: Notify inline review comment
-    if: >-
-      ${{
-        github.event_name == 'pull_request_review_comment' &&
-        !github.event.pull_request.head.repo.fork
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Notify Slack
-        continue-on-error: true
-        env:
-          ACTION: inline-review-comment
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
-        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
-
-  issue-comment:
-    name: Notify PR issue comment
-    if: >-
-      ${{
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Notify Slack
-        continue-on-error: true
-        env:
-          ACTION: issue-comment
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
-        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
-
-  merged:
-    name: React on merge
-    if: >-
-      ${{
-        github.event_name == 'pull_request' &&
-        github.event.action == 'closed' &&
-        github.event.pull_request.merged &&
-        !github.event.pull_request.head.repo.fork
-      }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Notify Slack
-        continue-on-error: true
-        env:
-          ACTION: merged
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}

--- a/.github/workflows/team-onboarding-pr-slack.yml
+++ b/.github/workflows/team-onboarding-pr-slack.yml
@@ -1,0 +1,215 @@
+##############################################################################################
+#
+# Team Onboarding PR Slack Bot
+#
+# Posts a Slack thread in #metamask-onboarding-mobile-internal when a team-onboarding PR
+# is ready for review, then replies on the thread for CI updates, reviews, and bot comments.
+#
+# Required secret: SLACK_BOT_TOKEN (bot needs chat:write, reactions:write, channels:read)
+# Optional repo variable: TEAM_ONBOARDING_SLACK_CHANNEL (default: metamask-onboarding-mobile-internal)
+#
+##############################################################################################
+name: Team Onboarding PR Slack Bot
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - labeled
+      - closed
+  pull_request_review:
+    types:
+      - submitted
+  pull_request_review_comment:
+    types:
+      - created
+  issue_comment:
+    types:
+      - created
+  workflow_run:
+    workflows:
+      - ci
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-thread:
+    name: Create Slack thread
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.head.repo.fork &&
+        !github.event.pull_request.draft &&
+        (
+          github.event.action == 'ready_for_review' ||
+          (github.event.action == 'opened' && !github.event.pull_request.draft) ||
+          (github.event.action == 'labeled' && github.event.label.name == 'team-onboarding')
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: create-thread
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
+
+  ci-status:
+    name: Notify CI status
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: ci-status
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
+
+  review-comment:
+    name: Notify review comment
+    if: >-
+      ${{
+        github.event_name == 'pull_request_review' &&
+        !github.event.pull_request.head.repo.fork
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: review-comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
+
+  inline-review-comment:
+    name: Notify inline review comment
+    if: >-
+      ${{
+        github.event_name == 'pull_request_review_comment' &&
+        !github.event.pull_request.head.repo.fork
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: inline-review-comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
+
+  issue-comment:
+    name: Notify PR issue comment
+    if: >-
+      ${{
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: issue-comment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs
+
+  merged:
+    name: React on merge
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged &&
+        !github.event.pull_request.head.repo.fork
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Notify Slack
+        continue-on-error: true
+        env:
+          ACTION: merged
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TEAM_ONBOARDING_SLACK_CHANNEL: ${{ vars.TEAM_ONBOARDING_SLACK_CHANNEL }}
+        run: node ./.github/scripts/team-onboarding-pr-slack.mjs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a GitHub Actions–based Slack bot for `team-onboarding` PRs that posts to `#metamask-onboarding-mobile-internal` and keeps a thread updated through the PR lifecycle.

## Behavior

1. **Thread creation** — When a non-draft, non-fork PR with the `team-onboarding` label is ready for review (`ready_for_review`, non-draft `opened`, or `team-onboarding` label added), the bot posts the initial message and stores thread metadata in a hidden PR comment.
2. **CI updates** — When the `ci` workflow completes for a tracked PR, the bot replies on the thread with pass/fail status and tags the author. Adds `:alert:` on the parent message when CI fails; removes it when CI passes.
3. **Cursor Bug Bot** — Replies on the thread when `cursor[bot]`, `cursorbot`, or `cursoragent` leaves PR comments or reviews.
4. **Reviewer feedback** — Replies on the thread for submitted PR reviews and inline review comments from human reviewers.
5. **Merge** — Replies on the thread when the PR merges and reacts with `:white_check_mark:` on the parent message.

## Implementation

- `.github/workflows/team-onboarding-pr-slack.yml` — single job wired to all relevant GitHub events
- `.github/scripts/team-onboarding-pr-slack.mjs` — Slack + GitHub API logic (thread state stored in a marker PR comment)
- `.github/scripts/team-onboarding-pr-slack.test.mjs` — unit tests for helper functions

## Setup required after merge

1. Ensure the existing `SLACK_BOT_TOKEN` secret’s bot is invited to `#metamask-onboarding-mobile-internal` with scopes: `chat:write`, `reactions:write`, `channels:read` (and `groups:read` if the channel is private).
2. Optionally set repo variable `TEAM_ONBOARDING_SLACK_CHANNEL` to override the default channel name (`metamask-onboarding-mobile-internal`).
3. Confirm the `team-onboarding` label is applied to onboarding-team PRs (via existing `add-team-label` automation).

## Testing

```bash
node --test .github/scripts/team-onboarding-pr-slack.test.mjs
```

Notifications are fail-open (`continue-on-error: true`) so Slack issues do not block CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0ARDAYCH19/p1782804668037729?thread_ts=1782804668.037729&cid=D0ARDAYCH19)

<div><a href="https://cursor.com/agents/bc-844c1e9b-9a41-57dc-b0f0-5cf21c0d3928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-844c1e9b-9a41-57dc-b0f0-5cf21c0d3928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

