### PR TITLE
chore: ensure that batch sell token select rows do not all rerender when clicked

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
@@ -47,95 +47,89 @@ interface BatchSellTokenRowProps {
   pricePercentChangeTextColor?: DSTextColor;
 }
 
-export const BatchSellTokenRow = React.memo(({
-  token,
-  isSelected,
-  networkName,
-  networkImageSource,
-  onTokenPress,
-  tokenPriceText,
-  pricePercentChangeText,
-  pricePercentChangeTextColor,
-}: BatchSellTokenRowProps) => {
-  // eslint-disable-next-line no-console
-  console.log('[BATCH_SELL_TOKEN_ROW_RENDER_TRACE] render', {
-    chainId: token.chainId,
-    address: token.address,
-    symbol: token.symbol,
+export const BatchSellTokenRow = React.memo(
+  ({
+    token,
     isSelected,
-  });
+    networkName,
+    networkImageSource,
+    onTokenPress,
+    tokenPriceText,
+    pricePercentChangeText,
+    pricePercentChangeTextColor,
+  }: BatchSellTokenRowProps) => {
+    const secondaryRowContent =
+      tokenPriceText || pricePercentChangeText ? (
+        <View style={styles.secondaryRow}>
+          {tokenPriceText && (
+            <Text
+              variant={DSTextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={DSTextColor.TextAlternative}
+              numberOfLines={1}
+              style={styles.priceText}
+            >
+              {tokenPriceText}
+            </Text>
+          )}
+          {tokenPriceText && pricePercentChangeText && (
+            <Text
+              variant={DSTextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={DSTextColor.TextAlternative}
+            >
+              {' • '}
+            </Text>
+          )}
+          {pricePercentChangeText && pricePercentChangeTextColor && (
+            <Text
+              variant={DSTextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={pricePercentChangeTextColor}
+              numberOfLines={1}
+            >
+              {pricePercentChangeText}
+            </Text>
+          )}
+        </View>
+      ) : undefined;
 
-  const secondaryRowContent =
-    tokenPriceText || pricePercentChangeText ? (
-      <View style={styles.secondaryRow}>
-        {tokenPriceText && (
-          <Text
-            variant={DSTextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={DSTextColor.TextAlternative}
-            numberOfLines={1}
-            style={styles.priceText}
-          >
-            {tokenPriceText}
-          </Text>
-        )}
-        {tokenPriceText && pricePercentChangeText && (
-          <Text
-            variant={DSTextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={DSTextColor.TextAlternative}
-          >
-            {' • '}
-          </Text>
-        )}
-        {pricePercentChangeText && pricePercentChangeTextColor && (
-          <Text
-            variant={DSTextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={pricePercentChangeTextColor}
-            numberOfLines={1}
-          >
-            {pricePercentChangeText}
-          </Text>
-        )}
-      </View>
-    ) : undefined;
+    const pressTargetAccessibilityLabel = `${token.symbol} ${strings(
+      'bridge.batch_sell_checkbox_label',
+    )}`;
 
-  const pressTargetAccessibilityLabel = `${token.symbol} ${strings(
-    'bridge.batch_sell_checkbox_label',
-  )}`;
-
-  return (
-    <TokenSelectorItem
-      token={token}
-      onPress={onTokenPress}
-      networkName={networkName}
-      networkImageSource={networkImageSource}
-      isSelected={isSelected}
-      shouldChangeSelectedStyle={false}
-      shouldShowNetworkIcon={false}
-      shouldIncludeChildrenInPressTarget
-      pressTargetAccessibilityLabel={pressTargetAccessibilityLabel}
-      secondaryRowContent={secondaryRowContent}
-      balanceLayoutConfigOverride={
-        TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
-          TokenSelectorBalanceLayoutVariant.Control
-        ]
-      }
-      tokenBalanceTextProps={{
-        textVariant: ComponentLibraryTextVariant.BodySMMedium,
-        textColor: ComponentLibraryTextColor.Alternative,
-        textStyle: styles.tokenBalance,
-      }}
-    >
-      <Checkbox
+    return (
+      <TokenSelectorItem
+        token={token}
+        onPress={onTokenPress}
+        networkName={networkName}
+        networkImageSource={networkImageSource}
         isSelected={isSelected}
-        // eslint-disable-next-line no-empty-function
-        onChange={() => {}}
-        pointerEvents="none"
-        importantForAccessibility="no-hide-descendants"
-        accessibilityElementsHidden
-      />
-    </TokenSelectorItem>
-  );
-});
+        shouldChangeSelectedStyle={false}
+        shouldShowNetworkIcon={false}
+        shouldIncludeChildrenInPressTarget
+        pressTargetAccessibilityLabel={pressTargetAccessibilityLabel}
+        secondaryRowContent={secondaryRowContent}
+        balanceLayoutConfigOverride={
+          TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+            TokenSelectorBalanceLayoutVariant.Control
+          ]
+        }
+        tokenBalanceTextProps={{
+          textVariant: ComponentLibraryTextVariant.BodySMMedium,
+          textColor: ComponentLibraryTextColor.Alternative,
+          textStyle: styles.tokenBalance,
+        }}
+      >
+        <Checkbox
+          isSelected={isSelected}
+          // eslint-disable-next-line no-empty-function
+          onChange={() => {}}
+          pointerEvents="none"
+          importantForAccessibility="no-hide-descendants"
+          accessibilityElementsHidden
+        />
+      </TokenSelectorItem>
+    );
+  },
+);

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { ImageSourcePropType, StyleSheet, View } from 'react-native';
-import { useSelector } from 'react-redux';
 import {
   Checkbox,
   FontWeight,
@@ -8,27 +7,11 @@ import {
   TextColor as DSTextColor,
   TextVariant as DSTextVariant,
 } from '@metamask/design-system-react-native';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import {
-  formatChainIdToHex,
-  isNativeAddress,
-} from '@metamask/bridge-controller';
-import { Hex } from '@metamask/utils';
 import {
   TextColor as ComponentLibraryTextColor,
   TextVariant as ComponentLibraryTextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import { RootState } from '../../../../../reducers';
-import {
-  selectCurrencyRates,
-  selectCurrentCurrency,
-} from '../../../../../selectors/currencyRateController';
-import { selectNativeCurrencyByChainId } from '../../../../../selectors/networkController';
-import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
-import { safeToChecksumAddress } from '../../../../../util/address';
 import { strings } from '../../../../../../locales/i18n';
-import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
-import { useTokenPricePercentageChange } from '../../../Tokens/hooks/useTokenPricePercentageChange';
 import { TokenSelectorItem } from '../../components/TokenSelectorItem';
 import {
   TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
@@ -53,122 +36,35 @@ const styles = StyleSheet.create({
   },
 });
 
-function getPricePercentChangeText(
-  pricePercentChange: number | undefined,
-): string | undefined {
-  if (
-    pricePercentChange === undefined ||
-    !Number.isFinite(pricePercentChange)
-  ) {
-    return undefined;
-  }
-
-  return `${pricePercentChange >= 0 ? '+' : ''}${pricePercentChange.toFixed(
-    2,
-  )}%`;
-}
-
-function getPricePercentChangeTextColor(
-  pricePercentChange: number,
-): DSTextColor {
-  if (pricePercentChange > 0) {
-    return DSTextColor.SuccessDefault;
-  }
-
-  if (pricePercentChange < 0) {
-    return DSTextColor.ErrorDefault;
-  }
-
-  return DSTextColor.TextAlternative;
-}
-
-function getTokenPriceInFiat({
-  token,
-  chainId,
-  isNative,
-  tokenMarketData,
-  currencyRates,
-  nativeCurrency,
-}: {
-  token: BridgeToken;
-  chainId: Hex;
-  isNative: boolean;
-  tokenMarketData: ReturnType<typeof selectTokenMarketData>;
-  currencyRates: ReturnType<typeof selectCurrencyRates>;
-  nativeCurrency?: string;
-}): number | undefined {
-  const addressToUse = isNative
-    ? getNativeTokenAddress(chainId)
-    : safeToChecksumAddress(token.address);
-  const marketPriceInNative =
-    tokenMarketData?.[chainId]?.[addressToUse as Hex]?.price;
-
-  if (marketPriceInNative != null) {
-    const nativeToFiatRate = nativeCurrency
-      ? currencyRates?.[nativeCurrency]?.conversionRate
-      : undefined;
-
-    return nativeToFiatRate
-      ? marketPriceInNative * nativeToFiatRate
-      : undefined;
-  }
-
-  const nativePriceInFiat = isNative
-    ? currencyRates?.[token.symbol]?.conversionRate
-    : undefined;
-
-  return nativePriceInFiat ?? undefined;
-}
-
 interface BatchSellTokenRowProps {
   token: BridgeToken;
   isSelected: boolean;
   networkName?: string;
   networkImageSource?: ImageSourcePropType;
   onTokenPress: (token: BridgeToken) => void;
+  tokenPriceText?: string;
+  pricePercentChangeText?: string;
+  pricePercentChangeTextColor?: DSTextColor;
 }
 
-export function BatchSellTokenRow({
+export const BatchSellTokenRow = React.memo(({
   token,
   isSelected,
   networkName,
   networkImageSource,
   onTokenPress,
-}: BatchSellTokenRowProps) {
-  const chainId = formatChainIdToHex(token.chainId);
-  const isNative = isNativeAddress(token.address);
-  const tokenMarketData = useSelector(selectTokenMarketData);
-  const currencyRates = useSelector(selectCurrencyRates);
-  const currentCurrency = useSelector(selectCurrentCurrency);
-  const nativeCurrency = useSelector((state: RootState) =>
-    selectNativeCurrencyByChainId(state, chainId),
-  );
-  const pricePercentChange = useTokenPricePercentageChange({
+  tokenPriceText,
+  pricePercentChangeText,
+  pricePercentChangeTextColor,
+}: BatchSellTokenRowProps) => {
+  // eslint-disable-next-line no-console
+  console.log('[BATCH_SELL_TOKEN_ROW_RENDER_TRACE] render', {
+    chainId: token.chainId,
     address: token.address,
-    chainId,
-    isNative,
+    symbol: token.symbol,
+    isSelected,
   });
-  const tokenPriceInFiat = useMemo(
-    () =>
-      getTokenPriceInFiat({
-        token,
-        chainId,
-        isNative,
-        tokenMarketData,
-        currencyRates,
-        nativeCurrency,
-      }),
-    [token, chainId, isNative, tokenMarketData, currencyRates, nativeCurrency],
-  );
-  const tokenPriceText =
-    tokenPriceInFiat !== undefined
-      ? formatPriceWithSubscriptNotation(tokenPriceInFiat, currentCurrency)
-      : undefined;
-  const pricePercentChangeText = getPricePercentChangeText(pricePercentChange);
-  const pricePercentChangeTextColor =
-    pricePercentChangeText && pricePercentChange !== undefined
-      ? getPricePercentChangeTextColor(pricePercentChange)
-      : undefined;
+
   const secondaryRowContent =
     tokenPriceText || pricePercentChangeText ? (
       <View style={styles.secondaryRow}>
@@ -242,4 +138,4 @@ export function BatchSellTokenRow({
       />
     </TokenSelectorItem>
   );
-}
+});

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.perf-test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.perf-test.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { measureRenders } from 'reassure';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import { BridgeToken } from '../../types';
+import { BatchSellTokenSelect } from './BatchSellTokenSelect';
+
+const mockDispatch = jest.fn();
+const mockNavigate = jest.fn();
+const mockOnSetRpcTarget = jest.fn();
+const mockOnNonEvmNetworkChange = jest.fn();
+const mockTrackBatchSellTokenPageContinueClicked = jest.fn();
+const mockUseTokensWithBalance = jest.fn();
+let mockWalletTokens: BridgeToken[] = [];
+let mockCommittedSourceTokens: BridgeToken[] = [];
+let mockTokenMarketData: Record<
+  Hex,
+  Record<Hex, { price?: number; pricePercentChange1d?: number }>
+> = {};
+let mockCurrencyRates: Record<string, { conversionRate: number }> = {};
+let mockCurrentCurrency = 'usd';
+let mockNativeCurrencyByChainId: Record<Hex, string | undefined> = {};
+let mockMultichainAssetsRates = {};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+  }),
+  useRoute: () => ({
+    params: {},
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
+  useRefreshSmartTransactionsLiveness: jest.fn(),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      BridgeController: {
+        setLocation: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../hooks/useTrackBatchSellTokenPageViewed', () => ({
+  useTrackBatchSellTokenPageViewed: jest.fn(),
+}));
+
+jest.mock('../../hooks/useTrackBatchSellTokenPageContinueClicked', () => ({
+  useTrackBatchSellTokenPageContinueClicked: jest.fn(
+    () => mockTrackBatchSellTokenPageContinueClicked,
+  ),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const DesignSystem = jest.requireActual(
+    '@metamask/design-system-react-native',
+  );
+  const ReactActual = jest.requireActual('react');
+  const { Pressable, Text } = jest.requireActual('react-native');
+
+  return {
+    ...DesignSystem,
+    Checkbox: ({
+      accessibilityLabel,
+      isSelected,
+      onChange,
+    }: {
+      accessibilityLabel?: string;
+      isSelected?: boolean;
+      onChange?: () => void;
+    }) =>
+      ReactActual.createElement(Pressable, {
+        accessibilityLabel,
+        accessibilityRole: 'checkbox',
+        accessibilityState: { checked: Boolean(isSelected) },
+        onPress: onChange,
+      }),
+    Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+      ReactActual.createElement(Text, props, children),
+  };
+});
+
+jest.mock('../../../../Views/NetworkSelector/useSwitchNetworks', () => ({
+  useSwitchNetworks: jest.fn(() => ({
+    onSetRpcTarget: mockOnSetRpcTarget,
+    onNonEvmNetworkChange: mockOnNonEvmNetworkChange,
+  })),
+}));
+
+jest.mock('../../../../../selectors/selectedNetworkController', () => ({
+  useNetworkInfo: jest.fn(() => ({
+    chainId: '0x1',
+    domainIsConnectedDapp: false,
+    networkName: 'Ethereum Mainnet',
+  })),
+}));
+
+jest.mock('../../../../../selectors/multichainNetworkController', () => ({
+  selectIsEvmNetworkSelected: jest.fn(() => true),
+  selectSelectedNonEvmNetworkChainId: jest.fn(() => undefined),
+}));
+
+jest.mock('../../hooks/useTokensWithBalance', () => ({
+  useTokensWithBalance: (options?: { chainIds?: CaipChainId[] }) =>
+    mockUseTokensWithBalance(options),
+}));
+
+jest.mock('../../../Tokens/hooks/useTokenPricePercentageChange', () => ({
+  useTokenPricePercentageChange: ({ address }: { address?: string }) =>
+    address ? 1.23 : undefined,
+}));
+
+jest.mock('../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(() => mockTokenMarketData),
+}));
+
+jest.mock('../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(() => mockCurrencyRates),
+  selectCurrentCurrency: jest.fn(() => mockCurrentCurrency),
+}));
+
+jest.mock('../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainAssetsRates: jest.fn(() => mockMultichainAssetsRates),
+}));
+
+jest.mock('../../../../../selectors/networkController', () => ({
+  selectNativeCurrencyByChainId: jest.fn(
+    (_state: unknown, chainId: Hex) => mockNativeCurrencyByChainId[chainId],
+  ),
+  selectEvmNetworkConfigurationsByChainId: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  resetBridgeState: jest.fn(() => ({
+    type: 'bridge/resetBridgeState',
+  })),
+  selectBatchSellDestStablecoins: jest.fn(() => []),
+  selectBatchSellDestStablecoinsByChain: jest.fn(() => ({})),
+  selectBatchSellSourceTokens: jest.fn(() => mockCommittedSourceTokens),
+  setBatchSellSourceTokens: jest.fn((tokens: BridgeToken[]) => ({
+    type: 'bridge/setBatchSellSourceTokens',
+    payload: tokens,
+  })),
+  setBatchSellSourceTokenAmounts: jest.fn(() => ({
+    type: 'bridge/setBatchSellSourceTokenAmounts',
+  })),
+  setBatchSellDestToken: jest.fn(() => ({
+    type: 'bridge/setBatchSellDestToken',
+  })),
+  setBatchSellTokenSlippages: jest.fn(() => ({
+    type: 'bridge/setBatchSellTokenSlippages',
+  })),
+}));
+
+jest.mock('../../components/TokenSelectorItem', () => {
+  const { Pressable, Text, View } = jest.requireActual('react-native');
+  return {
+    TokenSelectorItem: ({
+      children,
+      onPress,
+      secondaryRowContent,
+      token,
+    }: {
+      children?: React.ReactNode;
+      onPress: (token: BridgeToken) => void;
+      secondaryRowContent?: React.ReactNode;
+      token: BridgeToken;
+    }) => (
+      <Pressable
+        onPress={() => onPress(token)}
+        testID={`batch-sell-token-press-${token.symbol}`}
+      >
+        <Text>{token.symbol}</Text>
+        {secondaryRowContent ?? <Text>{token.name}</Text>}
+        <View>{children}</View>
+      </Pressable>
+    ),
+  };
+});
+
+function createToken(index: number): BridgeToken {
+  const address = `0x${index.toString(16).padStart(40, '0')}`;
+
+  return {
+    address,
+    chainId: '0x1' as Hex,
+    decimals: 18,
+    symbol: `TOK${index}`,
+    name: `Token ${index}`,
+    balance: String(index + 1),
+    balanceFiat: `$${index + 1}.00`,
+    tokenFiatAmount: index + 1,
+  };
+}
+
+function createTokenMarketData(tokens: BridgeToken[]) {
+  return tokens.reduce<
+    Record<Hex, { price: number; pricePercentChange1d: number }>
+  >((marketData, token, index) => {
+    marketData[token.address as Hex] = {
+      price: index + 1,
+      pricePercentChange1d: 1.23,
+    };
+
+    return marketData;
+  }, {});
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockWalletTokens = Array.from({ length: 40 }, (_value, index) =>
+    createToken(index + 1),
+  );
+  mockCommittedSourceTokens = [];
+  mockTokenMarketData = {
+    ['0x1' as Hex]: createTokenMarketData(mockWalletTokens),
+  };
+  mockCurrencyRates = {
+    ETH: { conversionRate: 1 },
+  };
+  mockCurrentCurrency = 'usd';
+  mockMultichainAssetsRates = {};
+  mockNativeCurrencyByChainId = {
+    ['0x1' as Hex]: 'ETH',
+  };
+  mockUseTokensWithBalance.mockImplementation(
+    (options?: { chainIds?: CaipChainId[] }) => {
+      if (!options?.chainIds) return mockWalletTokens;
+
+      return mockWalletTokens.filter((token) =>
+        options.chainIds?.includes(
+          formatChainIdToCaip(token.chainId) as CaipChainId,
+        ),
+      );
+    },
+  );
+});
+
+test('selects one token from a populated batch sell token list', async () => {
+  await measureRenders(<BatchSellTokenSelect />, {
+    scenario: async (screen) => {
+      fireEvent.press(screen.getByTestId('batch-sell-token-press-TOK35'));
+
+      await screen.findByText('Continue with (1) token');
+    },
+  });
+});

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -53,6 +53,7 @@ let mockTokenMarketData: Record<
 let mockCurrencyRates: Record<string, { conversionRate: number }> = {};
 let mockCurrentCurrency = 'usd';
 let mockNativeCurrencyByChainId: Record<Hex, string | undefined> = {};
+let mockMultichainAssetsRates = {};
 const usdcAssetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
 
@@ -163,6 +164,10 @@ jest.mock('../../../../../selectors/tokenRatesController', () => ({
 jest.mock('../../../../../selectors/currencyRateController', () => ({
   selectCurrencyRates: jest.fn(() => mockCurrencyRates),
   selectCurrentCurrency: jest.fn(() => mockCurrentCurrency),
+}));
+
+jest.mock('../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainAssetsRates: jest.fn(() => mockMultichainAssetsRates),
 }));
 
 jest.mock('../../../../../selectors/networkController', () => ({
@@ -419,6 +424,7 @@ describe('BatchSellTokenSelect', () => {
       ETH: { conversionRate: 1 },
     };
     mockCurrentCurrency = 'usd';
+    mockMultichainAssetsRates = {};
     mockCommittedSourceTokens = [];
     mockNativeCurrencyByChainId = {
       ['0x1' as Hex]: 'ETH',
@@ -680,8 +686,14 @@ describe('BatchSellTokenSelect', () => {
     };
     mockTokenMarketData = {
       ['0x1' as Hex]: {
-        [gainToken.address as Hex]: { price: 1.17226 },
-        [lossToken.address as Hex]: { price: 0.5 },
+        [gainToken.address as Hex]: {
+          price: 1.17226,
+          pricePercentChange1d: 1.23,
+        },
+        [lossToken.address as Hex]: {
+          price: 0.5,
+          pricePercentChange1d: -4.56,
+        },
       },
     };
 

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -717,6 +717,67 @@ describe('BatchSellTokenSelect', () => {
     });
   });
 
+  it('renders EVM percentage changes when multichain percentage change is null', () => {
+    const token = createToken({
+      symbol: 'EVM',
+      name: 'EVM Token',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 10,
+    });
+    mockWalletTokens = [token];
+    mockMultichainAssetsRates = {
+      [token.address]: {
+        marketData: {
+          pricePercentChange: {
+            P1D: null,
+          },
+        },
+      },
+    };
+    mockTokenMarketData = {
+      ['0x1' as Hex]: {
+        [token.address as Hex]: {
+          pricePercentChange1d: 2.34,
+        },
+      },
+    };
+
+    const { getByText } = render(<BatchSellTokenSelect />);
+
+    expect(getByText('+2.34%')).toBeOnTheScreen();
+  });
+
+  it('renders multichain percentage changes before EVM percentage changes', () => {
+    const token = createToken({
+      symbol: 'MCA',
+      name: 'Multichain Asset',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 10,
+    });
+    mockWalletTokens = [token];
+    mockMultichainAssetsRates = {
+      [token.address]: {
+        marketData: {
+          pricePercentChange: {
+            P1D: 3.45,
+          },
+        },
+      },
+    };
+    mockTokenMarketData = {
+      ['0x1' as Hex]: {
+        [token.address as Hex]: {
+          pricePercentChange1d: 2.34,
+        },
+      },
+    };
+
+    const { getByText, queryByText } = render(<BatchSellTokenSelect />);
+
+    expect(getByText('+3.45%')).toBeOnTheScreen();
+    expect(queryByText('+2.34%')).not.toBeOnTheScreen();
+  });
+
   it('disables TokenSelectorItem selected row styling and network icons for Batch Sell rows', () => {
     mockWalletTokens = [
       createToken({

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -11,6 +11,7 @@ import { FlatList, ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   AvatarBaseShape,
@@ -36,10 +37,11 @@ import {
   formatAddressToAssetId,
   formatChainIdToCaip,
   formatChainIdToHex,
+  isNativeAddress,
   isNonEvmChainId,
   BatchSellMetricsLocation,
 } from '@metamask/bridge-controller';
-import { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { NetworkConfiguration } from '@metamask/network-controller';
 
 import { strings } from '../../../../../../locales/i18n';
@@ -55,11 +57,20 @@ import {
   setBatchSellTokenSlippages,
 } from '../../../../../core/redux/slices/bridge';
 import { RootState } from '../../../../../reducers';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import {
+  selectEvmNetworkConfigurationsByChainId,
+  selectNativeCurrencyByChainId,
+} from '../../../../../selectors/networkController';
 import {
   selectIsEvmNetworkSelected,
   selectSelectedNonEvmNetworkChainId,
 } from '../../../../../selectors/multichainNetworkController';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../selectors/currencyRateController';
+import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
+import { selectMultichainAssetsRates } from '../../../../../selectors/multichain/multichain';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { BridgeToken } from '../../types';
@@ -83,6 +94,8 @@ import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefres
 import { useTrackBatchSellTokenPageViewed } from '../../hooks/useTrackBatchSellTokenPageViewed';
 import { useTrackBatchSellTokenPageContinueClicked } from '../../hooks/useTrackBatchSellTokenPageContinueClicked';
 import type { BatchSellTokenSelectRouteParams } from './types';
+import { safeToChecksumAddress } from '../../../../../util/address';
+import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 
 const getTokenKey = (token: BridgeToken) =>
   `${formatChainIdToCaip(token.chainId)}:${normalizeTokenAddress(
@@ -129,6 +142,108 @@ function getDefaultBatchSellSourceTokenAmounts(selectedTokens: BridgeToken[]) {
     {},
   );
 }
+
+function getPricePercentChangeText(
+  pricePercentChange: number | undefined,
+): string | undefined {
+  if (
+    pricePercentChange === undefined ||
+    !Number.isFinite(pricePercentChange)
+  ) {
+    return undefined;
+  }
+
+  return `${pricePercentChange >= 0 ? '+' : ''}${pricePercentChange.toFixed(
+    2,
+  )}%`;
+}
+
+function getPricePercentChangeTextColor(pricePercentChange: number): TextColor {
+  if (pricePercentChange > 0) {
+    return TextColor.SuccessDefault;
+  }
+
+  if (pricePercentChange < 0) {
+    return TextColor.ErrorDefault;
+  }
+
+  return TextColor.TextAlternative;
+}
+
+function getTokenPriceInFiat({
+  token,
+  chainId,
+  isNative,
+  tokenMarketData,
+  currencyRates,
+  nativeCurrency,
+}: {
+  token: BridgeToken;
+  chainId: Hex;
+  isNative: boolean;
+  tokenMarketData: ReturnType<typeof selectTokenMarketData>;
+  currencyRates: ReturnType<typeof selectCurrencyRates>;
+  nativeCurrency?: string;
+}): number | undefined {
+  const addressToUse = isNative
+    ? getNativeTokenAddress(chainId)
+    : safeToChecksumAddress(token.address);
+  const marketPriceInNative =
+    tokenMarketData?.[chainId]?.[addressToUse as Hex]?.price;
+
+  if (marketPriceInNative != null) {
+    const nativeToFiatRate = nativeCurrency
+      ? currencyRates?.[nativeCurrency]?.conversionRate
+      : undefined;
+
+    return nativeToFiatRate
+      ? marketPriceInNative * nativeToFiatRate
+      : undefined;
+  }
+
+  const nativePriceInFiat = isNative
+    ? currencyRates?.[token.symbol]?.conversionRate
+    : undefined;
+
+  return nativePriceInFiat ?? undefined;
+}
+
+function getTokenPricePercentChange({
+  token,
+  chainId,
+  isNative,
+  tokenMarketData,
+  multichainAssetsRates,
+}: {
+  token: BridgeToken;
+  chainId: Hex;
+  isNative: boolean;
+  tokenMarketData: ReturnType<typeof selectTokenMarketData>;
+  multichainAssetsRates: ReturnType<typeof selectMultichainAssetsRates>;
+}): number | undefined {
+  const multichainPricePercentChange =
+    multichainAssetsRates?.[token.address as CaipAssetType]?.marketData
+      ?.pricePercentChange?.P1D;
+
+  if (multichainPricePercentChange !== undefined) {
+    return multichainPricePercentChange;
+  }
+
+  const addressToUse = isNative
+    ? getNativeTokenAddress(chainId)
+    : token.address;
+
+  return tokenMarketData?.[chainId]?.[addressToUse as Hex]
+    ?.pricePercentChange1d;
+}
+
+interface TokenPriceDisplay {
+  tokenPriceText?: string;
+  pricePercentChangeText?: string;
+  pricePercentChangeTextColor?: TextColor;
+}
+
+const EMPTY_TOKEN_PRICE_DISPLAY: TokenPriceDisplay = {};
 
 export function BatchSellTokenSelect() {
   const navigation = useNavigation();
@@ -241,6 +356,18 @@ export function BatchSellTokenSelect() {
   }, [selectedChainId, sortedEligibleChains]);
 
   const activeChainId = selectedChainId ?? sortedEligibleChains[0]?.chainId;
+  const activeHexChainId = activeChainId
+    ? formatChainIdToHex(activeChainId)
+    : undefined;
+  const tokenMarketData = useSelector(selectTokenMarketData);
+  const currencyRates = useSelector(selectCurrencyRates);
+  const currentCurrency = useSelector(selectCurrentCurrency);
+  const multichainAssetsRates = useSelector(selectMultichainAssetsRates);
+  const activeChainNativeCurrency = useSelector((state: RootState) =>
+    activeHexChainId
+      ? selectNativeCurrencyByChainId(state, activeHexChainId)
+      : undefined,
+  );
 
   // Fetch STX liveness for the active batch sell source chain
   useRefreshSmartTransactionsLiveness(activeChainId);
@@ -257,6 +384,54 @@ export function BatchSellTokenSelect() {
         : sortedEligibleSourceTokens,
     [activeChainId, sortedEligibleSourceTokens],
   );
+  const tokenPriceDisplayByKey = useMemo(() => {
+    const priceDisplayByKey = new Map<string, TokenPriceDisplay>();
+
+    for (const token of selectedChainTokens) {
+      const chainId = formatChainIdToHex(token.chainId);
+      const isNative = isNativeAddress(token.address);
+      const tokenPriceInFiat = getTokenPriceInFiat({
+        token,
+        chainId,
+        isNative,
+        tokenMarketData,
+        currencyRates,
+        nativeCurrency: activeChainNativeCurrency,
+      });
+      const tokenPriceText =
+        tokenPriceInFiat !== undefined
+          ? formatPriceWithSubscriptNotation(tokenPriceInFiat, currentCurrency)
+          : undefined;
+      const pricePercentChange = getTokenPricePercentChange({
+        token,
+        chainId,
+        isNative,
+        tokenMarketData,
+        multichainAssetsRates,
+      });
+      const pricePercentChangeText =
+        getPricePercentChangeText(pricePercentChange);
+      const pricePercentChangeTextColor =
+        pricePercentChangeText && pricePercentChange !== undefined
+          ? getPricePercentChangeTextColor(pricePercentChange)
+          : undefined;
+
+      priceDisplayByKey.set(getTokenKey(token), {
+        tokenPriceText,
+        pricePercentChangeText,
+        pricePercentChangeTextColor,
+      });
+    }
+
+    return priceDisplayByKey;
+  }, [
+    activeChainNativeCurrency,
+    currencyRates,
+    currentCurrency,
+    multichainAssetsRates,
+    selectedChainTokens,
+    tokenMarketData,
+  ]);
   const selectedTokenKeys = useMemo(
     () => new Set(selectedTokens.map(getTokenKey)),
     [selectedTokens],
@@ -301,16 +476,6 @@ export function BatchSellTokenSelect() {
   const handleTokenPress = useCallback(
     (token: BridgeToken) => {
       const tokenKey = getTokenKey(token);
-
-      if (selectedTokenKeys.has(tokenKey)) {
-        setSelectedTokens((tokens) =>
-          tokens.filter(
-            (selectedToken) => getTokenKey(selectedToken) !== tokenKey,
-          ),
-        );
-        return;
-      }
-
       const tokenChainId = formatChainIdToCaip(token.chainId);
 
       if (selectedChainId && tokenChainId !== selectedChainId) {
@@ -323,9 +488,21 @@ export function BatchSellTokenSelect() {
         setSelectedChainId(tokenChainId);
       }
 
-      setSelectedTokens((tokens) => [...tokens, token]);
+      setSelectedTokens((tokens) => {
+        const isSelected = tokens.some(
+          (selectedToken) => getTokenKey(selectedToken) === tokenKey,
+        );
+
+        if (isSelected) {
+          return tokens.filter(
+            (selectedToken) => getTokenKey(selectedToken) !== tokenKey,
+          );
+        }
+
+        return [...tokens, token];
+      });
     },
-    [selectedChainId, selectedTokenKeys],
+    [selectedChainId],
   );
 
   const handleNextPress = useCallback(() => {
@@ -476,6 +653,8 @@ export function BatchSellTokenSelect() {
       const network = sortedEligibleChains.find(
         (eligibleNetwork) => eligibleNetwork.chainId === chainId,
       );
+      const tokenPriceDisplay =
+        tokenPriceDisplayByKey.get(tokenKey) ?? EMPTY_TOKEN_PRICE_DISPLAY;
 
       return (
         <Box
@@ -487,11 +666,21 @@ export function BatchSellTokenSelect() {
             networkName={network?.name}
             networkImageSource={getNetworkImageSource({ chainId })}
             isSelected={isSelected}
+            tokenPriceText={tokenPriceDisplay.tokenPriceText}
+            pricePercentChangeText={tokenPriceDisplay.pricePercentChangeText}
+            pricePercentChangeTextColor={
+              tokenPriceDisplay.pricePercentChangeTextColor
+            }
           />
         </Box>
       );
     },
-    [handleTokenPress, selectedTokenKeys, sortedEligibleChains],
+    [
+      handleTokenPress,
+      selectedTokenKeys,
+      sortedEligibleChains,
+      tokenPriceDisplayByKey,
+    ],
   );
 
   return (

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -221,20 +221,18 @@ function getTokenPricePercentChange({
   tokenMarketData: ReturnType<typeof selectTokenMarketData>;
   multichainAssetsRates: ReturnType<typeof selectMultichainAssetsRates>;
 }): number | undefined {
+  const tokenPercentageChange = token.address
+    ? tokenMarketData?.[chainId]?.[token.address as Hex]?.pricePercentChange1d
+    : undefined;
+  const evmPricePercentChange1d = isNative
+    ? tokenMarketData?.[chainId]?.[getNativeTokenAddress(chainId) as Hex]
+        ?.pricePercentChange1d
+    : tokenPercentageChange;
   const multichainPricePercentChange =
     multichainAssetsRates?.[token.address as CaipAssetType]?.marketData
       ?.pricePercentChange?.P1D;
 
-  if (multichainPricePercentChange !== undefined) {
-    return multichainPricePercentChange;
-  }
-
-  const addressToUse = isNative
-    ? getNativeTokenAddress(chainId)
-    : token.address;
-
-  return tokenMarketData?.[chainId]?.[addressToUse as Hex]
-    ?.pricePercentChange1d;
+  return multichainPricePercentChange ?? evmPricePercentChange1d;
 }
 
 interface TokenPriceDisplay {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.organization=metamask
 sonar.sources=app/
 
 # Excluded project files from analysis.
-sonar.exclusions=**.stories.**, e2e/**, tests/**, wdio/**, app/components/UI/Perps/utils/e2eBridgePerps.ts
+sonar.exclusions=**.stories.**, **/*.perf-test.tsx, e2e/**, tests/**, wdio/**, app/components/UI/Perps/utils/e2eBridgePerps.ts
 
 # Inclusions for test files.
 sonar.test.inclusions=**.test.**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Batch Sell token rows were doing high-churn price selector work per visible row and could all re-render when selecting a single token. This adds a focused Reassure scenario for the Batch Sell token list and moves price/percentage-change derivation up to `BatchSellTokenSelect` so row components receive display-ready scalar props.

The row component is now memoized, and the token press handler no longer changes identity whenever selection state changes. This keeps selection updates scoped to the affected row while preserving the existing UI and token-price display behavior.

Validation performed:

- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx --runInBand`
- `REASSURE=true yarn reassure --baseline --testMatch "**/BatchSellTokenSelect.perf-test.tsx" --commit-hash 6aac1a13b9a01a788136634a80aeba439448317f`
- `REASSURE=true yarn reassure --testMatch "**/BatchSellTokenSelect.perf-test.tsx" --commit-hash b7587493a8e0dab55eefe0374bc559619cd81904`

Latest Reassure comparison with `main` as baseline and the optimized branch as current:
# Performance Comparison Report

- **Current**: swaps-4668-batchSellTokenRow-not-memoized (9e44d5239b2f579ef21deae49e191ca05a8b54ba) - 2026-07-03 18:46:07Z
- **Baseline**: HEAD (b7587493a8e0dab55eefe0374bc559619cd81904) - 2026-07-03 18:45:53Z

### Significant Changes To Duration

<details open>
<summary>Show entries</summary>

| Name                                                     | Type   | Duration                               | Count  |
| -------------------------------------------------------- | ------ | -------------------------------------- | ------ |
| selects one token from a populated batch sell token list | render | 12.8 ms → 11.6 ms (-1.2 ms, -9.2%)  🟢 | 2 → 2  |

</details>

<details>
<summary>Show details</summary>

| Name                                                     | Type   | Duration                                                                                                                                                                                                                                                                                                                                              | Count                                                                                                                                                                                               |
| -------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| selects one token from a populated batch sell token list | render | **Baseline**<br/>Mean: 12.8 ms<br/>Stdev: 0.4 ms (3.1%)<br/>Runs: 12.3 12.3 12.9 13.2 13.2 12.7 12.4 12.8 13.1 13.2<br/>Warmup runs: 34.0<br/>Removed outliers: (none)<br/><br/>**Current**<br/>Mean: 11.6 ms<br/>Stdev: 0.4 ms (3.4%)<br/>Runs: 11.0 11.0 11.3 11.9 11.7 11.8 12.1 11.6 11.8 12.1<br/>Warmup runs: 36.1<br/>Removed outliers: (none) | **Baseline**<br/>Mean: 2<br/>Stdev: 0 (0.0%)<br/>Runs: 2 2 2 2 2 2 2 2 2 2<br/>Render issues:<br/><br/>**Current**<br/>Mean: 2<br/>Stdev: 0 (0.0%)<br/>Runs: 2 2 2 2 2 2 2 2 2 2<br/>Render issues: |

</details>

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #31366

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell token selection performance

  Scenario: user selects one token from a populated Batch Sell token list
    Given the user has multiple eligible sellable tokens on the same network
    And the user is viewing the Batch Sell token select screen

    When user selects one token from the visible token list
    Then the selected token is checked
    And the primary button updates to "Continue with (1) token"
    And the token list remains responsive during selection
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



 https://github.com/user-attachments/assets/f62d451b-77e3-416d-a7ff-b20622ab64f6

### **After**

https://github.com/user-attachments/assets/72281aac-fb68-491f-bc2c-f66006b89418

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance refactor in Bridge batch sell with preserved display behavior covered by updated and new tests; no auth, transactions, or data persistence changes.
> 
> **Overview**
> **Batch Sell token selection** no longer re-renders every visible row when one token is toggled. Price and 24h change display logic moves from `BatchSellTokenRow` into `BatchSellTokenSelect`, which builds a per-token map of formatted fiat price and percent-change strings/colors and passes them as props. Rows are wrapped in `React.memo` and no longer subscribe to Redux or call `useTokenPricePercentageChange` per row.
> 
> Percent change now uses **`getTokenPricePercentChange`**, preferring multichain `pricePercentChange.P1D` when present and falling back to EVM `pricePercentChange1d` (including when multichain is null). **`handleTokenPress`** toggles selection inside a functional `setSelectedTokens` update so its callback identity no longer depends on `selectedTokenKeys`.
> 
> Adds a **Reassure** scenario (`BatchSellTokenSelect.perf-test.tsx`) for selecting one token from a 40-token list, extends unit tests for multichain vs EVM percent display, and excludes `**/*.perf-test.tsx` from Sonar analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524e2f6e5716da5245c9dbb16679d446c9624cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->