### PR TITLE
test: add Price Alerts CV tests

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.view.test.tsx
@@ -3,6 +3,7 @@ import { renderCreatePriceAlertViewWithRoutes } from '../../../../../../../tests
 import {
   setupPriceAlertsApiMock,
   setupPriceAlertsPostMock,
+  setupPriceAlertsPatchMock,
   clearPriceAlertsApiMocks,
 } from '../../../../../../../tests/component-view/api-mocking/priceAlerts';
 import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
@@ -87,5 +88,88 @@ describeForPlatforms('CreatePriceAlertView', () => {
     expect(
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).toBeDisabled();
+  });
+
+  it('applies +5% quick percentage pill and updates the target price', async () => {
+    // currentPrice defaults to 2500 in the renderer, so +5% → 2625
+    const { getByTestId, findByText } = renderCreatePriceAlertViewWithRoutes();
+
+    fireEvent.press(
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
+    );
+
+    expect(await findByText('$2625')).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('saves alert with recurring=false after toggling the switch off', async () => {
+    const scope = setupPriceAlertsPostMock();
+    const { getByTestId } = renderCreatePriceAlertViewWithRoutes();
+
+    // Toggle recurring off (default is true)
+    fireEvent(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+      'valueChange',
+      false,
+    );
+
+    // Enter a target price so the save button is enabled
+    fireEvent.press(getByTestId('keypad-key-1'));
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    // POST was consumed, proving the alert was submitted with the toggled state
+    await waitFor(() => expect(scope.isDone()).toBe(true));
+  });
+
+  it('disables button with duplicate text when threshold matches an existing alert', async () => {
+    const { getByTestId, findByText } = renderCreatePriceAlertViewWithRoutes({
+      routeParams: {
+        existingThresholds: [3000],
+      },
+    });
+
+    // Type "3000" on keypad
+    fireEvent.press(getByTestId('keypad-key-3'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+
+    expect(
+      await findByText('An alert at this price already exists.'),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
+  });
+
+  it('submits PATCH when saving an edited alert with changed threshold', async () => {
+    const scope = setupPriceAlertsPatchMock(editingAlert.id);
+
+    const { getByTestId } = renderCreatePriceAlertViewWithRoutes({
+      routeParams: {
+        editingAlert,
+        existingThresholds: [],
+      },
+    });
+
+    // Change the threshold by pressing a keypad digit
+    fireEvent.press(getByTestId('keypad-key-1'));
+
+    await waitFor(() => {
+      expect(
+        getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+      ).not.toBeDisabled();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    await waitFor(() => expect(scope.isDone()).toBe(true));
   });
 });

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.view.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.view.test.tsx
@@ -4,13 +4,16 @@ import {
   setupPriceAlertsApiMock,
   clearPriceAlertsApiMocks,
   mockPriceAlertsData,
+  setupPriceAlertsDeleteMock,
+  setupPriceAlertsPatchMock,
 } from '../../../../../../../tests/component-view/api-mocking/priceAlerts';
 import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
-import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import { act, fireEvent, waitFor, within } from '@testing-library/react-native';
 import {
   ManagePriceAlertsTestIds,
   CreatePriceAlertTestIds,
 } from '../../constants';
+import Routes from '../../../../../../constants/navigation/Routes';
 
 beforeEach(() => {
   setupPriceAlertsApiMock();
@@ -83,5 +86,135 @@ describeForPlatforms('ManagePriceAlertsView', () => {
 
     expect(getByText('Edit ETH price alert')).toBeOnTheScreen();
     expect(getByText('$3000')).toBeOnTheScreen();
+  });
+
+  it('auto-redirects to Create view when no alerts exist for the token', async () => {
+    setupPriceAlertsApiMock([]);
+
+    const { findByTestId } = renderManagePriceAlertsViewWithRoutes();
+
+    await findByTestId(CreatePriceAlertTestIds.CONTAINER);
+  });
+
+  it('deletes an alert via trash icon and removes it from the list', async () => {
+    const alertToDelete = mockPriceAlertsData[0];
+    const scope = setupPriceAlertsDeleteMock(alertToDelete.id);
+
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      fireEvent.press(
+        await findByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-${alertToDelete.id}`,
+        ),
+      );
+    });
+
+    await waitFor(() => expect(scope.isDone()).toBe(true));
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${alertToDelete.id}`,
+        ),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('deletes the last remaining alert and empties the list', async () => {
+    const singleAlert = mockPriceAlertsData[0];
+    setupPriceAlertsApiMock([singleAlert]);
+    const scope = setupPriceAlertsDeleteMock(singleAlert.id);
+
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      fireEvent.press(
+        await findByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-${singleAlert.id}`,
+        ),
+      );
+    });
+
+    await waitFor(() => expect(scope.isDone()).toBe(true));
+
+    // After the last alert is deleted, the row is removed from the list
+    await waitFor(() => {
+      expect(
+        queryByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${singleAlert.id}`,
+        ),
+      ).not.toBeOnTheScreen();
+    });
+    // The "Add alert" button is also gone (only shown when alerts.length > 0)
+    expect(
+      queryByTestId(ManagePriceAlertsTestIds.ADD_ALERT_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('toggles an active alert off via PATCH', async () => {
+    const activeAlert = mockPriceAlertsData[0]; // active: true
+    const scope = setupPriceAlertsPatchMock(activeAlert.id);
+
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      fireEvent(
+        await findByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-${activeAlert.id}`,
+        ),
+        'valueChange',
+        false,
+      );
+    });
+
+    await waitFor(() => expect(scope.isDone()).toBe(true));
+  });
+
+  it('toggles an inactive alert on via PATCH', async () => {
+    const inactiveAlert = mockPriceAlertsData[1]; // active: false
+    const scope = setupPriceAlertsPatchMock(inactiveAlert.id);
+
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    await act(async () => {
+      fireEvent(
+        await findByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-${inactiveAlert.id}`,
+        ),
+        'valueChange',
+        true,
+      );
+    });
+
+    await waitFor(() => expect(scope.isDone()).toBe(true));
   });
 });

--- a/tests/component-view/api-mocking/priceAlerts.ts
+++ b/tests/component-view/api-mocking/priceAlerts.ts
@@ -83,6 +83,41 @@ export function setupPriceAlertsPostMock(): Scope {
 }
 
 /**
+ * Registers a one-shot DELETE /v1/alerts/:id nock interceptor.
+ * Returns the nock scope so callers can assert `scope.isDone()`.
+ */
+export function setupPriceAlertsDeleteMock(alertId: string): Scope {
+  return nock(PRICE_ALERTS_ORIGIN)
+    .delete(`${ALERTS_PATH}/${alertId}`)
+    .reply(200);
+}
+
+/**
+ * Registers a one-shot PATCH /v1/alerts/:id nock interceptor.
+ * Returns the nock scope so callers can assert `scope.isDone()`.
+ */
+export function setupPriceAlertsPatchMock(alertId: string): Scope {
+  return nock(PRICE_ALERTS_ORIGIN)
+    .patch(`${ALERTS_PATH}/${alertId}`)
+    .reply(200);
+}
+
+/**
+ * Sets up a nock interceptor for GET /v1/alerts/supported-chains.
+ * Used by TokenDetails to determine if the bell icon should be shown.
+ *
+ * @param chains - The list of CAIP-2 chain identifiers to return. Defaults to ['eip155:1'].
+ */
+export function setupPriceAlertsSupportedChainsMock(
+  chains: string[] = ['eip155:1'],
+): void {
+  nock(PRICE_ALERTS_ORIGIN)
+    .get('/v1/alerts/supported-chains')
+    .reply(200, chains)
+    .persist();
+}
+
+/**
  * Clears all nock interceptors after each price-alerts test.
  */
 export function clearPriceAlertsApiMocks(): void {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

 Add 9 new component view tests for Price Alerts covering AC scenarios not previously tested: delete, toggle active/inactive, quick percentage pills,  recurring toggle, duplicate threshold validation, PATCH for edit, and empty-state auto-redirect                                                                   

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified.
> 
> **Overview**
> Adds **component view tests** for Price Alerts create and manage screens, plus **nock helpers** so tests can assert real HTTP calls complete.
> 
> **CreatePriceAlertView** gains coverage for quick **+5%** target price, **recurring off** on POST, **duplicate threshold** validation, and **PATCH** when editing with a changed threshold.
> 
> **ManagePriceAlertsView** gains coverage for redirect to create when the list is empty, **DELETE** (including last alert and UI cleanup), and **active/inactive toggles** via PATCH.
> 
> Shared mocking adds one-shot **DELETE** and **PATCH** interceptors and a persistent **supported-chains** GET helper for related tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e9d01a36cfdf0df43692da2f91e7924d4e6724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->