### PR TITLE
fix: disable CTA swap button for Tron when no network fees retrieved

### DIFF
--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
@@ -67,7 +67,7 @@ describe('isQuoteNetworkFeeUnavailable', () => {
     expect(isQuoteNetworkFeeUnavailable(createQuote())).toBe(false);
   });
 
-  it('returns false for a non-BTC quote with zero network fee', () => {
+  it('returns false for a non-BTC/non-Tron quote with zero network fee', () => {
     expect(
       isQuoteNetworkFeeUnavailable(
         createQuote({
@@ -78,6 +78,70 @@ describe('isQuoteNetworkFeeUnavailable', () => {
           totalNetworkFee: {
             ...mockQuoteWithMetadata.totalNetworkFee,
             amount: '0',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for a Tron quote with zero network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.TRON,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '0',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Tron quote with negative network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.TRON,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '-1',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Tron quote with missing network fee amount', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.TRON,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: undefined,
+          } as unknown as NonNullable<ActiveQuote>['totalNetworkFee'],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a Tron quote with positive network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.TRON,
           },
         }),
       ),

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
-import { isBitcoinChainId } from '@metamask/bridge-controller';
+import { isBitcoinChainId, isTronChainId } from '@metamask/bridge-controller';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 
 type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
@@ -10,7 +10,10 @@ export const isQuoteNetworkFeeUnavailable = (
 ): boolean => {
   const sourceChainId = activeQuote?.quote?.srcChainId;
 
-  if (!sourceChainId || !isBitcoinChainId(sourceChainId)) {
+  if (
+    !sourceChainId ||
+    (!isBitcoinChainId(sourceChainId) && !isTronChainId(sourceChainId))
+  ) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
     "@expo/cli@npm:55.0.32": "patch:@expo/cli@npm%3A55.0.32#~/.yarn/patches/@expo-cli-npm-55.0.32-5fb47bae24.patch",
-    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch"
+    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",

--- a/package.json
+++ b/package.json
@@ -220,8 +220,7 @@
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
     "@expo/cli@npm:55.0.32": "patch:@expo/cli@npm%3A55.0.32#~/.yarn/patches/@expo-cli-npm-55.0.32-5fb47bae24.patch",
-    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch",
-    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947"
+    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -356,7 +355,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^68.2.0",
     "@metamask/transaction-pay-controller": "^23.17.4",
-    "@metamask/tron-wallet-snap": "^1.28.0",
+    "@metamask/tron-wallet-snap": "^1.29.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^6.0.0",
     "@myx-trade/sdk": "^0.1.265",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10545,10 +10545,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.28.0"
-  checksum: 10/e8fe563735e0fca306cd1caa2cde45b193d0f09f7a3da545be24eee55a64f1ff239a7460ad9c4a0c6b67552a1423ef18328350a4b76a2409a1fbe609f69b8769
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947":
+  version: 1.28.0-preview-9726947
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-9726947"
+  checksum: 10/de9bdcb7c8c7cd75009c6765145b7eecde3ba01d535fe793344a7a316f5af92e4386814f698b77aec4dcd167314bda9c08afa4a580064515f2ae34ff56541efa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10545,10 +10545,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947":
-  version: 1.28.0-preview-9726947
-  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-9726947"
-  checksum: 10/de9bdcb7c8c7cd75009c6765145b7eecde3ba01d535fe793344a7a316f5af92e4386814f698b77aec4dcd167314bda9c08afa4a580064515f2ae34ff56541efa
+"@metamask/tron-wallet-snap@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.29.0"
+  checksum: 10/8afc50c84215f63ae1d8ab985ff682f2a5d3b16cf15bb50f12c7d1d95df8e60d29881dbe13858941655e2163410dccba6b609307a4a3fb85458c042f799a6bb8
   languageName: node
   linkType: hard
 
@@ -35617,7 +35617,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^68.2.0"
     "@metamask/transaction-pay-controller": "npm:^23.17.4"
-    "@metamask/tron-wallet-snap": "npm:^1.28.0"
+    "@metamask/tron-wallet-snap": "npm:^1.29.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^6.0.0"
     "@myx-trade/sdk": "npm:^0.1.265"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This pull request updates the logic for determining if a network fee is unavailable for bridge quotes, specifically adding support for Tron chain IDs in addition to Bitcoin. It also expands the test coverage to ensure correct behavior for various Tron-related scenarios.

**Logic updates for network fee availability:**

* Updated `isQuoteNetworkFeeUnavailable` in `index.ts` to consider both Bitcoin and Tron chain IDs, returning `true` for Tron quotes with missing, zero, or negative network fees.

**Test coverage improvements:**

* Added multiple test cases in `index.test.ts` to verify that the function correctly handles Tron quotes with zero, negative, missing, and positive network fees, ensuring the new logic is thoroughly tested.
* Updated the description of an existing test to clarify that it applies to non-BTC/non-Tron quotes with zero network fee.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disable CTA swap button for Tron when no network fees retrieved

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: submit Tron swaps without network fees

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Go to swap page
Try a quote pair for Tron network
Make the compute fees from the Tron snap failed or throw in the bridge-status controller.
When the network fees are not returned, a 0$ network fees is displayed and the CTA button of the quote should not be enabled with the message "insufficient funds"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
n/a

### **After**

<!-- [screenshots/recordings] -->

<img width="300" height="600" alt="tron-fees" src="https://github.com/user-attachments/assets/d12d1b74-aeb5-4f52-8fc5-71b402e0f6d9" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap submission gating for Tron bridge flows; incorrect fee detection could block valid swaps or still allow bad ones, though behavior mirrors existing Bitcoin safeguards.
> 
> **Overview**
> Tron bridge quotes are now treated like Bitcoin when **network fees are missing or invalid**, so users cannot confirm a swap while fees show as $0 after a failed fee fetch.
> 
> `isQuoteNetworkFeeUnavailable` applies the existing BTC rules (missing, zero, or non-positive `totalNetworkFee`) to **Tron source chains** via `isTronChainId`, which keeps the swap CTA disabled in `BridgeView` and `SwapsConfirmButton` instead of allowing submission with bogus fees. Unit tests cover Tron zero, negative, missing, and valid fee cases.
> 
> `@metamask/tron-wallet-snap` is bumped **1.28.0 → 1.29.0** in lockfile alongside the logic change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3859859f59b8e0ab9fe90342c8e50ec8e09d23d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->