### PR TITLE
revert: VS Code color settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,25 +29,5 @@
   "editor.quickSuggestions": {
     "strings": true
   },
-  "editor.inlayHints.enabled": "on",
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#fff3f5",
-    "activityBar.background": "#fff3f5",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#20bf00",
-    "activityBarBadge.foreground": "#e7e7e7",
-    "commandCenter.border": "#15202b99",
-    "sash.hoverBorder": "#fff3f5",
-    "statusBar.background": "#ffc0cb",
-    "statusBar.foreground": "#15202b",
-    "statusBarItem.hoverBackground": "#ff8da1",
-    "statusBarItem.remoteBackground": "#ffc0cb",
-    "statusBarItem.remoteForeground": "#15202b",
-    "titleBar.activeBackground": "#ffc0cb",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveBackground": "#ffc0cb99",
-    "titleBar.inactiveForeground": "#15202b99"
-  },
-  "peacock.color": "pink"
+  "editor.inlayHints.enabled": "on"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reverts the `.vscode/settings.json` color customization and Peacock settings added by #32590
- Leaves existing editor, TypeScript, and Tailwind settings unchanged

## Testing
- Not run; settings-only revert
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1783016108795469?thread_ts=1783016108.795469&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-e31a470a-07a8-5028-a9b0-456b3e7b0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31a470a-07a8-5028-a9b0-456b3e7b0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

