### PR TITLE
feat: autofocus swap amount input from token entrypoints

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -1038,6 +1038,31 @@ describe('BridgeView', () => {
       expect(queryByTestId('keypad-delete-button')).toBeNull();
     });
 
+    it('displays keypad on initial focus when route requests source amount auto-focus', async () => {
+      mockRoute.params = {
+        sourcePage: 'test',
+        autoFocusSourceAmountInput: true,
+      } as BridgeRouteParams;
+
+      const { queryByTestId } = renderScreen(
+        BridgeView,
+        {
+          name: Routes.BRIDGE.ROOT,
+        },
+        { state: mockState },
+      );
+
+      act(() => {
+        mockFocusEffects.forEach((focusEffect) => {
+          focusEffect();
+        });
+      });
+
+      await waitFor(() => {
+        expect(queryByTestId('keypad-delete-button')).toBeTruthy();
+      });
+    });
+
     it('shows loading mode with quote skeleton only', () => {
       const testState = createBridgeTestState({
         bridgeControllerOverrides: {

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -228,7 +228,11 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   const hasInitializedRecipient = useRef(false);
   useRecipientInitialization(hasInitializedRecipient);
 
-  useBridgeViewOnFocus({ inputRef, keypadRef });
+  useBridgeViewOnFocus({
+    inputRef,
+    keypadRef,
+    autoFocusSourceAmountInput: route.params?.autoFocusSourceAmountInput,
+  });
 
   useFocusEffect(
     useCallback(() => {

--- a/app/components/UI/Bridge/hooks/useBridgeViewOnFocus/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeViewOnFocus/index.ts
@@ -1,21 +1,36 @@
 import { useFocusEffect } from '@react-navigation/native';
-import { RefObject, useCallback } from 'react';
+import { RefObject, useCallback, useRef } from 'react';
 import { TokenInputAreaRef } from '../../components/TokenInputArea';
 import { SwapsKeypadRef } from '../../components/SwapsKeypad/types';
 
 interface Params {
   inputRef: RefObject<TokenInputAreaRef | null>;
   keypadRef: RefObject<SwapsKeypadRef | null>;
+  autoFocusSourceAmountInput?: boolean;
 }
 
-export const useBridgeViewOnFocus = ({ inputRef, keypadRef }: Params) => {
+export const useBridgeViewOnFocus = ({
+  inputRef,
+  keypadRef,
+  autoFocusSourceAmountInput = false,
+}: Params) => {
+  const hasAutoFocusedRef = useRef(false);
+
   useFocusEffect(
     useCallback(
-      () => () => {
-        inputRef.current?.blur();
-        keypadRef.current?.close();
+      () => {
+        if (autoFocusSourceAmountInput && !hasAutoFocusedRef.current) {
+          inputRef.current?.focus();
+          keypadRef.current?.open();
+          hasAutoFocusedRef.current = true;
+        }
+
+        return () => {
+          inputRef.current?.blur();
+          keypadRef.current?.close();
+        };
       },
-      [inputRef, keypadRef],
+      [autoFocusSourceAmountInput, inputRef, keypadRef],
     ),
   );
 };

--- a/app/components/UI/Bridge/hooks/useBridgeViewOnFocus/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeViewOnFocus/index.ts
@@ -17,20 +17,23 @@ export const useBridgeViewOnFocus = ({
   const hasAutoFocusedRef = useRef(false);
 
   useFocusEffect(
-    useCallback(
-      () => {
-        if (autoFocusSourceAmountInput && !hasAutoFocusedRef.current) {
-          inputRef.current?.focus();
-          keypadRef.current?.open();
+    useCallback(() => {
+      if (autoFocusSourceAmountInput && !hasAutoFocusedRef.current) {
+        const input = inputRef.current;
+        const keypad = keypadRef.current;
+
+        input?.focus();
+        keypad?.open();
+
+        if (input && keypad) {
           hasAutoFocusedRef.current = true;
         }
+      }
 
-        return () => {
-          inputRef.current?.blur();
-          keypadRef.current?.close();
-        };
-      },
-      [autoFocusSourceAmountInput, inputRef, keypadRef],
-    ),
+      return () => {
+        inputRef.current?.blur();
+        keypadRef.current?.close();
+      };
+    }, [autoFocusSourceAmountInput, inputRef, keypadRef]),
   );
 };

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -77,6 +77,7 @@ export interface BridgeRouteParams {
   sourceAmount?: string;
   location: MetaMetricsSwapsEventSource;
   scrollToTopOnNav?: boolean;
+  autoFocusSourceAmountInput?: boolean;
   /**
    * Homepage / explicit flow `active_ab_tests` carried on the route and bound
    * to transactions when the user submits (not stored in Redux).
@@ -334,12 +335,19 @@ export const useSwapBridgeNavigation = ({
         Engine.context.BridgeController.setLocation(mappedLocation);
       }
 
+      const shouldAutoFocusSourceAmountInput = Boolean(
+        effectiveSourceTokenBase || effectiveDestTokenBase,
+      );
+
       const params: BridgeRouteParams = {
         sourceToken,
         sourcePage,
         bridgeViewMode,
         location: mappedLocation,
         ...(scrollToTopOnNav && { scrollToTopOnNav: true }),
+        ...(shouldAutoFocusSourceAmountInput && {
+          autoFocusSourceAmountInput: true,
+        }),
         ...(transactionActiveAbTests?.length && { transactionActiveAbTests }),
       };
 

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
@@ -278,6 +278,7 @@ describe('useSwapBridgeNavigation', () => {
         sourcePage: mockSourcePage,
         bridgeViewMode: BridgeViewMode.Unified,
         location: 'Main View',
+        autoFocusSourceAmountInput: true,
       },
     });
     expect(mockFetchPopularTokens).toHaveBeenCalledTimes(1);
@@ -319,6 +320,7 @@ describe('useSwapBridgeNavigation', () => {
         sourcePage: mockSourcePage,
         bridgeViewMode: BridgeViewMode.Unified,
         location: 'Main View',
+        autoFocusSourceAmountInput: true,
       },
     });
     expect(mockFetchPopularTokens).toHaveBeenCalledTimes(1);
@@ -369,6 +371,7 @@ describe('useSwapBridgeNavigation', () => {
         sourcePage: mockSourcePage,
         bridgeViewMode: BridgeViewMode.Unified,
         location: 'Main View',
+        autoFocusSourceAmountInput: true,
       },
     });
     expect(mockFetchPopularTokens).toHaveBeenCalledTimes(1);
@@ -466,6 +469,14 @@ describe('useSwapBridgeNavigation', () => {
 
     expect(mockSetIsDestTokenManuallySet).toHaveBeenCalledWith(true);
     expect(mockSetDestToken).toHaveBeenCalledWith(destOverride);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'Bridge',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          autoFocusSourceAmountInput: true,
+        }),
+      }),
+    );
   });
 
   it('uses home page filter network when no token is provided', () => {
@@ -718,6 +729,7 @@ describe('useSwapBridgeNavigation', () => {
           sourcePage: mockSourcePage,
           bridgeViewMode: BridgeViewMode.Unified,
           location: 'Main View',
+          autoFocusSourceAmountInput: true,
         },
       });
       expect(mockSetDestToken).toHaveBeenCalledWith(destOverride);
@@ -758,6 +770,7 @@ describe('useSwapBridgeNavigation', () => {
           sourcePage: mockSourcePage,
           bridgeViewMode: BridgeViewMode.Unified,
           location: 'Main View',
+          autoFocusSourceAmountInput: true,
         },
       });
     });


### PR DESCRIPTION
## **Description**

Adds an optional Bridge route flag so token-intent Swap entrypoints can open with the source amount input focused and the custom Swaps keypad visible. This reduces the extra tap currently required when a user enters Swaps from a token-specific surface such as Token Details.

The change keeps generic Swaps entrypoints unchanged. `useSwapBridgeNavigation` only sets the new `autoFocusSourceAmountInput` param when navigation includes an explicit source or destination token, and `BridgeView` forwards that param to the existing focus lifecycle hook. The hook opens the keypad once on initial focus and preserves the existing blur/close cleanup when leaving the screen.

## **Changelog**

CHANGELOG entry: Improved Swaps entry from token pages by focusing the amount input and opening the keypad automatically

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4709

## **Manual testing steps**

```gherkin
Feature: Token-intent Swaps entry

  Scenario: user opens Swaps from Token Details
    Given the user is viewing a token details page with the Swap action available
    When user taps Swap
    Then the Swap page opens with the source amount input focused
    And the custom Swaps keypad is visible

  Scenario: user opens Swaps from a generic entrypoint
    Given the user is on a generic wallet or trade entrypoint
    When user taps Swap
    Then the Swap page opens without automatically showing the keypad
```

## **Screenshots/Recordings**

N/A - behavior is focus/keypad state covered by targeted unit tests; no visual asset was captured for this metadata update.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A - unit-level route/focus behavior change; no performance-sensitive runtime path added.
- [x] I've tested with a power user scenario
  - N/A - behavior is independent of account/token list size.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A - no new long-running operation or performance traceable workflow.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation**

- `yarn jest app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts app/components/UI/Bridge/hooks/useBridgeViewOnFocus/useBridgeViewOnFocus.test.ts app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx --collectCoverage=false`
- `git diff --check`

`yarn lint:tsc` was also attempted and failed on an existing unrelated missing module: `app/util/termsOfUse/termsOfUseContent`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Swaps UI focus/keypad behavior driven by navigation params; no changes to auth, transactions, or data handling.
> 
> **Overview**
> Adds optional Bridge route param **`autoFocusSourceAmountInput`** so token-intent Swap navigation can open with the source amount field focused and the Swaps keypad visible, without an extra tap.
> 
> **`useSwapBridgeNavigation`** sets the flag when `goToSwaps` resolves an explicit source or destination token; generic Swap entrypoints stay unchanged. **`BridgeView`** forwards the param to **`useBridgeViewOnFocus`**, which on first screen focus calls `focus()` / `open()` once (guarded by a ref) and keeps the existing blur/close cleanup on leave.
> 
> Unit tests cover navigation params and BridgeView keypad visibility when the route requests auto-focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a925dc0db84e483bebd108b646375f639b272600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->