### PR TITLE
perf: fix `Set` input arg defeating memo in `selectAccountGroupsByAddress`

### DIFF
--- a/app/components/Snaps/SnapUIAddress/useDisplayName.ts
+++ b/app/components/Snaps/SnapUIAddress/useDisplayName.ts
@@ -3,6 +3,7 @@ import {
   KnownCaipNamespace,
   CaipNamespace,
 } from '@metamask/utils';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { decimalToHex } from '../../../util/conversions';
 import { RootState } from '../../../reducers';
@@ -54,8 +55,9 @@ export const useDisplayName = (
   );
 
   const parsedAddress = isEip155 ? toChecksumHexAddress(address) : address;
+  const addressArray = useMemo(() => [parsedAddress], [parsedAddress]);
   const accountGroups = useSelector((state: RootState) =>
-    selectAccountGroupsByAddress(state, [parsedAddress]),
+    selectAccountGroupsByAddress(state, addressArray),
   );
 
   const accountGroupName = accountGroups[0]?.metadata.name;

--- a/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
+++ b/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
@@ -33,8 +33,9 @@ export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
   );
   const avatarAccountType = useSelector(selectAvatarAccountType);
 
+  const addressArray = useMemo(() => [address], [address]);
   const accountGroups = useSelector((state: RootState) =>
-    selectAccountGroupsByAddress(state, [address]),
+    selectAccountGroupsByAddress(state, addressArray),
   );
 
   const accountGroupAddress = accountGroups[0]?.accounts.find((account) =>

--- a/app/selectors/multichainAccounts/accounts.test.ts
+++ b/app/selectors/multichainAccounts/accounts.test.ts
@@ -1546,6 +1546,16 @@ describe('accounts selectors', () => {
       expect(result[0].id).toBe(ACCOUNT_GROUP_ID_1);
       expect(result[1].id).toBe(ACCOUNT_GROUP_ID_3);
     });
+
+    it('returns a stable reference when called twice with equal-but-new addresses arrays', () => {
+      const firstResult = selectAccountGroupsByAddress(mockState, [
+        mockEvmAccount.address,
+      ]);
+      const secondResult = selectAccountGroupsByAddress(mockState, [
+        mockEvmAccount.address,
+      ]);
+      expect(secondResult).toBe(firstResult);
+    });
   });
 
   describe('selectIconSeedAddressByAccountGroupId', () => {

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -469,13 +469,13 @@ export const selectIconSeedAddressesByAccountGroupIds = createDeepEqualSelector(
 export const selectAccountGroupsByAddress = createDeepEqualSelector(
   [
     selectAccountGroupWithInternalAccounts,
-    (_state: RootState, addresses: string[]) =>
-      new Set(addresses.map((address) => address.toLowerCase())),
+    (_state: RootState, addresses: string[]) => addresses,
   ],
   (
     accountGroupWithInternalAccounts,
-    addressesSet: Set<string>,
+    addresses: string[],
   ): AccountGroupWithInternalAccounts[] => {
+    const addressesSet = new Set(addresses.map((a) => a.toLowerCase()));
     const matchingGroups = new Set<AccountGroupWithInternalAccounts>();
 
     accountGroupWithInternalAccounts.forEach((group) => {


### PR DESCRIPTION
## **Description**

`selectAccountGroupsByAddress` used `(_state, addresses) => new Set(addresses.map(...))` as its second input selector. A `Set` is compared by reference, so `createDeepEqualSelector` always saw a new input and re-ran the full result function on every call — even when the addresses were unchanged.

**Fix (3 parts):**

1. **Selector** — pass the raw `addresses` array as the input selector (deep-equal compares array contents) and build the `Set` inside the result function.
2. **`SnapUIAvatar`** — memoize `[address]` with `useMemo` so the array reference is stable across renders.
3. **`useDisplayName`** — same: memoize `[parsedAddress]` with `useMemo`.

With the raw array as input, `createDeepEqualSelector` can deep-compare the array contents and skip re-running the O(groups × accounts) result function when the addresses are unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31340

## **Manual testing steps**

N/A — internal performance change; behaviour and output are identical. Covered by the existing selector unit tests plus a new memoization-stability assertion (`yarn jest app/selectors/multichainAccounts/accounts.test.ts` — 64 tests, all passing).

## **Screenshots/Recordings**

N/A — no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal selector and hook memoization only; no API or UI behavior change, covered by existing and new unit tests.
> 
> **Overview**
> Fixes **broken memoization** in `selectAccountGroupsByAddress`: the second input selector used to allocate a new `Set` on every call, so `createDeepEqualSelector` always treated the input as changed and re-ran the O(groups × accounts) work even when addresses were unchanged.
> 
> The selector now passes the raw **`addresses` array** into the input selector (deep-equal on contents) and builds the lowercase `Set` inside the result function. **`SnapUIAvatar`** and **`useDisplayName`** wrap their single-address args in **`useMemo`** so callers don’t pass a fresh `[address]` literal each render. A unit test asserts **stable result references** when called twice with equal-but-new address arrays.
> 
> Selector output and behavior are unchanged; this is a performance-only fix (fixes #31340).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 763d32d2f49334ea46ffa16ab793ec1ad29b8000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->