### PR TITLE
chore(social): remove orphaned NOTIFICATION_TYPE analytics constant

### DIFF
--- a/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
+++ b/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
@@ -15,7 +15,6 @@ export const SocialLeaderboardEventProperties = {
   CHAIN_FILTER: 'chain_filter',
   IS_FOLLOWING: 'is_following',
   IS_OPEN: 'is_open',
-  NOTIFICATION_TYPE: 'notification_type',
   NOTIFICATION_SUBTYPE: 'notification_subtype',
   NOTIFICATION_TEMPLATE_VARIANT: 'notification_template_variant',
   PREVIOUS_CHAIN_FILTER: 'previous_chain_filter',


### PR DESCRIPTION
## Description

Removes the unused `NOTIFICATION_TYPE` key from `SocialLeaderboardEventProperties` in `app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts`.

It is dead code: no code or test references `SocialLeaderboardEventProperties.NOTIFICATION_TYPE`. It was the analytics property the social-trader-position deeplink handler used *before* #31765, which renamed the deeplink query param (`notification_event` → `notification_subtype`) and the analytics property (`NOTIFICATION_TYPE` → `NOTIFICATION_SUBTYPE`). The constant was left behind as an orphan.

Removing it also avoids confusion with the backend's distinct `notification_type` field (a NAAP notification category), which the mobile app never receives via the deeplink — the deeplink only carries `notification_subtype` and `notification_template_variant`.

## Changes
- Delete the single `NOTIFICATION_TYPE: 'notification_type'` entry. No behavior change.

## Testing
- No references exist anywhere in `app/` (verified via grep on `main`, including `*.test.*`), so nothing consumes this constant.
- Pure dead-code removal; type-check and existing analytics tests are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single unused constant removal with no consumers; analytics and product behavior are unchanged.
> 
> **Overview**
> Removes the unused **`NOTIFICATION_TYPE`** entry from **`SocialLeaderboardEventProperties`** in `socialLeaderboardEvents.ts`. Social leaderboard analytics already use **`NOTIFICATION_SUBTYPE`** (and related keys) after the deeplink/analytics rename; nothing in the app references the old key anymore.
> 
> This is **dead-code cleanup only**—no event payloads or runtime behavior change. It also avoids mixing up this constant with the backend’s separate `notification_type` field, which the mobile deeplink path does not use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0dcd5da8cbff568d4bf14191512fa08c8d8d661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->