### PR TITLE
fix(social-ai): polish mute chip colors and add leaderboard filter haptics

### DIFF
--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -20,11 +20,13 @@ jest.mock('../../../../util/Logger', () => ({
 
 const mockPlayErrorNotification = jest.fn(() => Promise.resolve());
 const mockPlayImpact = jest.fn();
+const mockPlaySelection = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../../../util/haptics', () => ({
   ...jest.requireActual('../../../../util/haptics'),
   playErrorNotification: () => mockPlayErrorNotification(),
   playImpact: (...args: unknown[]) => mockPlayImpact(...args),
+  playSelection: (...args: unknown[]) => mockPlaySelection(...args),
   fireSwitchHaptic: jest.fn(),
 }));
 
@@ -828,6 +830,19 @@ describe('TopTradersView', () => {
           previous_chain_filter: 'all',
         }),
       );
+    });
+
+    it('triggers a selection haptic when a different pill is tapped', () => {
+      renderWithProvider(<TopTradersView />);
+
+      fireEvent.press(
+        screen.getByTestId(TopTradersViewSelectorsIDs.TAB_FILTER_TOKENS),
+      );
+      fireEvent.press(
+        screen.getByTestId(TopTradersViewSelectorsIDs.TAB_FILTER_TOKENS),
+      );
+
+      expect(mockPlaySelection).toHaveBeenCalledTimes(1);
     });
 
     it('fires Trader Leaderboard Trader Clicked with rank and chain filter on row press', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -49,7 +49,11 @@ import {
 } from '../../../../selectors/featureFlagController/socialLeaderboard';
 import Logger from '../../../../util/Logger';
 import { buildSocialLoggerErrorOptions } from '../../../../util/social/socialServiceTelemetry';
-import { ImpactMoment, playImpact } from '../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../util/haptics';
 import { useTheme } from '../../../../util/theme';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useNotificationStoragePreferences } from '../../Settings/NotificationsSettings/hooks/useNotificationStoragePreferences';
@@ -201,10 +205,12 @@ const FilterTabs: React.FC<FilterTabsProps> = ({
 
   const handleTabPress = useCallback(
     (next: TabFilter) => {
+      if (optimisticSelectedTab === next) return;
+      playSelection().catch(() => undefined);
       setOptimisticSelectedTab(next);
       onTabPress(next);
     },
-    [onTabPress],
+    [onTabPress, optimisticSelectedTab],
   );
 
   return (

--- a/app/components/Views/SocialLeaderboard/components/TraderMuteChip.tsx
+++ b/app/components/Views/SocialLeaderboard/components/TraderMuteChip.tsx
@@ -208,11 +208,7 @@ const TraderMuteChip: React.FC<TraderMuteChipProps> = ({
             {
               width: diameter,
               height: diameter,
-              // Color marks the *active* state (getting alerts); muting is a
-              // calm, neutral preference so it falls back to the grey surface.
-              backgroundColor: isMuted
-                ? colors.background.muted
-                : colors.background.muted,
+              backgroundColor: colors.background.muted,
             },
           ]}
         >

--- a/app/components/Views/SocialLeaderboard/components/TraderMuteChip.tsx
+++ b/app/components/Views/SocialLeaderboard/components/TraderMuteChip.tsx
@@ -212,14 +212,14 @@ const TraderMuteChip: React.FC<TraderMuteChipProps> = ({
               // calm, neutral preference so it falls back to the grey surface.
               backgroundColor: isMuted
                 ? colors.background.muted
-                : colors.primary.muted,
+                : colors.background.muted,
             },
           ]}
         >
           <Icon
             name={IconName.Notification}
             size={iconSize}
-            color={isMuted ? IconColor.IconMuted : IconColor.PrimaryDefault}
+            color={isMuted ? IconColor.IconMuted : IconColor.IconDefault}
           />
           <Animated.View
             pointerEvents="none"


### PR DESCRIPTION
## **Description**

Two small Social AI polish items:

1. **Trader mute chip** — When a trader is unmuted, the bell chip now uses the neutral muted background and default icon color instead of the primary tint, matching the design intent for generic button.
2. **Leaderboard filter pills** — Tapping All / Tokens / Perps on the Weekly Top Traders screen now plays a selection haptic when the active filter changes (re-tapping the selected pill does not fire haptic).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Non-standard colors for the "Mute trader" icon button + missing haptics on pill selection

## **Manual testing steps**

```gherkin
Feature: Social AI leaderboard polish

  Scenario: unmuted trader bell uses neutral styling
    Given the user is on the Weekly Top Traders screen with trading signals enabled
    And a trader row shows an unmuted notification bell
    Then the bell chip has a muted grey background and default icon color

  Scenario: muted trader bell uses muted icon
    Given the user is on the Weekly Top Traders screen
    And a trader row shows a muted notification bell
    Then the bell chip has a muted grey background and muted icon color

  Scenario: filter pill selection haptic
    Given the user is on the Weekly Top Traders screen with perps enabled
    And the All filter pill is selected
    When the user taps the Tokens pill
    Then the device plays a selection haptic
    And the Tokens pill becomes selected
    When the user taps the Tokens pill again
    Then no additional selection haptic plays
```

## **Screenshots/Recordings**

### **Before**

<img width="657" height="663" alt="image" src="https://github.com/user-attachments/assets/afa1d919-bc6a-4618-9374-0c592f024f00" />

### **After**

<img width="696" height="683" alt="image" src="https://github.com/user-attachments/assets/ca6021b8-b322-4ec2-9a05-24622aebeafe" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)