### PR TITLE
chore: use mid price for live data moneyline

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
@@ -38,7 +38,7 @@ import { isDrawCapableLeague } from '../../constants/sports';
 import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/featureFlags';
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
-import { isValidPrice } from '../../utils/prices';
+import { getLiveMidPrice, isValidPrice } from '../../utils/prices';
 import FeaturedCarouselCardFooter from './FeaturedCarouselCardFooter';
 import FeaturedCarouselPayoutRow from './FeaturedCarouselPayoutRow';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
@@ -144,8 +144,8 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
         return token.price;
       }
 
-      const liveBestAsk = getPrice(token.id)?.bestAsk;
-      return isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
+      const liveMidPrice = getLiveMidPrice(getPrice(token.id));
+      return isValidPrice(liveMidPrice) ? liveMidPrice : token.price;
     },
     [getPrice, livePricesEnabled],
   );

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -23,6 +23,8 @@ import {
   GameChartSeriesConfig,
 } from './PredictGameChart.types';
 
+import { getLiveMidPrice } from '../../utils/prices';
+
 const TIMEFRAME_TO_INTERVAL: Record<
   Exclude<ChartTimeframe, 'live'>,
   PredictPriceHistoryInterval
@@ -229,8 +231,9 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
         const existingData = [...series.data];
         const lastPoint = existingData[existingData.length - 1];
 
-        const newValue = priceUpdate
-          ? Number((priceUpdate.bestAsk * 100).toFixed(2))
+        const liveMidPrice = getLiveMidPrice(priceUpdate);
+        const newValue = liveMidPrice
+          ? Number((liveMidPrice * 100).toFixed(2))
           : (lastPoint?.value ?? 50);
 
         const newPoint: GameChartDataPoint = {

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/utils.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/utils.ts
@@ -7,7 +7,7 @@ import type {
 import type { PredictBetButtonVariant } from '../PredictActionButtons/PredictActionButtons.types';
 import type { PredictSportOutcomeButton } from '../PredictSportOutcomeCard';
 import { formatVolume } from '../../utils/format';
-import { isValidPrice } from '../../utils/prices';
+import { getLiveMidPrice, isValidPrice } from '../../utils/prices';
 import { isMoneylineLikeMarketType } from '../../constants/sports';
 import { strings } from '../../../../../../locales/i18n';
 import Logger from '../../../../../util/Logger';
@@ -307,8 +307,8 @@ export const buildMoneylineButtons = (
   const buttonEntries = getMoneylineButtonEntries(outcomes, game);
 
   return buttonEntries.map(({ outcome, token }, i) => {
-    const liveBestAsk = getPrice?.(token.id)?.bestAsk;
-    const price = isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
+    const liveMidPrice = getLiveMidPrice(getPrice?.(token.id));
+    const price = isValidPrice(liveMidPrice) ? liveMidPrice : token.price;
 
     return {
       label: token.shortTitle ?? token.title,

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -44,7 +44,7 @@ import {
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import PredictSportScoreboard from '../PredictSportScoreboard';
 import { isGameEnded } from '../../utils/scoreboard';
-import { isValidPrice } from '../../utils/prices';
+import { getLiveMidPrice, isValidPrice } from '../../utils/prices';
 import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/featureFlags';
 
 interface PredictMarketSportCardProps {
@@ -314,8 +314,8 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
         return token.price;
       }
 
-      const liveBestAsk = getPrice(token.id)?.bestAsk;
-      return isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
+      const liveMidPrice = getLiveMidPrice(getPrice(token.id));
+      return isValidPrice(liveMidPrice) ? liveMidPrice : token.price;
     },
     [getPrice, livePricesEnabled],
   );

--- a/app/components/UI/Predict/utils/prices.ts
+++ b/app/components/UI/Predict/utils/prices.ts
@@ -8,6 +8,23 @@ export const isValidPrice = (price: number | undefined): price is number =>
   typeof price === 'number' && Number.isFinite(price) && price > 0;
 
 /**
+ * Live odds-oriented price from a WS tick.
+ *
+ * Prefer the mid-price (`(bid + ask) / 2`) to mirror implied probability shown
+ * in charts/odds labels. If one side is temporarily missing, fall back to the
+ * trade price field.
+ */
+export const getLiveMidPrice = (
+  livePrice: PriceUpdate | undefined,
+): number | undefined => {
+  if (isValidPrice(livePrice?.bestBid) && isValidPrice(livePrice?.bestAsk)) {
+    return (livePrice.bestBid + livePrice.bestAsk) / 2;
+  }
+
+  return isValidPrice(livePrice?.price) ? livePrice.price : undefined;
+};
+
+/**
  * Price to display on a BUY CTA from an already-priced token: the best ask
  * (`buyPrice`) when present, otherwise the token's mid `price`. Use this for
  * any "what you pay to buy" label so it never falls back to the odds mid on a


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix Wimbledon live odds mismatch between chart and moneyline display.

On live tennis markets (notably Wimbledon), the app was using bestAsk for chart ticks and moneyline button prices. This made the UI look stale/off compared to Polymarket web, where displayed odds track implied probability (mid-price behavior), not pure execution ask. In wide-spread or thin books, bestAsk can stay sticky while bids/trades move, causing visible divergence.

This change introduces a shared live odds helper (getLiveMidPrice) that prefers (bestBid + bestAsk) / 2 and falls back to trade price when one side is missing. We now use it in:

PredictGameChart live updates
Game details moneyline buttons
Feed/featured sport card moneyline display
Result: chart + moneyline odds now update in a way that matches Polymarket’s live odds view more closely, especially on Wimbledon matches.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
