### PR TITLE
fix(homepage): resolve react compiler blockers in discovery cluster

### DIFF
--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -100,15 +100,16 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
       useNetworkEnablement();
     const { detectNfts, abortDetection } = useNftDetection();
     const popularNetworksKey = popularNetworks.join(',');
-    const areAllPopularNetworksEnabled = useMemo(
-      () =>
-        popularNetworks.every((chainId) =>
+    const areAllPopularNetworksEnabled = useMemo(() => {
+      if (popularNetworksKey === '') {
+        return true;
+      }
+      return popularNetworksKey
+        .split(',')
+        .every((chainId) =>
           isNetworkEnabled(chainId as Parameters<typeof isNetworkEnabled>[0]),
-        ),
-      // popularNetworksKey stabilizes by content; popularNetworks is a new array ref every render from the hook
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [isNetworkEnabled, popularNetworksKey],
-    );
+        );
+    }, [isNetworkEnabled, popularNetworksKey]);
 
     // useFocusEffect (not useEffect) so we run every time the user focuses this screen
     // (e.g. switches to Wallet tab or returns from a section). With useEffect we would

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -5,6 +5,7 @@ import React, {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import {
   Animated,
@@ -16,8 +17,6 @@ import {
 } from 'react-native';
 import Reanimated, {
   SharedValue,
-  withTiming,
-  Easing,
   useSharedValue,
 } from 'react-native-reanimated';
 import LinearGradient from 'react-native-linear-gradient';
@@ -42,6 +41,11 @@ import { useTheme } from '../../../../../util/theme';
 import { AppThemeKey } from '../../../../../util/theme/models';
 import { TabIconAnimationContext } from '../../../../../component-library/components-temp/Tabs/TabsIconTab/TabsIconAnimationContext';
 import useTabViewedEvent, { HomeTabNames } from '../../hooks/useTabViewedEvent';
+import {
+  animateIconCollapseMirror,
+  animateIconCollapseProgress,
+  showDiscoveryWalletHeader,
+} from './homepageDiscoveryHeaderAnimation';
 
 // Tab indices — kept as a const so future tabs can be added without renumbering.
 const TAB_INDEX = {
@@ -174,11 +178,11 @@ const HomepageDiscoveryTabs = forwardRef<
     const isDarkMode = themeAppearance === AppThemeKey.dark;
     // One Animated.Value per tab — pre-rendered at mount so no re-render is needed
     // during a tab switch. Portfolio starts fully visible; others start at 0.
-    const tabGradientOpacities = useRef(
+    const [tabGradientOpacities] = useState(() =>
       Object.keys(TAB_GRADIENT_COLORS).map(
         (_, i) => new Animated.Value(i === TAB_INDEX.PORTFOLIO ? 1 : 0),
       ),
-    ).current;
+    );
     const activeTabIndexRef = useRef<number>(TAB_INDEX.PORTFOLIO);
     // Tracks whether the tab layer currently holds a pause so the unmount
     // cleanup only calls resume when it actually owns one, preventing an
@@ -191,31 +195,16 @@ const HomepageDiscoveryTabs = forwardRef<
     const iconCollapseProgress = useSharedValue(0);
     // RN Animated.Value mirror for the gradient overlay's Animated.multiply (which composes
     // with tabGradientOpacities). Updated alongside the SharedValue at every toggle.
-    const iconCollapseAnim = useRef(new Animated.Value(0)).current;
-    const iconCollapseAnimRef = useRef(iconCollapseAnim);
+    const [iconCollapseAnim] = useState(() => new Animated.Value(0));
 
     // Triggered directly from the scroll worklet via onHeaderHiddenChange —
     // fires in the same frame as the hide/show decision, not based on position.
     const animateIcons = useCallback(
       (hidden: boolean) => {
-        const toValue = hidden ? 1 : 0;
-        const duration = hidden ? 300 : 250;
-
-        // UI-thread layout animation via Reanimated.
-        // eslint-disable-next-line react-compiler/react-compiler -- mutating a Reanimated SharedValue is the documented pattern; it does not affect React render
-        iconCollapseProgress.value = withTiming(toValue, {
-          duration,
-          easing: Easing.out(Easing.cubic),
-        });
-
-        // Mirror onto the Animated.Value for the gradient overlay's Animated.multiply.
-        Animated.timing(iconCollapseAnimRef.current, {
-          toValue,
-          duration,
-          useNativeDriver: true,
-        }).start();
+        animateIconCollapseProgress(iconCollapseProgress, hidden);
+        animateIconCollapseMirror(iconCollapseAnim, hidden);
       },
-      [iconCollapseProgress],
+      [iconCollapseAnim, iconCollapseProgress],
     );
 
     const { scrollHandler, onTabEnter: portfolioOnTabEnter } =
@@ -266,38 +255,19 @@ const HomepageDiscoveryTabs = forwardRef<
           } else {
             // First visit — Perps not mounted yet so ref is null. It will mount
             // at the top of scroll, so show the header/icons immediately.
-            // eslint-disable-next-line react-compiler/react-compiler
-            walletHeaderTranslateY &&
-              (walletHeaderTranslateY.value = withTiming(0, {
-                duration: 250,
-                easing: Easing.out(Easing.cubic),
-              }));
-            iconCollapseProgress.value = withTiming(0, {
-              duration: 250,
-              easing: Easing.out(Easing.cubic),
-            });
-            Animated.timing(iconCollapseAnimRef.current, {
-              toValue: 0,
-              duration: 250,
-              useNativeDriver: true,
-            }).start();
+            showDiscoveryWalletHeader(
+              walletHeaderTranslateY,
+              iconCollapseProgress,
+              iconCollapseAnim,
+            );
           }
         } else {
           // Predictions has no scroll manager — always show header + icons on entry.
-          walletHeaderTranslateY &&
-            (walletHeaderTranslateY.value = withTiming(0, {
-              duration: 250,
-              easing: Easing.out(Easing.cubic),
-            }));
-          iconCollapseProgress.value = withTiming(0, {
-            duration: 250,
-            easing: Easing.out(Easing.cubic),
-          });
-          Animated.timing(iconCollapseAnimRef.current, {
-            toValue: 0,
-            duration: 250,
-            useNativeDriver: true,
-          }).start();
+          showDiscoveryWalletHeader(
+            walletHeaderTranslateY,
+            iconCollapseProgress,
+            iconCollapseAnim,
+          );
         }
 
         if (prevIndex !== i) {
@@ -341,6 +311,7 @@ const HomepageDiscoveryTabs = forwardRef<
         walletHeaderTranslateY,
         trackTabViewed,
         iconCollapseProgress,
+        iconCollapseAnim,
       ],
     );
 

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/homepageDiscoveryHeaderAnimation.ts
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/homepageDiscoveryHeaderAnimation.ts
@@ -1,0 +1,52 @@
+import { Animated } from 'react-native';
+import {
+  Easing,
+  SharedValue,
+  withTiming,
+  type WithTimingConfig,
+} from 'react-native-reanimated';
+
+const showAnimationConfig: WithTimingConfig = {
+  duration: 250,
+  easing: Easing.out(Easing.cubic),
+};
+
+const hideAnimationConfig: WithTimingConfig = {
+  duration: 300,
+  easing: Easing.out(Easing.cubic),
+};
+
+export function animateIconCollapseProgress(
+  iconCollapseProgress: SharedValue<number>,
+  hidden: boolean,
+): void {
+  iconCollapseProgress.value = withTiming(
+    hidden ? 1 : 0,
+    hidden ? hideAnimationConfig : showAnimationConfig,
+  );
+}
+
+export function animateIconCollapseMirror(
+  iconCollapseAnim: Animated.Value,
+  hidden: boolean,
+): void {
+  Animated.timing(iconCollapseAnim, {
+    toValue: hidden ? 1 : 0,
+    duration: hidden
+      ? hideAnimationConfig.duration
+      : showAnimationConfig.duration,
+    useNativeDriver: true,
+  }).start();
+}
+
+export function showDiscoveryWalletHeader(
+  walletHeaderTranslateY: SharedValue<number> | undefined,
+  iconCollapseProgress: SharedValue<number>,
+  iconCollapseAnim: Animated.Value,
+): void {
+  if (walletHeaderTranslateY) {
+    walletHeaderTranslateY.value = withTiming(0, showAnimationConfig);
+  }
+  animateIconCollapseProgress(iconCollapseProgress, false);
+  animateIconCollapseMirror(iconCollapseAnim, false);
+}

--- a/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
+++ b/app/components/Views/Homepage/hooks/useHomeSessionSummary.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -47,12 +47,16 @@ const useHomeSessionSummary = ({
     totalSectionsLoaded,
     appSessionId,
   });
-  latestRef.current = {
-    visitId,
-    entryPoint,
-    totalSectionsLoaded,
-    appSessionId,
-  };
+
+  // useLayoutEffect so blur handlers always read values from the latest commit.
+  useLayoutEffect(() => {
+    latestRef.current = {
+      visitId,
+      entryPoint,
+      totalSectionsLoaded,
+      appSessionId,
+    };
+  }, [visitId, entryPoint, totalSectionsLoaded, appSessionId]);
 
   // active_ab_tests is auto-injected by the analytics registry via
   // HOMEPAGE_TRENDING_SECTIONS_AB_TEST_ANALYTICS_MAPPING in abTestConfig.ts

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -49,7 +49,7 @@ const DEFAULT_RE_RENDER_WINDOW_MS = 500;
  * Captures three metrics via the existing trace/endTrace Sentry integration:
  * 1. **Time to Content** — mount until `contentReady` (valuable non-skeleton UI).
  * 2. **Data Fetch Latency** — first full `isLoading` cycle per mount (opt-in; refresh excluded).
- * 3. **Re-render Monitoring** — breadcrumb when commits exceed threshold in a window (runs in `useEffect` after paint, not during render).
+ * 3. **Re-render Monitoring** — breadcrumb when commits exceed threshold in a window (runs after every commit).
  *
  * Bookkeeping is ref-based; the hook does not intentionally trigger extra re-renders.
  */
@@ -115,8 +115,7 @@ export const useSectionPerformance = ({
         fetchStarted.current = false;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled]);
+  }, [enabled, sectionId]);
 
   // Time to Content — end span when content is ready
   useEffect(() => {
@@ -177,7 +176,7 @@ export const useSectionPerformance = ({
   }, [enabled, isLoading, sectionId, traceContentState]);
 
   // ──────────────────────────────────────────────
-  // 3. Re-render Monitoring — useEffect after commit (not during render)
+  // 3. Re-render Monitoring — runs after every commit (no dep array)
   //
   // In development, React 18 Strict Mode runs mount effects twice (setup → cleanup
   // → setup), which records one extra sample vs a single logical mount. Bump the
@@ -216,7 +215,5 @@ export const useSectionPerformance = ({
         },
       });
     }
-    // Intentionally every commit — do not add deps (would miss re-renders).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   });
 };

--- a/app/components/Views/Homepage/hooks/useTabViewedEvent.test.ts
+++ b/app/components/Views/Homepage/hooks/useTabViewedEvent.test.ts
@@ -192,8 +192,8 @@ describe('useTabViewedEvent', () => {
     });
   });
 
-  describe('ref-based context reads', () => {
-    it('uses the latest context values at call time, not render time', () => {
+  describe('context value freshness', () => {
+    it('uses the latest context values at call time after rerender', () => {
       const { result, rerender } = renderHook(() => useTabViewedEvent());
 
       // Update context after initial render

--- a/app/components/Views/Homepage/hooks/useTabViewedEvent.ts
+++ b/app/components/Views/Homepage/hooks/useTabViewedEvent.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { useHomepageScrollContext } from '../context/HomepageScrollContext';
@@ -23,13 +23,16 @@ const useTabViewedEvent = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const entryPointRef = useRef(entryPoint);
-  entryPointRef.current = entryPoint;
-
   const appSessionIdRef = useRef(appSessionId);
-  appSessionIdRef.current = appSessionId;
-
   const visitIdRef = useRef(visitId);
-  visitIdRef.current = visitId;
+
+  // useLayoutEffect keeps refs current before paint while preserving a stable
+  // trackTabViewed callback (HomepageDiscoveryTabs fires portfolio on mount only).
+  useLayoutEffect(() => {
+    entryPointRef.current = entryPoint;
+    appSessionIdRef.current = appSessionId;
+    visitIdRef.current = visitId;
+  }, [entryPoint, appSessionId, visitId]);
 
   const trackTabViewed = useCallback(
     (name: HomeTabName) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Part of epic [TMCU-866](https://consensyssoftware.atlassian.net/browse/TMCU-866) (React Compiler blockers — team-core-ux). This PR clears compiler violations in the homepage discovery cluster without changing user-facing behavior.

**Why:** These files were skipped by React Compiler due to ref-during-render access, disabled ESLint rules, and SharedValue mutations in render paths.

**What changed:**
- **`Homepage.tsx`** ([TMCU-890](https://consensyssoftware.atlassian.net/browse/TMCU-890)): derive `areAllPopularNetworksEnabled` from `popularNetworksKey` without eslint-disable.
- **`HomepageDiscoveryTabs.tsx`** ([TMCU-891](https://consensyssoftware.atlassian.net/browse/TMCU-891)): move Animated/Reanimated mutations into `homepageDiscoveryHeaderAnimation.ts`; replace ref-during-render patterns with `useState`/`useMemo`; memoize tab icon animation context.
- **`useHomeSessionSummary.ts`** ([TMCU-892](https://consensyssoftware.atlassian.net/browse/TMCU-892)): sync `latestRef` in `useLayoutEffect` instead of during render.
- **`useSectionPerformance.ts`** ([TMCU-893](https://consensyssoftware.atlassian.net/browse/TMCU-893)): restore per-commit re-render monitoring effect; add explicit mount effect deps.
- **`useTabViewedEvent.ts`** ([TMCU-894](https://consensyssoftware.atlassian.net/browse/TMCU-894)): sync context refs in `useLayoutEffect` to keep `trackTabViewed` stable and avoid duplicate portfolio events on refocus.

All six epic-scope files pass React Compiler scan locally.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TMCU-866](https://consensyssoftware.atlassian.net/browse/TMCU-866), [TMCU-890](https://consensyssoftware.atlassian.net/browse/TMCU-890), [TMCU-891](https://consensyssoftware.atlassian.net/browse/TMCU-891), [TMCU-892](https://consensyssoftware.atlassian.net/browse/TMCU-892), [TMCU-893](https://consensyssoftware.atlassian.net/browse/TMCU-893), [TMCU-894](https://consensyssoftware.atlassian.net/browse/TMCU-894)

## **Manual testing steps**

```gherkin
Feature: Homepage discovery cluster (React Compiler refactor)

  Background:
    Given I am logged into MetaMask Mobile on a dev build
    And feature flag override sets coreMCU589AbtestHubPageDiscoveryTabs to treatment

  Scenario: discovery tab switching and header animation
    Given I am on the Wallet home screen with Portfolio / Perpetuals / Predictions tabs

    When user switches to Perpetuals, then Predictions, then back to Portfolio
    Then each tab loads the expected content without crash or blank screen
    And scrolling Perps/Predictions hides and shows the wallet header with tab icon collapse animation

  Scenario: pull to refresh on portfolio tab
    Given I am on the Portfolio discovery tab

    When user pulls down to refresh
    Then the refresh indicator appears and homepage sections reload

  Scenario: control homepage smoke test
    Given feature flag override sets coreMCU589AbtestHubPageDiscoveryTabs to control

    When user opens the Wallet home screen
    Then scrollable homepage sections render and pull-to-refresh works
```

<details>
<summary>Unit tests</summary>

```bash
yarn run jest \
  app/components/Views/Homepage/Homepage.test.tsx \
  app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx \
  app/components/Views/Homepage/hooks/useHomeSessionSummary.test.ts \
  app/components/Views/Homepage/hooks/useSectionPerformance.test.ts \
  app/components/Views/Homepage/hooks/useTabViewedEvent.test.ts
```

</details>

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-866]: https://consensyssoftware.atlassian.net/browse/TMCU-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor for compiler/ESLint compliance with no intended UX change; minor risk around analytics ref timing on blur/tab events, covered by existing tests.
> 
> **Overview**
> Clears **React Compiler** violations in the homepage discovery cluster while keeping behavior the same. The work is mostly moving side effects out of render and centralizing animation helpers.
> 
> **`Homepage.tsx`** now computes `areAllPopularNetworksEnabled` from the stable `popularNetworksKey` string (split + `isNetworkEnabled`) instead of the `popularNetworks` array ref, removing the `exhaustive-deps` eslint-disable.
> 
> **`HomepageDiscoveryTabs`** pulls wallet header / tab icon collapse timing into **`homepageDiscoveryHeaderAnimation.ts`**, initializes `Animated.Value` instances with **`useState` lazy init** instead of `useRef`, and calls the shared helpers from scroll and tab-switch paths.
> 
> **Analytics hooks** (`useHomeSessionSummary`, `useTabViewedEvent`) sync “latest value” refs in **`useLayoutEffect`** so blur/tab events read up-to-date context without updating refs during render—keeping **`trackTabViewed` stable** for the portfolio mount effect.
> 
> **`useSectionPerformance`** adds **`sectionId`** to the mount cleanup effect deps and keeps the per-commit re-render breadcrumb effect dependency-free (comments only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62aa22adad0ee057f964ca186b1c4b75ef5d8979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->