### PR TITLE
perf: replace O(N²) i`ncludes()` with `Set.has()` in `selectAccountSections`

### DIFF
--- a/app/selectors/multichainAccounts/accountTreeController.ts
+++ b/app/selectors/multichainAccounts/accountTreeController.ts
@@ -75,12 +75,12 @@ export const selectAccountSections = createSelector(
 
     return Object.values(accountTreeState.accountTree.wallets).map(
       (wallet: AccountWalletObject) => {
-        const allAccountsIdInWallet = Object.values(wallet.groups).flatMap(
-          (group) => group.accounts,
+        const walletAccountIds = new Set(
+          Object.values(wallet.groups).flatMap((group) => group.accounts),
         );
         // To preserve the order of the accounts in the accounts controller
         const accountIds = internalAccounts
-          .filter((account) => allAccountsIdInWallet.includes(account.id))
+          .filter((account) => walletAccountIds.has(account.id))
           .map((account) => account.id);
 
         return {


### PR DESCRIPTION
## **Description**

`selectAccountSections` was building an `allAccountsIdInWallet` array per wallet and checking membership with `Array.prototype.includes()` — O(k) per account — making the overall filter O(N×k) across all internal accounts. For a power user with many accounts and wallets this quadratic pass runs on the JS thread on every selector recompute.

This change converts `allAccountsIdInWallet` to a `Set` so each membership check is O(1), reducing the overall complexity to O(N+k) per wallet.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31341

## **Manual testing steps**

N/A — internal performance change; behaviour and output are identical. Covered by the existing selector unit tests (`yarn jest app/selectors/multichainAccounts/accountTreeController.test.ts` — 84 tests, all passing).

## **Screenshots/Recordings**

N/A — no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.