### PR TITLE
fix(e2e): stabilize Appium iOS account list visibility after rename

### DIFF
--- a/tests/flows/accounts.flow.ts
+++ b/tests/flows/accounts.flow.ts
@@ -229,6 +229,10 @@ export const renameAccountAtIndex = async (
   await EditAccountName.updateAccountName(newName);
   await EditAccountName.tapSave();
   await AccountDetails.tapBackButton();
+
+  if (FrameworkDetector.isAppium()) {
+    await AccountListBottomSheet.waitForAccountListVisible();
+  }
 };
 
 export const assertAccountCount = async (

--- a/tests/page-objects/MultichainAccounts/AccountDetails.ts
+++ b/tests/page-objects/MultichainAccounts/AccountDetails.ts
@@ -75,10 +75,33 @@ class AccountDetails {
     });
   }
 
+  /**
+   * Appium iOS: `account-details-container` can exist with `visible=false` while
+   * the details sheet is on screen (same XCTest quirk as `account-list`). Use
+   * interactive child controls to detect the screen instead.
+   */
+  private async isAccountDetailsVisibleOnAppiumIos(): Promise<boolean> {
+    try {
+      const nameLink = await asPlaywrightElement(this.editAccountName);
+      if (await nameLink.isVisible()) {
+        return true;
+      }
+    } catch {
+      // fall through
+    }
+
+    try {
+      const backEl = await asPlaywrightElement(this.backButton);
+      return await backEl.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
   async tapBackButton(): Promise<void> {
     if (FrameworkDetector.isAppium() && PlatformDetector.isIOS()) {
-      const container = await asPlaywrightElement(this.container);
-      const isOnAccountDetails = await container.isVisible().catch(() => false);
+      const isOnAccountDetails =
+        await this.isAccountDetailsVisibleOnAppiumIos();
       if (!isOnAccountDetails) {
         return;
       }

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -38,7 +38,13 @@ const logger = createLogger({
 });
 
 class AccountListBottomSheet {
-  /** Account list container - Appium uses `account-list` testID; Detox uses the same ID. */
+  /**
+   * Account list container.
+   * Detox: `account-list` testID.
+   * Appium iOS: header title text — `account-list` is on a wrapper XCTest keeps
+   * `visible=false` while the sheet is open; "Accounts" is reliably displayed.
+   * Appium Android: `account-list` testID.
+   */
   get accountList(): EncapsulatedElementType {
     return encapsulated({
       detox: () =>
@@ -46,10 +52,14 @@ class AccountListBottomSheet {
           AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
         ),
       appium: () =>
-        PlaywrightMatchers.getElementById(
-          AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
-          { exact: true },
-        ),
+        PlatformDetector.isIOS()
+          ? PlaywrightMatchers.getElementByText(
+              AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
+            )
+          : PlaywrightMatchers.getElementById(
+              AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+              { exact: true },
+            ),
     });
   }
 
@@ -269,6 +279,41 @@ class AccountListBottomSheet {
     await Gestures.waitAndTap(this.backButton, {
       elemDescription: 'Account list header back button',
     });
+  }
+
+  /**
+   * Appium: poll until the account list sheet is open.
+   * Retries lookup + visibility — needed after rename/back navigation when the
+   * sheet is animating in and text/testID queries can briefly miss.
+   */
+  async waitForAccountListVisible(timeout = 15_000): Promise<void> {
+    if (!FrameworkDetector.isAppium()) {
+      await Assertions.expectElementToBeVisible(this.accountList, { timeout });
+      return;
+    }
+
+    await Utilities.executeWithRetry(
+      async () => {
+        try {
+          const el = PlatformDetector.isIOS()
+            ? await PlaywrightMatchers.getElementByText(
+                AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
+              )
+            : await PlaywrightMatchers.getElementById(
+                AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+                { exact: true },
+              );
+          return await el.isVisible();
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout,
+        interval: 500,
+        description: 'Account list sheet visible',
+      },
+    );
   }
 
   async tapAddAccountButtonV2(options?: {

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -294,8 +294,9 @@ class AccountListBottomSheet {
 
     await Utilities.executeWithRetry(
       async () => {
+        let el: PlaywrightElement;
         try {
-          const el = PlatformDetector.isIOS()
+          el = PlatformDetector.isIOS()
             ? await PlaywrightMatchers.getElementByText(
                 AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
               )
@@ -303,9 +304,13 @@ class AccountListBottomSheet {
                 AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
                 { exact: true },
               );
-          return await el.isVisible();
         } catch {
-          return false;
+          throw new Error('Account list sheet element not found');
+        }
+
+        const visible = await el.isVisible().catch(() => false);
+        if (!visible) {
+          throw new Error('Account list sheet is not visible yet');
         }
       },
       {


### PR DESCRIPTION
## **Description**

Android `appium-accounts-android-smoke` failures from #32639 were addressed in #32768. **`appium-accounts-ios-smoke` shard 1** still fails on main for `add-and-rename-accounts.spec.ts` (first test): after renaming an account, the test cannot find the account list because XCTest reports `account-list` as `visible=false` while the sheet is open, and `AccountDetails.tapBackButton()` returns early when `account-details-container` is also `visible=false`.

This PR adds iOS Appium–specific POM fixes (test-only; no production code):

- **`AccountListBottomSheet`**: use the **"Accounts" title text** as the iOS Appium locator instead of `account-list` testID; add `waitForAccountListVisible()` with retry polling after navigation.
- **`AccountDetails`**: detect account details on iOS Appium via visible child controls (name link / back button), not the container testID.
- **`accounts.flow`**: after rename + back, wait for the account list sheet on Appium.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #32639

## **Manual testing steps**

```gherkin
Feature: Appium iOS account add and rename smoke

  Scenario: Add and rename accounts smoke passes on iOS Appium
    Given a main-e2e iOS app bundle on a simulator with CI=true
    And the add-and-rename-accounts smoke fixture with account sync enabled
    When the test adds accounts, renames one, and navigates back to the account list
    Then the account list sheet is detected via the "Accounts" title
    And the renamed account name is visible in the list

  Scenario: Android account smoke remains stable
    Given the Android Appium account smoke suite on main (covered by #32768)
    When account add/rename specs run
    Then no regression from the iOS-specific locator split
```

Local verification:

```bash
CI=true IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
  yarn appium-smoke:ios --grep "Add and rename accounts"
```

Both tests in `tests/smoke-appium/accounts/add-and-rename-accounts.spec.ts` passed locally (~5.7m).

## **Screenshots/Recordings**

N/A — test infrastructure only; failure on main is log-based (`NoSuchElementError` / "Accounts" not found after rename).

### **Before**

N/A

### **After**

N/A — pending green `appium-accounts-ios-smoke` CI run on this PR.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — iOS-only POM branch; Android paths unchanged except shared `waitForAccountListVisible` guard
- [x] I've tested with a power user scenario
  - N/A
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — test-only change

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)