### PR TITLE
chore: match Top Traders Follow button size to filter pills

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -244,21 +244,22 @@ describe('TraderRow', () => {
       expect(buttonWithHeight).not.toBeNull();
     });
 
-    it('sets min-width 96px on the Follow button so the row edge does not jitter when toggling to Following', () => {
+    it('does not pin a min-width on the Follow button so it hugs its label like the filter pills', () => {
       renderWithProvider(
         <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
       );
 
       const followLabel = screen.getByText('Follow');
-      const buttonWithMinWidth = findAncestor(
+      const button = findAncestor(
         followLabel,
-        (node) => resolveMinWidth(node) === 96,
+        (node) => resolveHeight(node) === 40,
       );
 
-      expect(buttonWithMinWidth).not.toBeNull();
+      expect(button).not.toBeNull();
+      expect(resolveMinWidth(button as ReactTestInstance)).toBeUndefined();
     });
 
-    it('uses the same min-width on the Following button so the longer label can grow naturally', () => {
+    it('does not pin a min-width on the Following button either, so each state sizes to its own label', () => {
       const followingTrader: TopTrader = { ...baseTrader, isFollowing: true };
       renderWithProvider(
         <TraderRow
@@ -268,12 +269,13 @@ describe('TraderRow', () => {
       );
 
       const followingLabel = screen.getByText('Following');
-      const buttonWithMinWidth = findAncestor(
+      const button = findAncestor(
         followingLabel,
-        (node) => resolveMinWidth(node) === 96,
+        (node) => resolveHeight(node) === 40,
       );
 
-      expect(buttonWithMinWidth).not.toBeNull();
+      expect(button).not.toBeNull();
+      expect(resolveMinWidth(button as ReactTestInstance)).toBeUndefined();
     });
 
     it('vertically centers the Follow button so it sits in the middle of the row (overrides ButtonBase self-start default)', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -230,7 +230,7 @@ describe('TraderRow', () => {
       expect(statsText).not.toBeNull();
     });
 
-    it('uses ButtonSize.Sm (32px height from the design system)', () => {
+    it('uses ButtonSize.Md (40px height) to match the Top Traders filter pills', () => {
       renderWithProvider(
         <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
       );
@@ -238,29 +238,13 @@ describe('TraderRow', () => {
       const followLabel = screen.getByText('Follow');
       const buttonWithHeight = findAncestor(
         followLabel,
-        (node) => resolveHeight(node) === 32,
+        (node) => resolveHeight(node) === 40,
       );
 
       expect(buttonWithHeight).not.toBeNull();
     });
 
-    it('applies 8px horizontal padding to match the Following state visually', () => {
-      renderWithProvider(
-        <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
-      );
-
-      const followLabel = screen.getByText('Follow');
-      const buttonWithPadding = findAncestor(followLabel, (node) => {
-        const flat = StyleSheet.flatten(node.props.style) as
-          | { paddingLeft?: number; paddingRight?: number }
-          | undefined;
-        return flat?.paddingLeft === 8 && flat?.paddingRight === 8;
-      });
-
-      expect(buttonWithPadding).not.toBeNull();
-    });
-
-    it('sets min-width 60px on the Follow button so the label is not clipped', () => {
+    it('sets min-width 96px on the Follow button so the row edge does not jitter when toggling to Following', () => {
       renderWithProvider(
         <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
       );
@@ -268,7 +252,7 @@ describe('TraderRow', () => {
       const followLabel = screen.getByText('Follow');
       const buttonWithMinWidth = findAncestor(
         followLabel,
-        (node) => resolveMinWidth(node) === 60,
+        (node) => resolveMinWidth(node) === 96,
       );
 
       expect(buttonWithMinWidth).not.toBeNull();
@@ -286,7 +270,7 @@ describe('TraderRow', () => {
       const followingLabel = screen.getByText('Following');
       const buttonWithMinWidth = findAncestor(
         followingLabel,
-        (node) => resolveMinWidth(node) === 60,
+        (node) => resolveMinWidth(node) === 96,
       );
 
       expect(buttonWithMinWidth).not.toBeNull();

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -124,9 +124,9 @@ const TraderRow: React.FC<TraderRowProps> = ({
         variant={
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
-        size={ButtonSize.Sm}
+        size={ButtonSize.Md}
         onPress={() => onFollowPress(trader.id)}
-        twClassName="self-center min-w-[60px] px-2"
+        twClassName="self-center min-w-[96px]"
       >
         {trader.isFollowing
           ? strings('social_leaderboard.following')

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -126,7 +126,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
         }
         size={ButtonSize.Md}
         onPress={() => onFollowPress(trader.id)}
-        twClassName="self-center min-w-[96px]"
+        twClassName="self-center"
       >
         {trader.isFollowing
           ? strings('social_leaderboard.following')

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -38,9 +38,10 @@ const TraderRowSkeleton: React.FC = () => {
             <View style={tw.style('w-40 h-4 rounded')} />
           </View>
 
-          {/* Button placeholder — 80×32 matches the wider Following state so
-              the row's right edge stays stable when the button toggles. */}
-          <View style={tw.style('w-20 h-8 rounded-lg ml-3')} />
+          {/* Button placeholder — 80×40 (ButtonSize.Md) matches the real
+              button so the row's right edge stays stable when the button
+              toggles between Follow and Following. */}
+          <View style={tw.style('w-20 h-10 rounded-xl ml-3')} />
         </View>
       </SkeletonPlaceholder>
     </View>


### PR DESCRIPTION
  ## **Description**

  <!-- mms-check: type=text required=true -->

  <!--
  Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
  1. What is the reason for the change?
  2. What is the improvement/solution?
  -->

  The Follow/Following button on each Top Traders row was visually heavier than the "All / Tokens / Perps" filter pills that sit directly above it in the same view, which made the section feel inconsistent. The button was rendered at
  `ButtonSize.Sm` with a hand-tuned `min-w-[60px]` and extra `px-2` horizontal padding.

  This change aligns the button with the filter pills (`TabPill` in `TopTradersView.tsx`), which are `min-h-10 rounded-xl px-3`. The button now uses `ButtonSize.Md`, whose design-system defaults (`h-10` / 40px height, `px-3` / 12px horizontal padding, `rounded-xl`) already match the pills exactly, and the explicit `min-w`/`px` overrides are removed so the button hugs its own label just like each pill does. The net effect: the "Follow" state tightens up to match the pills' compact padding, and the button sizes to its content in both the Follow and Following states.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  <!--
  If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
  1. Write `CHANGELOG entry: null`
  2. Label with `no-changelog`

  If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
  `CHANGELOG entry: Added a new tab for users to see their NFTs`
  `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

  (This helps the Release Engineer do their job more quickly and accurately)
  -->

  CHANGELOG entry: Updated the Top Traders Follow button to match the size and padding of the leaderboard filter pills

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: https://consensyssoftware.atlassian.net/browse/TSA-833

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  ```gherkin
  Feature: Top Traders Follow button matches the filter pills

    Scenario: Follow button visual sizing on the Top Traders list
      Given the Social Leaderboard feature is enabled
      And the user is on the Homepage with the Top Traders section visible

      When the user views a trader row they are not following
      Then the "Follow" button is the same height (40px) and shape as the "All / Tokens / Perps" filter pills
      And the button hugs its label with the same horizontal padding as the pills

    Scenario: Button sizes to its label when toggled
      Given the user is viewing a trader row

      When the user taps "Follow"
      Then the label changes to "Following"
      And the button resizes to fit the longer "Following" label (no fixed minimum width)
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  <!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

  ### **Before**
<img width="440" height="857" alt="Screenshot 2026-07-01 at 4 24 54 PM" src="https://github.com/user-attachments/assets/dead1dd8-1236-4f6a-8696-74605f2c3745" />

  <!-- [screenshots/recordings] -->

  ### **After**
<img width="440" height="857" alt="Screenshot 2026-07-01 at 4 15 22 PM" src="https://github.com/user-attachments/assets/5ffb3189-ccb7-4873-8bee-3279fc923814" />

  <!-- [screenshots/recordings] -->

  ## **Pre-merge author checklist**

  <!-- mms-check: type=checklist required=true -->

  <!--
  Every checklist item must be consciously assessed before marking this PR as
  "Ready for review". A checked box means you deliberately considered that
  responsibility, not that you literally performed every action listed.

  Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
  a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
  semantics.
  -->

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  <!--
  Reviewer checklist items follow the same semantics as the author checklist: an
  unchecked box is ambiguous, a checked box means the reviewer consciously
  assessed that responsibility. See `docs/readme/ready-for-review.md`.
  -->

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage Top Traders UI-only styling and test updates; follow behavior is unchanged.
> 
> **Overview**
> Aligns each Top Traders row **Follow/Following** control with the **All / Tokens / Perps** filter pills above it.
> 
> `TraderRow` switches the action button from `ButtonSize.Sm` to **`ButtonSize.Md`** and drops the `min-w-[60px]` and `px-2` overrides so only **`self-center`** remains; height, padding, and corner radius come from the design system and the button width follows the label in both states. **`TraderRowSkeleton`** updates the button placeholder from **32px** (`h-8` / `rounded-lg`) to **40px** (`h-10` / `rounded-xl`) so loading rows match the real control. **`TraderRow.test.tsx`** layout tests now expect **40px** height and **no** fixed `minWidth` instead of Sm sizing, 8px padding, and 60px min-width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940b53dcbf5299a4f3446c1975929014707e8102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->