### PR TITLE
fix: perps lightweight charts live candle update cp-8.1.0

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react-native';
 import { CandlePeriod, type CandleData } from '@metamask/perps-controller';
 import TradingViewChart from './TradingViewChart';
+import { createTradingViewChartTemplate } from './TradingViewChartTemplate';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 const { mockTheme } = jest.requireActual('../../../../../util/theme');
@@ -204,6 +205,13 @@ describe('TradingViewChart — incremental update routing', () => {
 
     expect(typesAfterTick).toContain('UPDATE_LAST_CANDLE');
     expect(typesAfterTick).not.toContain('SET_CANDLESTICK_DATA');
+
+    const msg = JSON.parse(
+      mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0],
+    );
+    expect(msg.isNewBar).toBe(false);
+    expect(msg.previousCandleCount).toBe(2);
+    expect(msg.nextCandleCount).toBe(2);
   });
 
   // -----------------------------------------------------------------------
@@ -343,6 +351,27 @@ describe('TradingViewChart — incremental update routing', () => {
     });
 
     expect(lastMessageType()).toBe('UPDATE_LAST_CANDLE');
+    const msg = JSON.parse(mockPostMessage.mock.calls[0][0]);
+    expect(msg.isNewBar).toBe(true);
+    expect(msg.previousCandleCount).toBe(2);
+    expect(msg.nextCandleCount).toBe(3);
+    expect(msg.previousLastTime).toBe(twoCandles.candles[1].time);
+    expect(msg.nextLastTime).toBe(withNewBar.candles[2].time);
+  });
+
+  it('template follows appended bars only when currently tracking realtime', () => {
+    const template = createTradingViewChartTemplate(mockTheme, '', true);
+
+    expect(template).toContain('var wasTrackingRealtime =');
+    expect(template).toContain(
+      'visibleLogicalRangeBefore.to >= rightEdgeBefore - realtimeFollowThreshold',
+    );
+    expect(template).toContain(
+      'if ((message.isNewBar || appendedCandle) && wasTrackingRealtime)',
+    );
+    expect(template).toContain(
+      'window.applyZoom(window.visibleCandleCount, false)',
+    );
   });
 
   // -----------------------------------------------------------------------

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
@@ -435,7 +435,8 @@ describe('TradingViewChart — incremental update routing', () => {
   });
 
   // -----------------------------------------------------------------------
-  // CHART_READY resets the signature → next update is a full reload
+  // CHART_READY resets the signature → self-heal repaints immediately, and
+  // subsequent updates are routed against the freshly-painted signature.
   // -----------------------------------------------------------------------
 
   it('resets to full reload after a CHART_READY (WebView remount)', () => {
@@ -460,11 +461,17 @@ describe('TradingViewChart — incremental update routing', () => {
     });
     expect(lastMessageType()).toBe('UPDATE_LAST_CANDLE');
 
-    // Simulate WebView remount (CHART_READY fires again)
-    triggerChartReady(getByTestId, testID);
+    // Simulate WebView remount (CHART_READY fires again). The self-heal
+    // immediately repaints the currently-held data into the freshly blanked
+    // WebView — this is itself a full reload, so it must NOT wait for the
+    // next prop change.
     mockPostMessage.mockClear();
+    triggerChartReady(getByTestId, testID);
+    expect(lastMessageType()).toBe('SET_CANDLESTICK_DATA');
 
-    // Next update must be a full reload, not an incremental update
+    // A subsequent tick is now routed against the data that was just
+    // repainted, so a same-count close update is correctly incremental.
+    mockPostMessage.mockClear();
     const nextTick: CandleData = {
       ...twoCandles,
       candles: [twoCandles.candles[0], makeCandle(4, '46000')],
@@ -474,6 +481,50 @@ describe('TradingViewChart — incremental update routing', () => {
         <TradingViewChart candleData={nextTick} symbol="BTC" testID={testID} />,
       );
     });
+    expect(lastMessageType()).toBe('UPDATE_LAST_CANDLE');
+  });
+
+  // -----------------------------------------------------------------------
+  // Self-heal: a WebView reload with unchanged candleData must still repaint.
+  // Without a repaint trigger, a WebView that silently reloads in the
+  // background (e.g. iOS reclaiming the WKWebView content process) would
+  // re-fire CHART_READY into a blanked chart, but no prop change would occur
+  // to re-run the send effect — leaving the chart permanently empty.
+  // -----------------------------------------------------------------------
+
+  it('resends full candlestick data on a repeated CHART_READY even when candleData is unchanged', () => {
+    const testID = 'incremental-selfheal-repaint';
+    const { getByTestId, rerender } = render(
+      <TradingViewChart candleData={twoCandles} symbol="BTC" testID={testID} />,
+    );
+
+    // First boot — establishes isChartReady and the initial signature. Other
+    // effects (TPSL lines / volume sync) also fire on this first transition,
+    // so assert presence rather than relying on message ordering.
+    triggerChartReady(getByTestId, testID);
+    expect(allMessageTypes()).toContain('SET_CANDLESTICK_DATA');
+    mockPostMessage.mockClear();
+
+    // Re-render with the exact same candleData reference — simulates no new
+    // data having arrived, only the WebView having reloaded underneath.
+    act(() => {
+      rerender(
+        <TradingViewChart
+          candleData={twoCandles}
+          symbol="BTC"
+          testID={testID}
+        />,
+      );
+    });
+    expect(mockPostMessage).not.toHaveBeenCalled();
+
+    // Simulate the WebView reloading and re-firing CHART_READY with no
+    // accompanying prop change. isChartReady/tpslLines/showVolume are all
+    // unchanged, so only the self-heal (chartReadyNonce) effect re-runs.
+    triggerChartReady(getByTestId, testID);
+
+    // The chart must repaint from the data it already holds, not stay blank.
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
     expect(lastMessageType()).toBe('SET_CANDLESTICK_DATA');
   });
 });

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
@@ -362,7 +362,11 @@ describe('TradingViewChart — incremental update routing', () => {
   it('template follows appended bars only when currently tracking realtime', () => {
     const template = createTradingViewChartTemplate(mockTheme, '', true);
 
-    expect(template).toContain('var wasTrackingRealtime =');
+    expect(template).toContain('RIGHT_MARGIN_CANDLES: 2');
+    expect(template).toContain('const wasTrackingRealtime =');
+    expect(template).toContain(
+      'previousDataLength - 1 + window.ZOOM_LIMITS.RIGHT_MARGIN_CANDLES',
+    );
     expect(template).toContain(
       'visibleLogicalRangeBefore.to >= rightEdgeBefore - realtimeFollowThreshold',
     );

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -313,14 +313,6 @@ const TradingViewChart = React.forwardRef<
               );
               onNeedMoreHistory?.();
               break;
-            case 'CANDLE_UPDATE_DEBUG':
-              if (__DEV__) {
-                DevLogger.log(
-                  'TradingViewChart: WebView incremental candle update',
-                  message.data,
-                );
-              }
-              break;
             default:
               break;
           }
@@ -493,18 +485,6 @@ const TradingViewChart = React.forwardRef<
             ...dataToUse,
             candles: dataToUse.candles.slice(-sliceSize),
           });
-          if (__DEV__) {
-            DevLogger.log('TradingViewChart: Incremental candle update', {
-              symbol: nextSignature.symbol,
-              interval: nextSignature.interval,
-              isNewBar,
-              previousCandleCount: prev.count,
-              nextCandleCount: nextSignature.count,
-              previousLastTime: prev.lastTime,
-              nextLastTime: nextSignature.lastTime,
-              sliceSize,
-            });
-          }
           webViewRef.current.postMessage(
             JSON.stringify({
               type: 'UPDATE_LAST_CANDLE',

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -313,6 +313,14 @@ const TradingViewChart = React.forwardRef<
               );
               onNeedMoreHistory?.();
               break;
+            case 'CANDLE_UPDATE_DEBUG':
+              if (__DEV__) {
+                DevLogger.log(
+                  'TradingViewChart: WebView incremental candle update',
+                  message.data,
+                );
+              }
+              break;
             default:
               break;
           }
@@ -476,18 +484,36 @@ const TradingViewChart = React.forwardRef<
         // they actually send, instead of re-formatting the entire (up to ~1000)
         // candle array on every tick.
         if (canIncrementalUpdate) {
+          const isNewBar = nextSignature.count === prev.count + 1;
           // Send the last candle for same-count ticks, or the last two candles
           // for a bar-close transition (previous bar may have been finalized
           // at a different close than its last streamed value).
-          const sliceSize = nextSignature.count === prev.count + 1 ? 2 : 1;
+          const sliceSize = isNewBar ? 2 : 1;
           const incrementalCandles = formatCandleData({
             ...dataToUse,
             candles: dataToUse.candles.slice(-sliceSize),
           });
+          if (__DEV__) {
+            DevLogger.log('TradingViewChart: Incremental candle update', {
+              symbol: nextSignature.symbol,
+              interval: nextSignature.interval,
+              isNewBar,
+              previousCandleCount: prev.count,
+              nextCandleCount: nextSignature.count,
+              previousLastTime: prev.lastTime,
+              nextLastTime: nextSignature.lastTime,
+              sliceSize,
+            });
+          }
           webViewRef.current.postMessage(
             JSON.stringify({
               type: 'UPDATE_LAST_CANDLE',
               candles: incrementalCandles,
+              isNewBar,
+              previousCandleCount: prev.count,
+              nextCandleCount: nextSignature.count,
+              previousLastTime: prev.lastTime,
+              nextLastTime: nextSignature.lastTime,
             }),
           );
         } else {

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -99,6 +99,12 @@ const TradingViewChart = React.forwardRef<
     const [isChartReady, setIsChartReady] = useState(false);
     const [webViewError, setWebViewError] = useState<string | null>(null);
     const [ohlcData, setOhlcData] = useState<OhlcData | null>(null);
+    // Bumped on every CHART_READY message (including re-fires after a WebView
+    // reload/remount while isChartReady was already true, e.g. iOS reclaiming
+    // the WKWebView content process in the background). Included in the send-
+    // effect deps below so a reload always triggers a resend of currently-held
+    // candle data instead of leaving the newly-blanked chart stuck empty.
+    const [chartReadyNonce, setChartReadyNonce] = useState(0);
     // Buffer for candle data that arrives before WebView is ready (Android fix)
     const pendingCandleDataRef = useRef<{
       data: CandleData;
@@ -270,6 +276,10 @@ const TradingViewChart = React.forwardRef<
               // must be a full reload regardless of prior signature state.
               lastSentSignatureRef.current = null;
               setIsChartReady(true);
+              // Force the send-effect to re-run even if isChartReady was
+              // already true (e.g. the WebView silently reloaded in the
+              // background and re-fired CHART_READY) so the chart repaints.
+              setChartReadyNonce((n) => n + 1);
               onChartReady?.();
               break;
             case 'PRICE_LINES_UPDATE':
@@ -495,6 +505,7 @@ const TradingViewChart = React.forwardRef<
       }
     }, [
       isChartReady,
+      chartReadyNonce,
       candleDataVersion,
       formatCandleData,
       candleData,

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -1444,6 +1444,14 @@ export const createTradingViewChartTemplate = (
                             message.candles.length > 0
                         ) {
                             try {
+                                var previousDataLength = window.allCandleData ? window.allCandleData.length : 0;
+                                var visibleLogicalRangeBefore = window.chart.timeScale().getVisibleLogicalRange();
+                                var rightEdgeBefore = previousDataLength > 0 ? previousDataLength - 1 + 2 : 0;
+                                var realtimeFollowThreshold = 3;
+                                var wasTrackingRealtime = !visibleLogicalRangeBefore ||
+                                    visibleLogicalRangeBefore.to >= rightEdgeBefore - realtimeFollowThreshold;
+                                var appendedCandle = false;
+
                                 message.candles.forEach(function (candle) {
                                     // Update candlestick series (handles both in-place
                                     // tick updates and newly appended bars).
@@ -1463,6 +1471,7 @@ export const createTradingViewChartTemplate = (
                                             window.allCandleData[existingIndex] = candle;
                                         } else {
                                             window.allCandleData.push(candle);
+                                            appendedCandle = true;
                                         }
                                     }
 
@@ -1479,9 +1488,33 @@ export const createTradingViewChartTemplate = (
                                     }
                                 });
 
+                                // When a new interval bar is appended while the user is
+                                // already following realtime, advance the logical range so
+                                // the new bar enters the viewport. If the user has panned
+                                // away from realtime, preserve their current viewport.
+                                if ((message.isNewBar || appendedCandle) && wasTrackingRealtime) {
+                                    window.applyZoom(window.visibleCandleCount, false);
+                                }
+
                                 // Refresh dynamic Y-axis decimal precision without
                                 // triggering a zoom/range change.
                                 window.updateVisiblePriceRange();
+
+                                if (${__DEV__ ? 'true' : 'false'} && window.ReactNativeWebView) {
+                                    window.ReactNativeWebView.postMessage(JSON.stringify({
+                                        type: 'CANDLE_UPDATE_DEBUG',
+                                        data: {
+                                            isNewBar: !!message.isNewBar,
+                                            appendedCandle: appendedCandle,
+                                            previousDataLength: previousDataLength,
+                                            nextDataLength: window.allCandleData ? window.allCandleData.length : 0,
+                                            incomingTimes: message.candles.map(function(candle) { return candle.time; }),
+                                            visibleLogicalRangeBefore: visibleLogicalRangeBefore,
+                                            visibleLogicalRangeAfter: window.chart.timeScale().getVisibleLogicalRange(),
+                                            wasTrackingRealtime: wasTrackingRealtime
+                                        }
+                                    }));
+                                }
                             } catch (error) {
                                 console.error('TradingView: Error applying incremental update:', error);
                             }

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -376,7 +376,8 @@ export const createTradingViewChartTemplate = (
         window.ZOOM_LIMITS = {
             MIN_CANDLES: 10,  // Minimum candles visible when zoomed in
             MAX_CANDLES: 250, // Maximum candles visible when zoomed out
-            DEFAULT_CANDLES: 30 // Default visible candles (matches PERPS_CHART_CONFIG.CANDLE_COUNT.DEFAULT)
+            DEFAULT_CANDLES: 30, // Default visible candles (matches PERPS_CHART_CONFIG.CANDLE_COUNT.DEFAULT)
+            RIGHT_MARGIN_CANDLES: 2 // Small right margin after the latest candle
         };
         
         // Performance optimization variables
@@ -1190,7 +1191,7 @@ export const createTradingViewChartTemplate = (
                 // - from = dataLength - actualCandleCount (first visible bar index)
                 // - to = dataLength - 1 + small offset for right padding
                 const fromIndex = Math.max(0, dataLength - actualCandleCount);
-                const toIndex = dataLength - 1 + 2; // +2 for a small right margin
+                const toIndex = dataLength - 1 + window.ZOOM_LIMITS.RIGHT_MARGIN_CANDLES;
 
                 window.chart.timeScale().setVisibleLogicalRange({
                     from: fromIndex,
@@ -1444,13 +1445,13 @@ export const createTradingViewChartTemplate = (
                             message.candles.length > 0
                         ) {
                             try {
-                                var previousDataLength = window.allCandleData ? window.allCandleData.length : 0;
-                                var visibleLogicalRangeBefore = window.chart.timeScale().getVisibleLogicalRange();
-                                var rightEdgeBefore = previousDataLength > 0 ? previousDataLength - 1 + 2 : 0;
-                                var realtimeFollowThreshold = 3;
-                                var wasTrackingRealtime = !visibleLogicalRangeBefore ||
+                                const previousDataLength = window.allCandleData ? window.allCandleData.length : 0;
+                                const visibleLogicalRangeBefore = window.chart.timeScale().getVisibleLogicalRange();
+                                const rightEdgeBefore = previousDataLength > 0 ? previousDataLength - 1 + window.ZOOM_LIMITS.RIGHT_MARGIN_CANDLES : 0;
+                                const realtimeFollowThreshold = 3;
+                                const wasTrackingRealtime = !visibleLogicalRangeBefore ||
                                     visibleLogicalRangeBefore.to >= rightEdgeBefore - realtimeFollowThreshold;
-                                var appendedCandle = false;
+                                let appendedCandle = false;
 
                                 message.candles.forEach(function (candle) {
                                     // Update candlestick series (handles both in-place
@@ -1460,8 +1461,8 @@ export const createTradingViewChartTemplate = (
                                     // Keep allCandleData in sync so zoom/price-range
                                     // calculations use the latest candle values.
                                     if (window.allCandleData && window.allCandleData.length > 0) {
-                                        var existingIndex = -1;
-                                        for (var i = window.allCandleData.length - 1; i >= 0; i--) {
+                                        let existingIndex = -1;
+                                        for (let i = window.allCandleData.length - 1; i >= 0; i--) {
                                             if (window.allCandleData[i].time === candle.time) {
                                                 existingIndex = i;
                                                 break;
@@ -1477,7 +1478,7 @@ export const createTradingViewChartTemplate = (
 
                                     // Mirror the update on the volume series when visible.
                                     if (window.volumeSeries) {
-                                        var volumePoint = {
+                                        const volumePoint = {
                                             time: candle.time,
                                             value: (parseFloat(candle.volume) * parseFloat(candle.close)) || 0,
                                             color: window.coloredVolume

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -1499,22 +1499,6 @@ export const createTradingViewChartTemplate = (
                                 // Refresh dynamic Y-axis decimal precision without
                                 // triggering a zoom/range change.
                                 window.updateVisiblePriceRange();
-
-                                if (${__DEV__ ? 'true' : 'false'} && window.ReactNativeWebView) {
-                                    window.ReactNativeWebView.postMessage(JSON.stringify({
-                                        type: 'CANDLE_UPDATE_DEBUG',
-                                        data: {
-                                            isNewBar: !!message.isNewBar,
-                                            appendedCandle: appendedCandle,
-                                            previousDataLength: previousDataLength,
-                                            nextDataLength: window.allCandleData ? window.allCandleData.length : 0,
-                                            incomingTimes: message.candles.map(function(candle) { return candle.time; }),
-                                            visibleLogicalRangeBefore: visibleLogicalRangeBefore,
-                                            visibleLogicalRangeAfter: window.chart.timeScale().getVisibleLogicalRange(),
-                                            wasTrackingRealtime: wasTrackingRealtime
-                                        }
-                                    }));
-                                }
                             } catch (error) {
                                 console.error('TradingView: Error applying incremental update:', error);
                             }

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4134,6 +4134,59 @@ describe('PerpsStreamManager', () => {
       testStreamManager.prices.cleanupPrewarm();
       expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
     });
+
+    it('uses a direct price subscription while restoring prewarm for active subscribers', async () => {
+      const firstPrewarmUnsubscribe = jest.fn();
+      const directUnsubscribe = jest.fn();
+      const restoredPrewarmUnsubscribe = jest.fn();
+      mockSubscribeToPrices
+        .mockReturnValueOnce(firstPrewarmUnsubscribe)
+        .mockReturnValueOnce(directUnsubscribe)
+        .mockReturnValueOnce(restoredPrewarmUnsubscribe);
+
+      await testStreamManager.prices.prewarm();
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(1);
+
+      const unsubscribe = testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC'],
+        callback: jest.fn(),
+      });
+
+      // The existing all-market prewarm covers the direct subscriber.
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(1);
+
+      testStreamManager.clearAllChannels();
+
+      expect(firstPrewarmUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
+      expect(mockSubscribeToPrices).toHaveBeenNthCalledWith(2, {
+        symbols: ['BTC'],
+        callback: expect.any(Function),
+      });
+      expect(directUnsubscribe).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(3);
+      expect(directUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['BTC-PERP', 'ETH-PERP'],
+        includeMarketData: false,
+        callback: expect.any(Function),
+      });
+
+      unsubscribe();
+      testStreamManager.prices.cleanupPrewarm();
+      expect(restoredPrewarmUnsubscribe).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Cached user data preloading', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4098,6 +4098,42 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
       pricesDisconnect.mockRestore();
     });
+
+    it('recreates prewarmed price subscription when no direct price subscribers are active', async () => {
+      const firstUnsubscribe = jest.fn();
+      const secondUnsubscribe = jest.fn();
+      mockSubscribeToPrices
+        .mockReturnValueOnce(firstUnsubscribe)
+        .mockReturnValueOnce(secondUnsubscribe);
+
+      await testStreamManager.prices.prewarm();
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(1);
+
+      testStreamManager.clearAllChannels();
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(
+        mockEngine.context.PerpsController.getMarkets,
+      ).toHaveBeenCalledTimes(2);
+      expect(mockSubscribeToPrices).toHaveBeenCalledTimes(2);
+      expect(mockSubscribeToPrices).toHaveBeenLastCalledWith({
+        symbols: ['BTC-PERP', 'ETH-PERP'],
+        includeMarketData: false,
+        callback: expect.any(Function),
+      });
+
+      testStreamManager.prices.cleanupPrewarm();
+      expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Cached user data preloading', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -586,6 +586,21 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
     super.clearCache();
   }
 
+  public reconnect(): void {
+    const shouldRestorePrewarm = Boolean(this.prewarmUnsubscribe);
+
+    super.reconnect();
+
+    if (shouldRestorePrewarm) {
+      this.cleanupPrewarm();
+      this.prewarm().catch((error) => {
+        Logger.error(ensureError(error, 'PriceStreamChannel.reconnect'), {
+          context: 'PriceStreamChannel.reconnect',
+        });
+      });
+    }
+  }
+
   subscribeToSymbols(params: {
     symbols: string[];
     callback: (prices: Record<string, PriceUpdate>) => void;

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -589,10 +589,13 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
   public reconnect(): void {
     const shouldRestorePrewarm = Boolean(this.prewarmUnsubscribe);
 
+    if (shouldRestorePrewarm) {
+      this.cleanupPrewarm();
+    }
+
     super.reconnect();
 
     if (shouldRestorePrewarm) {
-      this.cleanupPrewarm();
       this.prewarm().catch((error) => {
         Logger.error(ensureError(error, 'PriceStreamChannel.reconnect'), {
           context: 'PriceStreamChannel.reconnect',
@@ -712,6 +715,11 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
 
         // Store the actual unsubscribe function
         this.actualPriceUnsubscribe = unsub;
+
+        if (this.wsSubscription) {
+          this.wsSubscription();
+          this.wsSubscription = null;
+        }
       })
       .catch((error) => {
         Logger.error(

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1590,10 +1590,11 @@ describe('PerpsConnectionManager', () => {
 
       // Should have reconnected
       expect(Engine.context.PerpsController.init).toHaveBeenCalled();
-      // The soft-reconnect path (ensureConnected) already re-establishes every
-      // subscription via connect() — clearAllChannels is only for the
-      // healthy-ping short-circuit path and must not be double-invoked here.
-      expect(mockStreamManagerInstance.clearAllChannels).not.toHaveBeenCalled();
+      // The soft-reconnect path preserves caches, so it must separately
+      // rebind active stream handles after the controller reconnects.
+      expect(mockStreamManagerInstance.clearAllChannels).toHaveBeenCalledTimes(
+        1,
+      );
       // Caches must NOT be cleared — preserveCaches=true prevents skeleton flash
       expect(
         mockStreamManagerInstance.positions.clearCache,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -76,6 +76,7 @@ const mockStreamManagerInstance = {
   topOfBook: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   candles: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
   resetDiskCacheThrottles: jest.fn(),
+  clearAllChannels: jest.fn(),
 };
 
 jest.mock('../providers/PerpsStreamManager', () => ({
@@ -1494,6 +1495,23 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
+    it('re-registers stream subscriptions when the first ping succeeds', async () => {
+      // Establish an initial connection
+      await PerpsConnectionManager.connect();
+      mockStreamManagerInstance.clearAllChannels.mockClear();
+
+      await PerpsConnectionManager.resumeFromForeground({
+        source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_MOUNT,
+        suppressError: true,
+      });
+
+      // A healthy ping alone doesn't guarantee the server kept the topic
+      // subscriptions alive — force a resubscribe so candles/prices resume.
+      expect(mockStreamManagerInstance.clearAllChannels).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
     it('retries ping after delay and skips reconnect when retry succeeds', async () => {
       // Establish an initial connection
       await PerpsConnectionManager.connect();
@@ -1520,6 +1538,29 @@ describe('PerpsConnectionManager', () => {
       );
     });
 
+    it('re-registers stream subscriptions when the retry ping succeeds', async () => {
+      // Establish an initial connection
+      await PerpsConnectionManager.connect();
+
+      const failPing = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('ping timeout'));
+      const succeedPing = jest.fn().mockResolvedValue(undefined);
+      (Engine.context.PerpsController.getActiveProvider as jest.Mock)
+        .mockReturnValueOnce({ ping: failPing })
+        .mockReturnValueOnce({ ping: succeedPing });
+
+      mockStreamManagerInstance.clearAllChannels.mockClear();
+
+      await PerpsConnectionManager.resumeFromForeground({
+        source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
+      });
+
+      expect(mockStreamManagerInstance.clearAllChannels).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
     it('soft-reconnects with preserveCaches when both pings fail', async () => {
       // Establish an initial connection
       await PerpsConnectionManager.connect();
@@ -1541,6 +1582,7 @@ describe('PerpsConnectionManager', () => {
       });
       (Engine.context.PerpsController.init as jest.Mock).mockClear();
       (Engine.context.PerpsController.disconnect as jest.Mock).mockClear();
+      mockStreamManagerInstance.clearAllChannels.mockClear();
 
       await PerpsConnectionManager.resumeFromForeground({
         source: PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND,
@@ -1548,6 +1590,10 @@ describe('PerpsConnectionManager', () => {
 
       // Should have reconnected
       expect(Engine.context.PerpsController.init).toHaveBeenCalled();
+      // The soft-reconnect path (ensureConnected) already re-establishes every
+      // subscription via connect() — clearAllChannels is only for the
+      // healthy-ping short-circuit path and must not be double-invoked here.
+      expect(mockStreamManagerInstance.clearAllChannels).not.toHaveBeenCalled();
       // Caches must NOT be cleared — preserveCaches=true prevents skeleton flash
       expect(
         mockStreamManagerInstance.positions.clearCache,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -472,7 +472,7 @@ class PerpsConnectionManagerClass {
    * header appear frozen after foregrounding until the user navigates away
    * and back (which happens to trigger a fresh subscription elsewhere).
    */
-  private resubscribeStreamsAfterHealthyPing(): void {
+  private resubscribeActiveStreamChannels(): void {
     getStreamManagerInstance().clearAllChannels();
   }
 
@@ -494,7 +494,7 @@ class PerpsConnectionManagerClass {
         if (!suppressError) {
           this.clearError();
         }
-        this.resubscribeStreamsAfterHealthyPing();
+        this.resubscribeActiveStreamChannels();
         return;
       } catch {
         // First ping failed — JS thread may be sluggish right after foregrounding.
@@ -510,7 +510,7 @@ class PerpsConnectionManagerClass {
           if (!suppressError) {
             this.clearError();
           }
-          this.resubscribeStreamsAfterHealthyPing();
+          this.resubscribeActiveStreamChannels();
           return;
         } catch {
           DevLogger.log(
@@ -1253,6 +1253,14 @@ class PerpsConnectionManagerClass {
       source: source ?? 'ensure_connected',
       suppressError,
     });
+
+    // A cache-preserving foreground reconnect intentionally skips stream cache
+    // clearing during disconnect. Rebind active channel handles after the
+    // controller comes back so subscribers do not keep stale WebSocket
+    // unsubscribe references from the pre-reconnect provider.
+    if (preserveCaches) {
+      this.resubscribeActiveStreamChannels();
+    }
   }
 
   async disconnect(): Promise<void> {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -461,6 +461,21 @@ class PerpsConnectionManagerClass {
     );
   }
 
+  /**
+   * Re-register all stream channel subscriptions (candles, prices, etc.) on a
+   * still-healthy connection. A ping success only proves the socket transport
+   * is alive — it does NOT prove the server-side topic subscriptions survived
+   * backgrounding. Mobile OSes frequently leave the WebSocket in a "zombie"
+   * state after backgrounding: ping/pong still works, but HyperLiquid has
+   * dropped the `candle`/`allMids` subscriptions, so no further ticks arrive
+   * until something forces a resubscribe. Without this, the chart and price
+   * header appear frozen after foregrounding until the user navigates away
+   * and back (which happens to trigger a fresh subscription elsewhere).
+   */
+  private resubscribeStreamsAfterHealthyPing(): void {
+    getStreamManagerInstance().clearAllChannels();
+  }
+
   async resumeFromForeground(options?: ConnectOptions): Promise<void> {
     const source =
       options?.source ?? PERPS_CONNECTION_SOURCE.WALLET_ROOT_FOREGROUND;
@@ -479,6 +494,7 @@ class PerpsConnectionManagerClass {
         if (!suppressError) {
           this.clearError();
         }
+        this.resubscribeStreamsAfterHealthyPing();
         return;
       } catch {
         // First ping failed — JS thread may be sluggish right after foregrounding.
@@ -494,6 +510,7 @@ class PerpsConnectionManagerClass {
           if (!suppressError) {
             this.clearError();
           }
+          this.resubscribeStreamsAfterHealthyPing();
           return;
         } catch {
           DevLogger.log(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes lightweight Perps charts failing to continue live updates after foreground recovery and interval rollover.

The issue was caused by stream subscriptions and chart viewport state becoming stale even when the underlying connection appeared healthy. The fix rebinds active Perps stream channels after foreground recovery, restores prewarmed price subscriptions during stream reconnects, and updates the lightweight chart bridge so newly appended candle bars are explicitly detected and brought into view only when the user is already following realtime.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed lightweight Perps charts failing to continue live updates

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3486

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Lightweight Perps chart live updates

  Scenario: user returns to a Perps market after backgrounding the app
    Given the user has lightweight charts enabled
    And the user is viewing a Perps market chart with live price updates

    When the user backgrounds the app and then returns to the same market page
    Then the chart continues receiving live price updates
    And new candle bars continue to appear at interval rollover
```
```
Feature: Lightweight Perps chart candle rollover

  Scenario: user watches the 1 minute chart at the live edge
    Given the user has lightweight charts enabled
    And the user is viewing a Perps market on the 1 minute interval
    And the chart is following the latest candle

    When the current 1 minute interval ends
    Then a new candle bar is drawn on the chart
    And the chart remains at the live edge
```
## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/decd17d4-006b-4790-9719-f515e4539b15



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes foreground stream re-subscription and the Perps chart WebView message path—high user visibility for live trading UI, but scoped to perps streaming/charting with broad test coverage and no auth or payment logic.
> 
> **Overview**
> Fixes lightweight Perps charts and prices appearing frozen after app foregrounding or when a new candle bar closes, by re-subscribing streams and tightening the RN ↔ WebView chart bridge.
> 
> **Foreground / connection recovery:** `PerpsConnectionManager` now calls `clearAllChannels()` when a foreground resume succeeds on ping (including retry ping) and after a cache-preserving soft reconnect, so candle and price topics are re-bound even when the socket still answers ping but server-side subscriptions were dropped. `PriceStreamChannel.reconnect()` restores prewarmed all-market price subscriptions after channel reconnect, and prewarm setup clears a stale `wsSubscription` when the prewarm path takes over.
> 
> **Chart live updates & self-heal:** `TradingViewChart` bumps a `chartReadyNonce` on every `CHART_READY` so held candle data is repainted immediately after a silent WebView reload (e.g. iOS WKWebView process reclaim), without waiting for new props. Incremental `UPDATE_LAST_CANDLE` messages now carry `isNewBar` and before/after candle metadata for the WebView.
> 
> **Viewport at interval rollover:** The chart template tracks whether the user is following the realtime edge; when a new bar is appended and they are, it calls `applyZoom` so the new candle enters view, while panned-away viewports stay put. Right margin uses `RIGHT_MARGIN_CANDLES` in zoom limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05fd2d9628242e7386159a2cab08c0f8c195c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->