### PR TITLE
test(e2e): add Appium smoke for RWA swap geo-block

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -10,6 +10,7 @@ export const BridgeViewSelectorsIDs = {
   FEE_DISCLAIMER: 'bridge-fee-disclaimer',
   QUOTE_DETAILS_SKELETON: 'bridge-quote-details-skeleton',
   MISSING_PRICE_BANNER: 'bridge-missing-price-banner',
+  NO_QUOTES_BANNER: 'bridge-no-quotes',
   APPROVAL_TOOLTIP: 'bridge-approval-text',
 } as const;
 

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -49,6 +49,8 @@ import {
   selectBridgeBalanceRefreshKey,
 } from '../../../../../core/redux/slices/bridge';
 import BannerBase from '../../../../../component-library/components/Banners/Banner/foundation/BannerBase';
+import Text from '../../../../../component-library/components/Texts/Text';
+import { TextVariant } from '../../../../../component-library/components/Texts/Text/Text.types';
 import { IconName as CLIconName } from '../../../../../component-library/components/Icons/Icon';
 import { TokenWarningModalMode } from '../../components/TokenWarningModal/constants';
 import {
@@ -564,6 +566,9 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
                       backgroundColor: colors.error.muted,
                       paddingLeft: 8,
                     };
+                    const quoteStreamErrorMessage = getQuoteStreamReasonString(
+                      quoteStreamComplete?.reason,
+                    );
                     return (
                       <BannerBase
                         style={quoteStreamErrorBannerStyle}
@@ -574,9 +579,15 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
                             size={IconSize.Lg}
                           />
                         }
-                        description={getQuoteStreamReasonString(
-                          quoteStreamComplete?.reason,
-                        )}
+                        description={
+                          <Text
+                            testID={BridgeViewSelectorsIDs.NO_QUOTES_BANNER}
+                            accessibilityLabel={quoteStreamErrorMessage}
+                            variant={TextVariant.BodySM}
+                          >
+                            {quoteStreamErrorMessage}
+                          </Text>
+                        }
                       />
                     );
                   })()

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -23,6 +23,8 @@ import {
   IconColor,
   IconName,
   IconSize,
+  Text,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import {
   getBridgeTokenSecurityConfig,
@@ -49,8 +51,6 @@ import {
   selectBridgeBalanceRefreshKey,
 } from '../../../../../core/redux/slices/bridge';
 import BannerBase from '../../../../../component-library/components/Banners/Banner/foundation/BannerBase';
-import Text from '../../../../../component-library/components/Texts/Text';
-import { TextVariant } from '../../../../../component-library/components/Texts/Text/Text.types';
 import { IconName as CLIconName } from '../../../../../component-library/components/Icons/Icon';
 import { TokenWarningModalMode } from '../../components/TokenWarningModal/constants';
 import {
@@ -583,7 +583,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
                           <Text
                             testID={BridgeViewSelectorsIDs.NO_QUOTES_BANNER}
                             accessibilityLabel={quoteStreamErrorMessage}
-                            variant={TextVariant.BodySM}
+                            variant={TextVariant.BodySm}
                           >
                             {quoteStreamErrorMessage}
                           </Text>

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -582,7 +582,6 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
                         description={
                           <Text
                             testID={BridgeViewSelectorsIDs.NO_QUOTES_BANNER}
-                            accessibilityLabel={quoteStreamErrorMessage}
                             variant={TextVariant.BodySm}
                           >
                             {quoteStreamErrorMessage}

--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -16,6 +16,11 @@ export interface VisibilityWithSettleOptions extends AssertionOptions {
   settleMs?: number;
 }
 
+export interface TextDisplayedOptions extends AssertionOptions {
+  /** When set, asserts text on this element instead of searching the screen. */
+  within?: PlaywrightElement | Promise<PlaywrightElement>;
+}
+
 /**
  * Assertion helpers that integrate with TimerHelper's automatic overhead
  * tracking so performance measurements reflect real app latency.
@@ -260,10 +265,15 @@ export default class PlaywrightAssertions {
 
   static async expectTextDisplayed(
     text: string,
-    options: AssertionOptions = {},
+    options: TextDisplayedOptions = {},
   ): Promise<void> {
+    const { within, ...assertionOptions } = options;
+    if (within) {
+      await this.expectElementText(within, text, assertionOptions);
+      return;
+    }
     const el = await PlaywrightMatchers.getElementByText(text);
-    await el.waitForDisplayed({ timeout: this.getTimeout(options) });
+    await el.waitForDisplayed({ timeout: this.getTimeout(assertionOptions) });
   }
 
   static async expectTextNotDisplayed(

--- a/tests/helpers/swap/swap-rwa-geoblock-mocks.ts
+++ b/tests/helpers/swap/swap-rwa-geoblock-mocks.ts
@@ -1,0 +1,95 @@
+import { QuoteStreamCompleteReason } from '@metamask/bridge-controller';
+import { Mockttp } from 'mockttp';
+import { TestSpecificMock } from '../../framework';
+import {
+  setupMockRequest,
+  setupSSEMockRequest,
+} from '../../api-mocking/helpers/mockHelpers';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import { getProductionRemoteFlagDefaults } from '../../feature-flags';
+import { toSSEResponse } from './constants';
+import { testSpecificMock } from './swap-mocks';
+
+const USDC_SRC_TOKEN_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const GOOGLON_DEST_TOKEN_ADDRESS = '0xba47214edd2bb43099611b208f75e4b42fdcfedc';
+
+const BRIDGE_CONFIG_V2_WITH_SSE = {
+  ...(getProductionRemoteFlagDefaults().bridgeConfigV2 as Record<
+    string,
+    unknown
+  >),
+  minimumVersion: '0.0.0',
+  support: true,
+  refreshRate: 30000,
+  maxRefreshCount: 5,
+  sse: {
+    enabled: true,
+    minimumVersion: '0.0.0',
+  },
+};
+
+export const RWA_GEO_BLOCK_REMOTE_FEATURE_FLAG_OVERRIDES = {
+  bridgeConfigV2: BRIDGE_CONFIG_V2_WITH_SSE,
+  rwaTokensEnabled: true,
+  stxMigrationBatchStatus: false,
+  stxMigrationCancel: false,
+  stxMigrationGetFees: false,
+  stxMigrationSubmitTransactions: false,
+  swapsSWAPS4543AbtestPostTradeModal: 'control',
+};
+
+const USDC_TO_GOOGLON_QUOTE_STREAM_PATTERN = new RegExp(
+  `getQuoteStream.*srcTokenAddress=${USDC_SRC_TOKEN_ADDRESS}.*destTokenAddress=${GOOGLON_DEST_TOKEN_ADDRESS}`,
+  'i',
+);
+
+const USDC_TO_GOOGLON_GET_QUOTE_PATTERN = new RegExp(
+  `\\/getQuote\\?.*srcTokenAddress=${USDC_SRC_TOKEN_ADDRESS}.*destTokenAddress=${GOOGLON_DEST_TOKEN_ADDRESS}`,
+  'i',
+);
+
+const RWA_GEO_BLOCKED_SSE_RESPONSE = toSSEResponse([], {
+  quoteCount: 0,
+  hasQuotes: false,
+  reason: QuoteStreamCompleteReason.RWA_GEO_RESTRICTED,
+});
+
+/**
+ * Mocks USDC → GOOGLON quote stream completing with RWA geo-restriction (no quotes).
+ */
+async function mockSwapUSDCtoGOOGLONGeoBlocked(
+  mockServer: Mockttp,
+): Promise<void> {
+  await setupSSEMockRequest(
+    mockServer,
+    USDC_TO_GOOGLON_QUOTE_STREAM_PATTERN,
+    RWA_GEO_BLOCKED_SSE_RESPONSE,
+    1002,
+  );
+
+  await setupMockRequest(
+    mockServer,
+    {
+      requestMethod: 'GET',
+      url: USDC_TO_GOOGLON_GET_QUOTE_PATTERN,
+      response: [],
+      responseCode: 200,
+    },
+    1002,
+  );
+}
+
+/**
+ * Standard swap mocks with USDC → GOOGLON overridden to return RWA_GEO_RESTRICTED.
+ */
+export const rwaSwapGeoBlockTestSpecificMock: TestSpecificMock = async (
+  mockServer,
+) => {
+  await testSpecificMock(mockServer);
+  await setupRemoteFeatureFlagsMock(
+    mockServer,
+    RWA_GEO_BLOCK_REMOTE_FEATURE_FLAG_OVERRIDES,
+    1002,
+  );
+  await mockSwapUSDCtoGOOGLONGeoBlocked(mockServer);
+};

--- a/tests/helpers/swap/swap-unified-ui.ts
+++ b/tests/helpers/swap/swap-unified-ui.ts
@@ -12,6 +12,29 @@ interface SwapOptions {
   slippage?: string;
 }
 
+/**
+ * Selects source/destination tokens and enters an amount without waiting for quotes.
+ */
+export async function enterSwapQuote(
+  quantity: string,
+  sourceTokenSymbol: string,
+  destTokenSymbol: string,
+  chainId: string,
+): Promise<void> {
+  await Assertions.expectElementToBeVisible(QuoteView.sourceTokenArea, {
+    timeout: 20000,
+  });
+  if (sourceTokenSymbol !== 'ETH') {
+    await QuoteView.tapSourceToken();
+    await QuoteView.tapToken(chainId, sourceTokenSymbol);
+  }
+  await QuoteView.tapSourceAmountInput();
+  await QuoteView.enterAmount(quantity);
+  await QuoteView.tapDestinationToken();
+  await QuoteView.tapToken(chainId, destTokenSymbol);
+  await QuoteView.dismissKeypad();
+}
+
 export async function submitSwapUnifiedUI(
   quantity: string,
   sourceTokenSymbol: string,

--- a/tests/page-objects/swaps/QuoteView.ts
+++ b/tests/page-objects/swaps/QuoteView.ts
@@ -523,6 +523,30 @@ class QuoteView {
       description: `Slippage should display ${value}%`,
     });
   }
+
+  /**
+   * Waits for the RWA geo-restricted quote stream banner.
+   */
+  async checkRwaGeoRestrictedMessageIsDisplayed(): Promise<void> {
+    const timeout = 60000;
+    const message = QuoteViewSelectorText.RWA_GEO_RESTRICTED_MESSAGE;
+    const banner = PlaywrightMatchers.getElementById(
+      QuoteViewSelectorIDs.NO_QUOTES_BANNER,
+      { exact: true },
+    );
+
+    await PlaywrightAssertions.expectElementToBeVisible(banner, {
+      timeout,
+      description:
+        'RWA geo-restricted banner should be visible on the swap screen',
+    });
+
+    await PlaywrightAssertions.expectTextDisplayed(message, {
+      within: banner,
+      timeout,
+      description: `RWA geo-restricted message "${message}" should be visible on the swap screen`,
+    });
+  }
 }
 
 export default new QuoteView();

--- a/tests/selectors/Bridge/QuoteView.selectors.ts
+++ b/tests/selectors/Bridge/QuoteView.selectors.ts
@@ -25,6 +25,8 @@ export const QuoteViewSelectorText = {
   MAX: enContent.bridge.max,
   INCLUDED: enContent.bridge.included,
   RATE: enContent.bridge.rate,
+  RWA_GEO_RESTRICTED_MESSAGE:
+    enContent.bridge.quote_stream_complete_rwa_geo_restricted,
 };
 
 // Performance tests only: Maps network name to chain ID for token selection.
@@ -49,6 +51,7 @@ export const QuoteViewSelectorIDs = {
   SOURCE_TOKEN_SELECTOR: 'select-source-token-selector',
   CONFIRM_BUTTON: 'bridge-confirm-button',
   BRIDGE_VIEW_SCROLL: 'bridge-view-scroll',
+  NO_QUOTES_BANNER: 'bridge-no-quotes',
   FEE_DISCLAIMER: 'bridge-fee-disclaimer',
   KEYPAD_DELETE_BUTTON: 'keypad-delete-button',
   BACK_BUTTON: 'button-icon',

--- a/tests/smoke-appium/swap/swap-rwa-geoblock.spec.ts
+++ b/tests/smoke-appium/swap/swap-rwa-geoblock.spec.ts
@@ -1,0 +1,82 @@
+import { merge } from 'lodash';
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokeSwap } from '../../tags.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import { LocalNodeType } from '../../framework/types.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import { getProductionRemoteFlagDefaults } from '../../feature-flags/index.js';
+import { loginToAppPlaywright } from '../../flows/wallet.flow.js';
+import WalletView from '../../page-objects/wallet/WalletView.js';
+import QuoteView from '../../page-objects/swaps/QuoteView.js';
+import { prepareSwapsTestEnvironment } from '../../helpers/swap/prepareSwapsTestEnvironment.js';
+import { enterSwapQuote } from '../../helpers/swap/swap-unified-ui.js';
+import {
+  RWA_GEO_BLOCK_REMOTE_FEATURE_FLAG_OVERRIDES,
+  rwaSwapGeoBlockTestSpecificMock,
+} from '../../helpers/swap/swap-rwa-geoblock-mocks.js';
+import { DEFAULT_ANVIL_PORT } from '../../seeder/anvil-manager.js';
+
+const USDC_TO_GOOGLON_QUOTE = {
+  quantity: '25',
+  sourceTokenSymbol: 'USDC',
+  destTokenSymbol: 'GOOGLON',
+  chainId: '0x1',
+} as const;
+
+appiumTest.describe(SmokeSwap('Swap RWA Geo-block'), () => {
+  appiumTest(
+    'shows geo-restricted message when swapping USDC to GOOGLON in a blocked region',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      const fixture = new FixtureBuilder()
+        .withNetworkController({
+          chainId: USDC_TO_GOOGLON_QUOTE.chainId,
+          rpcUrl: `http://localhost:${DEFAULT_ANVIL_PORT}`,
+          type: 'custom',
+          nickname: 'Localhost',
+          ticker: 'ETH',
+        })
+        .build();
+
+      merge(fixture.state.engine.backgroundState, {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {
+            ...getProductionRemoteFlagDefaults(),
+            ...RWA_GEO_BLOCK_REMOTE_FEATURE_FLAG_OVERRIDES,
+          },
+        },
+      });
+
+      await withFixtures(
+        {
+          fixture,
+          localNodeOptions: [
+            {
+              type: LocalNodeType.anvil,
+              options: {
+                chainId: 1,
+                loadState: './tests/smoke/swap/withTokens.json',
+              },
+            },
+          ],
+          testSpecificMock: rwaSwapGeoBlockTestSpecificMock,
+          restartDevice: true,
+          currentDeviceDetails,
+        },
+        async () => {
+          await loginToAppPlaywright({ scenarioType: 'e2e' });
+          await prepareSwapsTestEnvironment();
+          await WalletView.tapWalletSwapButton();
+
+          await enterSwapQuote(
+            USDC_TO_GOOGLON_QUOTE.quantity,
+            USDC_TO_GOOGLON_QUOTE.sourceTokenSymbol,
+            USDC_TO_GOOGLON_QUOTE.destTokenSymbol,
+            USDC_TO_GOOGLON_QUOTE.chainId,
+          );
+
+          await QuoteView.checkRwaGeoRestrictedMessageIsDisplayed();
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds Appium smoke coverage for the RWA swap geo-restriction flow (USDC → GOOGLON). When the quote stream completes with `RWA_GEO_RESTRICTED`, the swap screen should show the geo-blocked banner copy.

**Why:** Parity with extension geo-block behavior and regression protection for a compliance-sensitive path.

**What changed:**
- New Appium smoke spec with SSE/JSON mocks returning `RWA_GEO_RESTRICTED`
- `bridge-no-quotes` testID and `accessibilityLabel` on the quote-stream error banner text for reliable Appium assertions
- `enterSwapQuote` helper, page-object assertion, and optional `expectTextDisplayed({ within })` for scoped text checks

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MetaMask/metamask-extension#43933

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: RWA swap geo-block

  Scenario: user sees geo-restricted message when swapping USDC to GOOGLON
    Given a main-e2e build with test overrides enabled
    And remote flags enable bridge SSE and RWA tokens
    And quote stream mocks return RWA_GEO_RESTRICTED for USDC → GOOGLON

    When the user logs in and opens swap
    And selects USDC as source, GOOGLON as destination, and enters an amount

    Then the quote-stream error banner is visible
    And the message reads "This swap isn't available in your region."
```

Local command:
`yarn appium-smoke:ios --grep "Swap RWA Geo-block" tests/smoke-appium/swap/swap-rwa-geoblock.spec.ts`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E test-only change; behavior is validated by the Appium smoke spec.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are primarily E2E and test infrastructure; the only app change is adding a testID wrapper around existing banner copy with no behavior change to quoting or compliance logic.
> 
> **Overview**
> Adds **Appium smoke** coverage for the **RWA geo-restriction** swap path (USDC → GOOGLON) when the quote stream completes with **`RWA_GEO_RESTRICTED`**, using SSE/HTTP mocks and feature-flag overrides aligned with bridge SSE and RWA tokens.
> 
> The swap **quote-stream error banner** now wraps the localized reason string in a **`Text`** node with testID **`bridge-no-quotes`** so tests can assert the banner and copy reliably (including the geo-block message).
> 
> Test support includes **`enterSwapQuote`** (token/amount setup without waiting for quotes), **`QuoteView.checkRwaGeoRestrictedMessageIsDisplayed`**, scoped **`expectTextDisplayed({ within })`**, and shared **mock helpers** for the geo-blocked quote stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce920bedb75e45a42862fd992cf726de64a31b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->