### PR TITLE
fix(perps): strip asset namespace in order details

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.test.tsx
@@ -193,6 +193,30 @@ describe('PerpsOrderDetailsView', () => {
     expect(screen.getByText('BTC')).toBeOnTheScreen();
   });
 
+  it('strips DEX prefix from visible asset symbol while preserving raw symbol for cancellation', async () => {
+    mockRouteParams = {
+      order: {
+        ...mockOrder,
+        symbol: 'xyz:MSTR',
+      },
+    };
+
+    render(<PerpsOrderDetailsView />);
+
+    expect(screen.getByText('MSTR')).toBeOnTheScreen();
+    expect(screen.getAllByText('0.5000 MSTR')).toHaveLength(2);
+    expect(screen.queryByText('xyz:MSTR')).not.toBeOnTheScreen();
+
+    fireEvent.press(screen.getByText('perps.order_details.cancel_order'));
+
+    await waitFor(() => {
+      expect(mockCancelOrder).toHaveBeenCalledWith({
+        orderId: 'order-123',
+        symbol: 'xyz:MSTR',
+      });
+    });
+  });
+
   it('renders error state when no order is provided', () => {
     mockRouteParams = {};
 

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
@@ -298,12 +298,12 @@ const PerpsOrderDetailsView: React.FC = () => {
     {
       key: 'size',
       label: strings('perps.order_details.size'),
-      value: `${formatPositionSize(parseFloat(order.size))} ${displaySymbol}`,
+      value: `${formatPositionSize(Number.parseFloat(order.size))} ${displaySymbol}`,
     },
     {
       key: 'original-size',
       label: strings('perps.order_details.original_size'),
-      value: `${formatPositionSize(parseFloat(order.originalSize))} ${
+      value: `${formatPositionSize(Number.parseFloat(order.originalSize))} ${
         displaySymbol
       }`,
     },

--- a/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx
@@ -25,7 +25,11 @@ import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { usePerpsOrderFees } from '../../hooks/usePerpsOrderFees';
 import usePerpsToasts from '../../hooks/usePerpsToasts';
 import { TraceName } from '../../../../../util/trace';
-import { PERPS_CONSTANTS, type Order } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  PERPS_CONSTANTS,
+  type Order,
+} from '@metamask/perps-controller';
 import styleSheet from './PerpsOrderDetailsView.styles';
 import { PerpsOrderDetailsViewSelectorsIDs } from '../../Perps.testIds';
 import PerpsTokenLogo from '../../components/PerpsTokenLogo';
@@ -251,6 +255,8 @@ const PerpsOrderDetailsView: React.FC = () => {
     return null;
   }
 
+  const displaySymbol = getPerpsDisplaySymbol(order.symbol);
+
   const detailRows: DetailRow[] = [
     {
       key: 'date',
@@ -292,13 +298,13 @@ const PerpsOrderDetailsView: React.FC = () => {
     {
       key: 'size',
       label: strings('perps.order_details.size'),
-      value: `${formatPositionSize(parseFloat(order.size))} ${order.symbol}`,
+      value: `${formatPositionSize(parseFloat(order.size))} ${displaySymbol}`,
     },
     {
       key: 'original-size',
       label: strings('perps.order_details.original_size'),
       value: `${formatPositionSize(parseFloat(order.originalSize))} ${
-        order.symbol
+        displaySymbol
       }`,
     },
     {
@@ -350,7 +356,7 @@ const PerpsOrderDetailsView: React.FC = () => {
             <PerpsTokenLogo symbol={order.symbol} size={48} />
           </View>
           <Text variant={TextVariant.HeadingLG} style={styles.assetName}>
-            {order.symbol}
+            {displaySymbol}
           </Text>
         </View>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes the Perps Order Details screen so HIP-3/xyz market orders display the user-facing asset ticker, such as `MSTR`, instead of the internal namespaced asset identifier, such as `xyz:MSTR`.

The raw namespaced symbol is still preserved for provider operations like cancellation, token logo lookup, and routing, but visible labels now use the existing Perps display-symbol helper.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Perps Order Details screen so HIP-3/xyz market orders display the user facing asset ticker

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3479

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 21 42 56" src="https://github.com/user-attachments/assets/438c81b2-82c3-4eed-992a-fd58733b1071" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label change in one Perps screen, aligned with existing `getPerpsDisplaySymbol` usage elsewhere; provider calls still use the raw symbol.
> 
> **Overview**
> **Perps Order Details** now shows user-facing tickers (e.g. `MSTR`) for HIP-3/xyz markets by routing visible copy through `getPerpsDisplaySymbol`, instead of the raw namespaced `order.symbol` (e.g. `xyz:MSTR`).
> 
> The header title and size/original-size rows use the display symbol; **unchanged** paths still pass the full `order.symbol` for logo lookup, cancel, and toasts. A test asserts stripped UI labels and that cancel still receives the namespaced symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a46aa1b447232bfa128e98f1e2e75f670d45a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->