### PR TITLE
fix: disable gas sponsorship for hw wallets cp-8.2.0

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -910,6 +910,74 @@ describe('useTransactionConfirm', () => {
     });
   });
 
+  describe('isExternalSign revert for unsupported accounts', () => {
+    // Regression: on gas-sponsorship chains (e.g. Monad, SEI) the
+    // TransactionController sets `isExternalSign = true` from
+    // `isGasFeeSponsored` during gas simulation regardless of account type.
+    // For hardware wallets no relay is eligible (HW cannot hold an EIP-7702
+    // delegation), so leaving the flag set skips device signing and an empty
+    // `0x` payload reaches eth_sendRawTransaction. The fix reverts the flag
+    // whenever gasless sponsorship cannot apply for the account/chain.
+
+    it('reverts isExternalSign when gasless is unsupported (hardware wallet on sponsored chain)', async () => {
+      isHardwareAccountMock.mockReturnValue(true);
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSupported: false,
+        isSmartTransaction: false,
+        pending: false,
+      });
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        chainId: CHAIN_ID_MOCK,
+        isGasFeeSponsored: true,
+        isExternalSign: true,
+        txParams: { from: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' },
+      } as unknown as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.objectContaining({
+          isExternalSign: false,
+          isGasFeeSponsored: false,
+        }),
+      });
+    });
+
+    it('keeps isExternalSign when gasless is supported (EOA relay path intact)', async () => {
+      isHardwareAccountMock.mockReturnValue(false);
+      useIsGaslessSupportedMock.mockReturnValue({
+        isSupported: true,
+        isSmartTransaction: true,
+        pending: false,
+      });
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        chainId: CHAIN_ID_MOCK,
+        isGasFeeSponsored: true,
+        isExternalSign: true,
+        txParams: { from: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' },
+      } as unknown as TransactionMeta);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.objectContaining({
+          isExternalSign: true,
+          isGasFeeSponsored: true,
+        }),
+      });
+    });
+  });
+
   describe('fiat payment branching', () => {
     it('calls onFiatConfirm and returns early when fiat is selected and no orderId', async () => {
       jest.mocked(useFiatConfirm).mockReturnValue({

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -117,13 +117,22 @@ export function useTransactionConfirm() {
 
       const updatedMetadata = cloneDeep(transactionMetadata);
 
-      // Ensure the persisted `isGasFeeSponsored` flag reflects whether gasless
-      // is actually supported (e.g. HW wallets don't support gasless, so the
-      // flag must be cleared so the activity list does not show "Paid by MetaMask").
-      updatedMetadata.isGasFeeSponsored = shouldApplyGasFeeSponsorship({
+      // Sponsorship eligibility is account-specific (HW wallets are excluded),
+      // unlike the controller's account-agnostic simulation result.
+      const isGaslessEligible = shouldApplyGasFeeSponsorship({
         transactionMeta: transactionMetadata,
         isGaslessSupported,
       });
+      updatedMetadata.isGasFeeSponsored = isGaslessEligible;
+
+      // The controller sets `isExternalSign` from `isGasFeeSponsored` for any
+      // account. When gasless isn't eligible, revert it or signing is skipped
+      // and an empty `'0x'` reaches `eth_sendRawTransaction`.
+      const isExternalSignStale =
+        Boolean(transactionMetadata.isExternalSign) && !isGaslessEligible;
+      if (isExternalSignStale) {
+        updatedMetadata.isExternalSign = false;
+      }
 
       if (isGaslessSupportedSTX) {
         handleSmartTransaction(updatedMetadata);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

On gas-sponsorship networks, Monad, hardware-wallet transactions fail
instantly with no device prompt:

`eth_sendRawTransaction: Invalid parameters: transaction could not be decoded: not enough input to decode`

The `TransactionController` sets `isExternalSign = true` whenever a transaction
is gas-sponsored, regardless of account type. That flag skips the signing step,
so the device is never prompted and `rawTx` is never produced. EOA accounts are
unaffected because the EIP-7702 relay submits on their behalf; hardware wallets
cannot hold a 7702 delegation, so no relay catches the publish and an empty
payload is sent.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disable gas sponsorship for hw wallets

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1973

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirm metadata flags that gate signing vs relay publish; wrong logic could break gasless EOAs or reintroduce HW send failures, though scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **hardware wallet sends failing instantly** on gas-sponsorship chains (e.g. Monad) when simulation leaves `isExternalSign` and `isGasFeeSponsored` set even though the account cannot use gasless relay.
> 
> On confirm, `useTransactionConfirm` now derives **account-aware** gasless eligibility via `shouldApplyGasFeeSponsorship` (same helper used for clearing sponsored UI flags). When eligibility is false but `isExternalSign` was already true from the controller, it **clears `isExternalSign`** (and keeps `isGasFeeSponsored` aligned) so signing runs on-device instead of submitting an empty raw tx. Eligible EOAs still keep the external-sign / relay path unchanged.
> 
> Regression tests cover HW on a sponsored chain (flags reverted) and supported gasless EOAs (flags preserved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0853805da0624882f4faf7fa60bafc16e947dd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->