### PR TITLE
fix(confirmations): ignore injected Permit2 value sibling in revoke detection

### DIFF
--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.test.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.test.tsx
@@ -84,11 +84,14 @@ describe('PermitSimulation', () => {
   });
 
   it('ignores an injected "value": "0" sibling on a Permit2 PermitBatch and renders as a spending cap', async () => {
-    const { getByText, queryByText } = renderWithProvider(<PermitSimulation />, {
-      state: generateStateSignTypedData(
-        SignTypedDataMockType.BATCH_INJECTED_VALUE,
-      ),
-    });
+    const { getByText, queryByText } = renderWithProvider(
+      <PermitSimulation />,
+      {
+        state: generateStateSignTypedData(
+          SignTypedDataMockType.BATCH_INJECTED_VALUE,
+        ),
+      },
+    );
 
     expect(
       getByText(

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.test.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.test.tsx
@@ -83,6 +83,29 @@ describe('PermitSimulation', () => {
     await waitFor(() => expect(getByText('250')).toBeTruthy());
   });
 
+  it('ignores an injected "value": "0" sibling on a Permit2 PermitBatch and renders as a spending cap', async () => {
+    const { getByText, queryByText } = renderWithProvider(<PermitSimulation />, {
+      state: generateStateSignTypedData(
+        SignTypedDataMockType.BATCH_INJECTED_VALUE,
+      ),
+    });
+
+    expect(
+      getByText(
+        "You're giving the spender permission to spend this many tokens from your account.",
+      ),
+    ).toBeTruthy();
+    expect(getByText('Spending cap')).toBeTruthy();
+    expect(queryByText('Revoke')).toBeNull();
+    expect(
+      queryByText(
+        "You're removing someone's permission to spend tokens from your account.",
+      ),
+    ).toBeNull();
+
+    await waitFor(() => expect(getByText('1,461,501,637,3...')).toBeTruthy());
+  });
+
   it('renders for Permit NFTs', async () => {
     const { getByText } = renderWithProvider(<PermitSimulation />, {
       state: typedSignV4NFTConfirmationState,

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/typed-sign-permit/typed-sign-permit.tsx
@@ -9,7 +9,7 @@ import { safeToChecksumAddress } from '../../../../../../../../util/address';
 import { PrimaryType } from '../../../../../constants/signatures';
 import { useSignatureRequest } from '../../../../../hooks/signatures/useSignatureRequest';
 import {
-  isPermitDaiRevoke,
+  isPermitRevoke,
   parseAndNormalizeSignTypedData,
 } from '../../../../../utils/signature';
 import InfoRow from '../../../../UI/info-row';
@@ -77,6 +77,7 @@ const PermitSimulation = () => {
     message,
     message: { allowed, tokenId, value },
     primaryType,
+    types,
   } = parseAndNormalizeSignTypedData(msgData as string);
 
   const tokenDetails = extractTokenDetailsByPrimaryType(message, primaryType);
@@ -87,8 +88,13 @@ const PermitSimulation = () => {
     ? strings('confirm.simulation.label_change_type_permit_nft')
     : strings('confirm.simulation.label_change_type_permit');
 
-  const isDaiRevoke = isPermitDaiRevoke(verifyingContract, allowed, value);
-  const isRevoke = isDaiRevoke || value === '0';
+  const isRevoke = isPermitRevoke(
+    verifyingContract,
+    allowed,
+    value,
+    types,
+    primaryType,
+  );
 
   if (isRevoke) {
     labelChangeType = strings('confirm.simulation.label_change_type_revoke');

--- a/app/components/Views/confirmations/components/title/title.test.tsx
+++ b/app/components/Views/confirmations/components/title/title.test.tsx
@@ -131,6 +131,82 @@ describe('Confirm Title', () => {
     expect(queryByText('Remove permission')).toBeNull();
   });
 
+  it('renders spending cap title for a Permit2 PermitBatch with an injected "value": "0" sibling', () => {
+    const permitBatchInjectedValueData = JSON.stringify({
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+        PermitBatch: [
+          { name: 'details', type: 'PermitDetails[]' },
+          { name: 'spender', type: 'address' },
+          { name: 'sigDeadline', type: 'uint256' },
+        ],
+        PermitDetails: [
+          { name: 'token', type: 'address' },
+          { name: 'amount', type: 'uint160' },
+          { name: 'expiration', type: 'uint48' },
+          { name: 'nonce', type: 'uint48' },
+        ],
+      },
+      primaryType: 'PermitBatch',
+      domain: {
+        name: 'Permit2',
+        chainId: 1,
+        verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+      },
+      message: {
+        details: [
+          {
+            token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            amount: '1461501637330902918203684832716283019655932542975',
+            expiration: '281474976710655',
+            nonce: 0,
+          },
+        ],
+        spender: '0x4444444444444444444444444444444444444444',
+        sigDeadline: '281474976710655',
+        // Malicious undeclared sibling — stripped from the signed digest.
+        value: '0',
+      },
+    });
+
+    const state = merge({}, typedSignV4ConfirmationState, {
+      engine: {
+        backgroundState: {
+          ApprovalController: {
+            pendingApprovals: {
+              [typedSignRequestId]: {
+                requestData: {
+                  data: permitBatchInjectedValueData,
+                },
+              },
+            },
+          },
+          SignatureController: {
+            signatureRequests: {
+              [typedSignRequestId]: {
+                messageParams: {
+                  data: permitBatchInjectedValueData,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const { getByText, queryByText } = renderWithProvider(<Title />, {
+      state,
+    });
+
+    expect(getByText('Spending cap request')).toBeTruthy();
+    expect(queryByText('Remove permission')).toBeNull();
+  });
+
   it('renders the title and subtitle for a permit NFT signature', () => {
     const { getByText } = renderWithProvider(<Title />, {
       state: typedSignV4NFTConfirmationState,

--- a/app/components/Views/confirmations/components/title/title.tsx
+++ b/app/components/Views/confirmations/components/title/title.tsx
@@ -32,7 +32,7 @@ import {
   useApproveTransactionData,
 } from '../../hooks/useApproveTransactionData';
 import {
-  isPermitDaiRevoke,
+  isPermitRevoke,
   isRecognizedPermit,
   isSIWESignatureRequest,
   parseAndNormalizeSignTypedDataFromSignatureRequest,
@@ -112,6 +112,7 @@ const getTitleAndSubTitle = (
           parseAndNormalizeSignTypedDataFromSignatureRequest(signatureRequest);
         const { allowed, tokenId, value } = parsedData.message ?? {};
         const { verifyingContract } = parsedData.domain ?? {};
+        const { types, primaryType } = parsedData;
 
         const isERC721Permit = tokenId !== undefined;
         if (isERC721Permit) {
@@ -121,12 +122,13 @@ const getTitleAndSubTitle = (
           };
         }
 
-        const isDaiRevoke = isPermitDaiRevoke(
+        const isRevoke = isPermitRevoke(
           verifyingContract,
           allowed,
           value,
+          types,
+          primaryType,
         );
-        const isRevoke = isDaiRevoke || value === '0';
 
         if (isRevoke) {
           return {

--- a/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.test.ts
@@ -13,7 +13,7 @@ import { useSignatureRequest } from '../signatures/useSignatureRequest';
 import {
   isRecognizedPermit,
   parseAndNormalizeSignTypedData,
-  isPermitDaiRevoke,
+  isPermitRevoke,
 } from '../../utils/signature';
 import { extractSpenderFromApprovalData } from '../../../../../lib/address-scanning/address-scan-util';
 
@@ -36,7 +36,7 @@ jest.mock('../signatures/useSignatureRequest', () => ({
 jest.mock('../../utils/signature', () => ({
   isRecognizedPermit: jest.fn(),
   parseAndNormalizeSignTypedData: jest.fn(),
-  isPermitDaiRevoke: jest.fn(),
+  isPermitRevoke: jest.fn(),
 }));
 
 jest.mock('../../../../../lib/address-scanning/address-scan-util', () => ({
@@ -57,7 +57,7 @@ describe('useAddressTrustSignalAlerts', () => {
   const mockParseAndNormalizeSignTypedData = jest.mocked(
     parseAndNormalizeSignTypedData,
   );
-  const mockIsPermitDaiRevoke = jest.mocked(isPermitDaiRevoke);
+  const mockIsPermitRevoke = jest.mocked(isPermitRevoke);
   const mockExtractSpender = jest.mocked(extractSpenderFromApprovalData);
 
   beforeEach(() => {
@@ -81,7 +81,7 @@ describe('useAddressTrustSignalAlerts', () => {
       domain: { verifyingContract: '0x0' },
       message: {},
     });
-    mockIsPermitDaiRevoke.mockReturnValue(false);
+    mockIsPermitRevoke.mockReturnValue(false);
     mockExtractSpender.mockReturnValue(undefined);
   });
 
@@ -781,13 +781,14 @@ describe('useAddressTrustSignalAlerts', () => {
         },
       }) as Parameters<typeof renderHookWithProvider>[1];
 
-    it('returns no alerts for permit signature with value "0" (string)', () => {
+    it('suppresses alerts when the permit is classified as a revoke', () => {
       mockUseSignatureRequest.mockReturnValue(mockSignatureRequest);
       mockIsRecognizedPermit.mockReturnValue(true);
       mockParseAndNormalizeSignTypedData.mockReturnValue({
         domain: { verifyingContract: '0xTokenAddress' },
         message: { value: '0' },
       });
+      mockIsPermitRevoke.mockReturnValue(true);
 
       const { result } = renderHookWithProvider(
         () => useAddressTrustSignalAlerts(),
@@ -797,37 +798,71 @@ describe('useAddressTrustSignalAlerts', () => {
       expect(result.current).toEqual([]);
     });
 
-    it('returns no alerts for permit signature with value 0 (number)', () => {
+    it('forwards the parsed types and primaryType to isPermitRevoke', () => {
       mockUseSignatureRequest.mockReturnValue(mockSignatureRequest);
       mockIsRecognizedPermit.mockReturnValue(true);
-      mockParseAndNormalizeSignTypedData.mockReturnValue({
+      const parsed = {
         domain: { verifyingContract: '0xTokenAddress' },
-        message: { value: 0 },
-      });
+        message: { allowed: false, value: '0' },
+        types: { Permit: [{ name: 'value', type: 'uint256' }] },
+        primaryType: 'Permit',
+      };
+      mockParseAndNormalizeSignTypedData.mockReturnValue(parsed);
 
-      const { result } = renderHookWithProvider(
+      renderHookWithProvider(
         () => useAddressTrustSignalAlerts(),
         createMaliciousAddressState(),
       );
 
-      expect(result.current).toEqual([]);
+      expect(mockIsPermitRevoke).toHaveBeenCalledWith(
+        '0xTokenAddress',
+        false,
+        '0',
+        parsed.types,
+        'Permit',
+      );
     });
 
-    it('returns no alerts for DAI permit with allowed: false', () => {
+    it('does not suppress alerts for a Permit2 PermitBatch with an injected "value": "0" sibling', () => {
+      mockIsPermitRevoke.mockImplementation(
+        jest.requireActual('../../utils/signature').isPermitRevoke,
+      );
       mockUseSignatureRequest.mockReturnValue(mockSignatureRequest);
       mockIsRecognizedPermit.mockReturnValue(true);
       mockParseAndNormalizeSignTypedData.mockReturnValue({
-        domain: { verifyingContract: '0xDAIAddress' },
-        message: { allowed: false, value: '100' },
+        domain: {
+          verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+        },
+        message: {
+          details: [
+            {
+              token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              amount: '1461501637330902918203684832716283019655932542975',
+            },
+          ],
+          spender: '0x4444444444444444444444444444444444444444',
+          // Injected sibling not declared in PermitBatch.
+          value: '0',
+        },
+        types: {
+          PermitBatch: [
+            { name: 'details', type: 'PermitDetails[]' },
+            { name: 'spender', type: 'address' },
+            { name: 'sigDeadline', type: 'uint256' },
+          ],
+        },
+        primaryType: 'PermitBatch',
       });
-      mockIsPermitDaiRevoke.mockReturnValue(true);
 
       const { result } = renderHookWithProvider(
         () => useAddressTrustSignalAlerts(),
         createMaliciousAddressState(),
       );
 
-      expect(result.current).toEqual([]);
+      expect(result.current.length).toBe(1);
+      expect(result.current[0].key).toBe(
+        `${AlertKeys.AddressTrustSignalMalicious}_${RowAlertKey.FromToAddress}`,
+      );
     });
 
     it('returns alerts for permit signature with non-zero value', () => {

--- a/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
@@ -16,7 +16,7 @@ import { useApproveTransactionData } from '../useApproveTransactionData';
 import { useSignatureRequest } from '../signatures/useSignatureRequest';
 import {
   isRecognizedPermit,
-  isPermitDaiRevoke,
+  isPermitRevoke,
   parseAndNormalizeSignTypedData,
 } from '../../utils/signature';
 
@@ -45,6 +45,8 @@ export function useAddressTrustSignalAlerts(): Alert[] {
       const {
         domain: { verifyingContract },
         message: { allowed, tokenId, value },
+        types,
+        primaryType,
       } = parseAndNormalizeSignTypedData(msgData);
 
       const isNFTPermit = tokenId !== undefined;
@@ -52,10 +54,13 @@ export function useAddressTrustSignalAlerts(): Alert[] {
         return false;
       }
 
-      const isDaiRevoke = isPermitDaiRevoke(verifyingContract, allowed, value);
-      const isZeroValueRevoke = value === '0' || value === 0;
-
-      return isDaiRevoke || isZeroValueRevoke;
+      return isPermitRevoke(
+        verifyingContract,
+        allowed,
+        value,
+        types,
+        primaryType,
+      );
     } catch {
       return false;
     }

--- a/app/components/Views/confirmations/utils/signature.test.ts
+++ b/app/components/Views/confirmations/utils/signature.test.ts
@@ -258,7 +258,13 @@ describe('Signature Utils', () => {
 
     it('still classifies DAI revoke via the allowed flag regardless of value schema', () => {
       expect(
-        isPermitRevoke(TOKEN_ADDRESS.DAI, false, undefined, undefined, 'Permit'),
+        isPermitRevoke(
+          TOKEN_ADDRESS.DAI,
+          false,
+          undefined,
+          undefined,
+          'Permit',
+        ),
       ).toBe(true);
     });
 

--- a/app/components/Views/confirmations/utils/signature.test.ts
+++ b/app/components/Views/confirmations/utils/signature.test.ts
@@ -1,6 +1,7 @@
 import {
   isPermitDaiRevoke,
   isPermitDaiUnlimited,
+  isPermitRevoke,
   parseAndNormalizeSignTypedData,
   isRecognizedPermit,
   isTypedSignV3V4Request,
@@ -197,6 +198,72 @@ describe('Signature Utils', () => {
 
     it('classifies DAI permit as revoke when allowed is an empty string', () => {
       expect(isPermitDaiRevoke(TOKEN_ADDRESS.DAI, '')).toBe(true);
+    });
+  });
+
+  describe('isPermitRevoke', () => {
+    const PERMIT2_CONTRACT = '0x000000000022d473030f116ddee9f6b43ac78ba3';
+    const permitBatchTypes = {
+      PermitBatch: [
+        { name: 'details', type: 'PermitDetails[]' },
+        { name: 'spender', type: 'address' },
+        { name: 'sigDeadline', type: 'uint256' },
+      ],
+    };
+    const eip2612PermitTypes = {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    };
+
+    it('does not classify a Permit2 PermitBatch as revoke when an undeclared "value" sibling is "0"', () => {
+      expect(
+        isPermitRevoke(
+          PERMIT2_CONTRACT,
+          undefined,
+          '0',
+          permitBatchTypes,
+          'PermitBatch',
+        ),
+      ).toBe(false);
+    });
+
+    it('classifies an EIP-2612 Permit with a declared zero value as revoke', () => {
+      expect(
+        isPermitRevoke(
+          '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          undefined,
+          '0',
+          eip2612PermitTypes,
+          'Permit',
+        ),
+      ).toBe(true);
+    });
+
+    it('does not classify a declared non-zero value as revoke', () => {
+      expect(
+        isPermitRevoke(
+          '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+          undefined,
+          '3000',
+          eip2612PermitTypes,
+          'Permit',
+        ),
+      ).toBe(false);
+    });
+
+    it('still classifies DAI revoke via the allowed flag regardless of value schema', () => {
+      expect(
+        isPermitRevoke(TOKEN_ADDRESS.DAI, false, undefined, undefined, 'Permit'),
+      ).toBe(true);
+    });
+
+    it('ignores the value branch when types or primaryType are missing', () => {
+      expect(isPermitRevoke(PERMIT2_CONTRACT, undefined, '0')).toBe(false);
     });
   });
 

--- a/app/components/Views/confirmations/utils/signature.ts
+++ b/app/components/Views/confirmations/utils/signature.ts
@@ -108,9 +108,7 @@ const isSignedTypedDataField = (
 ) =>
   Boolean(
     primaryType &&
-      types?.[primaryType]?.some(
-        (field: BaseType) => field.name === fieldName,
-      ),
+      types?.[primaryType]?.some((field: BaseType) => field.name === fieldName),
   );
 
 /**

--- a/app/components/Views/confirmations/utils/signature.ts
+++ b/app/components/Views/confirmations/utils/signature.ts
@@ -98,6 +98,48 @@ export const isPermitDaiRevoke = (
 };
 
 /**
+ * Returns true when `fieldName` is declared in `primaryType`'s EIP-712 type
+ * schema. Only declared fields are included in the signed digest.
+ */
+const isSignedTypedDataField = (
+  types: Record<string, BaseType[]> | undefined,
+  primaryType: string | undefined,
+  fieldName: string,
+) =>
+  Boolean(
+    primaryType &&
+      types?.[primaryType]?.some(
+        (field: BaseType) => field.name === fieldName,
+      ),
+  );
+
+/**
+ * Determines whether a recognized Permit signature is a revoke request, used to
+ * switch the confirmation UI to "Remove permission" / "Revoke" labels.
+ *
+ * The zero-`value` branch is only honored when `value` is a declared field of
+ * the message's primary type. Permit2 batch/single types have no top-level
+ * `value` field; a malicious dapp can inject a `value: "0"` sibling that
+ * survives JSON parsing but is stripped from the signed EIP-712 digest.
+ * Trusting it would spoof a protective "Remove permission" screen while the
+ * user actually grants a max-allowance, so undeclared siblings are ignored.
+ */
+export const isPermitRevoke = (
+  verifyingContract: string,
+  allowed?: number | string | boolean | null,
+  value?: number | string | BigNumber | null,
+  types?: Record<string, BaseType[]>,
+  primaryType?: string,
+) => {
+  const isDaiRevoke = isPermitDaiRevoke(verifyingContract, allowed, value);
+  const isZeroValueRevoke =
+    isSignedTypedDataField(types, primaryType, 'value') &&
+    coerceNumberishToBigInt(value) === BigInt(0);
+
+  return isDaiRevoke || isZeroValueRevoke;
+};
+
+/**
  * Returns true if the request is Typed Sign V3 or V4 request
  *
  * @param signatureRequest - The signature request to check

--- a/app/util/test/confirm-data-helpers.ts
+++ b/app/util/test/confirm-data-helpers.ts
@@ -742,48 +742,50 @@ export enum SignTypedDataMockType {
   BATCH_INJECTED_VALUE = 'BATCH_INJECTED_VALUE',
 }
 
+const permitBatchData = {
+  types: {
+    EIP712Domain: mockTypeDefEIP712Domain,
+    PermitBatch: [
+      { name: 'details', type: 'PermitDetails[]' },
+      { name: 'spender', type: 'address' },
+      { name: 'sigDeadline', type: 'uint256' },
+    ],
+    PermitDetails: [
+      { name: 'token', type: 'address' },
+      { name: 'amount', type: 'uint160' },
+      { name: 'expiration', type: 'uint48' },
+      { name: 'nonce', type: 'uint48' },
+    ],
+  },
+  domain: {
+    name: 'Permit2',
+    chainId: '1',
+    version: '1',
+    verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+  },
+  primaryType: 'PermitBatch',
+  message: {
+    details: [
+      {
+        token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        amount: '1461501637330902918203684832716283019655932542975',
+        expiration: '1722887542',
+        nonce: '5',
+      },
+      {
+        token: '0xb0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        amount: '250',
+        expiration: '1722887642',
+        nonce: '6',
+      },
+    ],
+    spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+    sigDeadline: '1720297342',
+  },
+};
+
 const SIGN_TYPE_DATA: Record<SignTypedDataMockType, string> = {
-  [SignTypedDataMockType.BATCH]: JSON.stringify({
-    types: {
-      EIP712Domain: mockTypeDefEIP712Domain,
-      PermitBatch: [
-        { name: 'details', type: 'PermitDetails[]' },
-        { name: 'spender', type: 'address' },
-        { name: 'sigDeadline', type: 'uint256' },
-      ],
-      PermitDetails: [
-        { name: 'token', type: 'address' },
-        { name: 'amount', type: 'uint160' },
-        { name: 'expiration', type: 'uint48' },
-        { name: 'nonce', type: 'uint48' },
-      ],
-    },
-    domain: {
-      name: 'Permit2',
-      chainId: '1',
-      version: '1',
-      verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
-    },
-    primaryType: 'PermitBatch',
-    message: {
-      details: [
-        {
-          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          amount: '1461501637330902918203684832716283019655932542975',
-          expiration: '1722887542',
-          nonce: '5',
-        },
-        {
-          token: '0xb0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          amount: '250',
-          expiration: '1722887642',
-          nonce: '6',
-        },
-      ],
-      spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
-      sigDeadline: '1720297342',
-    },
-  }),
+  [SignTypedDataMockType.BATCH]: JSON.stringify(permitBatchData),
   [SignTypedDataMockType.DAI]: JSON.stringify({
     domain: {
       name: 'Dai Stablecoin',
@@ -810,47 +812,13 @@ const SIGN_TYPE_DATA: Record<SignTypedDataMockType, string> = {
       allowed: false,
     },
   }),
+  // Reuses the canonical PermitBatch payload with a malicious `value: "0"`
+  // sibling injected at the message root — not declared in PermitBatch, so it
+  // is stripped from the signed digest but present in the raw payload.
   [SignTypedDataMockType.BATCH_INJECTED_VALUE]: JSON.stringify({
-    types: {
-      EIP712Domain: mockTypeDefEIP712Domain,
-      PermitBatch: [
-        { name: 'details', type: 'PermitDetails[]' },
-        { name: 'spender', type: 'address' },
-        { name: 'sigDeadline', type: 'uint256' },
-      ],
-      PermitDetails: [
-        { name: 'token', type: 'address' },
-        { name: 'amount', type: 'uint160' },
-        { name: 'expiration', type: 'uint48' },
-        { name: 'nonce', type: 'uint48' },
-      ],
-    },
-    domain: {
-      name: 'Permit2',
-      chainId: '1',
-      version: '1',
-      verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
-    },
-    primaryType: 'PermitBatch',
+    ...permitBatchData,
     message: {
-      details: [
-        {
-          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          amount: '1461501637330902918203684832716283019655932542975',
-          expiration: '1722887542',
-          nonce: '5',
-        },
-        {
-          token: '0xb0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-          amount: '250',
-          expiration: '1722887642',
-          nonce: '6',
-        },
-      ],
-      spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
-      sigDeadline: '1720297342',
-      // Malicious sibling key — not declared in PermitBatch, stripped from the
-      // signed digest, but present in the raw payload.
+      ...permitBatchData.message,
       value: '0',
     },
   }),

--- a/app/util/test/confirm-data-helpers.ts
+++ b/app/util/test/confirm-data-helpers.ts
@@ -734,6 +734,12 @@ export const stakingClaimConfirmationState = merge(
 export enum SignTypedDataMockType {
   BATCH = 'BATCH',
   DAI = 'DAI',
+  // Permit2 PermitBatch max-allowance grant with a malicious `value: "0"`
+  // sibling injected at the message root. The field is not part of the
+  // PermitBatch schema, so it is stripped from the signed digest but could be
+  // read by rendering hooks to spoof a "Remove permission" / "Revoke" UI.
+  // See HackerOne #3714813.
+  BATCH_INJECTED_VALUE = 'BATCH_INJECTED_VALUE',
 }
 
 const SIGN_TYPE_DATA: Record<SignTypedDataMockType, string> = {
@@ -802,6 +808,50 @@ const SIGN_TYPE_DATA: Record<SignTypedDataMockType, string> = {
       nonce: 0,
       expiry: 0,
       allowed: false,
+    },
+  }),
+  [SignTypedDataMockType.BATCH_INJECTED_VALUE]: JSON.stringify({
+    types: {
+      EIP712Domain: mockTypeDefEIP712Domain,
+      PermitBatch: [
+        { name: 'details', type: 'PermitDetails[]' },
+        { name: 'spender', type: 'address' },
+        { name: 'sigDeadline', type: 'uint256' },
+      ],
+      PermitDetails: [
+        { name: 'token', type: 'address' },
+        { name: 'amount', type: 'uint160' },
+        { name: 'expiration', type: 'uint48' },
+        { name: 'nonce', type: 'uint48' },
+      ],
+    },
+    domain: {
+      name: 'Permit2',
+      chainId: '1',
+      version: '1',
+      verifyingContract: '0x000000000022d473030f116ddee9f6b43ac78ba3',
+    },
+    primaryType: 'PermitBatch',
+    message: {
+      details: [
+        {
+          token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          amount: '1461501637330902918203684832716283019655932542975',
+          expiration: '1722887542',
+          nonce: '5',
+        },
+        {
+          token: '0xb0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          amount: '250',
+          expiration: '1722887642',
+          nonce: '6',
+        },
+      ],
+      spender: '0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad',
+      sigDeadline: '1720297342',
+      // Malicious sibling key — not declared in PermitBatch, stripped from the
+      // signed digest, but present in the raw payload.
+      value: '0',
     },
   }),
 };


### PR DESCRIPTION
## **Description**

Fixes a confirmation-UI spoofing issue in Permit2 typed-data signing.

**Reason for the change:** When rendering a Permit2 `PermitBatch`/`PermitSingle` signature request, three rendering hooks read `message.value` directly from the raw wire payload and treated `value === '0'` (or `=== 0`) as a "revoke". Because a canonical Permit2 `PermitBatch`/`PermitSingle` has no top-level `value` field in its EIP-712 type schema, a malicious dapp could inject a `value: "0"` sibling that survives `JSON.parse` but is stripped from the signed digest during EIP-712 type-walk. This flipped the confirmation title to "Remove permission" and the estimated-changes section to "Revoke" while the user actually signed a max-allowance (`uint160.max`) grant, and could also suppress address trust-signal (Blockaid) alerts.

**Solution:** Revoke detection is centralized in a new `isPermitRevoke` helper (`utils/signature.ts`) that only honors the zero-`value` branch when `value` is a **declared field** of the message's primary type (checked against the EIP-712 `types` schema). Undeclared sibling keys are ignored. The three affected call sites now delegate to it:

- `components/title/title.tsx` — main confirmation title
- `.../simulation/typed-sign-permit/typed-sign-permit.tsx` — Estimated changes section
- `hooks/alerts/useAddressTrustSignalAlerts.ts` — trust-signal alert suppression

Legitimate signatures are unaffected: EIP-2612 `Permit` declares `value`, so a genuine `value: 0` still renders as a revoke; DAI revoke detection (via `allowed`) is unchanged. This is a UI-only change — the signed digest is byte-identical to baseline.

## **Changelog**

CHANGELOG entry: Fixed a confirmation-UI issue where an injected `value` field in a Permit2 signature request could display a "Remove permission" screen while granting a token allowance.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1625

## **Manual testing steps**

```gherkin
Feature: Permit2 signature confirmation UI

  Scenario: dapp injects a value:"0" sibling into a Permit2 PermitBatch max-allowance request
    Given a wallet on Ethereum Mainnet with Blockaid enabled
    When a dapp requests eth_signTypedData_v4 for a Permit2 PermitBatch granting max allowance
      And the message includes an undeclared "value": "0" sibling key
    Then the confirmation title shows "Spending cap request" (not "Remove permission")
      And the Estimated changes section shows "Spending cap" and "Unlimited" (not "Revoke")
      And address trust-signal alerts are not suppressed

  Scenario: legitimate EIP-2612 Permit revoke
    Given a wallet on Ethereum Mainnet
    When a dapp requests an EIP-2612 Permit with a declared value of 0
    Then the confirmation title shows "Remove permission"
```

## **Screenshots/Recordings**

### **Before**

N/A — UI-only logic change covered by unit and component tests.

### **After**

N/A — UI-only logic change covered by unit and component tests.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permit confirmation labeling and Blockaid alert suppression—security-sensitive UI paths—but behavior is narrowly scoped, well-tested, and does not change signing.
> 
> **Overview**
> Fixes **confirmation UI spoofing** for Permit2 typed-data signing: a dapp could add an undeclared `value: "0"` on `PermitBatch`/`PermitSingle` payloads so the wallet showed **Remove permission** / **Revoke** and hid trust alerts while the signed digest still granted max allowance.
> 
> **`isPermitRevoke`** in `signature.ts` centralizes revoke detection. Zero `value` counts as revoke only when `value` is a **declared** EIP-712 field on the message `primaryType`; undeclared JSON siblings are ignored. DAI revoke via `allowed` is unchanged.
> 
> **Title**, permit **simulation**, and **address trust-signal alert suppression** now call `isPermitRevoke` with parsed `types` and `primaryType` instead of treating any `message.value === '0'` as revoke. Tests add a `BATCH_INJECTED_VALUE` mock (HackerOne #3714813).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef8554faccc99be3742269b3f16520e52ede56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->