### PR TITLE
fix(ramp): make headless errors terminal

### DIFF
--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
@@ -72,7 +72,7 @@ jest.mock('../../headless/useHeadlessSessionFocusDismissal', () => ({
 // Keep the real `setHeadlessEntryCardTouchThrough` (asserted via the
 // navigation setOptions mock) but spy on `dismissHeadlessFlow` so the
 // terminal-error teardown can be asserted in isolation. `dismissHeadlessFlow`
-// pops the transparent HEADLESS_ENTRY modal — its absence on the error path
+// pops the transparent HEADLESS_ENTRY modal; its absence on the error path
 // was the bug that froze the app over the confirmation screen.
 const mockDismissHeadlessFlow = jest.fn();
 jest.mock('../../headless/headlessEntryNavigation', () => {
@@ -621,7 +621,7 @@ describe('HeadlessHost', () => {
   });
 
   // The bug: a headless flow that terminates with an ERROR called
-  // `failSession` (registry bookkeeping only — no navigation) but never
+  // `failSession` (registry bookkeeping only, no navigation) but never
   // dismissed the transparent HEADLESS_ENTRY modal. The modal stayed mounted
   // over the confirmation screen and intercepted every touch, so the app
   // looked frozen until relaunch. Each terminal-error path must now pop the

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
@@ -69,6 +69,21 @@ jest.mock('../../headless/useHeadlessSessionFocusDismissal', () => ({
     mockUseHeadlessSessionFocusDismissal(...args),
 }));
 
+// Keep the real `setHeadlessEntryCardTouchThrough` (asserted via the
+// navigation setOptions mock) but spy on `dismissHeadlessFlow` so the
+// terminal-error teardown can be asserted in isolation. `dismissHeadlessFlow`
+// pops the transparent HEADLESS_ENTRY modal — its absence on the error path
+// was the bug that froze the app over the confirmation screen.
+const mockDismissHeadlessFlow = jest.fn();
+jest.mock('../../headless/headlessEntryNavigation', () => {
+  const actual = jest.requireActual('../../headless/headlessEntryNavigation');
+  return {
+    ...actual,
+    dismissHeadlessFlow: (...args: unknown[]) =>
+      mockDismissHeadlessFlow(...args),
+  };
+});
+
 jest.mock('../../hooks/useContinueWithQuote', () => ({
   __esModule: true,
   default: (options?: unknown) => {
@@ -602,6 +617,99 @@ describe('HeadlessHost', () => {
       unmount();
 
       expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // The bug: a headless flow that terminates with an ERROR called
+  // `failSession` (registry bookkeeping only — no navigation) but never
+  // dismissed the transparent HEADLESS_ENTRY modal. The modal stayed mounted
+  // over the confirmation screen and intercepted every touch, so the app
+  // looked frozen until relaunch. Each terminal-error path must now pop the
+  // modal via `dismissHeadlessFlow` in addition to failing the session, and
+  // must do so exactly once even when paths race.
+  describe('Terminal-error modal teardown (stuck-screen fix)', () => {
+    it('dismisses the headless flow when continueWithQuote rejects, in addition to failing the session', async () => {
+      mockContinueWithQuote.mockRejectedValueOnce(new Error('quote expired'));
+      const quote = buildAggregatorQuote();
+      const session = seedSession(quote);
+      const callbacks = session.callbacks;
+
+      renderHost({ headlessSessionId: session.id });
+
+      await waitFor(() => {
+        expect(callbacks.onError).toHaveBeenCalledWith({
+          code: 'UNKNOWN',
+          message: 'quote expired',
+        });
+      });
+      // The session teardown (failSession) AND the modal dismissal both fire.
+      expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+      expect(getSession(session.id)).toBeUndefined();
+    });
+
+    it('dismisses the headless flow when the assetId is invalid, in addition to failing the session', () => {
+      mockUseRampAccountAddress.mockReturnValue(null);
+      const quote = buildAggregatorQuote();
+      const session = seedSession(quote, { assetId: 'not-a-caip-19' });
+      const callbacks = session.callbacks;
+
+      renderHost({ headlessSessionId: session.id });
+
+      expect(callbacks.onError).toHaveBeenCalledWith({
+        code: 'UNKNOWN',
+        message: expect.stringContaining('not-a-caip-19'),
+      });
+      expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses the headless flow when a nativeFlowError terminates the session', () => {
+      const quote = buildNativeQuote();
+      const session = seedSession(quote);
+
+      renderHost({
+        headlessSessionId: session.id,
+        nativeFlowError: 'OTP rejected',
+      });
+
+      expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+      expect(getSession(session.id)).toBeUndefined();
+    });
+
+    it('does NOT dismiss the headless flow on a normal in-progress render (no terminal error)', async () => {
+      mockContinueWithQuote.mockImplementation(
+        () => new Promise(() => undefined),
+      );
+      const quote = buildAggregatorQuote();
+      const session = seedSession(quote);
+
+      renderHost({ headlessSessionId: session.id });
+
+      await waitFor(() =>
+        expect(mockContinueWithQuote).toHaveBeenCalledTimes(1),
+      );
+      expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+      expect(getSession(session.id)).toBeDefined();
+    });
+
+    it('dismisses at most once even if the terminal-error guard is re-entered after teardown', async () => {
+      // First terminal error (continueWithQuote rejection) tears down and
+      // dismisses. The ref guard + failSession returning undefined for an
+      // already-removed session must prevent a second dismissal if any error
+      // path fires again (e.g. a re-render re-runs the effect body).
+      mockContinueWithQuote.mockRejectedValue(new Error('quote expired'));
+      const quote = buildAggregatorQuote();
+      const session = seedSession(quote);
+
+      renderHost({ headlessSessionId: session.id });
+
+      await waitFor(() =>
+        expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1),
+      );
+      // Let any additional pending microtasks settle.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
@@ -381,7 +381,7 @@ describe('HeadlessHost', () => {
         code: 'UNKNOWN',
         message: expect.stringContaining('not-a-caip-19'),
       });
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
       expect(getSession(session.id)).toBeUndefined();
       expect(mockContinueWithQuote).not.toHaveBeenCalled();
     });
@@ -398,7 +398,7 @@ describe('HeadlessHost', () => {
           message: 'quote expired',
         });
       });
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
       expect(getSession(session.id)).toBeUndefined();
     });
 
@@ -416,7 +416,7 @@ describe('HeadlessHost', () => {
           message: 'Daily limit exceeded',
         });
       });
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
       expect(getSession(session.id)).toBeUndefined();
     });
 
@@ -460,7 +460,7 @@ describe('HeadlessHost', () => {
         code: 'AUTH_FAILED',
         message: 'OTP rejected',
       });
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
       expect(getSession(session.id)).toBeUndefined();
       expect(mockContinueWithQuote).not.toHaveBeenCalled();
     });
@@ -566,7 +566,7 @@ describe('HeadlessHost', () => {
       expect(callbacks.onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('does not fire a second onClose when a Phase 7 nativeFlowError already closed the session before unmount', () => {
+    it('fires onError only (no onClose) when a Phase 7 nativeFlowError terminates the session, even across unmount', () => {
       const quote = buildNativeQuote();
       const session = seedSession(quote);
       const callbacks = session.callbacks;
@@ -575,13 +575,16 @@ describe('HeadlessHost', () => {
         nativeFlowError: 'OTP rejected',
       });
 
-      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onError).toHaveBeenCalledWith({
+        code: 'AUTH_FAILED',
+        message: 'OTP rejected',
+      });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
 
       registeredBeforeRemoveListener?.(DEFAULT_GO_BACK_EVENT);
       unmount();
 
-      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+      expect(callbacks.onClose).not.toHaveBeenCalled();
     });
 
     it('no-ops on unmount when the host mounted against an already-terminated session', () => {

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { useIsFocused, useNavigation } from '@react-navigation/native';
 import type { CaipChainId } from '@metamask/utils';
@@ -23,7 +23,10 @@ import {
   getSession,
   setStatus,
 } from '../../headless/sessionRegistry';
-import { setHeadlessEntryCardTouchThrough } from '../../headless/headlessEntryNavigation';
+import {
+  dismissHeadlessFlow,
+  setHeadlessEntryCardTouchThrough,
+} from '../../headless/headlessEntryNavigation';
 import { useHeadlessSessionFocusDismissal } from '../../headless/useHeadlessSessionFocusDismissal';
 import { useHeadlessSessionDismissal } from '../../headless/useHeadlessSessionDismissal';
 import { getChainIdFromAssetId } from '../../headless/useHeadlessBuy';
@@ -74,6 +77,40 @@ function HeadlessHost() {
   const { headlessSessionId, nativeFlowError, suppressFocusDismissal } =
     useParams<HeadlessHostParams>();
   const session = getSession(headlessSessionId);
+
+  // Guards the modal teardown so the transparent HEADLESS_ENTRY screen is
+  // popped exactly once on a terminal error, even if two error paths race
+  // (e.g. the continueWithQuote rejection and the nativeFlowError effect) or
+  // the existing beforeRemove / focus-dismissal listeners also fire. Mirrors
+  // Checkout's `hasTerminatedHeadlessSessionRef`.
+  const hasTerminatedHeadlessSessionRef = useRef(false);
+
+  // Terminal-error teardown: forward the error to the consumer via
+  // `failSession` (fires onError, removes the session), then pop the
+  // transparent HEADLESS_ENTRY modal so the underlying confirmation screen
+  // becomes interactive again. Without the dismissal the modal stays mounted
+  // and intercepts all touches, freezing the app until relaunch.
+  //
+  // `failSession` returns `undefined` when the session was already terminated
+  // elsewhere; in that case the other path owns teardown and we do not
+  // double-dismiss.
+  const failHeadlessSession = useCallback(
+    (
+      error: unknown,
+      fallbackCode?: Parameters<typeof failSession>[2],
+    ): boolean => {
+      if (hasTerminatedHeadlessSessionRef.current) {
+        return false;
+      }
+      if (!failSession(headlessSessionId, error, fallbackCode)) {
+        return false;
+      }
+      hasTerminatedHeadlessSessionRef.current = true;
+      dismissHeadlessFlow(navigation);
+      return true;
+    },
+    [headlessSessionId, navigation],
+  );
 
   useEffect(() => {
     setHeadlessEntryCardTouchThrough(navigation, isFocused);
@@ -136,15 +173,14 @@ function HeadlessHost() {
     if (!nativeFlowError) {
       return;
     }
-    failSession(
-      headlessSessionId,
+    failHeadlessSession(
       {
         code: 'AUTH_FAILED',
         message: nativeFlowError,
       },
       'AUTH_FAILED',
     );
-  }, [nativeFlowError, headlessSessionId]);
+  }, [nativeFlowError, failHeadlessSession]);
 
   // Process the session. Uses `useEffect` (not `useFocusEffect`) so that
   // it fires whenever `headlessSessionId` changes even when the screen is
@@ -191,7 +227,7 @@ function HeadlessHost() {
     if (!chainId) {
       const message = `HeadlessHost: invalid assetId "${currentSession.params.assetId}"`;
       Logger.error(new Error(message));
-      failSession(headlessSessionId, { code: 'UNKNOWN', message });
+      failHeadlessSession({ code: 'UNKNOWN', message });
       return;
     }
     // Defer until walletAddress resolves — avoids calling continueWithQuote
@@ -248,7 +284,10 @@ function HeadlessHost() {
       if (!liveSession) {
         return;
       }
-      failSession(headlessSessionId, error);
+      // Fails the session AND pops the transparent HEADLESS_ENTRY modal so the
+      // underlying confirmation is interactive again (was previously left
+      // mounted, freezing the app).
+      failHeadlessSession(error);
     });
     return () => {
       cancelled = true;
@@ -261,6 +300,7 @@ function HeadlessHost() {
     walletAddress,
     userRegion?.country?.currency,
     continueWithQuote,
+    failHeadlessSession,
   ]);
 
   return (

--- a/app/components/UI/Ramp/headless/sessionRegistry.test.ts
+++ b/app/components/UI/Ramp/headless/sessionRegistry.test.ts
@@ -186,6 +186,19 @@ describe('sessionRegistry', () => {
       setStatus(s.id, 'failed');
       expect(getActiveSessionId()).toBeUndefined();
     });
+
+    it('fires onClose exactly once after the terminateSession extraction', () => {
+      const callbacks = buildCallbacks();
+      const session = createSession(baseParams, callbacks);
+
+      closeSession(session.id, { reason: 'user_dismissed' });
+
+      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+      expect(callbacks.onClose).toHaveBeenCalledWith({
+        reason: 'user_dismissed',
+      });
+      expect(getSession(session.id)).toBeUndefined();
+    });
   });
 
   describe('toHeadlessBuyError', () => {
@@ -221,7 +234,7 @@ describe('sessionRegistry', () => {
   });
 
   describe('failSession', () => {
-    it('fires onError then onClose and removes the session', () => {
+    it('fires exactly one onError, never onClose, and removes the session', () => {
       const callbacks = buildCallbacks();
       const session = createSession(baseParams, callbacks);
 
@@ -235,13 +248,14 @@ describe('sessionRegistry', () => {
         message: 'Quote expired',
         details: undefined,
       });
+      expect(callbacks.onError).toHaveBeenCalledTimes(1);
       expect(callbacks.onError).toHaveBeenCalledWith(headlessError);
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
       expect(session.status).toBe('failed');
       expect(getSession(session.id)).toBeUndefined();
     });
 
-    it('logs onError failures but still closes the session', () => {
+    it('logs onError failures, still removes the session, and never fires onClose', () => {
       const callbacks = {
         ...buildCallbacks(),
         onError: jest.fn(() => {
@@ -256,8 +270,66 @@ describe('sessionRegistry', () => {
         expect.any(Error),
         'headless sessionRegistry: onError callback threw',
       );
-      expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+      expect(callbacks.onClose).not.toHaveBeenCalled();
+      expect(session.status).toBe('failed');
       expect(getSession(session.id)).toBeUndefined();
+    });
+
+    it('maps the raw error to a HeadlessBuyError with the fallback code', () => {
+      const callbacks = buildCallbacks();
+      const session = createSession(baseParams, callbacks);
+
+      const headlessError = failSession(
+        session.id,
+        new Error('provider exploded'),
+        'QUOTE_FAILED',
+      );
+
+      expect(headlessError).toEqual({
+        code: 'QUOTE_FAILED',
+        message: 'provider exploded',
+      });
+      expect(callbacks.onError).toHaveBeenCalledWith(headlessError);
+    });
+
+    it('is a no-op and returns undefined for an unknown or missing id', () => {
+      const callbacks = buildCallbacks();
+      createSession(baseParams, callbacks);
+
+      expect(failSession('does-not-exist', new Error('x'))).toBeUndefined();
+      expect(failSession(undefined, new Error('x'))).toBeUndefined();
+      expect(callbacks.onError).not.toHaveBeenCalled();
+      expect(callbacks.onClose).not.toHaveBeenCalled();
+    });
+
+    it('treats a failed session as inactive for getActiveSessionId', () => {
+      const session = createSession(baseParams, buildCallbacks());
+      failSession(session.id, new Error('provider failed'));
+      expect(getActiveSessionId()).toBeUndefined();
+    });
+
+    it('does not clear a consumer error set by onError (no trailing onClose)', () => {
+      // Mirrors MM Pay: onError records the error, onClose would clear it. The
+      // no-trailing-onClose contract guarantees the reported error survives.
+      let consumerError: string | undefined;
+      const callbacks: HeadlessBuyCallbacks = {
+        onOrderCreated: jest.fn(),
+        onError: jest.fn((error) => {
+          consumerError = error.message;
+        }),
+        onClose: jest.fn(() => {
+          consumerError = undefined;
+        }),
+      };
+      const session = createSession(baseParams, callbacks);
+
+      failSession(session.id, {
+        code: 'QUOTE_FAILED',
+        message: 'Quote expired',
+      });
+
+      expect(consumerError).toBe('Quote expired');
+      expect(callbacks.onClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/headless/sessionRegistry.ts
+++ b/app/components/UI/Ramp/headless/sessionRegistry.ts
@@ -251,7 +251,7 @@ export function closeSession(
  *
  * `onError` is terminal on its own: a session ends in exactly one of
  * `onOrderCreated`, `onError`, or `onClose`, never a pairing. This matters for
- * MM Pay, whose `onClose` handler clears the error set by `onError` — a trailing
+ * MM Pay, whose `onClose` handler clears the error set by `onError`; a trailing
  * `onClose` here would wipe the failure it just reported.
  */
 export function failSession(

--- a/app/components/UI/Ramp/headless/sessionRegistry.ts
+++ b/app/components/UI/Ramp/headless/sessionRegistry.ts
@@ -187,6 +187,23 @@ export function getActiveSessionId(): string | undefined {
 }
 
 /**
+ * Marks a session terminal (unless it is already terminal) and removes it from
+ * the registry. Shared by `closeSession` and `failSession`; it fires no consumer
+ * callback, so each caller stays in full control of which terminal event
+ * (`onClose` vs `onError`) it emits.
+ */
+function terminateSession(
+  session: HeadlessSession,
+  id: string,
+  terminalStatus: 'cancelled' | 'failed',
+): void {
+  if (!isTerminalSessionStatus(session.status)) {
+    session.status = terminalStatus;
+  }
+  sessions.delete(id);
+}
+
+/**
  * Idempotent "stop and notify" used by both consumer-driven cancellation
  * and the auto-cancel path of `startHeadlessBuy`.
  *
@@ -212,11 +229,11 @@ export function closeSession(
   if (!session) {
     return;
   }
-  if (!isTerminalSessionStatus(session.status)) {
-    session.status =
-      options?.terminalStatus === 'failed' ? 'failed' : 'cancelled';
-  }
-  sessions.delete(id);
+  terminateSession(
+    session,
+    id,
+    options?.terminalStatus === 'failed' ? 'failed' : 'cancelled',
+  );
   try {
     session.callbacks.onClose(info);
   } catch (e) {
@@ -230,7 +247,12 @@ export function closeSession(
 /**
  * Idempotent "fail and notify" for unrecoverable headless errors. It turns
  * thrown/native errors into the public HeadlessBuyError shape, fires `onError`,
- * then terminates the session through `closeSession`.
+ * then removes the session directly, WITHOUT firing `onClose`.
+ *
+ * `onError` is terminal on its own: a session ends in exactly one of
+ * `onOrderCreated`, `onError`, or `onClose`, never a pairing. This matters for
+ * MM Pay, whose `onClose` handler clears the error set by `onError` — a trailing
+ * `onClose` here would wipe the failure it just reported.
  */
 export function failSession(
   id: string | undefined,
@@ -253,13 +275,7 @@ export function failSession(
       'headless sessionRegistry: onError callback threw',
     );
   }
-  closeSession(
-    id,
-    { reason: 'unknown' },
-    {
-      terminalStatus: 'failed',
-    },
-  );
+  terminateSession(session, id, 'failed');
   return headlessError;
 }
 

--- a/app/components/UI/Ramp/headless/useHeadlessSessionDismissal.test.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessSessionDismissal.test.ts
@@ -119,7 +119,7 @@ describe('useHeadlessSessionDismissal', () => {
     expect(callbacks.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('no-ops on unmount after Phase 7 failSession already closed the session', () => {
+  it('no-ops on unmount after Phase 7 failSession already removed the session (onError only, no onClose)', () => {
     const callbacks = buildCallbacks();
     const session = createSession(baseParams, callbacks);
 
@@ -132,12 +132,13 @@ describe('useHeadlessSessionDismissal', () => {
 
     failSession(session.id, new Error('boom'), 'AUTH_FAILED');
     expect(callbacks.onError).toHaveBeenCalledTimes(1);
-    expect(callbacks.onClose).toHaveBeenCalledTimes(1);
-    expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+    // failSession is terminal on its own: no onClose is fired.
+    expect(callbacks.onClose).not.toHaveBeenCalled();
 
     unmount();
 
-    expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    // The session was already removed, so the unmount cleanup no-ops.
+    expect(callbacks.onClose).not.toHaveBeenCalled();
   });
 
   it('no-ops on unmount after the consumer cancelled the session', () => {

--- a/app/components/UI/Ramp/headless/useHeadlessSessionDismissal.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessSessionDismissal.ts
@@ -17,7 +17,7 @@ import { closeSession, getSession } from './sessionRegistry';
  * registry, so the cleanup re-reads `getSession(id)` and no-ops:
  *
  * - Phase 6 success — `closeSession({ reason: 'completed' })`
- * - Phase 7 errors — `failSession` → `closeSession({ reason: 'unknown' })`
+ * - Phase 7 errors: `failSession` removes the session directly, firing `onError` with no `onClose`
  * - Phase 5 single-live-session restart — `closeSession({ reason: 'consumer_cancelled' })`
  * - Consumer `cancel()` — same
  * - `handleBack` (this PR) — fires `closeSession({ reason: 'user_dismissed' })` synchronously before `goBack`, so the cleanup that follows the unmount is also a no-op.


### PR DESCRIPTION
## **Description**

This PR extracts the headless terminal-error bug fix that was previously inside #32682 so the provider-scope PR can stay under the 1k-line CI limit.

Failed headless sessions now end with `onError` only, with no trailing `onClose`, so consumers do not clear the error they just received. Terminal-error paths in `HeadlessHost` also dismiss the transparent `HEADLESS_ENTRY` modal, which prevents the app from leaving an invisible modal mounted over the confirmation screen after quote or native-flow failures.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/32682

## **Manual testing steps**

```gherkin
Feature: Headless terminal error handling

  Scenario: a terminal headless error does not leave the entry modal mounted
    Given a headless buy session is active
    And the quote continuation or native flow reports a terminal error

    When the error is handled by the headless host
    Then the session fires onError without a trailing onClose
    And the transparent headless entry modal is dismissed
```

Automated coverage run locally:
`NODE_OPTIONS='--max-old-space-size=12288' yarn jest app/components/UI/Ramp/headless/sessionRegistry.test.ts app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx --runInBand`

## **Screenshots/Recordings**

N/A. This is headless error-handling and session-registry behavior with no intended visual UI change.

### **Before**

N/A

### **After**
Video here in main PR: https://github.com/MetaMask/metamask-mobile/pull/32682

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)