### PR TITLE
refactor: add support for version-gated feature flags for activity redesign feature flags

### DIFF
--- a/app/selectors/featureFlagController/activityRedesign/index.test.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.test.ts
@@ -1,0 +1,116 @@
+import {
+  ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME,
+  ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME,
+  selectIsActivityRedesignEnabled,
+  selectIsTransactionsRedesignEnabled,
+} from './index';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(() => '7.60.0'),
+}));
+
+describe('activityRedesign selectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('selectIsActivityRedesignEnabled', () => {
+    it('supports the existing boolean list-items flag', () => {
+      const result = selectIsActivityRedesignEnabled.resultFunc({
+        [ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME]: true,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('supports a version-gated list-items flag', () => {
+      const result = selectIsActivityRedesignEnabled.resultFunc({
+        [ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '7.60.0',
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('supports a rollout-wrapped version-gated list-items flag', () => {
+      const result = selectIsActivityRedesignEnabled.resultFunc({
+        [ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME]: {
+          name: 'TMCU-854',
+          value: {
+            enabled: true,
+            minimumVersion: '7.60.0',
+          },
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the list-items version requirement fails', () => {
+      const result = selectIsActivityRedesignEnabled.resultFunc({
+        [ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectIsTransactionsRedesignEnabled', () => {
+    it('supports the existing boolean details-pages flag', () => {
+      const result = selectIsTransactionsRedesignEnabled.resultFunc(true, {
+        [ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME]: true,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('supports a version-gated details-pages flag', () => {
+      const result = selectIsTransactionsRedesignEnabled.resultFunc(true, {
+        [ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '7.60.0',
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('supports a rollout-wrapped version-gated details-pages flag', () => {
+      const result = selectIsTransactionsRedesignEnabled.resultFunc(true, {
+        [ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME]: {
+          name: 'TMCU-864',
+          value: {
+            enabled: true,
+            minimumVersion: '7.60.0',
+          },
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when list-items redesign is disabled', () => {
+      const result = selectIsTransactionsRedesignEnabled.resultFunc(false, {
+        [ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME]: true,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the details-pages version requirement fails', () => {
+      const result = selectIsTransactionsRedesignEnabled.resultFunc(true, {
+        [ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME]: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/selectors/featureFlagController/activityRedesign/index.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.ts
@@ -1,10 +1,21 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
+
+export const ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME =
+  'tmcuActivityRedesignEnabled';
+export const ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME =
+  'tmcuTransactionsRedesignEnabled';
+
+const isActivityRedesignFlagEnabled = (remoteFlag: unknown): boolean =>
+  validatedVersionGatedFeatureFlag(remoteFlag) ?? remoteFlag === true;
 
 export const selectIsActivityRedesignEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean =>
-    remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
+    isActivityRedesignFlagEnabled(
+      remoteFeatureFlags[ACTIVITY_REDESIGN_LIST_ITEMS_FLAG_NAME],
+    ),
 );
 
 export const selectIsTransactionsRedesignEnabled = createSelector(
@@ -12,5 +23,7 @@ export const selectIsTransactionsRedesignEnabled = createSelector(
   selectRemoteFeatureFlags,
   (isActivityRedesignEnabled, remoteFeatureFlags): boolean =>
     isActivityRedesignEnabled &&
-    remoteFeatureFlags.tmcuTransactionsRedesignEnabled === true,
+    isActivityRedesignFlagEnabled(
+      remoteFeatureFlags[ACTIVITY_REDESIGN_DETAILS_PAGES_FLAG_NAME],
+    ),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity redesign flags only accepted raw boolean values, so list item and details page rollouts could not be gated by app version.

This change aligns those selectors with the standard version-gated feature flag helper while preserving existing boolean flag behavior. It adds coverage for boolean, direct version-gated, and rollout-wrapped flag shapes for TMCU-854 list items and TMCU-864 details pages.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible feature-flag parsing only; no auth, data, or payment paths touched.
> 
> **Overview**
> Activity list-item and transaction details redesign toggles now go through the shared **`validatedVersionGatedFeatureFlag`** helper instead of requiring a raw `true`, so remote config can use **`enabled` + `minimumVersion`** (including rollout-wrapped shapes) while legacy boolean flags still work via **`?? remoteFlag === true`**.
> 
> **`selectIsTransactionsRedesignEnabled`** still requires list-items redesign to be on first; new tests cover boolean, version-gated, rollout-wrapped, and failure cases for both flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3921bcbb6251f49fff7cce0e7e7b9f32a8acdbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->