### PR TITLE
fix: foreground push notifications (iOS)

### DIFF
--- a/ios/MetaMask-Bridging-Header.h
+++ b/ios/MetaMask-Bridging-Header.h
@@ -9,6 +9,10 @@
 // Firebase Messaging — exposes FIRMessaging to Swift (see AppDelegate.swift willPresent).
 #import <FirebaseMessaging/FirebaseMessaging.h>
 
+// Notifee UNUserNotificationCenter singleton — used in AppDelegate.swift didReceive to
+// forward taps on Notifee-created notifications so onForegroundEvent(PRESS) fires in JS.
+#import <RNNotifee/NotifeeCore+UNUserNotificationCenter.h>
+
 // Thin C wrappers around BrazeReactBridge / BrazeReactUtils.
 // Implemented in BrazeHelper.mm.
 // Uses id (AnyObject in Swift) to avoid importing BrazeKit-Swift.h here,

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -117,16 +117,22 @@ class AppDelegate: ExpoAppDelegate {
 
     let superResult = super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
-    // Claim UNUserNotificationCenterDelegate AFTER all SDK initializations so we are
-    // stored as Notifee's _originalDelegate when its JS-side observe() runs asynchronously.
-    // Notifee (dispatch_once) will then take the slot, keeping us as its forwarding target:
-    //   - Notifee notifications → Notifee handles (fires PRESS events to JS)
-    //   - FCM notifications → Notifee forwards willPresent/didReceive to us
-    // Do NOT reassert self as delegate after this point (e.g. in applicationDidBecomeActive)
-    // or Notifee's forwarding chain is silently broken on every foreground entry.
+    // Claim UNUserNotificationCenterDelegate AFTER all SDK initializations.
+    // Braze (push.automation=true) and Notifee both try to set themselves as delegate
+    // during startup; we must win so our willPresent forwards to Firebase and triggers
+    // messaging().onMessage() in JS. We reassert on every foreground entry (see below).
     UNUserNotificationCenter.current().delegate = self
 
     return superResult
+  }
+
+  override func applicationDidBecomeActive(_ application: UIApplication) {
+    super.applicationDidBecomeActive(application)
+    // Re-assert our delegate on every foreground entry so Braze/Notifee cannot reclaim
+    // it asynchronously. Notifee tap forwarding is handled explicitly in didReceive
+    // (via NotifeeCoreUNUserNotificationCenter.instance()) rather than through Notifee's
+    // own delegate chain, so holding this slot does not break Notifee press events.
+    UNUserNotificationCenter.current().delegate = self
   }
 
   override func application(
@@ -196,15 +202,29 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
   }
 
   // Called when the user taps a notification or one of its action buttons.
-  // Forward to Braze so it can track opens and handle Braze-originated deep links.
   func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse,
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
-    if AppDelegate.braze?.notifications.handleUserNotification(response: response, withCompletionHandler: completionHandler) != true {
-      completionHandler()
+    let userInfo = response.notification.request.content.userInfo
+
+    // Notifee-created notification: forward to Notifee so onForegroundEvent(PRESS) fires.
+    // We own the delegate (see applicationDidBecomeActive), so Notifee never receives this
+    // through its own delegate chain — explicit forwarding is required.
+    if userInfo["__notifee_notification"] != nil {
+      NotifeeCoreUNUserNotificationCenter.instance().userNotificationCenter(
+        center, didReceive: response, withCompletionHandler: completionHandler)
+      return
     }
+
+    // Braze-originated notification: let Braze track the open and handle deep links.
+    if AppDelegate.braze?.notifications.handleUserNotification(
+      response: response, withCompletionHandler: completionHandler) == true {
+      return
+    }
+
+    completionHandler()
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In the previous [commit](https://github.com/MetaMask/metamask-mobile/pull/32100/changes/b2599c48129a69b1ae0a211f280ee0103750d60e) I removed this override, assuming Notifee's internal forwarding chain would handle FCM notifications once Notifee held the `UNUserNotificationCenter` delegate. This broke foreground notification display - if Notifee's `_originalDelegate` isn't captured correctly (a timing-sensitive `dispatch_once`), non-Notifee notifications silently drop.

> [!NOTE]
> It was harder to notice, because this is a race condition and sometimes it works - sometimes it's not. When I was testing after removeal it was working and I thought that this code can be safely removed.

In this PR I restored the re-assertion of self as delegate on every foreground entry so our `willPresent` is always called, which is what triggers `Messaging.messaging().appDidReceiveMessage()` -> `messaging().onMessage()` in JS.

But I didn't simply revert the commit. Since we now always win the delegate slot, Notifee never receives `didReceive` through its own chain. Tapping a Notifee-displayed notification would silently do nothing - `onForegroundEvent(EventType.PRESS)` never fired, so press actions like `OPEN_NOTIFICATIONS_VIEW` would be broken on iOS. To fix that I added an explicit check for `__notifee_notification` in `userInfo:` when present, the response is forwarded directly to `NotifeeCoreUNUserNotificationCenter.instance()`, Notifee's own singleton.

> [!NOTE]
> The testable build is https://github.com/MetaMask/metamask-mobile/actions/runs/28657540465. `8.3.0`/`5869`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: display foreground notifications on iOS

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-32

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: iOS notifications in foreground

  Scenario: user has an opened/foregrounded iOS app and receives a notification
    Given iOS app is currently opened and the push notification has been sent

    When user interacts with the iOS app
    Then he should see a system iOS popup with notification metadata
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="603" height="1311" alt="IMG_3899" src="https://github.com/user-attachments/assets/2ef4c2f7-aeec-4bd9-88fb-d4ae3691cf52" />

### **After**

<!-- [screenshots/recordings] -->

<img width="603" height="1311" alt="Screenshot 2026-06-25 at 13 38 08" src="https://github.com/user-attachments/assets/7802ca6b-723f-420a-8fc9-c20696f18c5e" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core iOS push delegate ordering and tap routing across Firebase, Braze, and Notifee; regressions could affect foreground display, JS `onMessage`, or notification tap/deep-link behavior.
> 
> **Overview**
> Fixes iOS foreground push handling when **Braze** and **Notifee** compete for `UNUserNotificationCenter` delegate ownership.
> 
> The app **re-asserts** `AppDelegate` as the notification center delegate on every **`applicationDidBecomeActive`**, replacing the prior rule that forbade reasserting (which let Braze/Notifee steal the slot and break Firebase `willPresent` → `messaging().onMessage()` in JS). **`didReceive`** now routes taps explicitly: Notifee payloads (`__notifee_notification`) go to **`NotifeeCoreUNUserNotificationCenter`**, then Braze opens are handled as before.
> 
> The bridging header imports **`NotifeeCore+UNUserNotificationCenter.h`** so Swift can forward Notifee press events without relying on Notifee’s delegate chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8975c0d2a5ead17c73cfeb18d55b3f9cb6b94382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->