### PR TITLE
fix: Add overlay for hw wallet loading state on iOS cp-8.1.0

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { FullWindowOverlay } from 'react-native-screens';
 
 import HardwareWalletContext from './contexts/HardwareWalletContext';
 import { HardwareWalletBottomSheet } from './components';
@@ -290,21 +291,23 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
   return (
     <HardwareWalletContext.Provider value={contextValue}>
       {children}
-      <HardwareWalletBottomSheet
-        connectionState={connectionState}
-        deviceSelection={deviceSelection}
-        walletType={effectiveWalletType}
-        forceHideBottomSheet={forceHideBottomSheet}
-        retryEnsureDeviceReady={handleRetryOrClose}
-        selectDevice={selectDevice}
-        rescan={rescan}
-        connect={connect}
-        onClose={handleCloseFlow}
-        onAwaitingConfirmationCancel={handleAwaitingConfirmationCancel}
-        onConnectionSuccess={handleBottomSheetConnectionSuccess}
-        onCTAClicked={trackCTAClicked}
-        onRetryQrScan={handleRetryQrScan}
-      />
+      <FullWindowOverlay>
+        <HardwareWalletBottomSheet
+          connectionState={connectionState}
+          deviceSelection={deviceSelection}
+          walletType={effectiveWalletType}
+          forceHideBottomSheet={forceHideBottomSheet}
+          retryEnsureDeviceReady={handleRetryOrClose}
+          selectDevice={selectDevice}
+          rescan={rescan}
+          connect={connect}
+          onClose={handleCloseFlow}
+          onAwaitingConfirmationCancel={handleAwaitingConfirmationCancel}
+          onConnectionSuccess={handleBottomSheetConnectionSuccess}
+          onCTAClicked={trackCTAClicked}
+          onRetryQrScan={handleRetryQrScan}
+        />
+      </FullWindowOverlay>
     </HardwareWalletContext.Provider>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This PR fixes the hardware bottom sheet not appearing for ios. 

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix hardware bottom sheet not appearing during ledger connection. 

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32569

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Open your Ledger and the Ethereum app
2. Go to Accounts list in MetaMask mobile app using iOS device
3. Click Add wallet
4. Click Connect hardware wallet
5. Click Ledger
6. Notice Looking for device screen

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

https://github.com/user-attachments/assets/b65edd80-b6dd-45d1-85b8-80dd8a08bc1b

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only change using an established in-repo pattern; no connection, signing, or state logic is modified.
> 
> **Overview**
> Fixes the **hardware wallet bottom sheet not showing on iOS** during Ledger (and other hardware) connection flows.
> 
> `HardwareWalletBottomSheet` is now rendered inside `FullWindowOverlay` from `react-native-screens` instead of as a sibling under the provider. On iOS, that overlay uses a separate window so the sheet can sit above native-stack screens and other native layers where a normal React tree view was hidden or clipped. Bottom sheet props and behavior are unchanged; only the presentation wrapper is new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32a76d4e91c49366f9ccf06a69b3b6ab40133ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->