### PR TITLE
feat(confirmations): add QR code scanner to send recipient input

### DIFF
--- a/app/components/Views/confirmations/components/recipient-input/recipient-input.test.tsx
+++ b/app/components/Views/confirmations/components/recipient-input/recipient-input.test.tsx
@@ -7,10 +7,15 @@ import { useSendContext } from '../../context/send-context/send-context';
 import { useToAddressValidation } from '../../hooks/send/useToAddressValidation';
 import { useRecipientSelectionMetrics } from '../../hooks/send/metrics/useRecipientSelectionMetrics';
 import { useSendActions } from '../../hooks/send/useSendActions';
+import { useScanRecipientQrCode } from '../../hooks/send/useScanRecipientQrCode';
 import { RecipientInput } from './recipient-input';
 
 jest.mock('../../context/send-context/send-context', () => ({
   useSendContext: jest.fn(),
+}));
+
+jest.mock('../../hooks/send/useScanRecipientQrCode', () => ({
+  useScanRecipientQrCode: jest.fn(),
 }));
 
 jest.mock('../../hooks/send/useToAddressValidation', () => ({
@@ -35,6 +40,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'send.to': 'To',
       'send.clear': 'Clear',
       'send.paste': 'Paste',
+      'send.scan_qr_code': 'Scan QR code',
       'send.enter_address_to_send_to': 'Enter address to send to',
     };
     return mockStrings[key] || key;
@@ -50,12 +56,14 @@ const mockUseRecipientSelectionMetrics = jest.mocked(
   useRecipientSelectionMetrics,
 );
 const mockUseSendActions = jest.mocked(useSendActions);
+const mockUseScanRecipientQrCode = jest.mocked(useScanRecipientQrCode);
 
 describe('RecipientInput', () => {
   const mockUpdateTo = jest.fn();
   const mockValidateToAddress = jest.fn();
   const mockCaptureRecipientSelected = jest.fn();
   const mockHandleSubmitPress = jest.fn();
+  const mockOpenScanner = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -92,6 +100,10 @@ describe('RecipientInput', () => {
       handleSubmitPress: mockHandleSubmitPress,
       handleCancelPress: jest.fn(),
       handleBackPress: jest.fn(),
+    });
+
+    mockUseScanRecipientQrCode.mockReturnValue({
+      openScanner: mockOpenScanner,
     });
   });
 
@@ -431,5 +443,106 @@ describe('RecipientInput', () => {
     );
 
     expect(getByText('Clear')).toBeOnTheScreen();
+  });
+
+  it('displays the QR scan button alongside paste when input is empty', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={noop}
+        setPastedRecipient={noop}
+      />,
+    );
+
+    expect(getByTestId('recipient-qr-scan-button')).toBeOnTheScreen();
+    expect(getByText('Paste')).toBeOnTheScreen();
+  });
+
+  it('does not display the QR scan button when input has a value', () => {
+    mockUseSendContext.mockReturnValue({
+      to: '0x1234567890123456789012345678901234567890',
+      updateTo: mockUpdateTo,
+      asset: undefined,
+      chainId: undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fromAccount: {} as any,
+      from: '',
+      maxValueMode: false,
+      updateAsset: jest.fn(),
+      updateValue: jest.fn(),
+      value: undefined,
+    });
+
+    const { queryByTestId } = renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={noop}
+        setPastedRecipient={noop}
+      />,
+    );
+
+    expect(queryByTestId('recipient-qr-scan-button')).toBeNull();
+  });
+
+  it('opens the scanner when the QR scan button is pressed', () => {
+    const { getByTestId } = renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={noop}
+        setPastedRecipient={noop}
+      />,
+    );
+
+    fireEvent.press(getByTestId('recipient-qr-scan-button'));
+
+    expect(mockOpenScanner).toHaveBeenCalledTimes(1);
+  });
+
+  it('populates the input and records the QR input method on scan success', () => {
+    const mockResetStateOnInput = jest.fn();
+    const mockSetPastedRecipient = jest.fn();
+    const mockSetAutoFilledInputMethod = jest.fn();
+
+    renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={mockResetStateOnInput}
+        setPastedRecipient={mockSetPastedRecipient}
+        setAutoFilledInputMethod={mockSetAutoFilledInputMethod}
+      />,
+    );
+
+    const scannedAddress = '0x1234567890123456789012345678901234567890';
+    const { onAddressScanned } =
+      mockUseScanRecipientQrCode.mock.calls[
+        mockUseScanRecipientQrCode.mock.calls.length - 1
+      ][0];
+    onAddressScanned(scannedAddress);
+
+    expect(mockResetStateOnInput).toHaveBeenCalled();
+    expect(mockUpdateTo).toHaveBeenCalledWith(scannedAddress);
+    expect(mockSetAutoFilledInputMethod).toHaveBeenCalledWith('qr_code_scan');
+    expect(mockSetPastedRecipient).toHaveBeenCalledWith(scannedAddress);
+  });
+
+  it('records the pasted input method on paste', async () => {
+    const mockAddress = '0x1234567890123456789012345678901234567890';
+    mockClipboardManager.getString.mockResolvedValue(mockAddress);
+    const mockSetAutoFilledInputMethod = jest.fn();
+
+    const { getByText } = renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={noop}
+        setPastedRecipient={noop}
+        setAutoFilledInputMethod={mockSetAutoFilledInputMethod}
+      />,
+    );
+
+    fireEvent.press(getByText('Paste'));
+
+    await waitFor(() => {
+      expect(mockSetAutoFilledInputMethod).toHaveBeenCalledWith('pasted');
+    });
   });
 });

--- a/app/components/Views/confirmations/components/recipient-input/recipient-input.tsx
+++ b/app/components/Views/confirmations/components/recipient-input/recipient-input.tsx
@@ -6,6 +6,9 @@ import {
   Button,
   ButtonVariant,
   ButtonBaseSize,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
   TextColor,
 } from '@metamask/design-system-react-native';
 
@@ -13,18 +16,52 @@ import { strings } from '../../../../../../locales/i18n';
 import TextField from '../../../../../component-library/components/Form/TextField';
 import ClipboardManager from '../../../../../core/ClipboardManager';
 import { useSendContext } from '../../context/send-context/send-context';
+import { RecipientInputMethod } from '../../context/send-context/send-metrics-context';
+import { useScanRecipientQrCode } from '../../hooks/send/useScanRecipientQrCode';
+
+const ScanRecipientButton = ({ onPress }: { onPress: () => void }) => (
+  <Box twClassName="h-[30px] items-center justify-center rounded-lg bg-muted px-1">
+    <ButtonIcon
+      iconName={IconName.ScanBarcode}
+      size={ButtonIconSize.Sm}
+      onPress={onPress}
+      accessibilityLabel={strings('send.scan_qr_code')}
+      testID="recipient-qr-scan-button"
+    />
+  </Box>
+);
 
 export const RecipientInput = ({
   isRecipientSelectedFromList,
   resetStateOnInput,
   setPastedRecipient,
+  setAutoFilledInputMethod,
 }: {
   isRecipientSelectedFromList: boolean;
   resetStateOnInput: () => void;
   setPastedRecipient: (recipient?: string) => void;
+  setAutoFilledInputMethod?: (
+    inputMethod:
+      | typeof RecipientInputMethod.Pasted
+      | typeof RecipientInputMethod.QrScan,
+  ) => void;
 }) => {
   const { to, updateTo } = useSendContext();
   const inputRef = useRef<TextInput>(null);
+
+  const handleAddressScanned = useCallback(
+    (scannedAddress: string) => {
+      resetStateOnInput();
+      updateTo(scannedAddress);
+      setAutoFilledInputMethod?.(RecipientInputMethod.QrScan);
+      setPastedRecipient(scannedAddress);
+    },
+    [resetStateOnInput, setAutoFilledInputMethod, setPastedRecipient, updateTo],
+  );
+
+  const { openScanner } = useScanRecipientQrCode({
+    onAddressScanned: handleAddressScanned,
+  });
 
   const handlePaste = useCallback(async () => {
     resetStateOnInput();
@@ -33,6 +70,7 @@ export const RecipientInput = ({
       if (clipboardText) {
         const trimmedText = clipboardText.trim();
         updateTo(trimmedText);
+        setAutoFilledInputMethod?.(RecipientInputMethod.Pasted);
         setPastedRecipient(trimmedText);
         setTimeout(() => {
           inputRef.current?.focus();
@@ -45,7 +83,13 @@ export const RecipientInput = ({
       // eslint-disable-next-line no-console
       console.log('error while pasting', error);
     }
-  }, [updateTo, inputRef, setPastedRecipient, resetStateOnInput]);
+  }, [
+    updateTo,
+    inputRef,
+    setAutoFilledInputMethod,
+    setPastedRecipient,
+    resetStateOnInput,
+  ]);
 
   const handleClearInput = useCallback(() => {
     updateTo('');
@@ -83,16 +127,25 @@ export const RecipientInput = ({
       );
     }
     return (
-      <Button
-        variant={ButtonVariant.Secondary}
-        size={ButtonBaseSize.Sm}
-        twClassName="-mr-2"
-        onPress={handlePaste}
-      >
-        {strings('send.paste')}
-      </Button>
+      <Box twClassName="flex-row items-center gap-2.5">
+        <ScanRecipientButton onPress={openScanner} />
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonBaseSize.Sm}
+          twClassName="-mr-2"
+          onPress={handlePaste}
+        >
+          {strings('send.paste')}
+        </Button>
+      </Box>
     );
-  }, [to, handleClearInput, handlePaste, isRecipientSelectedFromList]);
+  }, [
+    to,
+    handleClearInput,
+    handlePaste,
+    isRecipientSelectedFromList,
+    openScanner,
+  ]);
 
   return (
     <Box twClassName="w-full px-4 py-2">

--- a/app/components/Views/confirmations/components/send/recipient/recipient.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.tsx
@@ -36,6 +36,9 @@ export const Recipient = () => {
   const [isRecipientSelectedFromList, setIsRecipientSelectedFromList] =
     useState(false);
   const [pastedRecipient, setPastedRecipient] = useState<string>();
+  const [autoFilledInputMethod, setAutoFilledInputMethod] = useState<
+    typeof RecipientInputMethod.Pasted | typeof RecipientInputMethod.QrScan
+  >(RecipientInputMethod.Pasted);
   const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
   const { to, updateTo, asset, chainId } = useSendContext();
   const { header: renderRecipientHeader } = useSendNavbar().Recipient;
@@ -95,7 +98,7 @@ export const Recipient = () => {
       setIsSubmittingTransaction(true);
       setPastedRecipient(undefined);
       captureRecipientSelected(
-        isPasted ? RecipientInputMethod.Pasted : RecipientInputMethod.Manual,
+        isPasted ? autoFilledInputMethod : RecipientInputMethod.Manual,
       );
       await handleSubmitPress(resolvedAddress || to);
       setIsSubmittingTransaction(false);
@@ -104,6 +107,7 @@ export const Recipient = () => {
       to,
       handleSubmitPress,
       captureRecipientSelected,
+      autoFilledInputMethod,
       resolvedAddress,
       setPastedRecipient,
       isSubmittingTransaction,
@@ -222,6 +226,7 @@ export const Recipient = () => {
             isRecipientSelectedFromList={isRecipientSelectedFromList}
             resetStateOnInput={resetStateOnInput}
             setPastedRecipient={setPastedRecipient}
+            setAutoFilledInputMethod={setAutoFilledInputMethod}
           />
           <ScrollView>
             <RecipientList

--- a/app/components/Views/confirmations/context/send-context/send-metrics-context.tsx
+++ b/app/components/Views/confirmations/context/send-context/send-metrics-context.tsx
@@ -27,6 +27,7 @@ export const AmountInputMethod = {
 export const RecipientInputMethod = {
   Manual: 'manual',
   Pasted: 'pasted',
+  QrScan: 'qr_code_scan',
   SelectAccount: 'select_account',
   SelectContact: 'select_contact',
 };

--- a/app/components/Views/confirmations/hooks/send/useScanRecipientQrCode.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useScanRecipientQrCode.test.ts
@@ -1,0 +1,96 @@
+import { act } from '@testing-library/react-native';
+
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import Routes from '../../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useScanRecipientQrCode } from './useScanRecipientQrCode';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+const mockTrackEvent = jest.fn();
+const mockBuild = jest.fn().mockReturnValue({ event: 'qr_scanner_opened' });
+const mockCreateEventBuilder = jest.fn().mockReturnValue({ build: mockBuild });
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+describe('useScanRecipientQrCode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an openScanner function', () => {
+    const { result } = renderHookWithProvider(() =>
+      useScanRecipientQrCode({ onAddressScanned: jest.fn() }),
+    );
+
+    expect(typeof result.current.openScanner).toBe('function');
+  });
+
+  it('tracks QR_SCANNER_OPENED and navigates to the scanner with SEND_TO origin', () => {
+    const { result } = renderHookWithProvider(() =>
+      useScanRecipientQrCode({ onAddressScanned: jest.fn() }),
+    );
+
+    act(() => {
+      result.current.openScanner();
+    });
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.QR_SCANNER_OPENED,
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: 'qr_scanner_opened',
+    });
+    expect(mockNavigate.mock.calls[0][0]).toBe(Routes.QR_TAB_SWITCHER);
+    expect(mockNavigate.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ origin: Routes.SEND_FLOW.SEND_TO }),
+    );
+  });
+
+  it('forwards the scanned address to onAddressScanned on success', () => {
+    const onAddressScanned = jest.fn();
+    const { result } = renderHookWithProvider(() =>
+      useScanRecipientQrCode({ onAddressScanned }),
+    );
+
+    act(() => {
+      result.current.openScanner();
+    });
+
+    const { onScanSuccess } = mockNavigate.mock.calls[0][1];
+    onScanSuccess({
+      target_address: '0x1234567890123456789012345678901234567890',
+    });
+
+    expect(onAddressScanned).toHaveBeenCalledWith(
+      '0x1234567890123456789012345678901234567890',
+    );
+  });
+
+  it('does not call onAddressScanned when no target_address is present', () => {
+    const onAddressScanned = jest.fn();
+    const { result } = renderHookWithProvider(() =>
+      useScanRecipientQrCode({ onAddressScanned }),
+    );
+
+    act(() => {
+      result.current.openScanner();
+    });
+
+    const { onScanSuccess } = mockNavigate.mock.calls[0][1];
+    onScanSuccess({});
+
+    expect(onAddressScanned).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/confirmations/hooks/send/useScanRecipientQrCode.ts
+++ b/app/components/Views/confirmations/hooks/send/useScanRecipientQrCode.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+
+import Routes from '../../../../../constants/navigation/Routes';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import {
+  createQRScannerNavDetails,
+  QRTabSwitcherScreens,
+  type ScanSuccess,
+  // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+} from '../../../QRTabSwitcher';
+
+interface UseScanRecipientQrCodeParams {
+  onAddressScanned: (address: string) => void;
+}
+
+export const useScanRecipientQrCode = ({
+  onAddressScanned,
+}: UseScanRecipientQrCodeParams) => {
+  const { navigate } = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const handleScanSuccess = useCallback(
+    (data: ScanSuccess) => {
+      if (data.target_address) {
+        onAddressScanned(data.target_address);
+      }
+    },
+    [onAddressScanned],
+  );
+
+  const openScanner = useCallback(() => {
+    trackEvent(createEventBuilder(MetaMetricsEvents.QR_SCANNER_OPENED).build());
+
+    navigate(
+      ...createQRScannerNavDetails({
+        initialScreen: QRTabSwitcherScreens.Scanner,
+        disableTabber: true,
+        onScanSuccess: handleScanSuccess,
+        origin: Routes.SEND_FLOW.SEND_TO,
+      }),
+    );
+  }, [createEventBuilder, handleScanSuccess, navigate, trackEvent]);
+
+  return { openScanner };
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -702,6 +702,7 @@
     "paste": "Paste",
     "no_assets_available": "No assets available to send",
     "clear": "Clear",
+    "scan_qr_code": "Scan QR code",
     "to": "To",
     "enter_address_to_send_to": "Enter address to send to",
     "accounts": "Accounts",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

In the redesigned Send flow, the only ways to enter a recipient address on the recipient page were typing manually or pasting. Users with a recipient QR code (another wallet, an exchange withdrawal screen, a hardware device) had to leave
the flow, scan elsewhere, copy, and paste back — a common request and a feature competing wallets already ship.

This adds a QR scan button directly to the recipient input, next to "Paste". On scan, the existing camera scanner validates the address and returns it to the input, which auto-populates and proceeds through the same validation/auto-review path used by paste — without ever leaving the Send flow.

Scope for this PR is **EVM and non EVM chains** .


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a QR code scanner button to the Send flow recipient field for scanning EVM recipient addresses

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1613 

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Scan a recipient QR code in the Send flow

  Scenario: User scans a valid EVM address from the recipient page
    Given the user is on the Send flow recipient page with an asset already selected
    And the recipient input is empty

    When the user taps the QR scan button next to "Paste"
    And the user scans a QR code containing a valid EVM address (plain "0x..." or "ethereum:0x...")
    Then the address is populated into the recipient input
    And the flow proceeds to review (same behavior as paste)
    And a "Send Recipient Selected" event is recorded with input_method = "qr_code_scan"

```

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/b3795799-ac60-4e5a-928a-158ae3ce0847


https://github.com/user-attachments/assets/e45fd7cf-afce-4965-bcc2-1fc8e58597fa


<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation around recipient entry only; scanned addresses still go through existing validation and send guards, with solid unit test coverage.
> 
> **Overview**
> Adds **in-flow QR scanning** on the Send recipient field so users can fill an EVM address without leaving the flow.
> 
> When the recipient field is empty, a scan icon appears beside **Paste**; tapping it opens the existing QR tab scanner with `SEND_TO` origin, fires `QR_SCANNER_OPENED`, and on success fills the address through the same auto-review path as paste. The scan control is hidden once the field has text (Clear replaces the accessory row).
> 
> New **`useScanRecipientQrCode`** encapsulates navigation and scan callbacks for reuse outside Send. **`RecipientInput`** accepts optional **`setAutoFilledInputMethod`**; paste and scan set `pasted` vs **`qr_code_scan`**, and the recipient screen passes that into **`captureRecipientSelected`** on auto-submit instead of always reporting paste.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a40d8760f15948a81b7321f92b1945f84fe6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->