### PR TITLE
feat(money): update MMPay flow inputs (MUSD-1095)

### DIFF
--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -6,8 +6,14 @@ import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
 } from '../../../hooks/pay/useTransactionPayData';
+import { formatAmountWithLocaleSeparators } from '../../../../../UI/Bridge/utils/formatAmountWithLocaleSeparators';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../../../UI/Bridge/utils/formatAmountWithLocaleSeparators');
+
+const mockFormatAmountWithLocaleSeparators = jest.mocked(
+  formatAmountWithLocaleSeparators,
+);
 
 const mockUseTransactionPayIsMaxAmount = jest.mocked(
   useTransactionPayIsMaxAmount,
@@ -19,6 +25,7 @@ describe('CustomAmount', () => {
     jest.resetAllMocks();
     mockUseTransactionPayIsMaxAmount.mockReturnValue(false);
     mockUseIsTransactionPayLoading.mockReturnValue(false);
+    mockFormatAmountWithLocaleSeparators.mockImplementation((value) => value);
   });
 
   it('renders amount', () => {
@@ -27,6 +34,19 @@ describe('CustomAmount', () => {
     );
 
     expect(getByText('123.45')).toBeOnTheScreen();
+  });
+
+  it('renders the amount formatted with thousand separators', () => {
+    mockFormatAmountWithLocaleSeparators.mockImplementation(() => '1,000,000');
+
+    const { getByText } = renderWithProvider(
+      <CustomAmount amountFiat="1000000" />,
+    );
+
+    expect(mockFormatAmountWithLocaleSeparators).toHaveBeenCalledWith(
+      '1000000',
+    );
+    expect(getByText('1,000,000')).toBeOnTheScreen();
   });
 
   it('renders fiat symbol for specified currency', () => {

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './custom-amount.styles';
 import { getCurrencySymbol } from '../../../../../../util/number';
+import { formatAmountWithLocaleSeparators } from '../../../../../UI/Bridge/utils/formatAmountWithLocaleSeparators';
 import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
@@ -39,7 +40,8 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   const selectedCurrency = useSelector(selectCurrentCurrency);
   const currency = currencyProp ?? selectedCurrency;
   const fiatSymbol = getCurrencySymbol(currency);
-  const amountLength = amountFiat.length;
+  const formattedAmount = formatAmountWithLocaleSeparators(amountFiat);
+  const amountLength = formattedAmount.length;
 
   const { styles } = useStyles(styleSheet, {
     amountLength,
@@ -63,7 +65,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
         style={styles.input}
         onPress={disabled ? undefined : onPress}
       >
-        {amountFiat}
+        {formattedAmount}
       </Text>
     </View>
   );

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -28,7 +28,10 @@ import {
   useTransactionPayTotals,
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
+  useTransactionPayFiatPayment,
 } from '../pay/useTransactionPayData';
+import { useMMPayFiatConfig } from '../pay/useMMPayFiatConfig';
+import { useRampsBuyLimits } from '../../../../UI/Ramp/hooks/useRampsBuyLimits';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import {
   PaymentOverride,
@@ -48,6 +51,8 @@ jest.mock('../pay/useUpdateTransactionPayAmount');
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayHasSourceAmount');
+jest.mock('../pay/useMMPayFiatConfig');
+jest.mock('../../../../UI/Ramp/hooks/useRampsBuyLimits');
 jest.mock('../useTokenAmount');
 jest.mock('../../../../../util/navigation/navUtils');
 jest.mock('../../../../UI/Predict/hooks/usePredictBalance');
@@ -137,6 +142,11 @@ describe('useTransactionCustomAmount', () => {
   const useConfirmationMetricEventsMock = jest.mocked(
     useConfirmationMetricEvents,
   );
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
+  const useMMPayFiatConfigMock = jest.mocked(useMMPayFiatConfig);
+  const useRampsBuyLimitsMock = jest.mocked(useRampsBuyLimits);
 
   const updateTransactionPayAmountMock: ReturnType<
     typeof useUpdateTransactionPayAmount
@@ -174,6 +184,14 @@ describe('useTransactionCustomAmount', () => {
     useTransactionPayIsMaxAmountMock.mockReturnValue(false);
     useTransactionPayIsPostQuoteMock.mockReturnValue(false);
     useTransactionPayHasSourceAmountMock.mockReturnValue(true);
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [],
+    } as unknown as ReturnType<typeof useMMPayFiatConfig>);
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'usd',
+    } as ReturnType<typeof useRampsBuyLimits>);
   });
 
   it('returns pending amount provided by updatePendingAmount', async () => {
@@ -266,6 +284,55 @@ describe('useTransactionCustomAmount', () => {
     });
 
     expect(result.current.amountFiat).toBe('1'.repeat(27));
+  });
+
+  describe('fiat payment maximum purchase limit', () => {
+    function mockFiatBuyLimit(maxAmount?: number) {
+      useMMPayFiatConfigMock.mockReturnValue({
+        enabledTransactionTypes: [TransactionType.simpleSend],
+      } as unknown as ReturnType<typeof useMMPayFiatConfig>);
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: '/payments/apple-pay',
+      } as ReturnType<typeof useTransactionPayFiatPayment>);
+      useRampsBuyLimitsMock.mockReturnValue({
+        maxAmount,
+        amountLimitError: null,
+        currency: 'usd',
+      } as ReturnType<typeof useRampsBuyLimits>);
+    }
+
+    it('ignores input that exceeds the fiat maximum purchase', async () => {
+      mockFiatBuyLimit(3000);
+      const { result } = runHook();
+
+      await act(async () => {
+        result.current.updatePendingAmount('3000');
+        result.current.updatePendingAmount('30000');
+      });
+
+      expect(result.current.amountFiat).toBe('3000');
+    });
+
+    it('allows input equal to the fiat maximum purchase', async () => {
+      mockFiatBuyLimit(3000);
+      const { result } = runHook();
+
+      await act(async () => {
+        result.current.updatePendingAmount('3000');
+      });
+
+      expect(result.current.amountFiat).toBe('3000');
+    });
+
+    it('does not cap input when no fiat payment method is selected', async () => {
+      const { result } = runHook();
+
+      await act(async () => {
+        result.current.updatePendingAmount('30000');
+      });
+
+      expect(result.current.amountFiat).toBe('30000');
+    });
   });
 
   it('updateTokenAmount delegates to updateTransactionPayAmount with the human amount', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -333,6 +333,17 @@ describe('useTransactionCustomAmount', () => {
 
       expect(result.current.amountFiat).toBe('30000');
     });
+
+    it('does not cap input when the payment method has no maximum', async () => {
+      mockFiatBuyLimit(null as unknown as undefined);
+      const { result } = runHook();
+
+      await act(async () => {
+        result.current.updatePendingAmount('30000');
+      });
+
+      expect(result.current.amountFiat).toBe('30000');
+    });
   });
 
   it('updateTokenAmount delegates to updateTransactionPayAmount with the human amount', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -195,7 +195,7 @@ export function useTransactionCustomAmount({
 
       if (
         isFiatBuyLimited &&
-        fiatMaxAmount !== undefined &&
+        fiatMaxAmount != null &&
         Number(newAmount) > fiatMaxAmount
       ) {
         return;

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -24,10 +24,14 @@ import {
 } from '../../../../UI/Earn/constants/musd';
 import Engine from '../../../../../core/Engine';
 import {
+  useTransactionPayFiatPayment,
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
   useTransactionPayTotals,
 } from '../pay/useTransactionPayData';
+import { useMMPayFiatConfig } from '../pay/useMMPayFiatConfig';
+import { useRampsBuyLimits } from '../../../../UI/Ramp/hooks/useRampsBuyLimits';
+import { MONEY_ACCOUNT_CURRENCY } from '../../components/info/money-account-withdraw-info/money-account-withdraw-info';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
@@ -104,6 +108,19 @@ export function useTransactionCustomAmount({
 
   const { updateTransactionPayAmount } = useUpdateTransactionPayAmount();
 
+  // Gating mirrors useFiatBuyLimitAlert so the keypad cap and the limit alert agree.
+  const { enabledTransactionTypes } = useMMPayFiatConfig();
+  const fiatPaymentMethodId =
+    useTransactionPayFiatPayment()?.selectedPaymentMethodId;
+  const isFiatBuyLimited =
+    hasTransactionType(transactionMeta, enabledTransactionTypes) &&
+    Boolean(fiatPaymentMethodId);
+  const { maxAmount: fiatMaxAmount } = useRampsBuyLimits({
+    amount: 0,
+    paymentMethodId: fiatPaymentMethodId,
+    currency: MONEY_ACCOUNT_CURRENCY,
+  });
+
   const amountFiat = useMemo(() => {
     const targetAmountUsd = totals?.targetAmount.usd;
 
@@ -176,6 +193,14 @@ export function useTransactionCustomAmount({
         return;
       }
 
+      if (
+        isFiatBuyLimited &&
+        fiatMaxAmount !== undefined &&
+        Number(newAmount) > fiatMaxAmount
+      ) {
+        return;
+      }
+
       if (isMaxAmount) {
         setIsMax(false);
       }
@@ -188,7 +213,13 @@ export function useTransactionCustomAmount({
 
       setAmountFiat(newAmount);
     },
-    [isMaxAmount, setIsMax, setConfirmationMetric],
+    [
+      isFiatBuyLimited,
+      fiatMaxAmount,
+      isMaxAmount,
+      setIsMax,
+      setConfirmationMetric,
+    ],
   );
 
   const updatePendingAmountPercentage = useCallback(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Implements the two requirements from MUSD-1095 for the MMPay / Money "Add funds" amount inputs:

1. **Thousand separators** — the amount input now renders with locale-aware thousand separators (e.g. `1,000`, `10,000`), matching the design. This is display-only: the underlying value passed to the keypad and to all downstream parsing/quoting is unchanged. Formatting reuses the existing `formatAmountWithLocaleSeparators` helper.
2. **Maximum purchase cap** — for fiat payment methods (Apple Pay, debit, credit), the keypad now hard-caps input at the provider's maximum purchase limit, so a user can no longer type an amount that exceeds it. The cap reuses the same limit source (`useRampsBuyLimits`) and gating as the existing "Amount out of range" alert, so the two always agree.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added thousand separators to MMPay amount inputs and prevented entering amounts above the maximum purchase limit for fiat payment methods.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1095

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MMPay amount input formatting and limits

  Scenario: amount is formatted with thousand separators
    Given I am on the MMPay "Add funds" amount screen
    When I type "1000" on the keypad
    Then the input shows "$1,000"

  Scenario: input is capped at the maximum purchase for a fiat payment method
    Given I am on the MMPay "Add funds" amount screen
    And I have selected a fiat payment method with a $3,000.00 maximum purchase
    When I try to enter an amount greater than $3,000
    Then the input does not accept digits that would exceed $3,000.00
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/1055f316-a81e-4c9f-b655-9a16988e5f21


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment amount input validation and display in the MMPay confirmation flow; incorrect cap or formatting could block valid amounts or mislead users, but scope is UI/input-layer with existing limit hooks.
> 
> **Overview**
> MMPay **Add funds** amount UX now shows **locale thousand separators** in the confirmation amount field and **blocks keypad input** above the fiat payment provider’s max purchase limit.
> 
> **`CustomAmount`** formats the displayed fiat string via `formatAmountWithLocaleSeparators` while keeping the raw `amountFiat` value for logic; layout sizing uses the formatted string length.
> 
> **`useTransactionCustomAmount`** rejects manual keypad updates when the amount would exceed `useRampsBuyLimits`’ `maxAmount`, using the same gating as `useFiatBuyLimitAlert` (`useMMPayFiatConfig`, selected fiat payment method). Tests cover separator rendering and cap behavior (at max, over max, no fiat method, no max).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b376358b87f0336c324768f524a5c9d778862a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->