### PR TITLE
fix: `MultichainAddressList` navigation cp-8.2.0

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -906,20 +906,7 @@ const MultichainAccountGroupDetails = () => {
           animation: 'slide_from_right',
         }}
       />
-      {/* Registered inside this nested stack (in addition to the root AppFlow
-          stack) so that navigating from AccountGroupDetails resolves within the
-          same native stack. iOS native stack does not bubble cross-stack
-          navigation to the parent navigator, so relying on the root
-          registration alone fails silently here. The root registration is still
-          needed for other entry points (e.g. AddressCopy) that navigate from
-          outside this stack.
 
-          Uses the same MultichainAddressList sub-navigator wrapper as the root
-          registration (rather than the raw AddressList view) so the address
-          list renders in its own isolated native stack. AddressList sets its
-          header via navigation.setOptions; sharing this stack with
-          AccountGroupDetails (which renders its own in-content header) would
-          otherwise leave both headers visible and overlapping. */}
       <NativeStack.Screen
         name={Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST}
         component={MultichainAddressList}

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -854,8 +854,28 @@ const MultichainAccountDetails = () => {
   );
 };
 
+const MultichainAddressList = () => {
+  const route = useRoute();
+
+  return (
+    <NativeStack.Navigator
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+      }}
+    >
+      <NativeStack.Screen
+        name={Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST}
+        component={MultichainAccountAddressList}
+        initialParams={route?.params}
+      />
+    </NativeStack.Navigator>
+  );
+};
+
 const MultichainAccountGroupDetails = () => {
   const route = useRoute();
+  const { colors } = useTheme();
 
   return (
     <NativeStack.Navigator
@@ -884,6 +904,29 @@ const MultichainAccountGroupDetails = () => {
         options={{
           headerShown: false,
           animation: 'slide_from_right',
+        }}
+      />
+      {/* Registered inside this nested stack (in addition to the root AppFlow
+          stack) so that navigating from AccountGroupDetails resolves within the
+          same native stack. iOS native stack does not bubble cross-stack
+          navigation to the parent navigator, so relying on the root
+          registration alone fails silently here. The root registration is still
+          needed for other entry points (e.g. AddressCopy) that navigate from
+          outside this stack.
+
+          Uses the same MultichainAddressList sub-navigator wrapper as the root
+          registration (rather than the raw AddressList view) so the address
+          list renders in its own isolated native stack. AddressList sets its
+          header via navigation.setOptions; sharing this stack with
+          AccountGroupDetails (which renders its own in-content header) would
+          otherwise leave both headers visible and overlapping. */}
+      <NativeStack.Screen
+        name={Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST}
+        component={MultichainAddressList}
+        options={{
+          ...slideFromRightNativeOptions,
+          presentation: 'card',
+          contentStyle: { backgroundColor: colors.background.default },
         }}
       />
       <NativeStack.Screen
@@ -960,25 +1003,6 @@ const MultichainAccountDetailsActions = () => {
       <NativeStack.Screen
         name={Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.REVEAL_SRP_CREDENTIAL}
         component={RevealSRP}
-        initialParams={route?.params}
-      />
-    </NativeStack.Navigator>
-  );
-};
-
-const MultichainAddressList = () => {
-  const route = useRoute();
-
-  return (
-    <NativeStack.Navigator
-      screenOptions={{
-        headerShown: false,
-        animation: 'slide_from_right',
-      }}
-    >
-      <NativeStack.Screen
-        name={Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST}
-        component={MultichainAccountAddressList}
         initialParams={route?.params}
       />
     </NativeStack.Navigator>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

From "Account Details" → "Networks", the app tried to navigate to `MultichainAddressList`, but that route only existed on the root `AppFlow` stack. `AccountGroupDetails` lives inside the nested `MultichainAccountGroupDetails` stack. On iOS native stack, that cross-stack navigation fails silently; Android often worked because navigation bubbled up to the parent. 

The fix includes 2 aspects,

1. Register `MultichainAddressList` inside the nested `MultichainAccountGroupDetails` stack so tapping Networks resolves within the same native stack on iOS.
2. Use the `MultichainAddressList` wrapper sub-navigator, not the raw `AddressList` view. That matches the root registration and avoids overlapping titles: `AccountGroupDetails` has its own in-content header, and `AddressList` sets a nav header via `setOptions` — sharing one stack showed both.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix navigation for address list in Accounts Detail

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1952

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Go to "Account Details"
2. Tap the "Networks" options and navigate to the address list
3. Go back to the main wallet view
4. Press the "copy" icon and navigate to the address list

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://www.loom.com/share/c82c0b0bf9d34398aa0d91a96ba49397

### **After**

https://github.com/user-attachments/assets/aac998a2-7ad0-499e-b04b-91ab60ff184e

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change in multichain account flows; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **Networks → address list** from Account Details on iOS by registering `Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST` on the nested **`MultichainAccountGroupDetails`** stack, not only on root `AppFlow` (cross-stack navigation failed silently on iOS).
> 
> The screen uses the existing **`MultichainAddressList`** wrapper navigator (same as root), with slide-from-right card presentation and themed `contentStyle`, so navigation stays in-stack and avoids double headers. **`MultichainAddressList`** is defined once and placed above the group-details navigator; the duplicate definition lower in the file is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77eaf2a49b7a5a42435dd013e0594750eb599fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->