### PR TITLE
fix(social): cp-8.1.0 sync followed traders list after unfollow

### DIFF
--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
@@ -1,8 +1,17 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import { addBreadcrumb } from '@sentry/react-native';
 import Logger from '../../../../../util/Logger';
 import { useFollowedTraders } from './useFollowedTraders';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../../../../selectors/socialController', () => ({
+  selectFollowingProfileIds: jest.fn(),
+}));
 
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
@@ -18,6 +27,7 @@ const mockAddBreadcrumb = addBreadcrumb as jest.Mock;
 
 const mockRefetch = jest.fn();
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 const makeQueryResult = (
   overrides: Partial<ReturnType<typeof useQuery>> = {},
@@ -52,6 +62,7 @@ const fixtureFollowing = {
 describe('useFollowedTraders', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(['trader-1', 'trader-2']);
     mockUseQuery.mockReturnValue(makeQueryResult());
     mockAddBreadcrumb.mockClear();
   });
@@ -108,6 +119,23 @@ describe('useFollowedTraders', () => {
           username: 'trader2',
           address: '0x2',
           avatarUri: undefined,
+        },
+      ]);
+    });
+
+    it('excludes traders not present in Redux followingProfileIds', () => {
+      mockUseSelector.mockReturnValue(['trader-1']);
+      mockUseQuery.mockReturnValue(
+        makeQueryResult({ data: fixtureFollowing as never }),
+      );
+      const { result } = renderHook(() => useFollowedTraders());
+
+      expect(result.current.traders).toEqual([
+        {
+          id: 'trader-1',
+          username: 'trader1',
+          address: '0x1',
+          avatarUri: 'https://example.com/a1.png',
         },
       ]);
     });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import type { FollowingResponse } from '@metamask/social-controllers';
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { selectFollowingProfileIds } from '../../../../../selectors/socialController';
 import {
   formatSocialQueryErrorMessage,
@@ -75,14 +75,17 @@ export const useFollowedTraders = (
     if (!data?.following) {
       return EMPTY_TRADERS;
     }
-    return data.following
-      .filter((profile) => followingProfileIds.includes(profile.profileId))
-      .map((profile) => ({
-        id: profile.profileId,
-        username: profile.name,
-        address: profile.address,
-        avatarUri: profile.imageUrl ?? undefined,
-      }));
+    return (
+      data.following
+        // Technically not required, cache is invalidated on follow/unfollow. This is an extra belt-and-suspenders for instant UI during refetch
+        .filter((profile) => followingProfileIds.includes(profile.profileId))
+        .map((profile) => ({
+          id: profile.profileId,
+          username: profile.name,
+          address: profile.address,
+          avatarUri: profile.imageUrl ?? undefined,
+        }))
+    );
   }, [data, followingProfileIds]);
 
   const refresh = useCallback(async () => {

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import type { FollowingResponse } from '@metamask/social-controllers';
+import { selectFollowingProfileIds } from '../../../../../selectors/socialController';
 import {
   formatSocialQueryErrorMessage,
   reportSocialServiceFailure,
@@ -54,6 +56,7 @@ export const useFollowedTraders = (
   options?: UseFollowedTradersOptions,
 ): UseFollowedTradersResult => {
   const enabled = options?.enabled ?? true;
+  const followingProfileIds = useSelector(selectFollowingProfileIds);
 
   const { data, isLoading, error, refetch } = useQuery<FollowingResponse>({
     queryKey: ['SocialService:fetchFollowing'],
@@ -72,13 +75,15 @@ export const useFollowedTraders = (
     if (!data?.following) {
       return EMPTY_TRADERS;
     }
-    return data.following.map((profile) => ({
-      id: profile.profileId,
-      username: profile.name,
-      address: profile.address,
-      avatarUri: profile.imageUrl ?? undefined,
-    }));
-  }, [data]);
+    return data.following
+      .filter((profile) => followingProfileIds.includes(profile.profileId))
+      .map((profile) => ({
+        id: profile.profileId,
+        username: profile.name,
+        address: profile.address,
+        avatarUri: profile.imageUrl ?? undefined,
+      }));
+  }, [data, followingProfileIds]);
 
   const refresh = useCallback(async () => {
     try {

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -33,6 +33,16 @@ jest.mock('../../core/Engine', () => ({
   },
 }));
 
+const mockInvalidateQueries = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../core/ReactQueryService', () => ({
+  __esModule: true,
+  default: {
+    queryClient: {
+      invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args),
+    },
+  },
+}));
+
 jest.mock('../../util/haptics', () => ({
   ...jest.requireActual<typeof import('../../util/haptics')>(
     '../../util/haptics',
@@ -97,6 +107,46 @@ describe('useFollowToggle', () => {
         'SocialController:unfollowTrader',
         { targets: ['trader-1'] },
       );
+    });
+
+    it('invalidates the fetchFollowing query after a successful follow', async () => {
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['SocialService:fetchFollowing'],
+      });
+    });
+
+    it('invalidates the fetchFollowing query after a successful unfollow', async () => {
+      mockUseSelector.mockReturnValue(['trader-1']);
+
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['SocialService:fetchFollowing'],
+      });
+    });
+
+    it('does not invalidate the fetchFollowing query when the API call rejects', async () => {
+      (Engine.controllerMessenger.call as jest.Mock).mockRejectedValue(
+        new Error('boom'),
+      );
+
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow();
+      });
+
+      expect(mockInvalidateQueries).not.toHaveBeenCalled();
     });
 
     it('flips isFollowing optimistically before the API call resolves', async () => {

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -2,6 +2,7 @@ import { playImpact, ImpactMoment } from '../../util/haptics';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../core/Engine';
+import ReactQueryService from '../../core/ReactQueryService';
 import { reportSocialServiceFailure } from '../../util/social/socialServiceTelemetry';
 import { selectFollowingProfileIds } from '../../selectors/socialController';
 import {
@@ -99,6 +100,9 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
             : 'SocialController:unfollowTrader',
           opts,
         );
+        await ReactQueryService.queryClient.invalidateQueries({
+          queryKey: ['SocialService:fetchFollowing'],
+        });
         if (analyticsContext) {
           track(MetaMetricsEvents.SOCIAL_TRADER_FOLLOW_INTERACTION, {
             [SocialLeaderboardEventProperties.ACTION]: nextValue

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -2,7 +2,6 @@ import { playImpact, ImpactMoment } from '../../util/haptics';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../core/Engine';
-import ReactQueryService from '../../core/ReactQueryService';
 import { reportSocialServiceFailure } from '../../util/social/socialServiceTelemetry';
 import { selectFollowingProfileIds } from '../../selectors/socialController';
 import {
@@ -40,6 +39,21 @@ export interface UseFollowToggleManyResult {
     analyticsContext?: FollowToggleAnalyticsContext,
   ) => Promise<void>;
 }
+
+const FOLLOWING_QUERY_KEY = ['SocialService:fetchFollowing'] as const;
+
+/**
+ * Invalidates the followed-traders query without importing ReactQueryService at
+ * module load (that import pulls in Engine and breaks tests that mock Engine).
+ */
+const invalidateFollowingQuery = async (): Promise<void> => {
+  const { default: ReactQueryService } = await import(
+    '../../core/ReactQueryService'
+  );
+  await ReactQueryService.queryClient.invalidateQueries({
+    queryKey: FOLLOWING_QUERY_KEY,
+  });
+};
 
 /**
  * Shared primitive that optimistically toggles follow/unfollow state for one
@@ -100,9 +114,7 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
             : 'SocialController:unfollowTrader',
           opts,
         );
-        await ReactQueryService.queryClient.invalidateQueries({
-          queryKey: ['SocialService:fetchFollowing'],
-        });
+        await invalidateFollowingQuery();
         if (analyticsContext) {
           track(MetaMetricsEvents.SOCIAL_TRADER_FOLLOW_INTERACTION, {
             [SocialLeaderboardEventProperties.ACTION]: nextValue


### PR DESCRIPTION
## **Description**

Unfollowing a trader updated Redux follow state immediately, but the "Traders you follow" list in notification preferences still read from a cached `SocialService:fetchFollowing` React Query result (5-minute stale time) with no invalidation on follow/unfollow. That left unfollowed traders visible when returning to Settings > Notifications.

This PR invalidates the `fetchFollowing` query after successful follow/unfollow mutations and filters the notification preferences trader list against Redux `followingProfileIds` so unfollowed traders disappear immediately.

## **Changelog**

CHANGELOG entry: Fixed stale traders appearing in Trading Signals notification preferences after unfollowing a trader

## **Related issues**

Fixes: An issue where the list of followed traders in notification settings wouldn't update properly after a follow/unfollow.

## **Manual testing steps**

```gherkin
Feature: Trading Signals followed traders list

  Scenario: unfollowed trader is removed from notification preferences
    Given the user follows a trader (e.g. lyon1)
    And the trader appears under "Traders you follow" in Settings > Notifications

    When the user unfollows that trader from their profile
    And navigates back to Settings > Notifications

    Then the unfollowed trader no longer appears in the list

  Scenario: followed trader reappears after re-follow
    Given the user unfollowed a trader

    When the user follows that trader again from their profile
    And opens Settings > Notifications

    Then the trader appears again with the correct name and avatar
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/1633ccc0-e1bc-41f8-8592-ad7889cb41e9



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)