### PR TITLE
feat(perps): show leverage in compact position header

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -469,8 +469,14 @@ describe('TraderPositionView', () => {
     it('renders the perp leverage and direction badges in the header', () => {
       renderWithProvider(<TraderPositionView />, { state: mockState });
 
-      expect(screen.getByText('10x')).toBeOnTheScreen();
-      expect(screen.getByText('SHORT')).toBeOnTheScreen();
+      const headerPerpBadges = within(
+        screen.getByTestId(
+          TraderPositionViewSelectorsIDs.HEADER_COMPACT_PERP_BADGES,
+        ),
+      );
+
+      expect(headerPerpBadges.getByText('10x')).toBeOnTheScreen();
+      expect(headerPerpBadges.getByText('SHORT')).toBeOnTheScreen();
     });
 
     it('does not render the copy token address button for a perp position', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
@@ -8,6 +8,7 @@ export const TraderPositionViewSelectorsIDs = {
     'trader-position-view-header-compact-token-symbol',
   HEADER_COMPACT_TOKEN_CHANGE:
     'trader-position-view-header-compact-token-change',
+  HEADER_COMPACT_PERP_BADGES: 'trader-position-view-header-compact-perp-badges',
   COMPACT_TOKEN_STATS: 'trader-position-view-compact-token-stats',
   BUY_BUTTON: 'trader-position-view-buy-button',
   TRADE_BUTTON: 'trader-position-view-trade-button',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -75,7 +75,7 @@ import {
 } from '../analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { chainNameToId } from '../utils/chainMapping';
-import { isPerpPosition } from '../utils/perp';
+import { getPerpPositionDirection, isPerpPosition } from '../utils/perp';
 import PerpsTradeButton from './components/PerpsTradeButton';
 import {
   getPerpsDisplaySymbol,
@@ -347,6 +347,10 @@ const TraderPositionView = () => {
   // page. A minimal { symbol, name } market is enough — PerpsMarketDetailsView
   // enriches it from usePerpsMarkets (same pattern as PerpsPositionTransactionView).
   const isPerp = displayPosition ? isPerpPosition(displayPosition) : false;
+  const perpDirection =
+    isPerp && displayPosition
+      ? getPerpPositionDirection(displayPosition)
+      : null;
 
   // CAIP-19 asset id for the spot chart. Resolves only for non-perp positions on
   // a supported chain; when undefined the chart section uses the legacy SVG
@@ -637,6 +641,8 @@ const TraderPositionView = () => {
           symbol={symbol}
           pricePercentChange={displayPercentChange}
           activeTimePeriodLabel={activeTimePeriod}
+          perpDirection={perpDirection}
+          perpLeverage={displayPosition?.perpLeverage}
           onBack={handleBack}
           onTraderPress={handleTraderPress}
         />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
@@ -11,6 +11,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import TraderHeaderIdentity from '../../components/TraderHeaderIdentity';
+import type { PerpDirection } from '../../utils/perp';
 import { TraderPositionViewSelectorsIDs } from '../TraderPositionView.testIds';
 import TraderPositionCompactTokenStats from './TraderPositionCompactTokenStats';
 
@@ -26,6 +27,8 @@ export interface TraderPositionAnimatedHeaderProps {
   symbol: string;
   pricePercentChange: number | undefined;
   activeTimePeriodLabel: string;
+  perpDirection?: PerpDirection | null;
+  perpLeverage?: number | null;
   onBack: () => void;
   onTraderPress: () => void;
 }
@@ -59,6 +62,8 @@ const TraderPositionAnimatedHeader: React.FC<
   symbol,
   pricePercentChange,
   activeTimePeriodLabel,
+  perpDirection,
+  perpLeverage,
   onBack,
   onTraderPress,
 }) => {
@@ -133,6 +138,8 @@ const TraderPositionAnimatedHeader: React.FC<
             symbol={symbol}
             pricePercentChange={pricePercentChange}
             activeTimePeriodLabel={activeTimePeriodLabel}
+            perpDirection={perpDirection}
+            perpLeverage={perpLeverage}
             traderName={traderName}
             traderImageUrl={traderImageUrl}
             traderAddress={traderAddress}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.test.tsx
@@ -44,4 +44,41 @@ describe('TraderPositionCompactTokenStats', () => {
 
     expect(onTraderPress).toHaveBeenCalledTimes(1);
   });
+
+  it('renders perp leverage and direction badges beside the compact token symbol', () => {
+    renderWithProvider(
+      <TraderPositionCompactTokenStats
+        symbol="BTC"
+        pricePercentChange={-4.69}
+        activeTimePeriodLabel="1W"
+        traderName="trader1"
+        perpDirection="short"
+        perpLeverage={3}
+        onTraderPress={jest.fn()}
+      />,
+    );
+
+    expect(
+      within(
+        screen.getByTestId(
+          TraderPositionViewSelectorsIDs.HEADER_COMPACT_PERP_BADGES,
+        ),
+      ).getByText('3x'),
+    ).toBeOnTheScreen();
+    expect(
+      within(
+        screen.getByTestId(
+          TraderPositionViewSelectorsIDs.HEADER_COMPACT_PERP_BADGES,
+        ),
+      ).getByText('SHORT'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.COMPACT_TOKEN_STATS),
+    ).toHaveTextContent('BTC3xSHORT-4.69% 1W · trader1');
+    expect(
+      screen.getByTestId(
+        TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_CHANGE,
+      ),
+    ).toHaveTextContent('-4.69% 1W · trader1');
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.test.tsx
@@ -5,7 +5,7 @@ import { TraderPositionViewSelectorsIDs } from '../TraderPositionView.testIds';
 import TraderPositionCompactTokenStats from './TraderPositionCompactTokenStats';
 
 describe('TraderPositionCompactTokenStats', () => {
-  it('renders the token symbol and a single subtitle row with change and trader', () => {
+  it('renders trader on the first row and token change on the second', () => {
     const onTraderPress = jest.fn();
 
     renderWithProvider(
@@ -27,7 +27,7 @@ describe('TraderPositionCompactTokenStats', () => {
       screen.getByTestId(
         TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_CHANGE,
       ),
-    ).toHaveTextContent('+12.54% 1M · trader1');
+    ).toHaveTextContent('PEPE+12.54%1M');
     expect(
       within(
         screen.getByTestId(
@@ -45,7 +45,7 @@ describe('TraderPositionCompactTokenStats', () => {
     expect(onTraderPress).toHaveBeenCalledTimes(1);
   });
 
-  it('renders perp leverage and direction badges beside the compact token symbol', () => {
+  it('renders perp leverage and direction badges beside the trader on the first row', () => {
     renderWithProvider(
       <TraderPositionCompactTokenStats
         symbol="BTC"
@@ -74,11 +74,11 @@ describe('TraderPositionCompactTokenStats', () => {
     ).toBeOnTheScreen();
     expect(
       screen.getByTestId(TraderPositionViewSelectorsIDs.COMPACT_TOKEN_STATS),
-    ).toHaveTextContent('BTC3xSHORT-4.69% 1W · trader1');
+    ).toHaveTextContent('trader13xSHORTBTC-4.69%1W');
     expect(
       screen.getByTestId(
         TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_CHANGE,
       ),
-    ).toHaveTextContent('-4.69% 1W · trader1');
+    ).toHaveTextContent('BTC-4.69%1W');
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.tsx
@@ -9,7 +9,9 @@ import {
 } from '@metamask/design-system-react-native';
 import React from 'react';
 import TraderHeaderIdentity from '../../components/TraderHeaderIdentity';
+import PerpBadges from '../../components/PerpBadges';
 import { formatPercent } from '../../utils/formatters';
+import type { PerpDirection } from '../../utils/perp';
 import { TraderPositionViewSelectorsIDs } from '../TraderPositionView.testIds';
 
 export interface TraderPositionCompactTokenStatsProps {
@@ -19,6 +21,8 @@ export interface TraderPositionCompactTokenStatsProps {
   traderName: string;
   traderImageUrl?: string;
   traderAddress?: string;
+  perpDirection?: PerpDirection | null;
+  perpLeverage?: number | null;
   onTraderPress: () => void;
 }
 
@@ -31,6 +35,8 @@ const TraderPositionCompactTokenStats: React.FC<
   traderName,
   traderImageUrl,
   traderAddress,
+  perpDirection,
+  perpLeverage,
   onTraderPress,
 }) => {
   const hasChange = pricePercentChange != null;
@@ -40,15 +46,30 @@ const TraderPositionCompactTokenStats: React.FC<
       alignItems={BoxAlignItems.Center}
       testID={TraderPositionViewSelectorsIDs.COMPACT_TOKEN_STATS}
     >
-      <Text
-        variant={TextVariant.BodyMd}
-        fontWeight={FontWeight.Bold}
-        color={TextColor.TextDefault}
-        numberOfLines={1}
-        testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_SYMBOL}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+        twClassName="max-w-full"
       >
-        {symbol}
-      </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Bold}
+          color={TextColor.TextDefault}
+          numberOfLines={1}
+          twClassName="shrink"
+          testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_SYMBOL}
+        >
+          {symbol}
+        </Text>
+        {perpDirection ? (
+          <PerpBadges
+            direction={perpDirection}
+            leverage={perpLeverage}
+            testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_PERP_BADGES}
+          />
+        ) : null}
+      </Box>
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionCompactTokenStats.tsx
@@ -52,16 +52,16 @@ const TraderPositionCompactTokenStats: React.FC<
         gap={1}
         twClassName="max-w-full"
       >
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Bold}
-          color={TextColor.TextDefault}
-          numberOfLines={1}
-          twClassName="shrink"
-          testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_SYMBOL}
-        >
-          {symbol}
-        </Text>
+        <Box twClassName="min-w-0 flex-shrink">
+          <TraderHeaderIdentity
+            traderName={traderName}
+            traderImageUrl={traderImageUrl}
+            traderAddress={traderAddress}
+            variant="breadcrumb"
+            onPress={onTraderPress}
+            testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TRADER_LINK}
+          />
+        </Box>
         {perpDirection ? (
           <PerpBadges
             direction={perpDirection}
@@ -77,6 +77,16 @@ const TraderPositionCompactTokenStats: React.FC<
         twClassName="max-w-full px-1"
         testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_CHANGE}
       >
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Bold}
+          color={TextColor.TextDefault}
+          numberOfLines={1}
+          twClassName="shrink"
+          testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TOKEN_SYMBOL}
+        >
+          {symbol}
+        </Text>
         {hasChange ? (
           <>
             <Text
@@ -87,7 +97,7 @@ const TraderPositionCompactTokenStats: React.FC<
                   : 'text-error-default'
               }
             >
-              {`${formatPercent(pricePercentChange)} `}
+              {formatPercent(pricePercentChange)}
             </Text>
             <Text
               variant={TextVariant.BodySm}
@@ -101,19 +111,6 @@ const TraderPositionCompactTokenStats: React.FC<
             {'\u2014'}
           </Text>
         )}
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {' \u00b7 '}
-        </Text>
-        <Box twClassName="min-w-0 flex-shrink">
-          <TraderHeaderIdentity
-            traderName={traderName}
-            traderImageUrl={traderImageUrl}
-            traderAddress={traderAddress}
-            variant="breadcrumb"
-            onPress={onTraderPress}
-            testID={TraderPositionViewSelectorsIDs.HEADER_COMPACT_TRADER_LINK}
-          />
-        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
# feat(perps): show leverage in compact position header

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a trader's perps position detail screen collapses into the compact header, users need both **market context** (token + price movement) and **position context** (trader + leverage + direction) visible while scrolling trades.

**Before (compact header):**
- Row 1: token symbol only
- Row 2: price change · time period · trader

**After (compact header):**
- Row 1: **trader + leverage + direction** (position context)
- Row 2: **token symbol + price change + time period** (market context)

This change:
1. Passes resolved perp direction and leverage from `TraderPositionView` through `TraderPositionAnimatedHeader` into `TraderPositionCompactTokenStats`
2. Reuses existing `PerpBadges` so perp positions show metadata such as `10x SHORT` in the compact header
3. Reorganizes compact header rows so position-specific data (trader, leverage, side) is grouped separately from token market data

Spot positions are unchanged: row 1 shows the trader; row 2 shows symbol + change + time period.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved the compact header on trader perps positions to show leverage, direction, and a clearer two-row layout separating trader context from token price data

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trader perps position compact header

  Scenario: user scrolls a trader perps position detail screen
    Given a trader perps position detail screen is open
    And the position has leverage and a long or short direction
    When the user scrolls until the header collapses
    Then the compact header first row shows the trader with leverage and direction badges
    And the compact header second row shows the token symbol with price change and selected time period

  Scenario: user scrolls a spot position detail screen
    Given a trader spot position detail screen is open
    When the user scrolls until the header collapses
    Then the compact header first row shows the trader
    And the compact header second row shows the token symbol with price change and selected time period
    And no perp leverage or direction badges are shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/bff4f455-9d1d-4e34-82f9-24e0937d41da" />

### **After**

<img width="406" height="869" alt="image" src="https://github.com/user-attachments/assets/af0eb363-3d19-48a6-bd2c-e2eb64386016" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
