### PR TITLE
fix: predict page loader to custom amount loader when going from money home page to predict page

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useMoneyPredictDeposit.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useMoneyPredictDeposit.test.ts
@@ -5,7 +5,10 @@ import { usePredictTrading } from '../../../../UI/Predict/hooks/usePredictTradin
 import { useConfirmNavigation } from '../useConfirmNavigation';
 import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
 import Routes from '../../../../../constants/navigation/Routes';
-import { PayWithOption } from '../../components/confirm/confirm-component';
+import {
+  ConfirmationLoader,
+  PayWithOption,
+} from '../../components/confirm/confirm-component';
 
 const mockDepositWithConfirmation = jest
   .fn()
@@ -73,6 +76,7 @@ describe('useMoneyPredictDeposit', () => {
     });
 
     expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+      loader: ConfirmationLoader.CustomAmount,
       stack: Routes.PREDICT.ROOT,
       payWithOption: PayWithOption.MoneyAccount,
     });

--- a/app/components/Views/confirmations/hooks/pay/useMoneyPredictDeposit.ts
+++ b/app/components/Views/confirmations/hooks/pay/useMoneyPredictDeposit.ts
@@ -5,7 +5,10 @@ import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagCont
 import { usePredictTrading } from '../../../../UI/Predict/hooks/usePredictTrading';
 import { useConfirmNavigation } from '../useConfirmNavigation';
 import Routes from '../../../../../constants/navigation/Routes';
-import { PayWithOption } from '../../components/confirm/confirm-component';
+import {
+  ConfirmationLoader,
+  PayWithOption,
+} from '../../components/confirm/confirm-component';
 import Logger from '../../../../../util/Logger';
 
 const LOG_TAG = '[MoneyPredictDeposit]';
@@ -19,6 +22,7 @@ export function useMoneyPredictDeposit() {
 
   const initiatePredictDeposit = useCallback(async () => {
     navigateToConfirmation({
+      loader: ConfirmationLoader.CustomAmount,
       stack: Routes.PREDICT.ROOT,
       payWithOption: PayWithOption.MoneyAccount,
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix predict page loader to custom amount loader when going from money home page to predict page

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1518

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-parameter change in a pay flow hook with matching test coverage; no auth, data, or transaction logic changes.
> 
> **Overview**
> When a user starts a **Predict deposit** from the **Money** home flow, confirmation navigation now passes **`loader: ConfirmationLoader.CustomAmount`** along with the existing Predict stack and Money Account pay-with option.
> 
> That replaces the default confirmation loading UI (which was showing the wrong **Predict** loader) with the **custom amount** loader while the deposit is being prepared. The **`useMoneyPredictDeposit`** unit test was updated to assert the new `loader` argument on **`navigateToConfirmation`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ff35cad4a8cbcfa8352f23cb665fc16605ce72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->