### PR TITLE
fix: revert test assertions adapted to corrupted en.json translations

### DIFF
--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
@@ -260,7 +260,7 @@ describe('BatchSellFinalReviewModal', () => {
     expect(getByText('3,456.78 USDC')).toBeOnTheScreen();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
     expect(getByText('Network fee')).toBeOnTheScreen();
     expect(getByText('1.20 USDC')).toBeOnTheScreen();
@@ -360,7 +360,7 @@ describe('BatchSellFinalReviewModal', () => {
     expect(queryByText('UNI • 0.5% slippage')).toBeNull();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/BatchSellQuoteDetailsModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/BatchSellQuoteDetailsModal.test.tsx
@@ -182,7 +182,7 @@ describe('BatchSellQuoteDetailsModal', () => {
     expect(
       getByTestId(BatchSellQuoteDetailsModalSelectorsIDs.MINIMUM_RECEIVED_ROW),
     ).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 
@@ -312,7 +312,7 @@ describe('BatchSellQuoteDetailsModal', () => {
     expect(queryByText('UNI • 0.5% slippage')).toBeNull();
     expect(getByText('Total received')).toBeOnTheScreen();
     expect(getByText('7,638.23 USDC')).toBeOnTheScreen();
-    expect(getByText('Min. received:')).toBeOnTheScreen();
+    expect(getByText('Minimum received')).toBeOnTheScreen();
     expect(getByText('7,485.47 USDC')).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Predict/components/PredictActivityDetail/PredictActivityDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictActivityDetail/PredictActivityDetail.test.tsx
@@ -366,7 +366,7 @@ describe('PredictActivityDetails - Claim Activity', () => {
     });
 
     // Assert
-    expect(getByText('Total Net P&L')).toBeOnTheScreen();
+    expect(getByText('Total net P&L')).toBeOnTheScreen();
   });
 });
 


### PR DESCRIPTION
## Description

PR #32750 correctly restores `locales/languages/en.json` after a bad cherry-pick conflict resolution (`55c34128dcd`) had pulled in unrelated translation changes from `main`. However, two earlier commits on this release line had "fixed" unit tests by adapting their assertions to match the *corrupted* translation values instead of fixing the translation file itself:

- `07312dd1084` "fix unit test where trabslation was used" — changed 4 assertions from `'Minimum received'` to `'Min. received:'` in `BatchSellFinalReviewModal.test.tsx` and `BatchSellQuoteDetailsModal.test.tsx`
- `1ef4b039057` "fix unit test due to translation changes" — changed 1 assertion from `'Total net P&L'` to `'Total Net P&L'` in `PredictActivityDetail.test.tsx`

Now that `en.json` has been restored to the correct (pre-corruption) values by #32750, these 5 test assertions fail because they still expect the corrupted strings. This PR reverts those two commits so the tests match the restored translations again.

## Verification

- Checked all ~4,330 `strings('...')` keys used across `app/` against the restored `en.json`: no key used by code is missing.
- Diffed the restored `en.json` against the pre-corruption baseline: only the intentional `predict.reg_time_info` addition and key reordering/dedup remain — the translation restore itself is correct.
- Scanned every key touched by the bad cherry-pick for hardcoded literals in test/snapshot files: the only real dependents were the 3 test files fixed here.
- Ran all 13 test files whose assertions depend on the affected translation keys locally: all pass (307 tests, 13 suites).

## Changelog

CHANGELOG entry: Fixed unit tests that were incorrectly adapted to match corrupted English translations instead of the correct translations.

## Related issues

Follow-up to #32750.

## Manual testing steps

N/A — test-only change, no app behavior affected.

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

Made with [Cursor](https://cursor.com)