### PR TITLE
feat: `BannerDismiss` event

### DIFF
--- a/app/components/UI/Carousel/index.test.tsx
+++ b/app/components/UI/Carousel/index.test.tsx
@@ -424,6 +424,38 @@ describe('Carousel Slide Dismissal', () => {
     expect(closeButton).toBeOnTheScreen();
   });
 
+  it('tracks Banner Dismissed with the slide name when a slide is closed', async () => {
+    const mockTrackEvent = mockAnalyticsTracking();
+    const dismissibleSlide = createMockSlide({
+      id: 'contentful-dismissible',
+      variableName: 'dismissible',
+    });
+    mockFetchCarouselSlides.mockResolvedValue({
+      prioritySlides: [],
+      regularSlides: [dismissibleSlide],
+    });
+
+    const { findByTestId } = render(<Carousel />);
+
+    const closeButton = await findByTestId(
+      'carousel-slide-contentful-dismissible-close-button',
+    );
+    fireEvent.press(closeButton);
+
+    await waitFor(() => {
+      const dismissEvents = mockTrackEvent.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.name === 'Banner Dismissed');
+
+      expect(dismissEvents).toEqual([
+        expect.objectContaining<Partial<AnalyticsTrackingEvent>>({
+          name: 'Banner Dismissed',
+          properties: { name: 'dismissible' },
+        }),
+      ]);
+    });
+  });
+
   it('shows close button for all slides in new implementation', async () => {
     const testSlide = createMockSlide({
       id: 'test-slide',

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -42,7 +42,10 @@ import { selectContentfulCarouselEnabledFlag } from './selectors/featureFlags';
 import { createBuyNavigationDetails } from '../Ramp/Aggregator/routes/utils';
 import Routes from '../../../constants/navigation/Routes';
 import { subscribeToContentPreviewToken } from '../../../actions/notification/helpers';
-import { BANNER_EVENT_DISPLAY } from '../../../constants/engagement';
+import {
+  BANNER_EVENT_DISPLAY,
+  BANNER_EVENT_DISMISSED,
+} from '../../../constants/engagement';
 import SharedDeeplinkManager from '../../../core/DeeplinkManager/DeeplinkManager';
 import { isInternalDeepLink } from '../../../core/DeeplinkManager/util/deeplinks';
 import AppConstants from '../../../core/AppConstants';
@@ -479,6 +482,23 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
         // After animation, dismiss banner immediately so Redux knows it's gone
         dispatch(dismissBanner(slideId));
 
+        // Track the dismissal so the analytics funnel shows a "Banner Dismissed"
+        // event between two consecutive "Banner Display" events.
+        const dismissedSlide = visibleSlides.find(
+          (slide) => slide.id === slideId,
+        );
+        trackEvent(
+          createEventBuilder({
+            category: BANNER_EVENT_DISMISSED,
+          })
+            .addProperties({
+              name: dismissedSlide
+                ? getSlideAnalyticsName(dismissedSlide)
+                : slideId,
+            })
+            .build(),
+        );
+
         // Set up animations based on what's next
         requestAnimationFrame(() => {
           if (isNextCardEmpty) {
@@ -519,8 +539,10 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
     [
       transitionToNextCard,
       dispatch,
+      trackEvent,
+      createEventBuilder,
       safeActiveSlideIndex,
-      visibleSlides.length,
+      visibleSlides,
       nextSlide,
       currentCardOpacity,
       currentCardScale,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Added `Banner Dismissed` event when you close a banner.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added `Banner Dismissed` event

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-317

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: banner dismiss event

  Scenario: user presses close banner button
    Given user opened app

    When user taps "close button"
    Then Segment/MixPanel SDK should send corresponding event
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1202" height="266" alt="image" src="https://github.com/user-attachments/assets/c96a9718-d88e-431b-9add-4e618950bd4f" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change on the wallet carousel UI; no auth, payments, or persistence logic changes beyond existing dismiss flow.
> 
> **Overview**
> **Carousel banner dismissals now emit analytics** so funnels can show a **Banner Dismissed** step between successive **Banner Display** events.
> 
> When a user closes a slide (after the dismiss transition), the carousel fires **`Banner Dismissed`** via the existing analytics builder, with **`name`** set the same way as display/select (`variableName` when present, otherwise slide id). Redux `dismissBanner` behavior is unchanged; this is additive tracking only.
> 
> A unit test asserts that pressing the close button produces exactly one **Banner Dismissed** event with the expected `name` property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110399ccb8323fc21866b0205513bd92f5183096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->