### PR TITLE
fix: block money account deposits without quotes

### DIFF
--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -104,3 +104,11 @@ export const RELAY_DEPOSIT_TYPES = [
   TransactionType.perpsRelayDeposit,
   TransactionType.predictRelayDeposit,
 ];
+
+/**
+ * Transaction types that require a Pay quote before publishing.
+ * These transactions will fail if no quotes are available.
+ */
+export const QUOTE_REQUIRED_TRANSACTION_TYPES = [
+  TransactionType.moneyAccountDeposit,
+] as const;

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -24,9 +24,12 @@ import {
   TransactionPayRequiredToken,
   TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
 
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/useTransactionPayData');
+jest.mock('../transactions/useTransactionMetadataRequest');
 
 const STATE_MOCK = merge(
   {},
@@ -328,5 +331,85 @@ describe('useNoPayTokenQuotesAlert', () => {
         isBlocking: true,
       }),
     ]);
+  });
+
+  describe('quote-required transaction types', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: undefined,
+      } as ReturnType<typeof useTransactionPayToken>);
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPaySourceAmountsMock.mockReturnValue([]);
+      useTransactionPayIsPostQuoteMock.mockReturnValue(false);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '10000',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+      jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
+      jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(false);
+      jest.mocked(useTransactionMetadataRequest).mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+      } as never);
+    });
+
+    it('returns alert for moneyAccountDeposit with no quotes and positive required amount', () => {
+      const { result } = runHook();
+
+      expect(result.current).toEqual([
+        expect.objectContaining({
+          key: AlertKeys.NoPayTokenQuotes,
+          severity: Severity.Danger,
+          isBlocking: true,
+        }),
+      ]);
+    });
+
+    it('returns no alert for moneyAccountDeposit with no required amount', () => {
+      jest.mocked(useTransactionMetadataRequest).mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+      } as never);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '0',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert for moneyAccountDeposit when quotes are present', () => {
+      jest.mocked(useTransactionMetadataRequest).mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+      } as never);
+      useTransactionPayQuotesMock.mockReturnValue([
+        {} as TransactionPayQuote<Json>,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert for moneyAccountDeposit while quotes are loading', () => {
+      jest.mocked(useTransactionMetadataRequest).mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+      } as never);
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -13,6 +13,9 @@ import {
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { QUOTE_REQUIRED_TRANSACTION_TYPES } from '../../constants/confirmations';
+import { hasTransactionType } from '../../utils/transaction';
 
 export function useNoPayTokenQuotesAlert() {
   const { payToken } = useTransactionPayToken();
@@ -23,6 +26,7 @@ export function useNoPayTokenQuotesAlert() {
   const requiredTokens = useTransactionPayRequiredTokens();
   const isPostQuote = useTransactionPayIsPostQuote();
   const isMaxAmount = useTransactionPayIsMaxAmount();
+  const transactionMeta = useTransactionMetadataRequest();
 
   const fiatAmount = Number(fiatPayment?.amountFiat);
   const hasValidFiatAmount = Number.isFinite(fiatAmount) && fiatAmount > 0;
@@ -77,10 +81,17 @@ export function useNoPayTokenQuotesAlert() {
     !quotes?.length &&
     hasPositiveRequiredAmount;
 
+  const shouldShowQuoteRequiredNoQuotesAlert =
+    hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES) &&
+    !isQuotesLoading &&
+    !quotes?.length &&
+    hasPositiveRequiredAmount;
+
   const showAlert =
     shouldShowNonFiatNoQuotesAlert ||
     shouldShowFiatNoQuotesAlert ||
-    shouldShowPostQuoteNoQuotesAlert;
+    shouldShowPostQuoteNoQuotesAlert ||
+    shouldShowQuoteRequiredNoQuotesAlert;
 
   return useMemo(() => {
     if (!showAlert) {

--- a/app/util/transactions/hooks/index.test.ts
+++ b/app/util/transactions/hooks/index.test.ts
@@ -6,6 +6,7 @@ import {
   type TransactionController,
   type TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 
 import {
@@ -318,5 +319,76 @@ describe('getTransactionControllerHooks', () => {
         ] as PublishBatchHookTransaction[],
       }),
     ).rejects.toThrow('Could not find transaction with id missing-tx');
+  });
+
+  describe('quote-required transaction types', () => {
+    it('throws when moneyAccountDeposit has no quotes', async () => {
+      const request = buildRequest({
+        initMessenger: {
+          call: jest.fn((action: string) => {
+            if (action === 'PredictController:publish') {
+              return { transactionHash: undefined };
+            }
+
+            if (action === 'TransactionPayController:getState') {
+              return {
+                transactionData: {
+                  '123': {
+                    quotes: [],
+                  },
+                },
+              };
+            }
+
+            return undefined;
+          }),
+        } as unknown as TransactionControllerHookRequest['initMessenger'],
+      });
+
+      const hooks = getTransactionControllerHooks(request);
+      const moneyAccountTx = {
+        ...MOCK_TRANSACTION_META,
+        type: TransactionType.moneyAccountDeposit,
+      };
+
+      await expect(
+        hooks.publish?.(moneyAccountTx),
+      ).rejects.toThrow('MetaMask Pay: Cannot submit without quote');
+    });
+
+    it('does not throw for moneyAccountDeposit when quotes are present', async () => {
+      payHookMock.mockResolvedValue({
+        transactionHash: '0xpay-with-quote',
+      });
+
+      const hooks = getTransactionControllerHooks(buildRequest());
+      const moneyAccountTx = {
+        ...MOCK_TRANSACTION_META,
+        type: TransactionType.moneyAccountDeposit,
+      };
+
+      const result = await hooks.publish?.(moneyAccountTx);
+
+      expect(result).toStrictEqual({
+        transactionHash: '0xpay-with-quote',
+      });
+    });
+
+    it('does not throw when non-quote-required transaction has no quotes', async () => {
+      jest.mocked(accountSupports7702).mockResolvedValue(false);
+      jest.mocked(submitSmartTransactionHook).mockResolvedValue({
+        transactionHash: undefined,
+      });
+
+      const hooks = getTransactionControllerHooks(buildRequest());
+      const simpleSendTx = {
+        ...MOCK_TRANSACTION_META,
+        type: TransactionType.simpleSend,
+      };
+
+      const result = await hooks.publish?.(simpleSendTx);
+
+      expect(result).toStrictEqual({ transactionHash: undefined });
+    });
   });
 });

--- a/app/util/transactions/hooks/index.test.ts
+++ b/app/util/transactions/hooks/index.test.ts
@@ -351,9 +351,9 @@ describe('getTransactionControllerHooks', () => {
         type: TransactionType.moneyAccountDeposit,
       };
 
-      await expect(
-        hooks.publish?.(moneyAccountTx),
-      ).rejects.toThrow('MetaMask Pay: Cannot submit without quote');
+      await expect(hooks.publish?.(moneyAccountTx)).rejects.toThrow(
+        'MetaMask Pay: Cannot submit without quote',
+      );
     });
 
     it('does not throw for moneyAccountDeposit when quotes are present', async () => {

--- a/app/util/transactions/hooks/index.ts
+++ b/app/util/transactions/hooks/index.ts
@@ -127,18 +127,7 @@ function publishHook({
       return payResult;
     }
 
-    if (hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES)) {
-      const transactionPayState = initMessenger.call(
-        'TransactionPayController:getState',
-      );
-
-      const quotes =
-        transactionPayState.transactionData?.[transactionMeta.id]?.quotes ?? [];
-
-      if (!quotes.length) {
-        throw new Error('MetaMask Pay: Cannot submit without quote');
-      }
-    }
+    validateRequiredQuote(transactionMeta, initMessenger);
 
     const { isExternalSign } = transactionMeta;
     const isRevokeDelegation =
@@ -229,6 +218,25 @@ function publishHook({
 
     return { transactionHash: undefined };
   };
+}
+
+function validateRequiredQuote(
+  transactionMeta: TransactionMeta,
+  messenger: TransactionControllerInitMessenger,
+) {
+  if (!hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES)) {
+    return;
+  }
+
+  const { transactionData } = messenger.call(
+    'TransactionPayController:getState',
+  );
+
+  const quotes = transactionData?.[transactionMeta.id]?.quotes ?? [];
+
+  if (!quotes.length) {
+    throw new Error('MetaMask Pay: Cannot submit without quote');
+  }
 }
 
 function getSmartTransactionCommonParams(state: RootState, chainId: Hex) {

--- a/app/util/transactions/hooks/index.ts
+++ b/app/util/transactions/hooks/index.ts
@@ -34,6 +34,8 @@ import { getTransactionById } from '..';
 import { accountSupports7702 } from '../account-supports-7702';
 import { isSendBundleSupported } from '../sentinel-api';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
+import { QUOTE_REQUIRED_TRANSACTION_TYPES } from '../../../components/Views/confirmations/constants/confirmations';
+import { hasTransactionType } from '../../../components/Views/confirmations/utils/transaction';
 
 const TRANSACTION_SUBMISSION_METHOD_METRIC_NAME =
   'transaction_submission_method';
@@ -123,6 +125,19 @@ function publishHook({
 
     if (payResult?.transactionHash) {
       return payResult;
+    }
+
+    if (hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES)) {
+      const transactionPayState = initMessenger.call(
+        'TransactionPayController:getState',
+      );
+
+      const quotes =
+        transactionPayState.transactionData?.[transactionMeta.id]?.quotes ?? [];
+
+      if (!quotes.length) {
+        throw new Error('MetaMask Pay: Cannot submit without quote');
+      }
     }
 
     const { isExternalSign } = transactionMeta;


### PR DESCRIPTION
## **Description**

Money Account deposits should not be submitted unless MetaMask Pay has produced a quote. Previously, a deposit could continue with no selected Pay token and no quote, allowing the transaction submission flow to fall through to the generic gasless 7702 path instead of stopping as a Pay-managed deposit.

This PR adds a mobile-side quote requirement for Money Account deposits. The confirmation UI now shows the existing blocking no-quotes alert for quote-required transaction types even when no Pay token/source amount has been selected yet, and the transaction publish hook validates the same invariant before allowing fallback submission.

The quote requirement is defined as a client-side transaction-type allowlist so the behavior stays scoped to Mobile and avoids adding product-specific coupling to the shared controller package.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Money Account deposit quote requirement

  Scenario: user attempts to confirm a deposit before a Pay quote is available
    Given the user is on a Money Account deposit confirmation
    And no MetaMask Pay quote is available

    When the user enters a deposit amount
    Then a blocking no-quotes alert is shown
    And the deposit cannot be submitted
```

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit submission and publish fallback behavior for money account flows; scoped to one transaction type with UI and hook guards plus tests.
> 
> **Overview**
> **Money Account deposits** can no longer proceed without a MetaMask Pay quote. A mobile-only allowlist (`QUOTE_REQUIRED_TRANSACTION_TYPES`, starting with `moneyAccountDeposit`) defines which flows need a quote before publish.
> 
> On **confirmation**, `useNoPayTokenQuotesAlert` now shows the existing blocking **No Pay token quotes** alert for quote-required types when there is a positive required amount but no quotes—even if the user has not selected a Pay token or source amounts yet (paths that previously skipped the alert).
> 
> On **submit**, the transaction `publish` hook calls `validateRequiredQuote` after Pay publish returns no hash; quote-required transactions with an empty quote list throw `MetaMask Pay: Cannot submit without quote` instead of falling through to gasless 7702 / smart-tx paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5aaffd442a36f92adabd9ce40a07ea40031d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->