### PR TITLE
fix: restore release en.json translations on 8.0.3

### DIFF
--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
@@ -260,7 +260,7 @@ describe('BatchSellFinalReviewModal', () => {
     expect(getByText('3,456.78 USDC')).toBeOnTheScreen();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
     expect(getByText('Network fee')).toBeOnTheScreen();
     expect(getByText('1.20 USDC')).toBeOnTheScreen();
@@ -360,7 +360,7 @@ describe('BatchSellFinalReviewModal', () => {
     expect(queryByText('UNI • 0.5% slippage')).toBeNull();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/BatchSellQuoteDetailsModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/BatchSellQuoteDetailsModal.test.tsx
@@ -182,7 +182,7 @@ describe('BatchSellQuoteDetailsModal', () => {
     expect(
       getByTestId(BatchSellQuoteDetailsModalSelectorsIDs.MINIMUM_RECEIVED_ROW),
     ).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 
@@ -312,7 +312,7 @@ describe('BatchSellQuoteDetailsModal', () => {
     expect(queryByText('UNI • 0.5% slippage')).toBeNull();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Predict/components/PredictActivityDetail/PredictActivityDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictActivityDetail/PredictActivityDetail.test.tsx
@@ -366,7 +366,7 @@ describe('PredictActivityDetails - Claim Activity', () => {
     });
 
     // Assert
-    expect(getByText('Total Net P&L')).toBeOnTheScreen();
+    expect(getByText('Total net P&L')).toBeOnTheScreen();
   });
 });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -616,8 +616,6 @@
     "invalid_qr_code_title": "Invalid QR Code",
     "invalid_qr_code_message": "This QR code doesn't represent a valid Secret Recovery Phrase",
     "enter_your_secret_recovery_phrase": "Enter your Secret Recovery Phrase",
-    "or": "or",
-    "import_wallet_from_extension": "import from the MetaMask extension",
     "metamask_password": "MetaMask password",
     "metamask_password_description": "Unlocks MetaMask on this device only.",
     "seed_phrase_required": "Secret Recovery Phrase is required",
@@ -1094,7 +1092,6 @@
       "twitter_link": "View on X (Twitter)",
       "sort": {
         "value": "Value",
-        "top_trades": "Top Trades",
         "pnl_percent": "P&L %",
         "recent": "Recent"
       }
@@ -1103,10 +1100,9 @@
       "market_cap": "Market cap",
       "price": "Price",
       "position": "Position",
+      "trades": "Trades",
       "buy": "Buy",
       "trade": "Trade",
-      "unsupported_market": "Unsupported market",
-      "trades": "Trades",
       "bought": "Bought",
       "sold": "Sold",
       "no_trades": "No trades yet",
@@ -1134,8 +1130,6 @@
       "price_impact": "Price impact",
       "est_points": "Est. points",
       "no_quotes": "No quotes available for this token",
-      "quote_details_empty_no_amount": "Enter an amount to see quote details.",
-      "quote_details_empty_no_quote": "No quote available right now. Try a different amount.",
       "loading": "Loading...",
       "unavailable": "Swap unavailable",
       "unsupported_chain": "This chain is not supported for Quick Buy yet",
@@ -1163,7 +1157,7 @@
   "perps": {
     "basic_functionality_disabled_title": "Perps is not available",
     "title": "Perps",
-    "send_to_perps": "Send to Perps",
+    "transfer_to_perps": "Transfer to Perps",
     "perps_trading": "Perps trading",
     "perp_account_balance": "Perp account balance",
     "manage_balance": "Manage balance",
@@ -2041,8 +2035,7 @@
         "high": "High",
         "low": "Low",
         "close": "Close",
-        "volume": "Volume",
-        "change": "Change"
+        "volume": "Volume"
       }
     },
     "cancel": "Cancel",
@@ -2063,7 +2056,6 @@
       "commodities": "Commodities",
       "stocks_and_commodities": "Explore stocks and commodities",
       "tabs": {
-        "all": "All",
         "crypto": "Crypto",
         "pre_ipo": "Pre-IPO",
         "forex": "Forex",
@@ -2222,25 +2214,10 @@
       "funding": {
         "date": "Date",
         "fee": "Fee",
-        "funding_fee": "Funding fee",
         "rate": "Rate"
       },
       "view_on_explorer": "View on block explorer",
       "trade_again": "Trade again",
-      "fund_again": "Fund again",
-      "try_again": "Try again",
-      "steps": {
-        "title_completed": "Steps ({{completed}} completed)",
-        "title_pending": "Steps ({{completed}} completed, {{pending}} pending)",
-        "title_failed": "Steps ({{completed}} completed, {{failed}} failed)",
-        "approve_funds": "Approve funds",
-        "bridge_funds": "Bridge funds",
-        "receive_usdc": "Receive USDC on Arbitrum",
-        "add_funds": "Add funds",
-        "initiate_withdrawal": "Initiate withdrawal",
-        "process_withdrawal": "Process withdrawal",
-        "receive_funds": "Receive funds"
-      },
       "activity": {
         "deposit_title": "Deposit",
         "withdrawal_title": "Withdrawal",
@@ -2361,15 +2338,13 @@
   },
   "predict": {
     "title": "MetaMask Predictions",
-    "send_to_predictions": "Send to Predictions",
+    "transfer_to_predictions": "Transfer to Predictions",
     "select_predict_account": "Select predict account",
     "search_account": "Search an account",
     "home": {
       "live_now_title": "Live now",
-      "categories_title": "Categories",
-      "popular_today_placeholder": "Popular today",
-      "trending_title": "Trending",
-      "trending_unable_to_load": "Unable to load markets, please try again"
+      "categories_placeholder": "Categories",
+      "trending_placeholder": "Trending"
     },
     "homepage_discovery": {
       "btc_title": "BTC Price: {{price}}",
@@ -2390,15 +2365,11 @@
       "predictions_title": "World Cup predictions",
       "banner_title": "World Cup 2026",
       "banner_description": "Trade every match, every moment.",
-      "hub_banner_title": "$75K up for grabs",
-      "hub_banner_description": "Predict World Cup knockout games to win—join now",
       "tabs": {
         "all": "All",
         "props": "Props",
-        "live": "Live",
-        "games": "Games"
+        "live": "Live"
       },
-      "who_will_win": "Who will win the World Cup?",
       "stages": {
         "group_stage": "Group Stage",
         "round_of_32": "Round of 32",
@@ -2537,17 +2508,17 @@
       "soccer_anytime_goalscorer": "Goalscorers",
       "soccer_exact_score": "Exact Score",
       "soccer_halftime_result": "Halftime Result",
-      "soccer_team_to_advance": "Team to Advance",
       "soccer_first_to_score": "First Team to Score",
-      "soccer_extra_time": "Extra Time?",
-      "soccer_penalty_shootout": "Penalty Shootout?",
       "total_corners": "Corners",
       "tennis_set_totals": "Total Sets",
       "tennis_set_handicap": "Set Handicap",
       "tennis_match_totals": "Total Games",
       "tennis_first_set_totals": "1st Set Total Games",
       "tennis_first_set_winner": "1st Set Winner",
-      "tennis_completed_match": "Completed Match"
+      "tennis_completed_match": "Completed Match",
+      "soccer_team_to_advance": "Team to Advance",
+      "soccer_extra_time": "Extra Time?",
+      "soccer_penalty_shootout": "Penalty Shootout?"
     },
     "sell_position": "Sell position",
     "odds": "Odds",
@@ -2683,21 +2654,9 @@
       "price_per_share": "Price per share",
       "price_impact": "Price impact",
       "net_pnl": "Net P&L",
-      "total_net_pnl": "Total Net P&L",
+      "total_net_pnl": "Total net P&L",
       "market_net_pnl": "Market net P&L",
       "activity_details": "Activity details",
-      "you_predicted": "You predicted",
-      "view_on_polymarket": "View on Polymarket",
-      "place_another_prediction": "Place another prediction",
-      "fund_again": "Fund again",
-      "try_again": "Try again",
-      "steps": {
-        "title_completed": "Steps ({{completed}} completed)",
-        "title_pending": "Steps ({{completed}} completed, {{pending}} pending)",
-        "title_failed": "Steps ({{completed}} completed, {{failed}} failed)",
-        "bridge_funds": "Bridge from ETH to USDC.e",
-        "add_funds": "Add funds"
-      },
       "today": "Today",
       "yesterday": "Yesterday"
     },
@@ -2831,15 +2790,15 @@
       "volume_display": "${{volume}} Vol",
       "read_terms": "Read the full contract terms and conditions"
     },
+    "sports": {
+      "halftime": "Halftime",
+      "final": "Final"
+    },
     "reg_time_info": {
       "tag": "Reg time",
       "accessibility_label": "Regulation time market information",
       "title": "Regulation time",
       "description": "This market refers to the outcome during the 90 minutes of regular play plus stoppage time. It excludes extra time and penalties."
-    },
-    "sports": {
-      "halftime": "Halftime",
-      "final": "Final"
     }
   },
   "rwa": {
@@ -3099,7 +3058,7 @@
       "buy_sell": "Buy/Sell",
       "perps": "Perps",
       "predictions": "Predictions",
-      "metamask_card": "Card",
+      "metamask_card": "MetaMask Card",
       "money": "Money"
     },
     "empty_state": {
@@ -3596,8 +3555,6 @@
       "wallet_activity_desc": "Buy, sells, transfers, swaps and rewards",
       "perps_title": "Trading Activity",
       "perps_desc": "Perps position changes, liquidations, funding rates, and margin updates",
-      "agentic_cli_title": "Agentic CLI",
-      "agentic_cli_desc": "CLI connection requests, approvals, and session updates for Agentic",
       "social_ai_title": "Trading Signals",
       "social_ai_desc": "Updates from traders and assets you follow, plus currated market news",
       "marketing_title": "Updates and Rewards",
@@ -4031,38 +3988,6 @@
     "feature_flag_override": {
       "title": "Feature flag override",
       "description": "Override the feature flags for the app locally."
-    },
-    "add_device": {
-      "title": "Add device",
-      "enter_your_password": "Enter your password",
-      "enter_your_password_desc": "For account security, enter your password to view the QR code.",
-      "continue": "Continue",
-      "add_wallets": "Add wallets",
-      "add_wallets_desc": "Pick the wallets you’d like to use on this device. You can add or remove them later.",
-      "select_all": "Select all",
-      "scan_qr_code": "Scan QR code",
-      "scan_qr_code_desc": "Scan this with the MetaMask app on the device you want to add.",
-      "enter_verification_code": "Enter verification code",
-      "enter_verification_code_desc": "For security, enter the code shown in the MetaMask app on your device.",
-      "add_device_to_wallet": "Add this device to wallet",
-      "points": {
-        "one": "Open MetaMask on your other device",
-        "two": "Go to",
-        "two_bold_one": "Settings",
-        "two_bold_two": "Add device",
-        "two_icon": ">",
-        "three": "Scan the QR code with this device",
-        "four": "Enter the security code on your extension"
-      },
-      "scan_qr_code_button": "Scan QR code",
-      "enter_code_on_extension": "Enter code on extension",
-      "enter_code_on_extension_desc": "For security, enter the verification code below on your MetaMask extension.",
-      "done": "Done",
-      "waiting_for_extension": "Waiting for extension...",
-      "waiting_for_extension_description": "Finish choosing accounts on your computer to continue.",
-      "extension_cancelled_title": "Import cancelled",
-      "extension_cancelled_description": "The account import was cancelled/failed. Try again.",
-      "extension_cancelled_button": "Try again"
     }
   },
   "aes_crypto_test_form": {
@@ -4210,7 +4135,6 @@
   },
   "price_alerts": {
     "create_title": "Create {{ticker}} price alert",
-    "edit_title": "Edit {{ticker}} price alert",
     "price_reaches": "Price reaches",
     "price_change": "Price change",
     "enter_target_price": "Enter target price",
@@ -4221,13 +4145,8 @@
     "quick_percentage": "{{percentage}}%",
     "price_change_under_development": "This experience is currently under development",
     "set_price_alert": "Set price alert",
-    "update_price_alert": "Update price alert",
     "save_success": "Price alert for {{ticker}} saved successfully.",
-    "save_error": "Failed to save price alert. Please try again.",
     "delete_success": "Price alert deleted.",
-    "delete_error": "Failed to delete price alert. Please try again.",
-    "toggle_error": "Failed to update price alert. Please try again.",
-    "fetch_error": "Failed to load price alerts. Please try again.",
     "duplicate_threshold": "An alert at this price already exists.",
     "manage_title": "Price alerts",
     "add_alert": "Add alert",
@@ -4324,8 +4243,6 @@
       "3y": "3Y",
       "all": "All"
     },
-    "ma_picker_title": "Moving average",
-    "done": "Done",
     "no_chart_data": {
       "title": "No chart data",
       "description": "We could not fetch any data for this token",
@@ -4631,9 +4548,8 @@
     "confirmed": "Confirmed",
     "pending": "Pending",
     "submitted": "Submitted",
-    "queued": "Queued",
     "failed": "Failed",
-    "canceled": "Canceled",
+    "cancelled": "Cancelled",
     "signed": "Pending",
     "unconfirmed": "Pending",
     "tokenContractAddressWarning_1": "This address is a ",
@@ -4835,29 +4751,21 @@
     "activity_smart_account_upgrade": "Smart account upgrade",
     "activity_prediction_cashed_out": "Prediction cashed out",
     "activity_prediction_placed": "Prediction placed",
-    "activity_perps_balance": "Perps balance",
-    "activity_predictions_balance": "Predictions balance",
-    "activity_prediction_account_funded": "Account funded",
-    "activity_prediction_withdrawal": "Prediction withdrawal",
-    "activity_perps_account_funded": "Account funded",
-    "activity_perps_withdrawal": "Perps withdrawal",
     "activity_perps_open_long": "Opened long",
     "activity_perps_close_long": "Closed long",
-    "activity_perps_close_long_liquidated": "Closed long—liquidated",
-    "activity_perps_close_long_stop_loss": "Closed long—stop loss",
+    "activity_perps_close_long_liquidated": "Closed long - liquidated",
+    "activity_perps_close_long_stop_loss": "Closed long - stop loss",
     "activity_perps_open_short": "Opened short",
     "activity_perps_close_short": "Closed short",
-    "activity_perps_close_short_liquidated": "Closed short—liquidated",
-    "activity_perps_close_short_stop_loss": "Closed short—stop loss",
+    "activity_perps_close_short_liquidated": "Closed short - liquidated",
+    "activity_perps_close_short_stop_loss": "Closed short - stop loss",
     "activity_perps_paid_funding_fees": "Paid funding fees",
     "activity_perps_received_funding_fees": "Received funding fees",
-    "activity_perps_close_short_take_profit": "Closed short—take profit",
-    "activity_perps_close_long_take_profit": "Closed long—take profit",
+    "activity_perps_close_short_take_profit": "Closed short - take profit",
+    "activity_perps_close_long_take_profit": "Closed long - take profit",
     "activity_market_short": "Market short",
-    "activity_stop_market_close_short": "Stop market—close short",
-    "activity_market_close_short": "Market—close short",
-    "activity_limit_short": "Limit short",
-    "activity_limit_close_short": "Limit—close short",
+    "activity_stop_market_close_short": "Stop market - close short",
+    "activity_market_close_short": "Market - close short",
     "claim": "Claim",
     "sent_ether": "Sent ETH",
     "self_sent_ether": "Sent yourself ETH",
@@ -5021,8 +4929,7 @@
     "between_account": "Transfer between my accounts",
     "others": "Others",
     "memo": "Memo",
-    "network": "Network",
-    "custom": "Custom"
+    "network": "Network"
   },
   "duplicate_address": {
     "title": "This is a duplicate address",
@@ -5973,7 +5880,6 @@
     "empty_sell_orders_list": "You don't have any sell orders",
     "purchased_currency": "Purchased {{currency}}",
     "sold_currency": "Sold {{currency}}",
-    "date": "Date",
     "order_status_pending": "Pending",
     "order_status_processing": "Processing",
     "order_status_completed": "Completed",
@@ -7227,19 +7133,12 @@
       "link_card_sheet_description_suffix": " (variable).",
       "link_card_sheet_description_no_apy": "Link your card so you can spend your Money balance and earn mUSD back on purchases.",
       "link_card_sheet_cta": "Link card",
-      "unlink_card_sheet_title_no_funding_source": "Unlink Money account?",
-      "unlink_card_sheet_title_with_funding_source": "Are you sure?",
-      "unlink_card_sheet_description_no_funding_source": "You'll stop earning on purchases. Future card spend will be declined until you set a new funding source. Reconnect your Money account anytime.",
-      "unlink_card_sheet_description_with_funding_source": "You'll stop earning on purchases. Future card spend will be funded by {{fundingSource}}. Reconnect your Money account anytime.",
-      "unlink_card_sheet_another_money_account": "another Money account",
-      "unlink_card_sheet_keep_linked": "Keep linked",
-      "unlink_card_sheet_unlink_account": "Unlink account",
       "manage_card": "Manage",
       "avail_balance": "Avail. balance",
       "verification_pending": "Your identity verification is being reviewed. This typically takes less than 12 hours."
     },
     "what_you_get": {
-      "title": "Money account benefits",
+      "title": "What you get",
       "benefit_auto_earn": "Auto-earn up to",
       "benefit_auto_earn_variable": "(variable)",
       "benefit_dollar_backed": "Keep your money secure in mUSD, a 1:1 dollar-backed stablecoin",
@@ -7266,7 +7165,7 @@
     "more_sheet": {
       "title": "More",
       "how_it_works": "How it works",
-      "what_you_get": "Money account benefits",
+      "what_you_get": "What you get",
       "contact_support": "Contact support"
     },
     "transfer_sheet": {
@@ -7335,12 +7234,11 @@
       "pending": "Pending",
       "filter_all": "All",
       "filter_deposits": "Deposits",
-      "filter_sends": "Sends",
-      "filter_purchases": "Purchases"
+      "filter_sends": "Sends"
     },
     "condensed_cards": {
       "how_it_works_title": "How it works",
-      "how_it_works_subtitle": "See how your money works for you",
+      "how_it_works_subtitle": "See how your money can grow",
       "musd_title": "MetaMask USD",
       "musd_subtitle": "Learn more about mUSD",
       "what_you_get_title": "What you get",
@@ -7354,7 +7252,6 @@
       "cashback": "mUSD back",
       "card": "Card",
       "purchase": "Purchase",
-      "refund": "Refund",
       "musd_back": "mUSD back",
       "converted": "Converted",
       "depositing": "Depositing",
@@ -7372,7 +7269,6 @@
       "cashback_title": "mUSD back",
       "you_spent": "You spent",
       "you_earned": "You earned",
-      "you_were_refunded": "You were refunded",
       "completed": "Completed",
       "paid_to": "Paid to",
       "received_from": "Received from",
@@ -7399,29 +7295,26 @@
       "description_2": "Your Money balance is your spending balance. Link your MetaMask Card to spend at 150M+ merchants worldwide. Your money keeps earning until the moment you use it.",
       "description_3": "Money account is powered by Monad.",
       "faq_title": "FAQs",
-      "faq_q1": "What is a MetaMask Money account?",
-      "faq_a1": "An account that earns up to {{percentage}}% variable APY. You deposit funds, which are held in the account as mUSD, and earn up to {{percentage}}% APY. mUSD is MetaMask's dollar-backed stablecoin. You can use or withdraw your funds anytime with no penalties. You can spend your funds via MetaMask Card at 150+ million Mastercard merchants worldwide.",
-      "faq_q2": "Is MetaMask Money account safe?",
-      "faq_a2": "Yes, but like all DeFi products, it carries risk. It's a self-custodial wallet, meaning you have full control over your account with your Private Keys.\n\nRisks include smart-contract failures, protocol exploits, liquidity shortages, third-party failures, and legal or regulatory restrictions. The Money account isn't insured by the FDIC or any government agency. There is a risk of loss.",
-      "faq_q3": "Who controls my MetaMask Money account?",
-      "faq_a3": "You! MetaMask is a self-custodial wallet, meaning only the account holder's Private Keys control it. MetaMask can't access, freeze, or move your funds. This is what distinguishes us from traditional bank accounts and custodial crypto platforms—there's no third party holding your funds.",
-      "faq_q4": "What are MetaMask Money account fees?",
-      "faq_a4": "There's no fee to open a Money account and no fee to deposit stablecoins. You will get charged fees when depositing non-stablecoin tokens. There are also fees associated with MetaMask Card transactions, ATM withdrawals, and local currency offramp costs. ",
-      "faq_a4_link": "See the full Card fee breakdown here.",
-      "faq_q5": "How much can I earn with a MetaMask Money account?",
-      "faq_a5": "Up to {{percentage}}% APY. The rate is variable and fluctuates with market conditions. The current rate is always visible inside the Money account.",
+      "faq_q1": "What is a MetaMask Money Account?",
+      "faq_a1": "MetaMask Money Account is a self-custodial account built into MetaMask that earns up to {{percentage}}% variable APY on deposited funds—with no lockups, no withdrawal penalties, and no account fees. When you deposit a supported stablecoin ({{stablecoins}}) or aTokens into a Money Account, it converts to mUSD, MetaMask's dollar-backed stablecoin, with no conversion fees. You can also deposit any token into a Money Account, with a conversion fee. Your Money Account balance (mUSD) stays available to trade, send, and earn—or spend anytime via MetaMask Card, across 150+ million Mastercard merchants worldwide.",
+      "faq_q2": "Is MetaMask Money Account safe?",
+      "faq_a2": "MetaMask is a self-custodial wallet—only you control your private keys and funds. MetaMask cannot access, freeze, or move your balance. mUSD itself is backed 1:1 by US dollars and short-term US Treasury bills held in regulated custody by Bridge (a Stripe company). However, like all DeFi-based products, Money Account carries risks, including smart-contract failures, protocol exploits, liquidity shortages, third-party failures and legal or regulatory restrictions. The APY is variable and not guaranteed, and there is a risk of loss. The Money balance (mUSD) is not insured by the FDIC or any government agency.",
+      "faq_q3": "Who controls my MetaMask Money Account?",
+      "faq_a3": "You have full control over your Money Account. MetaMask is a self-custodial wallet, meaning only the account holder's private keys control the mUSD held in the Money Account. MetaMask cannot access, freeze, or move any Money Account balance. This is a core difference from traditional bank accounts and custodial crypto platforms, where a third party holds funds on behalf of the user.",
+      "faq_q4": "What are MetaMask Money Account fees?",
+      "faq_a4": "MetaMask Money Account is free to open. Stablecoin to mUSD conversions are at 1:1 parity with no conversion fees. The APY shown in the Money Account is the net rate you earn. All product fees—distributed among MetaMask, Veda, and Steakhouse—have already been deducted. For details on MetaMask Card transaction fees, ATM withdrawal fees, and fiat offramp costs, see the full fee breakdown inside MetaMask.",
+      "faq_q5": "How much can I earn with a MetaMask Money Account?",
+      "faq_a5": "MetaMask Money Account earns up to {{percentage}}% APY. The rate is variable and fluctuates with market conditions. The current rate is always visible inside the Money Account.",
       "faq_q6": "Where does the yield come from?",
-      "faq_a6": "When you deposit funds, they're put in established DeFi protocols, like Aave and Morpho, where they earn returns from real economic activity. These returns are then delivered to you in the form of APY.\n\nA third-party service provider called Steakhouse Financial monitors how funds are allocated in the protocols. Veda, a third-party infrastructure provider, deploys and maintains the vault smart contracts that hold your funds.\n\nEarnings are not interest paid by MetaMask or by the issuer of mUSD. They are the onchain returns generated by positions in third-party DeFi protocols.",
-      "faq_q7": "What tokens can I deposit into the Money account?",
-      "faq_a7": "You can deposit the following stablecoins and aTokens into your Money account with no conversion fees:\n\n{{tokenBullets}}\n\nAll other EVM tokens can be deposited into the Money account, but standard fees may apply. You can also fund your Money account using a debit card, credit card, bank account, PayPal, Apple Pay, or Google Pay.\n\nNote: There's an initial max deposit of $100,000 per token to ensure liquidity.",
-      "faq_q8": "Can I withdraw from the MetaMask Money account anytime?",
-      "faq_a8": "Yes. You can trade, send, spend, or withdraw your full balance at any time with no notice periods, no penalties, and no withdrawal fees from MetaMask. If liquidity is tight, there may be temporary delays.",
-      "faq_q9": "Do I need to complete identity verification to use MetaMask Money account?",
-      "faq_a9": "No, opening a Money account doesn't require identity verification. However, certain features, including Card and Ramps, do require verification. Checks are carried out by third-party providers that operate regulated services, not by MetaMask. If needed, you will be guided through the process inside the app during sign-up.",
-      "faq_q10": "Which countries is MetaMask Money account available in?",
-      "faq_a10": "Most places! We currently aren't available in the UK and countries on the USA sanctions list.",
-      "disclosures_title": "Risk and Disclosures",
-      "disclosures_body": "Money account is not a bank account, savings account, or insured deposit product. APY is variable and not guaranteed. Money account involves smart contract, protocol, liquidity, and other risks, and you may lose some or all of your funds. Subject to regional restrictions. Terms apply."
+      "faq_a6": "When funds are deposited into a Money Account, these assets go into a third-party smart contract vault. The vault interacts with established DeFi protocols—for example, lending markets like Aave and Morpho—where they earn returns from real economic activity, primarily interest paid by borrowers. Any resulting returns, after applicable protocol costs and product fees, show up as APY. Earnings are not interest paid by MetaMask or by the issuer of mUSD. They are the onchain returns generated by the vault's positions in third-party DeFi protocols.\n\nThe rate shown is an estimated Annual Percentage Yield (APY) based on current market conditions. APY is variable and is not guaranteed. The DeFi vault is administered by Veda with risk oversight by Steakhouse Financial.",
+      "faq_q7": "Which tokens can I deposit into the Money Account?",
+      "faq_a7": "You can deposit the following stablecoins and aTokens into your Money Account with no conversion fees:\n\n{{tokenBullets}}\n\nAll other EVM tokens can also be deposited into the Money Account, but standard exchange fees may apply. You can also fund your Money Account using a debit card, credit card, or Apple Pay.\n\nNote: There is an initial max deposit of $100,000 per token to ensure liquidity.",
+      "faq_q8": "Can I withdraw from the MetaMask Money Account anytime?",
+      "faq_a8": "Yes. Your mUSD is never locked. You can trade, send, spend, or withdraw your full balance at any time with no notice periods, no penalties, and no withdrawal fees from MetaMask. Withdrawals process immediately, subject to standard network confirmation times on the relevant blockchain. If liquidity is tight, there may be temporary delays.",
+      "faq_q9": "Do I need to complete KYC to use MetaMask Money Account?",
+      "faq_a9": "Opening a Money Account and holding mUSD does not require identity verification. However, certain MetaMask features—including MetaMask Card and Ramps—require KYC (Know Your Customer) verification as required by applicable regulations. These checks are carried out by the third-party providers that operate these regulated services, not by MetaMask. If needed, you will be guided through the process inside the app during sign-up.",
+      "faq_q10": "Which countries is MetaMask Money Account available in?",
+      "faq_a10": "MetaMask Money Account is available globally except in the following regions: the UK, and countries on the USA sanctions list."
     },
     "geo_block": {
       "title": "Money account unavailable",
@@ -7728,7 +7621,6 @@
       "network": "Network",
       "primary_type": "Primary type",
       "request_from": "Request from",
-      "external_app": "External app",
       "signing_in_with": "Signing in with",
       "spender": "Spender",
       "now": "Now",
@@ -7766,7 +7658,7 @@
       "predict_deposit": "Add Prediction funds",
       "predict_withdraw": "Withdraw",
       "money_account_add_money": "Add funds",
-      "money_account_send": "Send"
+      "money_account_transfer_money": "Transfer funds"
     },
     "sub_title": {
       "permit": "This site wants permission to spend your tokens.",
@@ -7804,7 +7696,7 @@
         "transaction_fee": "Conversion fees include network costs and may include provider fees."
       },
       "title": {
-        "transaction_fee": "Transaction fees"
+        "transaction_fee": "Fees"
       },
       "network_fee": "Network fees depend on how busy the network is and how complex your transaction is."
     },
@@ -7947,7 +7839,7 @@
     "batch_sell_review_title": "Batch Sell Review",
     "batch_sell_select_stablecoin": "Select a stablecoin",
     "batch_sell_total_received": "Total received",
-    "batch_sell_minimum_received": "Min. received:",
+    "batch_sell_minimum_received": "Minimum received",
     "batch_sell_quote_details_row": "{{tokenSymbol}} • {{slippage}} slippage",
     "batch_sell_no_quote_available": "No quote available",
     "batch_sell_high_price_impact": "High price impact",
@@ -8049,13 +7941,9 @@
       "rejected": "Rejected",
       "reconnect": "Reconnect",
       "done": "Done",
-      "network_fee_paid_with_symbol": "Network fee paid with {{symbol}}",
-      "paying_network_fee_with_symbol": "Paying network fee with {{symbol}}",
       "scan_next_qr_code": "Scan next QR code",
-      "scan_final_qr_code": "Scan final QR code",
       "scanner_step_text": "Step {{current}} of {{total}}: Scan the QR code shown on your wallet",
-      "scanner_last_step_text": "Last step: Scan the QR code shown on your wallet",
-      "qr_display_step_text": "Step {{current}} of {{total}}: Scan this QR code with your wallet"
+      "scanner_last_step_text": "Last step: Scan the QR code shown on your wallet"
     },
     "price_impact_info_title": "Price impact",
     "price_impact_info_description": "This is how your trade changes the market price of a token. It depends on the trade size, available liquidity, and provider fees. MetaMask doesn't control price impact.",
@@ -8316,8 +8204,6 @@
     "add_wallet_hardware_description": "Using Bluetooth or a QR Code",
     "add_hardware_wallet": "Add a hardware wallet",
     "syncing": "Syncing",
-    "link_metamask_extension" : "Import accounts from MetaMask extension",
-    "link_metamask_extension_description": "Import accounts from MetaMask extension to your wallet",
     "account_details": {
       "header_title": "Account details",
       "account_name": "Account name",
@@ -8728,7 +8614,6 @@
     "card_home": {
       "title": "Card",
       "authentication_error": "Your session has expired. Please log in again.",
-      "onboarding_token_revoked": "We couldn't continue your Card session. Please log in again.",
       "available_balance": "Available balance",
       "error_title": "Can't fetch data",
       "error_description": "It seems that there is an issue preventing you from viewing the content on this page. Please check your connection or try refreshing the page.",
@@ -8815,8 +8700,6 @@
         "manage_spending_limit": "Manage limit",
         "manage_spending_limit_description_restricted": "Limited spending is on",
         "manage_spending_limit_description_full": "Full access is on",
-        "unlink_money_account": "Unlink Money account",
-        "unlink_money_account_description": "Change your Card funding source",
         "travel_title": "MetaMask Travel",
         "travel_description": "Book hotels with up to 70% discounts",
         "card_tos_title": "Terms and conditions",
@@ -8929,7 +8812,6 @@
       "password_label": "Password",
       "login_button": "Log in",
       "signup_button": "Sign up",
-      "forgot_password_button": "Forgot password?",
       "errors": {
         "invalid_credentials": "Invalid login details",
         "invalid_otp_code": "Incorrect code, please try again",
@@ -8944,11 +8826,6 @@
         "server_error": "Server error. Please try again later.",
         "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
-    },
-    "card_forgot_password": {
-      "load_error": "Something went wrong loading the page. Please try again.",
-      "try_again": "Try again",
-      "reset_success": "Password reset successful"
     },
     "card_otp_authentication": {
       "title": "Confirm your phone number",
@@ -9150,11 +9027,7 @@
       "referee_error_description": "Check your connection and try again.",
       "referee_contact_support": "Contact support",
       "referee_priority_support_disclaimer": "By contacting priority support you will connect your wallet.",
-      "referral_tag_label": "VIP",
-      "last_updated": "Last updated: {{time}}",
-      "swaps_volume_info_label": "Swaps volume information",
-      "swaps_volume_info_title": "Swaps volume",
-      "swaps_volume_info_description": "Your swaps volume updates once per day, so recent swaps may take up to 24 hours to appear here."
+      "last_updated": "Last updated: {{time}}"
     },
     "referral_title": "Referrals",
     "referral_stats_earned_from_referrals": "Earned from referrals",
@@ -9595,9 +9468,9 @@
       "stats_title": "Stats",
       "label_rank": "Rank",
       "label_your_rank": "Your rank",
-      "label_roi": "ROI (after fees)",
+      "label_roi": "ROI",
       "label_total_volume": "Total volume",
-      "label_pnl": "PnL (after fees)",
+      "label_pnl": "PnL",
       "predict_now_cta": "Predict now",
       "positions_title": "Your predictions",
       "positions_open_section": "Open",
@@ -9758,32 +9631,6 @@
     },
     "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
-  "activity_details": {
-    "status": "Status",
-    "date": "Date",
-    "account": "Account",
-    "address": "Address",
-    "from": "From",
-    "to": "To",
-    "network": "Network",
-    "transaction_id": "Transaction ID",
-    "network_fee": "Network fee",
-    "bandwidth_fee": "Bandwidth",
-    "energy_fee": "Energy",
-    "bridge_fee": "Bridge fee",
-    "transaction_fee": "Transaction fee",
-    "unknown_token": "Unknown",
-    "total_amount": "Total amount",
-    "you_sent": "You sent",
-    "you_received": "You received",
-    "view_on_block_explorer": "View on block explorer",
-    "swap_again": "Swap again",
-    "bridge_again": "Bridge again",
-    "convert_again": "Convert again",
-    "wrap_again": "Wrap again",
-    "unwrap_again": "Unwrap again",
-    "not_found": "Transaction details are unavailable."
-  },
   "sdk_connect_v2": {
     "show_loading": {
       "title": "Connecting to dApp",
@@ -9878,7 +9725,6 @@
     "low_to_high": "Low to high",
     "apply": "Apply",
     "search_placeholder": "Search tokens, markets and URLs",
-    "quick_trade": "Quick Buy & Sell",
     "cancel": "Cancel",
     "perps": "Perps",
     "rwa_perps_section": "Perps",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9027,6 +9027,7 @@
       "referee_error_description": "Check your connection and try again.",
       "referee_contact_support": "Contact support",
       "referee_priority_support_disclaimer": "By contacting priority support you will connect your wallet.",
+      "referral_tag_label": "VIP",
       "last_updated": "Last updated: {{time}}"
     },
     "referral_title": "Referrals",


### PR DESCRIPTION
## **Description**

This PR restores `locales/languages/en.json` for the 8.0.x OTA line after a bad cherry-pick conflict resolution pulled in unrelated translation changes.

The file was rebuilt from the `release/8.0.0` baseline, then only the valid 8.0.x OTA translation additions were re-applied. This keeps the intended Predict Regulation Time copy while restoring release translations expected by the 8.0.x code.

## **Changelog**

CHANGELOG entry: Fixed missing English translations in the 8.0.x OTA release.

## **Related issues**

Refs: Release translation regression caused by bad `en.json` cherry-pick conflict resolution.

## **Manual testing steps**

N/A — this is an English translation file correction. Validation was done by checking JSON parsing and confirming the corrected file only differs from `release/8.0.0` by the intended OTA translation additions.

## **Screenshots/Recordings**

N/A — no UI behavior changed beyond restoring translation strings.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — translation-only change.
- [x] I've tested with a power user scenario
  - N/A — translation-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — translation-only change.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large en.json diff affects user-visible copy app-wide on the OTA release; wrong keys could show missing or stale strings, though scope is translation-only with no logic changes.
> 
> **Overview**
> Reverts **`locales/languages/en.json`** to the **`release/8.0.0`** baseline and reapplies only the intended **8.0.x OTA** strings (e.g. Predict **regulation time** copy and related Predict keys), undoing unrelated translation churn from a bad cherry-pick conflict.
> 
> **Restored / removed copy** spans many surfaces: Perps/Predict funding step labels and activity strings, Money account FAQs and Card unlink flows, price alerts and chart strings, hardware-wallet QR steps, **Add device** settings, **activity_details** block, Agentic CLI notifications, extension import links, and other keys that do not belong on the 8.0.x line.
> 
> **Aligned wording** with the 8.0.x UI includes batch sell **"Minimum received"** (not `Min. received:`), Predict **"Total net P&L"**, **"Transfer to Perps/Predictions"**, transaction status **"Cancelled"**, and similar release-consistent labels.
> 
> **Tests** in Batch Sell final review/quote details and Predict activity detail were updated to assert the restored English strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9406f72f5bb5f1a232a20f802fe235b36c8a2a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->