### PR TITLE
fix: pills in explore search taking too much space cp-8.2.0

### DIFF
--- a/app/components/Views/TrendingView/components/PillRow.tsx
+++ b/app/components/Views/TrendingView/components/PillRow.tsx
@@ -32,47 +32,49 @@ const PillRow: React.FC<PillRowProps> = ({
   const tw = useTailwind();
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-      testID={`${testIdPrefix}-pills`}
-      contentContainerStyle={tw.style('px-4')}
-    >
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        twClassName="gap-2"
+    <Box>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        testID={`${testIdPrefix}-pills`}
+        contentContainerStyle={tw.style('px-4 py-3')}
       >
-        {pills.map((pill) => {
-          const isSelected = activeKey === pill.key;
-          return (
-            <Pressable
-              key={pill.key}
-              accessibilityRole="button"
-              accessibilityState={{ selected: isSelected }}
-              onPress={() => onSelect(pill.key)}
-              testID={`${testIdPrefix}-pill-${pill.key}`}
-              style={tw.style(
-                'rounded-xl px-[12px] py-2',
-                isSelected ? 'bg-icon-default' : 'bg-muted',
-              )}
-            >
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={
-                  isSelected ? TextColor.InfoInverse : TextColor.TextDefault
-                }
-                testID={`${testIdPrefix}-pill-label-${pill.key}`}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-2"
+        >
+          {pills.map((pill) => {
+            const isSelected = activeKey === pill.key;
+            return (
+              <Pressable
+                key={pill.key}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isSelected }}
+                onPress={() => onSelect(pill.key)}
+                testID={`${testIdPrefix}-pill-${pill.key}`}
+                style={tw.style(
+                  'rounded-xl px-[12px] py-2',
+                  isSelected ? 'bg-icon-default' : 'bg-muted',
+                )}
               >
-                {pill.name}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </Box>
-    </ScrollView>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={
+                    isSelected ? TextColor.InfoInverse : TextColor.TextDefault
+                  }
+                  testID={`${testIdPrefix}-pill-label-${pill.key}`}
+                >
+                  {pill.name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </Box>
+      </ScrollView>
+    </Box>
   );
 };
 

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -158,7 +158,7 @@ const PerpsBlock: React.FC<PerpsBlockProps> = ({ refresh, navigation }) => {
         tabName="Now"
         sectionName="perps_movers"
       />
-      <Box twClassName="mb-3">
+      <Box twClassName="px-4 mb-3">
         <SegmentedControl
           value={activeMoverDirection}
           onChange={handleMoverPillSelect}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Pills in explore search are taking too much space after this PR #32561

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix pills in explore search taking too much space

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3545

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a6604b24-ce3e-4ada-84e3-fc3cabdd8dd0" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/73d09c2a-bae8-471e-9836-7adb11d39a53" />

<!-- [screenshots/recordings] -->

### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f4e8f72f-42cc-4760-b9ad-9fb14c330a2c" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bc77b2cc-fc08-4efc-870f-cd854ca2fa59" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational layout change in `PillRow` only; no logic, data, or auth impact.
> 
> **Overview**
> Addresses **excessive vertical space** in the explore search category pills (regression after a prior layout change).
> 
> **`PillRow`** now wraps the horizontal **`ScrollView`** in an outer **`Box`** so the pill strip doesn’t stretch incorrectly in the explore search flex layout. Scroll **`contentContainerStyle`** is updated from **`px-4`** to **`px-4 py-3`** so horizontal/vertical inset lives on the scroll content. Pill rendering, selection styling, and test IDs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b891bdaa1beac33aafb2549fa8aa4e57d896a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->