### PR TITLE
feat(agentic): target dev-app installs from .js.env device vars

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -75,7 +75,7 @@ export SEGMENT_FLUSH_INTERVAL="1"
 export SEGMENT_FLUSH_EVENT_LIMIT="1"
 
 # URL of the decoding API used to provide additional data from signature requests
-export DECODING_API_URL: 'https://signature-insights.api.cx.metamask.io/v1'
+export DECODING_API_URL="https://signature-insights.api.cx.metamask.io/v1"
 
 # URL of security alerts API used to validate dApp requests.
 export SECURITY_ALERTS_API_URL="https://security-alerts.api.cx.metamask.io"
@@ -251,3 +251,8 @@ export MM_PURE_BLACK_PREVIEW="false"
 # For babel use
 # Set to "true" to log react compiler failures
 export REACT_COMPILER_LOG_FAILURES='false'
+
+# Optional: target local dev-app installs to a specific simulator/emulator.
+# export IOS_SIMULATOR="mm-1"
+# export ADB_SERIAL="emulator-5554"
+# export ANDROID_DEVICE="Pixel_8_API_35"

--- a/scripts/install-android-dev-app.sh
+++ b/scripts/install-android-dev-app.sh
@@ -23,6 +23,7 @@ readonly BUILD_DIR="$REPO_ROOT/build"
 readonly DOWNLOAD_DIR="$BUILD_DIR/gh-expo-dev-build/android"
 readonly STABLE_APK_PATH="$BUILD_DIR/metamask-dev.apk"
 readonly GHA_LIB="$SCRIPT_DIR/lib/download-gha-expo-dev-build.sh"
+readonly DEVICE_TARGET_LIB="$SCRIPT_DIR/lib/dev-device-target.sh"
 
 if [[ "$(pwd)" != "$REPO_ROOT" ]]; then
   echo -e "${RED}❌ This script must be run from the repository root${NC}"
@@ -34,6 +35,8 @@ fi
 
 # shellcheck source=lib/download-gha-expo-dev-build.sh
 source "$GHA_LIB"
+# shellcheck source=lib/dev-device-target.sh
+source "$DEVICE_TARGET_LIB"
 
 GITHUB_REPO="$(resolve_github_repo)"
 BRANCH="main"
@@ -77,6 +80,7 @@ while [[ $# -gt 0 ]]; do
     *)
       echo -e "${RED}Unknown option: $1${NC}"
       echo "Usage: $0 [--branch main] [--run RUN_ID] [--skip-download] [--skipInstall] [--uninstall]"
+      echo "Targets ADB_SERIAL or ANDROID_DEVICE from .js.env; falls back to first connected device."
       exit 1
       ;;
   esac
@@ -130,15 +134,9 @@ echo -e "${BLUE}━━━ Step 4: Installing on emulator/device ━━━${NC}"
 
 require_cmd adb "Ensure Android SDK platform-tools are on PATH."
 
-BOOTED_DEVICES="$(adb devices | grep -E '^[^ ]+\s+device$' | awk '{print $1}' || true)"
-if [[ -z "$BOOTED_DEVICES" ]]; then
-  echo -e "${RED}❌ No emulator/device in 'device' state.${NC}"
-  echo -e "${YELLOW}Start an Android emulator and run: adb devices${NC}"
-  exit 1
-fi
-
-echo -e "${GREEN}✓ Device(s):${NC}"
-echo "$BOOTED_DEVICES" | while read -r dev; do echo "  $dev"; done
+ADB_TARGET_SERIAL=$(dev_resolve_android_adb_serial)
+export ANDROID_SERIAL="$ADB_TARGET_SERIAL"
+echo -e "${GREEN}✓ Target device:${NC} ${ADB_TARGET_SERIAL}"
 
 if [[ ! -f "$STABLE_APK_PATH" ]]; then
   echo -e "${RED}❌ No APK found at ${STABLE_APK_PATH}${NC}"
@@ -148,13 +146,13 @@ fi
 
 if [[ "$UNINSTALL" == true ]]; then
   echo -e "${YELLOW}Uninstalling existing app...${NC}"
-  adb uninstall "$PACKAGE_ID" 2>/dev/null || true
+  adb -s "$ADB_TARGET_SERIAL" uninstall "$PACKAGE_ID" 2>/dev/null || true
   echo -e "${GREEN}✓ Uninstall complete${NC}"
 fi
 
 echo -e "${BLUE}Installing APK on device...${NC}"
 set +e
-INSTALL_OUTPUT="$(adb install -r "$STABLE_APK_PATH" 2>&1)"
+INSTALL_OUTPUT="$(adb -s "$ADB_TARGET_SERIAL" install -r "$STABLE_APK_PATH" 2>&1)"
 INSTALL_EXIT=$?
 set -e
 

--- a/scripts/install-ios-dev-app.sh
+++ b/scripts/install-ios-dev-app.sh
@@ -23,6 +23,7 @@ readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly BUILD_DIR="$REPO_ROOT/build"
 readonly DOWNLOAD_DIR="$BUILD_DIR/gh-expo-dev-build/ios"
 readonly GHA_LIB="$SCRIPT_DIR/lib/download-gha-expo-dev-build.sh"
+readonly DEVICE_TARGET_LIB="$SCRIPT_DIR/lib/dev-device-target.sh"
 
 if [[ "$(pwd)" != "$REPO_ROOT" ]]; then
   echo -e "${RED}❌ This script must be run from the repository root${NC}"
@@ -34,6 +35,8 @@ fi
 
 # shellcheck source=lib/download-gha-expo-dev-build.sh
 source "$GHA_LIB"
+# shellcheck source=lib/dev-device-target.sh
+source "$DEVICE_TARGET_LIB"
 
 GITHUB_REPO="$(resolve_github_repo)"
 BRANCH="main"
@@ -92,6 +95,7 @@ while [[ $# -gt 0 ]]; do
     *)
       echo -e "${RED}Unknown option: $1${NC}"
       echo "Usage: $0 [--branch main] [--run RUN_ID] [--skip-download] [--skipInstall] [--uninstall]"
+      echo "Targets IOS_SIMULATOR from .js.env (boots if needed); falls back to booted simulator."
       exit 1
       ;;
   esac
@@ -165,15 +169,11 @@ fi
 
 echo -e "${BLUE}━━━ Step 4: Installing on simulator ━━━${NC}"
 
-BOOTED_DEVICE="$(xcrun simctl list devices | grep "Booted" || true)"
-if [[ -z "$BOOTED_DEVICE" ]]; then
-  echo -e "${RED}❌ No simulator is currently running.${NC}"
-  echo -e "${YELLOW}Boot one (Xcode > Open Developer Tool > Simulator) and re-run.${NC}"
-  exit 1
-fi
-
-echo -e "${GREEN}✓ Simulator is running:${NC}"
-echo "  $BOOTED_DEVICE"
+SIMULATOR_UDID=$(dev_resolve_ios_simulator_udid)
+SIMULATOR_NAME=$(xcrun simctl list devices available -j | jq -r --arg udid "$SIMULATOR_UDID" '
+  [.devices[][] | select(.udid == $udid)] | first | .name // "unknown"
+')
+echo -e "${GREEN}✓ Target simulator:${NC} ${SIMULATOR_NAME} (${SIMULATOR_UDID})"
 
 APP_PATH="$BUILD_DIR/$APP_NAME"
 if [[ ! -d "$APP_PATH" ]]; then
@@ -186,12 +186,12 @@ echo -e "${GREEN}Found app:${NC} $(basename "$APP_PATH")"
 
 if [[ "$UNINSTALL" == true ]]; then
   echo -e "${YELLOW}Uninstalling existing app...${NC}"
-  xcrun simctl uninstall booted "$BUNDLE_ID" 2>/dev/null || {
+  xcrun simctl uninstall "$SIMULATOR_UDID" "$BUNDLE_ID" 2>/dev/null || {
     echo -e "${YELLOW}App was not installed or already uninstalled${NC}"
   }
   echo -e "${GREEN}✓ Uninstall complete${NC}"
 fi
 
 echo -e "${BLUE}Installing app on simulator...${NC}"
-xcrun simctl install booted "$APP_PATH"
+xcrun simctl install "$SIMULATOR_UDID" "$APP_PATH"
 echo -e "${GREEN}✓ Successfully installed app on simulator!${NC}"

--- a/scripts/lib/dev-device-target.sh
+++ b/scripts/lib/dev-device-target.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Shared device targeting for expo dev-app install scripts.
+# Reads slot-specific targets from .js.env (same as scripts/build.sh):
+#   IOS_SIMULATOR  — simulator name (e.g. mm-1); boots if needed
+#   ADB_SERIAL     — adb serial (e.g. emulator-5554); takes precedence on Android
+#   ANDROID_DEVICE — AVD name or emulator serial when ADB_SERIAL is unset
+
+dev_load_js_env() {
+  local js_env_file="${REPO_ROOT:?REPO_ROOT must be set}/.js.env"
+  if [[ -f "$js_env_file" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    source "$js_env_file"
+    set +a
+  fi
+}
+
+dev_require_jq() {
+  if ! command -v jq &> /dev/null; then
+    echo "❌ jq is required but not installed"
+    echo "Install with: brew install jq"
+    exit 1
+  fi
+}
+
+dev_get_ios_simulator_udid_by_name() {
+  local device_name="$1"
+  xcrun simctl list devices available -j | jq -r --arg name "$device_name" '
+    [.devices[][] | select(.name == $name)] as $matches |
+    (($matches | map(select(.state == "Booted")) | first) // ($matches | first)) |
+    .udid // empty
+  '
+}
+
+dev_is_ios_simulator_booted() {
+  local udid="$1"
+  xcrun simctl list devices available -j | jq -e --arg udid "$udid" '
+    [.devices[][] | select(.udid == $udid and .state == "Booted")] | length > 0
+  ' > /dev/null
+}
+
+dev_boot_ios_simulator() {
+  local udid="$1"
+  local device_name="$2"
+
+  if dev_is_ios_simulator_booted "$udid"; then
+    echo -e "${GREEN}✓ iOS simulator \"${device_name}\" (${udid}) is already booted${NC}" >&2
+    return 0
+  fi
+
+  echo -e "${BLUE}Booting iOS simulator: ${device_name} (${udid})${NC}" >&2
+  xcrun simctl boot "$udid" 2>/dev/null || true
+  xcrun simctl bootstatus "$udid" -b >&2
+  open -a Simulator --args -CurrentDeviceUDID "$udid" 2>/dev/null || open -a Simulator
+  echo -e "${GREEN}✓ iOS simulator \"${device_name}\" is booted and ready${NC}" >&2
+}
+
+# Prints the target simulator UDID to stdout.
+dev_resolve_ios_simulator_udid() {
+  dev_load_js_env
+  dev_require_jq
+
+  if [[ -n "${IOS_SIMULATOR:-}" ]]; then
+    local udid
+    udid=$(dev_get_ios_simulator_udid_by_name "$IOS_SIMULATOR")
+    if [[ -z "$udid" ]]; then
+      echo -e "${RED}❌ iOS simulator \"${IOS_SIMULATOR}\" not found${NC}" >&2
+      echo -e "${YELLOW}Set IOS_SIMULATOR in .js.env or run: xcrun simctl list devices available${NC}" >&2
+      exit 1
+    fi
+
+    echo -e "${BLUE}Using IOS_SIMULATOR from .js.env: ${IOS_SIMULATOR}${NC}" >&2
+    dev_boot_ios_simulator "$udid" "$IOS_SIMULATOR"
+    echo "$udid"
+    return 0
+  fi
+
+  local booted_udid booted_name
+  booted_udid=$(xcrun simctl list devices booted -j | jq -r '
+    [.devices[][] | select(.state == "Booted")] | first | .udid // empty
+  ')
+  if [[ -z "$booted_udid" ]]; then
+    echo -e "${RED}❌ No simulator is currently running.${NC}" >&2
+    echo -e "${YELLOW}Set IOS_SIMULATOR in .js.env or boot a simulator first.${NC}" >&2
+    exit 1
+  fi
+
+  booted_name=$(xcrun simctl list devices booted -j | jq -r --arg udid "$booted_udid" '
+    [.devices[][] | select(.udid == $udid)] | first | .name // "unknown"
+  ')
+  echo -e "${YELLOW}IOS_SIMULATOR not set in .js.env — using booted simulator: ${booted_name} (${booted_udid})${NC}" >&2
+  echo "$booted_udid"
+}
+
+dev_android_serial_is_ready() {
+  local serial="$1"
+  [[ "$(adb -s "$serial" get-state 2>/dev/null || true)" == "device" ]]
+}
+
+dev_list_android_device_serials() {
+  adb devices | awk '/^[^ ]+[[:space:]]+device$/ { print $1 }'
+}
+
+dev_resolve_android_serial_from_avd_name() {
+  local avd_name="$1"
+  local serial avd
+
+  while IFS= read -r serial; do
+    [[ -z "$serial" ]] && continue
+    avd=$(adb -s "$serial" emu avd name 2>/dev/null | head -1 | tr -d '\r')
+    if [[ "$avd" == "$avd_name" ]]; then
+      echo "$serial"
+      return 0
+    fi
+  done < <(dev_list_android_device_serials)
+
+  return 1
+}
+
+# Prints the target adb serial to stdout.
+dev_resolve_android_adb_serial() {
+  dev_load_js_env
+
+  if ! command -v adb &> /dev/null; then
+    echo -e "${RED}❌ adb not found. Ensure Android SDK platform-tools are on PATH.${NC}" >&2
+    exit 1
+  fi
+
+  if [[ -n "${ADB_SERIAL:-}" ]]; then
+    if ! dev_android_serial_is_ready "$ADB_SERIAL"; then
+      echo -e "${RED}❌ ADB_SERIAL from .js.env is not connected: ${ADB_SERIAL}${NC}" >&2
+      echo -e "${YELLOW}Start the emulator/device or update ADB_SERIAL in .js.env${NC}" >&2
+      exit 1
+    fi
+    echo -e "${BLUE}Using ADB_SERIAL from .js.env: ${ADB_SERIAL}${NC}" >&2
+    echo "$ADB_SERIAL"
+    return 0
+  fi
+
+  if [[ -n "${ANDROID_DEVICE:-}" ]]; then
+    local serial=""
+    if [[ "$ANDROID_DEVICE" =~ ^emulator-[0-9]+$ ]]; then
+      serial="$ANDROID_DEVICE"
+    else
+      serial=$(dev_resolve_android_serial_from_avd_name "$ANDROID_DEVICE" || true)
+    fi
+
+    if [[ -z "$serial" ]] || ! dev_android_serial_is_ready "$serial"; then
+      echo -e "${RED}❌ ANDROID_DEVICE from .js.env is not available: ${ANDROID_DEVICE}${NC}" >&2
+      echo -e "${YELLOW}Start the matching emulator or set ADB_SERIAL in .js.env${NC}" >&2
+      exit 1
+    fi
+
+    echo -e "${BLUE}Using ANDROID_DEVICE from .js.env: ${ANDROID_DEVICE} (${serial})${NC}" >&2
+    echo "$serial"
+    return 0
+  fi
+
+  local fallback_serial
+  fallback_serial=$(dev_list_android_device_serials | head -1 || true)
+  if [[ -z "$fallback_serial" ]]; then
+    echo -e "${RED}❌ No emulator/device in 'device' state.${NC}" >&2
+    echo -e "${YELLOW}Set ADB_SERIAL or ANDROID_DEVICE in .js.env, or start an Android emulator.${NC}" >&2
+    exit 1
+  fi
+
+  echo -e "${YELLOW}ADB_SERIAL / ANDROID_DEVICE not set in .js.env — using first connected device: ${fallback_serial}${NC}" >&2
+  echo "$fallback_serial"
+}


### PR DESCRIPTION
## **Description**

Dev-app install scripts (`yarn install:ios:dev` / `yarn install:android:dev`, and the `install:*:runway` aliases) previously installed to whichever simulator or emulator happened to be booted. That breaks multi-slot local setups where `.js.env` defines slot-specific targets such as `IOS_SIMULATOR="mm-1"`, `ADB_SERIAL`, and `ANDROID_DEVICE`.

This PR adds `scripts/lib/dev-device-target.sh` and wires it into the GHA artifact install scripts so installs respect the same `.js.env` device variables used by `yarn start:ios` / `yarn start:android`.

**iOS**
- Reads `IOS_SIMULATOR` from `.js.env`
- Boots the named simulator if needed
- Installs to that UDID instead of `simctl booted`
- Falls back to the first booted simulator when `IOS_SIMULATOR` is unset

**Android**
- Prefers `ADB_SERIAL`, then resolves `ANDROID_DEVICE` (AVD name or `emulator-####`)
- Installs via `adb -s <serial>`
- Falls back to the first connected device when neither env var is set

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A — developer tooling improvement for agentic / multi-slot local workflows

## **Manual testing steps**

```gherkin
Feature: dev-app install targets slot simulator from .js.env

  Scenario: install iOS dev build on named simulator
    Given .js.env sets IOS_SIMULATOR to "mm-1"
    And the mm-1 simulator is shut down
    When I run yarn install:ios:dev --skip-download
    Then mm-1 boots automatically
    And MetaMask.app is installed on mm-1

  Scenario: install Android dev build on configured adb serial
    Given .js.env sets ADB_SERIAL to a connected emulator serial
    When I run yarn install:android:dev --skip-download
    Then the APK is installed on that serial only
```

Verified locally on iOS: `yarn install:ios:runway --skip-download` booted `mm-1` from `.js.env` and installed successfully.

## **Screenshots/Recordings**

N/A — shell script / developer tooling change with no UI impact.

### **Before**

Install scripts used `simctl booted` / first `adb devices` entry regardless of `.js.env`.

### **After**

Install scripts resolve the target device from `.js.env` and print which simulator/emulator was selected.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)