### PR TITLE
test: fix feature flag sync script to deduplicate entries and run lin…

### DIFF
--- a/tests/feature-flags/sync-production-flags.test.ts
+++ b/tests/feature-flags/sync-production-flags.test.ts
@@ -515,6 +515,27 @@ describe('validateRegistryFile', () => {
     const errors = validateRegistryFile(content);
     expect(errors).toContainEqual(expect.stringContaining('tsc failed to run'));
   });
+
+  it('reports error when tsc exits with non-TS diagnostic output', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      const err = new Error('tsc failed') as Error & {
+        stdout: string;
+        stderr: string;
+      };
+      err.stdout = 'Some unexpected compiler crash output';
+      err.stderr = '';
+      throw err;
+    });
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const errors = validateRegistryFile(content);
+    expect(errors).toContainEqual(
+      expect.stringContaining('tsc exited with an error'),
+    );
+  });
 });
 
 describe('compareProductionFlagsToRegistry - key ordering', () => {

--- a/tests/feature-flags/sync-production-flags.test.ts
+++ b/tests/feature-flags/sync-production-flags.test.ts
@@ -5,7 +5,12 @@ jest.mock('prettier', () => ({
   },
 }));
 
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
 /* eslint-disable import-x/no-nodejs-modules -- Node.js script for CI/sync */
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import {
   getProductionRemoteFlagApiResponse,
@@ -13,7 +18,9 @@ import {
 } from './feature-flag-registry';
 import {
   compareProductionFlagsToRegistry,
+  findDuplicateRegistryKeys,
   updateRegistryFile,
+  validateRegistryFile,
 } from './sync-production-flags';
 
 // Synthetic registry fixture matching structure required by updateRegistryFile
@@ -333,5 +340,222 @@ describe('updateRegistryFile', () => {
     expect(written).not.toContain(
       'Production defaults last synced: 2020-01-01',
     );
+  });
+
+  it('skips appending a new flag that already exists in the registry', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = {
+      newInProduction: [{ name: 'flagA', value: { updated: true } }],
+      removedFromProduction: [],
+      valueMismatches: [],
+      inProdMismatches: [],
+      hasDrift: true,
+    };
+    await updateRegistryFile(result);
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    const written = writeFileSyncMock.mock.calls[0][1] as string;
+    const matches = written.match(/flagA:\s*\{/gu) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping duplicate: "flagA"'),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('serializes object values with sorted keys for deterministic output', async () => {
+    const result = {
+      newInProduction: [
+        { name: 'sortedFlag', value: { zebra: 1, alpha: 2, middle: 3 } },
+      ],
+      removedFromProduction: [],
+      valueMismatches: [],
+      inProdMismatches: [],
+      hasDrift: true,
+    };
+    await updateRegistryFile(result);
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    const written = writeFileSyncMock.mock.calls[0][1] as string;
+    const alphaIdx = written.indexOf('"alpha"');
+    const middleIdx = written.indexOf('"middle"');
+    const zebraIdx = written.indexOf('"zebra"');
+    expect(alphaIdx).toBeLessThan(middleIdx);
+    expect(middleIdx).toBeLessThan(zebraIdx);
+  });
+});
+
+describe('findDuplicateRegistryKeys', () => {
+  it('returns empty array when no duplicates exist', () => {
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+  flagB: {
+    name: 'flagB',
+  },
+`;
+    expect(findDuplicateRegistryKeys(content)).toHaveLength(0);
+  });
+
+  it('detects duplicate unquoted keys', () => {
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+  flagB: {
+    name: 'flagB',
+  },
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const dupes = findDuplicateRegistryKeys(content);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]).toContain('flagA');
+  });
+
+  it('detects duplicate quoted keys', () => {
+    const content = `
+  "myFlag": {
+    name: 'myFlag',
+  },
+  "myFlag": {
+    name: 'myFlag',
+  },
+`;
+    const dupes = findDuplicateRegistryKeys(content);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]).toContain('myFlag');
+  });
+});
+
+describe('validateRegistryFile', () => {
+  const mockedExecFileSync = execFileSync as unknown as jest.Mock;
+
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+  });
+
+  it('returns empty array for valid content with no duplicates and clean tsc', () => {
+    mockedExecFileSync.mockReturnValue('');
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+  flagB: {
+    name: 'flagB',
+  },
+`;
+    expect(validateRegistryFile(content)).toHaveLength(0);
+  });
+
+  it('returns duplicate key errors', () => {
+    mockedExecFileSync.mockReturnValue('');
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const errors = validateRegistryFile(content);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain('flagA');
+  });
+
+  it('returns TypeScript errors from tsc', () => {
+    const tsError =
+      'feature-flag-registry.ts(10,3): error TS1117: Duplicate property';
+    mockedExecFileSync.mockImplementation(() => {
+      const err = new Error('tsc failed') as Error & { stdout: string };
+      err.stdout = tsError;
+      throw err;
+    });
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const errors = validateRegistryFile(content);
+    expect(errors).toContainEqual(expect.stringContaining('error TS1117'));
+  });
+
+  it('catches chained TypeScript errors from imported files', () => {
+    const chainedError =
+      'node_modules/@metamask/utils/types.d.ts(5,1): error TS2305: Module has no exported member';
+    mockedExecFileSync.mockImplementation(() => {
+      const err = new Error('tsc failed') as Error & { stdout: string };
+      err.stdout = chainedError;
+      throw err;
+    });
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const errors = validateRegistryFile(content);
+    expect(errors).toContainEqual(expect.stringContaining('error TS2305'));
+  });
+
+  it('reports error when tsc fails to spawn with no output', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      const err = new Error('ENOENT') as Error & {
+        stdout: string;
+        stderr: string;
+      };
+      err.stdout = '';
+      err.stderr = '';
+      throw err;
+    });
+    const content = `
+  flagA: {
+    name: 'flagA',
+  },
+`;
+    const errors = validateRegistryFile(content);
+    expect(errors).toContainEqual(expect.stringContaining('tsc failed to run'));
+  });
+});
+
+describe('compareProductionFlagsToRegistry - key ordering', () => {
+  it('does not flag reordered object keys as drift', () => {
+    const registryMap = { myFlag: { alpha: 1, zebra: 2 } };
+    const prodResponse = [{ myFlag: { zebra: 2, alpha: 1 } }];
+    const result = compareProductionFlagsToRegistry(prodResponse, registryMap);
+
+    expect(result.valueMismatches).toHaveLength(0);
+    expect(result.hasDrift).toBe(false);
+  });
+
+  it('does not flag deeply nested reordered keys as drift', () => {
+    const registryMap = {
+      myFlag: {
+        versions: {
+          '1.0.0': { alpha: true, beta: false },
+        },
+      },
+    };
+    const prodResponse = [
+      {
+        myFlag: {
+          versions: {
+            '1.0.0': { beta: false, alpha: true },
+          },
+        },
+      },
+    ];
+    const result = compareProductionFlagsToRegistry(prodResponse, registryMap);
+
+    expect(result.valueMismatches).toHaveLength(0);
+    expect(result.hasDrift).toBe(false);
+  });
+
+  it('still detects actual value changes even with different key order', () => {
+    const registryMap = { myFlag: { alpha: 1, zebra: 2 } };
+    const prodResponse = [{ myFlag: { zebra: 999, alpha: 1 } }];
+    const result = compareProductionFlagsToRegistry(prodResponse, registryMap);
+
+    expect(result.valueMismatches).toHaveLength(1);
+    expect(result.hasDrift).toBe(true);
   });
 });

--- a/tests/feature-flags/sync-production-flags.ts
+++ b/tests/feature-flags/sync-production-flags.ts
@@ -352,7 +352,7 @@ function escapeRegex(str: string): string {
  */
 function registryEntryLineRegex(name: string): RegExp {
   return new RegExp(
-    `^  (?:"${escapeRegex(name)}"|${escapeRegex(name)}):\\s*\\{`,
+    `^ {2}(?:"${escapeRegex(name)}"|'${escapeRegex(name)}'|${escapeRegex(name)}):\\s*\\{`,
     'mu',
   );
 }
@@ -488,6 +488,10 @@ export function validateRegistryFile(content: string): string[] {
         .filter((line: string) => line.includes('error TS'));
       if (tsErrors.length > 0) {
         errors.push(...tsErrors);
+      } else {
+        errors.push(
+          `tsc exited with an error but no TS diagnostics found: ${output.trim().split('\n')[0]}`,
+        );
       }
     }
   }

--- a/tests/feature-flags/sync-production-flags.ts
+++ b/tests/feature-flags/sync-production-flags.ts
@@ -22,6 +22,8 @@
  */
 
 // eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
+import { execFileSync } from 'child_process';
+// eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
 import fs from 'fs';
 // eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
 import path from 'path';
@@ -359,8 +361,22 @@ function entryOpenBraceIndex(entryMatch: RegExpExecArray): number {
   return entryMatch.index + entryMatch[0].length - 1;
 }
 
+function sortKeysDeep(val: unknown): unknown {
+  if (Array.isArray(val)) {
+    return val.map(sortKeysDeep);
+  }
+  if (val !== null && typeof val === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+      sorted[key] = sortKeysDeep((val as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return val;
+}
+
 function serializeValue(value: unknown, indent = 0): string {
-  const json = JSON.stringify(value, null, 2);
+  const json = JSON.stringify(sortKeysDeep(value), null, 2);
   if (indent <= 0) {
     return json;
   }
@@ -422,6 +438,61 @@ function findBalancedEnd(content: string, openIndex: number): number {
     i += 1;
   }
   return -1;
+}
+
+export function findDuplicateRegistryKeys(content: string): string[] {
+  const entryPattern = /^ {2}([a-zA-Z][a-zA-Z0-9_]*):\s*\{/gmu;
+  const quotedPattern = /^ {2}"([^"]+)":\s*\{/gmu;
+  const seen = new Map<string, number>();
+  const duplicates: string[] = [];
+
+  for (const pattern of [entryPattern, quotedPattern]) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+      const key = match[1];
+      const line = content.slice(0, match.index).split('\n').length;
+      if (seen.has(key)) {
+        duplicates.push(
+          `Duplicate key "${key}" at lines ${seen.get(key)} and ${line}`,
+        );
+      } else {
+        seen.set(key, line);
+      }
+    }
+  }
+  return duplicates;
+}
+
+export function validateRegistryFile(content: string): string[] {
+  const errors: string[] = [];
+
+  const duplicates = findDuplicateRegistryKeys(content);
+  errors.push(...duplicates);
+
+  const rootDir = path.resolve(__dirname, '../..');
+  try {
+    execFileSync(
+      path.resolve(rootDir, 'node_modules/.bin/tsc'),
+      ['--noEmit', '-p', path.resolve(rootDir, 'tsconfig.json')],
+      { encoding: 'utf-8', stdio: 'pipe', cwd: rootDir },
+    );
+  } catch (err: unknown) {
+    const stdout = (err as { stdout?: string }).stdout ?? '';
+    const stderr = (err as { stderr?: string }).stderr ?? '';
+    if (!stdout && !stderr) {
+      errors.push('tsc failed to run (no output — binary may be missing)');
+    } else {
+      const output = stdout || stderr;
+      const tsErrors = output
+        .split('\n')
+        .filter((line: string) => line.includes('error TS'));
+      if (tsErrors.length > 0) {
+        errors.push(...tsErrors);
+      }
+    }
+  }
+
+  return errors;
 }
 
 /**
@@ -618,25 +689,37 @@ export async function updateRegistryFile(result: SyncResult): Promise<void> {
   }
 
   if (result.newInProduction.length > 0) {
-    const newEntries = result.newInProduction
-      .map(({ name, value }) => {
-        const serialized = serializeValue(value, 4);
-        return [
-          `  ${JSON.stringify(name)}: {`,
-          `    name: '${name.replace(/'/gu, "\\'")}',`,
-          '    type: FeatureFlagType.Remote,',
-          '    inProd: true,',
-          `    productionDefault: ${serialized},`,
-          '    status: FeatureFlagStatus.Active,',
-          '  },',
-        ].join('\n');
-      })
-      .join('\n\n');
+    const uniqueNewFlags = result.newInProduction.filter(({ name }) => {
+      const exists = registryEntryLineRegex(name).test(content);
+      if (exists) {
+        console.warn(
+          `[sync] Skipping duplicate: "${name}" already exists in registry`,
+        );
+      }
+      return !exists;
+    });
 
-    content = content.replace(
-      /(\n)(\};\s*\/\/ =+\s*\n\/\/ Helper Functions)/u,
-      (_, g1, g2) => `\n${newEntries}\n${g1}${g2}`,
-    );
+    if (uniqueNewFlags.length > 0) {
+      const newEntries = uniqueNewFlags
+        .map(({ name, value }) => {
+          const serialized = serializeValue(value, 4);
+          return [
+            `  ${JSON.stringify(name)}: {`,
+            `    name: '${name.replace(/'/gu, "\\'")}',`,
+            '    type: FeatureFlagType.Remote,',
+            '    inProd: true,',
+            `    productionDefault: ${serialized},`,
+            '    status: FeatureFlagStatus.Active,',
+            '  },',
+          ].join('\n');
+        })
+        .join('\n\n');
+
+      content = content.replace(
+        /(\n)(\};\s*\/\/ =+\s*\n\/\/ Helper Functions)/u,
+        (_, g1, g2) => `\n${newEntries}\n${g1}${g2}`,
+      );
+    }
   }
 
   // Use require to avoid ts-node type resolution issues with prettier
@@ -654,7 +737,20 @@ export async function updateRegistryFile(result: SyncResult): Promise<void> {
     ...prettierOptions,
     filepath: REGISTRY_FILE_PATH,
   });
-  fs.writeFileSync(REGISTRY_FILE_PATH, formatted ?? content, 'utf-8');
+  const finalContent = formatted ?? content;
+  fs.writeFileSync(REGISTRY_FILE_PATH, finalContent, 'utf-8');
+
+  const validationErrors = validateRegistryFile(finalContent);
+  if (validationErrors.length > 0) {
+    console.error(c.red('\n✗ Post-write validation failed:'));
+    for (const err of validationErrors) {
+      console.error(c.red(`  - ${err}`));
+    }
+    throw new Error(
+      `Registry file has ${validationErrors.length} validation error(s)`,
+    );
+  }
+
   console.log(c.green(`\n✓ Registry file updated: ${REGISTRY_FILE_PATH}`));
   console.log(c.yellow('Run `yarn feature-flags:sync` to verify.'));
 }


### PR DESCRIPTION
…t before committing

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Updates the FF registry sync script to make sure no duplicate entries are added to the registry and linting errors if any are fixed. 

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2020

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

NA

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI/dev sync tooling and tests; no runtime app or production flag delivery behavior is modified.
> 
> **Overview**
> Hardens the **production feature-flag registry sync** script so auto-updates are safer and registry output is more stable.
> 
> **`updateRegistryFile`** now skips appending flags that already exist (with a warning), deep-sorts object keys when serializing `productionDefault` values, and runs **post-write validation** via duplicate-key scanning plus `tsc --noEmit`—failing the update if the registry is invalid. Registry entry matching also accepts single-quoted keys.
> 
> Adds exported **`findDuplicateRegistryKeys`** and **`validateRegistryFile`**, with broad Jest coverage (duplicates, `tsc` success/failure paths, dedupe-on-append, sorted serialization, and lodash-style key-order drift behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8371cb52db90466f20f4d38dbd67bd095a8771e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->