### PR TITLE
fix(settings): resolve react compiler blockers in modals cluster

### DIFF
--- a/app/components/UI/DeleteWalletModal/index.tsx
+++ b/app/components/UI/DeleteWalletModal/index.tsx
@@ -106,8 +106,8 @@ const DeleteWalletModal: React.FC = () => {
   };
 
   const deleteWallet = async () => {
+    setIsDeletingWallet(true);
     try {
-      setIsDeletingWallet(true);
       dispatch(clearHistory(isEnabled(), isDataCollectionForMarketingEnabled));
       signOut();
       await CookieManager.clearAll(true);
@@ -120,9 +120,8 @@ const DeleteWalletModal: React.FC = () => {
     } catch (error) {
       console.error('Error during wallet deletion:', error);
       triggerClose();
-    } finally {
-      setIsDeletingWallet(false);
     }
+    setIsDeletingWallet(false);
   };
 
   return (

--- a/app/components/UI/TurnOffRememberMeModal/TurnOffRememberMeModal.tsx
+++ b/app/components/UI/TurnOffRememberMeModal/TurnOffRememberMeModal.tsx
@@ -93,9 +93,8 @@ const TurnOffRememberMeModal = () => {
 
       // Dismiss modal even on error
       dismissModal();
-    } finally {
-      setIsLoading(false);
     }
+    setIsLoading(false);
   }, [passwordText]);
 
   const disableRememberMe = useCallback(async () => {

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -166,6 +166,7 @@ export const useNotificationStoragePreferences =
         try {
           await persistWrite;
           lastConfirmedPreferencesRef.current = nextPreferences;
+          finishWrite();
         } catch (err) {
           Logger.error(
             err as Error,
@@ -177,9 +178,8 @@ export const useNotificationStoragePreferences =
               lastConfirmedPreferencesRef.current ?? previousSnapshot,
             );
           }
-          throw err;
-        } finally {
           finishWrite();
+          throw err;
         }
       },
       [beginWrite, data, finishWrite, getCachedPreferences, queryClient],

--- a/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeleteMetaMetricsData.tsx
@@ -132,10 +132,25 @@ const DeleteMetaMetricsData = (props: DeleteMetaMetricsDataProps) => {
   };
 
   const deleteMetaMetrics = async () => {
-    try {
-      const deleteResponse = await createDataDeletionTask();
+    let deleteResponse:
+      | Awaited<ReturnType<typeof createDataDeletionTask>>
+      | undefined;
 
-      if (DataDeleteResponseStatus.ok === deleteResponse?.status) {
+    try {
+      deleteResponse = await createDataDeletionTask();
+    } catch (error: unknown) {
+      showDeleteTaskError();
+      Logger.log('Error deleteMetaMetrics -', error);
+      return;
+    }
+
+    const responseStatus =
+      deleteResponse === null || deleteResponse === undefined
+        ? undefined
+        : deleteResponse.status;
+
+    if (DataDeleteResponseStatus.ok === responseStatus) {
+      try {
         // Local-to-screen reset: no new event has been generated since this
         // deletion request was just initiated, so the button must reflect
         // "no data tracked since last deletion" regardless of metricsOptin.
@@ -143,14 +158,12 @@ const DeleteMetaMetricsData = (props: DeleteMetaMetricsDataProps) => {
         setDataTrackedSinceLastDeletion(false);
         await checkInitialStatus();
         trackDataDeletionRequest();
-      } else {
+      } catch (error: unknown) {
         showDeleteTaskError();
+        Logger.log('Error deleteMetaMetrics -', error);
       }
-      // TODO: Replace "any" with type
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } else {
       showDeleteTaskError();
-      Logger.log('Error deleteMetaMetrics -', error);
     }
   };
 

--- a/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.tsx
@@ -114,9 +114,8 @@ const DeviceSecurityToggle = ({
                   updateError as Error,
                   'Failed to update auth preference after password entry',
                 );
-              } finally {
-                setOptimisticValue(null);
               }
+              setOptimisticValue(null);
             },
             onCancel: () => {
               setOptimisticValue(null);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Part of epic [TMCU-866](https://consensyssoftware.atlassian.net/browse/TMCU-866) (React Compiler blockers — team-core-ux). Clears compiler violations in modals and settings flows without changing user-facing behavior.

**Why:** React Compiler cannot yet lower `try/finally` or certain value blocks inside `try/catch`. These files were skipped for optimization.

**What changed:**
- **`DeleteWalletModal`** ([TMCU-886](https://consensyssoftware.atlassian.net/browse/TMCU-886)): replace `finally` with post-`try/catch` cleanup for loading state.
- **`TurnOffRememberMeModal`** ([TMCU-887](https://consensyssoftware.atlassian.net/browse/TMCU-887)): same pattern for `setIsLoading`.
- **`useNotificationStoragePreferences`** ([TMCU-900](https://consensyssoftware.atlassian.net/browse/TMCU-900)): call `finishWrite()` on both success and failure paths (no `finally`).
- **`DeleteMetaMetricsData`** ([TMCU-901](https://consensyssoftware.atlassian.net/browse/TMCU-901)): split API fetch from response handling; wrap post-success steps in error handling; remove optional chaining inside `try`.
- **`DeviceSecurityToggle`** ([TMCU-902](https://consensyssoftware.atlassian.net/browse/TMCU-902)): replace inner `finally` with post-`try/catch` optimistic reset.

All five files pass React Compiler scan locally. Bugbot review clean.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [TMCU-866](https://consensyssoftware.atlassian.net/browse/TMCU-866), [TMCU-886](https://consensyssoftware.atlassian.net/browse/TMCU-886), [TMCU-887](https://consensyssoftware.atlassian.net/browse/TMCU-887), [TMCU-900](https://consensyssoftware.atlassian.net/browse/TMCU-900), [TMCU-901](https://consensyssoftware.atlassian.net/browse/TMCU-901), [TMCU-902](https://consensyssoftware.atlassian.net/browse/TMCU-902)

## **Manual testing steps**

```gherkin
Feature: Modals and settings React Compiler refactor

  Background:
    Given I am logged into MetaMask Mobile on a dev build

  Scenario: delete wallet modal loading state clears
    Given I open the delete wallet modal from Settings

    When user taps Cancel
    Then the modal closes without a stuck loading spinner

  Scenario: turn off remember me modal
    Given Remember Me is enabled and the turn-off modal is shown

    When user confirms with password
    Then the modal dismisses and loading state clears

  Scenario: notification preferences toggle
    Given I am on Settings → Notifications

    When user toggles a notification channel on and off
    Then the toggle updates optimistically and does not get stuck updating

  Scenario: delete MetaMetrics data
    Given I am on Settings → Security with analytics enabled

    When user requests data deletion
    Then success or error UI appears without crash

  Scenario: device security toggle
    Given I am on Settings → Security → device security toggle

    When user toggles biometrics on or off
    Then the toggle reflects the new state after the update completes
```

<details>
<summary>Unit tests</summary>

```bash
yarn run jest \
  app/components/UI/DeleteWalletModal/index.test.tsx \
  app/components/UI/DeleteWalletModal/DeleteWalletModal.view.test.tsx \
  app/components/UI/TurnOffRememberMeModal/TurnOffRememberMeModal.test.tsx \
  app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
```

</details>

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-866]: https://consensyssoftware.atlassian.net/browse/TMCU-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical control-flow refactors aimed at compiler compatibility; behavior is intended to stay the same, with existing tests covering the touched modals and notification hook.
> 
> **Overview**
> Refactors **settings and modal async handlers** so they no longer use `try/finally` (and similar patterns the React Compiler cannot lower), while keeping the same loading/cleanup behavior.
> 
> **Delete wallet** and **turn off Remember Me** now set loading state before `try`, then clear it after the `try/catch` instead of in `finally`. **Notification preference persistence** calls `finishWrite()` on both success and failure paths explicitly. **Delete MetaMetrics data** separates the deletion API call from post-success UI updates, uses explicit status checks instead of optional chaining inside `try`, and tightens error typing. **Device security toggle** clears optimistic UI state after the password callback’s `try/catch` rather than in an inner `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9724e9148d17d758cb34d550c5dd7a54707567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->