### PR TITLE
feat: gate addDeviceSyncEnabled behind minimum version

### DIFF
--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -21,6 +21,9 @@ export enum FeatureFlagNames {
   hapticsKillSwitch = 'hapticsKillSwitch',
 }
 
+/** Minimum expected app version required for QR add-device account sync. Will update if extends */
+export const ADD_DEVICE_SYNC_MINIMUM_VERSION = '8.6.0';
+
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   Record<FeatureFlagNames, Json>
 > = {
@@ -29,6 +32,9 @@ export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   [FeatureFlagNames.tokenDetailsV2ButtonLayout]: false,
   [FeatureFlagNames.tronClaimUnstakedTrxButtonEnabled]: false,
   [FeatureFlagNames.googleLoginIosUnsupportedBlockingEnabled]: false,
-  [FeatureFlagNames.addDeviceSyncEnabled]: false,
+  [FeatureFlagNames.addDeviceSyncEnabled]: {
+    enabled: false,
+    minimumVersion: ADD_DEVICE_SYNC_MINIMUM_VERSION,
+  },
   [FeatureFlagNames.telegramLoginEnabled]: false,
 };

--- a/app/selectors/featureFlagController/addDeviceSync/index.test.ts
+++ b/app/selectors/featureFlagController/addDeviceSync/index.test.ts
@@ -1,44 +1,175 @@
-import { Json } from '@metamask/utils';
 import { selectAddDeviceSyncEnabled } from '.';
+import mockedEngine from '../../../core/__mocks__/MockedEngine';
+import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
 import {
-  DEFAULT_FEATURE_FLAG_VALUES,
+  ADD_DEVICE_SYNC_MINIMUM_VERSION,
   FeatureFlagNames,
 } from '../../../constants/featureFlags';
+import { getVersion } from 'react-native-device-info';
 
-describe('Add Device Sync feature flag selector', () => {
-  describe('selectAddDeviceSyncEnabled', () => {
-    it('returns true when remote flag is explicitly true', () => {
-      const result = selectAddDeviceSyncEnabled.resultFunc({
-        [FeatureFlagNames.addDeviceSyncEnabled]: true,
-      });
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
 
-      expect(result).toBe(true);
-    });
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
 
-    it('returns false when remote flag is explicitly false', () => {
-      const result = selectAddDeviceSyncEnabled.resultFunc({
-        [FeatureFlagNames.addDeviceSyncEnabled]: false,
-      });
+jest.mock(
+  '../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
 
-      expect(result).toBe(false);
-    });
+describe('Add Device Sync feature flag selector (version-gated)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getVersion as jest.MockedFunction<typeof getVersion>).mockReturnValue(
+      ADD_DEVICE_SYNC_MINIMUM_VERSION,
+    );
+  });
 
-    it('returns default value when remote flag is not set', () => {
-      const result = selectAddDeviceSyncEnabled.resultFunc({});
+  it('returns true when enabled and minimum version requirement passes', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: {
+                enabled: true,
+                minimumVersion: ADD_DEVICE_SYNC_MINIMUM_VERSION,
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
 
-      expect(result).toBe(
-        DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.addDeviceSyncEnabled],
-      );
-    });
+    expect(selectAddDeviceSyncEnabled(state)).toBe(true);
+  });
 
-    it('returns default value when remote flag is undefined', () => {
-      const result = selectAddDeviceSyncEnabled.resultFunc({
-        [FeatureFlagNames.addDeviceSyncEnabled]: undefined as unknown as Json,
-      });
+  it('returns false when enabled but minimum version requirement fails', () => {
+    (getVersion as jest.MockedFunction<typeof getVersion>).mockReturnValue(
+      '1.0.0',
+    );
 
-      expect(result).toBe(
-        DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.addDeviceSyncEnabled],
-      );
-    });
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: {
+                enabled: true,
+                minimumVersion: '99.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(false);
+  });
+
+  it('returns false when disabled regardless of version', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: {
+                enabled: false,
+                minimumVersion: '0.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(false);
+  });
+
+  it('returns false when remote flag is missing', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              someOtherFlag: true,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(false);
+  });
+
+  it('returns false when feature flag state is empty', () => {
+    expect(selectAddDeviceSyncEnabled(mockedEmptyFlagsState)).toBe(false);
+  });
+
+  it('returns false when RemoteFeatureFlagController state is undefined', () => {
+    expect(selectAddDeviceSyncEnabled(mockedUndefinedFlagsState)).toBe(false);
+  });
+
+  it('supports boolean dev-tool overrides when true', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: true,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(true);
+  });
+
+  it('supports boolean dev-tool overrides when false', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: false,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(false);
+  });
+
+  it('returns false when flag has invalid shape', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.addDeviceSyncEnabled]: {
+                enabled: 'true',
+                minimumVersion: 100,
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectAddDeviceSyncEnabled(state)).toBe(false);
   });
 });

--- a/app/selectors/featureFlagController/addDeviceSync/index.ts
+++ b/app/selectors/featureFlagController/addDeviceSync/index.ts
@@ -1,15 +1,38 @@
+import { hasProperty } from '@metamask/utils';
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import {
-  DEFAULT_FEATURE_FLAG_VALUES,
+  ADD_DEVICE_SYNC_MINIMUM_VERSION,
   FeatureFlagNames,
 } from '../../../constants/featureFlags';
+import {
+  validatedVersionGatedFeatureFlag,
+  type VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+const DEFAULT_ADD_DEVICE_SYNC_ENABLED = false;
 
 export const selectAddDeviceSyncEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags) =>
-    Boolean(
-      remoteFeatureFlags[FeatureFlagNames.addDeviceSyncEnabled] ??
-        DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.addDeviceSyncEnabled],
-    ),
+  (remoteFeatureFlags) => {
+    if (
+      !hasProperty(remoteFeatureFlags, FeatureFlagNames.addDeviceSyncEnabled)
+    ) {
+      return DEFAULT_ADD_DEVICE_SYNC_ENABLED;
+    }
+
+    const rawFlag = remoteFeatureFlags[FeatureFlagNames.addDeviceSyncEnabled];
+
+    if (typeof rawFlag === 'boolean') {
+      return rawFlag;
+    }
+
+    const remoteFlag = rawFlag as unknown as VersionGatedFeatureFlag;
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_ADD_DEVICE_SYNC_ENABLED
+    );
+  },
 );
+
+export { ADD_DEVICE_SYNC_MINIMUM_VERSION };

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -78,7 +78,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'addDeviceSyncEnabled',
     type: FeatureFlagType.Remote,
     inProd: false,
-    productionDefault: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '8.6.0',
+    },
     status: FeatureFlagStatus.Active,
   },
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
* Gate the addDeviceSyncEnabled feature flag behind a minimum app version so QR add-device account sync can be rolled out safely via LaunchDarkly.
* Jira: https://consensyssoftware.atlassian.net/browse/TO-875
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Gate addDeviceSyncEnabled behind minimum version

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add device sync version-gated feature flag

  Scenario: Add device sync is hidden on app versions below minimum
    Given the app is running on a version below 8.6.0
    And the addDeviceSyncEnabled LaunchDarkly flag is set to { "enabled": true, "minimumVersion": "8.6.0" }

    When the user navigates to Add Wallet or Import from Secret Recovery Phrase
    Then the add-device sync / scan QR option is not shown

  Scenario: Add device sync is visible on supported app versions when enabled
    Given the app is running on version 8.6.0 or higher

    And the addDeviceSyncEnabled LaunchDarkly flag is set to { "enabled": true, "minimumVersion": "8.6.0" }
    When the user navigates to Add Wallet or Import from Secret Recovery Phrase
    Then the add-device sync / scan QR option is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding/import UI gating for account sync; incorrect version or flag parsing could hide or expose QR sync on the wrong app builds.
> 
> **Overview**
> **`addDeviceSyncEnabled`** is no longer a plain boolean from LaunchDarkly. It now uses the shared **version-gated** shape `{ enabled, minimumVersion }`, with **`ADD_DEVICE_SYNC_MINIMUM_VERSION` (`8.6.0`)** as the default floor for QR add-device account sync.
> 
> **`selectAddDeviceSyncEnabled`** evaluates that object via **`validatedVersionGatedFeatureFlag`** (app version from device info), returns **false** when the flag is missing or malformed, and still accepts **boolean** remote values for dev-tool overrides. Defaults and the E2E **feature-flag registry** were updated to match the new payload shape.
> 
> Selector tests were expanded to cover version pass/fail, disabled flags, missing controller state, boolean overrides, and invalid flag shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6feac62ec25e3ec0ee2e9ec3a22b60ee2731a775. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->