### PR TITLE
fix: redirect to filtered activity page from perps

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.tsx
@@ -6,7 +6,7 @@ import {
   useSharedValue,
 } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -33,10 +33,16 @@ import { ActivityTypeFilter } from './types';
 import { useNetworkFilterOptions } from './hooks/useNetworkFilterOptions';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import ErrorBoundary from '../ErrorBoundary';
+import { useParams } from '../../../util/navigation/navUtils';
+
+interface ActivityScreenParams {
+  redirectToPerpsTransactions?: boolean;
+}
 
 const ActivityScreen = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
+  const params = useParams<ActivityScreenParams>();
 
   const scrollY = useSharedValue(0);
   const titleSectionHeight = useSharedValue(0);
@@ -52,8 +58,10 @@ const ActivityScreen = () => {
   // const [searchQuery, setSearchQuery] = useState('');
   // TODO: restore `ActivityTypeFilter.All` as the default once data-source
   // unification lands. See `ACTIVITY_TYPE_FILTER_ORDER` in ./types.ts.
-  const [typeFilter, setTypeFilter] = useState<ActivityTypeFilter>(
-    ActivityTypeFilter.Transactions,
+  const [typeFilter, setTypeFilter] = useState<ActivityTypeFilter>(() =>
+    params.redirectToPerpsTransactions
+      ? ActivityTypeFilter.Perps
+      : ActivityTypeFilter.Transactions,
   );
   const [isTypeSheetOpen, setIsTypeSheetOpen] = useState(false);
   const [networkFilter, setNetworkFilter] = useState<CaipChainId[] | null>(
@@ -120,6 +128,17 @@ const ActivityScreen = () => {
   const handleSelectNetwork = useCallback((chainIds: CaipChainId[] | null) => {
     setNetworkFilter(chainIds);
   }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!params.redirectToPerpsTransactions) {
+        return;
+      }
+
+      setTypeFilter(ActivityTypeFilter.Perps);
+      navigation.setParams({ redirectToPerpsTransactions: false });
+    }, [navigation, params.redirectToPerpsTransactions]),
+  );
 
   const handleBackPress = useCallback(() => {
     if (navigation.canGoBack()) {

--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -45,6 +45,22 @@ describeForPlatforms('ActivityScreen', () => {
     });
   });
 
+  it('starts with the Perps type filter when opened from Perps', async () => {
+    const { getAllByText, getByTestId } = renderActivityScreenView({
+      initialParams: {
+        redirectToPerpsTransactions: true,
+        showBackButton: true,
+      },
+    });
+
+    expect(
+      getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Perps)).length,
+    ).toBeGreaterThan(0);
+    expect(
+      getByTestId(ActivityScreenSelectorsIDs.NETWORK_FILTER_CHIP),
+    ).toBeDisabled();
+  });
+
   it('updates the selected network filter through the real network sheet', async () => {
     const { getByTestId, getAllByText, findByText } = renderActivityScreenView({
       overrides: activityLineaNetworkOverride,

--- a/tests/component-view/renderers/activity.ts
+++ b/tests/component-view/renderers/activity.ts
@@ -16,6 +16,7 @@ import {
 interface RenderActivityScreenViewOptions {
   overrides?: DeepPartial<RootState>;
   state?: DeepPartial<RootState>;
+  initialParams?: Record<string, unknown>;
 }
 
 interface RenderActivityScreenViewWithRoutesOptions
@@ -95,6 +96,7 @@ export function renderActivityScreenView(
     ActivityScreenWithProviders,
     { name: Routes.TRANSACTIONS_VIEW },
     { state },
+    options.initialParams,
   );
 }
 
@@ -108,6 +110,7 @@ export function renderActivityScreenViewWithRoutes(
     { name: Routes.TRANSACTIONS_VIEW },
     options.extraRoutes,
     { state },
+    options.initialParams,
   );
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When users opened Activity from Perps, the redesigned Activity screen ignored the existing Perps redirect param and defaulted to the Transactions type filter. This made users manually switch filters before seeing their Perps activity.

This change makes the redesigned Activity screen initialize to the Perps type filter when `redirectToPerpsTransactions` is provided, then clears that one-shot route param after applying it. The Activity component-view renderer now supports initial route params, and a regression test verifies the Perps entry path starts already filtered.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Activity showing transactions instead of Perps activity when opened from Perps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-964

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Activity filter redirect

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled
    And the redesigned Activity screen is enabled

  Scenario: user opens Activity from Perps
    Given I am on a Perps screen with an Activity entry point

    When user taps the Activity entry point
    Then the Activity screen should open
    And the activity type filter should be set to "Perps"
    And Perps activity rows should be shown instead of default Transactions rows
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/147dcb4f-da70-4837-8ced-802a58c66832


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation param handling and filter state on Activity; no auth, data, or payment changes.
> 
> **Overview**
> Fixes the redesigned **Activity** screen so navigation from Perps with `redirectToPerpsTransactions` opens on the **Perps** type filter instead of defaulting to **Transactions**.
> 
> `ActivityScreen` reads that route param via `useParams`, initializes `typeFilter` to Perps when it is set, and uses **`useFocusEffect`** to re-apply Perps on focus and clear the one-shot param with `navigation.setParams`. Component-view helpers accept **`initialParams`** for tests; a regression test asserts the Perps label and disabled network chip on that entry path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02a34c26ac9418d88fec7a9cabd955a06c745e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->