### PR TITLE
test: Add 14 Sell flow CVT tests

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.view.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.view.test.tsx
@@ -23,6 +23,7 @@ import {
   RAMPS_SDK_LIMITS,
 } from '../../../../../../../tests/component-view/presets/ramps';
 import { MULTICHAIN_TEST_ACCOUNTS } from '../../../../../../../tests/component-view/presets/multichainAccounts';
+import Routes from '../../../../../../constants/navigation/Routes';
 
 const ETH_MAINNET_ASSET_ID = 'eip155:1/slip44:60';
 
@@ -239,6 +240,242 @@ describe('Aggregator BuildQuote', () => {
         ).not.toBeOnTheScreen();
       });
       expect(await findByText('You want to sell')).toBeOnTheScreen();
+    });
+
+    it('shows insufficient balance error when sell amount exceeds ETH balance', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const {
+        findByText,
+        getByText,
+        queryByText,
+        findByTestId,
+        findByRole,
+        getByTestId,
+      } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // France fixture has 100 ETH. Enter amount exceeding it.
+      await enterSellAmountViaKeypad(
+        { findByRole, findByTestId, getByTestId },
+        '101',
+        'ETH',
+      );
+
+      // Wait for the insufficient balance error to appear — amountBNMinimalUnit
+      // recomputation is async after keypad state updates propagate.
+      expect(
+        await findByTestId(
+          BuildQuoteSelectors.INSUFFICIENT_BALANCE_ERROR,
+          {},
+          { timeout: 5000 },
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('navigates to Quotes screen when "Get quotes" is pressed with a valid sell amount', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+        includeQuotesRoute: true,
+      });
+      const {
+        findByText,
+        findByRole,
+        getByText,
+        queryByText,
+        findByTestId,
+        getByTestId,
+      } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // Wait for all SDK data to load (fiat, payment, limits)
+      await findByText('EUR');
+      await findByText('Apple Pay');
+
+      await enterSellAmountViaKeypad(
+        { findByRole, findByTestId, getByTestId },
+        '50',
+        'ETH',
+      );
+
+      // Wait for "Get quotes" button to become enabled (isFetching=false)
+      const getQuotesButton = await findByRole('button', {
+        name: 'Get quotes',
+      });
+      await waitFor(() => {
+        expect(getQuotesButton).not.toBeDisabled();
+      });
+
+      fireEvent.press(getQuotesButton);
+
+      await findByTestId(`route-${Routes.RAMP.QUOTES}`, {}, { timeout: 5000 });
+    });
+
+    it('changes fiat currency from EUR to USD in sell mode', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const { findByText, getByText, queryByText } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      expect(await findByText('EUR')).toBeOnTheScreen();
+
+      fireEvent.press(await findByText('EUR'));
+      fireEvent.press(await findByText('US Dollar'));
+
+      await waitFor(() => {
+        expect(queryByText('EUR')).not.toBeOnTheScreen();
+      });
+      expect(await findByText('USD')).toBeOnTheScreen();
+    });
+
+    it('changes region from France to Spain in sell mode', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const { findByText, getByText, queryByText, getByTestId } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      expect(await findByText(RAMPS_FRANCE_REGION.emoji)).toBeOnTheScreen();
+
+      fireEvent.press(getByTestId(BuildQuoteSelectors.REGION_DROPDOWN));
+      fireEvent.press(await findByText('Spain'));
+
+      await waitFor(() => {
+        expect(queryByText(RAMPS_FRANCE_REGION.emoji)).not.toBeOnTheScreen();
+      });
+      expect(await findByText('🇪🇸')).toBeOnTheScreen();
+    });
+
+    it('fills 50% of balance via quick percentage pill for mUSD', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const {
+        findByText,
+        getByText,
+        queryByText,
+        findByTestId,
+        queryByTestId,
+        getAllByText,
+      } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // Switch to mUSD — quick amounts only show for ERC-20 tokens
+      // (native ETH requires gas estimation for maxSellAmount)
+      await selectTokenViaSearch(
+        { findByText, findByTestId, queryByTestId, getAllByText },
+        'mUSD',
+        'mUSD',
+      );
+
+      // Open keypad so quick amounts are visible
+      fireEvent.press(await findByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
+
+      fireEvent.press(await findByText('50%'));
+
+      // After pressing 50%, the amount should no longer be "0 mUSD"
+      await waitFor(() => {
+        expect(queryByText('0 mUSD')).not.toBeOnTheScreen();
+      });
+    });
+
+    it('resets sell amount to zero when switching token', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const {
+        findByText,
+        getByText,
+        queryByText,
+        findByRole,
+        findByTestId,
+        queryByTestId,
+        getByTestId,
+        getAllByText,
+      } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // Enter 60 ETH
+      await enterSellAmountViaKeypad(
+        { findByRole, findByTestId, getByTestId },
+        '60',
+        'ETH',
+      );
+
+      // Switch to mUSD
+      await selectTokenViaSearch(
+        { findByText, findByTestId, queryByTestId, getAllByText },
+        'mUSD',
+        'mUSD',
+      );
+
+      // Amount should reset to 0
+      expect(await findByText('0 mUSD')).toBeOnTheScreen();
+    });
+
+    it('changes payment method via "Send cash to" selector in sell mode', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const { findByText, getByText, queryByText } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // Sell mode shows "Send cash to" label (not "Update payment method")
+      fireEvent.press(await findByText('Apple Pay'));
+      fireEvent.press(await findByText('SEPA Bank Transfer'));
+
+      await waitFor(() => {
+        expect(queryByText('Apple Pay')).not.toBeOnTheScreen();
+      });
+      expect(await findByText('SEPA Bank Transfer')).toBeOnTheScreen();
+    });
+
+    it('shows min limit error when sell amount is below minimum', async () => {
+      const renderApi = renderBuildQuoteWithRoutes({
+        rampType: RampType.SELL,
+        useFranceSellFixture: true,
+      });
+      const {
+        findByText,
+        getByText,
+        queryByText,
+        findByRole,
+        findByTestId,
+        getByTestId,
+      } = renderApi;
+
+      await waitForBuildQuoteReady({ getByText, queryByText });
+
+      // SDK limits minAmount is 10. Enter 5 which is below.
+      await enterSellAmountViaKeypad(
+        { findByRole, findByTestId, getByTestId },
+        '5',
+        'ETH',
+      );
+
+      expect(
+        await findByTestId(
+          BuildQuoteSelectors.MIN_LIMIT_ERROR,
+          {},
+          { timeout: 5000 },
+        ),
+      ).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.view.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.view.test.tsx
@@ -1,5 +1,5 @@
 import '../../../../../../../tests/component-view/mocks';
-import { waitFor } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import {
   CryptoCurrency,
   FiatCurrency,
@@ -136,6 +136,82 @@ describe('Aggregator Quotes screen', () => {
         expect.anything(),
       );
     });
+  });
+
+  it('displays sell quote amount and shows CTA after pressing the quote', async () => {
+    const sellQuote = buildSellQuote({
+      amountOut: 45.5,
+      providerFee: 2.5,
+      networkFee: 1.0,
+    });
+    const getSellQuotes = jest.fn().mockResolvedValue({
+      quotes: [sellQuote],
+      sorted: [],
+      customActions: [],
+    });
+
+    const { render } = renderAggregatorQuotesView({
+      rampType: RampType.SELL,
+      amount: 50,
+      selectedAsset: ETH,
+      selectedFiatCurrency: EUR,
+      selectedPaymentMethodId: PAYMENT_METHOD_ID,
+      selectedAddress: WALLET_ADDRESS,
+      sdkMocks: { getSellQuotes },
+    });
+
+    expect(await render.findByText('MoonPay (Staging)')).toBeOnTheScreen();
+
+    fireEvent.press(await render.findByText('MoonPay (Staging)'));
+
+    expect(
+      await render.findByText('Continue with MoonPay (Staging)'),
+    ).toBeOnTheScreen();
+    await waitFor(() => {
+      expect(render.getByText(/45\.5/)).toBeOnTheScreen();
+    });
+  });
+
+  it('renders multiple sell quotes and reveals second provider via "Explore more options"', async () => {
+    const moonpayQuote = buildSellQuote({
+      amountOut: 38.42,
+    });
+    const transakQuote = buildSellQuote({
+      provider: {
+        id: '/providers/transak-staging',
+        name: 'Transak (Staging)',
+        description: '',
+        hqAddress: '',
+        links: [],
+        logos: { light: '', dark: '', height: 24, width: 90 },
+        features: {} as never,
+      },
+      amountOut: 37.5,
+    });
+
+    const getSellQuotes = jest.fn().mockResolvedValue({
+      quotes: [moonpayQuote, transakQuote],
+      sorted: [],
+      customActions: [],
+    });
+
+    const { render } = renderAggregatorQuotesView({
+      rampType: RampType.SELL,
+      amount: 50,
+      selectedAsset: ETH,
+      selectedFiatCurrency: EUR,
+      selectedPaymentMethodId: PAYMENT_METHOD_ID,
+      selectedAddress: WALLET_ADDRESS,
+      sdkMocks: { getSellQuotes },
+    });
+
+    // First (recommended) quote is visible immediately
+    expect(await render.findByText('MoonPay (Staging)')).toBeOnTheScreen();
+
+    // Expand to see other providers
+    fireEvent.press(await render.findByText('Explore more options'));
+
+    expect(await render.findByText('Transak (Staging)')).toBeOnTheScreen();
   });
 
   it('loads buy quotes via getQuotes and renders the recommended provider', async () => {

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.view.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/Quotes.view.test.tsx
@@ -185,6 +185,7 @@ describe('Aggregator Quotes screen', () => {
         links: [],
         logos: { light: '', dark: '', height: 24, width: 90 },
         features: {} as never,
+        environmentType: '' as never,
       },
       amountOut: 37.5,
     });

--- a/tests/component-view/renderers/ramps.tsx
+++ b/tests/component-view/renderers/ramps.tsx
@@ -286,6 +286,11 @@ export interface RenderBuildQuoteWithRoutesOptions
    * history navigation is observable.
    */
   includeBuySettingsAndTransactionsRoutes?: boolean;
+  /**
+   * Register a Quotes route placeholder so "Get quotes" navigation from
+   * BuildQuote can be asserted via route probe.
+   */
+  includeQuotesRoute?: boolean;
 }
 
 /**
@@ -331,6 +336,7 @@ export function renderBuildQuoteWithRoutes(
     includeAccountSelector = false,
     useFranceSellFixture = false,
     includeBuySettingsAndTransactionsRoutes = false,
+    includeQuotesRoute = false,
     state: stateOverride,
   } = options;
 
@@ -365,6 +371,10 @@ export function renderBuildQuoteWithRoutes(
   const MainStack = createNativeStackNavigator();
   const ModalsStack = createNativeStackNavigator();
 
+  const QuotesPlaceholder = () => (
+    <Text testID={`route-${Routes.RAMP.QUOTES}`}>Quotes placeholder</Text>
+  );
+
   const MainRoutes = () => (
     <MainStack.Navigator
       initialRouteName={Routes.RAMP.BUILD_QUOTE}
@@ -377,6 +387,12 @@ export function renderBuildQuoteWithRoutes(
         component={BuildQuote}
         initialParams={initialParams}
       />
+      {includeQuotesRoute ? (
+        <MainStack.Screen
+          name={Routes.RAMP.QUOTES}
+          component={QuotesPlaceholder}
+        />
+      ) : null}
     </MainStack.Navigator>
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

### Existing sell CVTs (5 tests)

| Test | What it covers |
|------|----------------|
| Deeplink intent initializes sell amount | Entry with pre-filled amount |
| Select mUSD + France defaults + sell limits | Token selection, region/fiat/payment defaults, min/max validation |
| Switch accounts in sell mode | Account picker interaction |
| Sell quotes render recommended provider | Quotes screen with `getSellQuotes` |
| (buy mode tests — 3 tests) | Not sell-specific |

### BuildQuote — Sell Mode (11 new tests)

| Test | Steps |
|------|-------|
| Initializes sell amount from deeplink intent | Renders with amount=50 + assetId → asserts "50 ETH" shown |
| Selects mUSD, France defaults, sell limits | Searches mUSD → selects it → enters over-max amount → asserts max error → clears → enters valid amount → asserts no error |
| Switches accounts | Presses account picker → selects Account 3 → asserts Account 3 shown, Account 1 gone |
| Insufficient balance error | Enters 101 ETH via keypad → asserts insufficient balance error (fixture has 100 ETH) |
| Navigates to Quotes screen | Waits for EUR + Apple Pay → enters 50 ETH → waits for button enabled → presses "Get quotes" → asserts Quotes route reached |
| Changes fiat currency | Presses EUR → selects US Dollar → asserts EUR gone, USD shown |
| Changes region | Presses region dropdown → selects Spain → asserts France emoji gone, Spain emoji shown |
| Quick percentage pill fills from balance | Switches to mUSD → opens keypad → presses 50% → asserts amount changed from "0 mUSD" |
| Amount resets on token switch | Enters 60 ETH via keypad → switches to mUSD → asserts amount reset to "0 mUSD" |
| Payment method change | Presses Apple Pay → selects SEPA Bank Transfer → asserts Apple Pay gone, SEPA shown |
| Min limit error | Enters 5 via keypad → asserts min limit error shown (minAmount is 10) |

### Quotes — Sell Mode (3 new tests)

| Test | Steps |
|------|-------|
| Loads quotes and renders provider | Renders with getSellQuotes mock → asserts "MoonPay (Staging)" shown → asserts SDK called with correct params |
| Quote amount + CTA on press | Renders with amountOut=45.5 → presses "MoonPay (Staging)" → asserts "Continue with MoonPay (Staging)" + amount 45.5 shown |
| Multiple quotes expand | Renders with 2 quotes → asserts MoonPay shown → presses "Explore more options" → asserts Transak shown |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to CVT files and the ramps test renderer; no application logic, auth, or data paths are modified.
> 
> **Overview**
> Expands **component view test** coverage for the aggregator **sell** ramp flow without changing production UI or navigation behavior.
> 
> **BuildQuote (sell mode)** gains scenarios for insufficient balance, min-limit validation, fiat/region/payment changes, 50% quick-fill on mUSD, amount reset on token switch, and **Get quotes** navigation (asserted via a new optional **Quotes** route placeholder in `renderBuildQuoteWithRoutes`).
> 
> **Quotes (sell mode)** adds tests for selecting a quote (continue CTA + payout amount) and expanding **Explore more options** when multiple providers are mocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfbbc9bad67b56ccd0591d7b2b6c988036f56d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->