### PR TITLE
feat(transaction-pay-controller): support metamask pay alternate caveats

### DIFF
--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -21,8 +21,8 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
   try {
     const transactionPayController = new TransactionPayController({
       getAmountData,
-      getDelegationTransaction: ({ transaction, caveats }) =>
-        getDelegationTransaction(initMessenger, transaction, caveats),
+      getDelegationTransaction: ({ transaction, isSubsidized }) =>
+        getDelegationTransaction(initMessenger, transaction, isSubsidized),
       fiatOptions: getTransactionPayFiatTestOptions(),
       getPaymentOverrideData: (paymentOverrideRequest) =>
         getPaymentOverrideData(paymentOverrideRequest, initMessenger),

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -21,8 +21,8 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
   try {
     const transactionPayController = new TransactionPayController({
       getAmountData,
-      getDelegationTransaction: ({ transaction }) =>
-        getDelegationTransaction(initMessenger, transaction),
+      getDelegationTransaction: ({ transaction, caveats }) =>
+        getDelegationTransaction(initMessenger, transaction, caveats),
       fiatOptions: getTransactionPayFiatTestOptions(),
       getPaymentOverrideData: (paymentOverrideRequest) =>
         getPaymentOverrideData(paymentOverrideRequest, initMessenger),

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -183,28 +183,86 @@ describe('Transaction Delegation Utils', () => {
       ).rejects.toThrow('Upgrade contract address not found');
     });
 
-    it('uses provided caveats instead of building default ones', async () => {
-      const customCaveats: Caveat[] = [
-        {
-          enforcer: '0xc2b0d624c1c4319760C96503BA27C347F3260f55' as Hex,
-          terms:
-            '0x0000000000000000000000000000000000000000000000000000000000000000a9059cbb0000000000000000000000001234567890abcdef1234567890abcdef12345678' as Hex,
-          args: '0x' as Hex,
-        },
-      ];
+    it('builds subsidized caveats when isSubsidized is true', async () => {
+      // ERC20 transfer calldata: selector (0xa9059cbb) + recipient (padded to 32 bytes) + amount (padded to 32 bytes)
+      // Recipient: 0x1111111111111111111111111111111111111111 padded = 0x0000000000000000000000001111111111111111111111111111111111111111
+      // Amount: 0x0989680 padded = 0x0000000000000000000000000000000000000000000000000000000000989680
+      const transferCalldata =
+        '0xa9059cbb0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000000000000000000000000000000000000989680' as Hex;
+
+      const transactionWithNested: TransactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [
+          {
+            data: transferCalldata,
+            to: '0x1234567890123456789012345678901234567890' as Hex,
+            value: '0x0' as Hex,
+          },
+        ],
+      };
 
       await getDelegationTransaction(
         messengerMock,
-        TRANSACTION_META_MOCK,
-        customCaveats,
+        transactionWithNested,
+        true,
       );
 
       expect(signDelegationMock).toHaveBeenCalledWith({
-        chainId: TRANSACTION_META_MOCK.chainId,
+        chainId: transactionWithNested.chainId,
         delegation: expect.objectContaining({
-          caveats: customCaveats,
+          caveats: expect.arrayContaining([
+            expect.objectContaining({
+              enforcer: expect.any(String),
+            }),
+          ]),
         }),
       });
+
+      // Verify 4 caveats were built (limitedCalls, allowedTargets, 2x allowedCalldata)
+      const delegationCall = signDelegationMock.mock.calls[0][0];
+      const caveats = ((delegationCall as Record<string, unknown>).delegation as Record<string, unknown>)
+        .caveats as Caveat[];
+      expect(caveats).toHaveLength(4);
+    });
+
+    it('throws when subsidized execute has no nestedTransactions', async () => {
+      const transactionWithoutNested: TransactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [],
+      };
+
+      await expect(
+        getDelegationTransaction(
+          messengerMock,
+          transactionWithoutNested,
+          true,
+        ),
+      ).rejects.toThrow(
+        'Subsidized Relay execute: expected single-step deposit route',
+      );
+    });
+
+    it('throws when subsidized execute is missing token address or calldata', async () => {
+      const transactionWithoutCalldata: TransactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [
+          {
+            data: undefined as unknown as Hex,
+            to: undefined as unknown as Hex,
+            value: '0x0' as Hex,
+          },
+        ],
+      };
+
+      await expect(
+        getDelegationTransaction(
+          messengerMock,
+          transactionWithoutCalldata,
+          true,
+        ),
+      ).rejects.toThrow(
+        'Subsidized Relay execute: missing token address or calldata',
+      );
     });
   });
 });

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -6,6 +6,7 @@ import {
 import { SignMessenger, getDelegationTransaction } from './delegation';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import { Hex } from '@metamask/utils';
+import { type Caveat } from '../../core/Delegation';
 
 const mockGetNonceLock = jest.fn();
 
@@ -180,6 +181,30 @@ describe('Transaction Delegation Utils', () => {
       await expect(
         getDelegationTransaction(messengerMock, TRANSACTION_META_MOCK),
       ).rejects.toThrow('Upgrade contract address not found');
+    });
+
+    it('uses provided caveats instead of building default ones', async () => {
+      const customCaveats: Caveat[] = [
+        {
+          enforcer: '0xc2b0d624c1c4319760C96503BA27C347F3260f55' as Hex,
+          terms:
+            '0x0000000000000000000000000000000000000000000000000000000000000000a9059cbb0000000000000000000000001234567890abcdef1234567890abcdef12345678' as Hex,
+          args: '0x' as Hex,
+        },
+      ];
+
+      await getDelegationTransaction(
+        messengerMock,
+        TRANSACTION_META_MOCK,
+        customCaveats,
+      );
+
+      expect(signDelegationMock).toHaveBeenCalledWith({
+        chainId: TRANSACTION_META_MOCK.chainId,
+        delegation: expect.objectContaining({
+          caveats: customCaveats,
+        }),
+      });
     });
   });
 });

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -183,128 +183,249 @@ describe('Transaction Delegation Utils', () => {
       ).rejects.toThrow('Upgrade contract address not found');
     });
 
-    it('builds subsidized caveats when isSubsidized is true', async () => {
-      // ERC20 transfer calldata: selector (0xa9059cbb) + recipient (padded to 32 bytes) + amount (padded to 32 bytes)
-      // Recipient: 0x1111111111111111111111111111111111111111 padded = 0x0000000000000000000000001111111111111111111111111111111111111111
-      // Amount: 0x0989680 padded = 0x0000000000000000000000000000000000000000000000000000000000989680
-      const transferCalldata =
-        '0xa9059cbb00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000989680' as Hex;
+    describe('subsidized', () => {
+      const ORDER_ID_PLACEHOLDER =
+        '0x07cece46d0aec658b12c9d194b3ac3cc74aadf102176005c76f96422b57328b2';
+      const PLACEHOLDER_BODY = ORDER_ID_PLACEHOLDER.slice(2);
+      const SELF_TARGET = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
 
-      const transactionWithNested: TransactionMeta = {
-        ...TRANSACTION_META_MOCK,
-        nestedTransactions: [
-          {
-            data: transferCalldata,
-            to: '0x1234567890123456789012345678901234567890' as Hex,
-            value: '0x0' as Hex,
-          },
-        ],
+      const APPROVE_SELECTOR = '095ea7b3';
+      const DEPOSIT_SELECTOR = 'f9e4bab4';
+      const EXECUTE_SELECTOR = '1a2b3c4d';
+
+      // Full calldata of each nested call (selector + args), matching the real
+      // `transferAndMulticall` shape:
+      //  - APPROVE_DATA carries NO order-ID placeholder -> no split point (merges left).
+      //  - DEPOSIT_DATA carries the order-ID placeholder -> its selector gets a split.
+      // The deposit's args also embed the approve selector twice, reproducing the
+      // collision where a selector appears inside another call's arguments — those
+      // coincidental matches must NOT create split points.
+      const APPROVE_DATA = `${APPROVE_SELECTOR}${'22'.repeat(28)}`;
+      const DEPOSIT_DATA = `${DEPOSIT_SELECTOR}${APPROVE_SELECTOR}${'33'.repeat(
+        12,
+      )}${PLACEHOLDER_BODY}${APPROVE_SELECTOR}${'33'.repeat(12)}`;
+
+      // Batch-encoded 7702 calldata (txParams.data). The two nested calls appear
+      // verbatim and whole-byte aligned; the fixed order-ID placeholder is embedded
+      // `occurrences` times.
+      //   [execute selector][fill][approve call][deposit call]
+      //   [placeholder]([fill][placeholder]...)[suffix]
+      const buildBatchData = (occurrences = 1): Hex => {
+        const fill = (byte: string) => byte.repeat(16);
+        const header = `${EXECUTE_SELECTOR}${fill('11')}${APPROVE_DATA}${DEPOSIT_DATA}`;
+        const windows = Array.from(
+          { length: occurrences },
+          (_, index) => `${PLACEHOLDER_BODY}${fill(index === 0 ? '44' : '55')}`,
+        ).join('');
+        return `0x${header}${windows}${fill('cd')}` as Hex;
       };
 
-      await getDelegationTransaction(
-        messengerMock,
-        transactionWithNested,
-        true,
-      );
+      const buildSubsidizedTransaction = (data: Hex): TransactionMeta =>
+        ({
+          ...TRANSACTION_META_MOCK,
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            to: SELF_TARGET,
+            data,
+            value: '0x0',
+          },
+          nestedTransactions: [
+            {
+              data: `0x${APPROVE_DATA}` as Hex,
+              to: '0x1111111111111111111111111111111111111111' as Hex,
+              value: '0x0' as Hex,
+            },
+            {
+              data: `0x${DEPOSIT_DATA}` as Hex,
+              to: '0x2222222222222222222222222222222222222222' as Hex,
+              value: '0x0' as Hex,
+            },
+          ],
+        }) as TransactionMeta;
 
-      expect(signDelegationMock).toHaveBeenCalledWith({
-        chainId: transactionWithNested.chainId,
-        delegation: expect.objectContaining({
-          caveats: expect.arrayContaining([
-            expect.objectContaining({
-              enforcer: expect.any(String),
-            }),
-          ]),
-        }),
+      const getCaveats = (): Caveat[] => {
+        const delegationCall = signDelegationMock.mock.calls[0][0];
+        return (
+          (delegationCall as Record<string, unknown>).delegation as Record<
+            string,
+            unknown
+          >
+        ).caveats as Caveat[];
+      };
+
+      // Byte value (index + slice) of an AllowedCalldata caveat term. Terms are
+      // `0x` + 32-byte start index + enforced bytes.
+      const parseAllowedCalldata = (terms: string) => ({
+        startIndex: parseInt(terms.slice(2, 2 + 64), 16),
+        value: terms.slice(2 + 64).toLowerCase(),
       });
 
-      // Verify 4 caveats were built (limitedCalls, allowedTargets, 2x allowedCalldata)
-      const delegationCall = signDelegationMock.mock.calls[0][0];
-      const caveats = (
-        (delegationCall as Record<string, unknown>).delegation as Record<
-          string,
-          unknown
-        >
-      ).caveats as Caveat[];
-      expect(caveats).toHaveLength(4);
-    });
+      const getAllowedCalldataTerms = (caveats: Caveat[]) =>
+        caveats
+          .map((c) => c.terms)
+          .filter((terms) => terms.length > 2 + 64)
+          .map(parseAllowedCalldata);
 
-    it('throws when subsidized execute has no nestedTransactions', async () => {
-      const transactionWithoutNested: TransactionMeta = {
-        ...TRANSACTION_META_MOCK,
-        nestedTransactions: [],
-      };
+      it('splits only after order-ID-bearing call selectors, folding the selector into the preceding segment', async () => {
+        const data = buildBatchData(1);
+        const body = data.slice(2).toLowerCase();
 
-      await expect(
-        getDelegationTransaction(messengerMock, transactionWithoutNested, true),
-      ).rejects.toThrow(
-        'Subsidized Caveats: expected single-step deposit route',
-      );
-    });
+        await getDelegationTransaction(
+          messengerMock,
+          buildSubsidizedTransaction(data),
+          true,
+        );
 
-    it('throws when subsidized execute is missing token address or calldata', async () => {
-      const transactionWithoutCalldata: TransactionMeta = {
-        ...TRANSACTION_META_MOCK,
-        nestedTransactions: [
-          {
+        const enforced = getAllowedCalldataTerms(getCaveats());
+
+        // No segment is the bare selector: the selector is folded into the run that
+        // precedes the split, so an enforced segment ends with (not equals) the selector.
+        expect(enforced).not.toContainEqual(
+          expect.objectContaining({ value: APPROVE_SELECTOR }),
+        );
+        expect(enforced).not.toContainEqual(
+          expect.objectContaining({ value: DEPOSIT_SELECTOR }),
+        );
+
+        const approveSplit = body.indexOf(APPROVE_DATA) / 2 + 4;
+        const depositSplit = body.indexOf(DEPOSIT_DATA) / 2 + 4;
+        const segmentEnds = enforced.map(
+          ({ startIndex, value }) => startIndex + value.length / 2,
+        );
+
+        // The deposit carries the order-ID placeholder -> its selector gets a split.
+        expect(segmentEnds).toContain(depositSplit);
+
+        // The approve carries no order-ID placeholder -> no split; it merges into the
+        // preceding run, so no segment ends at its post-selector offset.
+        expect(segmentEnds).not.toContain(approveSplit);
+
+        // The coincidental approve selectors inside the deposit args must NOT create
+        // split points either: no segment ends there.
+        const depositStart = body.indexOf(DEPOSIT_DATA) / 2;
+        const innerApprove1 = depositStart + 4 + 4; // after deposit selector + inner approve selector
+        expect(segmentEnds).not.toContain(innerApprove1);
+      });
+
+      it('produces far fewer caveats than the per-selector split (regression: 9 -> few)', async () => {
+        const data = buildBatchData(2);
+
+        await getDelegationTransaction(
+          messengerMock,
+          buildSubsidizedTransaction(data),
+          true,
+        );
+
+        // allowedTargets + limitedCalls + allowedCalldata segments. The old
+        // per-selector isolation emitted ~9 caveats for this two-call shape; splitting
+        // only at the single order-ID-bearing call (the deposit) — not the approve, and
+        // not the coincidental inner selectors — keeps it well under that.
+        const caveats = getCaveats();
+        expect(caveats.length).toBeLessThanOrEqual(7);
+      });
+
+      it('leaves the order-ID placeholder window free and enforces the full remainder', async () => {
+        const data = buildBatchData(1);
+
+        await getDelegationTransaction(
+          messengerMock,
+          buildSubsidizedTransaction(data),
+          true,
+        );
+
+        const body = data.slice(2).toLowerCase();
+        const enforced = getAllowedCalldataTerms(getCaveats());
+
+        // No enforced segment overlaps the placeholder window.
+        for (const { value } of enforced) {
+          expect(value).not.toContain(PLACEHOLDER_BODY);
+        }
+
+        // Every non-placeholder byte is enforced exactly once: reassembling the enforced
+        // segments at their offsets plus the placeholder window reproduces the body.
+        const rebuilt = Array.from(body);
+        for (const { startIndex, value } of enforced) {
+          for (let i = 0; i < value.length; i++) {
+            rebuilt[startIndex * 2 + i] = value[i];
+          }
+        }
+        expect(rebuilt.join('')).toBe(body);
+
+        // The placeholder window itself is not covered by any segment.
+        const placeholderStart = body.indexOf(PLACEHOLDER_BODY) / 2;
+        const covered = enforced.some(
+          ({ startIndex, value }) =>
+            startIndex <= placeholderStart &&
+            placeholderStart < startIndex + value.length / 2,
+        );
+        expect(covered).toBe(false);
+      });
+
+      it('frees every occurrence when the placeholder appears multiple times', async () => {
+        const data = buildBatchData(2);
+
+        await getDelegationTransaction(
+          messengerMock,
+          buildSubsidizedTransaction(data),
+          true,
+        );
+
+        const enforced = getAllowedCalldataTerms(getCaveats());
+
+        for (const { value } of enforced) {
+          expect(value).not.toContain(PLACEHOLDER_BODY);
+        }
+
+        // Every placeholder occurrence remains free — the two trailing windows plus
+        // the one embedded inside the deposit call.
+        const body = data.slice(2).toLowerCase();
+        let searchIndex = body.indexOf(PLACEHOLDER_BODY);
+        const placeholderStarts: number[] = [];
+        while (searchIndex !== -1) {
+          placeholderStarts.push(searchIndex / 2);
+          searchIndex = body.indexOf(PLACEHOLDER_BODY, searchIndex + 1);
+        }
+        expect(placeholderStarts).toHaveLength(3);
+
+        for (const start of placeholderStarts) {
+          const covered = enforced.some(
+            ({ startIndex, value }) =>
+              startIndex <= start && start < startIndex + value.length / 2,
+          );
+          expect(covered).toBe(false);
+        }
+      });
+
+      it('redeems the batch as a single execution in single mode', async () => {
+        const data = buildBatchData(1);
+
+        const result = await getDelegationTransaction(
+          messengerMock,
+          buildSubsidizedTransaction(data),
+          true,
+        );
+
+        // Delegation transaction is produced without throwing on the two-step batch.
+        expect(result.data).toBeDefined();
+        expect(result.to).toBeDefined();
+      });
+
+      it('throws with the subsidized prefix when batch calldata is missing', async () => {
+        const transaction = {
+          ...TRANSACTION_META_MOCK,
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            to: SELF_TARGET,
             data: undefined as unknown as Hex,
-            to: undefined as unknown as Hex,
-            value: '0x0' as Hex,
           },
-        ],
-      };
+        } as TransactionMeta;
 
-      await expect(
-        getDelegationTransaction(
-          messengerMock,
-          transactionWithoutCalldata,
-          true,
-        ),
-      ).rejects.toThrow(
-        'Subsidized Caveats: missing token address or calldata',
-      );
-    });
-
-    it('throws when subsidized execute calldata is not an ERC20 transfer', async () => {
-      const transactionWithNonTransfer: TransactionMeta = {
-        ...TRANSACTION_META_MOCK,
-        nestedTransactions: [
-          {
-            data: `0xdeadbeef${'0'.repeat(128)}` as Hex,
-            to: '0x1234567890123456789012345678901234567890' as Hex,
-            value: '0x0' as Hex,
-          },
-        ],
-      };
-
-      await expect(
-        getDelegationTransaction(
-          messengerMock,
-          transactionWithNonTransfer,
-          true,
-        ),
-      ).rejects.toThrow('Subsidized Caveats: expected ERC20 transfer calldata');
-    });
-
-    it('throws when subsidized execute transfer calldata is too short', async () => {
-      const transactionWithShortCalldata: TransactionMeta = {
-        ...TRANSACTION_META_MOCK,
-        nestedTransactions: [
-          {
-            data: `0xa9059cbb${'0'.repeat(100)}` as Hex,
-            to: '0x1234567890123456789012345678901234567890' as Hex,
-            value: '0x0' as Hex,
-          },
-        ],
-      };
-
-      await expect(
-        getDelegationTransaction(
-          messengerMock,
-          transactionWithShortCalldata,
-          true,
-        ),
-      ).rejects.toThrow('Subsidized Caveats: transfer calldata too short');
+        await expect(
+          getDelegationTransaction(messengerMock, transaction, true),
+        ).rejects.toThrow(
+          'Subsidized Caveats: missing batch target or calldata',
+        );
+      });
     });
   });
 });

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -188,7 +188,7 @@ describe('Transaction Delegation Utils', () => {
       // Recipient: 0x1111111111111111111111111111111111111111 padded = 0x0000000000000000000000001111111111111111111111111111111111111111
       // Amount: 0x0989680 padded = 0x0000000000000000000000000000000000000000000000000000000000989680
       const transferCalldata =
-        '0xa9059cbb0000000000000000000000001111111111111111111111111111111111111111000000000000000000000000000000000000000000000000000000000989680' as Hex;
+        '0xa9059cbb00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000989680' as Hex;
 
       const transactionWithNested: TransactionMeta = {
         ...TRANSACTION_META_MOCK,
@@ -220,8 +220,12 @@ describe('Transaction Delegation Utils', () => {
 
       // Verify 4 caveats were built (limitedCalls, allowedTargets, 2x allowedCalldata)
       const delegationCall = signDelegationMock.mock.calls[0][0];
-      const caveats = ((delegationCall as Record<string, unknown>).delegation as Record<string, unknown>)
-        .caveats as Caveat[];
+      const caveats = (
+        (delegationCall as Record<string, unknown>).delegation as Record<
+          string,
+          unknown
+        >
+      ).caveats as Caveat[];
       expect(caveats).toHaveLength(4);
     });
 
@@ -232,13 +236,9 @@ describe('Transaction Delegation Utils', () => {
       };
 
       await expect(
-        getDelegationTransaction(
-          messengerMock,
-          transactionWithoutNested,
-          true,
-        ),
+        getDelegationTransaction(messengerMock, transactionWithoutNested, true),
       ).rejects.toThrow(
-        'Subsidized Relay execute: expected single-step deposit route',
+        'Subsidized Caveats: expected single-step deposit route',
       );
     });
 
@@ -261,8 +261,50 @@ describe('Transaction Delegation Utils', () => {
           true,
         ),
       ).rejects.toThrow(
-        'Subsidized Relay execute: missing token address or calldata',
+        'Subsidized Caveats: missing token address or calldata',
       );
+    });
+
+    it('throws when subsidized execute calldata is not an ERC20 transfer', async () => {
+      const transactionWithNonTransfer: TransactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [
+          {
+            data: `0xdeadbeef${'0'.repeat(128)}` as Hex,
+            to: '0x1234567890123456789012345678901234567890' as Hex,
+            value: '0x0' as Hex,
+          },
+        ],
+      };
+
+      await expect(
+        getDelegationTransaction(
+          messengerMock,
+          transactionWithNonTransfer,
+          true,
+        ),
+      ).rejects.toThrow('Subsidized Caveats: expected ERC20 transfer calldata');
+    });
+
+    it('throws when subsidized execute transfer calldata is too short', async () => {
+      const transactionWithShortCalldata: TransactionMeta = {
+        ...TRANSACTION_META_MOCK,
+        nestedTransactions: [
+          {
+            data: `0xa9059cbb${'0'.repeat(100)}` as Hex,
+            to: '0x1234567890123456789012345678901234567890' as Hex,
+            value: '0x0' as Hex,
+          },
+        ],
+      };
+
+      await expect(
+        getDelegationTransaction(
+          messengerMock,
+          transactionWithShortCalldata,
+          true,
+        ),
+      ).rejects.toThrow('Subsidized Caveats: transfer calldata too short');
     });
   });
 });

--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -423,7 +423,7 @@ describe('Transaction Delegation Utils', () => {
         await expect(
           getDelegationTransaction(messengerMock, transaction, true),
         ).rejects.toThrow(
-          'Subsidized Caveats: missing batch target or calldata',
+          'Subsidized Caveats: Missing batch target or calldata',
         );
       });
     });

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -265,7 +265,7 @@ function buildSubsidizedExecutions(
   const callData = txParams.data as Hex | undefined;
 
   if (!target || !callData) {
-    throw new Error('Subsidized execution: missing batch target or calldata');
+    throw new Error('Missing batch target or calldata');
   }
 
   return [
@@ -323,7 +323,7 @@ function buildSubsidizedCaveatsInternal(
   const calldata = txParams.data as Hex | undefined;
 
   if (!target || !calldata) {
-    throw new Error('missing batch target or calldata');
+    throw new Error('Missing batch target or calldata');
   }
 
   caveatBuilder.addCaveat(allowedTargets, [target]);

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -22,6 +22,8 @@ import {
 } from '../../core/Delegation/delegation';
 import { Hex, createProjectLogger } from '@metamask/utils';
 import { limitedCalls } from '../../core/Delegation/caveatBuilder/limitedCallsBuilder';
+import { allowedTargets } from '../../core/Delegation/caveatBuilder/allowedTargetsBuilder';
+import { allowedCalldata } from '../../core/Delegation/caveatBuilder/allowedCalldataBuilder';
 import { Messenger } from '@metamask/messenger';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
@@ -51,7 +53,7 @@ export async function getDelegationTransaction<
 >(
   messenger: MessengerType,
   transaction: TransactionMeta,
-  caveats?: Caveat[],
+  isSubsidized?: boolean,
 ): Promise<DelegationTransaction> {
   const { chainId } = transaction;
   const delegationEnvironment = getDeleGatorEnvironment(parseInt(chainId, 16));
@@ -63,7 +65,7 @@ export async function getDelegationTransaction<
     delegationEnvironment,
     transaction,
     messenger,
-    caveats,
+    isSubsidized,
   );
 
   const executions = buildExecutions(transaction);
@@ -182,12 +184,12 @@ async function buildDelegation<MessengerType extends SignMessenger>(
   delegationEnvironment: DeleGatorEnvironment,
   transactionMeta: TransactionMeta,
   messenger: MessengerType,
-  caveats?: Caveat[],
+  isSubsidized?: boolean,
 ): Promise<Delegation[][]> {
   const unsignedDelegation = buildUnsignedDelegation(
     delegationEnvironment,
     transactionMeta,
-    caveats,
+    isSubsidized,
   );
 
   log('Signing delegation');
@@ -232,9 +234,11 @@ function buildExecutions(
 function buildUnsignedDelegation(
   environment: DeleGatorEnvironment,
   transactionMeta: TransactionMeta,
-  caveats?: Caveat[],
+  isSubsidized?: boolean,
 ): UnsignedDelegation {
-  const resolvedCaveats = caveats ?? buildCaveats(environment, transactionMeta);
+  const resolvedCaveats = isSubsidized
+    ? buildSubsidizedCaveats(environment, transactionMeta)
+    : buildCaveats(environment, transactionMeta);
 
   log('Caveats', resolvedCaveats);
 
@@ -247,6 +251,45 @@ function buildUnsignedDelegation(
   log('Delegation', delegation);
 
   return delegation;
+}
+
+function buildSubsidizedCaveats(
+  environment: DeleGatorEnvironment,
+  transaction: TransactionMeta,
+): Caveat[] {
+  const caveatBuilder = createCaveatBuilder(environment);
+  const nestedTransactions = transaction.nestedTransactions ?? [];
+
+  // Subsidized execute only supports single-step deposit routes
+  if (nestedTransactions.length !== 1) {
+    throw new Error(
+      'Subsidized Relay execute: expected single-step deposit route',
+    );
+  }
+
+  const transferTx = nestedTransactions[0];
+  const token = transferTx.to as Hex | undefined;
+  const calldata = transferTx.data as Hex | undefined;
+
+  if (!token || !calldata) {
+    throw new Error(
+      'Subsidized Relay execute: missing token address or calldata',
+    );
+  }
+
+  // Extract selector (0x + bytes 2-10) and recipient+amount (bytes 10-138)
+  // Split to prevent Relay post-deposit parser from misreading caveat terms as transfer
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const transferSelector = `0x${calldata.slice(2, 10)}` as Hex;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const recipientAndAmount = `0x${calldata.slice(10, 138)}` as Hex;
+
+  caveatBuilder.addCaveat(limitedCalls, 1);
+  caveatBuilder.addCaveat(allowedTargets, [token]);
+  caveatBuilder.addCaveat(allowedCalldata, 0, transferSelector);
+  caveatBuilder.addCaveat(allowedCalldata, 4, recipientAndAmount);
+
+  return caveatBuilder.build();
 }
 
 function buildCaveats(

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -51,6 +51,7 @@ export async function getDelegationTransaction<
 >(
   messenger: MessengerType,
   transaction: TransactionMeta,
+  caveats?: Caveat[],
 ): Promise<DelegationTransaction> {
   const { chainId } = transaction;
   const delegationEnvironment = getDeleGatorEnvironment(parseInt(chainId, 16));
@@ -62,6 +63,7 @@ export async function getDelegationTransaction<
     delegationEnvironment,
     transaction,
     messenger,
+    caveats,
   );
 
   const executions = buildExecutions(transaction);
@@ -180,10 +182,12 @@ async function buildDelegation<MessengerType extends SignMessenger>(
   delegationEnvironment: DeleGatorEnvironment,
   transactionMeta: TransactionMeta,
   messenger: MessengerType,
+  caveats?: Caveat[],
 ): Promise<Delegation[][]> {
   const unsignedDelegation = buildUnsignedDelegation(
     delegationEnvironment,
     transactionMeta,
+    caveats,
   );
 
   log('Signing delegation');
@@ -228,15 +232,16 @@ function buildExecutions(
 function buildUnsignedDelegation(
   environment: DeleGatorEnvironment,
   transactionMeta: TransactionMeta,
+  caveats?: Caveat[],
 ): UnsignedDelegation {
-  const caveats = buildCaveats(environment, transactionMeta);
+  const resolvedCaveats = caveats ?? buildCaveats(environment, transactionMeta);
 
-  log('Caveats', caveats);
+  log('Caveats', resolvedCaveats);
 
   const delegation = createDelegation({
     from: transactionMeta.txParams.from as Hex,
     to: ANY_BENEFICIARY,
-    caveats,
+    caveats: resolvedCaveats,
   });
 
   log('Delegation', delegation);

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -32,9 +32,29 @@ import Engine from '../../core/Engine';
 import { exactExecutionBatch } from '../../core/Delegation/caveatBuilder/exactExecutionBatchBuilder';
 import { exactExecution } from '../../core/Delegation/caveatBuilder/exactExecutionBuilder';
 import { prefixError } from './error-prefix';
-import { TRANSFER_FUNCTION_SIGNATURE } from './index';
 
 const log = createProjectLogger('transaction-delegation');
+
+/**
+ * Must match placeholder used by Intents API.
+ */
+export const SUBSIDIZED_ORDER_ID_PLACEHOLDER =
+  '0x07cece46d0aec658b12c9d194b3ac3cc74aadf102176005c76f96422b57328b2' as Hex;
+
+/** The number of bytes in a function selector. */
+const SELECTOR_BYTES = 4;
+
+/** A byte range within calldata: [start, end) in bytes, not hex characters. */
+interface ByteRange {
+  start: number;
+  end: number;
+}
+
+/** A run of calldata bytes to enforce, plus its byte start index. */
+interface EnforcedSegment {
+  startIndex: number;
+  value: Hex;
+}
 
 export type SignMessenger = Messenger<
   string,
@@ -70,10 +90,14 @@ export async function getDelegationTransaction<
     isSubsidized,
   );
 
-  const executions = buildExecutions(transaction);
+  const executions = isSubsidized
+    ? buildSubsidizedExecutions(transaction)
+    : buildExecutions(transaction);
 
   const modes: ExecutionMode[] = [
-    executions[0].length > 1 ? BATCH_DEFAULT_MODE : SINGLE_DEFAULT_MODE,
+    isSubsidized || executions[0].length <= 1
+      ? SINGLE_DEFAULT_MODE
+      : BATCH_DEFAULT_MODE,
   ];
 
   log('Built delegations', { delegations, modes, executions });
@@ -233,6 +257,28 @@ function buildExecutions(
   ];
 }
 
+function buildSubsidizedExecutions(
+  transactionMeta: TransactionMeta,
+): ExecutionStruct[][] {
+  const { txParams } = transactionMeta;
+  const target = txParams.to as Hex | undefined;
+  const callData = txParams.data as Hex | undefined;
+
+  if (!target || !callData) {
+    throw new Error('Subsidized execution: missing batch target or calldata');
+  }
+
+  return [
+    [
+      {
+        target,
+        value: BigInt(txParams.value ?? '0x0'),
+        callData,
+      },
+    ],
+  ];
+}
+
 function buildUnsignedDelegation(
   environment: DeleGatorEnvironment,
   transactionMeta: TransactionMeta,
@@ -271,44 +317,172 @@ function buildSubsidizedCaveatsInternal(
   transaction: TransactionMeta,
 ): Caveat[] {
   const caveatBuilder = createCaveatBuilder(environment);
-  const nestedTransactions = transaction.nestedTransactions ?? [];
 
-  // Subsidized execute only supports single-step deposit routes
-  if (nestedTransactions.length !== 1) {
-    throw new Error('expected single-step deposit route');
+  const { txParams } = transaction;
+  const target = txParams.to as Hex | undefined;
+  const calldata = txParams.data as Hex | undefined;
+
+  if (!target || !calldata) {
+    throw new Error('missing batch target or calldata');
   }
 
-  const transferTx = nestedTransactions[0];
-  const token = transferTx.to as Hex | undefined;
-  const calldata = transferTx.data as Hex | undefined;
-
-  if (!token || !calldata) {
-    throw new Error('missing token address or calldata');
-  }
-
-  // Only ERC20 transfer calldata can be split into selector + recipient/amount caveats
-  if (calldata.slice(0, 10).toLowerCase() !== TRANSFER_FUNCTION_SIGNATURE) {
-    throw new Error('expected ERC20 transfer calldata');
-  }
-
-  // 0x + selector (8) + recipient (64) + amount (64) = 138
-  if (calldata.length < 138) {
-    throw new Error('transfer calldata too short');
-  }
-
-  // Extract selector (0x + bytes 2-10) and recipient+amount (bytes 10-138)
-  // Split to prevent Relay post-deposit parser from misreading caveat terms as transfer
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const transferSelector = `0x${calldata.slice(2, 10)}` as Hex;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const recipientAndAmount = `0x${calldata.slice(10, 138)}` as Hex;
-
+  caveatBuilder.addCaveat(allowedTargets, [target]);
   caveatBuilder.addCaveat(limitedCalls, 1);
-  caveatBuilder.addCaveat(allowedTargets, [token]);
-  caveatBuilder.addCaveat(allowedCalldata, 0, transferSelector);
-  caveatBuilder.addCaveat(allowedCalldata, 4, recipientAndAmount);
+
+  for (const { startIndex, value } of getEnforcedSegments(
+    calldata,
+    transaction.nestedTransactions ?? [],
+  )) {
+    caveatBuilder.addCaveat(allowedCalldata, startIndex, value);
+  }
 
   return caveatBuilder.build();
+}
+
+/**
+ * Enforces every calldata byte except the order-ID placeholder window(s).
+ *
+ * @param calldata - The 0x-prefixed batch calldata (txParams.data).
+ * @param nestedTransactions - The batch's nested calls, used to locate split points.
+ * @returns The segments to enforce, ordered by byte start index.
+ */
+function getEnforcedSegments(
+  calldata: Hex,
+  nestedTransactions: { data?: string }[],
+): EnforcedSegment[] {
+  const freeRanges = findByteRanges(calldata, [
+    SUBSIDIZED_ORDER_ID_PLACEHOLDER,
+  ]);
+
+  const splitPoints = getSplitPoints(calldata, nestedTransactions);
+
+  return getSegmentsBetweenFreeRanges(calldata, freeRanges, splitPoints);
+}
+
+/**
+ * Byte offset after the selector of each order-ID-bearing nested call.
+ *
+ * @param calldata - The 0x-prefixed batch calldata.
+ * @param nestedTransactions - The nested calls to locate.
+ * @returns The post-selector byte offsets, sorted ascending, deduplicated.
+ */
+function getSplitPoints(
+  calldata: Hex,
+  nestedTransactions: { data?: string }[],
+): number[] {
+  const placeholderBody =
+    SUBSIDIZED_ORDER_ID_PLACEHOLDER.slice(2).toLowerCase();
+
+  const nestedData = nestedTransactions
+    .map((tx) => tx.data)
+    // length >= 10 ensures at least a 0x-prefixed 4-byte selector.
+    .filter((data): data is string => data !== undefined && data.length >= 10)
+    .map((data) => data.toLowerCase() as Hex)
+    // Only order-ID-bearing calls need an isolated boundary.
+    .filter((data) => data.includes(placeholderBody));
+
+  const ranges = findByteRanges(calldata, nestedData);
+
+  const points = ranges.map((range) => range.start + SELECTOR_BYTES);
+
+  return [...new Set(points)].sort((a, b) => a - b);
+}
+
+/**
+ * Every whole-byte-aligned occurrence of each needle in calldata.
+ *
+ * @param calldata - The 0x-prefixed calldata to search.
+ * @param needles - The 0x-prefixed values to locate.
+ * @returns The byte ranges [start, end) of every occurrence, unsorted.
+ */
+function findByteRanges(calldata: Hex, needles: Hex[]): ByteRange[] {
+  const haystack = calldata.slice(2).toLowerCase();
+
+  return needles.flatMap((needle) => {
+    const body = needle.slice(2).toLowerCase();
+    const byteLength = body.length / 2;
+    const ranges: ByteRange[] = [];
+
+    let charIndex = haystack.indexOf(body);
+    while (charIndex !== -1) {
+      // Only whole-byte boundaries are meaningful (each byte is two hex chars).
+      if (charIndex % 2 === 0) {
+        const start = charIndex / 2;
+        ranges.push({ start, end: start + byteLength });
+      }
+      charIndex = haystack.indexOf(body, charIndex + 1);
+    }
+
+    return ranges;
+  });
+}
+
+/**
+ * Enforces the bytes outside the free ranges, ending a segment at each split point.
+ *
+ * @param calldata - The 0x-prefixed calldata.
+ * @param freeRanges - Ranges to leave free (order-ID placeholder windows).
+ * @param splitPoints - Byte offsets at which to end a segment (post-selector).
+ * @returns The enforced segments ordered by byte start index.
+ */
+function getSegmentsBetweenFreeRanges(
+  calldata: Hex,
+  freeRanges: ByteRange[],
+  splitPoints: number[],
+): EnforcedSegment[] {
+  const totalBytes = (calldata.length - 2) / 2;
+  const sliceValue = (start: number, end: number): Hex =>
+    `0x${calldata.slice(2 + start * 2, 2 + end * 2)}` as Hex;
+
+  const sortedFree = [...freeRanges].sort((a, b) => a.start - b.start);
+  const sortedSplitPoints = [...splitPoints].sort((a, b) => a - b);
+
+  const segments: EnforcedSegment[] = [];
+
+  // Walk the ranges between free windows, ending a segment at each split point.
+  let cursor = 0;
+  for (const free of [...sortedFree, { start: totalBytes, end: totalBytes }]) {
+    addSegments(cursor, free.start, sortedSplitPoints, segments, sliceValue);
+    cursor = Math.max(cursor, free.end);
+  }
+
+  return segments;
+}
+
+/**
+ * Enforces [start, end), ending a segment at each split point inside it; the preceding
+ * selector folds into that segment.
+ *
+ * @param start - The first byte of the range (inclusive).
+ * @param end - The end of the range (exclusive).
+ * @param sortedSplitPoints - Split points sorted ascending, spanning the whole calldata.
+ * @param segments - The accumulator to push enforced segments onto.
+ * @param sliceValue - Extracts the 0x-prefixed value for a byte range.
+ */
+function addSegments(
+  start: number,
+  end: number,
+  sortedSplitPoints: number[],
+  segments: EnforcedSegment[],
+  sliceValue: (from: number, to: number) => Hex,
+): void {
+  const pushSegment = (from: number, to: number) => {
+    if (to > from) {
+      segments.push({ startIndex: from, value: sliceValue(from, to) });
+    }
+  };
+
+  const pointsInRange = sortedSplitPoints.filter(
+    (point) => point > start && point < end,
+  );
+
+  let cursor = start;
+  for (const point of pointsInRange) {
+    pushSegment(cursor, point);
+    cursor = point;
+  }
+
+  pushSegment(cursor, end);
 }
 
 function buildCaveats(

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -31,6 +31,8 @@ import { toHex } from '@metamask/controller-utils';
 import Engine from '../../core/Engine';
 import { exactExecutionBatch } from '../../core/Delegation/caveatBuilder/exactExecutionBatchBuilder';
 import { exactExecution } from '../../core/Delegation/caveatBuilder/exactExecutionBuilder';
+import { prefixError } from './error-prefix';
+import { TRANSFER_FUNCTION_SIGNATURE } from './index';
 
 const log = createProjectLogger('transaction-delegation');
 
@@ -257,14 +259,23 @@ function buildSubsidizedCaveats(
   environment: DeleGatorEnvironment,
   transaction: TransactionMeta,
 ): Caveat[] {
+  try {
+    return buildSubsidizedCaveatsInternal(environment, transaction);
+  } catch (error) {
+    throw prefixError(error, 'Subsidized Caveats: ');
+  }
+}
+
+function buildSubsidizedCaveatsInternal(
+  environment: DeleGatorEnvironment,
+  transaction: TransactionMeta,
+): Caveat[] {
   const caveatBuilder = createCaveatBuilder(environment);
   const nestedTransactions = transaction.nestedTransactions ?? [];
 
   // Subsidized execute only supports single-step deposit routes
   if (nestedTransactions.length !== 1) {
-    throw new Error(
-      'Subsidized Relay execute: expected single-step deposit route',
-    );
+    throw new Error('expected single-step deposit route');
   }
 
   const transferTx = nestedTransactions[0];
@@ -272,9 +283,17 @@ function buildSubsidizedCaveats(
   const calldata = transferTx.data as Hex | undefined;
 
   if (!token || !calldata) {
-    throw new Error(
-      'Subsidized Relay execute: missing token address or calldata',
-    );
+    throw new Error('missing token address or calldata');
+  }
+
+  // Only ERC20 transfer calldata can be split into selector + recipient/amount caveats
+  if (calldata.slice(0, 10).toLowerCase() !== TRANSFER_FUNCTION_SIGNATURE) {
+    throw new Error('expected ERC20 transfer calldata');
+  }
+
+  // 0x + selector (8) + recipient (64) + amount (64) = 138
+  if (calldata.length < 138) {
+    throw new Error('transfer calldata too short');
   }
 
   // Extract selector (0x + bytes 2-10) and recipient+amount (bytes 10-138)

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     ]
   },
   "resolutions": {
-    "@metamask/transaction-pay-controller": "npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-b538ab03c",
     "@metamask/network-controller": "34.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",
@@ -215,7 +214,7 @@
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
-    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@68.2.2-preview-380bb5c",
+    "@metamask/transaction-controller": "68.4.0",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
@@ -358,7 +357,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^68.2.0",
-    "@metamask/transaction-pay-controller": "^23.17.4",
+    "@metamask/transaction-pay-controller": "^24.0.1",
     "@metamask/tron-wallet-snap": "^1.29.1",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^6.0.0",
@@ -831,12 +830,6 @@
     }
   },
   "packageManager": "yarn@4.14.1+sha256.5c7a0c5ea1c5b690df603c8e16b3742f87169b814d56bb5e63881145e8a84033",
-  "previewBuilds": {
-    "@metamask/transaction-pay-controller": {
-      "type": "non-breaking",
-      "previewVersion": "23.17.4-preview-380bb5c"
-    }
-  },
   "foundryup": {
     "binaries": [
       "anvil"

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     ]
   },
   "resolutions": {
-    "@metamask/transaction-pay-controller": "npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-8b02acdf0",
+    "@metamask/transaction-pay-controller": "npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-b538ab03c",
     "@metamask/network-controller": "34.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",
@@ -831,6 +831,12 @@
     }
   },
   "packageManager": "yarn@4.14.1+sha256.5c7a0c5ea1c5b690df603c8e16b3742f87169b814d56bb5e63881145e8a84033",
+  "previewBuilds": {
+    "@metamask/transaction-pay-controller": {
+      "type": "non-breaking",
+      "previewVersion": "23.17.4-preview-b538ab03c"
+    }
+  },
   "foundryup": {
     "binaries": [
       "anvil"

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     ]
   },
   "resolutions": {
+    "@metamask/transaction-pay-controller": "npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-8b02acdf0",
     "@metamask/network-controller": "34.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",
@@ -847,11 +848,5 @@
       }
     },
     "version": "v0.3.0"
-  },
-  "previewBuilds": {
-    "@metamask/transaction-pay-controller": {
-      "type": "non-breaking",
-      "previewVersion": "23.17.4-preview-8b02acdf0"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
-    "@metamask/transaction-controller": "^68.2.0",
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@68.2.2-preview-380bb5c",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
@@ -832,10 +832,6 @@
   },
   "packageManager": "yarn@4.14.1+sha256.5c7a0c5ea1c5b690df603c8e16b3742f87169b814d56bb5e63881145e8a84033",
   "previewBuilds": {
-    "@metamask/transaction-controller": {
-      "type": "non-breaking",
-      "previewVersion": "68.2.2-preview-380bb5c"
-    },
     "@metamask/transaction-pay-controller": {
       "type": "non-breaking",
       "previewVersion": "23.17.4-preview-380bb5c"

--- a/package.json
+++ b/package.json
@@ -832,9 +832,13 @@
   },
   "packageManager": "yarn@4.14.1+sha256.5c7a0c5ea1c5b690df603c8e16b3742f87169b814d56bb5e63881145e8a84033",
   "previewBuilds": {
+    "@metamask/transaction-controller": {
+      "type": "non-breaking",
+      "previewVersion": "68.2.2-preview-380bb5c"
+    },
     "@metamask/transaction-pay-controller": {
       "type": "non-breaking",
-      "previewVersion": "23.17.4-preview-b538ab03c"
+      "previewVersion": "23.17.4-preview-380bb5c"
     }
   },
   "foundryup": {

--- a/package.json
+++ b/package.json
@@ -847,5 +847,11 @@
       }
     },
     "version": "v0.3.0"
+  },
+  "previewBuilds": {
+    "@metamask/transaction-pay-controller": {
+      "type": "non-breaking",
+      "previewVersion": "23.17.4-preview-8b02acdf0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
-    "@metamask/transaction-controller": "68.2.0",
+    "@metamask/transaction-controller": "^68.2.0",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9063,7 +9063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gas-fee-controller@npm:^26.1.0, @metamask/gas-fee-controller@npm:^26.2.3, @metamask/gas-fee-controller@npm:^26.2.4":
+"@metamask/gas-fee-controller@npm:^26.1.0, @metamask/gas-fee-controller@npm:^26.2.4":
   version: 26.2.4
   resolution: "@metamask/gas-fee-controller@npm:26.2.4"
   dependencies:
@@ -9931,6 +9931,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ramps-controller@npm:^15.1.0":
+  version: 15.1.0
+  resolution: "@metamask/ramps-controller@npm:15.1.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.2.0"
+  checksum: 10/54f664646ece5a30dba4913c8d00d4a77a8894b640cf54a61d50ebe0dd5c582e8fa55df3113d5c87cd352c2440b4418a8e50f5658aee17de7b53a1fe835eae1b
+  languageName: node
+  linkType: hard
+
 "@metamask/react-data-query@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/react-data-query@npm:0.2.0"
@@ -10611,9 +10623,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:68.2.0":
-  version: 68.2.0
-  resolution: "@metamask/transaction-controller@npm:68.2.0"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@68.2.2-preview-380bb5c":
+  version: 68.2.2-preview-380bb5c
+  resolution: "@metamask-previews/transaction-controller@npm:68.2.2-preview-380bb5c"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -10622,15 +10634,15 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.3"
+    "@metamask/accounts-controller": "npm:^39.0.4"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^6.3.3"
-    "@metamask/gas-fee-controller": "npm:^26.2.3"
-    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/core-backend": "npm:^6.5.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.4"
+    "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/nonce-tracker": "npm:^6.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/rpc-errors": "npm:^7.0.2"
@@ -10645,13 +10657,13 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/f754016f3fe61f3f9e4399e44efc125f279a0bbc0f61ac572677b2d542e61caf1ad41a4906f1804c747bbf5f4b6f15313b7d545d6025c9fd880d3f7536d80340
+  checksum: 10/3c26aec9f8aa2a7c39b8140bcd4f959e796371c731f0403ec5a205b8e7ed01dcfde4509ed4f1143a2c00edc6d9a90bc6a5a02137a3165312b8c0dbf634123e8a
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-b538ab03c":
-  version: 23.17.4-preview-b538ab03c
-  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-b538ab03c"
+"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-380bb5c":
+  version: 23.17.4-preview-380bb5c
+  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-380bb5c"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10662,10 +10674,10 @@ __metadata:
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/gas-fee-controller": "npm:^26.2.4"
     "@metamask/keyring-controller": "npm:^27.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^34.0.0"
-    "@metamask/ramps-controller": "npm:^15.0.0"
+    "@metamask/ramps-controller": "npm:^15.1.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/transaction-controller": "npm:^68.2.2"
     "@metamask/utils": "npm:^11.11.0"
@@ -10673,7 +10685,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/348473a4f1ce3142a29dce6df8a93c91753dc3d25cadd50099b4b2e30fda2e2569adf9d08aafd68b3bd54da7156a83d196f884141d85e9266c04dc0708c31bb3
+  checksum: 10/2566f3cc4263b1a5bd30badb6d16c0468ca005decd66186867cce70968b4d163ec53022530e77b56ee9dfd20b84324c6945f8cca3dc29b6bdd5b6d7d77f43f14
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10649,9 +10649,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-8b02acdf0":
-  version: 23.17.4-preview-8b02acdf0
-  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-8b02acdf0"
+"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-b538ab03c":
+  version: 23.17.4-preview-b538ab03c
+  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-b538ab03c"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10673,7 +10673,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/4b7493369e289654d9ee2ad5f4ca8c3c96d5fcc8d02f2c519b437c5f32afd616572eecec2a2028c7562d88964b91e27c6f2f5e1f774ee3d4611c16a2bf376265
+  checksum: 10/348473a4f1ce3142a29dce6df8a93c91753dc3d25cadd50099b4b2e30fda2e2569adf9d08aafd68b3bd54da7156a83d196f884141d85e9266c04dc0708c31bb3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10649,9 +10649,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^23.17.4":
-  version: 23.17.4
-  resolution: "@metamask/transaction-pay-controller@npm:23.17.4"
+"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-8b02acdf0":
+  version: 23.17.4-preview-8b02acdf0
+  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-8b02acdf0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10673,7 +10673,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/7501ce059e3d7a13eadd2bad8b70bea56dd881cb6007eb71efaf1ad4edbc5450180355328152da1d490079a5ff17611cede9d90284a80e41dbca797c1274cf59
+  checksum: 10/4b7493369e289654d9ee2ad5f4ca8c3c96d5fcc8d02f2c519b437c5f32afd616572eecec2a2028c7562d88964b91e27c6f2f5e1f774ee3d4611c16a2bf376265
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8013,7 +8013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^10.0.1, @metamask/assets-controller@npm:^10.2.0":
+"@metamask/assets-controller@npm:^10.2.0":
   version: 10.2.0
   resolution: "@metamask/assets-controller@npm:10.2.0"
   dependencies:
@@ -10611,9 +10611,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@68.2.2-preview-380bb5c":
-  version: 68.2.2-preview-380bb5c
-  resolution: "@metamask-previews/transaction-controller@npm:68.2.2-preview-380bb5c"
+"@metamask/transaction-controller@npm:68.4.0":
+  version: 68.4.0
+  resolution: "@metamask/transaction-controller@npm:68.4.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -10645,19 +10645,19 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/3c26aec9f8aa2a7c39b8140bcd4f959e796371c731f0403ec5a205b8e7ed01dcfde4509ed4f1143a2c00edc6d9a90bc6a5a02137a3165312b8c0dbf634123e8a
+  checksum: 10/12a9ea21e6a5d7d0ca8a504dde2a453fdfb74d826e80432f775bbaaab1acae5faf561bcfbef37d5cc36acf927f0bba53e4f56353ca0e0fb0ae866e450226e73b
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.17.4-preview-380bb5c":
-  version: 23.17.4-preview-380bb5c
-  resolution: "@metamask-previews/transaction-pay-controller@npm:23.17.4-preview-380bb5c"
+"@metamask/transaction-pay-controller@npm:^24.0.1":
+  version: 24.0.1
+  resolution: "@metamask/transaction-pay-controller@npm:24.0.1"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controller": "npm:^10.0.1"
-    "@metamask/assets-controllers": "npm:^109.3.0"
+    "@metamask/assets-controller": "npm:^10.2.0"
+    "@metamask/assets-controllers": "npm:^109.4.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/gas-fee-controller": "npm:^26.2.4"
@@ -10667,13 +10667,13 @@ __metadata:
     "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/ramps-controller": "npm:^15.1.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/transaction-controller": "npm:^68.2.2"
+    "@metamask/transaction-controller": "npm:^68.4.0"
     "@metamask/utils": "npm:^11.11.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/2566f3cc4263b1a5bd30badb6d16c0468ca005decd66186867cce70968b4d163ec53022530e77b56ee9dfd20b84324c6945f8cca3dc29b6bdd5b6d7d77f43f14
+  checksum: 10/681f121bfa10a67c7f6759e2491b66a2d58cc282ec952b9817eb35a229aeb0e7f79589ac56ae8a4f65d13b4a837e5dc9f072a2a372ceacd3d62e9b9b744d4a40
   languageName: node
   linkType: hard
 
@@ -10903,9 +10903,9 @@ __metadata:
   linkType: hard
 
 "@nktkas/rews@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@nktkas/rews@npm:4.0.1"
-  checksum: 10/7c4434b9a717c4b955aa665f6d25dc3ae351e77f4cf78850379fdaab77f4e6505e99c6214f0a133a8050659624438a1e6c22c859b5395d81ad8fbc1ef3bdbffa
+  version: 4.1.0
+  resolution: "@nktkas/rews@npm:4.1.0"
+  checksum: 10/07130006a7e226729100ec1ffbf6c07e0c55a5c62c1662b2f484e099c21b76e71ff8752a04cf2d6de926546489078882e15805ec82063df4ed2e2cdd090d08ac
   languageName: node
   linkType: hard
 
@@ -35940,7 +35940,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^68.2.0"
-    "@metamask/transaction-pay-controller": "npm:^23.17.4"
+    "@metamask/transaction-pay-controller": "npm:^24.0.1"
     "@metamask/tron-wallet-snap": "npm:^1.29.1"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^6.0.0"
@@ -46748,14 +46748,14 @@ __metadata:
   linkType: hard
 
 "valibot@npm:^1.2.0, valibot@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "valibot@npm:1.4.1"
+  version: 1.4.2
+  resolution: "valibot@npm:1.4.2"
   peerDependencies:
     typescript: ">=5"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/39092725e4045e332e3593e9b95253c1a3429033e13be1805597fb8d346ad20a727bef82971e3b9a1b7d631bb8ad65fff186ec55d430e16f25b6bbba151c4e80
+  checksum: 10/bb88d083a3f8f37a19796cd9c4e06004ad939a1bdb996b77a7246fceb133d5da5d1ba21c89baebaec327f421f23200fea54d1e682de3452a30138e2e70548521
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8494,7 +8494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^6.3.0, @metamask/core-backend@npm:^6.3.3, @metamask/core-backend@npm:^6.5.0":
+"@metamask/core-backend@npm:^6.3.0, @metamask/core-backend@npm:^6.5.0":
   version: 6.5.0
   resolution: "@metamask/core-backend@npm:6.5.0"
   dependencies:
@@ -9916,18 +9916,6 @@ __metadata:
   peerDependencies:
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/50194c608fb308cee268c6eefb8c8d439a9d07aa41d07cb5ddcd7e706819aea7e746150f32688fe06d20309b49346440855b5d56aacf286b343da6fcb217cc12
-  languageName: node
-  linkType: hard
-
-"@metamask/ramps-controller@npm:^15.0.0, @metamask/ramps-controller@npm:^15.1.0":
-  version: 15.1.0
-  resolution: "@metamask/ramps-controller@npm:15.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/profile-sync-controller": "npm:^28.2.0"
-  checksum: 10/54f664646ece5a30dba4913c8d00d4a77a8894b640cf54a61d50ebe0dd5c582e8fa55df3113d5c87cd352c2440b4418a8e50f5658aee17de7b53a1fe835eae1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

## What

Mobile now receives an optional `isSubsidized` flag from TransactionPayController instead of a caveats array. It builds the four subsidized delegation caveats using native caveat builders with per-chain enforcer addresses.

## How

- **`isSubsidized` flag pass-through.** `TransactionPayControllerInit` forwards core's optional `isSubsidized` argument into Mobile's `getDelegationTransaction`; when set, a subsidized caveat set is built instead of the default one.
- **Constrained subsidized delegation.** Subsidized delegations apply multiple calldata caveats (alongside target and call-count caveats) so the delegation tightly constrains the batch calldata that may be redeemed.
- **Default behavior unchanged.** Callers that omit `isSubsidized` still use Mobile's existing default caveat builder.

## Changelog

CHANGELOG entry: null

## Related issues

Refs: no public issue

## Manual testing steps

N/A - internal plumbing covered by unit test: `yarn jest app/util/transactions/delegation.test.ts`

## Screenshots/Recordings

N/A

### Before

N/A

### After

N/A

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes delegation signing constraints for subsidized MetaMask Pay flows; incorrect calldata segmentation could allow overly permissive or broken redemptions.
> 
> **Overview**
> Adds an optional **`isSubsidized`** path from **Transaction Pay** into **`getDelegationTransaction`**. When set, mobile builds **subsidized delegation caveats** locally instead of the default exact-execution caveats.
> 
> **Subsidized delegations** redeem the full **7702 batch** (`txParams.to` / `txParams.data`) in **single** execution mode. Caveats use **`allowedTargets`**, **`limitedCalls` (1)**, and multiple **`allowedCalldata`** segments that lock every byte except the Intents API **order-ID placeholder**, with splits only after selectors of nested calls that contain that placeholder (avoiding spurious splits from selectors embedded in other call args).
> 
> **Non-subsidized** behavior is unchanged when the flag is omitted. **`@metamask/transaction-pay-controller`** is bumped to **^24.0.1** (with **`transaction-controller` 68.4.0**); coverage is in **`delegation.test.ts`** subsidized cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afc60006cacff597c5325ffd0ff919c08a7d9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->