### PR TITLE
feat(mm-connect): enforce per-domain uniqueness for self-reported origins in the SDKv2 ConnectionRegistry

### DIFF
--- a/app/core/SDKConnectV2/services/connection-registry.test.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.test.ts
@@ -1034,6 +1034,178 @@ describe('ConnectionRegistry', () => {
       });
     });
 
+    describe('per-domain uniqueness', () => {
+      // Seeds the registry with a set of already-active connections by
+      // returning them from the cold-start resume path (store.list ->
+      // Connection.create -> resume). Mocks are cleared afterwards so
+      // assertions only see the effects of the subsequent deeplink.
+      const seedRegistryWithConnections = async (
+        seeded: ReturnType<typeof createMockConnection>[],
+      ): Promise<void> => {
+        mockStore.list.mockResolvedValue(
+          seeded.map((c) => ({
+            id: c.id,
+            metadata: c.info.metadata,
+            expiresAt: c.info.expiresAt,
+          })),
+        );
+        seeded.forEach((c) => {
+          (Connection.create as jest.Mock).mockResolvedValueOnce(c);
+        });
+
+        registry = new ConnectionRegistry(
+          RELAY_URL,
+          mockKeyManager,
+          mockHostApp,
+          mockStore,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        jest.clearAllMocks();
+        // Restore the default resolution for the *new* connection created by
+        // the deeplink under test (clearAllMocks wipes queued *Once values).
+        (Connection.create as jest.Mock).mockResolvedValue(mockConnection);
+      };
+
+      it('evicts an existing connection that reports the same domain before creating the new one', async () => {
+        // Existing connection reports the same host as validDeeplink
+        // (https://test.dapp) but via a different path — hostnames still match.
+        const existing = createMockConnection('existing-same-domain', {
+          info: {
+            id: 'existing-same-domain',
+            metadata: {
+              dapp: { name: 'Older session', url: 'https://test.dapp/app' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 100000,
+          },
+        });
+
+        await seedRegistryWithConnections([existing]);
+
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        // The stale same-domain connection is fully torn down...
+        expect(existing.disconnect).toHaveBeenCalledTimes(1);
+        expect(mockStore.delete).toHaveBeenCalledWith('existing-same-domain');
+        expect(mockHostApp.revokePermissions).toHaveBeenCalledWith(
+          'existing-same-domain',
+        );
+
+        // ...and the new connection is still created and persisted.
+        expect(Connection.create).toHaveBeenCalledTimes(1);
+        expect(mockConnection.connect).toHaveBeenCalledTimes(1);
+        expect(mockStore.save).toHaveBeenCalledTimes(1);
+      });
+
+      it('is case-insensitive when comparing domains', async () => {
+        const existing = createMockConnection('existing-mixed-case', {
+          info: {
+            id: 'existing-mixed-case',
+            metadata: {
+              dapp: { name: 'Older session', url: 'https://TEST.dapp' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 100000,
+          },
+        });
+
+        await seedRegistryWithConnections([existing]);
+
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        expect(existing.disconnect).toHaveBeenCalledTimes(1);
+        expect(mockStore.delete).toHaveBeenCalledWith('existing-mixed-case');
+      });
+
+      it('evicts every existing connection sharing the domain', async () => {
+        const existingA = createMockConnection('existing-a', {
+          info: {
+            id: 'existing-a',
+            metadata: {
+              dapp: { name: 'Session A', url: 'https://test.dapp' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 100000,
+          },
+        });
+        const existingB = createMockConnection('existing-b', {
+          info: {
+            id: 'existing-b',
+            metadata: {
+              dapp: { name: 'Session B', url: 'https://test.dapp/other' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 200000,
+          },
+        });
+
+        await seedRegistryWithConnections([existingA, existingB]);
+
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        expect(existingA.disconnect).toHaveBeenCalledTimes(1);
+        expect(existingB.disconnect).toHaveBeenCalledTimes(1);
+        expect(mockStore.delete).toHaveBeenCalledWith('existing-a');
+        expect(mockStore.delete).toHaveBeenCalledWith('existing-b');
+        expect(Connection.create).toHaveBeenCalledTimes(1);
+        expect(mockStore.save).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not evict connections that report a different domain', async () => {
+        const other = createMockConnection('other-domain', {
+          info: {
+            id: 'other-domain',
+            metadata: {
+              dapp: { name: 'Different dapp', url: 'https://other.dapp' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 100000,
+          },
+        });
+
+        await seedRegistryWithConnections([other]);
+
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        // The unrelated-domain connection is untouched...
+        expect(other.disconnect).not.toHaveBeenCalled();
+        expect(mockStore.delete).not.toHaveBeenCalledWith('other-domain');
+        expect(mockHostApp.revokePermissions).not.toHaveBeenCalledWith(
+          'other-domain',
+        );
+
+        // ...and the new connection is still created.
+        expect(Connection.create).toHaveBeenCalledTimes(1);
+        expect(mockStore.save).toHaveBeenCalledTimes(1);
+      });
+
+      it('still creates the new connection when a same-domain eviction fails', async () => {
+        const existing = createMockConnection('existing-evict-fails', {
+          info: {
+            id: 'existing-evict-fails',
+            metadata: {
+              dapp: { name: 'Older session', url: 'https://test.dapp' },
+              sdk: { version: '2.0.0', platform: 'JavaScript' },
+            },
+            expiresAt: Date.now() + 100000,
+          },
+          disconnect: jest.fn().mockRejectedValue(new Error('teardown failed')),
+        });
+
+        await seedRegistryWithConnections([existing]);
+
+        await registry.handleConnectDeeplink(validDeeplink);
+
+        expect(existing.disconnect).toHaveBeenCalledTimes(1);
+        // Eviction failure is swallowed; the new connection still succeeds.
+        expect(Connection.create).toHaveBeenCalledTimes(1);
+        expect(mockConnection.connect).toHaveBeenCalledTimes(1);
+        expect(mockStore.save).toHaveBeenCalledTimes(1);
+        expect(mockHostApp.showConnectionError).not.toHaveBeenCalled();
+      });
+    });
+
     it('blocks connection requests with an internal origin as dapp name', async () => {
       registry = new ConnectionRegistry(
         RELAY_URL,

--- a/app/core/SDKConnectV2/services/connection-registry.ts
+++ b/app/core/SDKConnectV2/services/connection-registry.ts
@@ -46,6 +46,24 @@ import Logger from '../../../util/Logger';
 export const MAX_CONNECTIONS = 20;
 
 /**
+ * Extracts the normalized domain (lowercased hostname) from a self-reported
+ * dapp URL, or `null` when the value cannot be parsed as a URL.
+ *
+ * `metadata.dapp.url` is validated as a valid http(s) URL by
+ * {@link isConnectionRequest}, so parsing should succeed for any request that
+ * reaches the registry. We still parse defensively and treat unparseable
+ * values as "no domain" so a malformed value can never be considered a match
+ * for another connection.
+ */
+export function getSelfReportedDomain(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The ConnectionRegistry is the central service responsible for managing the
  * lifecycle of all SDKConnectV2 connections.
  */
@@ -305,6 +323,16 @@ export class ConnectionRegistry {
         return;
       }
 
+      // Enforce per-domain uniqueness for the self-reported dapp origin before
+      // creating the new connection. Any existing connection reporting the same
+      // domain is disconnected first ("newest wins"). This runs before the
+      // capacity check so freeing a same-domain slot can avoid an unnecessary
+      // oldest-connection eviction.
+      await this.evictConnectionsForDomain(
+        getSelfReportedDomain(connInfo.metadata.dapp.url),
+        connInfo.id,
+      );
+
       await this.evictIfAtCapacity();
 
       this.hostapp.showConnectionLoading(connInfo);
@@ -384,6 +412,56 @@ export class ConnectionRegistry {
       const shouldHideLoadingToast = didConnectionFail || !isQrFlow;
       if (connInfo && shouldHideLoadingToast) {
         this.hostapp.hideConnectionLoading(connInfo);
+      }
+    }
+  }
+
+  /**
+   * Enforces per-domain uniqueness for self-reported dapp origins.
+   *
+   * A dapp's `metadata.dapp.url` is self-reported and unverified, but the
+   * wallet still treats it as the user-facing identity of a connection.
+   * Allowing multiple concurrent connections for the same domain lets a single
+   * dapp accumulate duplicate sessions — each persisting for the full
+   * DEFAULT_SESSION_TTL, consuming the {@link MAX_CONNECTIONS} budget, and
+   * showing up as separate entries in the connections UI. To prevent this we
+   * allow at most one active connection per domain: before a new connection is
+   * created, every existing connection reporting the same domain is
+   * disconnected ("newest wins").
+   *
+   * @param domain The normalized domain of the incoming connection, or `null`
+   * when it could not be derived (in which case no eviction is performed).
+   * @param excludeId The id of the incoming connection, excluded from the
+   * match so an in-progress request never evicts itself. Duplicate-id requests
+   * are already short-circuited earlier in {@link handleConnectDeeplink}.
+   */
+  private async evictConnectionsForDomain(
+    domain: string | null,
+    excludeId: string,
+  ): Promise<void> {
+    if (!domain) return;
+
+    const duplicates = Array.from(this.connections.values()).filter(
+      (conn) =>
+        conn.id !== excludeId &&
+        getSelfReportedDomain(conn.info.metadata.dapp.url) === domain,
+    );
+
+    for (const conn of duplicates) {
+      try {
+        logger.debug(
+          'Evicting existing connection to enforce per-domain uniqueness:',
+          domain,
+          conn.id,
+        );
+        await this.disconnect(conn.id);
+      } catch (error) {
+        logger.error(
+          'Failed to evict existing connection for domain:',
+          domain,
+          conn.id,
+          error,
+        );
       }
     }
   }


### PR DESCRIPTION
## **Description**

SDKv2 (MetaMask Connect / MWP) connections carry a self-reported `metadata.dapp.url`. It is dapp-supplied and unverified, but the wallet still treats it as the user-facing identity of a connection (shown in the confirmation UI and the connections list, and mirrored into the Redux `v2Connections` `origin` field).

Today the `ConnectionRegistry` keys connections solely by session UUID. Nothing stops a single domain from accumulating multiple concurrent connections — each incoming connect deeplink with a fresh session id creates a brand new connection. Because every connection persists for the full `DEFAULT_SESSION_TTL` (30 days) and counts against the `MAX_CONNECTIONS` (20) budget, repeated connects from the same dapp pile up stale duplicate sessions, amplify startup reconnection bursts, and show up as duplicate entries in the connections UI.

This PR makes the registry enforce **at most one active connection per domain** for the self-reported origin. Before creating a new connection, `handleConnectDeeplink` disconnects any existing connection whose self-reported `dapp.url` resolves to the same (lowercased) hostname — "newest wins". Disconnecting reuses the existing `disconnect()` path, so the stale session's transport is torn down, its persisted record is deleted, and its permissions are revoked.

Notes on the implementation:
- A small `getSelfReportedDomain()` helper normalizes `dapp.url` to its lowercased hostname and returns `null` for unparseable values (which are then never treated as a match). In practice `isConnectionRequest()` already guarantees a valid `http(s)` URL, so this is defensive.
- The domain eviction runs **before** the existing capacity check, so freeing a same-domain slot avoids an unnecessary oldest-connection eviction.
- A same-domain eviction that throws is logged and swallowed; the new connection still proceeds.
- Scope is intentionally limited to the new-connection path (`handleConnectDeeplink`). Cold-start resume is left untouched so legitimately-persisted sessions aren't dropped on startup; any pre-existing duplicate for a domain is cleaned up the next time that domain connects.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the app with this branch and open MetaMask.
2. From a dapp using the SDKv2 / MWP flow (e.g. `https://example.com`), initiate a connect and approve it. Confirm one connection appears for that domain.
3. From the same dapp/domain, initiate another connect (this generates a new session id) and approve it.
4. Confirm the previous connection for that domain is gone (only the newest session remains) rather than both coexisting.
5. Connect from a different domain and confirm it does **not** evict the connection from step 3 — different domains are independent.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection lifecycle on connect (disconnects existing sessions and revokes permissions) based on self-reported, unverified dapp URLs; behavior is scoped to new deeplinks with tests but affects user-visible sessions.
> 
> **Overview**
> SDKv2 connect deeplinks can no longer leave multiple active sessions for the same self-reported dapp hostname. Before creating a new connection, **`ConnectionRegistry`** disconnects any existing session whose `metadata.dapp.url` resolves to the same lowercased hostname (**newest wins**), using the full `disconnect()` path (transport, store, permissions).
> 
> A new **`getSelfReportedDomain()`** helper normalizes URLs to hostname (case-insensitive); unparseable URLs skip eviction. Domain eviction runs **before** the existing **`MAX_CONNECTIONS`** cap so freeing a duplicate domain can avoid evicting the oldest unrelated session. Failed evictions are logged and do not block the new connect. Cold-start resume is unchanged—duplicates are cleaned on the next connect from that domain.
> 
> Tests cover same/different domains, case insensitivity, multiple duplicates, and eviction failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68066de3324eb6616249c2d882af4f028fa7d74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->