### PR TITLE
fix: MUSD-1096 Fix Misleading Money Account Deeplink Handling cp-8.0.2

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -182,6 +182,7 @@ import BenefitFullView from '../../UI/Rewards/Views/BenefitFullView';
 import BenefitsFullView from '../../UI/Rewards/Views/BenefitsFullView';
 import MoneyTabPressTracker from '../../UI/Money/components/MoneyTabPressTracker';
 import { withMessenger } from '../../../messengers/helpers/route-messenger-helpers';
+import MoneyDeeplinkModal from '../../UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal';
 
 const NativeStack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -1274,6 +1275,19 @@ const MainNavigator = () => {
           />
         </>
       )}
+      {/*
+       * Rendered outside isMoneyAccountEnabled so we can display modal when feature is disabled.
+       * - Maintenance modal when the feature is disabled.
+       * - Gradual rollout modal when the user is not part of the gradual rollout cohort yet but feature is enabled.
+       */}
+      <NativeStack.Screen
+        name={Routes.MONEY.MODALS.DEEPLINK_MODAL}
+        component={MoneyDeeplinkModal}
+        options={{
+          ...clearNativeStackNavigatorOptions,
+          ...transparentModalScreenOptions,
+        }}
+      />
       <NativeStack.Screen
         name="StakeModals"
         component={StakeModalStack}

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -149,6 +149,7 @@ describe('MainNavigator Route Constants', () => {
     expect(Routes.MONEY.MODALS.MONEY_BALANCE_INFO_SHEET).toBeDefined();
     expect(Routes.MONEY.MODALS.LINK_CARD_SHEET).toBeDefined();
     expect(Routes.MONEY.MODALS.EARN_CRYPTO_INFO_SHEET).toBeDefined();
+    expect(Routes.MONEY.MODALS.DEEPLINK_MODAL).toBeDefined();
   });
 });
 

--- a/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.test.tsx
+++ b/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.test.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MoneyDeeplinkModal from './MoneyDeeplinkModal';
+import { MoneyDeeplinkModalTestIds } from './MoneyDeeplinkModal.testIds';
+import { strings } from '../../../../../../locales/i18n';
+import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockTrackBottomSheetViewed = jest.fn();
+const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => callback?.());
+const mockNavigate = jest.fn();
+
+const DEFAULT_TITLE = 'Money account is temporarily unavailable';
+const DEFAULT_DESCRIPTION =
+  "We're working on it. Money Account will be back up shortly — check back soon.";
+
+jest.mock('../../hooks/useMoneyAnalytics', () => ({
+  useMoneyAnalytics: jest.fn(),
+}));
+
+jest.mock('../../../../../util/theme/themeUtils', () => ({
+  useElevatedSurface: () => 'bg-default',
+}));
+
+const mockUseRoute = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+    useRoute: () => mockUseRoute(),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  const MockBottomSheet = ReactActual.forwardRef(
+    (
+      {
+        children,
+        testID,
+        onClose,
+      }: {
+        children: React.ReactNode;
+        testID?: string;
+        onClose?: () => void;
+      },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: mockOnCloseBottomSheet,
+        onOpenBottomSheet: jest.fn(),
+      }));
+
+      return ReactActual.createElement(View, { testID, onClose }, children);
+    },
+  );
+
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+  };
+});
+
+describe('MoneyDeeplinkModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRoute.mockReturnValue({
+      params: {
+        title: DEFAULT_TITLE,
+        description: DEFAULT_DESCRIPTION,
+      },
+    });
+    (useMoneyAnalytics as jest.Mock).mockReturnValue({
+      trackBottomSheetViewed: mockTrackBottomSheetViewed,
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders the bottom sheet container', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(getByTestId(MoneyDeeplinkModalTestIds.SHEET)).toBeOnTheScreen();
+    });
+
+    it('renders the title from route params', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(getByTestId(MoneyDeeplinkModalTestIds.TITLE)).toHaveTextContent(
+        DEFAULT_TITLE,
+      );
+    });
+
+    it('renders the description from route params', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(
+        getByTestId(MoneyDeeplinkModalTestIds.DESCRIPTION),
+      ).toHaveTextContent(DEFAULT_DESCRIPTION);
+    });
+
+    it('renders an empty title when title param is undefined', () => {
+      mockUseRoute.mockReturnValue({
+        params: { description: DEFAULT_DESCRIPTION },
+      });
+
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(getByTestId(MoneyDeeplinkModalTestIds.TITLE)).toHaveTextContent(
+        '',
+      );
+    });
+
+    it('renders an empty description when description param is undefined', () => {
+      mockUseRoute.mockReturnValue({ params: { title: DEFAULT_TITLE } });
+
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(
+        getByTestId(MoneyDeeplinkModalTestIds.DESCRIPTION),
+      ).toHaveTextContent('');
+    });
+
+    it('renders an empty title and description when params are undefined', () => {
+      mockUseRoute.mockReturnValue({ params: undefined });
+
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(getByTestId(MoneyDeeplinkModalTestIds.TITLE)).toHaveTextContent(
+        '',
+      );
+      expect(
+        getByTestId(MoneyDeeplinkModalTestIds.DESCRIPTION),
+      ).toHaveTextContent('');
+    });
+
+    it('renders the primary button with correct copy', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(
+        getByTestId(MoneyDeeplinkModalTestIds.PRIMARY_BUTTON),
+      ).toHaveTextContent(strings('money.deeplink_modal.button'));
+    });
+
+    it('renders the close button', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(
+        getByTestId(MoneyDeeplinkModalTestIds.CLOSE_BUTTON),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('navigation', () => {
+    it('closes sheet and navigates to wallet home when primary button is pressed', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      fireEvent.press(getByTestId(MoneyDeeplinkModalTestIds.PRIMARY_BUTTON));
+
+      expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+    });
+
+    it('closes sheet and navigates to wallet home when header close button is pressed', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+
+      fireEvent.press(getByTestId(MoneyDeeplinkModalTestIds.CLOSE_BUTTON));
+
+      expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+    });
+
+    it('closes sheet and navigates to wallet home when bottom sheet onClose callback runs', () => {
+      const { getByTestId } = renderWithProvider(<MoneyDeeplinkModal />);
+      const sheet = getByTestId(MoneyDeeplinkModalTestIds.SHEET);
+
+      sheet.props.onClose();
+
+      expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+    });
+  });
+
+  describe('analytics', () => {
+    it('initialises useMoneyAnalytics with MONEY_DEEPLINK_MODAL bottom_sheet_name', () => {
+      renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(useMoneyAnalytics).toHaveBeenCalledWith({
+        bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_DEEPLINK_MODAL,
+      });
+    });
+
+    it('calls trackBottomSheetViewed on mount', () => {
+      renderWithProvider(<MoneyDeeplinkModal />);
+
+      expect(mockTrackBottomSheetViewed).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.testIds.ts
+++ b/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.testIds.ts
@@ -1,0 +1,7 @@
+export const MoneyDeeplinkModalTestIds = {
+  SHEET: 'money-deeplink-modal-sheet',
+  TITLE: 'money-deeplink-modal-title',
+  DESCRIPTION: 'money-deeplink-modal-description',
+  CLOSE_BUTTON: 'money-deeplink-modal-close-button',
+  PRIMARY_BUTTON: 'money-deeplink-modal-primary-button',
+} as const;

--- a/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.tsx
+++ b/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.tsx
@@ -1,0 +1,99 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  BottomSheetRef,
+  Box,
+  ButtonsAlignment,
+  ButtonSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+import { MoneyDeeplinkModalTestIds } from './MoneyDeeplinkModal.testIds';
+import { strings } from '../../../../../../locales/i18n';
+import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
+import useMountEffect from '../../hooks/useMountEffect';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+import { AppStackNavigationProp } from '../../../../../core/NavigationService/types';
+
+interface MoneyDeeplinkModalParams {
+  title?: string;
+  description?: string;
+}
+
+const MoneyDeeplinkModal = () => {
+  const navigation = useNavigation<AppStackNavigationProp>();
+
+  const route =
+    useRoute<RouteProp<{ params: MoneyDeeplinkModalParams }, 'params'>>();
+
+  const title = route.params?.title;
+  const description = route.params?.description;
+
+  const surfaceClass = useElevatedSurface();
+
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+  const { trackBottomSheetViewed } = useMoneyAnalytics({
+    bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_DEEPLINK_MODAL,
+  });
+
+  useMountEffect(trackBottomSheetViewed);
+
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.onCloseBottomSheet(() => {
+      navigation.navigate(Routes.WALLET.HOME);
+    });
+  }, [navigation]);
+
+  const primaryButtonProps = useMemo(
+    () => ({
+      children: strings('money.deeplink_modal.button'),
+      onPress: handleClose,
+      testID: MoneyDeeplinkModalTestIds.PRIMARY_BUTTON,
+      size: ButtonSize.Lg,
+    }),
+    [handleClose],
+  );
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      testID={MoneyDeeplinkModalTestIds.SHEET}
+      twClassName={surfaceClass}
+      onClose={handleClose}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        testID={MoneyDeeplinkModalTestIds.TITLE}
+        closeButtonProps={{
+          testID: MoneyDeeplinkModalTestIds.CLOSE_BUTTON,
+        }}
+      >
+        {title}
+      </BottomSheetHeader>
+      <Box paddingHorizontal={4}>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          testID={MoneyDeeplinkModalTestIds.DESCRIPTION}
+          twClassName="text-center"
+        >
+          {description}
+        </Text>
+      </Box>
+      <BottomSheetFooter
+        buttonsAlignment={ButtonsAlignment.Horizontal}
+        primaryButtonProps={primaryButtonProps}
+        twClassName="pt-6"
+      />
+    </BottomSheet>
+  );
+};
+
+export default MoneyDeeplinkModal;

--- a/app/components/UI/Money/constants/moneyEvents.ts
+++ b/app/components/UI/Money/constants/moneyEvents.ts
@@ -30,6 +30,7 @@ export enum BOTTOM_SHEET_NAMES {
   MONEY_MORE_SHEET = 'money_more_sheet',
   MONEY_BALANCE_INFO_SHEET = 'money_balance_info_sheet',
   MONEY_GEO_BLOCK_SHEET = 'money_geo_block_sheet',
+  MONEY_DEEPLINK_MODAL = 'money_deeplink_modal',
 }
 
 export enum REDIRECT_TARGETS_TYPES {

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -482,6 +482,7 @@ const Routes = {
       LINK_CARD_SHEET: 'MoneyLinkCardSheet',
       EARN_CRYPTO_INFO_SHEET: 'MoneyEarnCryptoInfoSheet',
       GEO_BLOCK_SHEET: 'MoneyGeoBlockSheet',
+      DEEPLINK_MODAL: 'MoneyDeeplinkModal',
     },
   },
   FULL_SCREEN_CONFIRMATIONS: {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
@@ -1,20 +1,31 @@
+import type { Json } from '@metamask/utils';
+import { getVersion } from 'react-native-device-info';
 import { handleMoney } from '../handleMoney';
-import handleDeepLinkModalDisplay from '../handleDeepLinkModalDisplay';
 import NavigationService from '../../../../NavigationService';
 import ReduxService from '../../../../redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import DevLogger from '../../../../SDKConnect/utils/DevLogger';
 import Logger from '../../../../../util/Logger';
 import { selectMoneyOnboardingSeen } from '../../../../../reducers/user';
-import { selectMoneyEnableMoneyAccountFlag } from '../../../../../components/UI/Money/selectors/featureFlags';
 import { selectIsMoneyAccountGeoEligible } from '../../../../../components/UI/Money/selectors/eligibility';
 import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
-import { DeepLinkModalLinkType } from '../../../types/deepLink.types';
+import {
+  selectRawRemoteFeatureFlags,
+  selectRemoteFeatureFlags,
+} from '../../../../../selectors/featureFlagController';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../../lib/Money/feature-flags';
 
 jest.mock('../../../../NavigationService');
 jest.mock('../../../../SDKConnect/utils/DevLogger');
 jest.mock('../../../../../util/Logger');
-jest.mock('../handleDeepLinkModalDisplay', () => jest.fn());
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('8.0.1'),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
 
 jest.mock('../../../../redux', () => ({
   __esModule: true,
@@ -29,10 +40,6 @@ jest.mock('../../../../../reducers/user', () => ({
   selectMoneyOnboardingSeen: jest.fn(),
 }));
 
-jest.mock('../../../../../components/UI/Money/selectors/featureFlags', () => ({
-  selectMoneyEnableMoneyAccountFlag: jest.fn(),
-}));
-
 jest.mock('../../../../../components/UI/Money/selectors/eligibility', () => ({
   selectIsMoneyAccountGeoEligible: jest.fn(),
 }));
@@ -44,9 +51,87 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../../../selectors/featureFlagController', () => ({
+  selectRawRemoteFeatureFlags: jest.fn(),
+  selectRemoteFeatureFlags: jest.fn(),
+}));
+
+interface VersionGatedFlag {
+  enabled: boolean;
+  minimumVersion: string;
+}
+
+interface GradualRolloutFlag {
+  scope: {
+    type: 'threshold';
+    value: number;
+  };
+  thresholdName: string;
+  thresholdVersion: number;
+  value: VersionGatedFlag;
+}
+
+const enabledFlag: VersionGatedFlag = {
+  enabled: true,
+  minimumVersion: '8.0.1',
+};
+
+const disabledFlag: VersionGatedFlag = {
+  enabled: false,
+  minimumVersion: '0.0.0',
+};
+
+const enabledRolloutFlag: GradualRolloutFlag = {
+  scope: {
+    type: 'threshold',
+    value: 0.25,
+  },
+  thresholdName: 'enabled',
+  thresholdVersion: 2,
+  value: enabledFlag,
+};
+
+const disabledRolloutFlag: GradualRolloutFlag = {
+  scope: {
+    type: 'threshold',
+    value: 1,
+  },
+  thresholdName: 'disabled',
+  thresholdVersion: 2,
+  value: disabledFlag,
+};
+
 describe('handleMoney', () => {
   let mockNavigate: jest.Mock;
   const mockState = {} as ReturnType<typeof ReduxService.store.getState>;
+
+  const setMoneyAccountFlags = ({
+    rawFlag = enabledFlag,
+    resolvedFlag = enabledFlag,
+  }: {
+    rawFlag?: unknown;
+    resolvedFlag?: unknown;
+  } = {}) => {
+    jest.mocked(selectRawRemoteFeatureFlags).mockReturnValue({
+      [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: rawFlag as Json,
+    });
+    jest.mocked(selectRemoteFeatureFlags).mockReturnValue({
+      [MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME]: resolvedFlag as Json,
+    });
+  };
+
+  const expectDeeplinkModalNavigation = (
+    title: string,
+    description: string,
+  ) => {
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.MONEY.MODALS.DEEPLINK_MODAL,
+      {
+        title,
+        description,
+      },
+    );
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,7 +142,8 @@ describe('handleMoney', () => {
     } as unknown as typeof NavigationService.navigation;
 
     jest.mocked(ReduxService.store.getState).mockReturnValue(mockState);
-    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(true);
+    jest.mocked(getVersion).mockReturnValue('8.0.1');
+    setMoneyAccountFlags();
     jest.mocked(selectIsMoneyAccountGeoEligible).mockReturnValue(true);
     jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(true);
     jest
@@ -65,27 +151,80 @@ describe('handleMoney', () => {
       .mockReturnValue(true);
   });
 
-  it('opens unsupported deep link modal when money account flag is disabled', () => {
-    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(false);
+  it('navigates to disabled deeplink modal when type 1 flag is disabled', () => {
+    setMoneyAccountFlags({
+      rawFlag: disabledFlag,
+      resolvedFlag: disabledFlag,
+    });
 
     handleMoney();
 
-    expect(handleDeepLinkModalDisplay).toHaveBeenCalledWith({
-      linkType: DeepLinkModalLinkType.UNSUPPORTED,
-      onBack: expect.any(Function),
-    });
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expectDeeplinkModalNavigation(
+      'money.deeplink_modal.money_account_disabled.title',
+      'money.deeplink_modal.money_account_disabled.description',
+    );
   });
 
-  it('navigates to WALLET.HOME when unsupported modal back callback runs', () => {
-    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(false);
+  it('navigates to disabled deeplink modal when type 1 flag minimum version fails', () => {
+    jest.mocked(getVersion).mockReturnValue('7.0.0');
+    setMoneyAccountFlags({
+      rawFlag: enabledFlag,
+      resolvedFlag: enabledFlag,
+    });
 
     handleMoney();
 
-    const [{ onBack }] = jest.mocked(handleDeepLinkModalDisplay).mock.calls[0];
-    onBack();
+    expectDeeplinkModalNavigation(
+      'money.deeplink_modal.money_account_disabled.title',
+      'money.deeplink_modal.money_account_disabled.description',
+    );
+  });
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  it('navigates to rollout exclusion deeplink modal when rollout cohort is disabled', () => {
+    setMoneyAccountFlags({
+      rawFlag: [enabledRolloutFlag, disabledRolloutFlag],
+      resolvedFlag: disabledFlag,
+    });
+
+    handleMoney();
+
+    expectDeeplinkModalNavigation(
+      'money.deeplink_modal.excluded_from_gradual_rollout.title',
+      'money.deeplink_modal.excluded_from_gradual_rollout.description',
+    );
+  });
+
+  it('navigates to disabled deeplink modal when rollout enabled cohort minimum version fails', () => {
+    jest.mocked(getVersion).mockReturnValue('7.0.0');
+    setMoneyAccountFlags({
+      rawFlag: [enabledRolloutFlag, disabledRolloutFlag],
+      resolvedFlag: enabledFlag,
+    });
+
+    handleMoney();
+
+    expectDeeplinkModalNavigation(
+      'money.deeplink_modal.money_account_disabled.title',
+      'money.deeplink_modal.money_account_disabled.description',
+    );
+  });
+
+  it('logs malformed rollout flag and navigates to disabled deeplink modal', () => {
+    setMoneyAccountFlags({
+      rawFlag: [enabledRolloutFlag, disabledRolloutFlag],
+      resolvedFlag: { enabled: true },
+    });
+
+    handleMoney();
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      '[handleMoney] getMoneyAccountFlagStatus received an invalid resolved rollout flag',
+    );
+    expectDeeplinkModalNavigation(
+      'money.deeplink_modal.money_account_disabled.title',
+      'money.deeplink_modal.money_account_disabled.description',
+    );
   });
 
   it('navigates to geo block modal when user is not geo eligible', () => {
@@ -106,7 +245,7 @@ describe('handleMoney', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ONBOARDING);
   });
 
-  it('navigates to MONEY.HOME when flag is disabled even if onboarding not seen', () => {
+  it('navigates to MONEY.HOME when onboarding has not been seen and onboarding is disabled', () => {
     jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(false);
     jest
       .mocked(selectMoneyOnboardingStepperAnimationEnabled)
@@ -131,7 +270,7 @@ describe('handleMoney', () => {
 
   it('logs error and navigates to WALLET.HOME when selector throws', () => {
     const error = new Error('Selector failed');
-    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockImplementation(() => {
+    jest.mocked(selectRawRemoteFeatureFlags).mockImplementation(() => {
       throw error;
     });
 
@@ -151,7 +290,7 @@ describe('handleMoney', () => {
   it('logs fallback navigation error when fallback screen navigation fails', () => {
     const deepLinkError = new Error('Deep link failed');
     const fallbackNavigationError = new Error('Fallback navigation failed');
-    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockImplementation(() => {
+    jest.mocked(selectRawRemoteFeatureFlags).mockImplementation(() => {
       throw deepLinkError;
     });
     mockNavigate.mockImplementation(() => {

--- a/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
@@ -1,5 +1,5 @@
+/* eslint-disable jsdoc/check-indentation */
 import { selectIsMoneyAccountGeoEligible } from '../../../../components/UI/Money/selectors/eligibility';
-import { selectMoneyEnableMoneyAccountFlag } from '../../../../components/UI/Money/selectors/featureFlags';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectMoneyOnboardingSeen } from '../../../../reducers/user';
 import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
@@ -7,8 +7,107 @@ import Logger from '../../../../util/Logger';
 import NavigationService from '../../../NavigationService';
 import ReduxService from '../../../redux';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
-import { DeepLinkModalLinkType } from '../../types/deepLink.types';
-import handleDeepLinkModalDisplay from './handleDeepLinkModalDisplay';
+import {
+  hasMinimumRequiredVersion,
+  isVersionGatedFeatureFlag,
+  validatedVersionGatedFeatureFlag,
+} from '../../../../util/remoteFeatureFlag';
+import {
+  selectRawRemoteFeatureFlags,
+  selectRemoteFeatureFlags,
+} from '../../../../selectors/featureFlagController';
+import { RootState } from '../../../../reducers';
+import { MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME } from '../../../../lib/Money/feature-flags';
+import { strings } from '../../../../../locales/i18n';
+
+enum MoneyAccountFlagStatus {
+  Enabled = 'enabled',
+  Disabled = 'disabled',
+  NotInRollout = 'not_in_rollout',
+}
+
+/**
+ * We use 2 shapes for feature flags:
+ *
+ * Type 1: Standard flags.
+ * {
+ *   enabled: boolean,
+ *   minimumVersion: string
+ * }
+ *
+ * Type 2: Gradual rollout flags.
+ * [
+ *   {
+ *     scope: {
+ *       type: string,
+ *       value: number,
+ *     },
+ *     thresholdName: string,
+ *     thresholdVersion: number,
+ *     value: {
+ *       enabled: boolean,
+ *       minimumVersion: string,
+ *     },
+ *   },
+ *   {
+ *     scope: {
+ *       type: string,
+ *       value: number,
+ *     },
+ *     thresholdName: string,
+ *     thresholdVersion: number,
+ *     value: {
+ *       enabled: boolean,
+ *       minimumVersion: string,
+ *     },
+ *   },
+ * ]
+ */
+const getMoneyAccountFlagStatus = (
+  state: RootState,
+): MoneyAccountFlagStatus => {
+  // Raw flag contains gradual rollout config shape
+  const rawFlag =
+    selectRawRemoteFeatureFlags(state)?.[MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME];
+
+  // Resolved flag contains the winning cohort's { enabled, minimumVersion } value
+  const resolvedFlag =
+    selectRemoteFeatureFlags(state)?.[MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME];
+
+  if (!Array.isArray(rawFlag)) {
+    /**
+     * Plain object → NOT a rollout (maintenance kill-switch or GA)
+     * Has shape { enabled: boolean, minimumVersion: string }
+     */
+    return validatedVersionGatedFeatureFlag(rawFlag)
+      ? MoneyAccountFlagStatus.Enabled // { enabled: true }  → GA
+      : MoneyAccountFlagStatus.Disabled; // { enabled: false } → State 1 (maintenance/unavailable)
+  }
+
+  // Array → active gradual rollout; resolvedFlag is the selected cohort's value
+  if (!isVersionGatedFeatureFlag(resolvedFlag)) {
+    Logger.error(
+      new Error('Malformed money account rollout flag value'),
+      '[handleMoney] getMoneyAccountFlagStatus received an invalid resolved rollout flag',
+    );
+    return MoneyAccountFlagStatus.Disabled;
+  }
+
+  if (!resolvedFlag.enabled) {
+    return MoneyAccountFlagStatus.NotInRollout; // in the "disabled" cohort
+  }
+
+  // In the "enabled" cohort, but still version-gated
+  return hasMinimumRequiredVersion(resolvedFlag.minimumVersion)
+    ? MoneyAccountFlagStatus.Enabled
+    : MoneyAccountFlagStatus.Disabled;
+};
+
+const navigateToDeeplinkModal = (title: string, description: string) =>
+  NavigationService.navigation.navigate(Routes.MONEY.MODALS.DEEPLINK_MODAL, {
+    title,
+    description,
+  });
 
 export const handleMoney = () => {
   DevLogger.log('[handleMoney] Starting deeplink handling');
@@ -16,18 +115,28 @@ export const handleMoney = () => {
   try {
     const state = ReduxService.store.getState();
     const isMoneyAccountGeoEligible = selectIsMoneyAccountGeoEligible(state);
-    const isMoneyAccountEnabled = selectMoneyEnableMoneyAccountFlag(state);
     const hasSeenMoneyOnboarding = selectMoneyOnboardingSeen(state);
     const isOnboardingEnabled =
       selectMoneyOnboardingStepperAnimationEnabled(state);
 
-    if (!isMoneyAccountEnabled) {
-      handleDeepLinkModalDisplay({
-        linkType: DeepLinkModalLinkType.UNSUPPORTED,
-        onBack: () => {
-          NavigationService.navigation.navigate(Routes.WALLET.HOME);
-        },
-      });
+    const moneyAccountFlagStatus = getMoneyAccountFlagStatus(state);
+
+    if (moneyAccountFlagStatus === MoneyAccountFlagStatus.Disabled) {
+      navigateToDeeplinkModal(
+        strings('money.deeplink_modal.money_account_disabled.title'),
+        strings('money.deeplink_modal.money_account_disabled.description'),
+      );
+      return;
+    }
+
+    // User not part of gradual rollout cohort yet.
+    if (moneyAccountFlagStatus === MoneyAccountFlagStatus.NotInRollout) {
+      navigateToDeeplinkModal(
+        strings('money.deeplink_modal.excluded_from_gradual_rollout.title'),
+        strings(
+          'money.deeplink_modal.excluded_from_gradual_rollout.description',
+        ),
+      );
       return;
     }
 
@@ -42,6 +151,7 @@ export const handleMoney = () => {
       NavigationService.navigation.navigate(Routes.MONEY.ONBOARDING);
       return;
     }
+
     NavigationService.navigation.navigate(Routes.HOME_TABS, {
       screen: Routes.MONEY.ROOT,
       params: { screen: Routes.MONEY.HOME },

--- a/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
@@ -66,22 +66,19 @@ enum MoneyAccountFlagStatus {
 const getMoneyAccountFlagStatus = (
   state: RootState,
 ): MoneyAccountFlagStatus => {
-  // Raw flag contains gradual rollout config shape
+  // Raw flag contains gradual rollout config shape.
   const rawFlag =
     selectRawRemoteFeatureFlags(state)?.[MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME];
 
-  // Resolved flag contains the winning cohort's { enabled, minimumVersion } value
+  // Resolved flag respects basic-functionality gating, local overrides, and rollout cohort resolution.
   const resolvedFlag =
     selectRemoteFeatureFlags(state)?.[MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME];
 
   if (!Array.isArray(rawFlag)) {
-    /**
-     * Plain object → NOT a rollout (maintenance kill-switch or GA)
-     * Has shape { enabled: boolean, minimumVersion: string }
-     */
-    return validatedVersionGatedFeatureFlag(rawFlag)
-      ? MoneyAccountFlagStatus.Enabled // { enabled: true }  → GA
-      : MoneyAccountFlagStatus.Disabled; // { enabled: false } → State 1 (maintenance/unavailable)
+    // Standard flags must use the resolved selector to match Money stack registration.
+    return validatedVersionGatedFeatureFlag(resolvedFlag)
+      ? MoneyAccountFlagStatus.Enabled
+      : MoneyAccountFlagStatus.Disabled;
   }
 
   // Array → active gradual rollout; resolvedFlag is the selected cohort's value

--- a/app/lib/Money/feature-flags.ts
+++ b/app/lib/Money/feature-flags.ts
@@ -3,6 +3,8 @@ import {
   VersionGatedFeatureFlag,
 } from '../../util/remoteFeatureFlag';
 
+export const MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME = 'moneyEnableMoneyAccount';
+
 /**
  * Checks if the Money account feature is enabled based on
  * environment variables and remote feature flags.
@@ -13,8 +15,9 @@ import {
 export function isMoneyAccountEnabled(
   remoteFeatureFlags: Record<string, unknown> | undefined,
 ): boolean {
-  const remoteFlag =
-    remoteFeatureFlags?.moneyEnableMoneyAccount as VersionGatedFeatureFlag;
+  const remoteFlag = remoteFeatureFlags?.[
+    MONEY_ENABLE_MONEY_ACCOUNT_FLAG_NAME
+  ] as VersionGatedFeatureFlag;
 
   return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7428,6 +7428,17 @@
       "title": "Money account unavailable",
       "description": "Money account isn't available in your location due to local restrictions or sanctions.",
       "button": "Got it"
+    },
+    "deeplink_modal": {
+      "button": "Got it",
+      "money_account_disabled": {
+        "title": "Money account is temporarily unavailable",
+        "description": "We're working on it. Money Account will be back up shortly — check back soon."
+      },
+      "excluded_from_gradual_rollout": {
+        "title": "Money Account is on its way",
+        "description": "We're rolling out Money Account gradually to ensure everything works smoothly. Check back soon."
+      }
     }
   },
   "stake": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The `handleMoney` deeplink handler was showing misleading screen for all non-happy-path cases, regardless of why the feature was unavailable. This PR replaces that with three distinct states:

1. **Disabled** (maintenance / kill-switch) — shows "Money account is temporarily unavailable"
2. **Not in gradual rollout cohort** — shows "Money Account is on its way"
3. **Enabled** — navigates to onboarding or Money Home as before

The implementation reads both the raw remote flag (to detect the rollout array shape) and the resolved flag (to get the winning cohort value), applies version gating per cohort, and navigates to the new `MoneyDeeplinkModal` screen with the appropriate title/description passed as route params.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: fix: improved Money account deeplink handling to surface accurate unavailability messages for maintenance, gradual rollout exclusion, and version-gate states

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1096: Fix Misleading Money Account Deeplink Handling](https://consensyssoftware.atlassian.net/browse/MUSD-1096)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Use this command to open Money account deeplink in simulator 

`xcrun simctl openurl booted "https://link.metamask.io/money"`

```gherkin
Feature: Money account deeplink handling

  Scenario: feature disabled (maintenance)
    Given the remote flag moneyEnableMoneyAccount has enabled=false
    When a user opens Money account deeplink
    Then the "Money account is temporarily unavailable" bottom sheet appears
    And tapping "Got it" navigates to Wallet Home

  Scenario: user not in gradual rollout cohort
    Given the remote flag has rollout format (array) and the user lands in the disabled cohort
    When a user opens Money account deeplink
    Then the "Money Account is on its way" bottom sheet appears
    And tapping "Got it" navigates to Wallet Home

  Scenario: feature enabled, onboarding not seen
    Given the remote flag is enabled and version gate passes
    And the user has not seen Money onboarding and onboarding is enabled
    When a user opens Money account deeplink
    Then the app navigates to the Money onboarding screen

  Scenario: feature enabled, onboarding already seen
    Given the remote flag is enabled and version gate passes
    And the user has already seen Money onboarding
    When a user opens Money account deeplink
    Then the app navigates to Money Home
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
This screen was displayed for all non-happy paths
<img width="980" height="2042" alt="image" src="https://github.com/user-attachments/assets/8f68167a-36ff-456d-9a22-18d1c48b883a" />

### **After**

<!-- [screenshots/recordings] -->

#### Money account enabled (Happy Paths)
Covers scenario where user has and hasn't seen the Money onboarding flow.

https://github.com/user-attachments/assets/bdfa8fbf-f6aa-45ba-8d21-828545c18f2c

#### User Geo-Blocked

https://github.com/user-attachments/assets/c4b5a075-17b2-4947-ab3d-4f5add4d3dd6

#### Money Account Enabled but User Not Part of Rollout Cohort (Money account on the way)

https://github.com/user-attachments/assets/95158487-9416-48dc-bb7e-49fa8736522a

#### Money Account Unavailable (e.g. disabled for maintenance)

https://github.com/user-attachments/assets/067fa197-94f6-4b04-b658-b18535b65f7b


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deeplink routing and remote feature-flag interpretation for Money account access; mistakes could block valid users or show wrong messaging, but scope is limited to Money deeplink handling with tests.
> 
> **Overview**
> Money deeplinks no longer show a single generic “unsupported” screen for every blocked case. **`handleMoney`** now classifies `moneyEnableMoneyAccount` using **raw** vs **resolved** remote flags (standard version-gated object vs gradual-rollout array), then routes to a dedicated **`MoneyDeeplinkModal`** with copy for **maintenance/disabled** vs **not yet in the rollout cohort**; happy paths (geo block, onboarding, Money Home) are unchanged.
> 
> A new **`MoneyDeeplinkModal`** bottom sheet takes `title`/`description` from navigation params, tracks Money analytics, and sends users to **Wallet Home** on dismiss. **`Routes.MONEY.MODALS.DEEPLINK_MODAL`** is registered in **`MainNavigator`** **outside** the Money feature gate so the modal can appear when Money screens are not mounted. Locale strings and expanded **`handleMoney`** tests cover the new flag shapes and navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdd68fb1d991c6b7bf57f068088a46a24eb31c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->