### PR TITLE
chore: bigger machine ota update

### DIFF
--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   push-update:
     name: Push EAS Update (${{ inputs.platform }})
-    runs-on: ubuntu-latest
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
     environment: ${{ inputs.github_environment }}
     env:
       # OTA-specific vars only — build config + secrets come from builds.yml via steps below
@@ -165,7 +165,27 @@ jobs:
         env:
           SKIP_TRANSFORM_LINT: 'true'
           NODE_OPTIONS: '--max_old_space_size=8192'
+          # Verbose Expo/EAS logging so a stalled asset upload shows where it hangs.
+          EXPO_DEBUG: '1'
         run: |
+          # --- Resource monitor ---------------------------------------------------
+          # GitHub-hosted runners expose no live machine metrics, so log memory,
+          # CPU load and disk every 15s. This makes CPU/Memory starvation visible
+          # during the EAS publish (the phase where the runner lost communication).
+          monitor_resources() {
+            while true; do
+              mem=$(free -m 2>/dev/null | awk '/Mem:/{printf "mem=%sMB/%sMB", $3, $2}')
+              load=$(cut -d' ' -f1-3 /proc/loadavg 2>/dev/null)
+              disk=$(df -h / 2>/dev/null | awk 'NR==2{print $4" free"}')
+              echo "🩺 [resmon $(date -u +%H:%M:%S)] ${mem} load=${load} disk=${disk}"
+              sleep 15
+            done
+          }
+          monitor_resources &
+          MONITOR_PID=$!
+          # Always stop the monitor when the step exits, however it exits.
+          trap 'kill "${MONITOR_PID}" 2>/dev/null || true' EXIT
+
           echo "📦 Configuring EXPO key..."
           if [[ -z "$EXPO_KEY_PRIV_B64" ]]; then
             echo "⚠️ EXPO_KEY_PRIV_B64 is not set. Skipping keystore decoding."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with no app runtime or secret-handling logic changes; runner label is already allowlisted and used elsewhere.
> 
> **Overview**
> **EAS Update Platform** jobs now run on the Cirrus **`ubuntu-runner-amd64:24.04-lg`** image instead of `ubuntu-latest`, matching other heavy CI workflows and giving more CPU/RAM for publish/asset upload.
> 
> The **Build & Push EAS Update** step adds **`EXPO_DEBUG=1`** for verbose Expo/EAS logs when uploads stall, plus a background **resource monitor** that logs memory, load average, and disk every 15s (with an `EXIT` trap to stop it) so runner starvation is visible when the job loses communication during publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb7864111a5ad99cf2ebce9d6972e06a3c6bb49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->