### PR TITLE
fix(ramps): refresh countries catalog on startup (TRAM-3682)

### DIFF
--- a/app/core/Engine/controllers/ramps-controller/__snapshots__/prepareRampsControllerStartupState.test.ts.snap
+++ b/app/core/Engine/controllers/ramps-controller/__snapshots__/prepareRampsControllerStartupState.test.ts.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prepareRampsControllerStartupState discards persisted countries while keeping other persisted fields 1`] = `
+{
+  "countries": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "nativeProviders": {
+    "transak": {
+      "buyQuote": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "isAuthenticated": false,
+      "kycRequirement": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "userDetails": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+    },
+  },
+  "orders": [],
+  "paymentMethods": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "providerAutoSelected": false,
+  "providers": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "requests": {},
+  "tokens": {
+    "data": null,
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "userRegion": {
+    "country": {
+      "currency": "USD",
+      "defaultAmount": 100,
+      "flag": "🇺🇸",
+      "id": "/regions/us",
+      "isoCode": "US",
+      "name": "United States",
+      "phone": {
+        "placeholder": "201 555 0123",
+        "prefix": "+1",
+        "template": "XXX XXX XXXX",
+      },
+      "quickAmounts": [
+        100,
+        250,
+        500,
+      ],
+      "supported": {
+        "buy": true,
+        "sell": true,
+      },
+    },
+    "regionCode": "us",
+    "state": null,
+  },
+}
+`;
+
+exports[`prepareRampsControllerStartupState matches snapshot when no persisted state is provided 1`] = `
+{
+  "countries": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "nativeProviders": {
+    "transak": {
+      "buyQuote": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "isAuthenticated": false,
+      "kycRequirement": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "userDetails": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+    },
+  },
+  "orders": [],
+  "paymentMethods": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "providerAutoSelected": false,
+  "providers": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "requests": {},
+  "tokens": {
+    "data": null,
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "userRegion": null,
+}
+`;

--- a/app/core/Engine/controllers/ramps-controller/__snapshots__/ramps-controller-init.test.ts.snap
+++ b/app/core/Engine/controllers/ramps-controller/__snapshots__/ramps-controller-init.test.ts.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ramps controller init uses initial state when initial state is passed in 1`] = `
+{
+  "countries": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "nativeProviders": {
+    "transak": {
+      "buyQuote": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "isAuthenticated": false,
+      "kycRequirement": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+      "userDetails": {
+        "data": null,
+        "error": null,
+        "isLoading": false,
+        "selected": null,
+      },
+    },
+  },
+  "orders": [],
+  "paymentMethods": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "providerAutoSelected": false,
+  "providers": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "requests": {},
+  "tokens": {
+    "data": null,
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "userRegion": {
+    "country": {
+      "currency": "",
+      "flag": "🏳️",
+      "isoCode": "US",
+      "name": "US",
+      "phone": {
+        "placeholder": "",
+        "prefix": "",
+        "template": "",
+      },
+      "supported": {
+        "buy": true,
+        "sell": true,
+      },
+    },
+    "regionCode": "us-ca",
+    "state": {
+      "name": "CA",
+      "stateId": "CA",
+      "supported": {
+        "buy": true,
+        "sell": true,
+      },
+    },
+  },
+}
+`;

--- a/app/core/Engine/controllers/ramps-controller/prepareRampsControllerStartupState.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/prepareRampsControllerStartupState.test.ts
@@ -1,0 +1,56 @@
+import {
+  getDefaultRampsControllerState,
+  type Country,
+  type RampsControllerState,
+  type UserRegion,
+} from '@metamask/ramps-controller';
+import { prepareRampsControllerStartupState } from './prepareRampsControllerStartupState';
+
+const createMockCountry = (): Country => ({
+  isoCode: 'US',
+  id: '/regions/us',
+  flag: '🇺🇸',
+  name: 'United States',
+  phone: {
+    prefix: '+1',
+    placeholder: '201 555 0123',
+    template: 'XXX XXX XXXX',
+  },
+  currency: 'USD',
+  supported: { buy: true, sell: true },
+  defaultAmount: 100,
+  quickAmounts: [100, 250, 500],
+});
+
+const createMockUserRegion = (): UserRegion => ({
+  country: createMockCountry(),
+  state: null,
+  regionCode: 'us',
+});
+
+const createPersistedState = (): RampsControllerState => {
+  const defaultState = getDefaultRampsControllerState();
+
+  return {
+    ...defaultState,
+    userRegion: createMockUserRegion(),
+    countries: {
+      data: [createMockCountry()],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+  };
+};
+
+describe('prepareRampsControllerStartupState', () => {
+  it('matches snapshot when no persisted state is provided', () => {
+    expect(prepareRampsControllerStartupState(undefined)).toMatchSnapshot();
+  });
+
+  it('discards persisted countries while keeping other persisted fields', () => {
+    const persistedState = createPersistedState();
+
+    expect(prepareRampsControllerStartupState(persistedState)).toMatchSnapshot();
+  });
+});

--- a/app/core/Engine/controllers/ramps-controller/prepareRampsControllerStartupState.ts
+++ b/app/core/Engine/controllers/ramps-controller/prepareRampsControllerStartupState.ts
@@ -1,0 +1,22 @@
+import {
+  getDefaultRampsControllerState,
+  type RampsControllerState,
+} from '@metamask/ramps-controller';
+
+/**
+ * Prepare persisted RampsController state for startup.
+ *
+ * Until mobile picks up MetaMask/core#9261, discard any persisted countries
+ * catalog so init() refetches fresh preset amounts instead of reusing stale
+ * values across app restarts.
+ */
+export function prepareRampsControllerStartupState(
+  persistedState: RampsControllerState | undefined,
+): RampsControllerState {
+  const state = persistedState ?? getDefaultRampsControllerState();
+
+  return {
+    ...state,
+    countries: getDefaultRampsControllerState().countries,
+  };
+}

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
@@ -131,7 +131,23 @@ describe('ramps controller init', () => {
       ...defaultState,
       userRegion: createMockUserRegion('us-ca'),
       countries: {
-        data: [],
+        data: [
+          {
+            isoCode: 'US',
+            id: '/regions/us',
+            flag: '🇺🇸',
+            name: 'United States',
+            phone: {
+              prefix: '+1',
+              placeholder: '201 555 0123',
+              template: 'XXX XXX XXXX',
+            },
+            currency: 'USD',
+            supported: { buy: true, sell: true },
+            defaultAmount: 100,
+            quickAmounts: [100, 250, 500],
+          },
+        ],
         selected: null,
         isLoading: false,
         error: null,
@@ -192,14 +208,15 @@ describe('ramps controller init', () => {
     const rampsControllerState =
       rampsControllerClassMock.mock.calls[0][0].state;
 
-    expect(rampsControllerState).toStrictEqual(initialRampsControllerState);
+    expect(rampsControllerState).toMatchSnapshot();
   });
 
-  it('calls init at startup', async () => {
+  it('calls init with forceRefresh at startup', async () => {
     rampsControllerInit(initRequestMock);
 
     await waitFor(() => {
       expect(mockInit).toHaveBeenCalledTimes(1);
+      expect(mockInit).toHaveBeenCalledWith({ forceRefresh: true });
     });
   });
 

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -2,11 +2,11 @@ import type { MessengerClientInitFunction } from '../../types';
 import {
   RampsController,
   RampsControllerMessenger,
-  getDefaultRampsControllerState,
 } from '@metamask/ramps-controller';
 import type { RampsControllerInitMessenger } from '../../messengers/ramps-controller-messenger';
 import { handleOrderStatusChangedForNotifications } from './event-handlers/notification';
 import { handleOrderStatusChangedForMetrics } from './event-handlers/analytics';
+import { prepareRampsControllerStartupState } from './prepareRampsControllerStartupState';
 
 /**
  * Opt-in for the Ramps WebSocket debug dashboard (`RAMPS_DEBUG_DASHBOARD=true` in `.js.env`).
@@ -30,8 +30,9 @@ export const rampsControllerInit: MessengerClientInitFunction<
   RampsControllerMessenger,
   RampsControllerInitMessenger
 > = ({ controllerMessenger, persistedState, initMessenger }) => {
-  const rampsControllerState =
-    persistedState.RampsController ?? getDefaultRampsControllerState();
+  const rampsControllerState = prepareRampsControllerStartupState(
+    persistedState.RampsController,
+  );
 
   const controller = new RampsController({
     messenger: controllerMessenger,
@@ -58,7 +59,7 @@ export const rampsControllerInit: MessengerClientInitFunction<
   const startRampsController = (): void => {
     registerOrderSubscriptions();
     controller
-      .init()
+      .init({ forceRefresh: true })
       .then(() => {
         controller.startOrderPolling();
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes stale preset amounts (e.g. $100 / $250 / $500) after app restarts by ensuring the Ramps countries catalog is refetched on startup instead of reusing persisted data.

This mirrors the controller-only fix in [MetaMask/core#9261](https://github.com/MetaMask/core/pull/9261) until mobile can bump `@metamask/ramps-controller` to a release that includes it.

**What changed:**
- `prepareRampsControllerStartupState` discards any persisted `countries` catalog before `RampsController` is constructed.
- `ramps-controller-init` calls `init({ forceRefresh: true })` so startup always refetches countries and re-applies `userRegion` from the fresh catalog.

**Follow-up:** Once `@metamask/ramps-controller` ships with core#9261, remove the mobile workaround and bump the dependency instead.

## Related issues

- [TRAM-3682](https://consensyssoftware.atlassian.net/browse/TRAM-3682)
- Depends on / pairs with [MetaMask/core#9261](https://github.com/MetaMask/core/pull/9261)

## Manual testing steps

```gherkin
Feature: Ramps countries catalog refresh on startup

  Scenario: preset amounts update after restart
    Given I have a persisted Ramps region with stale quick amounts
    When I cold-start the app and open the Ramps buy flow
    Then preset amounts match the latest countries API values without changing region
```

## Tests

- `yarn jest app/core/Engine/controllers/ramps-controller/prepareRampsControllerStartupState.test.ts`
- `yarn jest app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42a26b22-62e4-4706-a388-6ed057f310c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42a26b22-62e4-4706-a388-6ed057f310c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TRAM-3682]: https://consensyssoftware.atlassian.net/browse/TRAM-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ