### PR TITLE
chore: bump assets controller to v10.0.1

### DIFF
--- a/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch
@@ -1,0 +1,100 @@
+diff --git a/dist/AssetsController.cjs b/dist/AssetsController.cjs
+index 480338e18fc5d1b9a1dc247318ebac15c90f3015..d0336478a03cf52d1a5cdc21c377bd4d78097ee9 100644
+--- a/dist/AssetsController.cjs
++++ b/dist/AssetsController.cjs
+@@ -1237,17 +1237,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             previousCount: __classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").size,
+             currentCount: currentIds.size,
+         });
++        const newAccounts = accounts.filter((account) => !__classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").has(account.id));
+         __classPrivateFieldSet(this, _AssetsController_lastKnownAccountIds, currentIds, "f");
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_ensureNativeBalancesDefaultZero).call(this);
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_ensureDefaultTrackedAssetsSeeded).call(this);
+-        __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_runAccountTreeRefresh).call(this, accounts).catch((error) => {
++        __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_runAccountTreeRefresh).call(this, accounts, newAccounts).catch((error) => {
+             log('Failed to refresh assets after tree change', error);
+         });
+     }
+     else {
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_start).call(this);
+     }
+-}, _AssetsController_runAccountTreeRefresh = async function _AssetsController_runAccountTreeRefresh(accounts) {
++}, _AssetsController_runAccountTreeRefresh = async function _AssetsController_runAccountTreeRefresh(accounts, newAccounts = []) {
+     const releaseLock = await __classPrivateFieldGet(this, _AssetsController_accountRefreshMutex, "f").acquire();
+     try {
+         await this.getAssets(accounts, {
+@@ -1255,6 +1256,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             forceUpdate: true,
+         });
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
++        if (newAccounts.length > 0) {
++            await this.getAssets(newAccounts, {
++                chainIds: [...__classPrivateFieldGet(this, _AssetsController_enabledChains, "f")],
++                forceUpdate: true,
++            });
++        }
+     }
+     catch (error) {
+         log('Failed to fetch assets after tree change', error);
+@@ -2141,8 +2148,9 @@ async function _AssetsController_handleAccountGroupChanged() {
+     // Refresh subscriptions for new chain set
+     __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
+     // Do one-time fetch for newly enabled chains; merge so we keep existing chain balances
+-    if (addedChains.length > 0 && __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this).length > 0) {
+-        await this.getAssets(__classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this), {
++    const accounts = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this);
++    if (addedChains.length > 0 && accounts.length > 0) {
++        await this.getAssets(accounts, {
+             chainIds: addedChains,
+             forceUpdate: true,
+             updateMode: 'merge',
+diff --git a/dist/AssetsController.mjs b/dist/AssetsController.mjs
+index b2bec5f3ac0e3ee5aa2e4b4438c18899cce6f1d5..7dea54b53eff656dc70de340e1c50c4ea6e36260 100644
+--- a/dist/AssetsController.mjs
++++ b/dist/AssetsController.mjs
+@@ -1230,17 +1230,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             previousCount: __classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").size,
+             currentCount: currentIds.size,
+         });
++        const newAccounts = accounts.filter((account) => !__classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").has(account.id));
+         __classPrivateFieldSet(this, _AssetsController_lastKnownAccountIds, currentIds, "f");
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_ensureNativeBalancesDefaultZero).call(this);
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_ensureDefaultTrackedAssetsSeeded).call(this);
+-        __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_runAccountTreeRefresh).call(this, accounts).catch((error) => {
++        __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_runAccountTreeRefresh).call(this, accounts, newAccounts).catch((error) => {
+             log('Failed to refresh assets after tree change', error);
+         });
+     }
+     else {
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_start).call(this);
+     }
+-}, _AssetsController_runAccountTreeRefresh = async function _AssetsController_runAccountTreeRefresh(accounts) {
++}, _AssetsController_runAccountTreeRefresh = async function _AssetsController_runAccountTreeRefresh(accounts, newAccounts = []) {
+     const releaseLock = await __classPrivateFieldGet(this, _AssetsController_accountRefreshMutex, "f").acquire();
+     try {
+         await this.getAssets(accounts, {
+@@ -1248,6 +1249,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             forceUpdate: true,
+         });
+         __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
++        if (newAccounts.length > 0) {
++            await this.getAssets(newAccounts, {
++                chainIds: [...__classPrivateFieldGet(this, _AssetsController_enabledChains, "f")],
++                forceUpdate: true,
++            });
++        }
+     }
+     catch (error) {
+         log('Failed to fetch assets after tree change', error);
+@@ -2134,8 +2141,9 @@ async function _AssetsController_handleAccountGroupChanged() {
+     // Refresh subscriptions for new chain set
+     __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
+     // Do one-time fetch for newly enabled chains; merge so we keep existing chain balances
+-    if (addedChains.length > 0 && __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this).length > 0) {
+-        await this.getAssets(__classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this), {
++    const accounts = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getSelectedAccounts).call(this);
++    if (addedChains.length > 0 && accounts.length > 0) {
++        await this.getAssets(accounts, {
+             chainIds: addedChains,
+             forceUpdate: true,
+             updateMode: 'merge',

--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.test.ts
@@ -5,6 +5,45 @@ import {
   getAssetsControllerInitMessenger,
 } from './assets-controller-messenger';
 
+const ASSETS_CONTROLLER_DELEGATED_ACTIONS = [
+  'AccountTreeController:getAccountsFromSelectedAccountGroup',
+  'NetworkEnablementController:getState',
+  'NetworkController:getState',
+  'NetworkController:getNetworkClientById',
+  'AccountsController:getSelectedAccount',
+  'BackendWebSocketService:subscribe',
+  'BackendWebSocketService:getConnectionInfo',
+  'BackendWebSocketService:findSubscriptionsByChannelPrefix',
+  'BackendWebSocketService:addChannelCallback',
+  'BackendWebSocketService:removeChannelCallback',
+  'SnapController:handleRequest',
+  'SnapController:getRunnableSnaps',
+  'PermissionController:getPermissions',
+  'PhishingController:bulkScanTokens',
+] as const;
+
+const ASSETS_CONTROLLER_DELEGATED_EVENTS = [
+  'AccountTreeController:selectedAccountGroupChange',
+  'AccountTreeController:stateChanged',
+  'NetworkEnablementController:stateChanged',
+  'NetworkEnablementController:stateChange',
+  'ClientController:stateChanged',
+  'KeyringController:lock',
+  'KeyringController:unlock',
+  'NetworkController:networkDidChange',
+  'NetworkController:networkAdded',
+  'NetworkController:networkRemoved',
+  'NetworkController:stateChange',
+  'BackendWebSocketService:connectionStateChanged',
+  'AccountsController:accountBalancesUpdated',
+  'PermissionController:stateChange',
+  'SnapController:snapInstalled',
+  'PreferencesController:stateChange',
+  'TransactionController:transactionConfirmed',
+  'TransactionController:unapprovedTransactionAdded',
+  'AccountActivityService:balanceUpdated',
+] as const;
+
 const getRootMessenger = () =>
   new ExtendedMessenger<MockAnyNamespace, never, never>({
     namespace: MOCK_ANY_NAMESPACE,
@@ -29,18 +68,99 @@ describe('getAssetsControllerMessenger', () => {
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         actions: expect.arrayContaining([
-          'AccountTreeController:getAccountsFromSelectedAccountGroup',
-          'NetworkEnablementController:getState',
-          'NetworkController:getState',
-          'NetworkController:getNetworkClientById',
+          ...ASSETS_CONTROLLER_DELEGATED_ACTIONS,
+        ]),
+      }),
+    );
+  });
+
+  it('delegates AccountsController accountBalancesUpdated event', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          'AccountsController:accountBalancesUpdated',
+        ]),
+      }),
+    );
+  });
+
+  it('delegates AccountActivityService balanceUpdated event', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          'AccountActivityService:balanceUpdated',
+        ]),
+      }),
+    );
+  });
+
+  it('delegates core#9388 account-group and network-enablement events', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          'AccountTreeController:selectedAccountGroupChange',
+          'AccountTreeController:stateChanged',
+          'NetworkEnablementController:stateChanged',
+        ]),
+      }),
+    );
+  });
+
+  it('delegates NetworkController networkDidChange event', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining(['NetworkController:networkDidChange']),
+      }),
+    );
+  });
+
+  it('delegates NetworkController stateChange event', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining(['NetworkController:stateChange']),
+      }),
+    );
+  });
+
+  it('delegates BackendWebsocketDataSource WebSocket actions', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: expect.arrayContaining([
           'BackendWebSocketService:subscribe',
           'BackendWebSocketService:getConnectionInfo',
           'BackendWebSocketService:findSubscriptionsByChannelPrefix',
-          'SnapController:handleRequest',
-          'SnapController:getRunnableSnaps',
-          'PermissionController:getPermissions',
-          'PhishingController:bulkScanTokens',
-          'AccountsController:getSelectedAccount',
+          'BackendWebSocketService:addChannelCallback',
+          'BackendWebSocketService:removeChannelCallback',
         ]),
       }),
     );
@@ -54,22 +174,7 @@ describe('getAssetsControllerMessenger', () => {
 
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        events: expect.arrayContaining([
-          'AccountTreeController:selectedAccountGroupChange',
-          'ClientController:stateChange',
-          'NetworkEnablementController:stateChange',
-          'KeyringController:lock',
-          'KeyringController:unlock',
-          'PreferencesController:stateChange',
-          'NetworkController:stateChange',
-          'TransactionController:transactionConfirmed',
-          'BackendWebSocketService:connectionStateChanged',
-          'AccountsController:accountBalancesUpdated',
-          'PermissionController:stateChange',
-          'TransactionController:unapprovedTransactionAdded',
-          'NetworkController:networkRemoved',
-          'NetworkController:networkAdded',
-        ]),
+        events: expect.arrayContaining([...ASSETS_CONTROLLER_DELEGATED_EVENTS]),
       }),
     );
   });

--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
@@ -10,6 +10,36 @@ import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote
 import type { AnalyticsControllerActions } from '@metamask/analytics-controller';
 import { RootMessenger } from '../../types';
 
+const ASSETS_CONTROLLER_DELEGATED_EVENTS = [
+  // core#9388: RPC balance refresh on account-group switch / tree updates
+  'AccountTreeController:selectedAccountGroupChange',
+  'AccountTreeController:stateChanged',
+  // core#9388: RPC balance refresh when enabling custom RPC networks (e.g. DXC)
+  'NetworkEnablementController:stateChanged',
+  // StakedBalanceDataSource
+  'NetworkEnablementController:stateChange',
+  // UI + keyring lifecycle (RpcDataSource only runs when UI open + unlocked)
+  'ClientController:stateChanged',
+  'KeyringController:lock',
+  'KeyringController:unlock',
+  // Network picker (EVM selected network switch)
+  'NetworkController:networkDidChange',
+  'NetworkController:networkAdded',
+  'NetworkController:networkRemoved',
+  // RpcDataSource + StakedBalanceDataSource
+  'NetworkController:stateChange',
+  // Snap + WS + tx + preferences
+  'BackendWebSocketService:connectionStateChanged',
+  'AccountsController:accountBalancesUpdated',
+  'PermissionController:stateChange',
+  'SnapController:snapInstalled',
+  'PreferencesController:stateChange',
+  'TransactionController:transactionConfirmed',
+  'TransactionController:unapprovedTransactionAdded',
+  // Real-time post-tx balances (AccountActivityService WS path)
+  'AccountActivityService:balanceUpdated',
+] as const;
+
 /**
  * Get the messenger for the AssetsController. This is scoped to the
  * actions and events that the AssetsController is allowed to handle.
@@ -20,6 +50,7 @@ import { RootMessenger } from '../../types';
 export function getAssetsControllerMessenger(
   rootMessenger: RootMessenger<
     MessengerActions<AssetsControllerMessenger>,
+    // @ts-expect-error assets-controller v10 AllowedEvents include stateChanged events not yet on GlobalEvents
     MessengerEvents<AssetsControllerMessenger>
   >,
 ): AssetsControllerMessenger {
@@ -27,38 +58,26 @@ export function getAssetsControllerMessenger(
     namespace: 'AssetsController',
     parent: rootMessenger,
   });
+
   rootMessenger.delegate({
     actions: [
+      // Account group + network context for RpcDataSource (core#9388)
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'NetworkEnablementController:getState',
       'NetworkController:getState',
       'NetworkController:getNetworkClientById',
+      'AccountsController:getSelectedAccount',
       'BackendWebSocketService:subscribe',
       'BackendWebSocketService:getConnectionInfo',
       'BackendWebSocketService:findSubscriptionsByChannelPrefix',
+      'BackendWebSocketService:addChannelCallback',
+      'BackendWebSocketService:removeChannelCallback',
       'SnapController:handleRequest',
       'SnapController:getRunnableSnaps',
       'PermissionController:getPermissions',
       'PhishingController:bulkScanTokens',
-      'AccountsController:getSelectedAccount',
     ],
-    events: [
-      'AccountTreeController:selectedAccountGroupChange',
-      'ClientController:stateChange',
-      'NetworkEnablementController:stateChange',
-      'KeyringController:lock',
-      'KeyringController:unlock',
-      'PreferencesController:stateChange',
-      'NetworkController:stateChange',
-      'TransactionController:transactionConfirmed',
-      'BackendWebSocketService:connectionStateChanged',
-      'AccountsController:accountBalancesUpdated',
-      'PermissionController:stateChange',
-      'TransactionController:unapprovedTransactionAdded',
-      'NetworkController:networkRemoved',
-      'NetworkController:networkAdded',
-      'SnapController:snapInstalled',
-    ],
+    events: [...ASSETS_CONTROLLER_DELEGATED_EVENTS],
     messenger,
   });
 

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
     "@metamask/accounts-controller": "^39.0.3",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
     "@expo/cli@npm:55.0.32": "patch:@expo/cli@npm%3A55.0.32#~/.yarn/patches/@expo-cli-npm-55.0.32-5fb47bae24.patch",
-    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch"
+    "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch",
+    "@metamask/assets-controller@npm:^10.0.1": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -245,7 +246,7 @@
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^9.1.0",
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch",
     "@metamask/assets-controllers": "^109.2.1",
     "@metamask/authenticated-user-storage": "^3.0.0",
     "@metamask/base-controller": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8013,7 +8013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^10.0.1":
+"@metamask/assets-controller@npm:10.0.1":
   version: 10.0.1
   resolution: "@metamask/assets-controller@npm:10.0.1"
   dependencies:
@@ -8050,44 +8050,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "@metamask/assets-controller@npm:9.1.0"
+"@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch":
+  version: 10.0.1
+  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch::version=10.0.1&hash=4676d1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/account-tree-controller": "npm:^7.5.3"
-    "@metamask/accounts-controller": "npm:^39.0.3"
-    "@metamask/assets-controllers": "npm:^109.2.2"
+    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/assets-controllers": "npm:^109.3.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/client-controller": "npm:^1.0.1"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^6.3.3"
+    "@metamask/core-backend": "npm:^6.5.0"
     "@metamask/keyring-api": "npm:^23.3.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
     "@metamask/keyring-snap-client": "npm:^9.0.2"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^33.0.0"
-    "@metamask/network-enablement-controller": "npm:^5.4.0"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.4.1"
     "@metamask/permission-controller": "npm:^13.1.1"
     "@metamask/phishing-controller": "npm:^17.2.0"
-    "@metamask/polling-controller": "npm:^16.0.7"
+    "@metamask/polling-controller": "npm:^16.0.8"
     "@metamask/preferences-controller": "npm:^23.1.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/transaction-controller": "npm:^68.1.1"
+    "@metamask/transaction-controller": "npm:^68.2.2"
     "@metamask/utils": "npm:^11.11.0"
     async-mutex: "npm:^0.5.0"
     bignumber.js: "npm:^9.1.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/c46357539608a0e46dbd0fb4d987ac07047e64d56cc5a6e1084d0fde0d24d68cfb848f0da383d4bac34140d8a104cf373478845774fdd762844e3acdf1a1f251
+  checksum: 10/8b0ce9b7d1169290f52dc5a0a2a4d201d54ea8b1f9df46f5fa17723fe00666da4e0ff16396b20e35b7faeb31f2f67f652b12e5bd9034d3aa9f3417add4bf6171
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^109.2.1, @metamask/assets-controllers@npm:^109.2.2, @metamask/assets-controllers@npm:^109.3.0":
+"@metamask/assets-controllers@npm:^109.2.1, @metamask/assets-controllers@npm:^109.3.0":
   version: 109.3.0
   resolution: "@metamask/assets-controllers@npm:109.3.0"
   dependencies:
@@ -9534,7 +9534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^5.3.0, @metamask/network-enablement-controller@npm:^5.4.0, @metamask/network-enablement-controller@npm:^5.4.1":
+"@metamask/network-enablement-controller@npm:^5.3.0, @metamask/network-enablement-controller@npm:^5.4.1":
   version: 5.4.1
   resolution: "@metamask/network-enablement-controller@npm:5.4.1"
   dependencies:
@@ -35492,7 +35492,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^9.1.0"
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch"
     "@metamask/assets-controllers": "npm:^109.2.1"
     "@metamask/authenticated-user-storage": "npm:^3.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `@metamask/assets-controller` from `^9.1.0` to `10.0.1` and updates the AssetsController messenger wiring required by v10 (WebSocket channel callbacks and additional delegated events).

`10.0.1` is consumed via a Yarn patch that applies [MetaMask/core#9388](https://github.com/MetaMask/core/pull/9388) until that PR lands in a published release. The patch adds RPC balance fetching on account-tree / network / EVM-account-switch paths and requires delegating `AccountsController:selectedEvmAccountChange` on the AssetsController messenger.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/core/pull/9388

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: AssetsController v10 bump

  Scenario: wallet loads with existing balances
    Given an unlocked wallet with at least one account
    When the user opens the Wallet tab
    Then native and token balances render without errors

  Scenario: new account shows balances
    Given an unlocked wallet
    When the user adds or imports a new account
    Then the new account shows native/token balances

  Scenario: switching networks refreshes balances
    Given an unlocked wallet with multiple networks enabled
    When the user switches the active network
    Then balances reflect the selected network
```

**Automated checks run locally:**

```bash
yarn jest app/core/Engine/messengers/assets-controller/ app/core/Engine/controllers/assets-controller/ --no-coverage
yarn lint:tsc
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency bump with no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet balance refresh and RPC/WebSocket subscription wiring via a patched dependency; regressions could show stale or missing balances without obvious UI errors.
> 
> **Overview**
> Upgrades **`@metamask/assets-controller`** from **9.1.0** to **10.0.1** via a **Yarn patch** (until [MetaMask/core#9388](https://github.com/MetaMask/core/pull/9388) ships upstream). The patch changes account-tree refresh so **newly added accounts** trigger an extra **`getAssets`** across **all enabled chains** after the usual refresh, and lightly refactors the **newly enabled chains** fetch path.
> 
> **`getAssetsControllerMessenger`** is updated for v10: delegates **`BackendWebSocketService:addChannelCallback`** / **`removeChannelCallback`**, and additional events (e.g. **`AccountTreeController:stateChanged`**, **`NetworkEnablementController:stateChanged`**, **`NetworkController:networkDidChange`**, **`AccountActivityService:balanceUpdated`**). Messenger tests now use shared action/event lists and assert these delegations explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef46e95f64800c8f96ed3c8f39585bed399fc1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->