### PR TITLE
perf: use `createSelector` in `selectSelectedInternalAccount`

### DIFF
--- a/app/selectors/accountsController.test.ts
+++ b/app/selectors/accountsController.test.ts
@@ -736,9 +736,14 @@ describe('selectSelectedInternalAccountId', () => {
     const internalAccount = arrangeAccount();
     const state = getStateWithAccount(internalAccount);
     const result1 = selectSelectedInternalAccountId(state);
+    const recomputationsAfterFirstCall =
+      selectSelectedInternalAccountId.recomputations();
     const result2 = selectSelectedInternalAccountId(state);
     expect(result1).toBe(result2);
-    expect(selectSelectedInternalAccountId.recomputations()).toBe(1);
+    // A subsequent call with the same state must not trigger a recomputation.
+    expect(selectSelectedInternalAccountId.recomputations()).toBe(
+      recomputationsAfterFirstCall,
+    );
   });
 });
 

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -1,7 +1,4 @@
-import {
-  AccountId,
-  AccountsControllerState,
-} from '@metamask/accounts-controller';
+import { AccountId } from '@metamask/accounts-controller';
 import { captureException } from '@sentry/react-native';
 import { createSelector } from 'reselect';
 import { RootState } from '../reducers';
@@ -103,20 +100,26 @@ export const selectInternalAccountsWithCaipAccountId = createDeepEqualSelector(
 );
 
 /**
- * A memoized selector that returns the selected internal account from the AccountsController
+ * A memoized selector that returns the selected internal account from the AccountsController.
+ *
+ * Uses reference equality on the two granular inputs it actually depends on — the
+ * `accounts` map and the `selectedAccount` id — instead of a deep-equality check over the
+ * entire AccountsController state. The underlying account object is already reference-stable
+ * (it only changes when the account's own data changes), so this returns the same object
+ * reference whenever the selected account is unchanged, at the cost of two cheap reference
+ * checks rather than a full deep comparison on every call.
  */
-export const selectSelectedInternalAccount = createDeepEqualSelector(
-  selectAccountsControllerState,
-  (
-    accountsControllerState: AccountsControllerState,
-  ): InternalAccount | undefined => {
-    const accountId = accountsControllerState.internalAccounts.selectedAccount;
-    const account =
-      accountsControllerState.internalAccounts.accounts[accountId];
+export const selectSelectedInternalAccount = createSelector(
+  (state: RootState) =>
+    selectAccountsControllerState(state).internalAccounts.accounts,
+  (state: RootState) =>
+    selectAccountsControllerState(state).internalAccounts.selectedAccount,
+  (accounts, selectedAccountId): InternalAccount | undefined => {
+    const account = accounts[selectedAccountId];
 
     if (!account) {
       const err = new Error(
-        `selectSelectedInternalAccount: Account with ID ${accountId} not found.`,
+        `selectSelectedInternalAccount: Account with ID ${selectedAccountId} not found.`,
       );
       captureException(err);
       return undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The previous implementation with `createDeepEqualSelector` would call in every run a lodash deep-equality over the entire `AccountsControllerState` (all accounts + all their metadata). This scales with account count and data size.

With the current change, there are now two `===` reference checks on internalAccounts.accounts and internalAccounts.selectedAccount which has O(1) complexity. We can see the execution time improvement in the following table,

|            Metric           | Baseline (createDeepEqualSelector) | Optimized (createSelector) | Improvement  |
|---------------------------|----------------------------------|----------------------------|--------------|
| avg call time @100 calls    | 5.397ms                            | 0.022ms                    | ~245x faster |
| avg call time @1200 calls   | 1.463ms                            | 0.006ms                    | ~244x faster |
| recomputations / 1200 calls | 3                                  | 4                          | equivalent   |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31491
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1974

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The selected-account selector is used widely across the app; memoization now depends on immutable updates to the accounts map and selected id, so incorrect in-place mutations could theoretically leave dependents stale.
> 
> **Overview**
> **`selectSelectedInternalAccount`** is reimplemented from **`createDeepEqualSelector`** over the full AccountsController slice to **`createSelector`** with two inputs: the **`internalAccounts.accounts`** map and **`selectedAccount`** id, compared with reference equality instead of a lodash deep compare on the whole controller state.
> 
> The JSDoc explains the tradeoff: O(1) ref checks vs deep equality that grew with account count and metadata size, while still returning the same **`InternalAccount`** object reference when the selected account is unchanged.
> 
> The **`selectSelectedInternalAccountId`** memoization test now snapshots recomputation count after the first call and asserts a second call with identical state does not increment it, rather than assuming a fixed count of **`1`**. Unused **`AccountsControllerState`** import is removed from **`accountsController.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248a15ecc4644d8bb48e81133184bebb593742ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->