### PR TITLE
fix: deposit wallet address resolution for beacon wallets cp-8.0.2

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -18,10 +18,10 @@ import type { PredictFeatureFlags } from '../../types/flags';
 import { PolymarketProvider } from './PolymarketProvider';
 import { OrderType, SignatureType } from './types';
 import {
-  deriveDepositWalletAddress,
   executeDepositWalletBatch,
   getDepositWalletRelayerTransactionId,
   requestDepositWalletCreate,
+  resolveDepositWalletAddress,
   syncDepositWalletCollateralBalanceAllowance,
   toDepositWalletCalls,
   waitForDepositWalletDeployed,
@@ -161,10 +161,10 @@ jest.mock('./protocol/transport', () => ({
 }));
 
 jest.mock('./depositWallet', () => ({
-  deriveDepositWalletAddress: jest.fn(),
   executeDepositWalletBatch: jest.fn(),
   getDepositWalletRelayerTransactionId: jest.fn(),
   requestDepositWalletCreate: jest.fn(),
+  resolveDepositWalletAddress: jest.fn(),
   syncDepositWalletCollateralBalanceAllowance: jest.fn(),
   toDepositWalletCalls: jest.fn(),
   waitForDepositWalletDeployed: jest.fn(),
@@ -199,7 +199,6 @@ jest.mock('./preflight/withdraw', () => ({
 const mockAnalyticsIdentify = jest.mocked(analytics.identify);
 const mockComputeProxyAddress = jest.mocked(computeProxyAddress);
 const mockCreateApiKey = jest.mocked(createApiKey);
-const mockDeriveDepositWalletAddress = jest.mocked(deriveDepositWalletAddress);
 const mockExecuteDepositWalletBatch = jest.mocked(executeDepositWalletBatch);
 const mockGetDepositWalletRelayerTransactionId = jest.mocked(
   getDepositWalletRelayerTransactionId,
@@ -235,6 +234,9 @@ const mockParsePolymarketActivity = jest.mocked(parsePolymarketActivity);
 const mockParsePolymarketEvents = jest.mocked(parsePolymarketEvents);
 const mockParsePolymarketPositions = jest.mocked(parsePolymarketPositions);
 const mockPreviewOrder = jest.mocked(previewOrder);
+const mockResolveDepositWalletAddress = jest.mocked(
+  resolveDepositWalletAddress,
+);
 const mockSubmitProtocolClobOrder = jest.mocked(submitProtocolClobOrder);
 const mockBuildClaimTransaction = jest.mocked(buildClaimTransaction);
 const mockPlanDepositWalletClaim = jest.mocked(planDepositWalletClaim);
@@ -650,7 +652,7 @@ describe('PolymarketProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockComputeProxyAddress.mockReturnValue(legacySafeAddress);
-    mockDeriveDepositWalletAddress.mockReturnValue(depositWalletAddress);
+    mockResolveDepositWalletAddress.mockResolvedValue(depositWalletAddress);
     mockCreateApiKey.mockResolvedValue({
       apiKey: 'api-key',
       secret: 'secret',
@@ -763,6 +765,9 @@ describe('PolymarketProvider', () => {
       isDeployed: true,
       walletType: 'deposit-wallet',
     });
+    expect(mockResolveDepositWalletAddress).toHaveBeenCalledWith({
+      ownerAddress: signer.address,
+    });
     expect(global.fetch).not.toHaveBeenCalled();
     expect(mockIsSmartContractAddress).toHaveBeenNthCalledWith(
       1,
@@ -789,6 +794,7 @@ describe('PolymarketProvider', () => {
     expect(global.fetch).toHaveBeenCalledWith(
       `https://data-api.polymarket.com/activity?user=${legacySafeAddress}&limit=1`,
     );
+    expect(mockResolveDepositWalletAddress).not.toHaveBeenCalled();
   });
 
   it('routes deployed legacy Safe with empty raw activity to deposit wallet', async () => {
@@ -808,6 +814,9 @@ describe('PolymarketProvider', () => {
       address: depositWalletAddress,
       isDeployed: false,
       walletType: 'deposit-wallet',
+    });
+    expect(mockResolveDepositWalletAddress).toHaveBeenCalledWith({
+      ownerAddress: signer.address,
     });
   });
 
@@ -1332,6 +1341,9 @@ describe('PolymarketProvider', () => {
     });
 
     expect(result).toBe(true);
+    expect(mockResolveDepositWalletAddress).toHaveBeenCalledWith({
+      ownerAddress: signer.address,
+    });
     expect(mockRequestDepositWalletCreate).toHaveBeenCalledWith({
       ownerAddress: signer.address,
     });
@@ -1409,7 +1421,7 @@ describe('PolymarketProvider', () => {
       getSigner: () => signer,
     });
 
-    await Promise.resolve();
+    await flushPromises();
 
     expect(mockRequestDepositWalletCreate).toHaveBeenCalled();
     expect(mockWaitForDepositWalletDeployed).not.toHaveBeenCalled();

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -156,10 +156,10 @@ import { buildLegacySafeMigrationSweepTransaction } from './preflight/legacySafe
 import { buildTradeAllowancesTx } from './preflight/trade';
 import { buildWithdrawTransaction } from './preflight/withdraw';
 import {
-  deriveDepositWalletAddress,
   executeDepositWalletBatch,
   getDepositWalletRelayerTransactionId,
   requestDepositWalletCreate,
+  resolveDepositWalletAddress,
   syncDepositWalletCollateralBalanceAllowance,
   toDepositWalletCalls,
   waitForDepositWalletDeployed,
@@ -2727,9 +2727,9 @@ export class PolymarketProvider implements PredictProvider {
         }
       }
 
-      const depositWalletAddress = deriveDepositWalletAddress(
-        normalizedOwnerAddress,
-      );
+      const depositWalletAddress = await resolveDepositWalletAddress({
+        ownerAddress: normalizedOwnerAddress,
+      });
       const depositWalletIsDeployed = await isSmartContractAddress(
         depositWalletAddress,
         numberToHex(POLYGON_MAINNET_CHAIN_ID),
@@ -2828,12 +2828,15 @@ export class PolymarketProvider implements PredictProvider {
     }
   }
 
-  private getDepositWalletDepositTransaction(transactionMeta: TransactionMeta):
+  private async getDepositWalletDepositTransaction(
+    transactionMeta: TransactionMeta,
+  ): Promise<
     | {
         ownerAddress: Hex;
         depositWalletAddress: Hex;
       }
-    | undefined {
+    | undefined
+  > {
     const ownerAddress = transactionMeta.txParams.from;
 
     if (!ownerAddress) {
@@ -2872,7 +2875,9 @@ export class PolymarketProvider implements PredictProvider {
       return undefined;
     }
 
-    const depositWalletAddress = deriveDepositWalletAddress(ownerAddress);
+    const depositWalletAddress = await resolveDepositWalletAddress({
+      ownerAddress,
+    });
 
     if (getAddress(recipient) !== getAddress(depositWalletAddress)) {
       return undefined;
@@ -2886,8 +2891,10 @@ export class PolymarketProvider implements PredictProvider {
 
   public isDepositWalletDepositTransaction(
     transactionMeta: TransactionMeta,
-  ): boolean {
-    return Boolean(this.getDepositWalletDepositTransaction(transactionMeta));
+  ): Promise<boolean> {
+    return this.getDepositWalletDepositTransaction(transactionMeta).then(
+      Boolean,
+    );
   }
 
   private async ensureDepositWalletReady({
@@ -3037,7 +3044,7 @@ export class PolymarketProvider implements PredictProvider {
     getSigner: (address?: string) => Signer;
   }): Promise<boolean> {
     const depositWalletDeposit =
-      this.getDepositWalletDepositTransaction(transactionMeta);
+      await this.getDepositWalletDepositTransaction(transactionMeta);
 
     if (!depositWalletDeposit) {
       return true;
@@ -3115,7 +3122,7 @@ export class PolymarketProvider implements PredictProvider {
     signerAddress: string;
   }): Promise<void> {
     const depositWalletDeposit =
-      this.getDepositWalletDepositTransaction(transactionMeta);
+      await this.getDepositWalletDepositTransaction(transactionMeta);
 
     if (!depositWalletDeposit) {
       return;

--- a/app/components/UI/Predict/providers/polymarket/depositWallet.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/depositWallet.test.ts
@@ -1,20 +1,47 @@
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
+import { query } from '@metamask/controller-utils';
 import type { Signer } from '../types';
 import {
   DEPOSIT_WALLET_FACTORY_ADDRESS,
+  deriveDepositWalletBeaconAddress,
   deriveDepositWalletAddress,
+  deriveDepositWalletUupsAddress,
   executeDepositWalletBatch,
   executeDepositWalletBatchAndWaitForCompletion,
   getDepositWalletNonce,
+  readDepositWalletFactoryBeacon,
   requestDepositWalletCreate,
+  resolveDepositWalletAddress,
   syncDepositWalletCollateralBalanceAllowance,
   toDepositWalletCalls,
   waitForDepositWalletDeployed,
   waitForDepositWalletTransaction,
 } from './depositWallet';
+import Engine from '../../../../../core/Engine';
 import { POLYMARKET_V2_PROTOCOL } from './protocol/definitions';
 import { OperationType } from './safe/types';
 import { getL2Headers } from './utils';
+
+jest.mock('@metamask/controller-utils', () => ({
+  ...jest.requireActual('@metamask/controller-utils'),
+  query: jest.fn(),
+}));
+
+jest.mock('@metamask/eth-query', () =>
+  jest.fn().mockImplementation(() => ({})),
+);
+
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      NetworkController: {
+        findNetworkClientIdByChainId: jest.fn(() => 'polygon-mainnet'),
+        getNetworkClientById: jest.fn(() => ({ provider: {} })),
+      },
+    },
+  },
+}));
 
 jest.mock('./utils', () => ({
   getPolymarketEndpoints: jest.fn(() => ({
@@ -24,6 +51,8 @@ jest.mock('./utils', () => ({
 }));
 
 const mockGetL2Headers = jest.mocked(getL2Headers);
+const mockQuery = jest.mocked(query);
+const mockNetworkController = jest.mocked(Engine.context.NetworkController);
 const mockFetch = jest.fn();
 
 type MockResponseBody = Record<string, unknown> | Record<string, unknown>[];
@@ -41,6 +70,9 @@ function getFetchBody(callIndex = 0): unknown {
 }
 
 const ownerAddress = '0x1111111111111111111111111111111111111111';
+const beaconAddress = '0x7A18EDfe055488A3128f01F563e5B479D92ffc3a';
+const uupsWalletAddress = '0xfAeA0f08159fcF2f573fE24E9E989B0d48f7651B';
+const beaconWalletAddress = '0x574548bC296A44a39a7828343FC262244f37a7e5';
 
 const signer: Signer = {
   address: ownerAddress,
@@ -70,6 +102,110 @@ describe('depositWallet', () => {
 
     expect(lowerResult).toMatch(/^0x[a-fA-F0-9]{40}$/u);
     expect(checksumResult).toBe(lowerResult);
+  });
+
+  it('derives legacy UUPS deposit-wallet address for owner', () => {
+    const result = deriveDepositWalletUupsAddress(ownerAddress);
+
+    expect(result).toBe(uupsWalletAddress);
+    expect(deriveDepositWalletAddress(ownerAddress)).toBe(uupsWalletAddress);
+  });
+
+  it('derives beacon deposit-wallet address for owner', () => {
+    const result = deriveDepositWalletBeaconAddress({
+      ownerAddress,
+      beaconAddress,
+    });
+
+    expect(result).toBe(beaconWalletAddress);
+  });
+
+  it('resolves UUPS wallet when factory beacon is unavailable', async () => {
+    const readFactoryBeacon = jest.fn().mockResolvedValue(undefined);
+    const isWalletDeployed = jest.fn();
+
+    const result = await resolveDepositWalletAddress({
+      ownerAddress,
+      readFactoryBeacon,
+      isWalletDeployed,
+    });
+
+    expect(result).toBe(uupsWalletAddress);
+    expect(readFactoryBeacon).toHaveBeenCalledTimes(1);
+    expect(isWalletDeployed).not.toHaveBeenCalled();
+  });
+
+  it('resolves deployed UUPS wallet when factory exposes beacon', async () => {
+    const readFactoryBeacon = jest.fn().mockResolvedValue(beaconAddress);
+    const isWalletDeployed = jest.fn().mockResolvedValue(true);
+
+    const result = await resolveDepositWalletAddress({
+      ownerAddress,
+      readFactoryBeacon,
+      isWalletDeployed,
+    });
+
+    expect(result).toBe(uupsWalletAddress);
+    expect(isWalletDeployed).toHaveBeenCalledWith(uupsWalletAddress);
+  });
+
+  it('resolves beacon wallet when factory exposes beacon and UUPS wallet is undeployed', async () => {
+    const readFactoryBeacon = jest.fn().mockResolvedValue(beaconAddress);
+    const isWalletDeployed = jest.fn().mockResolvedValue(false);
+
+    const result = await resolveDepositWalletAddress({
+      ownerAddress,
+      readFactoryBeacon,
+      isWalletDeployed,
+    });
+
+    expect(result).toBe(beaconWalletAddress);
+    expect(isWalletDeployed).toHaveBeenCalledWith(uupsWalletAddress);
+  });
+
+  it('reads factory beacon address from Polygon RPC', async () => {
+    mockQuery.mockResolvedValue(
+      `0x000000000000000000000000${beaconAddress.slice(2)}`,
+    );
+
+    const result = await readDepositWalletFactoryBeacon();
+
+    expect(result).toBe(beaconAddress);
+    expect(
+      mockNetworkController.findNetworkClientIdByChainId,
+    ).toHaveBeenCalledWith('0x89');
+    expect(mockQuery).toHaveBeenCalledWith(expect.anything(), 'call', [
+      {
+        to: DEPOSIT_WALLET_FACTORY_ADDRESS,
+        data: '0x49493a4d',
+      },
+    ]);
+  });
+
+  it('returns undefined when factory beacon call reverts', async () => {
+    mockQuery.mockRejectedValue(
+      Object.assign(new Error('execution reverted'), { code: 3 }),
+    );
+
+    const result = await readDepositWalletFactoryBeacon();
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws contextual error when factory beacon response is malformed', async () => {
+    mockQuery.mockResolvedValue('0x1234');
+
+    await expect(readDepositWalletFactoryBeacon()).rejects.toThrow(
+      'Polymarket deposit wallet factory BEACON returned malformed address data',
+    );
+  });
+
+  it('throws contextual error when factory beacon call fails without revert', async () => {
+    mockQuery.mockRejectedValue(new Error('network offline'));
+
+    await expect(readDepositWalletFactoryBeacon()).rejects.toThrow(
+      'Polymarket deposit wallet factory BEACON call failed: network offline',
+    );
   });
 
   it('maps Safe transactions to deposit-wallet calls', () => {

--- a/app/components/UI/Predict/providers/polymarket/depositWallet.ts
+++ b/app/components/UI/Predict/providers/polymarket/depositWallet.ts
@@ -1,5 +1,7 @@
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
-import { Hex } from '@metamask/utils';
+import { query } from '@metamask/controller-utils';
+import EthQuery from '@metamask/eth-query';
+import { Hex, numberToHex } from '@metamask/utils';
 import { ethers } from 'ethers';
 import {
   getAddress,
@@ -8,6 +10,8 @@ import {
   hexZeroPad,
   keccak256,
 } from 'ethers/lib/utils';
+import Engine from '../../../../../core/Engine';
+import { isSmartContractAddress } from '../../../../../util/transactions';
 import { POLYGON_MAINNET_CHAIN_ID } from './constants';
 import type { PolymarketProtocolDefinition } from './protocol/definitions';
 import type { SafeTransaction } from './safe/types';
@@ -19,6 +23,8 @@ export const DEPOSIT_WALLET_FACTORY_ADDRESS =
   '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07';
 export const DEPOSIT_WALLET_IMPLEMENTATION_ADDRESS =
   '0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const DEPOSIT_WALLET_FACTORY_BEACON_SELECTOR = '0x49493a4d';
 
 const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
 const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
@@ -28,6 +34,15 @@ const DEPOSIT_WALLET_BATCH_DEADLINE_SECONDS = 300;
 
 const RELAYER_SUCCESS_STATES = new Set(['STATE_CONFIRMED']);
 const RELAYER_FAILURE_STATES = new Set(['STATE_FAILED', 'STATE_INVALID']);
+const CONTRACT_REVERT_ERROR_CODE = 3;
+const CONTRACT_REVERT_ERROR_PATTERNS = [
+  'execution reverted',
+  'contract function reverted',
+  'function selector was not recognized',
+  'missing revert data',
+  'call revert exception',
+  'reverted',
+];
 
 /**
  * Byte constants from Solady LibClone.initCodeHashERC1967 used by the
@@ -38,6 +53,13 @@ const ERC1967_CONST1 =
 const ERC1967_CONST2 =
   '0x5155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076';
 const ERC1967_PREFIX = 0x61003d3d8160233d3973n;
+const ERC1967_BEACON_CONST1 =
+  '0x60195155f3363d3d373d3d363d602036600436635c60da';
+const ERC1967_BEACON_CONST2 =
+  '0x1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6c';
+const ERC1967_BEACON_CONST3 =
+  '0xb3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3';
+const ERC1967_BEACON_PREFIX = 0x6100523d8160233d3973n;
 
 export interface DepositWalletCall {
   target: string;
@@ -99,21 +121,57 @@ function initCodeHashERC1967({
   ) as Hex;
 }
 
+function initCodeHashERC1967BeaconProxy({
+  beacon,
+  args,
+}: {
+  beacon: string;
+  args: Hex;
+}): Hex {
+  const argsLength = BigInt((args.length - 2) / 2);
+  const prefix = toFixedSizeHex(
+    ERC1967_BEACON_PREFIX + (argsLength << 56n),
+    10,
+  );
+
+  return keccak256(
+    hexConcat([
+      prefix,
+      getAddress(beacon),
+      ERC1967_BEACON_CONST1,
+      ERC1967_BEACON_CONST2,
+      ERC1967_BEACON_CONST3,
+      args,
+    ]),
+  ) as Hex;
+}
+
 export function getDepositWalletId(ownerAddress: string): Hex {
   return hexZeroPad(getAddress(ownerAddress), 32) as Hex;
 }
 
-export function deriveDepositWalletAddress(ownerAddress: string): Hex {
+function getDepositWalletCreate2Inputs(ownerAddress: string): {
+  factoryAddress: string;
+  args: Hex;
+  salt: Hex;
+} {
   const factoryAddress = getAddress(DEPOSIT_WALLET_FACTORY_ADDRESS);
-  const implementationAddress = getAddress(
-    DEPOSIT_WALLET_IMPLEMENTATION_ADDRESS,
-  );
   const walletId = getDepositWalletId(ownerAddress);
   const args = ethers.utils.defaultAbiCoder.encode(
     ['address', 'bytes32'],
     [factoryAddress, walletId],
   ) as Hex;
   const salt = keccak256(args) as Hex;
+
+  return { factoryAddress, args, salt };
+}
+
+export function deriveDepositWalletUupsAddress(ownerAddress: string): Hex {
+  const implementationAddress = getAddress(
+    DEPOSIT_WALLET_IMPLEMENTATION_ADDRESS,
+  );
+  const { factoryAddress, args, salt } =
+    getDepositWalletCreate2Inputs(ownerAddress);
   const bytecodeHash = initCodeHashERC1967({
     implementation: implementationAddress,
     args,
@@ -122,6 +180,145 @@ export function deriveDepositWalletAddress(ownerAddress: string): Hex {
   return getAddress(
     getCreate2Address(factoryAddress, salt, bytecodeHash),
   ) as Hex;
+}
+
+export function deriveDepositWalletBeaconAddress({
+  ownerAddress,
+  beaconAddress,
+}: {
+  ownerAddress: string;
+  beaconAddress: string;
+}): Hex {
+  const { factoryAddress, args, salt } =
+    getDepositWalletCreate2Inputs(ownerAddress);
+  const bytecodeHash = initCodeHashERC1967BeaconProxy({
+    beacon: beaconAddress,
+    args,
+  });
+
+  return getAddress(
+    getCreate2Address(factoryAddress, salt, bytecodeHash),
+  ) as Hex;
+}
+
+export function deriveDepositWalletAddress(ownerAddress: string): Hex {
+  return deriveDepositWalletUupsAddress(ownerAddress);
+}
+
+function getErrorCode(error: unknown): unknown {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? (error as { code?: unknown }).code
+    : undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isContractRevertError(error: unknown): boolean {
+  if (getErrorCode(error) === CONTRACT_REVERT_ERROR_CODE) {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+
+  return CONTRACT_REVERT_ERROR_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
+}
+
+function decodeBeaconAddress(response: unknown): Hex | undefined {
+  if (typeof response !== 'string') {
+    throw new Error(
+      `Polymarket deposit wallet factory BEACON returned non-string response: ${String(
+        response,
+      )}`,
+    );
+  }
+
+  if (response === '0x') {
+    return undefined;
+  }
+
+  try {
+    const [beaconAddress] = ethers.utils.defaultAbiCoder.decode(
+      ['address'],
+      response,
+    );
+    const normalizedBeaconAddress = getAddress(String(beaconAddress)) as Hex;
+
+    return normalizedBeaconAddress === ZERO_ADDRESS
+      ? undefined
+      : normalizedBeaconAddress;
+  } catch (error) {
+    throw new Error(
+      `Polymarket deposit wallet factory BEACON returned malformed address data: ${response}. ${
+        error instanceof Error ? error.message : 'Unknown decode error'
+      }`,
+    );
+  }
+}
+
+export async function readDepositWalletFactoryBeacon(): Promise<
+  Hex | undefined
+> {
+  const { NetworkController } = Engine.context;
+  const networkClientId = NetworkController.findNetworkClientIdByChainId(
+    numberToHex(POLYGON_MAINNET_CHAIN_ID),
+  );
+  const ethQuery = new EthQuery(
+    NetworkController.getNetworkClientById(networkClientId).provider,
+  );
+
+  try {
+    const response = await query(ethQuery, 'call', [
+      {
+        to: DEPOSIT_WALLET_FACTORY_ADDRESS,
+        data: DEPOSIT_WALLET_FACTORY_BEACON_SELECTOR,
+      },
+    ]);
+
+    return decodeBeaconAddress(response);
+  } catch (error) {
+    if (isContractRevertError(error)) {
+      return undefined;
+    }
+
+    throw new Error(
+      `Polymarket deposit wallet factory BEACON call failed: ${getErrorMessage(
+        error,
+      )}`,
+    );
+  }
+}
+
+export async function resolveDepositWalletAddress({
+  ownerAddress,
+  readFactoryBeacon = readDepositWalletFactoryBeacon,
+  isWalletDeployed = async (walletAddress) =>
+    isSmartContractAddress(
+      walletAddress,
+      numberToHex(POLYGON_MAINNET_CHAIN_ID),
+    ),
+}: {
+  ownerAddress: string;
+  readFactoryBeacon?: () => Promise<Hex | undefined>;
+  isWalletDeployed?: (walletAddress: Hex) => Promise<boolean>;
+}): Promise<Hex> {
+  const uupsWalletAddress = deriveDepositWalletUupsAddress(ownerAddress);
+  const beaconAddress = await readFactoryBeacon();
+
+  if (!beaconAddress) {
+    return uupsWalletAddress;
+  }
+
+  const uupsWalletIsDeployed = await isWalletDeployed(uupsWalletAddress);
+
+  if (uupsWalletIsDeployed) {
+    return uupsWalletAddress;
+  }
+
+  return deriveDepositWalletBeaconAddress({ ownerAddress, beaconAddress });
 }
 
 export function toDepositWalletCalls(

--- a/app/components/UI/Predict/providers/polymarket/protocol/transport.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/transport.test.ts
@@ -57,6 +57,31 @@ describe('polymarket protocol transport', () => {
     );
   });
 
+  it('adds JSON content type for CLOB order upload body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+      }),
+    });
+
+    await submitProtocolClobOrder({
+      protocol: POLYMARKET_V2_PROTOCOL,
+      headers,
+      clobOrder,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://predict.api.cx.metamask.io/order',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
   it('normalizes relay errors into the existing result shape', async () => {
     mockFetch.mockRejectedValue(new Error('boom'));
 

--- a/app/components/UI/Predict/providers/polymarket/protocol/transport.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/transport.ts
@@ -34,6 +34,7 @@ export async function submitProtocolClobOrder({
   const url = `${CLOB_RELAYER}/order`;
   const requestHeaders = normalizeRelayerHeaders(headers);
 
+  requestHeaders['Content-Type'] = 'application/json';
   requestHeaders['X-Clob-Version'] = protocol.transport.clobVersionHeader;
 
   const body = {

--- a/app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.test.ts
@@ -6,8 +6,8 @@ import {
 import type { Hex } from '@metamask/utils';
 
 import {
-  deriveDepositWalletAddress,
   executeDepositWalletBatchAndWaitForCompletion,
+  resolveDepositWalletAddress,
 } from '../../../../components/UI/Predict/providers/polymarket/depositWallet';
 import type { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { createPolymarketCallbacks } from './polymarket-callbacks';
@@ -35,8 +35,8 @@ function buildInitMessenger() {
 }
 
 describe('createPolymarketCallbacks', () => {
-  const deriveDepositWalletAddressMock = jest.mocked(
-    deriveDepositWalletAddress,
+  const resolveDepositWalletAddressMock = jest.mocked(
+    resolveDepositWalletAddress,
   );
   const executeDepositWalletBatchAndWaitForCompletionMock = jest.mocked(
     executeDepositWalletBatchAndWaitForCompletion,
@@ -45,7 +45,7 @@ describe('createPolymarketCallbacks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    deriveDepositWalletAddressMock.mockReturnValue(DEPOSIT_WALLET_MOCK);
+    resolveDepositWalletAddressMock.mockResolvedValue(DEPOSIT_WALLET_MOCK);
     executeDepositWalletBatchAndWaitForCompletionMock.mockResolvedValue(
       SOURCE_HASH_MOCK,
     );
@@ -62,7 +62,9 @@ describe('createPolymarketCallbacks', () => {
       const result = await callbacks.getDepositWalletAddress({ eoa: EOA_MOCK });
 
       expect(result).toBe(DEPOSIT_WALLET_MOCK);
-      expect(deriveDepositWalletAddressMock).toHaveBeenCalledWith(EOA_MOCK);
+      expect(resolveDepositWalletAddressMock).toHaveBeenCalledWith({
+        ownerAddress: EOA_MOCK,
+      });
     });
   });
 

--- a/app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.ts
@@ -7,8 +7,8 @@ import type { PolymarketCallbacks } from '@metamask/transaction-pay-controller';
 import type { Hex } from '@metamask/utils';
 
 import {
-  deriveDepositWalletAddress,
   executeDepositWalletBatchAndWaitForCompletion,
+  resolveDepositWalletAddress,
 } from '../../../../components/UI/Predict/providers/polymarket/depositWallet';
 import type { Signer } from '../../../../components/UI/Predict/providers/types';
 import type { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
@@ -29,7 +29,7 @@ export function createPolymarketCallbacks(
 }
 
 async function getDepositWalletAddress(eoa: Hex): Promise<Hex> {
-  return deriveDepositWalletAddress(eoa) as Hex;
+  return resolveDepositWalletAddress({ ownerAddress: eoa });
 }
 
 async function submitDepositWalletBatch(


### PR DESCRIPTION
## **Description**

This PR fixes Polymarket deposit-wallet compatibility after Polymarket changed how new deposit wallets are deployed and derived.

Previously, MetaMask Mobile always derived a Predict deposit wallet with the legacy ERC-1967 UUPS clone formula using a hardcoded implementation address. That worked for older deposit-wallet accounts, but it no longer matched Polymarket's current deployment flow for newly-created accounts. New deposit wallets are now ERC-1967 BeaconProxy clones, while older UUPS wallets remain valid at their original addresses.

The new implementation mirrors Polymarket's current resolver flow:

- derive the legacy UUPS deposit-wallet candidate
- call the deposit wallet factory `BEACON()` view
- if the factory does not expose a beacon, keep the UUPS address
- if the UUPS address is already deployed, keep the UUPS address so existing users are preserved
- otherwise derive the BeaconProxy deposit-wallet address from the returned beacon

This lets all supported Predict wallet generations resolve to the correct account:

- legacy Safe users keep their existing Safe flow
- existing UUPS deposit-wallet users continue using their already-deployed UUPS wallet
- new BeaconProxy deposit-wallet users resolve to the new canonical wallet address

The PR also aligns all app-side address consumers with the canonical resolver, including account state, deposit transaction detection, and Transaction Pay callbacks. The beacon probe now reports specific errors for malformed data or RPC/provider failures instead of silently falling back to the UUPS address, which makes debugging safer and easier.

Additionally, a deposit-wallet-specific withdraw path was added so deposit-wallet withdrawals do not build Safe `execTransaction` calldata for deposit-wallet accounts. Safe withdraws continue using the existing Safe signing path, while deposit-wallet withdraws can be marked as external-sign transactions and published through the Polymarket relayer `WALLET` batch flow.

Known follow-up: manual testing found that an old legacy Safe wallet can still buy and sell, but withdraw currently fails through the MM Pay delegation relay (`/relay/execute`) with `UNKNOWN_CUSTOM_ERROR_0x3db6791c`. That appears separate from the deposit-wallet derivation fix and needs MM Pay / relay investigation.

## **Changelog**

CHANGELOG entry: Fixed Predict deposit-wallet address resolution for new Polymarket BeaconProxy wallets while preserving existing wallets

## **Related issues**

Refs:

## **Manual testing steps**

```gherkin
Feature: Predict deposit wallet compatibility

  Scenario: new Predict account uses the new deposit-wallet implementation
    Given a new Predict account created after the Polymarket deposit-wallet factory change
    When the user deposits funds into Predict
    Then the app resolves the BeaconProxy deposit wallet address
    And the deposit completes successfully

  Scenario: new Predict account can trade after funding
    Given a new Predict account with a funded BeaconProxy deposit wallet
    When the user buys a market outcome
    Then the buy order is placed successfully
    When the user sells the position
    Then the sell order is placed successfully

  Scenario: existing pre-change deposit-wallet account keeps working
    Given an existing Predict account created before the BeaconProxy change
    When the user deposits, withdraws, buys, and sells
    Then the app keeps resolving the already-deployed legacy UUPS deposit wallet
    And all tested flows complete successfully

  Scenario: old legacy Safe wallet still trades
    Given an older Predict account that still uses the legacy Safe wallet path
    When the user buys or sells
    Then the trade completes successfully

  Scenario: old legacy Safe wallet withdraw currently fails
    Given an older Predict account that still uses the legacy Safe wallet path
    When the user attempts to withdraw
    Then the withdraw currently fails through the MM Pay relay path
    And the failure should be investigated separately from deposit-wallet derivation
```

Automated tests run:

```bash
npx jest app/components/UI/Predict/providers/polymarket/depositWallet.test.ts --coverage=false
npx jest app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.test.ts --coverage=false
npx jest app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts --coverage=false
npx jest app/components/UI/Predict/controllers/PredictController.test.ts --coverage=false
npx jest app/components/UI/Predict/providers/polymarket/preflight/withdraw.test.ts --coverage=false
```

## **Screenshots/Recordings**

### **Before**

N/A - logic-only fix for wallet address derivation and transaction routing.

### **After**

N/A - logic-only fix for wallet address derivation and transaction routing.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wrong resolved addresses would misroute deposits and relayer batches; the change adds on-chain factory reads on critical Predict funding paths.
> 
> **Overview**
> Replaces synchronous UUPS-only deposit wallet derivation with **`resolveDepositWalletAddress`**, which mirrors Polymarket’s resolver: derive the legacy UUPS candidate, read the factory **`BEACON()`** on Polygon, keep UUPS when no beacon or when that wallet is already deployed, otherwise derive the **BeaconProxy** address. **`readDepositWalletFactoryBeacon`** uses the network provider; reverts fall back to UUPS, while malformed RPC data or non-revert failures throw explicit errors instead of silently defaulting.
> 
> **`PolymarketProvider`** and Transaction Pay **`polymarket-callbacks`** now await this resolver for account state, deposit preflight, balance sync, and pay flows. Deposit-wallet detection (`getDepositWalletDepositTransaction` / **`isDepositWalletDepositTransaction`**) is async because resolution can hit the chain.
> 
> Separately, CLOB order submission sets **`Content-Type: application/json`** on relayer POSTs, with a transport test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d5ea1d73f0471eb473d75084bdc4c88d74c0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->