### PR TITLE
feat: add feature flag for dmk

### DIFF
--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -19,10 +19,14 @@ export enum FeatureFlagNames {
   tronClaimUnstakedTrxButtonEnabled = 'tronClaimUnstakedTrxButtonEnabled',
   addDeviceSyncEnabled = 'addDeviceSyncEnabled',
   hapticsKillSwitch = 'hapticsKillSwitch',
+  ledgerDmk = 'ledgerDmk',
 }
 
 /** Minimum expected app version required for QR add-device account sync. Will update if extends */
 export const ADD_DEVICE_SYNC_MINIMUM_VERSION = '8.6.0';
+
+/** Minimum expected app version required for Ledger DMK (Device Management Key). */
+export const LEDGER_DMK_MINIMUM_VERSION = '8.2.0';
 
 export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   Record<FeatureFlagNames, Json>
@@ -35,6 +39,10 @@ export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   [FeatureFlagNames.addDeviceSyncEnabled]: {
     enabled: false,
     minimumVersion: ADD_DEVICE_SYNC_MINIMUM_VERSION,
+  },
+  [FeatureFlagNames.ledgerDmk]: {
+    enabled: false,
+    minimumVersion: null,
   },
   [FeatureFlagNames.telegramLoginEnabled]: false,
 };

--- a/app/selectors/featureFlagController/ledgerDmk/index.test.ts
+++ b/app/selectors/featureFlagController/ledgerDmk/index.test.ts
@@ -1,0 +1,195 @@
+import { selectLedgerDmkEnabled } from '.';
+import mockedEngine from '../../../core/__mocks__/MockedEngine';
+import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
+import {
+  LEDGER_DMK_MINIMUM_VERSION,
+  FeatureFlagNames,
+} from '../../../constants/featureFlags';
+import { getVersion } from 'react-native-device-info';
+
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+
+jest.mock(
+  '../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
+describe('Ledger DMK feature flag selector (version-gated)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getVersion as jest.MockedFunction<typeof getVersion>).mockReturnValue(
+      LEDGER_DMK_MINIMUM_VERSION,
+    );
+  });
+
+  it('returns true when enabled and minimum version requirement passes', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: {
+                enabled: true,
+                minimumVersion: LEDGER_DMK_MINIMUM_VERSION,
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(true);
+  });
+
+  it('returns false when enabled but minimum version requirement fails', () => {
+    (getVersion as jest.MockedFunction<typeof getVersion>).mockReturnValue(
+      '1.0.0',
+    );
+
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: {
+                enabled: true,
+                minimumVersion: '99.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+
+  it('returns false for the production disabled shape (null minimumVersion)', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: {
+                enabled: false,
+                minimumVersion: null,
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+
+  it('returns false when disabled regardless of version', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: {
+                enabled: false,
+                minimumVersion: '0.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+
+  it('returns false when remote flag is missing', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              someOtherFlag: true,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+
+  it('returns false when feature flag state is empty', () => {
+    expect(selectLedgerDmkEnabled(mockedEmptyFlagsState)).toBe(false);
+  });
+
+  it('returns false when RemoteFeatureFlagController state is undefined', () => {
+    expect(selectLedgerDmkEnabled(mockedUndefinedFlagsState)).toBe(false);
+  });
+
+  it('supports boolean dev-tool overrides when true', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: true,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(true);
+  });
+
+  it('supports boolean dev-tool overrides when false', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: false,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+
+  it('returns false when flag has invalid shape', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [FeatureFlagNames.ledgerDmk]: {
+                enabled: 'true',
+                minimumVersion: 100,
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    };
+
+    expect(selectLedgerDmkEnabled(state)).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/ledgerDmk/index.ts
+++ b/app/selectors/featureFlagController/ledgerDmk/index.ts
@@ -1,0 +1,41 @@
+import { hasProperty } from '@metamask/utils';
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import { FeatureFlagNames } from '../../../constants/featureFlags';
+import {
+  validatedVersionGatedFeatureFlag,
+  type VersionGatedFeatureFlag,
+} from '../../../util/remoteFeatureFlag';
+
+const DEFAULT_LEDGER_DMK_ENABLED = false;
+
+/**
+ * Selector for the Ledger DMK feature flag.
+ *
+ * Resolution order:
+ * 1. Boolean dev-tool local override (takes precedence).
+ * 2. Remote version-gated flag via `validatedVersionGatedFeatureFlag`.
+ * 3. Default (`false`) when the flag is absent, undefined, or override-activated.
+ *
+ * @returns Boolean indicating whether Ledger DMK is enabled.
+ */
+export const selectLedgerDmkEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, FeatureFlagNames.ledgerDmk)) {
+      return DEFAULT_LEDGER_DMK_ENABLED;
+    }
+
+    const rawFlag = remoteFeatureFlags[FeatureFlagNames.ledgerDmk];
+
+    // Boolean dev-tool local overrides take precedence.
+    if (typeof rawFlag === 'boolean') {
+      return rawFlag;
+    }
+
+    const remoteFlag = rawFlag as unknown as VersionGatedFeatureFlag;
+    return (
+      validatedVersionGatedFeatureFlag(remoteFlag) ?? DEFAULT_LEDGER_DMK_ENABLED
+    );
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This PR adds a new feature flag to enable the DMK

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1858?atlOrigin=eyJpIjoiZDQzMzRkZDI2YjQ2NGExMzg2ODc0NDk1ZTYzMDkxOWMiLCJwIjoiaiJ9

## **Manual testing steps**

Not wired therefore cannot be tested. 

<!-- mms-check: type=manual-testing required=true -->

## **Screenshots/Recordings**

No visual changes.

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag and selector-only change with safe defaults and no runtime wiring; limited blast radius until DMK code reads the selector.
> 
> **Overview**
> Introduces a **remote feature flag** for **Ledger DMK** (Device Management Key) so rollout can be controlled from remote config before DMK UI or flows land.
> 
> `FeatureFlagNames.ledgerDmk` is registered with a default of **disabled** (`enabled: false`, `minimumVersion: null`) and a documented floor version constant `LEDGER_DMK_MINIMUM_VERSION` (`8.2.0`) for when the flag is turned on remotely. **`selectLedgerDmkEnabled`** resolves the flag like other version-gated flags: boolean dev-tool overrides win, otherwise `validatedVersionGatedFeatureFlag` checks `enabled` plus app version against `minimumVersion`, defaulting to **false** if the flag is missing or malformed.
> 
> Unit tests cover version pass/fail, production-off shape, missing state, dev overrides, and invalid payloads. **Nothing in the app consumes this selector yet** (per author notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee88e31ccfa3e4873d9b313878dda979148f5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->