### PR TITLE
ci(build): extend node_modules cache to workflow_dispatch builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
       signing_android_keystore_path: ${{ steps.config.outputs.signing_android_keystore_path }}
       script_name: ${{ steps.config.outputs.script_name }}
       checkout_ref_for_setup: ${{ inputs.source_branch }}
+      should_cache: ${{ startsWith(github.ref_name, 'release/') || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -186,9 +187,9 @@ jobs:
       checkout-submodules: true
       platform: ${{ matrix.platform }}
       build_name: ${{ inputs.build_name }}
-      use-cache: ${{ startsWith(github.ref_name, 'release/') }}
-      use-tarball: ${{ !startsWith(github.ref_name, 'release/') }}
-      upload-artifact: ${{ !startsWith(github.ref_name, 'release/') }}
+      use-cache: ${{ needs.prepare.outputs.should_cache == 'true' }}
+      use-tarball: ${{ needs.prepare.outputs.should_cache != 'true' }}
+      upload-artifact: ${{ needs.prepare.outputs.should_cache != 'true' }}
       artifact-name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
       artifact-retention-days: 1
       runner_provider: ${{ inputs.runner_provider }}
@@ -245,10 +246,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      # release/* branches: restore node_modules from GitHub Actions cache (fast, no artifact download).
+      # release/* branches and manual workflow_dispatch: restore node_modules from GitHub Actions cache (fast, no artifact download).
       - name: Compute node_modules cache key
         id: cache-key
-        if: ${{ startsWith(github.ref_name, 'release/') }}
+        if: ${{ needs.prepare.outputs.should_cache == 'true' }}
         run: |
           NODE_VERSION=$(node --version | sed 's/v//')
           KEY="node-modules-${{ env.CACHE_GENERATION }}-${{ inputs.build_name }}-${{ matrix.platform }}-${RUNNER_OS}-${NODE_VERSION}-${{ hashFiles('yarn.lock', 'patches/**', 'scripts/inpage-bridge/**', 'scripts/build-inpage-bridge.sh') }}"
@@ -256,7 +257,7 @@ jobs:
           echo "Cache key: ${KEY}"
 
       - name: Restore node_modules cache
-        if: ${{ startsWith(github.ref_name, 'release/') }}
+        if: ${{ needs.prepare.outputs.should_cache == 'true' }}
         uses: actions/cache/restore@v4
         with:
           path: |
@@ -269,13 +270,13 @@ jobs:
 
       # All other branches: download tarball artifact from setup-dependencies job.
       - name: Download node_modules tarball
-        if: ${{ !startsWith(github.ref_name, 'release/') }}
+        if: ${{ needs.prepare.outputs.should_cache != 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
 
       - name: Ensure zstd is available
-        if: ${{ !startsWith(github.ref_name, 'release/') }}
+        if: ${{ needs.prepare.outputs.should_cache != 'true' }}
         shell: bash
         run: |
           if command -v zstd >/dev/null 2>&1; then
@@ -289,7 +290,7 @@ jobs:
           fi
 
       - name: Extract tarball (preserves symlinks)
-        if: ${{ !startsWith(github.ref_name, 'release/') }}
+        if: ${{ needs.prepare.outputs.should_cache != 'true' }}
         run: |
           echo "📦 Extracting tarball..."
           tar --use-compress-program 'zstd -d' -xf node-modules-${{ matrix.platform }}.tar.zst


### PR DESCRIPTION

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `setup-dependencies` → `build` job handoff in `build.yml` uses GitHub Actions cache (instead of the slower zstd tarball artifact) when running on `release/*` branches (introduced in #32494). However, manually dispatched builds — whether triggered directly on `build.yml` or via `build-and-upload-to-testflight.yml` — were not benefiting from this cache even though they are low-volume, high-value runs where the speed improvement matters most.

This PR extends the cache path to any `workflow_dispatch` trigger by centralising the decision into a single `should_cache` output on the `prepare` job:

```yaml
should_cache: ${{ startsWith(github.ref_name, 'release/') || github.event_name == 'workflow_dispatch' }}
```

All eight previously duplicated `startsWith(github.ref_name, 'release/')` conditions in `build.yml` are replaced by references to `needs.prepare.outputs.should_cache`, eliminating drift risk. No changes are needed in `setup-node-modules.yml` or `build-and-upload-to-testflight.yml` — the `github.event_name` context propagates automatically from the top-level caller into all reusable workflows.

**Cache is now used for:**
- `release/*` branch builds (unchanged)
- Any `workflow_dispatch` run of `build.yml` (new)
- Any `workflow_dispatch` run of `build-and-upload-to-testflight.yml` (new, automatic via context propagation)

**Tarball artifact path is preserved for:**
- Pull requests and feature branch pushes (high volume)
- `main` branch pushes
- Scheduled nightly builds (`schedule` event)
- `post-release-cut-testflight.yml` (triggered by `push`)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: node_modules cache on workflow_dispatch builds

  Scenario: cache is used when build.yml is manually dispatched
    Given the branch chore/cache-build-when-dispatched with these changes
    When build.yml is dispatched manually with any build_name and platform
    Then the setup-dependencies job runs "Compute cache key" and "Save node_modules cache" steps
    And the build job runs "Restore node_modules cache" with a cache hit
    And the build job does NOT run "Download node_modules tarball" or "Extract tarball"

  Scenario: cache is used when build-and-upload-to-testflight.yml is manually dispatched
    When build-and-upload-to-testflight.yml is dispatched manually
    Then the nested build.yml sees github.event_name == workflow_dispatch
    And the cache path is taken (no tarball artifact upload or download)

  Scenario: tarball path is unchanged for PR / main / schedule builds
    When build.yml is triggered by a pull_request, push to main, or schedule event
    Then should_cache evaluates to false
    And the setup-dependencies job uploads a tarball artifact
    And the build job downloads and extracts that tarball
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)