### PR TITLE
chore: split useTraderPositionData spot/perp price hooks

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/traderPositionData.shared.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/traderPositionData.shared.ts
@@ -1,0 +1,52 @@
+import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
+
+export const TIME_PERIODS = ['1H', '1D', '1W', '1M', 'All'] as const;
+export type TimePeriod = (typeof TIME_PERIODS)[number];
+
+export const PERIOD_TO_API: Record<TimePeriod, string> = {
+  '1H': '1d',
+  '1D': '1d',
+  '1W': '7d',
+  '1M': '1m',
+  All: '3y',
+};
+
+export const PERIOD_DURATION_MS: Record<TimePeriod, number> = {
+  '1H': 60 * 60 * 1000,
+  '1D': 24 * 60 * 60 * 1000,
+  '1W': 7 * 24 * 60 * 60 * 1000,
+  '1M': 30 * 24 * 60 * 60 * 1000,
+  All: 3 * 365 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Derives percentage change from historical price data points.
+ * For "1H" we find the point closest to one hour ago within the data set.
+ * @param nowMs - Same clock as used to slice 1H prices (avoids mismatched "now").
+ */
+export function derivePercentChange(
+  prices: TokenPrice[],
+  period: TimePeriod,
+  nowMs: number,
+): number | undefined {
+  if (!prices.length) return undefined;
+
+  const endPrice = prices[prices.length - 1][1];
+  let startPrice: number;
+
+  if (period === '1H') {
+    const oneHourAgo = nowMs - 60 * 60 * 1000;
+    const closest = prices.reduce((best, pt) =>
+      Math.abs(Number(pt[0]) - oneHourAgo) <
+      Math.abs(Number(best[0]) - oneHourAgo)
+        ? pt
+        : best,
+    );
+    startPrice = closest[1];
+  } else {
+    startPrice = prices[0][1];
+  }
+
+  if (startPrice === 0) return undefined;
+  return ((endPrice - startPrice) / startPrice) * 100;
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/traderPositionData.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/traderPositionData.ts
@@ -31,16 +31,20 @@ export function derivePercentChange(
 ): number | undefined {
   if (!prices.length) return undefined;
 
-  const endPrice = prices[prices.length - 1][1];
+  const endPrice = prices.at(-1)?.[1];
+  if (endPrice == null) return undefined;
+
   let startPrice: number;
 
   if (period === '1H') {
     const oneHourAgo = nowMs - 60 * 60 * 1000;
-    const closest = prices.reduce((best, pt) =>
-      Math.abs(Number(pt[0]) - oneHourAgo) <
-      Math.abs(Number(best[0]) - oneHourAgo)
-        ? pt
-        : best,
+    const closest = prices.reduce(
+      (best, pt) =>
+        Math.abs(Number(pt[0]) - oneHourAgo) <
+        Math.abs(Number(best[0]) - oneHourAgo)
+          ? pt
+          : best,
+      prices[0],
     );
     startPrice = closest[1];
   } else {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.test.ts
@@ -70,6 +70,37 @@ describe('usePerpsTraderPositionPrices', () => {
     }
   });
 
+  it('clears loading when the active period resolves without waiting on earlier periods', async () => {
+    const oneMonthPrices: TokenPrice[] = [
+      ['1', 100],
+      ['2', 101],
+    ];
+    let resolveSlowPeriods: () => void = () => undefined;
+    const slowPeriodsPromise = new Promise<TokenPrice[]>((resolve) => {
+      resolveSlowPeriods = () => resolve([]);
+    });
+
+    mockFetchHyperliquid.mockImplementation(({ interval }) => {
+      if (interval === '4h') {
+        return Promise.resolve(oneMonthPrices);
+      }
+      if (interval === '1m' || interval === '15m' || interval === '1h') {
+        return slowPeriodsPromise;
+      }
+      return Promise.resolve([]);
+    });
+
+    const { result } = renderPerpPrices();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
+
+    resolveSlowPeriods();
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
   it('does not refetch already-loaded periods when positionParam gets a new reference', async () => {
     const goodPrices: TokenPrice[] = [
       ['1', 100],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.test.ts
@@ -1,0 +1,175 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { Position } from '@metamask/social-controllers';
+import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
+import {
+  fetchHyperliquidHistoricalPrices,
+  type HyperliquidCandleInterval,
+} from '../utils/hyperliquidPrices';
+import { usePerpsTraderPositionPrices } from './usePerpsTraderPositionPrices';
+
+jest.mock('../utils/hyperliquidPrices', () => ({
+  ...jest.requireActual('../utils/hyperliquidPrices'),
+  fetchHyperliquidHistoricalPrices: jest.fn().mockResolvedValue([]),
+}));
+
+const mockFetchHyperliquid =
+  fetchHyperliquidHistoricalPrices as jest.MockedFunction<
+    typeof fetchHyperliquidHistoricalPrices
+  >;
+
+const perpPosition = {
+  chain: 'hyperliquid',
+  perpPositionType: 'long',
+  tokenSymbol: 'ETH',
+  tokenAddress: '0x0000000000000000000000000000000000000000',
+  trades: [],
+} as unknown as Position;
+
+const renderPerpPrices = (position: Position = perpPosition) =>
+  renderHook(() =>
+    usePerpsTraderPositionPrices(
+      {
+        positionParam: position,
+        activeTimePeriod: '1M',
+        earliestTradeMs: undefined,
+      },
+      { enabled: true },
+    ),
+  );
+
+describe('usePerpsTraderPositionPrices', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchHyperliquid.mockResolvedValue([]);
+  });
+
+  it('pre-fetches every period up front so an interval switch needs no network', async () => {
+    renderPerpPrices();
+
+    await waitFor(() => expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5));
+
+    const intervals = mockFetchHyperliquid.mock.calls.map(
+      ([opts]) => opts.interval,
+    );
+    const expected: HyperliquidCandleInterval[] = [
+      '1m',
+      '15m',
+      '1h',
+      '4h',
+      '1d',
+    ];
+    expect(new Set(intervals)).toEqual(new Set(expected));
+  });
+
+  it('requests every period for the position symbol', async () => {
+    renderPerpPrices();
+
+    await waitFor(() => expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5));
+    for (const [opts] of mockFetchHyperliquid.mock.calls) {
+      expect(opts.symbol).toBe('ETH');
+    }
+  });
+
+  it('does not refetch already-loaded periods when positionParam gets a new reference', async () => {
+    const goodPrices: TokenPrice[] = [
+      ['1', 100],
+      ['2', 101],
+    ];
+    mockFetchHyperliquid.mockResolvedValue(goodPrices);
+
+    const { rerender } = renderHook(
+      (position: Position) =>
+        usePerpsTraderPositionPrices(
+          {
+            positionParam: position,
+            activeTimePeriod: '1M',
+            earliestTradeMs: undefined,
+          },
+          { enabled: true },
+        ),
+      { initialProps: perpPosition },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
+
+    rerender({ ...perpPosition } as Position);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
+  });
+
+  it('refetches with a larger limit when an earlier trade extends the required window', async () => {
+    const savedNow = Date.now;
+    Date.now = () => 2_000_000_000_000;
+    try {
+      mockFetchHyperliquid.mockResolvedValue([
+        ['1', 100],
+        ['2', 101],
+      ] as TokenPrice[]);
+
+      const snapshot = { ...perpPosition, trades: [] } as unknown as Position;
+      const { rerender } = renderHook(
+        (position: Position) =>
+          usePerpsTraderPositionPrices(
+            {
+              positionParam: position,
+              activeTimePeriod: '1M',
+              earliestTradeMs: position.trades?.length
+                ? 1_000_000_000_000
+                : undefined,
+            },
+            { enabled: true },
+          ),
+        { initialProps: snapshot },
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
+      const initialOneMinLimit = mockFetchHyperliquid.mock.calls.find(
+        ([opts]) => opts.interval === '1m',
+      )?.[0].limit as number;
+
+      const withOldTrade = {
+        ...perpPosition,
+        trades: [{ timestamp: 1_000_000_000_000 }],
+      } as unknown as Position;
+      rerender(withOldTrade);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockFetchHyperliquid.mock.calls.length).toBeGreaterThan(5);
+      const oneMinCalls = mockFetchHyperliquid.mock.calls.filter(
+        ([opts]) => opts.interval === '1m',
+      );
+      expect(oneMinCalls.length).toBeGreaterThanOrEqual(2);
+      expect(oneMinCalls.at(-1)?.[0].limit).toBeGreaterThan(initialOneMinLimit);
+    } finally {
+      Date.now = savedNow;
+    }
+  });
+
+  it('does not fetch when enabled is false', async () => {
+    renderHook(() =>
+      usePerpsTraderPositionPrices(
+        {
+          positionParam: perpPosition,
+          activeTimePeriod: '1M',
+          earliestTradeMs: undefined,
+        },
+        { enabled: false },
+      ),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockFetchHyperliquid).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Position } from '@metamask/social-controllers';
+import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
+import { isPerpPosition } from '../utils/perp';
+import {
+  fetchHyperliquidHistoricalPrices,
+  resolveHyperliquidCandleLimit,
+  type HyperliquidCandleInterval,
+} from '../utils/hyperliquidPrices';
+import { TIME_PERIODS, type TimePeriod } from './traderPositionData.shared';
+
+/**
+ * Hyperliquid candle interval + baseline candle count per chart period. The base
+ * count fills the period's default window when a position has no (or only recent)
+ * trades; for older / closed positions {@link resolveHyperliquidCandleLimit} grows
+ * it to reach the earliest trade, capped at the API's per-request maximum
+ * (~5000 candles). Counts stay well above CHART_DATA_THRESHOLD so the line stays
+ * smooth. Unlike the spot API, each period maps to a distinct interval
+ * (granularity), so there's no 1D→1H reuse.
+ */
+const PERP_PERIOD_TO_CANDLES: Record<
+  TimePeriod,
+  { interval: HyperliquidCandleInterval; baseLimit: number }
+> = {
+  '1H': { interval: '1m', baseLimit: 60 },
+  '1D': { interval: '15m', baseLimit: 96 },
+  '1W': { interval: '1h', baseLimit: 168 },
+  '1M': { interval: '4h', baseLimit: 180 },
+  All: { interval: '1d', baseLimit: 1095 },
+};
+
+export interface PerpsTraderPositionPricesParams {
+  positionParam: Position | undefined;
+  activeTimePeriod: TimePeriod;
+  earliestTradeMs: number | undefined;
+}
+
+export interface PerpsTraderPositionPricesOptions {
+  enabled: boolean;
+}
+
+export interface PerpsTraderPositionPricesResult {
+  pricesByPeriod: Partial<Record<TimePeriod, TokenPrice[]>>;
+  isLoading: boolean;
+  perpKey: string;
+}
+
+export function usePerpsTraderPositionPrices(
+  {
+    positionParam,
+    activeTimePeriod,
+    earliestTradeMs,
+  }: PerpsTraderPositionPricesParams,
+  { enabled }: PerpsTraderPositionPricesOptions,
+): PerpsTraderPositionPricesResult {
+  const isPerp =
+    enabled && positionParam != null && isPerpPosition(positionParam);
+
+  const perpKey = useMemo(
+    () =>
+      isPerp && positionParam
+        ? `${positionParam.chain}:${positionParam.tokenSymbol}`
+        : '',
+    [isPerp, positionParam],
+  );
+
+  const [perpCache, setPerpCache] = useState<{
+    key: string;
+    prices: Partial<Record<TimePeriod, TokenPrice[]>>;
+    limits: Partial<Record<TimePeriod, number>>;
+  }>({ key: '', prices: {}, limits: {} });
+  const [isLoading, setIsLoading] = useState(true);
+
+  const perpCacheRef = useRef(perpCache);
+  perpCacheRef.current = perpCache;
+
+  useEffect(() => {
+    if (!enabled || !positionParam || !isPerp) return;
+
+    let cancelled = false;
+    const nowMs = Date.now();
+    const { tokenSymbol: perpSymbol } = positionParam;
+
+    TIME_PERIODS.forEach((period) => {
+      const { interval, baseLimit } = PERP_PERIOD_TO_CANDLES[period];
+      const limit = resolveHyperliquidCandleLimit({
+        interval,
+        baseLimit,
+        earliestTradeMs,
+        nowMs,
+      });
+
+      const cached = perpCacheRef.current;
+      if (
+        cached.key === perpKey &&
+        cached.prices[period]?.length &&
+        (cached.limits[period] ?? 0) >= limit
+      ) {
+        return;
+      }
+
+      fetchHyperliquidHistoricalPrices({
+        symbol: perpSymbol,
+        interval,
+        limit,
+        nowMs,
+      }).then((prices) => {
+        if (cancelled) return;
+        setPerpCache((prev) => {
+          const samePos = prev.key === perpKey;
+          if (samePos && prev.prices[period]?.length && !prices.length) {
+            return prev;
+          }
+          return {
+            key: perpKey,
+            prices: samePos
+              ? { ...prev.prices, [period]: prices }
+              : { [period]: prices },
+            limits: samePos
+              ? { ...prev.limits, [period]: limit }
+              : { [period]: limit },
+          };
+        });
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, positionParam, isPerp, perpKey, earliestTradeMs]);
+
+  useEffect(() => {
+    if (!enabled || !isPerp) return;
+    const hasActivePeriod =
+      perpCache.key === perpKey && Boolean(perpCache.prices[activeTimePeriod]);
+    setIsLoading(!hasActivePeriod);
+  }, [enabled, isPerp, perpKey, activeTimePeriod, perpCache]);
+
+  const pricesByPeriod = useMemo(
+    () => (perpCache.key === perpKey ? perpCache.prices : {}),
+    [perpCache, perpKey],
+  );
+
+  return {
+    pricesByPeriod: enabled ? pricesByPeriod : {},
+    isLoading: enabled ? isLoading : false,
+    perpKey,
+  };
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
@@ -7,7 +7,7 @@ import {
   resolveHyperliquidCandleLimit,
   type HyperliquidCandleInterval,
 } from '../utils/hyperliquidPrices';
-import { TIME_PERIODS, type TimePeriod } from './traderPositionData.shared';
+import { TIME_PERIODS, type TimePeriod } from './traderPositionData';
 
 /**
  * Hyperliquid candle interval + baseline candle count per chart period. The base
@@ -28,6 +28,86 @@ const PERP_PERIOD_TO_CANDLES: Record<
   '1M': { interval: '4h', baseLimit: 180 },
   All: { interval: '1d', baseLimit: 1095 },
 };
+
+interface PerpCacheState {
+  key: string;
+  prices: Partial<Record<TimePeriod, TokenPrice[]>>;
+  limits: Partial<Record<TimePeriod, number>>;
+}
+
+function mergePerpPeriodIntoCache(
+  prev: PerpCacheState,
+  perpKey: string,
+  period: TimePeriod,
+  prices: TokenPrice[],
+  limit: number,
+): PerpCacheState {
+  const samePos = prev.key === perpKey;
+  if (samePos && prev.prices[period]?.length && !prices.length) {
+    return prev;
+  }
+  return {
+    key: perpKey,
+    prices: samePos
+      ? { ...prev.prices, [period]: prices }
+      : { [period]: prices },
+    limits: samePos ? { ...prev.limits, [period]: limit } : { [period]: limit },
+  };
+}
+
+function isPerpPeriodCached(
+  cached: PerpCacheState,
+  perpKey: string,
+  period: TimePeriod,
+  limit: number,
+): boolean {
+  return (
+    cached.key === perpKey &&
+    Boolean(cached.prices[period]?.length) &&
+    (cached.limits[period] ?? 0) >= limit
+  );
+}
+
+async function fetchPerpPeriodCandles({
+  period,
+  perpSymbol,
+  perpKey,
+  earliestTradeMs,
+  nowMs,
+  cached,
+}: {
+  period: TimePeriod;
+  perpSymbol: string;
+  perpKey: string;
+  earliestTradeMs: number | undefined;
+  nowMs: number;
+  cached: PerpCacheState;
+}): Promise<{
+  period: TimePeriod;
+  prices: TokenPrice[];
+  limit: number;
+} | null> {
+  const { interval, baseLimit } = PERP_PERIOD_TO_CANDLES[period];
+  const limit = resolveHyperliquidCandleLimit({
+    interval,
+    baseLimit,
+    earliestTradeMs,
+    nowMs,
+  });
+
+  if (isPerpPeriodCached(cached, perpKey, period, limit)) {
+    return null;
+  }
+
+  const prices = await fetchHyperliquidHistoricalPrices({
+    symbol: perpSymbol,
+    interval,
+    limit,
+    nowMs,
+  });
+
+  return { period, prices, limit };
+}
 
 export interface PerpsTraderPositionPricesParams {
   positionParam: Position | undefined;
@@ -64,11 +144,11 @@ export function usePerpsTraderPositionPrices(
     [isPerp, positionParam],
   );
 
-  const [perpCache, setPerpCache] = useState<{
-    key: string;
-    prices: Partial<Record<TimePeriod, TokenPrice[]>>;
-    limits: Partial<Record<TimePeriod, number>>;
-  }>({ key: '', prices: {}, limits: {} });
+  const [perpCache, setPerpCache] = useState<PerpCacheState>({
+    key: '',
+    prices: {},
+    limits: {},
+  });
   const [isLoading, setIsLoading] = useState(true);
 
   const perpCacheRef = useRef(perpCache);
@@ -81,48 +161,33 @@ export function usePerpsTraderPositionPrices(
     const nowMs = Date.now();
     const { tokenSymbol: perpSymbol } = positionParam;
 
-    TIME_PERIODS.forEach((period) => {
-      const { interval, baseLimit } = PERP_PERIOD_TO_CANDLES[period];
-      const limit = resolveHyperliquidCandleLimit({
-        interval,
-        baseLimit,
-        earliestTradeMs,
-        nowMs,
-      });
-
-      const cached = perpCacheRef.current;
-      if (
-        cached.key === perpKey &&
-        cached.prices[period]?.length &&
-        (cached.limits[period] ?? 0) >= limit
-      ) {
-        return;
-      }
-
-      fetchHyperliquidHistoricalPrices({
-        symbol: perpSymbol,
-        interval,
-        limit,
-        nowMs,
-      }).then((prices) => {
+    const prefetchAllPeriods = async () => {
+      for (const period of TIME_PERIODS) {
         if (cancelled) return;
-        setPerpCache((prev) => {
-          const samePos = prev.key === perpKey;
-          if (samePos && prev.prices[period]?.length && !prices.length) {
-            return prev;
-          }
-          return {
-            key: perpKey,
-            prices: samePos
-              ? { ...prev.prices, [period]: prices }
-              : { [period]: prices },
-            limits: samePos
-              ? { ...prev.limits, [period]: limit }
-              : { [period]: limit },
-          };
+
+        const result = await fetchPerpPeriodCandles({
+          period,
+          perpSymbol,
+          perpKey,
+          earliestTradeMs,
+          nowMs,
+          cached: perpCacheRef.current,
         });
-      });
-    });
+        if (cancelled || !result) continue;
+
+        setPerpCache((prev) =>
+          mergePerpPeriodIntoCache(
+            prev,
+            perpKey,
+            result.period,
+            result.prices,
+            result.limit,
+          ),
+        );
+      }
+    };
+
+    void prefetchAllPeriods();
 
     return () => {
       cancelled = true;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 import type { Position } from '@metamask/social-controllers';
 import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
 import { isPerpPosition } from '../utils/perp';
@@ -109,6 +116,55 @@ async function fetchPerpPeriodCandles({
   return { period, prices, limit };
 }
 
+function applyPerpPeriodFetchResult(
+  setPerpCache: Dispatch<SetStateAction<PerpCacheState>>,
+  perpKey: string,
+  result: { period: TimePeriod; prices: TokenPrice[]; limit: number },
+) {
+  setPerpCache((prev) =>
+    mergePerpPeriodIntoCache(
+      prev,
+      perpKey,
+      result.period,
+      result.prices,
+      result.limit,
+    ),
+  );
+}
+
+/** Fires every period at once so the active interval can resolve without waiting on earlier ones. */
+function prefetchPerpPeriodsInParallel({
+  perpSymbol,
+  perpKey,
+  earliestTradeMs,
+  nowMs,
+  getCached,
+  setPerpCache,
+  isCancelled,
+}: {
+  perpSymbol: string;
+  perpKey: string;
+  earliestTradeMs: number | undefined;
+  nowMs: number;
+  getCached: () => PerpCacheState;
+  setPerpCache: Dispatch<SetStateAction<PerpCacheState>>;
+  isCancelled: () => boolean;
+}) {
+  for (const period of TIME_PERIODS) {
+    fetchPerpPeriodCandles({
+      period,
+      perpSymbol,
+      perpKey,
+      earliestTradeMs,
+      nowMs,
+      cached: getCached(),
+    }).then((result) => {
+      if (isCancelled() || !result) return;
+      applyPerpPeriodFetchResult(setPerpCache, perpKey, result);
+    });
+  }
+}
+
 export interface PerpsTraderPositionPricesParams {
   positionParam: Position | undefined;
   activeTimePeriod: TimePeriod;
@@ -161,33 +217,15 @@ export function usePerpsTraderPositionPrices(
     const nowMs = Date.now();
     const { tokenSymbol: perpSymbol } = positionParam;
 
-    const prefetchAllPeriods = async () => {
-      for (const period of TIME_PERIODS) {
-        if (cancelled) return;
-
-        const result = await fetchPerpPeriodCandles({
-          period,
-          perpSymbol,
-          perpKey,
-          earliestTradeMs,
-          nowMs,
-          cached: perpCacheRef.current,
-        });
-        if (cancelled || !result) continue;
-
-        setPerpCache((prev) =>
-          mergePerpPeriodIntoCache(
-            prev,
-            perpKey,
-            result.period,
-            result.prices,
-            result.limit,
-          ),
-        );
-      }
-    };
-
-    void prefetchAllPeriods();
+    prefetchPerpPeriodsInParallel({
+      perpSymbol,
+      perpKey,
+      earliestTradeMs,
+      nowMs,
+      getCached: () => perpCacheRef.current,
+      setPerpCache,
+      isCancelled: () => cancelled,
+    });
 
     return () => {
       cancelled = true;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import type { Position } from '@metamask/social-controllers';
+import { chainNameToId } from '../utils/chainMapping';
+import { fetchHyperliquidHistoricalPrices } from '../utils/hyperliquidPrices';
+import { useSpotTraderPositionPrices } from './useSpotTraderPositionPrices';
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../selectors/currencyRateController', () => ({
+  selectCurrentCurrency: jest.fn(() => 'usd'),
+}));
+
+jest.mock('../utils/chainMapping', () => ({
+  chainNameToId: jest.fn(() => 'eip155:8453'),
+}));
+
+jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
+  getAssetImageUrl: jest.fn(() => undefined),
+  toAssetId: jest.fn(() => 'eip155:8453/erc20:0xabc'),
+}));
+
+jest.mock('@metamask/controller-utils', () => ({
+  handleFetch: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../../../util/Logger', () => ({ error: jest.fn() }));
+
+jest.mock('../utils/hyperliquidPrices', () => ({
+  ...jest.requireActual('../utils/hyperliquidPrices'),
+  fetchHyperliquidHistoricalPrices: jest.fn().mockResolvedValue([]),
+}));
+
+const mockFetchHyperliquid =
+  fetchHyperliquidHistoricalPrices as jest.MockedFunction<
+    typeof fetchHyperliquidHistoricalPrices
+  >;
+
+const spotPosition = {
+  chain: 'base',
+  tokenSymbol: 'STARKBOT',
+  tokenAddress: '0xabc',
+  trades: [],
+} as unknown as Position;
+
+describe('useSpotTraderPositionPrices', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ prices: [[1_700_000_000, 1.5]] }),
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('fetches spot historical prices when enabled', async () => {
+    renderHook(() =>
+      useSpotTraderPositionPrices(
+        {
+          positionParam: spotPosition,
+          caipChainId: 'eip155:8453',
+        },
+        { enabled: true },
+      ),
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const urls = (global.fetch as jest.Mock).mock.calls.map(
+      ([url]) => url as string,
+    );
+    expect(
+      urls.some((url) => url.includes('historical-prices/eip155:8453')),
+    ).toBe(true);
+    expect(mockFetchHyperliquid).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when enabled is false', async () => {
+    renderHook(() =>
+      useSpotTraderPositionPrices(
+        {
+          positionParam: spotPosition,
+          caipChainId: 'eip155:8453',
+        },
+        { enabled: false },
+      ),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockFetchHyperliquid).not.toHaveBeenCalled();
+  });
+
+  it('resolves caipChainId via chain mapping when passed from facade', () => {
+    (chainNameToId as jest.Mock).mockReturnValue('eip155:8453');
+    const { result } = renderHook(() =>
+      useSpotTraderPositionPrices(
+        {
+          positionParam: spotPosition,
+          caipChainId: chainNameToId(spotPosition.chain),
+        },
+        { enabled: true },
+      ),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
@@ -9,7 +9,7 @@ import { caipChainIdToHex } from '../../../UI/Rewards/utils/formatUtils';
 import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import Logger from '../../../../util/Logger';
-import { PERIOD_TO_API, type TimePeriod } from './traderPositionData.shared';
+import { PERIOD_TO_API, type TimePeriod } from './traderPositionData';
 
 export interface SpotTraderPositionPricesParams {
   positionParam: Position | undefined;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { Position } from '@metamask/social-controllers';
 import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
-import type { Hex } from '@metamask/utils';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import { handleFetch } from '@metamask/controller-utils';
 import { toAssetId } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import { caipChainIdToHex } from '../../../UI/Rewards/utils/formatUtils';
@@ -13,7 +13,7 @@ import { PERIOD_TO_API, type TimePeriod } from './traderPositionData.shared';
 
 export interface SpotTraderPositionPricesParams {
   positionParam: Position | undefined;
-  caipChainId: string | undefined;
+  caipChainId: CaipChainId | undefined;
 }
 
 export interface SpotTraderPositionPricesOptions {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import type { Position } from '@metamask/social-controllers';
+import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
+import type { Hex } from '@metamask/utils';
+import { handleFetch } from '@metamask/controller-utils';
+import { toAssetId } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import { caipChainIdToHex } from '../../../UI/Rewards/utils/formatUtils';
+import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
+import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
+import Logger from '../../../../util/Logger';
+import { PERIOD_TO_API, type TimePeriod } from './traderPositionData.shared';
+
+export interface SpotTraderPositionPricesParams {
+  positionParam: Position | undefined;
+  caipChainId: string | undefined;
+}
+
+export interface SpotTraderPositionPricesOptions {
+  enabled: boolean;
+}
+
+export interface SpotTraderPositionPricesResult {
+  pricesByPeriod: Partial<Record<TimePeriod, TokenPrice[]>>;
+  isLoading: boolean;
+  marketCap: number | undefined;
+}
+
+export function useSpotTraderPositionPrices(
+  { positionParam, caipChainId }: SpotTraderPositionPricesParams,
+  { enabled }: SpotTraderPositionPricesOptions,
+): SpotTraderPositionPricesResult {
+  const hexChainId = useMemo(
+    () => (caipChainId ? caipChainIdToHex(caipChainId) : undefined),
+    [caipChainId],
+  );
+
+  const allMarketData = useSelector(selectTokenMarketData);
+  const currentCurrency = useSelector(selectCurrentCurrency);
+  const cachedMarket = hexChainId
+    ? allMarketData?.[hexChainId]?.[
+        positionParam?.tokenAddress?.toLowerCase() as Hex
+      ]
+    : undefined;
+
+  const [fetchedMarketCap, setFetchedMarketCap] = useState<number>();
+
+  useEffect(() => {
+    setFetchedMarketCap(undefined);
+
+    if (
+      !enabled ||
+      cachedMarket?.marketCap != null ||
+      !positionParam ||
+      !caipChainId
+    ) {
+      return;
+    }
+    const assetId = toAssetId(positionParam.tokenAddress, caipChainId);
+    if (!assetId) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = `https://price.api.cx.metamask.io/v3/spot-prices?${new URLSearchParams(
+          {
+            assetIds: assetId,
+            includeMarketData: 'true',
+            vsCurrency: currentCurrency.toLowerCase(),
+          },
+        )}`;
+        const response = (await handleFetch(url)) as Record<
+          string,
+          Record<string, unknown>
+        >;
+        const cap = response?.[assetId]?.marketCap;
+        if (!cancelled && typeof cap === 'number') {
+          setFetchedMarketCap(cap);
+        }
+      } catch (err) {
+        Logger.error(
+          err as Error,
+          'useSpotTraderPositionPrices: failed to fetch market data',
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    enabled,
+    cachedMarket?.marketCap,
+    positionParam,
+    caipChainId,
+    currentCurrency,
+  ]);
+
+  const marketCap = cachedMarket?.marketCap ?? fetchedMarketCap;
+
+  const [pricesByPeriod, setPricesByPeriod] = useState<
+    Partial<Record<TimePeriod, TokenPrice[]>>
+  >({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    if (!positionParam) {
+      setPricesByPeriod({});
+      setIsLoading(false);
+      return;
+    }
+
+    if (!caipChainId) {
+      setPricesByPeriod({});
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    let cancelled = false;
+
+    const assetIdentifier = `erc20:${positionParam.tokenAddress}`;
+    const vsCurrency = currentCurrency.toLowerCase();
+
+    const fetchPeriod = async (period: TimePeriod) => {
+      const apiPeriod = PERIOD_TO_API[period];
+      const uri = `https://price.api.cx.metamask.io/v3/historical-prices/${caipChainId}/${assetIdentifier}?timePeriod=${apiPeriod}&vsCurrency=${vsCurrency}`;
+      try {
+        const response = await fetch(uri);
+        if (response.status === 204 || !response.ok)
+          return { period, prices: [] as TokenPrice[] };
+        const data: { prices: [number, number][] } = await response.json();
+        const prices: TokenPrice[] = (data.prices ?? []).map(
+          ([timestamp, price]) =>
+            [timestamp.toString(), Number(price)] as TokenPrice,
+        );
+        return { period, prices };
+      } catch (err) {
+        Logger.error(
+          err as Error,
+          `useSpotTraderPositionPrices: failed to fetch ${period} prices`,
+        );
+        return { period, prices: [] as TokenPrice[] };
+      }
+    };
+
+    const uniquePeriods: TimePeriod[] = ['1D', '1W', '1M', 'All'];
+
+    Promise.all(uniquePeriods.map(fetchPeriod)).then((results) => {
+      if (cancelled) return;
+      const cache: Partial<Record<TimePeriod, TokenPrice[]>> = {};
+      for (const { period, prices } of results) {
+        cache[period] = prices;
+        if (period === '1D') cache['1H'] = prices;
+      }
+      setPricesByPeriod(cache);
+      setIsLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, positionParam, caipChainId, currentCurrency]);
+
+  return {
+    pricesByPeriod,
+    isLoading: enabled ? isLoading : false,
+    marketCap: enabled ? marketCap : undefined,
+  };
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.test.ts
@@ -1,14 +1,11 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import type { Position } from '@metamask/social-controllers';
-import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
 import {
   fetchHyperliquidHistoricalPrices,
   type HyperliquidCandleInterval,
 } from '../utils/hyperliquidPrices';
 import { useTraderPositionData } from './useTraderPositionData';
 
-// useSelector calls the selector with no state; the mocked selectors below return
-// fixed values, so the hook reads `{}` market data and `usd` currency.
 jest.mock('react-redux', () => ({
   useSelector: (selector: () => unknown) => selector(),
 }));
@@ -21,10 +18,10 @@ jest.mock('../../../../selectors/currencyRateController', () => ({
   selectCurrentCurrency: jest.fn(() => 'usd'),
 }));
 
-// Keep caipChainId undefined so the spot/market-cap machinery stays dormant and
-// the test isolates the perp candle pre-fetch path.
 jest.mock('../utils/chainMapping', () => ({
-  chainNameToId: jest.fn(() => undefined),
+  chainNameToId: jest.fn((chain: string) =>
+    chain === 'hyperliquid' ? undefined : 'eip155:8453',
+  ),
 }));
 
 jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
@@ -36,15 +33,12 @@ jest.mock('@metamask/controller-utils', () => ({
   handleFetch: jest.fn().mockResolvedValue({}),
 }));
 
-// The real module pulls in PerpsController (and a native dep) at import time;
-// only the display-symbol helper is needed here.
 jest.mock('@metamask/perps-controller', () => ({
   getPerpsDisplaySymbol: (symbol: string) => symbol,
 }));
 
 jest.mock('../../../../util/Logger', () => ({ error: jest.fn() }));
 
-// Partial mock: keep resolveHyperliquidCandleLimit (pure) real; stub the network.
 jest.mock('../utils/hyperliquidPrices', () => ({
   ...jest.requireActual('../utils/hyperliquidPrices'),
   fetchHyperliquidHistoricalPrices: jest.fn().mockResolvedValue([]),
@@ -55,25 +49,107 @@ const mockFetchHyperliquid =
     typeof fetchHyperliquidHistoricalPrices
   >;
 
+const baseSpotPosition = {
+  chain: 'base',
+  tokenSymbol: 'STARKBOT',
+  tokenAddress: '0x123',
+  positionAmount: 100,
+  boughtUsd: 1000,
+  soldUsd: 0,
+  realizedPnl: 0,
+  currentValueUSD: 1500,
+  pnlValueUsd: 500,
+  pnlPercent: 50,
+  trades: [{ timestamp: Date.now() - 60_000 }],
+} as unknown as Position;
+
 const perpPosition = {
   chain: 'hyperliquid',
   perpPositionType: 'long',
   tokenSymbol: 'ETH',
   tokenAddress: '0x0000000000000000000000000000000000000000',
-  trades: [],
+  boughtUsd: 1000,
+  realizedPnl: 200,
+  pnlValueUsd: 300,
+  pnlPercent: 30,
+  trades: [{ timestamp: Date.now() - 60_000 }],
 } as unknown as Position;
 
-describe('useTraderPositionData — perp candle pre-fetch', () => {
+describe('useTraderPositionData — facade', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetchHyperliquid.mockResolvedValue([]);
   });
 
-  it('pre-fetches every period up front so an interval switch needs no network', async () => {
+  it('marks perp positions with isPerp true', () => {
+    const { result } = renderHook(() => useTraderPositionData(perpPosition));
+    expect(result.current.isPerp).toBe(true);
+    expect(result.current.symbol).toBe('ETH');
+  });
+
+  it('marks spot positions with isPerp false', () => {
+    const { result } = renderHook(() =>
+      useTraderPositionData(baseSpotPosition),
+    );
+    expect(result.current.isPerp).toBe(false);
+    expect(result.current.symbol).toBe('STARKBOT');
+  });
+
+  it('uses unrealized PnL for an open spot position', () => {
+    const { result } = renderHook(() =>
+      useTraderPositionData(baseSpotPosition),
+    );
+    expect(result.current.isClosed).toBe(false);
+    expect(result.current.pnlValue).toBe(500);
+    expect(result.current.pnlPercent).toBe(50);
+    expect(result.current.isPnlPositive).toBe(true);
+  });
+
+  it('uses realized PnL for a closed spot position', () => {
+    const closedSpot = {
+      ...baseSpotPosition,
+      positionAmount: 0,
+      soldUsd: 1200,
+      realizedPnl: 200,
+      pnlValueUsd: null,
+      pnlPercent: null,
+    } as unknown as Position;
+
+    const { result } = renderHook(() => useTraderPositionData(closedSpot));
+    expect(result.current.isClosed).toBe(true);
+    expect(result.current.pnlValue).toBe(200);
+    expect(result.current.pnlPercent).toBe(20);
+  });
+
+  it('prefers pnlValueUsd for perp positions', () => {
+    const { result } = renderHook(() => useTraderPositionData(perpPosition));
+    expect(result.current.pnlValue).toBe(300);
+    expect(result.current.pnlPercent).toBe(30);
+  });
+
+  it('filters chartTrades by the active time period', () => {
+    const oldTrade = { timestamp: Date.now() - 40 * 24 * 60 * 60 * 1000 };
+    const recentTrade = { timestamp: Date.now() - 60_000 };
+    const position = {
+      ...baseSpotPosition,
+      trades: [oldTrade, recentTrade],
+    } as unknown as Position;
+
+    const { result } = renderHook(() => useTraderPositionData(position));
+
+    expect(result.current.allTrades).toHaveLength(2);
+    expect(result.current.chartTrades).toHaveLength(1);
+
+    act(() => {
+      result.current.setActiveTimePeriod('All');
+    });
+
+    expect(result.current.chartTrades).toHaveLength(2);
+  });
+
+  it('delegates perp candle pre-fetch to the perp prices hook end-to-end', async () => {
     renderHook(() => useTraderPositionData(perpPosition));
 
-    // One candleSnapshot request per period (1H, 1D, 1W, 1M, All), each with its
-    // own distinct Hyperliquid interval — warmed on mount, not on demand.
     await waitFor(() => expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5));
 
     const intervals = mockFetchHyperliquid.mock.calls.map(
@@ -89,95 +165,18 @@ describe('useTraderPositionData — perp candle pre-fetch', () => {
     expect(new Set(intervals)).toEqual(new Set(expected));
   });
 
-  it('requests every period for the position symbol', async () => {
-    renderHook(() => useTraderPositionData(perpPosition));
-
-    await waitFor(() => expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5));
-    for (const [opts] of mockFetchHyperliquid.mock.calls) {
-      expect(opts.symbol).toBe('ETH');
-    }
-  });
-
-  it('does not refetch already-loaded periods when positionParam gets a new reference', async () => {
-    // Each period resolves to non-empty candles, so all five get cached.
-    const goodPrices: TokenPrice[] = [
-      ['1', 100],
-      ['2', 101],
-    ];
-    mockFetchHyperliquid.mockResolvedValue(goodPrices);
-
-    const { rerender } = renderHook(
-      (position: Position) => useTraderPositionData(position),
-      { initialProps: perpPosition },
+  it('exposes time period controls from the facade', () => {
+    const { result } = renderHook(() =>
+      useTraderPositionData(baseSpotPosition),
     );
 
-    // Let all five fetches resolve and populate the cache.
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
+    expect(result.current.timePeriods).toEqual(['1H', '1D', '1W', '1M', 'All']);
+    expect(result.current.activeTimePeriod).toBe('1M');
 
-    // Pull-to-refresh hands down a NEW positionParam reference with the same
-    // identity (chain + symbol → same perpKey), re-running the pre-fetch effect.
-    rerender({ ...perpPosition } as Position);
-    await act(async () => {
-      await Promise.resolve();
+    act(() => {
+      result.current.setActiveTimePeriod('1W');
     });
 
-    // Every period already holds non-empty candles, so none are refetched — a
-    // transient empty response therefore cannot overwrite the cached data.
-    expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
-  });
-
-  it('refetches with a larger limit when an earlier trade extends the required window', async () => {
-    // resolveHyperliquidCandleLimit grows the limit from `nowMs - earliestTradeMs`,
-    // and the test harness pins Date.now() to a tiny value — push it forward so an
-    // old trade produces a meaningfully larger window. Restore the harness clock
-    // afterwards.
-    const savedNow = Date.now;
-    Date.now = () => 2_000_000_000_000; // ~2033
-    try {
-      mockFetchHyperliquid.mockResolvedValue([
-        ['1', 100],
-        ['2', 101],
-      ] as TokenPrice[]);
-
-      // Row-tap snapshot has no trades → each period uses its baseLimit.
-      const snapshot = { ...perpPosition, trades: [] } as unknown as Position;
-      const { rerender } = renderHook(
-        (position: Position) => useTraderPositionData(position),
-        { initialProps: snapshot },
-      );
-      await act(async () => {
-        await Promise.resolve();
-      });
-      expect(mockFetchHyperliquid).toHaveBeenCalledTimes(5);
-      const initialOneMinLimit = mockFetchHyperliquid.mock.calls.find(
-        ([opts]) => opts.interval === '1m',
-      )?.[0].limit as number;
-
-      // Fetched position (same market) arrives with a much older trade (~2001),
-      // growing the required candle window beyond what the cached candles cover.
-      const withOldTrade = {
-        ...perpPosition,
-        trades: [{ timestamp: 1_000_000_000_000 }],
-      } as unknown as Position;
-      rerender(withOldTrade);
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      // The fine-interval periods are refetched with a larger limit so the older
-      // trade can be framed — without this fix the cache skip would keep the
-      // shorter window and total calls would stay at 5.
-      expect(mockFetchHyperliquid.mock.calls.length).toBeGreaterThan(5);
-      const oneMinCalls = mockFetchHyperliquid.mock.calls.filter(
-        ([opts]) => opts.interval === '1m',
-      );
-      expect(oneMinCalls.length).toBeGreaterThanOrEqual(2);
-      expect(oneMinCalls.at(-1)?.[0].limit).toBeGreaterThan(initialOneMinLimit);
-    } finally {
-      Date.now = savedNow;
-    }
+    expect(result.current.activeTimePeriod).toBe('1W');
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.test.ts
@@ -76,9 +76,20 @@ const perpPosition = {
 } as unknown as Position;
 
 describe('useTraderPositionData — facade', () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetchHyperliquid.mockResolvedValue([]);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ prices: [[1_700_000_000, 1.5]] }),
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it('marks perp positions with isPerp true', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
@@ -12,7 +12,7 @@ import {
   PERIOD_DURATION_MS,
   TIME_PERIODS,
   type TimePeriod,
-} from './traderPositionData.shared';
+} from './traderPositionData';
 
 export type { TimePeriod };
 export { TIME_PERIODS };
@@ -120,8 +120,9 @@ export function useTraderPositionData(
       prices = lastHour.length >= 5 ? lastHour : prices;
     }
 
+    const lastPrice = prices.at(-1)?.[1];
     const diff =
-      prices.length < 2 ? 0 : prices[prices.length - 1][1] - prices[0][1];
+      prices.length < 2 || lastPrice == null ? 0 : lastPrice - prices[0][1];
 
     return {
       historicalPrices: prices,
@@ -138,7 +139,7 @@ export function useTraderPositionData(
       resolvedPrices['1M'] ??
       resolvedPrices.All;
     if (!source?.length) return undefined;
-    return source[source.length - 1][1];
+    return source.at(-1)?.[1];
   }, [resolvedPrices]);
 
   const symbol = getPerpsDisplaySymbol(

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
@@ -1,104 +1,21 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useMemo, useState } from 'react';
 import type { Position } from '@metamask/social-controllers';
 import { getPerpsDisplaySymbol } from '@metamask/perps-controller';
 import type { TokenPrice } from '../../../hooks/useTokenHistoricalPrices';
-import type { Hex } from '@metamask/utils';
-import { handleFetch } from '@metamask/controller-utils';
 import { chainNameToId } from '../utils/chainMapping';
 import { isPerpPosition, isClosedPosition } from '../utils/perp';
+import { getAssetImageUrl } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import { usePerpsTraderPositionPrices } from './usePerpsTraderPositionPrices';
+import { useSpotTraderPositionPrices } from './useSpotTraderPositionPrices';
 import {
-  fetchHyperliquidHistoricalPrices,
-  resolveHyperliquidCandleLimit,
-  type HyperliquidCandleInterval,
-} from '../utils/hyperliquidPrices';
-import {
-  getAssetImageUrl,
-  toAssetId,
-} from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
-import { caipChainIdToHex } from '../../../UI/Rewards/utils/formatUtils';
-import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
-import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
-import Logger from '../../../../util/Logger';
+  derivePercentChange,
+  PERIOD_DURATION_MS,
+  TIME_PERIODS,
+  type TimePeriod,
+} from './traderPositionData.shared';
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const TIME_PERIODS = ['1H', '1D', '1W', '1M', 'All'] as const;
-type TimePeriod = (typeof TIME_PERIODS)[number];
-
-const PERIOD_TO_API: Record<TimePeriod, string> = {
-  '1H': '1d',
-  '1D': '1d',
-  '1W': '7d',
-  '1M': '1m',
-  All: '3y',
-};
-
-const PERIOD_DURATION_MS: Record<TimePeriod, number> = {
-  '1H': 60 * 60 * 1000,
-  '1D': 24 * 60 * 60 * 1000,
-  '1W': 7 * 24 * 60 * 60 * 1000,
-  '1M': 30 * 24 * 60 * 60 * 1000,
-  All: 3 * 365 * 24 * 60 * 60 * 1000,
-};
-
-/**
- * Hyperliquid candle interval + baseline candle count per chart period. The base
- * count fills the period's default window when a position has no (or only recent)
- * trades; for older / closed positions {@link resolveHyperliquidCandleLimit} grows
- * it to reach the earliest trade, capped at the API's per-request maximum
- * (~5000 candles). Counts stay well above CHART_DATA_THRESHOLD so the line stays
- * smooth. Unlike the spot API, each period maps to a distinct interval
- * (granularity), so there's no 1D→1H reuse.
- */
-const PERP_PERIOD_TO_CANDLES: Record<
-  TimePeriod,
-  { interval: HyperliquidCandleInterval; baseLimit: number }
-> = {
-  '1H': { interval: '1m', baseLimit: 60 }, // 60 × 1m  = 1 hour
-  '1D': { interval: '15m', baseLimit: 96 }, // 96 × 15m = 24 hours
-  '1W': { interval: '1h', baseLimit: 168 }, // 168 × 1h = 7 days
-  '1M': { interval: '4h', baseLimit: 180 }, // 180 × 4h = 30 days
-  All: { interval: '1d', baseLimit: 1095 }, // 1095 × 1d ≈ 3 years (matches spot 'All')
-};
-
-/**
- * Derives percentage change from historical price data points.
- * For "1H" we find the point closest to one hour ago within the data set.
- * @param nowMs - Same clock as used to slice 1H prices (avoids mismatched "now").
- */
-function derivePercentChange(
-  prices: TokenPrice[],
-  period: TimePeriod,
-  nowMs: number,
-): number | undefined {
-  if (!prices.length) return undefined;
-
-  const endPrice = prices[prices.length - 1][1];
-  let startPrice: number;
-
-  if (period === '1H') {
-    const oneHourAgo = nowMs - 60 * 60 * 1000;
-    const closest = prices.reduce((best, pt) =>
-      Math.abs(Number(pt[0]) - oneHourAgo) <
-      Math.abs(Number(best[0]) - oneHourAgo)
-        ? pt
-        : best,
-    );
-    startPrice = closest[1];
-  } else {
-    startPrice = prices[0][1];
-  }
-
-  if (startPrice === 0) return undefined;
-  return ((endPrice - startPrice) / startPrice) * 100;
-}
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+export type { TimePeriod };
+export { TIME_PERIODS };
 
 export interface TraderPositionData {
   // Token
@@ -131,9 +48,6 @@ export interface TraderPositionData {
   timePeriods: readonly TimePeriod[];
 }
 
-export type { TimePeriod };
-export { TIME_PERIODS };
-
 export function useTraderPositionData(
   positionParam: Position | undefined,
   tokenSymbol?: string,
@@ -150,11 +64,6 @@ export function useTraderPositionData(
     [positionParam],
   );
 
-  const hexChainId = useMemo(
-    () => (caipChainId ? caipChainIdToHex(caipChainId) : undefined),
-    [caipChainId],
-  );
-
   const tokenImageUrl = useMemo(() => {
     if (!positionParam || !caipChainId) return undefined;
     return getAssetImageUrl(positionParam.tokenAddress, caipChainId);
@@ -165,18 +74,6 @@ export function useTraderPositionData(
     [positionParam],
   );
 
-  // Stable cache key per perp position; prices cached under a different key (a
-  // previously-viewed position) are treated as a miss (see `resolvedPrices`).
-  const perpKey = useMemo(
-    () =>
-      isPerp && positionParam
-        ? `${positionParam.chain}:${positionParam.tokenSymbol}`
-        : '',
-    [isPerp, positionParam],
-  );
-
-  // Earliest trade time (ms) — anchors the perp candle window back to the
-  // position's first trade so closed positions still frame their trades.
   const earliestTradeMs = useMemo(() => {
     const trades = positionParam?.trades;
     if (!trades?.length) return undefined;
@@ -191,251 +88,21 @@ export function useTraderPositionData(
     return Number.isFinite(min) ? min : undefined;
   }, [positionParam?.trades]);
 
-  // ── Market cap ──────────────────────────────────────────────────────────
-
-  const allMarketData = useSelector(selectTokenMarketData);
-  const currentCurrency = useSelector(selectCurrentCurrency);
-  const cachedMarket = hexChainId
-    ? allMarketData?.[hexChainId]?.[
-        positionParam?.tokenAddress?.toLowerCase() as Hex
-      ]
-    : undefined;
-
-  const [fetchedMarketCap, setFetchedMarketCap] = useState<number>();
-
-  useEffect(() => {
-    setFetchedMarketCap(undefined);
-
-    if (cachedMarket?.marketCap != null || !positionParam || !caipChainId)
-      return;
-    const assetId = toAssetId(positionParam.tokenAddress, caipChainId);
-    if (!assetId) return;
-
-    let cancelled = false;
-    (async () => {
-      try {
-        const url = `https://price.api.cx.metamask.io/v3/spot-prices?${new URLSearchParams(
-          {
-            assetIds: assetId,
-            includeMarketData: 'true',
-            vsCurrency: currentCurrency.toLowerCase(),
-          },
-        )}`;
-        const response = (await handleFetch(url)) as Record<
-          string,
-          Record<string, unknown>
-        >;
-        const cap = response?.[assetId]?.marketCap;
-        if (!cancelled && typeof cap === 'number') {
-          setFetchedMarketCap(cap);
-        }
-      } catch (err) {
-        Logger.error(
-          err as Error,
-          'useTraderPositionData: failed to fetch market data',
-        );
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [cachedMarket?.marketCap, positionParam, caipChainId, currentCurrency]);
-
-  const marketCap = cachedMarket?.marketCap ?? fetchedMarketCap;
-
-  // ── Historical prices ───────────────────────────────────────────────────
-
-  const [allPrices, setAllPrices] = useState<
-    Partial<Record<TimePeriod, TokenPrice[]>>
-  >({});
-  // Perp prices are cached lazily, per selected period, scoped to one position
-  // via `key`. A stale-position cache is ignored rather than cleared, so there's
-  // no flash of empty data when switching positions.
-  const [perpCache, setPerpCache] = useState<{
-    key: string;
-    prices: Partial<Record<TimePeriod, TokenPrice[]>>;
-    // Candle limit each period was fetched with. A later, earlier trade grows the
-    // required limit, so a period is refetched when its cached limit no longer
-    // covers it (see the pre-fetch effect).
-    limits: Partial<Record<TimePeriod, number>>;
-  }>({ key: '', prices: {}, limits: {} });
-  const [isPricesLoading, setIsPricesLoading] = useState(true);
-
-  // Latest cache mirrored into a ref so the pre-fetch effect can read it WITHOUT
-  // depending on `perpCache` — depending on it would re-run the effect on every
-  // per-period resolve and refetch the still-in-flight periods (a 5+4+3+2+1
-  // cascade). The ref lets the effect skip already-loaded periods cheaply.
-  const perpCacheRef = useRef(perpCache);
-  perpCacheRef.current = perpCache;
-
-  useEffect(() => {
-    if (!positionParam) {
-      setAllPrices({});
-      setIsPricesLoading(false);
-      return;
-    }
-
-    // Hyperliquid perps have no CAIP id and use the exchange's candle feed
-    // directly; they're fetched lazily, per selected period, by the effect below.
-    if (isPerpPosition(positionParam)) return;
-
-    // Spot tokens resolve prices via the MetaMask price API, which needs a CAIP
-    // chain id.
-    if (!caipChainId) {
-      setAllPrices({});
-      setIsPricesLoading(false);
-      return;
-    }
-
-    setIsPricesLoading(true);
-    let cancelled = false;
-
-    // ── Spot tokens: MetaMask price API ──────────────────────────────────────
-    const assetIdentifier = `erc20:${positionParam.tokenAddress}`;
-    const vsCurrency = currentCurrency.toLowerCase();
-
-    const fetchPeriod = async (period: TimePeriod) => {
-      const apiPeriod = PERIOD_TO_API[period];
-      const uri = `https://price.api.cx.metamask.io/v3/historical-prices/${caipChainId}/${assetIdentifier}?timePeriod=${apiPeriod}&vsCurrency=${vsCurrency}`;
-      try {
-        const response = await fetch(uri);
-        if (response.status === 204 || !response.ok)
-          return { period, prices: [] as TokenPrice[] };
-        const data: { prices: [number, number][] } = await response.json();
-        const prices: TokenPrice[] = (data.prices ?? []).map(
-          ([timestamp, price]) =>
-            [timestamp.toString(), Number(price)] as TokenPrice,
-        );
-        return { period, prices };
-      } catch (err) {
-        Logger.error(
-          err as Error,
-          `useTraderPositionData: failed to fetch ${period} prices`,
-        );
-        return { period, prices: [] as TokenPrice[] };
-      }
-    };
-
-    // 1H and 1D share the same API call ('1d') — fetch once, reuse.
-    const uniquePeriods: TimePeriod[] = ['1D', '1W', '1M', 'All'];
-
-    Promise.all(uniquePeriods.map(fetchPeriod)).then((results) => {
-      if (cancelled) return;
-      const cache: Partial<Record<TimePeriod, TokenPrice[]>> = {};
-      for (const { period, prices } of results) {
-        cache[period] = prices;
-        if (period === '1D') cache['1H'] = prices;
-      }
-      setAllPrices(cache);
-      setIsPricesLoading(false);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [positionParam, caipChainId, currentCurrency]);
-
-  // ── Hyperliquid perps: cached candleSnapshot data ─────────────────────────
-  // Pre-fetch EVERY period up front (like the spot path) so an interval switch is
-  // an instant cache read with no network round-trip. Previously only the active
-  // period + 1M/All were warmed, so the first tap on a cold period (1H, 1D, 1W)
-  // fetched on demand and the chart flashed the stale period until the new candles
-  // arrived. Each perp period maps to a distinct Hyperliquid interval, so there's
-  // no reuse — up to 5 candleSnapshot requests. The candle count is anchored back
-  // to the earliest trade (capped at the API max) so closed positions still frame
-  // their trades. The cache is scoped by `perpKey` so a stale-position result is
-  // ignored, not flashed.
-  //
-  // Re-runs when `positionParam` gets a new reference (e.g. pull-to-refresh) or
-  // `earliestTradeMs` changes. A period is skipped only when it already holds
-  // NON-EMPTY candles fetched with a limit that still covers the required
-  // look-back. Two reasons NOT to skip:
-  //   1. An earlier trade (e.g. the fetched position replacing the row-tap
-  //      snapshot) grows the required `limit`, so the cached shorter window must
-  //      be refetched or the older trade can't be framed/drawn.
-  //   2. The period is empty/missing — retry so a prior failure can recover.
-  // A transient failure resolves to `[]`; the merge below refuses to overwrite
-  // good candles with it (the loading gate treats a cached empty array as
-  // "loaded", which would otherwise strand the chart on the fallback state).
-  useEffect(() => {
-    if (!positionParam || !isPerp) return;
-
-    let cancelled = false;
-    const nowMs = Date.now();
-    const { tokenSymbol: perpSymbol } = positionParam;
-
-    TIME_PERIODS.forEach((period) => {
-      const { interval, baseLimit } = PERP_PERIOD_TO_CANDLES[period];
-      const limit = resolveHyperliquidCandleLimit({
-        interval,
-        baseLimit,
-        earliestTradeMs,
-        nowMs,
-      });
-
-      const cached = perpCacheRef.current;
-      if (
-        cached.key === perpKey &&
-        cached.prices[period]?.length &&
-        (cached.limits[period] ?? 0) >= limit
-      ) {
-        return;
-      }
-
-      fetchHyperliquidHistoricalPrices({
-        symbol: perpSymbol,
-        interval,
-        limit,
-        nowMs,
-      }).then((prices) => {
-        if (cancelled) return;
-        setPerpCache((prev) => {
-          const samePos = prev.key === perpKey;
-          // Don't replace good candles with a transient empty result; leave the
-          // cached limit trailing so the next refresh retries the larger window.
-          if (samePos && prev.prices[period]?.length && !prices.length) {
-            return prev;
-          }
-          return {
-            key: perpKey,
-            prices: samePos
-              ? { ...prev.prices, [period]: prices }
-              : { [period]: prices },
-            limits: samePos
-              ? { ...prev.limits, [period]: limit }
-              : { [period]: limit },
-          };
-        });
-      });
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [positionParam, isPerp, perpKey, earliestTradeMs]);
-
-  // Perp loading reflects only the ACTIVE period: clear as soon as its candles are
-  // cached so the initial skeleton doesn't wait on the slowest of the five
-  // requests, while the others keep warming in the background. Switching to an
-  // already-warmed period clears instantly → no flash.
-  useEffect(() => {
-    if (!isPerp) return;
-    const hasActivePeriod =
-      perpCache.key === perpKey && Boolean(perpCache.prices[activeTimePeriod]);
-    setIsPricesLoading(!hasActivePeriod);
-  }, [isPerp, perpKey, activeTimePeriod, perpCache]);
-
-  // Active price cache: perps read their position-scoped lazy cache (ignoring a
-  // stale-position one); spot reads the eagerly-fetched `allPrices`.
-  const resolvedPrices = useMemo<Partial<Record<TimePeriod, TokenPrice[]>>>(
-    () =>
-      isPerp ? (perpCache.key === perpKey ? perpCache.prices : {}) : allPrices,
-    [isPerp, perpCache, perpKey, allPrices],
+  const spotPrices = useSpotTraderPositionPrices(
+    { positionParam, caipChainId },
+    { enabled: !isPerp },
+  );
+  const perpPrices = usePerpsTraderPositionPrices(
+    { positionParam, activeTimePeriod, earliestTradeMs },
+    { enabled: isPerp },
   );
 
-  // Resolve with fallbacks (single useMemo + one Date.now() per recompute so 1H
-  // slice and derivePercentChange share the same clock; deps omit "now" so
-  // window updates when price data or period changes, not on every parent render).
+  const resolvedPrices = isPerp
+    ? perpPrices.pricesByPeriod
+    : spotPrices.pricesByPeriod;
+  const isPricesLoading = isPerp ? perpPrices.isLoading : spotPrices.isLoading;
+  const marketCap = spotPrices.marketCap;
+
   const { historicalPrices, priceDiff, pricePercentChange } = useMemo(() => {
     const now = Date.now();
     let prices = resolvedPrices[activeTimePeriod] ?? [];
@@ -463,8 +130,6 @@ export function useTraderPositionData(
     };
   }, [resolvedPrices, activeTimePeriod]);
 
-  // Latest price for the header (perps show this in place of market cap).
-  // Prefers the freshest dataset so it's stable regardless of selected period.
   const currentPrice = useMemo(() => {
     const source =
       resolvedPrices['1H'] ??
@@ -476,10 +141,6 @@ export function useTraderPositionData(
     return source[source.length - 1][1];
   }, [resolvedPrices]);
 
-  // ── Position card ──────────────────────────────────────────────────────
-
-  // Display symbol strips the HIP-3 provider prefix (`xyz:SPCX` → `SPCX`);
-  // non-HIP-3 symbols pass through unchanged.
   const symbol = getPerpsDisplaySymbol(
     positionParam?.tokenSymbol ?? tokenSymbol ?? '',
   );
@@ -489,9 +150,6 @@ export function useTraderPositionData(
 
   const positionValue = isClosed ? null : positionParam?.currentValueUSD;
 
-  // Perps reliably populate pnlValueUsd / pnlPercent (realized + unrealized) for
-  // both open and closed positions, so prefer those. Spot keeps the
-  // realized-on-close / unrealized-while-open split.
   const pnlValue = isPerp
     ? (positionParam?.pnlValueUsd ?? positionParam?.realizedPnl)
     : isClosed
@@ -509,8 +167,6 @@ export function useTraderPositionData(
       : (positionParam?.pnlPercent ?? null);
   const isPnlPositive = (pnlValue ?? 0) >= 0;
 
-  // ── Trades ─────────────────────────────────────────────────────────────
-
   const allTrades = useMemo(
     () => positionParam?.trades ?? [],
     [positionParam?.trades],
@@ -526,8 +182,6 @@ export function useTraderPositionData(
       return tsMs >= now - PERIOD_DURATION_MS[activeTimePeriod];
     });
   }, [allTrades, activeTimePeriod]);
-
-  // ── Return ─────────────────────────────────────────────────────────────
 
   return {
     symbol,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This PR splits `useTraderPositionData` into a thin facade plus `useSpotTraderPositionPrices` and `usePerpsTraderPositionPrices` hooks. Both sub-hooks have enabled gates, fetching (Rules of Hooks safe)
Shared PnL, trades, with time-period logic stays in the facade.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of leaderboard chart data hooks with behavior preserved and expanded unit tests; no auth, payments, or security-sensitive paths.
> 
> **Overview**
> Refactors **Social Leaderboard trader position** data loading by turning `useTraderPositionData` into a thin facade and moving price/market-cap fetching into dedicated hooks.
> 
> **Spot** positions now use `useSpotTraderPositionPrices` (MetaMask historical + optional market cap fetch), gated with `enabled: !isPerp`. **Perp** positions use `usePerpsTraderPositionPrices` for parallel Hyperliquid candle prefetch, per-period cache/limits, and active-period loading—gated with `enabled: isPerp`.
> 
> Shared chart helpers (`TIME_PERIODS`, `derivePercentChange`, etc.) move to `traderPositionData.ts`. The facade keeps PnL, trades, time-period UI state, and chart slicing; it picks prices/loading/market cap from the active hook.
> 
> Tests are split: perp prefetch/cache behavior lives in `usePerpsTraderPositionPrices.test.ts`, spot fetch gating in `useSpotTraderPositionPrices.test.ts`, and `useTraderPositionData.test.ts` focuses on facade behavior (perp vs spot flags, PnL, trade filtering, delegation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe8edefe5bdc17de847d76e5657f54cb6fc5c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->