### PR TITLE
chore(predict): add reg time tag across all applicable world cup markets cp-8.0.2

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -130,7 +130,7 @@ jest.mock('../PredictGameChart', () => {
 });
 
 jest.mock('./PredictGameDetailsTabsContent', () => {
-  const { View } = jest.requireActual('react-native');
+  const { Pressable, Text, View } = jest.requireActual('react-native');
   const { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS: IDS } = jest.requireActual(
     './PredictGameDetailsContent.testIds',
   );
@@ -138,8 +138,10 @@ jest.mock('./PredictGameDetailsTabsContent', () => {
     __esModule: true,
     default: function MockPredictGameDetailsTabsContent({
       market,
+      onRegTimeInfoPress,
     }: {
       market?: { id: string };
+      onRegTimeInfoPress?: () => void;
     }) {
       return (
         <View testID="mock-game-details-tabs-content">
@@ -147,6 +149,12 @@ jest.mock('./PredictGameDetailsTabsContent', () => {
             testID={IDS.GAME_PICK}
             accessibilityHint={`marketId:${market?.id ?? 'undefined'}`}
           />
+          <Pressable
+            testID="mock-reg-time-info-button"
+            onPress={onRegTimeInfoPress}
+          >
+            <Text>Reg Time Info</Text>
+          </Pressable>
         </View>
       );
     },
@@ -171,10 +179,9 @@ jest.mock('../PredictPicks/PredictPicks', () => {
   };
 });
 
-const mockGetRefHandlers = jest.fn(() => ({
-  onOpenBottomSheet: jest.fn(),
-  onCloseBottomSheet: jest.fn(),
-}));
+const mockAboutSheetOpen = jest.fn();
+const mockRegTimeSheetOpen = jest.fn();
+const mockGetRefHandlers = jest.fn();
 
 jest.mock('../../hooks/usePredictBottomSheet', () => ({
   usePredictBottomSheet: () => ({
@@ -300,6 +307,16 @@ describe('PredictGameDetailsContent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetRefHandlers.mockReset();
+    mockGetRefHandlers
+      .mockReturnValueOnce({
+        onOpenBottomSheet: mockAboutSheetOpen,
+        onCloseBottomSheet: jest.fn(),
+      })
+      .mockReturnValueOnce({
+        onOpenBottomSheet: mockRegTimeSheetOpen,
+        onCloseBottomSheet: jest.fn(),
+      });
     mockUsePredictGame.mockImplementation((market) => ({
       game: market?.game,
       isConnected: false,
@@ -470,6 +487,25 @@ describe('PredictGameDetailsContent', () => {
       const infoButton = getByTestId('mock-info-button');
 
       expect(infoButton).toBeOnTheScreen();
+    });
+
+    it('opens the root Reg Time sheet from the outcomes content trigger', () => {
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      fireEvent.press(getByTestId('mock-reg-time-info-button'));
+
+      expect(mockRegTimeSheetOpen).toHaveBeenCalledTimes(1);
+      expect(mockAboutSheetOpen).not.toHaveBeenCalled();
     });
 
     it('hides the prediction footer when extended sports markets are enabled', () => {

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -29,6 +29,7 @@ import PredictShareButton from '../PredictShareButton/PredictShareButton';
 import PredictSportScoreboard from '../PredictSportScoreboard';
 import PredictMarketDetailsTabBar from '../../views/PredictMarketDetails/components/PredictMarketDetailsTabBar';
 import PredictGameDetailsTabsContent from './PredictGameDetailsTabsContent';
+import PredictRegTimeInfoSheet from './PredictRegTimeInfoSheet';
 import { useGameDetailsTabs } from '../../hooks/useGameDetailsTabs';
 import { usePredictGame } from '../../hooks/usePredictGame';
 import { PredictGameDetailsContentProps } from './PredictGameDetailsContent.types';
@@ -50,6 +51,7 @@ const PredictGameDetailsContentComponent: React.FC<
   claimableAmount = 0,
   isLoading = false,
   isClaimPending = false,
+  nonRegTimeSportsMarketTypes = [],
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
@@ -57,13 +59,26 @@ const PredictGameDetailsContentComponent: React.FC<
 
   const { sheetRef, isVisible, handleSheetClosed, getRefHandlers } =
     usePredictBottomSheet();
+  const {
+    sheetRef: regTimeSheetRef,
+    isVisible: isRegTimeSheetVisible,
+    handleSheetClosed: handleRegTimeSheetClosed,
+    getRefHandlers: getRegTimeRefHandlers,
+  } = usePredictBottomSheet();
 
   const sheetHandlers = useMemo(() => getRefHandlers(), [getRefHandlers]);
+  const regTimeSheetHandlers = useMemo(
+    () => getRegTimeRefHandlers(),
+    [getRegTimeRefHandlers],
+  );
   const { game } = usePredictGame(market, { live: true });
 
   const handleInfoPress = useCallback(() => {
     sheetHandlers.onOpenBottomSheet();
   }, [sheetHandlers]);
+  const handleRegTimeInfoPress = useCallback(() => {
+    regTimeSheetHandlers.onOpenBottomSheet();
+  }, [regTimeSheetHandlers]);
 
   const outcome = useMemo(() => market.outcomes[0], [market.outcomes]);
 
@@ -212,6 +227,8 @@ const PredictGameDetailsContentComponent: React.FC<
           resolvedOutcomeGroups={resolvedGroups}
           activeChipKey={activeChipKey}
           onBetPress={onBetPress}
+          nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+          onRegTimeInfoPress={handleRegTimeInfoPress}
         />
       </ScrollView>
 
@@ -233,6 +250,12 @@ const PredictGameDetailsContentComponent: React.FC<
           ref={sheetRef}
           description={market.description ?? ''}
           onClose={handleSheetClosed}
+        />
+      )}
+      {isRegTimeSheetVisible && (
+        <PredictRegTimeInfoSheet
+          ref={regTimeSheetRef}
+          onClose={handleRegTimeSheetClosed}
         />
       )}
     </SafeAreaView>

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.types.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.types.ts
@@ -10,4 +10,5 @@ export interface PredictGameDetailsContentProps {
   claimableAmount?: number;
   isLoading?: boolean;
   isClaimPending?: boolean;
+  nonRegTimeSportsMarketTypes?: string[];
 }

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsTabsContent.tsx
@@ -26,6 +26,8 @@ interface PredictGameDetailsTabsContentProps {
   resolvedOutcomeGroups?: PredictOutcomeGroup[];
   activeChipKey: string;
   onBetPress: (token: PredictOutcomeToken) => void;
+  nonRegTimeSportsMarketTypes?: string[];
+  onRegTimeInfoPress?: () => void;
 }
 
 const PredictGameDetailsTabsContent = memo(
@@ -41,6 +43,8 @@ const PredictGameDetailsTabsContent = memo(
     resolvedOutcomeGroups = [],
     activeChipKey,
     onBetPress,
+    nonRegTimeSportsMarketTypes = [],
+    onRegTimeInfoPress,
   }: PredictGameDetailsTabsContentProps) => {
     const { game } = usePredictGame(market, { live: false });
     const handleBuyPress = useCallback(
@@ -99,6 +103,8 @@ const PredictGameDetailsTabsContent = memo(
           game={game}
           activeChipKey={activeChipKey}
           onBuyPress={handleBuyPress}
+          nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+          onRegTimeInfoPress={onRegTimeInfoPress}
         />
       );
     }
@@ -127,6 +133,8 @@ const PredictGameDetailsTabsContent = memo(
             game={game}
             activeChipKey={activeChipKey}
             onBuyPress={handleBuyPress}
+            nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+            onRegTimeInfoPress={onRegTimeInfoPress}
           />
         )}
       </>

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCards.tsx
@@ -17,6 +17,22 @@ import {
   getTranslatedSportsMarketTypeLabel,
 } from './utils';
 
+const shouldShowRegTimeTag = (
+  showRegTimeTag: boolean,
+  sportsMarketType: string | undefined,
+  nonRegTimeSportsMarketTypes: string[],
+): boolean => {
+  if (!showRegTimeTag) {
+    return false;
+  }
+
+  if (!sportsMarketType) {
+    return true;
+  }
+
+  return !nonRegTimeSportsMarketTypes.includes(sportsMarketType.toLowerCase());
+};
+
 const SimpleOutcomeCard = memo(
   ({
     outcome,
@@ -24,6 +40,9 @@ const SimpleOutcomeCard = memo(
     onBuyPress,
     game,
     sportsMarketType,
+    showRegTimeTag,
+    nonRegTimeSportsMarketTypes,
+    onRegTimeInfoPress,
     testID,
   }: {
     outcome: PredictOutcomeGroup['outcomes'][number];
@@ -31,12 +50,21 @@ const SimpleOutcomeCard = memo(
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     sportsMarketType?: string;
+    showRegTimeTag: boolean;
+    nonRegTimeSportsMarketTypes: string[];
+    onRegTimeInfoPress?: () => void;
     testID: string;
   }) => (
     <PredictSportOutcomeCard
       title={title}
       subtitle={buildSubtitle(outcome)}
       buttons={buildButtons(outcome, onBuyPress, game, sportsMarketType)}
+      showRegTimeTag={shouldShowRegTimeTag(
+        showRegTimeTag,
+        sportsMarketType,
+        nonRegTimeSportsMarketTypes,
+      )}
+      onPressRegTimeInfo={onRegTimeInfoPress}
       testID={testID}
     />
   ),
@@ -51,6 +79,9 @@ const LineOutcomeCard = memo(
     onBuyPress,
     game,
     sportsMarketType,
+    showRegTimeTag,
+    nonRegTimeSportsMarketTypes,
+    onRegTimeInfoPress,
     testID,
   }: {
     outcomes: PredictOutcomeGroup['outcomes'];
@@ -58,6 +89,9 @@ const LineOutcomeCard = memo(
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     sportsMarketType?: string;
+    showRegTimeTag: boolean;
+    nonRegTimeSportsMarketTypes: string[];
+    onRegTimeInfoPress?: () => void;
     testID: string;
   }) => {
     const lineIndices = useMemo(
@@ -108,6 +142,12 @@ const LineOutcomeCard = memo(
           game,
           sportsMarketType,
         )}
+        showRegTimeTag={shouldShowRegTimeTag(
+          showRegTimeTag,
+          sportsMarketType,
+          nonRegTimeSportsMarketTypes,
+        )}
+        onPressRegTimeInfo={onRegTimeInfoPress}
         lines={lines}
         selectedLine={lines[selectedIdx]}
         selectedIndex={selectedIdx}
@@ -126,12 +166,20 @@ const MoneylineCard = memo(
     onBuyPress,
     game,
     title,
+    sportsMarketType,
+    showRegTimeTag,
+    nonRegTimeSportsMarketTypes,
+    onRegTimeInfoPress,
     testID,
   }: {
     outcomes: PredictOutcomeGroup['outcomes'];
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     title: string;
+    sportsMarketType?: string;
+    showRegTimeTag: boolean;
+    nonRegTimeSportsMarketTypes: string[];
+    onRegTimeInfoPress?: () => void;
     testID: string;
   }) => {
     const subtitle = useMemo(
@@ -157,6 +205,12 @@ const MoneylineCard = memo(
         subtitle={subtitle}
         buttons={buttons}
         buttonLayout="inlineNoSeparator"
+        showRegTimeTag={shouldShowRegTimeTag(
+          showRegTimeTag,
+          sportsMarketType,
+          nonRegTimeSportsMarketTypes,
+        )}
+        onPressRegTimeInfo={onRegTimeInfoPress}
         testID={testID}
       />
     );
@@ -172,12 +226,18 @@ const SubgroupCards = memo(
     game,
     groupKey,
     index,
+    showRegTimeTag,
+    nonRegTimeSportsMarketTypes,
+    onRegTimeInfoPress,
   }: {
     subgroup: PredictOutcomeGroup;
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
     groupKey: string;
     index: number;
+    showRegTimeTag: boolean;
+    nonRegTimeSportsMarketTypes: string[];
+    onRegTimeInfoPress?: () => void;
   }) => {
     const translatedTitle = subgroup.title
       ? undefined
@@ -205,6 +265,10 @@ const SubgroupCards = memo(
           onBuyPress={onBuyPress}
           game={game}
           title={title}
+          sportsMarketType={subgroup.key}
+          showRegTimeTag={showRegTimeTag}
+          nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+          onRegTimeInfoPress={onRegTimeInfoPress}
           testID={testID}
         />
       );
@@ -218,6 +282,9 @@ const SubgroupCards = memo(
           onBuyPress={onBuyPress}
           game={game}
           sportsMarketType={subgroup.key}
+          showRegTimeTag={showRegTimeTag}
+          nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+          onRegTimeInfoPress={onRegTimeInfoPress}
           testID={testID}
         />
       );
@@ -230,6 +297,9 @@ const SubgroupCards = memo(
         onBuyPress={onBuyPress}
         game={game}
         sportsMarketType={subgroup.key}
+        showRegTimeTag={showRegTimeTag}
+        nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+        onRegTimeInfoPress={onRegTimeInfoPress}
         testID={testID}
       />
     );
@@ -243,10 +313,16 @@ export const OutcomesContent = memo(
     group,
     onBuyPress,
     game,
+    showRegTimeTag = false,
+    nonRegTimeSportsMarketTypes = [],
+    onRegTimeInfoPress,
   }: {
     group: PredictOutcomeGroup;
     onBuyPress: BuyHandler;
     game?: PredictMarketGame;
+    showRegTimeTag?: boolean;
+    nonRegTimeSportsMarketTypes?: string[];
+    onRegTimeInfoPress?: () => void;
   }) => {
     if (group.subgroups && group.subgroups.length > 0) {
       return (
@@ -259,6 +335,9 @@ export const OutcomesContent = memo(
               game={game}
               groupKey={group.key}
               index={index}
+              showRegTimeTag={showRegTimeTag}
+              nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+              onRegTimeInfoPress={onRegTimeInfoPress}
             />
           ))}
         </>
@@ -277,6 +356,10 @@ export const OutcomesContent = memo(
             formatOutcomeCardTitle(group.outcomes[0]),
             game,
           )}
+          sportsMarketType={firstType}
+          showRegTimeTag={showRegTimeTag}
+          nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+          onRegTimeInfoPress={onRegTimeInfoPress}
           testID={`${group.key}-moneyline`}
         />
       );
@@ -292,6 +375,9 @@ export const OutcomesContent = memo(
             onBuyPress={onBuyPress}
             game={game}
             sportsMarketType={outcome.sportsMarketType}
+            showRegTimeTag={showRegTimeTag}
+            nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+            onRegTimeInfoPress={onRegTimeInfoPress}
             testID={`${group.key}-outcome-${index}`}
           />
         ))}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -42,7 +42,6 @@ jest.mock('../../../../../../locales/i18n', () => ({
         '1st Set Total Games',
       'predict.sports_market_types.tennis_first_set_winner': '1st Set Winner',
       'predict.sports_market_types.tennis_completed_match': 'Completed Match',
-      'predict.sports_market_types.soccer_team_to_advance': 'Team to Advance',
     };
     if (key.startsWith('predict.sports_market_types.basketball_')) {
       return translations[key] ?? `[missing "${key}" translation]`;

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -12,6 +12,14 @@ import type { PredictSportOutcomeButton } from '../PredictSportOutcomeCard';
 import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from './PredictGameDetailsContent.testIds';
 import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
 
+jest.mock('./PredictRegTimeInfoSheet', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: jest.fn(() => <View testID="predict-reg-time-info-sheet" />),
+  };
+});
+
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
@@ -34,6 +42,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
         '1st Set Total Games',
       'predict.sports_market_types.tennis_first_set_winner': '1st Set Winner',
       'predict.sports_market_types.tennis_completed_match': 'Completed Match',
+      'predict.sports_market_types.soccer_team_to_advance': 'Team to Advance',
     };
     if (key.startsWith('predict.sports_market_types.basketball_')) {
       return translations[key] ?? `[missing "${key}" translation]`;
@@ -95,6 +104,7 @@ interface CapturedCard {
   lines?: number[];
   selectedLine?: number;
   selectedIndex?: number;
+  showRegTimeTag?: boolean;
   testID?: string;
 }
 
@@ -108,6 +118,8 @@ interface MockCardProps {
   lines?: number[];
   selectedLine?: number;
   selectedIndex?: number;
+  showRegTimeTag?: boolean;
+  onPressRegTimeInfo?: () => void;
   onSelectLine?: (line: number, index: number) => void;
   testID?: string;
 }
@@ -129,12 +141,19 @@ jest.mock('../PredictSportOutcomeCard', () => {
       lines: props.lines,
       selectedLine: props.selectedLine,
       selectedIndex: props.selectedIndex,
+      showRegTimeTag: props.showRegTimeTag,
       testID: props.testID,
     });
     return (
       <View testID={props.testID}>
         <Text testID={`${props.testID}-title`}>{props.title}</Text>
         <Text testID={`${props.testID}-subtitle`}>{props.subtitle}</Text>
+        {props.showRegTimeTag ? (
+          <View
+            testID={`${props.testID}-reg-time-info`}
+            onTouchEnd={props.onPressRegTimeInfo}
+          />
+        ) : null}
         {props.buttons.map((button, index) => (
           <View
             key={`${button.label}-${index}`}
@@ -443,6 +462,98 @@ describe('PredictGameOutcomesTab', () => {
 
       expect(getByTestId('points-outcome-0')).toBeOnTheScreen();
       expect(getByTestId('points-outcome-1')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Reg Time tag', () => {
+    it('shows the Reg Time tag for regulation-time market types', () => {
+      const groups = [
+        createGroup({
+          key: 'game_lines',
+          outcomes: [createOutcome({ sportsMarketType: 'moneyline' })],
+        }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockWorldCupGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+          nonRegTimeSportsMarketTypes={['soccer_team_to_advance']}
+        />,
+      );
+
+      expect(mockCapturedCards[0].showRegTimeTag).toBe(true);
+    });
+
+    it('hides the Reg Time tag for non-World-Cup games', () => {
+      const groups = [
+        createGroup({
+          key: 'game_lines',
+          outcomes: [createOutcome({ sportsMarketType: 'moneyline' })],
+        }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+          nonRegTimeSportsMarketTypes={['soccer_team_to_advance']}
+        />,
+      );
+
+      expect(mockCapturedCards[0].showRegTimeTag).toBe(false);
+    });
+
+    it('hides the Reg Time tag for excluded full-tie market types', () => {
+      const groups = [
+        createGroup({
+          key: 'game_lines',
+          outcomes: [
+            createOutcome({ sportsMarketType: 'soccer_team_to_advance' }),
+          ],
+        }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockWorldCupGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+          nonRegTimeSportsMarketTypes={['soccer_team_to_advance']}
+        />,
+      );
+
+      expect(mockCapturedCards[0].showRegTimeTag).toBe(false);
+    });
+
+    it('calls onRegTimeInfoPress when the tag is pressed', () => {
+      const groups = [
+        createGroup({
+          key: 'game_lines',
+          outcomes: [createOutcome({ sportsMarketType: 'moneyline' })],
+        }),
+      ];
+      const mockOnRegTimeInfoPress = jest.fn();
+
+      const { getByTestId } = render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockWorldCupGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+          nonRegTimeSportsMarketTypes={['soccer_team_to_advance']}
+          onRegTimeInfoPress={mockOnRegTimeInfoPress}
+        />,
+      );
+
+      fireEvent(getByTestId('game_lines-moneyline-reg-time-info'), 'touchEnd');
+
+      expect(mockOnRegTimeInfoPress).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -13,15 +13,13 @@ import type {
 } from '../../types';
 import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from './PredictGameDetailsContent.testIds';
 import { OutcomesContent } from './PredictGameOutcomeCards';
+import { WORLD_CUP_LEAGUE } from '../../constants/sports';
 import PredictMarketOutcomeResolved from '../PredictMarketOutcomeResolved';
 import PredictResolvedOutcomesDropdown from '../PredictResolvedOutcomesDropdown';
 import { usePricedOutcomeGroup } from './usePricedOutcomeGroup';
 import { getOutcomeGroupLabel } from '../../utils/outcomeGroupLabel';
 import { countOutcomeGroupOutcomes } from '../../utils/outcomeGroups';
-import {
-  getSportsMarketTypeLabel,
-  getSportsMarketTypeLabelForGame,
-} from './utils';
+import { getSportsMarketTypeLabelForGame } from './utils';
 
 export { getSportsMarketTypeLabel } from './utils';
 
@@ -31,6 +29,8 @@ export interface OutcomesTabProps {
   game?: PredictMarketGame;
   activeChipKey: string;
   onBuyPress: (outcome: PredictOutcome, token: PredictOutcomeToken) => void;
+  nonRegTimeSportsMarketTypes?: string[];
+  onRegTimeInfoPress?: () => void;
 }
 
 const ResolvedOutcomeGroup = memo(
@@ -127,9 +127,12 @@ const PredictGameOutcomesTab = memo(
     game,
     activeChipKey,
     onBuyPress,
+    nonRegTimeSportsMarketTypes = [],
+    onRegTimeInfoPress,
   }: OutcomesTabProps) => {
     const selectedGroup = groupMap.get(activeChipKey);
     const pricedGroup = usePricedOutcomeGroup(selectedGroup);
+    const showRegTimeTag = game?.league === WORLD_CUP_LEAGUE;
 
     return (
       <Box testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.OUTCOMES_CONTENT}>
@@ -139,6 +142,9 @@ const PredictGameOutcomesTab = memo(
               group={pricedGroup}
               onBuyPress={onBuyPress}
               game={game}
+              showRegTimeTag={showRegTimeTag}
+              nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
+              onRegTimeInfoPress={onRegTimeInfoPress}
             />
           </Box>
         )}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictRegTimeInfoSheet.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictRegTimeInfoSheet.tsx
@@ -1,0 +1,34 @@
+import React, { forwardRef } from 'react';
+import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import SheetHeader from '../../../../../component-library/components/Sheet/SheetHeader';
+import { strings } from '../../../../../../locales/i18n';
+
+interface PredictRegTimeInfoSheetProps {
+  onClose?: () => void;
+}
+
+const PredictRegTimeInfoSheet = forwardRef<
+  BottomSheetRef,
+  PredictRegTimeInfoSheetProps
+>(({ onClose }, ref) => (
+  <BottomSheet ref={ref} onClose={onClose} shouldNavigateBack={false}>
+    <SheetHeader title={strings('predict.reg_time_info.title')} />
+    <Box twClassName="px-4 pb-4">
+      <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
+        {strings('predict.reg_time_info.description')}
+      </Text>
+    </Box>
+  </BottomSheet>
+));
+
+PredictRegTimeInfoSheet.displayName = 'PredictRegTimeInfoSheet';
+
+export default PredictRegTimeInfoSheet;

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx
@@ -148,6 +148,26 @@ describe('PredictSportOutcomeCard', () => {
       expect(screen.getByTestId('custom-card')).toBeOnTheScreen();
     });
 
+    it('renders the Reg Time tag when enabled', () => {
+      const props = createDefaultProps({ showRegTimeTag: true });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.getByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.REG_TIME_TAG),
+      ).toHaveTextContent('Reg time');
+    });
+
+    it('does not render the Reg Time tag by default', () => {
+      const props = createDefaultProps();
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+
+      expect(
+        screen.queryByTestId(PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.REG_TIME_TAG),
+      ).not.toBeOnTheScreen();
+    });
+
     it('assigns indexed testIDs to each button', () => {
       const props = createDefaultProps();
 
@@ -234,6 +254,23 @@ describe('PredictSportOutcomeCard', () => {
 
       expect(buttons[0].onPress).not.toHaveBeenCalled();
       expect(buttons[1].onPress).not.toHaveBeenCalled();
+    });
+
+    it('calls onPressRegTimeInfo when the Reg Time tag is pressed', () => {
+      const onPressRegTimeInfo = jest.fn();
+      const props = createDefaultProps({
+        showRegTimeTag: true,
+        onPressRegTimeInfo,
+      });
+
+      renderWithProvider(<PredictSportOutcomeCard {...props} />);
+      fireEvent.press(
+        screen.getByTestId(
+          PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.REG_TIME_INFO_BUTTON,
+        ),
+      );
+
+      expect(onPressRegTimeInfo).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.testIds.ts
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.testIds.ts
@@ -2,6 +2,8 @@ export const PREDICT_SPORT_OUTCOME_CARD_TEST_IDS = {
   CONTAINER: 'predict-sport-outcome-card',
   TITLE: 'predict-sport-outcome-card-title',
   SUBTITLE: 'predict-sport-outcome-card-subtitle',
+  REG_TIME_TAG: 'predict-sport-outcome-card-reg-time-tag',
+  REG_TIME_INFO_BUTTON: 'predict-sport-outcome-card-reg-time-info-button',
   BUTTONS: 'predict-sport-outcome-card-buttons',
   LINE_SELECTOR: 'predict-sport-outcome-card-line-selector',
 } as const;

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
+import { Pressable } from 'react-native';
 import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  IconName,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
   FontWeight,
+  IconColor,
 } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
 import PredictBetButton from '../PredictActionButtons/PredictBetButton';
 import type { PredictBetButtonVariant } from '../PredictActionButtons/PredictActionButtons.types';
 import { PredictSportLineSelector } from '../PredictSportLineSelector';
@@ -31,6 +37,8 @@ interface PredictSportOutcomeCardProps {
   onSelectLine?: (line: number, index: number) => void;
   buttonLayout?: 'inline' | 'inlineNoSeparator' | 'stacked';
   disabled?: boolean;
+  showRegTimeTag?: boolean;
+  onPressRegTimeInfo?: () => void;
   testID?: string;
 }
 
@@ -44,6 +52,8 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
   onSelectLine,
   buttonLayout = 'inline',
   disabled = false,
+  showRegTimeTag = false,
+  onPressRegTimeInfo,
   testID = PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.CONTAINER,
 }) => {
   const showLineSelector =
@@ -60,14 +70,50 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
         twClassName="justify-between mb-3"
       >
         <Box twClassName="flex-1">
-          <Text
-            testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE}
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="flex-wrap gap-1"
           >
-            {title}
-          </Text>
+            <Text
+              testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.TITLE}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
+              {title}
+            </Text>
+            {showRegTimeTag ? (
+              <Pressable
+                onPress={onPressRegTimeInfo}
+                accessibilityRole="button"
+                accessibilityLabel={strings(
+                  'predict.reg_time_info.accessibility_label',
+                )}
+                testID={
+                  PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.REG_TIME_INFO_BUTTON
+                }
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <Tag
+                  severity={TagSeverity.Neutral}
+                  endIconName={IconName.Info}
+                  endIconProps={{
+                    color: IconColor.IconAlternative,
+                  }}
+                  testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.REG_TIME_TAG}
+                >
+                  <Text
+                    variant={TextVariant.BodyXs}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings('predict.reg_time_info.tag')}
+                  </Text>
+                </Tag>
+              </Pressable>
+            ) : null}
+          </Box>
           {subtitle ? (
             <Text
               testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.SUBTITLE}

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -34,6 +34,10 @@ export const DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG: PredictExtendedSportsMarketsF
     enabledSportsMarketTypes: [],
   };
 
+export const DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES = [
+  'soccer_team_to_advance',
+];
+
 export const DEFAULT_MARKET_HIGHLIGHTS_FLAG: PredictMarketHighlightsFlag = {
   enabled: false,
   highlights: [],

--- a/app/components/UI/Predict/constants/flags.ts
+++ b/app/components/UI/Predict/constants/flags.ts
@@ -34,10 +34,6 @@ export const DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG: PredictExtendedSportsMarketsF
     enabledSportsMarketTypes: [],
   };
 
-export const DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES = [
-  'soccer_team_to_advance',
-];
-
 export const DEFAULT_MARKET_HIGHLIGHTS_FLAG: PredictMarketHighlightsFlag = {
   enabled: false,
   highlights: [],

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -65,6 +65,10 @@ export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = [
 
 export const WORLD_CUP_LEAGUE: PredictSportsLeague = 'fifwc';
 
+export const DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES = [
+  'soccer_team_to_advance',
+];
+
 export const filterSupportedLeagues = (
   leagues: string[],
 ): PredictSportsLeague[] =>

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -63,6 +63,8 @@ export const SUPPORTED_SPORTS_LEAGUES: PredictSportsLeague[] = [
   'itf',
 ];
 
+export const WORLD_CUP_LEAGUE: PredictSportsLeague = 'fifwc';
+
 export const filterSupportedLeagues = (
   leagues: string[],
 ): PredictSportsLeague[] =>

--- a/app/components/UI/Predict/constants/sports.ts
+++ b/app/components/UI/Predict/constants/sports.ts
@@ -67,6 +67,8 @@ export const WORLD_CUP_LEAGUE: PredictSportsLeague = 'fifwc';
 
 export const DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES = [
   'soccer_team_to_advance',
+  'soccer_extra_time',
+  'soccer_penalty_shootout',
 ];
 
 export const filterSupportedLeagues = (

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -354,6 +354,7 @@ const defaultFeatureFlags: PredictFeatureFlags = {
   liveSportsLeagues: [],
   extendedSportsMarketsLeagues: [],
   enabledSportsMarketTypes: [],
+  nonRegTimeSportsMarketTypes: [],
   marketHighlightsFlag: {
     enabled: false,
     highlights: [],

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -131,7 +131,6 @@ export const SUPPORTED_SPORTS_MARKET_TYPES: ReadonlySet<string> = new Set([
   'soccer_team_totals',
   'basketball_team_to_score_first',
   'soccer_exact_score',
-  'soccer_team_to_advance',
 ]);
 
 export const GROUP_ORDER: string[] = [

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -131,6 +131,7 @@ export const SUPPORTED_SPORTS_MARKET_TYPES: ReadonlySet<string> = new Set([
   'soccer_team_totals',
   'basketball_team_to_score_first',
   'soccer_exact_score',
+  'soccer_team_to_advance',
 ]);
 
 export const GROUP_ORDER: string[] = [

--- a/app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts
@@ -3,6 +3,7 @@ import { POLYMARKET_PROVIDER_ID } from './constants';
 import {
   buildOutcomeGroups,
   normalizeEnabledSportsMarketTypes,
+  normalizeSportsMarketTypes,
 } from './outcomeGrouping';
 
 function createGroupingOutcome(
@@ -44,6 +45,7 @@ describe('outcomeGrouping', () => {
         'soccer_team_totals',
         'basketball_team_to_score_first',
         'soccer_exact_score',
+        'soccer_team_to_advance',
       ]);
     });
 
@@ -62,6 +64,23 @@ describe('outcomeGrouping', () => {
           'points',
         ]),
       ).toEqual(['moneyline', 'spreads', 'totals']);
+    });
+  });
+
+  describe('normalizeSportsMarketTypes', () => {
+    it('returns an empty list for non-array values', () => {
+      expect(normalizeSportsMarketTypes(undefined)).toEqual([]);
+      expect(normalizeSportsMarketTypes('moneyline')).toEqual([]);
+    });
+
+    it('filters unsupported types and deduplicates case-insensitively', () => {
+      expect(
+        normalizeSportsMarketTypes([
+          'soccer_team_to_advance',
+          'SOCCER_TEAM_TO_ADVANCE',
+          'unsupported_market',
+        ]),
+      ).toEqual(['soccer_team_to_advance']);
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts
@@ -45,7 +45,6 @@ describe('outcomeGrouping', () => {
         'soccer_team_totals',
         'basketball_team_to_score_first',
         'soccer_exact_score',
-        'soccer_team_to_advance',
       ]);
     });
 

--- a/app/components/UI/Predict/providers/polymarket/outcomeGrouping.ts
+++ b/app/components/UI/Predict/providers/polymarket/outcomeGrouping.ts
@@ -129,15 +129,17 @@ const buildSubgroupsForType = (
   ];
 };
 
-export const normalizeEnabledSportsMarketTypes = (value: unknown): string[] => {
-  const rawTypes = Array.isArray(value)
-    ? value
-    : [...SUPPORTED_SPORTS_MARKET_TYPES];
-
+export const normalizeSportsMarketTypes = (value: unknown): string[] => {
+  const rawTypes = Array.isArray(value) ? value : [];
   return [
     ...new Set(rawTypes.map((type) => String(type).toLowerCase())),
   ].filter((type) => SUPPORTED_SPORTS_MARKET_TYPES.has(type));
 };
+
+export const normalizeEnabledSportsMarketTypes = (value: unknown): string[] =>
+  normalizeSportsMarketTypes(
+    Array.isArray(value) ? value : [...SUPPORTED_SPORTS_MARKET_TYPES],
+  );
 
 export const filterGroupableOutcomes = (
   outcomes: PredictOutcome[],

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -127,6 +127,11 @@ export const selectExtendedSportsMarketsLeagues = createSelector(
   (flags) => flags.extendedSportsMarketsLeagues,
 );
 
+export const selectNonRegTimeSportsMarketTypes = createSelector(
+  selectPredictFeatureFlags,
+  (flags) => flags.nonRegTimeSportsMarketTypes,
+);
+
 export const selectPredictFeeCollectionFlag = createSelector(
   selectPredictFeatureFlags,
   (flags) => flags.feeCollection,

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -23,6 +23,7 @@ export interface PredictExtendedSportsMarketsFlag
   extends VersionGatedFeatureFlag {
   leagues: string[];
   enabledSportsMarketTypes: string[];
+  nonRegTimeSportsMarketTypes?: string[];
 }
 
 export interface PredictWorldCupStageConfig {
@@ -54,6 +55,7 @@ export interface PredictFeatureFlags {
   liveSportsLeagues: string[];
   extendedSportsMarketsLeagues: string[];
   enabledSportsMarketTypes: string[];
+  nonRegTimeSportsMarketTypes: string[];
   marketHighlightsFlag: PredictMarketHighlightsFlag;
   fakOrdersEnabled: boolean;
   predictWithAnyTokenEnabled: boolean;

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -842,7 +842,6 @@ describe('resolvePredictFeatureFlags', () => {
         'soccer_team_totals',
         'basketball_team_to_score_first',
         'soccer_exact_score',
-        'soccer_team_to_advance',
       ]);
     });
 

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
   DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../constants/flags';
+import { DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES } from '../constants/sports';
 import { resolvePredictFeatureFlags } from './resolvePredictFeatureFlags';
 
 jest.mock('../../../../util/remoteFeatureFlag', () => ({
@@ -30,7 +31,7 @@ describe('resolvePredictFeatureFlags', () => {
       liveSportsLeagues: [],
       extendedSportsMarketsLeagues: [],
       enabledSportsMarketTypes: [],
-      nonRegTimeSportsMarketTypes: ['soccer_team_to_advance'],
+      nonRegTimeSportsMarketTypes: DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
       marketHighlightsFlag: DEFAULT_MARKET_HIGHLIGHTS_FLAG,
       fakOrdersEnabled: false,
       predictWithAnyTokenEnabled: false,
@@ -1005,9 +1006,9 @@ describe('resolvePredictFeatureFlags', () => {
     it('returns the default full-tie market type when flag is missing', () => {
       const result = resolvePredictFeatureFlags({});
 
-      expect(result.nonRegTimeSportsMarketTypes).toEqual([
-        'soccer_team_to_advance',
-      ]);
+      expect(result.nonRegTimeSportsMarketTypes).toEqual(
+        DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
+      );
     });
 
     it('uses the default full-tie market type when the optional remote field is missing', () => {
@@ -1029,9 +1030,9 @@ describe('resolvePredictFeatureFlags', () => {
         },
       });
 
-      expect(result.nonRegTimeSportsMarketTypes).toEqual([
-        'soccer_team_to_advance',
-      ]);
+      expect(result.nonRegTimeSportsMarketTypes).toEqual(
+        DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
+      );
     });
 
     it('replaces the default list when the optional remote field is present', () => {
@@ -1079,9 +1080,9 @@ describe('resolvePredictFeatureFlags', () => {
         },
       });
 
-      expect(result.nonRegTimeSportsMarketTypes).toEqual([
-        'soccer_team_to_advance',
-      ]);
+      expect(result.nonRegTimeSportsMarketTypes).toEqual(
+        DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
+      );
     });
   });
 });

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -30,6 +30,7 @@ describe('resolvePredictFeatureFlags', () => {
       liveSportsLeagues: [],
       extendedSportsMarketsLeagues: [],
       enabledSportsMarketTypes: [],
+      nonRegTimeSportsMarketTypes: ['soccer_team_to_advance'],
       marketHighlightsFlag: DEFAULT_MARKET_HIGHLIGHTS_FLAG,
       fakOrdersEnabled: false,
       predictWithAnyTokenEnabled: false,
@@ -841,6 +842,7 @@ describe('resolvePredictFeatureFlags', () => {
         'soccer_team_totals',
         'basketball_team_to_score_first',
         'soccer_exact_score',
+        'soccer_team_to_advance',
       ]);
     });
 
@@ -997,6 +999,90 @@ describe('resolvePredictFeatureFlags', () => {
       });
 
       expect(result.enabledSportsMarketTypes).toEqual(['totals']);
+    });
+  });
+
+  describe('nonRegTimeSportsMarketTypes', () => {
+    it('returns the default full-tie market type when flag is missing', () => {
+      const result = resolvePredictFeatureFlags({});
+
+      expect(result.nonRegTimeSportsMarketTypes).toEqual([
+        'soccer_team_to_advance',
+      ]);
+    });
+
+    it('uses the default full-tie market type when the optional remote field is missing', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return true;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            leagues: ['ucl'],
+            enabledSportsMarketTypes: ['moneyline'],
+          },
+        },
+      });
+
+      expect(result.nonRegTimeSportsMarketTypes).toEqual([
+        'soccer_team_to_advance',
+      ]);
+    });
+
+    it('replaces the default list when the optional remote field is present', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return true;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+            leagues: ['ucl'],
+            nonRegTimeSportsMarketTypes: [
+              'moneyline',
+              'MONEYLINE',
+              'unsupported_market',
+            ],
+          },
+        },
+      });
+
+      expect(result.nonRegTimeSportsMarketTypes).toEqual(['moneyline']);
+    });
+
+    it('falls back to the default list when the flag fails the version gate', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (flag && typeof flag === 'object' && 'leagues' in flag) {
+          return false;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictExtendedSportsMarkets: {
+            enabled: true,
+            minimumVersion: '99.0.0',
+            leagues: ['ucl'],
+            nonRegTimeSportsMarketTypes: ['moneyline'],
+          },
+        },
+      });
+
+      expect(result.nonRegTimeSportsMarketTypes).toEqual([
+        'soccer_team_to_advance',
+      ]);
     });
   });
 });

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
@@ -3,6 +3,7 @@ import {
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 import {
+  DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
   DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG,
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
@@ -11,7 +12,10 @@ import {
   DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../constants/flags';
 import { filterSupportedLeagues } from '../constants/sports';
-import { normalizeEnabledSportsMarketTypes } from '../providers/polymarket/outcomeGrouping';
+import {
+  normalizeEnabledSportsMarketTypes,
+  normalizeSportsMarketTypes,
+} from '../providers/polymarket/outcomeGrouping';
 import {
   parse,
   PredictFeeCollectionSchema,
@@ -99,6 +103,16 @@ export function resolvePredictFeatureFlags(
         extendedSportsFlag.enabledSportsMarketTypes,
       )
     : [];
+  const hasNonRegTimeSportsMarketTypes = Object.prototype.hasOwnProperty.call(
+    extendedSportsFlag,
+    'nonRegTimeSportsMarketTypes',
+  );
+  const nonRegTimeSportsMarketTypes =
+    extendedSportsMarketsEnabled && hasNonRegTimeSportsMarketTypes
+      ? normalizeSportsMarketTypes(
+          extendedSportsFlag.nonRegTimeSportsMarketTypes,
+        )
+      : normalizeSportsMarketTypes(DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES);
   const fakOrdersEnabled = resolveVersionGatedBooleanFlag(
     flags.predictFakOrders,
   );
@@ -146,6 +160,7 @@ export function resolvePredictFeatureFlags(
     liveSportsLeagues,
     extendedSportsMarketsLeagues,
     enabledSportsMarketTypes,
+    nonRegTimeSportsMarketTypes,
     marketHighlightsFlag,
     fakOrdersEnabled,
     predictWithAnyTokenEnabled,

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
@@ -3,7 +3,6 @@ import {
   validatedVersionGatedFeatureFlag,
 } from '../../../../util/remoteFeatureFlag';
 import {
-  DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
   DEFAULT_EXTENDED_SPORTS_MARKETS_FLAG,
   DEFAULT_FEE_COLLECTION_FLAG,
   DEFAULT_LIVE_SPORTS_FLAG,
@@ -11,7 +10,10 @@ import {
   DEFAULT_PREDICT_WORLD_CUP_FLAG,
   DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../constants/flags';
-import { filterSupportedLeagues } from '../constants/sports';
+import {
+  DEFAULT_NON_REG_TIME_SPORTS_MARKET_TYPES,
+  filterSupportedLeagues,
+} from '../constants/sports';
 import {
   normalizeEnabledSportsMarketTypes,
   normalizeSportsMarketTypes,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -371,6 +371,7 @@ jest.mock('../../selectors/featureFlags', () => ({
   selectPredictFeeCollectionFlag: jest.fn(
     () => mockSelectPredictFeeCollectionFlag,
   ),
+  selectNonRegTimeSportsMarketTypes: jest.fn(() => ['soccer_team_to_advance']),
 }));
 
 jest.mock('../../../../Base/TabBar', () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -50,6 +50,7 @@ import { isCryptoUpDown } from '../../utils/cryptoUpDown';
 import {
   selectPredictUpDownEnabledFlag,
   selectPredictFeeCollectionFlag,
+  selectNonRegTimeSportsMarketTypes,
 } from '../../selectors/featureFlags';
 import PredictMarketDetailsStatus from './components/PredictMarketDetailsStatus';
 import PredictMarketDetailsHeader from './components/PredictMarketDetailsHeader';
@@ -82,6 +83,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
 
   const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
+  const nonRegTimeSportsMarketTypes = useSelector(
+    selectNonRegTimeSportsMarketTypes,
+  );
   const {
     marketId,
     series,
@@ -496,6 +500,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         )}
         isLoading={isClaimablePositionsLoading}
         isClaimPending={isClaimPending}
+        nonRegTimeSportsMarketTypes={nonRegTimeSportsMarketTypes}
       />
     );
   }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2536,6 +2536,7 @@
       "soccer_anytime_goalscorer": "Goalscorers",
       "soccer_exact_score": "Exact Score",
       "soccer_halftime_result": "Halftime Result",
+      "soccer_team_to_advance": "Team to Advance",
       "soccer_first_to_score": "First Team to Score",
       "soccer_team_to_advance": "Team to Advance",
       "soccer_extra_time": "Extra Time?",
@@ -2829,6 +2830,12 @@
       "make_your_prediction": "Make your prediction",
       "volume_display": "${{volume}} Vol",
       "read_terms": "Read the full contract terms and conditions"
+    },
+    "reg_time_info": {
+      "tag": "Reg time",
+      "accessibility_label": "Regulation time market information",
+      "title": "Regulation time",
+      "description": "This market refers to the outcome during the 90 minutes of regular play plus stoppage time. It excludes extra time and penalties."
     },
     "sports": {
       "halftime": "Halftime",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2538,7 +2538,6 @@
       "soccer_halftime_result": "Halftime Result",
       "soccer_team_to_advance": "Team to Advance",
       "soccer_first_to_score": "First Team to Score",
-      "soccer_team_to_advance": "Team to Advance",
       "soccer_extra_time": "Extra Time?",
       "soccer_penalty_shootout": "Penalty Shootout?",
       "total_corners": "Corners",


### PR DESCRIPTION
## **Description**

This PR adds a `Reg Time` context to applicable World Cup predict markets and surfaces supporting explanatory UI so users can understand when outcomes are scoped to regulation time.

The changes include:
- Adding regulation-time market-type handling in sports constants and Polymarket outcome grouping.
- Wiring a new regulation-time info sheet flow through game details tabs/outcomes content.
- Updating `PredictSportOutcomeCard` to display and test the new `Reg Time` affordance where applicable.
- Adding feature-flag resolution support and associated tests for the new behavior.

## **Changelog**

CHANGELOG entry: Added a Regulation Time tag and contextual info for applicable World Cup prediction markets.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1069

## **Manual testing steps**

```gherkin
Feature: Regulation-time context for World Cup markets

  Scenario: user sees Reg Time context on applicable World Cup markets
    Given Predict markets are enabled and user opens a World Cup market details screen
    When user views outcomes for an applicable regulation-time market type
    Then the UI shows a Reg Time indicator and allows opening the regulation-time info sheet

  Scenario: user does not see Reg Time context for non-applicable markets
    Given user opens a non-World-Cup market or an excluded market type
    When user views outcomes in the details screen
    Then the Reg Time indicator is not shown
```

Suggested automated tests:
- `npx jest app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx --coverage=false`
- `npx jest app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts --coverage=false`
- `npx jest app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.test.tsx --coverage=false`

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A (please attach screenshots/recordings from World Cup market details flow)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predict UI and remote-config-driven display rules only; no trading, auth, or payment logic changes.
> 
> **Overview**
> Adds a **Reg time** indicator on applicable World Cup (`fifwc`) sport outcome cards, with a bottom sheet that explains regulation-time scope (90 minutes plus stoppage; excludes extra time and penalties).
> 
> **UI flow:** `PredictSportOutcomeCard` gains an optional info tag; visibility is driven from `PredictGameOutcomesTab` (World Cup league only) and filtered per market type via `shouldShowRegTimeTag` in outcome cards. Tapping the tag opens `PredictRegTimeInfoSheet` from `PredictGameDetailsContent` (second `usePredictBottomSheet` instance), wired through tabs content and `onRegTimeInfoPress`.
> 
> **Config:** `nonRegTimeSportsMarketTypes` is resolved from extended sports feature flags (defaults: advance, extra time, penalty shootout), exposed via `selectNonRegTimeSportsMarketTypes` and passed from `PredictMarketDetails`. `normalizeSportsMarketTypes` refactors shared normalization; `WORLD_CUP_LEAGUE` and defaults live in `constants/sports`.
> 
> **i18n:** New `predict.reg_time_info.*` strings; minor reorder in `en.json` sports market types.
> 
> Tests cover tag visibility, sheet open vs about sheet, flag resolution, and card press behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8553d4f0c98c94fda479c3688a10d946e64ff29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->