### PR TITLE
fix: support OTA release branches in close-release-bug-report-issue

### DIFF
--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
 
   // Extract semver version number from the branch name
   const releaseVersionNumberMatch = branchName.match(
-    /^release\/(\d+\.\d+\.\d+)$/,
+    /^release\/(\d+\.\d+\.\d+)(?:-ota)?$/u,
   );
 
   if (!releaseVersionNumberMatch) {


### PR DESCRIPTION
## **Description**

The `close-release-bug-report-issue` GitHub Action failed when a release PR merged from an OTA hotfix branch (`release/X.Y.Z-ota`). The script only accepted the `release/X.Y.Z` format and exited before it could close the matching bug report issue.

This change updates the branch-name regex to optionally accept the `-ota` suffix while still extracting the bare semver version (`8.0.4` from `release/8.0.4-ota`). That matches how `create-bug-report.yml` creates issues titled `vX.Y.Z Bug Report`.

Example failure: https://github.com/MetaMask/metamask-mobile/actions/runs/28672716097/job/85039414384

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

Check the GitHub action is fixed on next release

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI script regex change with no runtime, security, or data-handling impact.
> 
> **Overview**
> The **close-release-bug-report-issue** GitHub Action now recognizes OTA hotfix release branches (`release/X.Y.Z-ota`) in addition to the legacy `release/X.Y.Z` pattern.
> 
> The branch-name regex in `.github/scripts/close-release-bug-report-issue.ts` adds an optional `(?:-ota)?` suffix and the `u` flag so merges from OTA release PRs no longer fail version extraction; the captured semver stays **X.Y.Z** (e.g. `8.0.4` from `release/8.0.4-ota`), aligning with bug report issues titled `vX.Y.Z Bug Report`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b0074a0c12058c54d485b867e2cd40409b4e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->