### PR TITLE
fix(activity): open block explorer links with InAppBrowser

### DIFF
--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -18,6 +18,12 @@ import Engine from '../../../core/Engine';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import Routes from '../../../constants/navigation/Routes';
 import decodeTransaction from '../../UI/TransactionElement/utils';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+
+jest.mock('react-native-inappbrowser-reborn', () => ({
+  isAvailable: jest.fn(),
+  open: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -628,6 +634,8 @@ describe('ActivityList', () => {
     (useSelector as unknown as jest.Mock).mockImplementation((selector) =>
       selector(selectorValues),
     );
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(true);
+    (InAppBrowser.open as jest.Mock).mockResolvedValue(undefined);
   });
 
   it('renders local pending and confirmed rows, refreshes, paginates, and opens the EVM explorer', async () => {
@@ -652,13 +660,12 @@ describe('ActivityList', () => {
     expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
 
     fireEvent.press(screen.getByTestId('evm-footer'));
-    expect(mockNavigate).toHaveBeenCalledWith('Webview', {
-      params: {
-        title: 'Configured Explorer',
-        url: 'https://configured.explorer/address/0xevm',
-      },
-      screen: 'SimpleWebview',
-    });
+    await waitFor(() =>
+      expect(InAppBrowser.open).toHaveBeenCalledWith(
+        'https://configured.explorer/address/0xevm',
+      ),
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith('Webview', expect.anything());
     expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
       expect.any(Function),
       expect.any(Function),
@@ -1315,7 +1322,7 @@ describe('ActivityList', () => {
     });
   });
 
-  it('renders non-EVM bridge rows and footer when only non-EVM chains are enabled', () => {
+  it('renders non-EVM bridge rows and footer when only non-EVM chains are enabled', async () => {
     selectorValues.enabledEvm = [];
     selectorValues.enabledNonEvm = ['solana:mainnet'];
     selectorValues.nonEvmState = {
@@ -1338,9 +1345,28 @@ describe('ActivityList', () => {
 
     expect(screen.getByTestId('bridge-solanaBridge')).toBeOnTheScreen();
     fireEvent.press(screen.getByTestId('non-evm-footer'));
-    expect(mockNavigate).toHaveBeenCalledWith('Webview', {
-      params: { url: 'https://solana.explorer/address/sol' },
-      screen: 'SimpleWebview',
-    });
+    await waitFor(() =>
+      expect(InAppBrowser.open).toHaveBeenCalledWith(
+        'https://solana.explorer/address/sol',
+      ),
+    );
+  });
+
+  it('falls back to SimpleWebview when InAppBrowser is unavailable', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(false);
+
+    render(<ActivityList header={<></>} />);
+    fireEvent.press(screen.getByTestId('evm-footer'));
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+        params: {
+          title: 'Configured Explorer',
+          url: 'https://configured.explorer/address/0xevm',
+        },
+        screen: 'SimpleWebview',
+      }),
+    );
+    expect(InAppBrowser.open).not.toHaveBeenCalled();
   });
 });

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -61,6 +61,7 @@ import {
 } from '../../../util/networks';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { openUrlWithInAppBrowser } from '../../../util/browser/openUrlWithInAppBrowser';
 import { useTheme } from '../../../util/theme';
 import Engine from '../../../core/Engine';
 import { useStyles } from '../../hooks/useStyles';
@@ -569,10 +570,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         url,
       });
 
-      navigation.navigate('Webview', {
-        screen: 'SimpleWebview',
-        params: { url, title },
-      });
+      void openUrlWithInAppBrowser(url, navigation, title);
     }, [
       navigation,
       blockExplorerUrl,
@@ -620,10 +618,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         text: getBlockExplorerTrackingText(nonEvmExplorerUrl),
         url: nonEvmExplorerUrl,
       });
-      navigation.navigate('Webview', {
-        screen: 'SimpleWebview',
-        params: { url: nonEvmExplorerUrl },
-      });
+      void openUrlWithInAppBrowser(nonEvmExplorerUrl, navigation);
     }, [navigation, nonEvmExplorerUrl, trackEvent, createEventBuilder]);
 
     const perpsRelevantForFilter =

--- a/app/util/browser/openUrlWithInAppBrowser.test.ts
+++ b/app/util/browser/openUrlWithInAppBrowser.test.ts
@@ -1,0 +1,62 @@
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+import { openUrlWithInAppBrowser } from './openUrlWithInAppBrowser';
+
+jest.mock('react-native-inappbrowser-reborn', () => ({
+  isAvailable: jest.fn(),
+  open: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+const navigation = { navigate: mockNavigate };
+
+describe('openUrlWithInAppBrowser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens InAppBrowser when available', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(true);
+    (InAppBrowser.open as jest.Mock).mockResolvedValue(undefined);
+
+    await openUrlWithInAppBrowser(
+      'https://arbiscan.io/address/0xabc',
+      navigation,
+      'Arbiscan',
+    );
+
+    expect(InAppBrowser.open).toHaveBeenCalledWith(
+      'https://arbiscan.io/address/0xabc',
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to SimpleWebview when InAppBrowser is unavailable', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(false);
+
+    await openUrlWithInAppBrowser(
+      'https://arbiscan.io/address/0xabc',
+      navigation,
+      'Arbiscan',
+    );
+
+    expect(InAppBrowser.open).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+      screen: 'SimpleWebview',
+      params: { url: 'https://arbiscan.io/address/0xabc', title: 'Arbiscan' },
+    });
+  });
+
+  it('omits title in SimpleWebview params when not provided', async () => {
+    (InAppBrowser.isAvailable as jest.Mock).mockResolvedValue(false);
+
+    await openUrlWithInAppBrowser(
+      'https://solana.explorer/address/sol',
+      navigation,
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+      screen: 'SimpleWebview',
+      params: { url: 'https://solana.explorer/address/sol' },
+    });
+  });
+});

--- a/app/util/browser/openUrlWithInAppBrowser.ts
+++ b/app/util/browser/openUrlWithInAppBrowser.ts
@@ -1,0 +1,25 @@
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+
+interface WebviewNavigation {
+  navigate: (name: string, params: object) => void;
+}
+
+/**
+ * Opens a URL in the native in-app browser (SFSafariViewController / Chrome
+ * Custom Tabs). Falls back to the embedded SimpleWebview when unavailable.
+ */
+export async function openUrlWithInAppBrowser(
+  url: string,
+  navigation: WebviewNavigation,
+  title?: string,
+): Promise<void> {
+  if (await InAppBrowser.isAvailable()) {
+    await InAppBrowser.open(url);
+    return;
+  }
+
+  navigation.navigate('Webview', {
+    screen: 'SimpleWebview',
+    params: title ? { url, title } : { url },
+  });
+}


### PR DESCRIPTION
## **Description**

On iOS, tapping **View full history on Arbiscan** from the activity tab (with Arbitrum filtered) opened the embedded `SimpleWebview`, where Arbiscan’s Cloudflare verification failed. Other block explorers were unaffected.

This change routes activity-tab block explorer links through `react-native-inappbrowser-reborn` (SFSafariViewController on iOS), matching the pattern already used in Token Details and Ramps. A shared `openUrlWithInAppBrowser` helper opens the native in-app browser when available and falls back to `SimpleWebview` otherwise.

## **Changelog**

CHANGELOG entry: Fixed an issue where viewing full transaction history on Arbiscan from the activity tab could fail on iOS.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-639

## **Manual testing steps**

```gherkin
Feature: Activity tab block explorer on iOS

  Scenario: View full Arbiscan history from filtered activity
    Given I am on iOS with MetaMask mobile and an account that has Arbitrum activity
    And I open the Activity tab
    And I filter activity to Arbitrum only

    When I tap "View full history on Arbiscan"
    Then Arbiscan opens in the native in-app browser
    And I can view my address transaction history without a Cloudflare verification error

  Scenario: Fallback when InAppBrowser is unavailable
    Given InAppBrowser is not available on the device

    When I tap "View full history on Arbiscan" from the activity tab
    Then the app falls back to the embedded SimpleWebview
```

## **Screenshots/Recordings**

N/A — fix verified via unit tests; device recording to be added after on-device confirmation.

### **Before**

Embedded SimpleWebview showed Arbiscan Cloudflare verification failure on iOS (see MCWP-639 attachment).

### **After**

N/A — pending on-device capture after QA.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — navigation-only change; no new rendering or data paths.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)