### PR TITLE
fix: add content type for Predict CLOB orders

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/protocol/transport.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/transport.test.ts
@@ -57,6 +57,31 @@ describe('polymarket protocol transport', () => {
     );
   });
 
+  it('adds JSON content type for CLOB order upload body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+      }),
+    });
+
+    await submitProtocolClobOrder({
+      protocol: POLYMARKET_V2_PROTOCOL,
+      headers,
+      clobOrder,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://predict.api.cx.metamask.io/order',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
   it('normalizes relay errors into the existing result shape', async () => {
     mockFetch.mockRejectedValue(new Error('boom'));
 

--- a/app/components/UI/Predict/providers/polymarket/protocol/transport.ts
+++ b/app/components/UI/Predict/providers/polymarket/protocol/transport.ts
@@ -34,6 +34,7 @@ export async function submitProtocolClobOrder({
   const url = `${CLOB_RELAYER}/order`;
   const requestHeaders = normalizeRelayerHeaders(headers);
 
+  requestHeaders['Content-Type'] = 'application/json';
   requestHeaders['X-Clob-Version'] = protocol.transport.clobVersionHeader;
 
   const body = {


### PR DESCRIPTION
## Summary
- add JSON Content-Type to Predict CLOB relayer order POST requests
- cover the header in the Polymarket protocol transport test

## Context
Android Nitro/Cronet rejects upload requests without a Content-Type before the request is submitted, which surfaces as: Failed to submit CLOB order: Requests with upload data must have a Content-Type.

## Testing
- Started focused Jest verification, then stopped local testing per request before green completion.
- Pre-commit hook ran prettier --write and eslint --fix on staged TS files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-header addition on an existing JSON POST path with test coverage; no auth or data-model changes.
> 
> **Overview**
> Fixes **Android Nitro/Cronet** rejecting Predict CLOB relayer uploads with *"Requests with upload data must have a Content-Type"* by setting **`Content-Type: application/json`** on the normalized headers in `submitProtocolClobOrder` before the POST to `/order`.
> 
> Adds a Jest case in the Polymarket protocol transport tests to assert the fetch call includes that header alongside the existing CLOB version header checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8d5d73d6281c5acb91222dc2c6bfd4102ec71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->