### PR TITLE
fix(token-details): hide contract address for native tokens

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.test.tsx
@@ -238,15 +238,33 @@ describe('TokenDetailsInlineHeader', () => {
       expect(queryByText('Ethereum')).toBeNull();
     });
 
-    it('renders short contract address in description', () => {
-      const { getByText } = renderHeader();
+    it('does not render description or copy button for native tokens', () => {
+      const { queryByTestId, queryByText } = renderHeader();
+
+      expect(queryByTestId('copy-contract-address-button')).toBeNull();
+      expect(queryByText('0x00000...short')).toBeNull();
+    });
+
+    it('renders short contract address in description for non-native tokens', () => {
+      const { getByText } = renderHeader({
+        token: {
+          ...mockToken,
+          isETH: false,
+          isNative: false,
+        },
+      });
 
       expect(getByText('0x00000...short')).toBeOnTheScreen();
     });
 
-    it('renders copy button and calls onCopyAddress when pressed', () => {
+    it('renders copy button and calls onCopyAddress when pressed for non-native tokens', () => {
       const mockOnCopyAddress = jest.fn();
       const { getByTestId } = renderHeader({
+        token: {
+          ...mockToken,
+          isETH: false,
+          isNative: false,
+        },
         onCopyAddress: mockOnCopyAddress,
       });
 

--- a/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
@@ -57,10 +57,13 @@ export const TokenDetailsInlineHeader = ({
   const { securityConfig, handleSecurityBadgePress } =
     useTokenSecurityBadgePress(token, securityData);
 
-  const contractAddress = useMemo(
-    () => resolveTokenContractAddress(token),
-    [token],
-  );
+  const isNativeToken = token.isETH || token.isNative;
+  const contractAddress = useMemo(() => {
+    if (isNativeToken) {
+      return null;
+    }
+    return resolveTokenContractAddress(token);
+  }, [token, isNativeToken]);
   const handleCopyContractAddress = useCopyTokenContractAddress(
     contractAddress,
     onCopyAddress,


### PR DESCRIPTION
## **Description**

Native assets (e.g. ETH, POL, TRX) were incorrectly showing a zero contract address (`0x0000…0000`) and a copy button in the asset details `HeaderSubpage`. Native tokens do not have a contract address, so displaying the zero address was misleading.

This PR updates `TokenDetailsInlineHeader` to treat native tokens (`token.isETH || token.isNative`) as having no contract address. When a token is native, the header description and copy button are omitted. Non-native ERC-20 and other token types continue to show the shortened contract address and copy action as before.

Unit tests were updated to cover both native and non-native token cases.

## **Changelog**

CHANGELOG entry: Fixed native token asset details header incorrectly showing a zero contract address and copy button

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-903

## **Manual testing steps**

Feature: Asset details header for native tokens

  Scenario: Native token header does not show contract address
    Given I am on the wallet with Ethereum mainnet selected
    And I have ETH in my token list

    When I open the ETH asset details page
    Then the header shows the token ticker and logo
    And the header does not show a contract address
    And the header does not show a copy address button

  Scenario: Non-native token header still shows contract address
    Given I am on the wallet with Ethereum mainnet selected
    And I have a non-native ERC-20 token in my token list

    When I open that token's asset details page
    Then the header shows the shortened contract address
    And the header shows a copy address button
    And tapping the copy button copies the contract address

## **Screenshots/Recordings**

### **Before**

<img width="590" height="1280" alt="image" src="https://github.com/user-attachments/assets/79d07e7d-10d3-486c-bbd7-49371a1f0331" />

### **After**

https://github.com/user-attachments/assets/3c4e7f32-eec5-4ad9-80cf-2dd4a85671d1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix in the token details header with no auth, data, or payment impact; behavior is covered by updated unit tests.
> 
> **Overview**
> **Native token asset details headers no longer show a misleading zero contract address or copy control.**
> 
> `TokenDetailsInlineHeader` now treats tokens with `token.isETH` or `token.isNative` as having no contract address, skipping `resolveTokenContractAddress` so the subtitle and copy button stay hidden. ERC-20 and other non-native tokens still show the shortened address and copy action unchanged.
> 
> Tests split the default ETH fixture (native) from explicit non-native tokens for address and copy behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63244b8ed87e942633cef50d743b951e4b489895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->