### PR TITLE
chore(runway): cherry-pick E2E stabilization fixes cp-8.2.0

### DIFF
--- a/tests/flows/accounts.flow.ts
+++ b/tests/flows/accounts.flow.ts
@@ -229,6 +229,10 @@ export const renameAccountAtIndex = async (
   await EditAccountName.updateAccountName(newName);
   await EditAccountName.tapSave();
   await AccountDetails.tapBackButton();
+
+  if (FrameworkDetector.isAppium()) {
+    await AccountListBottomSheet.waitForAccountListVisible();
+  }
 };
 
 export const assertAccountCount = async (

--- a/tests/flows/perps.flow.ts
+++ b/tests/flows/perps.flow.ts
@@ -204,7 +204,7 @@ export const isPlaceOrderButtonVisible = async (): Promise<boolean> => {
  * @returns {Promise<void>} Resolves when the order screen is visible.
  */
 export const waitForOrderScreenVisible = async (
-  timeout = 20000,
+  timeout = 45000,
   interval = 1000,
 ): Promise<void> => {
   const start = Date.now();
@@ -282,6 +282,8 @@ export const placeLimitOrderAtPreset = async (
   await PerpsOrderView.confirmLimitPrice();
   await PerpsOrderView.tapPlaceOrderButton();
   await dismissPerpsNotificationTooltipIfPresent();
+  await PerpsMarketDetailsView.waitForScreenReady();
+  await PerpsMarketDetailsView.expectCompactOpenOrderVisible({ direction });
 };
 
 export const openPosition = async (

--- a/tests/page-objects/MultichainAccounts/AccountDetails.ts
+++ b/tests/page-objects/MultichainAccounts/AccountDetails.ts
@@ -75,10 +75,33 @@ class AccountDetails {
     });
   }
 
+  /**
+   * Appium iOS: `account-details-container` can exist with `visible=false` while
+   * the details sheet is on screen (same XCTest quirk as `account-list`). Use
+   * interactive child controls to detect the screen instead.
+   */
+  private async isAccountDetailsVisibleOnAppiumIos(): Promise<boolean> {
+    try {
+      const nameLink = await asPlaywrightElement(this.editAccountName);
+      if (await nameLink.isVisible()) {
+        return true;
+      }
+    } catch {
+      // fall through
+    }
+
+    try {
+      const backEl = await asPlaywrightElement(this.backButton);
+      return await backEl.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
   async tapBackButton(): Promise<void> {
     if (FrameworkDetector.isAppium() && PlatformDetector.isIOS()) {
-      const container = await asPlaywrightElement(this.container);
-      const isOnAccountDetails = await container.isVisible().catch(() => false);
+      const isOnAccountDetails =
+        await this.isAccountDetailsVisibleOnAppiumIos();
       if (!isOnAccountDetails) {
         return;
       }

--- a/tests/page-objects/Perps/PerpsMarketDetailsView.ts
+++ b/tests/page-objects/Perps/PerpsMarketDetailsView.ts
@@ -330,6 +330,83 @@ class PerpsMarketDetailsView {
     });
   }
 
+  /**
+   * Waits for a newly placed limit order to appear on market details (compact orders section).
+   * Perps navigates here immediately after Place order while the WebSocket feed catches up.
+   */
+  async expectCompactOpenOrderVisible(options: {
+    direction: 'long' | 'short';
+    timeout?: number;
+  }): Promise<void> {
+    const { direction, timeout = 60000 } = options;
+    const orderLabel = `Limit ${direction}`;
+    const firstRow = Matchers.getElementByID(
+      PerpsCompactOrderRowSelectorsIDs.FIRST_ROW,
+    );
+    const scrollContainer = Matchers.scrollContainer(
+      PerpsMarketDetailsViewSelectorsIDs.SCROLL_VIEW,
+    );
+
+    await Utilities.executeWithRetry(
+      async () => {
+        try {
+          await Gestures.scrollToElement(
+            Matchers.getElementByText(orderLabel),
+            scrollContainer,
+            {
+              direction: 'down',
+              scrollAmount: 200,
+              timeout: 5000,
+              elemDescription: `Scroll to ${orderLabel} on market details`,
+            },
+          );
+        } catch {
+          // Order row may not be in the DOM yet.
+        }
+
+        try {
+          await Assertions.expectElementToBeVisible(firstRow, {
+            description: 'Compact open order row on market details',
+            timeout: 3000,
+          });
+          return;
+        } catch {
+          await Assertions.expectTextDisplayed(orderLabel, {
+            description: `${orderLabel} visible on market details`,
+            timeout: 3000,
+          });
+        }
+      },
+      { interval: 1000, timeout },
+    );
+  }
+
+  /** Asserts the compact open-order row for this limit direction is gone (e.g. after cancel or fill). */
+  async expectCompactOpenOrderNotVisible(options: {
+    direction: 'long' | 'short';
+    timeout?: number;
+  }): Promise<void> {
+    const { direction, timeout = 60000 } = options;
+    const orderLabel = `Limit ${direction}`;
+    const firstRow = Matchers.getElementByID(
+      PerpsCompactOrderRowSelectorsIDs.FIRST_ROW,
+    );
+
+    await Utilities.executeWithRetry(
+      async () => {
+        await Assertions.expectElementToNotBeVisible(firstRow, {
+          description: 'Compact open order row cleared from market details',
+          timeout: 3000,
+        });
+        await Assertions.expectTextNotDisplayed(orderLabel, {
+          description: `${orderLabel} cleared from market details`,
+          timeout: 3000,
+        });
+      },
+      { interval: 1000, timeout },
+    );
+  }
+
   // Verify that Orders tab has at least one open order card
   async expectOpenOrderVisible() {
     const openOrderCard = Matchers.getElementByID(

--- a/tests/page-objects/Perps/PerpsView.ts
+++ b/tests/page-objects/Perps/PerpsView.ts
@@ -136,6 +136,12 @@ class PerpsView {
     );
   }
 
+  private getPortfolioOrderCard(index = 0): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      `${PerpsHomeViewSelectorsIDs.ORDER_CARD}-${index}`,
+    );
+  }
+
   private getWalletHomePositionRow(symbol: string): EncapsulatedElementType {
     return Matchers.getElementByID(`perps-position-row-${symbol}`);
   }
@@ -169,6 +175,31 @@ class PerpsView {
     });
   }
 
+  private async scrollLimitOrderIntoViewOnPortfolio(
+    orderLabel: string,
+  ): Promise<void> {
+    const orderCard = this.getPortfolioOrderCard(0);
+    if (await Utilities.isElementVisible(orderCard, 750)) {
+      return;
+    }
+
+    const scrollView = Matchers.scrollContainer(
+      PerpsHomeViewSelectorsIDs.SCROLL_CONTENT,
+    );
+    const orderElement = Matchers.getElementByText(orderLabel);
+
+    try {
+      await Gestures.scrollToElement(orderElement, scrollView, {
+        direction: 'up',
+        scrollAmount: 150,
+        timeout: 5000,
+        elemDescription: `scrollToElement(up) for ${orderLabel} on Perps portfolio`,
+      });
+    } catch {
+      await this.scrollDownOnPerpsTab(1);
+    }
+  }
+
   /**
    * Open limit order visible on portfolio/home (`formatOrderLabel` / PerpsCard).
    */
@@ -177,26 +208,25 @@ class PerpsView {
   ): Promise<void> {
     const { symbol, direction } = options;
     const orderLabel = options.orderLabel ?? `Limit ${direction}`;
-    // Android may land mid-scroll after back navigation; scroll the order into view first
-    if (PlatformDetector.isAndroid()) {
-      const orderElement = Matchers.getElementByText(orderLabel);
-      const scrollView = Matchers.scrollContainer(
-        PerpsHomeViewSelectorsIDs.SCROLL_CONTENT,
-      );
-      await Gestures.scrollToElement(orderElement, scrollView, {
-        direction: 'up',
-        scrollAmount: 150,
-        elemDescription: `scrollToElement(up) for ${orderLabel} on Perps portfolio`,
-      });
-    }
     await Utilities.executeWithRetry(
       async () => {
+        await this.scrollLimitOrderIntoViewOnPortfolio(orderLabel);
+
+        const orderCard = this.getPortfolioOrderCard(0);
+        if (await Utilities.isElementVisible(orderCard, 1500)) {
+          await Assertions.expectElementToBeVisible(orderCard, {
+            description: `${orderLabel} order card on Perps portfolio (${symbol})`,
+            timeout: 3000,
+          });
+          return;
+        }
+
         await Assertions.expectTextDisplayed(orderLabel, {
           description: `${orderLabel} order visible on Perps portfolio (${symbol})`,
           timeout: 5000,
         });
       },
-      { interval: 1000, timeout: 30000 },
+      { interval: 1000, timeout: 60000 },
     );
   }
 

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -25,6 +25,7 @@ import {
   encapsulatedAction,
   LogLevel,
   PlaywrightGestures,
+  sleep,
   Utilities,
 } from '../../framework';
 import AddAccountBottomSheet from './AddAccountBottomSheet';
@@ -37,7 +38,7 @@ const logger = createLogger({
 });
 
 class AccountListBottomSheet {
-  /** Account list container - wdio uses getElementByText('Accounts') for Appium */
+  /** Account list container - Appium uses `account-list` testID; Detox uses the same ID. */
   get accountList(): EncapsulatedElementType {
     return encapsulated({
       detox: () =>
@@ -45,8 +46,9 @@ class AccountListBottomSheet {
           AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
         ),
       appium: () =>
-        PlaywrightMatchers.getElementByText(
-          AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
+        PlaywrightMatchers.getElementById(
+          AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+          { exact: true },
         ),
     });
   }
@@ -242,7 +244,7 @@ class AccountListBottomSheet {
   }
 
   async openAddAccountSheet(): Promise<void> {
-    if (FrameworkDetector.isAppium() && PlatformDetector.isIOS()) {
+    if (FrameworkDetector.isAppium()) {
       await this.waitForAccountSyncToComplete();
     }
 
@@ -253,7 +255,7 @@ class AccountListBottomSheet {
   }
 
   async openAddWalletSheet(): Promise<void> {
-    if (FrameworkDetector.isAppium() && PlatformDetector.isIOS()) {
+    if (FrameworkDetector.isAppium()) {
       await this.waitForAccountSyncToComplete();
     }
 
@@ -291,25 +293,23 @@ class AccountListBottomSheet {
         });
       },
       appium: async () => {
-        if (PlatformDetector.isIOS()) {
-          // Account sync/discovery can keep the row visible but not yet tappable.
-          // Wait for the sync phase to settle before tapping "Add account".
-          await this.waitForAccountSyncToComplete();
-        }
+        const buttonIndex = options?.srpIndex ?? 0;
 
-        await Assertions.expectElementToHaveText(button, 'Add account', {
-          description: 'Add Account button should be ready (not syncing)',
-          timeout: 30000,
+        // Account sync/discovery can keep the row visible but not yet tappable.
+        // Wait for the sync phase to settle before tapping "Add account".
+        await this.waitForAccountSyncToComplete(90_000, {
+          addAccountButtonIndex: buttonIndex,
         });
 
-        await UnifiedGestures.waitAndTap(button, {
-          description: 'Add Account button in V2 multichain accounts',
+        // Re-query after sync settle — never reuse a pre-sync element handle.
+        const tapTarget = await this.getAddAccountButtonTapTarget(buttonIndex);
+
+        await PlaywrightGestures.waitAndTap(tapTarget, {
           delay: options?.shouldWait ? 5000 : 0,
           timeout: 20_000,
           checkForDisplayed: true,
           checkForEnabled: true,
-          waitForInteractive: true,
-          enabledStableReads: 3,
+          waitForInteractive: false,
           postEnabledSettleMs: 500,
         });
       },
@@ -557,12 +557,97 @@ class AccountListBottomSheet {
     await this.swipeToDismissAccountsModal();
   }
 
+  private static readonly ADD_ACCOUNT_READY_LABEL = 'Add account';
+
+  /**
+   * Appium: fresh lookup of the V2 footer label (`CREATE_ACCOUNT` testID).
+   */
+  private async getAddAccountButtonLabel(
+    srpIndex: number,
+  ): Promise<PlaywrightElement> {
+    return PlaywrightMatchers.getElementById(
+      AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT,
+      { exact: true, index: srpIndex },
+    );
+  }
+
+  /**
+   * Appium: true while the footer label is not yet showing the idle copy.
+   * Catches fast sync/discovery flashes that Step 1 can miss via global text search.
+   */
+  private async isAddAccountFooterBusy(srpIndex: number): Promise<boolean> {
+    try {
+      const label = await this.getAddAccountButtonLabel(srpIndex);
+      const text = (await label.textContent()).trim();
+      return text !== AccountListBottomSheet.ADD_ACCOUNT_READY_LABEL;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Appium: resolve the tappable row for "Add account" (V2 multichain footer).
+   * `CREATE_ACCOUNT` is on the label `Text`; the disabled state lives on the parent
+   * `TouchableOpacity`, so taps must target the clickable ancestor on Android.
+   */
+  private async getAddAccountButtonTapTarget(
+    srpIndex: number,
+  ): Promise<PlaywrightElement> {
+    const createAccountId = AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT;
+
+    if (PlatformDetector.isAndroid()) {
+      return PlaywrightMatchers.getElementByXPath(
+        `(//*[@resource-id='${createAccountId}'])[${srpIndex + 1}]/ancestor::*[@clickable='true'][1]`,
+      );
+    }
+
+    return PlaywrightMatchers.getElementById(createAccountId, {
+      exact: true,
+      index: srpIndex,
+    });
+  }
+
+  /**
+   * Appium: poll with fresh DOM queries until the footer label reads "Add account"
+   * and the clickable row is stably interactive.
+   */
+  private async waitForAddAccountButtonReady(
+    srpIndex: number,
+    timeoutMs: number,
+  ): Promise<void> {
+    await Utilities.executeWithRetry(
+      async () => {
+        const label = await this.getAddAccountButtonLabel(srpIndex);
+        const text = (await label.textContent()).trim();
+        if (text !== AccountListBottomSheet.ADD_ACCOUNT_READY_LABEL) {
+          throw new Error(
+            `Add account footer label is "${text}", expected "${AccountListBottomSheet.ADD_ACCOUNT_READY_LABEL}"`,
+          );
+        }
+
+        const tapTarget = await this.getAddAccountButtonTapTarget(srpIndex);
+        await PlaywrightGestures.waitUntilInteractive(tapTarget, 3000, {
+          requiredStableReads: 3,
+        });
+      },
+      {
+        timeout: timeoutMs,
+        interval: 500,
+        description: `Add account button (index ${srpIndex}) ready`,
+      },
+    );
+  }
+
   /**
    * Waits for the account sync to complete.
    * @param timeout - The timeout in milliseconds.
+   * @param options.addAccountButtonIndex - When set (Appium V2 add-account flows), also wait until that footer row is interactive after sync/discovery text clears.
    * @returns {Promise<void>} Resolves when the account sync is complete.
    */
-  async waitForAccountSyncToComplete(timeout = 90000): Promise<void> {
+  async waitForAccountSyncToComplete(
+    timeout = 90000,
+    options?: { addAccountButtonIndex?: number },
+  ): Promise<void> {
     logger.debug('⏳ waitForSyncingToComplete: Starting...');
     const startTime = Date.now();
     const pollInterval = 500;
@@ -585,52 +670,93 @@ class AccountListBottomSheet {
       '⏳ Step 1: Waiting up to 5s for "Syncing" or "Discovering" to appear...',
     );
     let syncingDetected = false;
+    const footerIndex = options?.addAccountButtonIndex;
     while (Date.now() - startTime < initialWaitTimeout) {
       const isSyncing = await isTextVisible('Syncing');
       const isDiscovering = await isTextVisible('Discovering');
+      const footerBusy =
+        footerIndex !== undefined &&
+        (await this.isAddAccountFooterBusy(footerIndex));
 
-      if (isSyncing || isDiscovering) {
+      if (isSyncing || isDiscovering || footerBusy) {
         syncingDetected = true;
         logger.debug(
-          `✅ Step 1: Loading detected after ${getElapsed()}s (Syncing: ${isSyncing}, Discovering: ${isDiscovering})`,
+          `✅ Step 1: Loading detected after ${getElapsed()}s (Syncing: ${isSyncing}, Discovering: ${isDiscovering}, footerBusy: ${footerBusy})`,
         );
         break;
       }
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      await sleep(pollInterval);
     }
 
-    // If nothing appeared after 5 seconds, we're done
     if (!syncingDetected) {
       logger.debug(
-        `✅ waitForSyncingToComplete: No syncing detected after 5s, finishing after ${getElapsed()}s`,
+        `⏳ Step 1: No syncing/discovering/footer-busy within 5s — skipping text-settle steps`,
       );
-      return;
+    } else if (footerIndex !== undefined) {
+      // Step 2–4 (footer path): re-query label until idle copy shows, even when
+      // global "Syncing"/"Discovering" text was never visible or flashed quickly.
+      logger.debug(
+        `⏳ Step 2: Waiting for Add account footer label (index ${footerIndex})...`,
+      );
+      while (Date.now() - startTime < timeout) {
+        if (!(await this.isAddAccountFooterBusy(footerIndex))) {
+          logger.debug(
+            `✅ Step 2: Add account footer label ready after ${getElapsed()}s`,
+          );
+          break;
+        }
+        await sleep(pollInterval);
+      }
+
+      logger.debug('⏳ Step 3: Waiting 1 second...');
+      await sleep(1000);
+    } else {
+      // Step 2: Wait for "Syncing" to disappear
+      logger.debug('⏳ Step 2: Waiting for "Syncing" to disappear...');
+      while (Date.now() - startTime < timeout) {
+        if (!(await isTextVisible('Syncing'))) {
+          logger.debug(
+            `✅ Step 2: "Syncing" disappeared after ${getElapsed()}s`,
+          );
+          break;
+        }
+        await sleep(pollInterval);
+      }
+
+      // Step 3: Wait 1 second delay
+      logger.debug('⏳ Step 3: Waiting 1 second...');
+      await sleep(1000);
+
+      // Step 4: Wait for "Discovering" to disappear
+      logger.debug('⏳ Step 4: Waiting for "Discovering" to disappear...');
+      while (Date.now() - startTime < timeout) {
+        if (!(await isTextVisible('Discovering'))) {
+          logger.debug(
+            `✅ Step 4: "Discovering" disappeared after ${getElapsed()}s`,
+          );
+          break;
+        }
+        await sleep(pollInterval);
+      }
     }
 
-    // Step 2: Wait for "Syncing" to disappear
-    logger.debug('⏳ Step 2: Waiting for "Syncing" to disappear...');
-    while (Date.now() - startTime < timeout) {
-      if (!(await isTextVisible('Syncing'))) {
-        logger.debug(`✅ Step 2: "Syncing" disappeared after ${getElapsed()}s`);
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
-    }
+    if (
+      FrameworkDetector.isAppium() &&
+      options?.addAccountButtonIndex !== undefined
+    ) {
+      const remainingMs = Math.max(timeout - (Date.now() - startTime), 1000);
+      logger.debug(
+        `⏳ Step 5: Waiting up to ${remainingMs}ms for Add account control (index ${options.addAccountButtonIndex}) — re-querying each attempt...`,
+      );
 
-    // Step 3: Wait 1 second delay
-    logger.debug('⏳ Step 3: Waiting 1 second...');
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+      await this.waitForAddAccountButtonReady(
+        options.addAccountButtonIndex,
+        remainingMs,
+      );
 
-    // Step 4: Wait for "Discovering" to disappear
-    logger.debug('⏳ Step 4: Waiting for "Discovering" to disappear...');
-    while (Date.now() - startTime < timeout) {
-      if (!(await isTextVisible('Discovering'))) {
-        logger.debug(
-          `✅ Step 4: "Discovering" disappeared after ${getElapsed()}s`,
-        );
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      logger.debug(
+        `✅ Step 5: Add account control is interactive after ${getElapsed()}s`,
+      );
     }
 
     logger.debug(

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -38,7 +38,13 @@ const logger = createLogger({
 });
 
 class AccountListBottomSheet {
-  /** Account list container - Appium uses `account-list` testID; Detox uses the same ID. */
+  /**
+   * Account list container.
+   * Detox: `account-list` testID.
+   * Appium iOS: header title text — `account-list` is on a wrapper XCTest keeps
+   * `visible=false` while the sheet is open; "Accounts" is reliably displayed.
+   * Appium Android: `account-list` testID.
+   */
   get accountList(): EncapsulatedElementType {
     return encapsulated({
       detox: () =>
@@ -46,10 +52,14 @@ class AccountListBottomSheet {
           AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
         ),
       appium: () =>
-        PlaywrightMatchers.getElementById(
-          AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
-          { exact: true },
-        ),
+        PlatformDetector.isIOS()
+          ? PlaywrightMatchers.getElementByText(
+              AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
+            )
+          : PlaywrightMatchers.getElementById(
+              AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+              { exact: true },
+            ),
     });
   }
 
@@ -269,6 +279,46 @@ class AccountListBottomSheet {
     await Gestures.waitAndTap(this.backButton, {
       elemDescription: 'Account list header back button',
     });
+  }
+
+  /**
+   * Appium: poll until the account list sheet is open.
+   * Retries lookup + visibility — needed after rename/back navigation when the
+   * sheet is animating in and text/testID queries can briefly miss.
+   */
+  async waitForAccountListVisible(timeout = 15_000): Promise<void> {
+    if (!FrameworkDetector.isAppium()) {
+      await Assertions.expectElementToBeVisible(this.accountList, { timeout });
+      return;
+    }
+
+    await Utilities.executeWithRetry(
+      async () => {
+        let el: PlaywrightElement;
+        try {
+          el = PlatformDetector.isIOS()
+            ? await PlaywrightMatchers.getElementByText(
+                AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
+              )
+            : await PlaywrightMatchers.getElementById(
+                AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+                { exact: true },
+              );
+        } catch {
+          throw new Error('Account list sheet element not found');
+        }
+
+        const visible = await el.isVisible().catch(() => false);
+        if (!visible) {
+          throw new Error('Account list sheet is not visible yet');
+        }
+      },
+      {
+        timeout,
+        interval: 500,
+        description: 'Account list sheet visible',
+      },
+    );
   }
 
   async tapAddAccountButtonV2(options?: {

--- a/tests/smoke-appium/perps/perps-limit-order-cancel.spec.ts
+++ b/tests/smoke-appium/perps/perps-limit-order-cancel.spec.ts
@@ -2,7 +2,6 @@ import { test as appiumTest } from '../../framework/fixtures/playwright/index.js
 import { SmokePerps } from '../../tags.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { placeLimitOrderAtPreset } from '../../flows/perps.flow.js';
-import PerpsView from '../../page-objects/Perps/PerpsView.js';
 import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView.js';
 import PerpsOrderDetailsView from '../../page-objects/Perps/PerpsOrderDetailsView.js';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers.js';
@@ -40,23 +39,11 @@ appiumTest.describe(SmokePerps('Perps - Limit order cancel'), () => {
             'long',
             'Mid',
           );
-          await PerpsView.navigateToPerpsPortfolioHomeFromMarketOrderFlow();
 
-          await PerpsView.expectLimitOrderVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
-            direction: 'long',
-          });
-
-          await PerpsView.tapLimitOrderOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
-            direction: 'long',
-          });
           await PerpsMarketDetailsView.tapFirstCompactOrderRow();
           await PerpsOrderDetailsView.tapCancelOrderButton();
-          await PerpsView.navigateToPerpsPortfolioHomeFromMarketOrderFlow();
 
-          await PerpsView.expectLimitOrderNotVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
+          await PerpsMarketDetailsView.expectCompactOpenOrderNotVisible({
             direction: 'long',
           });
 
@@ -66,8 +53,7 @@ appiumTest.describe(SmokePerps('Perps - Limit order cancel'), () => {
             '2125.00',
           );
 
-          await PerpsView.expectLimitOrderNotVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
+          await PerpsMarketDetailsView.expectCompactOpenOrderNotVisible({
             direction: 'long',
           });
         },

--- a/tests/smoke-appium/perps/perps-limit-order-no-fill.spec.ts
+++ b/tests/smoke-appium/perps/perps-limit-order-no-fill.spec.ts
@@ -2,9 +2,8 @@ import { test as appiumTest } from '../../framework/fixtures/playwright/index.js
 import { SmokePerps } from '../../tags.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { placeLimitOrderAtPreset } from '../../flows/perps.flow.js';
-import PerpsView from '../../page-objects/Perps/PerpsView.js';
+import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView.js';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers.js';
-import Assertions from '../../framework/Assertions.js';
 import { TestSuiteParams } from '../../framework/types.js';
 import {
   beginPerpsSmokeTestPlaywright,
@@ -35,10 +34,8 @@ appiumTest.describe(SmokePerps('Perps - Limit order no fill'), () => {
           await beginPerpsSmokeTestPlaywright();
 
           await placeLimitOrderAtPreset(PERPS_SMOKE_MARKET_SYMBOL, 'long', -1);
-          await PerpsView.navigateToPerpsPortfolioHomeFromMarketOrderFlow();
 
-          await PerpsView.expectLimitOrderVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
+          await PerpsMarketDetailsView.expectCompactOpenOrderVisible({
             direction: 'long',
           });
 
@@ -48,22 +45,11 @@ appiumTest.describe(SmokePerps('Perps - Limit order no fill'), () => {
             '2480.00',
           );
 
-          await PerpsView.expectLimitOrderVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
+          await PerpsMarketDetailsView.expectCompactOpenOrderVisible({
             direction: 'long',
           });
 
-          await Assertions.expectElementToNotBeVisible(
-            PerpsView.getPositionItemAnyLeverage(
-              PERPS_SMOKE_MARKET_SYMBOL,
-              'long',
-            ),
-            {
-              description:
-                'No ETH long position row while limit order remains unfilled',
-              timeout: 5000,
-            },
-          );
+          await PerpsMarketDetailsView.expectClosePositionButtonNotVisible();
         },
       );
     },

--- a/tests/smoke-appium/perps/perps-limit-short-fill.spec.ts
+++ b/tests/smoke-appium/perps/perps-limit-short-fill.spec.ts
@@ -2,8 +2,9 @@ import { test as appiumTest } from '../../framework/fixtures/playwright/index.js
 import { SmokePerps } from '../../tags.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { placeLimitOrderAtPreset } from '../../flows/perps.flow.js';
-import PerpsView from '../../page-objects/Perps/PerpsView.js';
+import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView.js';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers.js';
+import Utilities from '../../framework/Utilities.js';
 import { TestSuiteParams } from '../../framework/types.js';
 import {
   beginPerpsSmokeTestPlaywright,
@@ -38,10 +39,8 @@ appiumTest.describe(SmokePerps('Perps - ETH limit short fill'), () => {
             'short',
             'Mid',
           );
-          await PerpsView.navigateToPerpsPortfolioHomeFromMarketOrderFlow();
 
-          await PerpsView.expectLimitOrderVisibleOnPortfolio({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
+          await PerpsMarketDetailsView.expectCompactOpenOrderVisible({
             direction: 'short',
           });
 
@@ -51,10 +50,16 @@ appiumTest.describe(SmokePerps('Perps - ETH limit short fill'), () => {
             '2875.00',
           );
 
-          await PerpsView.expectPositionRowAfterLimitOrderFilled({
-            symbol: PERPS_SMOKE_MARKET_SYMBOL,
-            direction: 'short',
-          });
+          await Utilities.executeWithRetry(
+            async () => {
+              await PerpsMarketDetailsView.expectClosePositionButtonVisible();
+            },
+            {
+              interval: 1000,
+              timeout: 60000,
+              description: 'wait for limit short to fill into an open position',
+            },
+          );
         },
       );
     },

--- a/tests/smoke/perps/perps-limit-long-fill.spec.ts
+++ b/tests/smoke/perps/perps-limit-long-fill.spec.ts
@@ -7,7 +7,8 @@ import {
   mockPerpsGeolocation,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
 import { placeLimitOrderAtPreset } from '../../flows/perps.flow';
-import PerpsView from '../../page-objects/Perps/PerpsView';
+import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView';
+import Utilities from '../../framework/Utilities';
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
 import { TestSuiteParams } from '../../framework/types';
@@ -61,10 +62,7 @@ describe(SmokePerps('Perps - ETH limit long fill'), () => {
 
         await placeLimitOrderAtPreset('ETH', 'long', 'Mid');
 
-        await PerpsView.navigateToPerpsPortfolioHomeFromMarketOrderFlow();
-
-        await PerpsView.expectLimitOrderVisibleOnPortfolio({
-          symbol: 'ETH',
+        await PerpsMarketDetailsView.expectCompactOpenOrderVisible({
           direction: 'long',
         });
 
@@ -74,10 +72,16 @@ describe(SmokePerps('Perps - ETH limit long fill'), () => {
           '2125.00',
         );
 
-        await PerpsView.expectPositionRowAfterLimitOrderFilled({
-          symbol: 'ETH',
-          direction: 'long',
-        });
+        await Utilities.executeWithRetry(
+          async () => {
+            await PerpsMarketDetailsView.expectClosePositionButtonVisible();
+          },
+          {
+            interval: 1000,
+            timeout: 60000,
+            description: 'wait for limit long to fill into an open position',
+          },
+        );
       },
     );
   });


### PR DESCRIPTION
- fix(e2e): stabilize Android Appium add-account sync waits cp-8.2.0 (#32768)
- fix(e2e): stabilize Appium iOS account list visibility after rename cp-8.2.0 (#32777)
- fix(e2e): stabilize flaky perps limit-order smoke specs cp-8.2.0 (#32780)

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only
expected follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by
.github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in
rendered markdown and must NOT be removed or edited without updating the
validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Cherry-picks three `main` E2E stabilization fixes onto `release/8.2.0` to recover Appium account/perps smoke and Detox perps limit-order coverage after #32639.

**Why:** `release/8.2.0` already includes #32639 (stricter Appium add-account interaction checks) but not the follow-up fixes merged on `main` Fri–Mon. Open `cp-8.2.0` cherry-picks were still failing `appium-accounts-android-smoke`, `appium-perps-android-smoke`, and Detox perps limit-order specs.

**What (in cherry-pick order):**

1. #32768 — Android Appium add-account sync waits (`appium-accounts-android-smoke`)
2. #32777 — iOS Appium account list visibility after rename (`appium-accounts-ios-smoke`)
3. #32780 — Perps limit-order smoke stabilization (Appium + Detox `perps-limit-long-fill`)

**Not included:** #32772 (temporary `describe.skip` superseded by #32780).

<!-- mms-check: type=text required=true -->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #32768, #32777, #32780

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: release/8.2.0 E2E stabilization cherry-pick

  Scenario: Appium account smoke passes on release branch CI
    Given a main-e2e release build on release/8.2.0 with this cherry-pick applied
    When CI runs appium-accounts-android-smoke and appium-accounts-ios-smoke
    Then add-account and rename-account specs complete without interactive-check or account-list visibility failures

  Scenario: Appium and Detox perps limit-order smoke pass on release branch CI
    Given a main-e2e release build on release/8.2.0 with this cherry-pick applied
    When CI runs appium-perps-android-smoke and perps-ios-smoke (Detox)
    Then perps limit-order specs complete without portfolio sync timing failures or "Order screen not visible after 20000ms"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — test-only E2E infrastructure; failures reproduced in release-branch CI logs on open `cp-8.2.0` PRs.

### **After**

N/A — pending green Appium account/perps and Detox perps jobs on this PR.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — test-only POM/flow changes; no production code
- [x] I've tested with a power user scenario
  - N/A — test-only change
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — test-only change

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.