### PR TITLE
perf: hoist `keyExtractor` to module scope

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
@@ -44,6 +44,24 @@ import {
   isAddressCompatibleWithChainId,
 } from '../../../../util/address';
 
+const keyExtractor = (
+  item: FlattenedMultichainAccountListItem,
+  index: number,
+) => {
+  switch (item.type) {
+    case 'header':
+      return `header-${item.data.walletName}`;
+    case 'cell':
+      return `account-${item.data.id}`;
+    case 'external':
+      return `external-${item.data.address}`;
+    case 'footer':
+      return `footer-${item.data.walletName}`;
+    default:
+      return `item-${index}`;
+  }
+};
+
 const MultichainAccountSelectorList = ({
   onSelectAccount,
   selectedAccountGroups,
@@ -377,24 +395,6 @@ const MultichainAccountSelectorList = ({
         selectedExternalAddress,
       ],
     );
-
-  const keyExtractor = useCallback(
-    (item: FlattenedMultichainAccountListItem, index: number) => {
-      switch (item.type) {
-        case 'header':
-          return `header-${item.data.walletName}`;
-        case 'cell':
-          return `account-${item.data.id}`;
-        case 'external':
-          return `external-${item.data.address}`;
-        case 'footer':
-          return `footer-${item.data.walletName}`;
-        default:
-          return `item-${index}`;
-      }
-    },
-    [],
-  );
 
   const getItemType = useCallback(
     (item: FlattenedMultichainAccountListItem) => item.type,


### PR DESCRIPTION
## **Description**

`keyExtractor` in `MultichainAccountSelectorList` was wrapped in `useCallback([])`. Since the function closes over nothing component-specific, hoisting it to module scope is equivalent in terms of referential stability but avoids the `useCallback` hook call on every render and makes the intent clearer.

The original ticket (#31309) targeted `CaipAccountSelectorList` (now deleted). This applies the same fix to its replacement, `MultichainAccountSelectorList`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31309

## **Manual testing steps**

N/A — internal performance change; behaviour and output are identical. Covered by the existing unit tests (`yarn jest app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx` — 35 tests, all passing).

## **Screenshots/Recordings**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.