### PR TITLE
feat(swaps): add view activity cta and refine post-trade modal cp-8.1.0

### DIFF
--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeTokenSuggestions.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeTokenSuggestions.tsx
@@ -129,10 +129,10 @@ export const PostTradeTokenSuggestions = ({
 
   return (
     <Box
-      twClassName="px-4 pb-2"
+      twClassName="px-4 pb-4"
       testID={PostTradeBottomSheetTestIds.SUGGESTIONS_SECTION}
     >
-      <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+      <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
         {strings('bridge.post_trade_modal.what_to_swap_next')}
       </Text>
       <PillScrollList
@@ -144,7 +144,7 @@ export const PostTradeTokenSuggestions = ({
         rowCount={2}
         maxPills={20}
         listTestId={PostTradeBottomSheetTestIds.SUGGESTIONS_LIST}
-        wrapperTwClassName="-mx-4 bg-transparent mt-3 mb-0"
+        wrapperTwClassName="-mx-4 bg-transparent mt-2 mb-0"
       />
     </Box>
   );

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
@@ -374,7 +374,15 @@ export const PostTradeBottomSheet = () => {
             testID: PostTradeBottomSheetTestIds.TRY_AGAIN_BUTTON,
           },
         }
-      : undefined;
+      : {
+          secondaryButtonProps: {
+            children: strings('bridge.post_trade_modal.view_activity'),
+            size: ButtonSize.Lg,
+            onPress: handleViewActivity,
+            testID: PostTradeBottomSheetTestIds.VIEW_ACTIVITY_BUTTON,
+          },
+          primaryButtonProps: undefined,
+        };
 
   return (
     <BottomSheet
@@ -385,6 +393,7 @@ export const PostTradeBottomSheet = () => {
       <BottomSheetHeader
         onClose={handleClose}
         closeButtonProps={{ testID: PostTradeBottomSheetTestIds.CLOSE_BUTTON }}
+        twClassName="pt-4 h-auto"
       >
         <StatusIcon status={status} />
       </BottomSheetHeader>
@@ -407,14 +416,12 @@ export const PostTradeBottomSheet = () => {
         destToken={params.destToken}
         onTokenPress={handleSuggestionPress}
       />
-      {footerButtonProps ? (
-        <BottomSheetFooter
-          buttonsAlignment={ButtonsAlignment.Vertical}
-          secondaryButtonProps={footerButtonProps.secondaryButtonProps}
-          primaryButtonProps={footerButtonProps.primaryButtonProps}
-          style={styles.footer}
-        />
-      ) : null}
+      <BottomSheetFooter
+        buttonsAlignment={ButtonsAlignment.Vertical}
+        secondaryButtonProps={footerButtonProps.secondaryButtonProps}
+        primaryButtonProps={footerButtonProps.primaryButtonProps}
+        style={styles.footer}
+      />
     </BottomSheet>
   );
 };


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Refines the post-trade swap/bridge bottom sheet to address SWAPS-4689 and SWAPS-4693 in a single change.

- **SWAPS-4689**: Reduces the "What to swap next" section header from `TextVariant.HeadingMd` to `TextVariant.HeadingSm` and tightens the section/list spacing (section bottom padding `pb-2` → `pb-4`, pill list top margin `mt-3` → `mt-2`) so the header is less heavy and the layout balances better with the new CTA below.
- **SWAPS-4693**: Adds a `View activity` secondary CTA at the bottom of the post-trade modal (below the "What to swap next" section) for non-failed states. The existing `handleViewActivity` handler is reused, so the new CTA inherits the same analytics (`cta_clicked: 'view_activity'`), dismissal-suppression, and navigation to the transactions view. The failed-state footer (secondary `View activity` + primary `Try again`) is unchanged.
- Adds top padding (`pt-4 h-auto`) to the `BottomSheetHeader` so there is a little more breathing room between the status icon and the top of the sheet.

The footer is now always rendered; for non-failed states only the secondary `View activity` button is shown (`primaryButtonProps` is `undefined`), which the design-system `BottomSheetFooter` supports.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added a "View activity" CTA to the post-trade modal and refined the "What to swap next" section spacing/typography

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [SWAPS-4689](https://consensyssoftware.atlassian.net/browse/SWAPS-4689), [SWAPS-4693](https://consensyssoftware.atlassian.net/browse/SWAPS-4693)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Post-trade modal View activity CTA and spacing

  Background:
    Given I am logged into MetaMask Mobile
    And I have completed a swap

  Scenario: user views the post-trade modal after a successful swap
    Given a swap transaction has succeeded

    When user views the post-trade bottom sheet
    Then the "What to swap next" header should use the smaller heading style
    And a "View activity" secondary button should appear below the trending token pills
    And no "Try again" button should be shown

  Scenario: user taps View activity after a successful swap
    Given a swap transaction has succeeded
    And the post-trade bottom sheet is open

    When user taps the "View activity" button
    Then the modal should close
    And the user should be navigated to the transactions activity view
    And a `cta_clicked: view_activity` analytics event should be tracked

  Scenario: user views the post-trade modal after a failed swap
    Given a swap transaction has failed

    When user views the post-trade bottom sheet
    Then both "View activity" (secondary) and "Try again" (primary) buttons should be shown
    And the "What to swap next" suggestions section should be hidden
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — to be attached.

### **After**

N/A — to be attached.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[SWAPS-4689]: https://consensyssoftware.atlassian.net/browse/SWAPS-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to post-trade modal layout and CTAs; existing handlers and failed-state behavior are preserved.
> 
> **Overview**
> The post-trade swap/bridge bottom sheet now always shows a footer with a **View activity** secondary action for success and in-progress states (reusing existing navigation and analytics), while **failed** still shows **View activity** plus **Try again** as primary.
> 
> **What to swap next** is visually lighter: the section title moves from `HeadingMd` to `HeadingSm`, pill list top margin is tightened (`mt-3` → `mt-2`), and section bottom padding increases (`pb-2` → `pb-4`) to balance the new footer. The sheet header gets extra top padding (`pt-4 h-auto`) above the status icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771e6e2ea2c4580645c26239ea5695ae1d7d3059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->