### PR TITLE
feat(whats-happening): render deep-linked outdated item in the carousel

### DIFF
--- a/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch
+++ b/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch
@@ -1,0 +1,584 @@
+diff --git a/dist/AiDigestController-method-action-types.d.cts b/dist/AiDigestController-method-action-types.d.cts
+index 074019c6cddf9bab5c14feb5f1250a588ecbe975..016ed431a4a8be3814f4e2d9420acbdcd173b35c 100644
+--- a/dist/AiDigestController-method-action-types.d.cts
++++ b/dist/AiDigestController-method-action-types.d.cts
+@@ -28,8 +28,22 @@ export type AiDigestControllerFetchMarketOverviewAction = {
+     type: `AiDigestController:fetchMarketOverview`;
+     handler: AiDigestController['fetchMarketOverview'];
+ };
++/**
++ * Fetches a single market overview front page by id.
++ *
++ * Unlike the market overview report (which only returns the latest items),
++ * this resolves an older item that has since dropped out of the report, so
++ * clients can render it directly (e.g. from a deep link).
++ *
++ * @param id - The front-page identifier (UUID).
++ * @returns The market overview front page, or `null` if none exists.
++ */
++export type AiDigestControllerFetchFrontPageItemAction = {
++    type: `AiDigestController:fetchFrontPageItem`;
++    handler: AiDigestController['fetchFrontPageItem'];
++};
+ /**
+  * Union of all AiDigestController action types.
+  */
+-export type AiDigestControllerMethodActions = AiDigestControllerFetchMarketInsightsAction | AiDigestControllerFetchMarketOverviewAction;
++export type AiDigestControllerMethodActions = AiDigestControllerFetchMarketInsightsAction | AiDigestControllerFetchMarketOverviewAction | AiDigestControllerFetchFrontPageItemAction;
+ //# sourceMappingURL=AiDigestController-method-action-types.d.cts.map
+\ No newline at end of file
+diff --git a/dist/AiDigestController-method-action-types.d.mts b/dist/AiDigestController-method-action-types.d.mts
+index 539646f0ea4f366dec4822edae1b25bc64c4b55d..9a1619cfc3001f44864f77f5401ad4fec06d79a6 100644
+--- a/dist/AiDigestController-method-action-types.d.mts
++++ b/dist/AiDigestController-method-action-types.d.mts
+@@ -28,8 +28,22 @@ export type AiDigestControllerFetchMarketOverviewAction = {
+     type: `AiDigestController:fetchMarketOverview`;
+     handler: AiDigestController['fetchMarketOverview'];
+ };
++/**
++ * Fetches a single market overview front page by id.
++ *
++ * Unlike the market overview report (which only returns the latest items),
++ * this resolves an older item that has since dropped out of the report, so
++ * clients can render it directly (e.g. from a deep link).
++ *
++ * @param id - The front-page identifier (UUID).
++ * @returns The market overview front page, or `null` if none exists.
++ */
++export type AiDigestControllerFetchFrontPageItemAction = {
++    type: `AiDigestController:fetchFrontPageItem`;
++    handler: AiDigestController['fetchFrontPageItem'];
++};
+ /**
+  * Union of all AiDigestController action types.
+  */
+-export type AiDigestControllerMethodActions = AiDigestControllerFetchMarketInsightsAction | AiDigestControllerFetchMarketOverviewAction;
++export type AiDigestControllerMethodActions = AiDigestControllerFetchMarketInsightsAction | AiDigestControllerFetchMarketOverviewAction | AiDigestControllerFetchFrontPageItemAction;
+ //# sourceMappingURL=AiDigestController-method-action-types.d.mts.map
+\ No newline at end of file
+diff --git a/dist/AiDigestController.cjs b/dist/AiDigestController.cjs
+index 9adc717d517cf56ef9df7e7bbd50c16131c80067..1571b3b7558c8ba9d1b97da3d5ff611910ec3ff3 100644
+--- a/dist/AiDigestController.cjs
++++ b/dist/AiDigestController.cjs
+@@ -39,6 +39,7 @@ const aiDigestControllerMetadata = {
+ const MESSENGER_EXPOSED_METHODS = [
+     'fetchMarketInsights',
+     'fetchMarketOverview',
++    'fetchFrontPageItem',
+ ];
+ class AiDigestController extends base_controller_1.BaseController {
+     constructor({ messenger, state, digestService }) {
+@@ -127,6 +128,22 @@ class AiDigestController extends base_controller_1.BaseController {
+         });
+         return data;
+     }
++    /**
++     * Fetches a single market overview front page by id.
++     *
++     * Unlike the market overview report (which only returns the latest items),
++     * this resolves an older item that has since dropped out of the report, so
++     * clients can render it directly (e.g. from a deep link).
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists.
++     */
++    async fetchFrontPageItem(id) {
++        if (!id) {
++            throw new Error(ai_digest_constants_1.AiDigestControllerErrorMessage.INVALID_FRONT_PAGE_ID);
++        }
++        return __classPrivateFieldGet(this, _AiDigestController_digestService, "f").fetchFrontPageItem(id);
++    }
+ }
+ exports.AiDigestController = AiDigestController;
+ _AiDigestController_digestService = new WeakMap(), _AiDigestController_instances = new WeakSet(), _AiDigestController_evictStaleCachedEntries = function _AiDigestController_evictStaleCachedEntries(cache) {
+diff --git a/dist/AiDigestController.d.cts b/dist/AiDigestController.d.cts
+index e854b83f16d06e83b7668d96a1d5d86ae4066aa3..7959541301465114ae72bf594edac90a1e3bc127 100644
+--- a/dist/AiDigestController.d.cts
++++ b/dist/AiDigestController.d.cts
+@@ -2,7 +2,7 @@ import type { ControllerStateChangeEvent, ControllerGetStateAction } from "@meta
+ import { BaseController } from "@metamask/base-controller";
+ import type { Messenger } from "@metamask/messenger";
+ import { controllerName } from "./ai-digest-constants.cjs";
+-import type { AiDigestControllerState, DigestService, MarketInsightsReport, MarketOverview } from "./ai-digest-types.cjs";
++import type { AiDigestControllerState, DigestService, MarketInsightsReport, MarketOverview, MarketOverviewFrontPage } from "./ai-digest-types.cjs";
+ import type { AiDigestControllerMethodActions } from "./AiDigestController-method-action-types.cjs";
+ export type AiDigestControllerGetStateAction = ControllerGetStateAction<typeof controllerName, AiDigestControllerState>;
+ export type AiDigestControllerActions = AiDigestControllerGetStateAction | AiDigestControllerMethodActions;
+@@ -37,5 +37,16 @@ export declare class AiDigestController extends BaseController<typeof controller
+      * @returns The market overview report, or `null` if none exists.
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetches a single market overview front page by id.
++     *
++     * Unlike the market overview report (which only returns the latest items),
++     * this resolves an older item that has since dropped out of the report, so
++     * clients can render it directly (e.g. from a deep link).
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists.
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+ }
+ //# sourceMappingURL=AiDigestController.d.cts.map
+\ No newline at end of file
+diff --git a/dist/AiDigestController.d.mts b/dist/AiDigestController.d.mts
+index 39cc9a57ca96ac76d31751fb391f1137f1332477..fb8f63983898a7a453368f3e5f6db7752358b4ec 100644
+--- a/dist/AiDigestController.d.mts
++++ b/dist/AiDigestController.d.mts
+@@ -2,7 +2,7 @@ import type { ControllerStateChangeEvent, ControllerGetStateAction } from "@meta
+ import { BaseController } from "@metamask/base-controller";
+ import type { Messenger } from "@metamask/messenger";
+ import { controllerName } from "./ai-digest-constants.mjs";
+-import type { AiDigestControllerState, DigestService, MarketInsightsReport, MarketOverview } from "./ai-digest-types.mjs";
++import type { AiDigestControllerState, DigestService, MarketInsightsReport, MarketOverview, MarketOverviewFrontPage } from "./ai-digest-types.mjs";
+ import type { AiDigestControllerMethodActions } from "./AiDigestController-method-action-types.mjs";
+ export type AiDigestControllerGetStateAction = ControllerGetStateAction<typeof controllerName, AiDigestControllerState>;
+ export type AiDigestControllerActions = AiDigestControllerGetStateAction | AiDigestControllerMethodActions;
+@@ -37,5 +37,16 @@ export declare class AiDigestController extends BaseController<typeof controller
+      * @returns The market overview report, or `null` if none exists.
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetches a single market overview front page by id.
++     *
++     * Unlike the market overview report (which only returns the latest items),
++     * this resolves an older item that has since dropped out of the report, so
++     * clients can render it directly (e.g. from a deep link).
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists.
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+ }
+ //# sourceMappingURL=AiDigestController.d.mts.map
+\ No newline at end of file
+diff --git a/dist/AiDigestController.mjs b/dist/AiDigestController.mjs
+index 579496ce8e671f95f972f802f7e4e91e77bac899..c9f96e0746312ab60e0d12a0b9776ebeb4e0729c 100644
+--- a/dist/AiDigestController.mjs
++++ b/dist/AiDigestController.mjs
+@@ -35,6 +35,7 @@ const aiDigestControllerMetadata = {
+ const MESSENGER_EXPOSED_METHODS = [
+     'fetchMarketInsights',
+     'fetchMarketOverview',
++    'fetchFrontPageItem',
+ ];
+ export class AiDigestController extends BaseController {
+     constructor({ messenger, state, digestService }) {
+@@ -123,6 +124,22 @@ export class AiDigestController extends BaseController {
+         });
+         return data;
+     }
++    /**
++     * Fetches a single market overview front page by id.
++     *
++     * Unlike the market overview report (which only returns the latest items),
++     * this resolves an older item that has since dropped out of the report, so
++     * clients can render it directly (e.g. from a deep link).
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists.
++     */
++    async fetchFrontPageItem(id) {
++        if (!id) {
++            throw new Error(AiDigestControllerErrorMessage.INVALID_FRONT_PAGE_ID);
++        }
++        return __classPrivateFieldGet(this, _AiDigestController_digestService, "f").fetchFrontPageItem(id);
++    }
+ }
+ _AiDigestController_digestService = new WeakMap(), _AiDigestController_instances = new WeakSet(), _AiDigestController_evictStaleCachedEntries = function _AiDigestController_evictStaleCachedEntries(cache) {
+     const now = Date.now();
+diff --git a/dist/AiDigestService.cjs b/dist/AiDigestService.cjs
+index eb27a06c38727b6a86858d82155964eafe187e41..b5662e8f4eedf058d6397948ece2d40d31330ae5 100644
+--- a/dist/AiDigestService.cjs
++++ b/dist/AiDigestService.cjs
+@@ -94,15 +94,26 @@ const MarketOverviewStruct = (0, superstruct_1.type)({
+ const MarketOverviewReportEnvelopeStruct = (0, superstruct_1.type)({
+     report: MarketOverviewStruct,
+ });
++// A single front-page row. `item` shares the exact same schema as an
++// individual market overview trend; `ctaTitle`/`ctaDescription` are the
++// AI-authored call-to-action copy layered on top.
++const MarketOverviewFrontPageStruct = (0, superstruct_1.type)({
++    id: (0, superstruct_1.string)(),
++    item: MarketOverviewTrendStruct,
++    ctaTitle: (0, superstruct_1.string)(),
++    ctaDescription: (0, superstruct_1.string)(),
++    createdAt: (0, superstruct_1.string)(),
++});
++const normalizeItemRelatedAssets = (item) => ({
++    ...item,
++    relatedAssets: item.relatedAssets.map((asset) => ({
++        ...asset,
++        caip19: asset.caip19 ?? [],
++    })),
++});
+ const normalizeRelatedAssets = (raw) => ({
+     ...raw,
+-    trends: raw.trends.map((trend) => ({
+-        ...trend,
+-        relatedAssets: trend.relatedAssets.map((asset) => ({
+-            ...asset,
+-            caip19: asset.caip19 ?? [],
+-        })),
+-    })),
++    trends: raw.trends.map(normalizeItemRelatedAssets),
+ });
+ const getNormalizedMarketOverview = (value) => {
+     if ((0, superstruct_1.is)(value, MarketOverviewStruct)) {
+@@ -113,6 +124,12 @@ const getNormalizedMarketOverview = (value) => {
+     }
+     return null;
+ };
++const getNormalizedFrontPage = (value) => {
++    if (!(0, superstruct_1.is)(value, MarketOverviewFrontPageStruct)) {
++        return null;
++    }
++    return { ...value, item: normalizeItemRelatedAssets(value.item) };
++};
+ const getNormalizedMarketInsightsReport = (value) => {
+     if ((0, superstruct_1.is)(value, MarketInsightsDigestEnvelopeStruct)) {
+         return { ...value.digest, digestId: value.id };
+@@ -145,6 +162,28 @@ class AiDigestService {
+         }
+         return overview;
+     }
++    /**
++     * Fetch a single market overview front page by id.
++     *
++     * Calls `GET ${this.#baseUrl}/market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    async fetchFrontPageItem(id) {
++        const response = await fetch(`${__classPrivateFieldGet(this, _AiDigestService_baseUrl, "f")}/market-overview/front-page/${encodeURIComponent(id)}`);
++        if (response.status === 404) {
++            return null;
++        }
++        if (!response.ok) {
++            throw new Error(`${ai_digest_constants_1.AiDigestControllerErrorMessage.API_REQUEST_FAILED}: ${response.status}`);
++        }
++        const frontPage = getNormalizedFrontPage(await response.json());
++        if (!frontPage) {
++            throw new Error(ai_digest_constants_1.AiDigestControllerErrorMessage.API_INVALID_RESPONSE);
++        }
++        return frontPage;
++    }
+     /**
+      * Search for market insights by asset identifier.
+      *
+diff --git a/dist/AiDigestService.d.cts b/dist/AiDigestService.d.cts
+index c9b06acbe67ad8e15cde16d123c0cb902513dc0a..846144562856937ab9923d66a3cc31a907d1b068 100644
+--- a/dist/AiDigestService.d.cts
++++ b/dist/AiDigestService.d.cts
+@@ -1,4 +1,4 @@
+-import type { DigestService, MarketInsightsReport, MarketOverview } from "./ai-digest-types.cjs";
++import type { DigestService, MarketInsightsReport, MarketOverview, MarketOverviewFrontPage } from "./ai-digest-types.cjs";
+ export type AiDigestServiceConfig = {
+     baseUrl: string;
+ };
+@@ -13,6 +13,15 @@ export declare class AiDigestService implements DigestService {
+      * @returns The market overview report, or `null` if none exists (404).
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetch a single market overview front page by id.
++     *
++     * Calls `GET ${this.#baseUrl}/market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+     /**
+      * Search for market insights by asset identifier.
+      *
+diff --git a/dist/AiDigestService.d.mts b/dist/AiDigestService.d.mts
+index ea89ddc81cc505885272b90608277a5c737e6fc9..08ad0ed2c3696fcf61b6556866bbbc8cfb6c195b 100644
+--- a/dist/AiDigestService.d.mts
++++ b/dist/AiDigestService.d.mts
+@@ -1,4 +1,4 @@
+-import type { DigestService, MarketInsightsReport, MarketOverview } from "./ai-digest-types.mjs";
++import type { DigestService, MarketInsightsReport, MarketOverview, MarketOverviewFrontPage } from "./ai-digest-types.mjs";
+ export type AiDigestServiceConfig = {
+     baseUrl: string;
+ };
+@@ -13,6 +13,15 @@ export declare class AiDigestService implements DigestService {
+      * @returns The market overview report, or `null` if none exists (404).
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetch a single market overview front page by id.
++     *
++     * Calls `GET ${this.#baseUrl}/market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+     /**
+      * Search for market insights by asset identifier.
+      *
+diff --git a/dist/AiDigestService.mjs b/dist/AiDigestService.mjs
+index bbc2c232d3a64eddc21ab3a162455a84562875f0..fa36d4ffe349a4b1692161a80b50253e8fd19d3a 100644
+--- a/dist/AiDigestService.mjs
++++ b/dist/AiDigestService.mjs
+@@ -91,15 +91,26 @@ const MarketOverviewStruct = structType({
+ const MarketOverviewReportEnvelopeStruct = structType({
+     report: MarketOverviewStruct,
+ });
++// A single front-page row. `item` shares the exact same schema as an
++// individual market overview trend; `ctaTitle`/`ctaDescription` are the
++// AI-authored call-to-action copy layered on top.
++const MarketOverviewFrontPageStruct = structType({
++    id: string(),
++    item: MarketOverviewTrendStruct,
++    ctaTitle: string(),
++    ctaDescription: string(),
++    createdAt: string(),
++});
++const normalizeItemRelatedAssets = (item) => ({
++    ...item,
++    relatedAssets: item.relatedAssets.map((asset) => ({
++        ...asset,
++        caip19: asset.caip19 ?? [],
++    })),
++});
+ const normalizeRelatedAssets = (raw) => ({
+     ...raw,
+-    trends: raw.trends.map((trend) => ({
+-        ...trend,
+-        relatedAssets: trend.relatedAssets.map((asset) => ({
+-            ...asset,
+-            caip19: asset.caip19 ?? [],
+-        })),
+-    })),
++    trends: raw.trends.map(normalizeItemRelatedAssets),
+ });
+ const getNormalizedMarketOverview = (value) => {
+     if (is(value, MarketOverviewStruct)) {
+@@ -110,6 +121,12 @@ const getNormalizedMarketOverview = (value) => {
+     }
+     return null;
+ };
++const getNormalizedFrontPage = (value) => {
++    if (!is(value, MarketOverviewFrontPageStruct)) {
++        return null;
++    }
++    return { ...value, item: normalizeItemRelatedAssets(value.item) };
++};
+ const getNormalizedMarketInsightsReport = (value) => {
+     if (is(value, MarketInsightsDigestEnvelopeStruct)) {
+         return { ...value.digest, digestId: value.id };
+@@ -142,6 +159,28 @@ export class AiDigestService {
+         }
+         return overview;
+     }
++    /**
++     * Fetch a single market overview front page by id.
++     *
++     * Calls `GET ${this.#baseUrl}/market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    async fetchFrontPageItem(id) {
++        const response = await fetch(`${__classPrivateFieldGet(this, _AiDigestService_baseUrl, "f")}/market-overview/front-page/${encodeURIComponent(id)}`);
++        if (response.status === 404) {
++            return null;
++        }
++        if (!response.ok) {
++            throw new Error(`${AiDigestControllerErrorMessage.API_REQUEST_FAILED}: ${response.status}`);
++        }
++        const frontPage = getNormalizedFrontPage(await response.json());
++        if (!frontPage) {
++            throw new Error(AiDigestControllerErrorMessage.API_INVALID_RESPONSE);
++        }
++        return frontPage;
++    }
+     /**
+      * Search for market insights by asset identifier.
+      *
+diff --git a/dist/ai-digest-constants.cjs b/dist/ai-digest-constants.cjs
+index ea5c8a00e8957911102a82a94991530fc65a95e5..55c426c580578ec04408bf75377303fc0fb51075 100644
+--- a/dist/ai-digest-constants.cjs
++++ b/dist/ai-digest-constants.cjs
+@@ -8,5 +8,6 @@ exports.AiDigestControllerErrorMessage = {
+     API_REQUEST_FAILED: 'API request failed',
+     API_INVALID_RESPONSE: 'API returned invalid response',
+     INVALID_ASSET_IDENTIFIER: 'Invalid asset identifier',
++    INVALID_FRONT_PAGE_ID: 'Invalid front page id',
+ };
+ //# sourceMappingURL=ai-digest-constants.cjs.map
+\ No newline at end of file
+diff --git a/dist/ai-digest-constants.d.cts b/dist/ai-digest-constants.d.cts
+index cc6038e58ac7a9e23c712f64d4955b94f68f8671..db24a562c3e2d37917d14e700e8d7da13e596f2d 100644
+--- a/dist/ai-digest-constants.d.cts
++++ b/dist/ai-digest-constants.d.cts
+@@ -5,5 +5,6 @@ export declare const AiDigestControllerErrorMessage: {
+     readonly API_REQUEST_FAILED: "API request failed";
+     readonly API_INVALID_RESPONSE: "API returned invalid response";
+     readonly INVALID_ASSET_IDENTIFIER: "Invalid asset identifier";
++    readonly INVALID_FRONT_PAGE_ID: "Invalid front page id";
+ };
+ //# sourceMappingURL=ai-digest-constants.d.cts.map
+\ No newline at end of file
+diff --git a/dist/ai-digest-constants.d.mts b/dist/ai-digest-constants.d.mts
+index 9b6c3676dee6fb0cf25a00d619173ba76dab6f10..0e36e356b7a4a83b649925490944a6af0feb495c 100644
+--- a/dist/ai-digest-constants.d.mts
++++ b/dist/ai-digest-constants.d.mts
+@@ -5,5 +5,6 @@ export declare const AiDigestControllerErrorMessage: {
+     readonly API_REQUEST_FAILED: "API request failed";
+     readonly API_INVALID_RESPONSE: "API returned invalid response";
+     readonly INVALID_ASSET_IDENTIFIER: "Invalid asset identifier";
++    readonly INVALID_FRONT_PAGE_ID: "Invalid front page id";
+ };
+ //# sourceMappingURL=ai-digest-constants.d.mts.map
+\ No newline at end of file
+diff --git a/dist/ai-digest-constants.mjs b/dist/ai-digest-constants.mjs
+index e05c504ade16e49034f97566504e926854bea43a..092a22238fe48cf9aee40af7ace8b79bf810bc50 100644
+--- a/dist/ai-digest-constants.mjs
++++ b/dist/ai-digest-constants.mjs
+@@ -5,5 +5,6 @@ export const AiDigestControllerErrorMessage = {
+     API_REQUEST_FAILED: 'API request failed',
+     API_INVALID_RESPONSE: 'API returned invalid response',
+     INVALID_ASSET_IDENTIFIER: 'Invalid asset identifier',
++    INVALID_FRONT_PAGE_ID: 'Invalid front page id',
+ };
+ //# sourceMappingURL=ai-digest-constants.mjs.map
+\ No newline at end of file
+diff --git a/dist/ai-digest-types.d.cts b/dist/ai-digest-types.d.cts
+index 2de03acb27497633ef6694e52b971a5607c58f77..fca612534b25749b026d98e01853779f0ca52416 100644
+--- a/dist/ai-digest-types.d.cts
++++ b/dist/ai-digest-types.d.cts
+@@ -152,6 +152,31 @@ export type MarketOverview = {
+     trends: MarketOverviewTrend[];
+     metadata?: AIResponseMetadata[];
+ };
++/**
++ * A single market overview item. Shares the exact same schema as a
++ * {@link MarketOverviewTrend} — i.e. one entry of `MarketOverview.trends`.
++ */
++export type MarketOverviewItem = MarketOverviewTrend;
++/**
++ * A market overview "front page": a single AI-selected item (mirroring the
++ * front page of a newspaper) plus its call-to-action copy, addressable by id.
++ *
++ * Returned by `GET /market-overview/front-page/:id` (and `.../latest`). Unlike
++ * `/market-overview`, which only ever returns the latest report, this lets
++ * clients fetch an older item that has since dropped out of the report.
++ */
++export type MarketOverviewFrontPage = {
++    /** Unique identifier of the front-page row (UUID). */
++    id: string;
++    /** The selected item — same schema as an individual market overview item. */
++    item: MarketOverviewItem;
++    /** Call-to-action title for the front-page item. */
++    ctaTitle: string;
++    /** Call-to-action description for the front-page item. */
++    ctaDescription: string;
++    /** ISO date string when the front-page row was created. */
++    createdAt: string;
++};
+ export type AiDigestControllerState = {
+     marketInsights: Record<string, MarketInsightsEntry>;
+     marketOverview: MarketOverviewEntry | null;
+@@ -177,5 +202,13 @@ export type DigestService = {
+      * @returns The market overview report, or `null` if none exists (404).
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetch a single market overview front page by id.
++     * Calls `GET /market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+ };
+ //# sourceMappingURL=ai-digest-types.d.cts.map
+\ No newline at end of file
+diff --git a/dist/ai-digest-types.d.mts b/dist/ai-digest-types.d.mts
+index f4043feeeb2c9243ea5fe087f863de895e23c914..2c57241a768a439a33d6c080c31350b6f7196a3d 100644
+--- a/dist/ai-digest-types.d.mts
++++ b/dist/ai-digest-types.d.mts
+@@ -152,6 +152,31 @@ export type MarketOverview = {
+     trends: MarketOverviewTrend[];
+     metadata?: AIResponseMetadata[];
+ };
++/**
++ * A single market overview item. Shares the exact same schema as a
++ * {@link MarketOverviewTrend} — i.e. one entry of `MarketOverview.trends`.
++ */
++export type MarketOverviewItem = MarketOverviewTrend;
++/**
++ * A market overview "front page": a single AI-selected item (mirroring the
++ * front page of a newspaper) plus its call-to-action copy, addressable by id.
++ *
++ * Returned by `GET /market-overview/front-page/:id` (and `.../latest`). Unlike
++ * `/market-overview`, which only ever returns the latest report, this lets
++ * clients fetch an older item that has since dropped out of the report.
++ */
++export type MarketOverviewFrontPage = {
++    /** Unique identifier of the front-page row (UUID). */
++    id: string;
++    /** The selected item — same schema as an individual market overview item. */
++    item: MarketOverviewItem;
++    /** Call-to-action title for the front-page item. */
++    ctaTitle: string;
++    /** Call-to-action description for the front-page item. */
++    ctaDescription: string;
++    /** ISO date string when the front-page row was created. */
++    createdAt: string;
++};
+ export type AiDigestControllerState = {
+     marketInsights: Record<string, MarketInsightsEntry>;
+     marketOverview: MarketOverviewEntry | null;
+@@ -177,5 +202,13 @@ export type DigestService = {
+      * @returns The market overview report, or `null` if none exists (404).
+      */
+     fetchMarketOverview(): Promise<MarketOverview | null>;
++    /**
++     * Fetch a single market overview front page by id.
++     * Calls `GET /market-overview/front-page/:id`.
++     *
++     * @param id - The front-page identifier (UUID).
++     * @returns The market overview front page, or `null` if none exists (404).
++     */
++    fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
+ };
+ //# sourceMappingURL=ai-digest-types.d.mts.map
+\ No newline at end of file
+diff --git a/dist/index.d.cts b/dist/index.d.cts
+index 5ae730fdf3fff71f07bc2135b1696e6e480f83ee..3a3a2235bda90d078f9e0eb00aa5f42c6fb6cb47 100644
+--- a/dist/index.d.cts
++++ b/dist/index.d.cts
+@@ -1,8 +1,8 @@
+ export type { AiDigestControllerActions, AiDigestControllerEvents, AiDigestControllerGetStateAction, AiDigestControllerMessenger, AiDigestControllerOptions, AiDigestControllerStateChangeEvent, } from "./AiDigestController.cjs";
+ export { AiDigestController, getDefaultAiDigestControllerState, } from "./AiDigestController.cjs";
+-export type { AiDigestControllerFetchMarketInsightsAction, AiDigestControllerFetchMarketOverviewAction, } from "./AiDigestController-method-action-types.cjs";
++export type { AiDigestControllerFetchMarketInsightsAction, AiDigestControllerFetchMarketOverviewAction, AiDigestControllerFetchFrontPageItemAction, } from "./AiDigestController-method-action-types.cjs";
+ export type { AiDigestServiceConfig } from "./AiDigestService.cjs";
+ export { AiDigestService } from "./AiDigestService.cjs";
+-export type { AiDigestControllerState, AIResponseMetadata, Article, DigestService, MarketInsightsArticle, MarketInsightsEntry, MarketInsightsReport, MarketInsightsSource, MarketInsightsTrend, MarketInsightsTweet, MarketOverview, MarketOverviewEntry, MarketOverviewTrend, RelatedAsset, Source, Tweet, } from "./ai-digest-types.cjs";
++export type { AiDigestControllerState, AIResponseMetadata, Article, DigestService, MarketInsightsArticle, MarketInsightsEntry, MarketInsightsReport, MarketInsightsSource, MarketInsightsTrend, MarketInsightsTweet, MarketOverview, MarketOverviewEntry, MarketOverviewFrontPage, MarketOverviewItem, MarketOverviewTrend, RelatedAsset, Source, Tweet, } from "./ai-digest-types.cjs";
+ export { controllerName as aiDigestControllerName, CACHE_DURATION_MS, MAX_CACHE_ENTRIES, AiDigestControllerErrorMessage, } from "./ai-digest-constants.cjs";
+ //# sourceMappingURL=index.d.cts.map
+\ No newline at end of file
+diff --git a/dist/index.d.mts b/dist/index.d.mts
+index 87d2efe7985aaa6b8a317b3091284f3f668c9283..93aaacfe411d2ede1e7fe189827e37095879efac 100644
+--- a/dist/index.d.mts
++++ b/dist/index.d.mts
+@@ -1,8 +1,8 @@
+ export type { AiDigestControllerActions, AiDigestControllerEvents, AiDigestControllerGetStateAction, AiDigestControllerMessenger, AiDigestControllerOptions, AiDigestControllerStateChangeEvent, } from "./AiDigestController.mjs";
+ export { AiDigestController, getDefaultAiDigestControllerState, } from "./AiDigestController.mjs";
+-export type { AiDigestControllerFetchMarketInsightsAction, AiDigestControllerFetchMarketOverviewAction, } from "./AiDigestController-method-action-types.mjs";
++export type { AiDigestControllerFetchMarketInsightsAction, AiDigestControllerFetchMarketOverviewAction, AiDigestControllerFetchFrontPageItemAction, } from "./AiDigestController-method-action-types.mjs";
+ export type { AiDigestServiceConfig } from "./AiDigestService.mjs";
+ export { AiDigestService } from "./AiDigestService.mjs";
+-export type { AiDigestControllerState, AIResponseMetadata, Article, DigestService, MarketInsightsArticle, MarketInsightsEntry, MarketInsightsReport, MarketInsightsSource, MarketInsightsTrend, MarketInsightsTweet, MarketOverview, MarketOverviewEntry, MarketOverviewTrend, RelatedAsset, Source, Tweet, } from "./ai-digest-types.mjs";
++export type { AiDigestControllerState, AIResponseMetadata, Article, DigestService, MarketInsightsArticle, MarketInsightsEntry, MarketInsightsReport, MarketInsightsSource, MarketInsightsTrend, MarketInsightsTweet, MarketOverview, MarketOverviewEntry, MarketOverviewFrontPage, MarketOverviewItem, MarketOverviewTrend, RelatedAsset, Source, Tweet, } from "./ai-digest-types.mjs";
+ export { controllerName as aiDigestControllerName, CACHE_DURATION_MS, MAX_CACHE_ENTRIES, AiDigestControllerErrorMessage, } from "./ai-digest-constants.mjs";
+ //# sourceMappingURL=index.d.mts.map
+\ No newline at end of file

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
@@ -151,6 +151,21 @@ describe('WhatsHappeningCard', () => {
     expect(screen.queryByText('Neutral')).toBeNull();
   });
 
+  it('renders the Outdated badge when the item is outdated', () => {
+    const item = { ...baseItem, isOutdated: true };
+    renderWithProvider(
+      <WhatsHappeningCard item={item} cardIndex={0} source="homepage" />,
+    );
+    expect(screen.getByText('Outdated')).toBeOnTheScreen();
+  });
+
+  it('does not render the Outdated badge by default', () => {
+    renderWithProvider(
+      <WhatsHappeningCard item={baseItem} cardIndex={0} source="homepage" />,
+    );
+    expect(screen.queryByText('Outdated')).toBeNull();
+  });
+
   it('renders the asset symbol on the pill when there is a single related asset', () => {
     renderWithProvider(
       <WhatsHappeningCard item={baseItem} cardIndex={0} source="homepage" />,

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningCard.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningCard.tsx
@@ -23,6 +23,7 @@ import { useViewportTracking } from '../../MarketInsights/hooks/useViewportTrack
 import { formatRelativeTime } from '../../MarketInsights/utils/marketInsightsFormatting';
 import { getWhatsHappeningEventProps } from '../eventProperties';
 import type { WhatsHappeningSourceValue } from '../constants';
+import { strings } from '../../../../../locales/i18n';
 import WhatsHappeningAssetSlider from './WhatsHappeningAssetSlider';
 
 interface WhatsHappeningCardProps {
@@ -71,28 +72,43 @@ const WhatsHappeningCard: React.FC<WhatsHappeningCardProps> = ({
         )}
       >
         <Box gap={3} twClassName="mb-2">
-          {(item.impact || formattedDate) && (
+          {(item.isOutdated || item.impact || formattedDate) && (
             <Box
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
               justifyContent={BoxJustifyContent.Between}
               twClassName="w-full"
             >
-              {item.impact ? (
-                <Box
-                  twClassName={`rounded ${getImpactBackgroundClass(item.impact)} px-2 py-0.5`}
-                >
-                  <Text
-                    variant={TextVariant.BodyXs}
-                    color={getImpactTextColor(item.impact)}
-                    fontWeight={FontWeight.Medium}
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                twClassName="gap-1"
+              >
+                {item.isOutdated ? (
+                  <Box twClassName="rounded bg-warning-muted px-2 py-0.5">
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.WarningDefault}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {strings('whats_happening.outdated')}
+                    </Text>
+                  </Box>
+                ) : null}
+                {item.impact ? (
+                  <Box
+                    twClassName={`rounded ${getImpactBackgroundClass(item.impact)} px-2 py-0.5`}
                   >
-                    {getImpactLabel(item.impact)}
-                  </Text>
-                </Box>
-              ) : (
-                <Box />
-              )}
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={getImpactTextColor(item.impact)}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {getImpactLabel(item.impact)}
+                    </Text>
+                  </Box>
+                ) : null}
+              </Box>
               {formattedDate ? (
                 <Text
                   variant={TextVariant.BodyXs}

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -4,8 +4,11 @@ import {
   isWhatsHappeningSectionVisible,
   useWhatsHappening,
 } from './useWhatsHappening';
+import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import { selectWhatsHappeningOutdatedItemId } from '../../../../reducers/whatsHappeningDeeplink';
 
 const mockFetchMarketOverview = jest.fn();
+const mockFetchFrontPageItem = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   __esModule: true,
@@ -14,6 +17,8 @@ jest.mock('../../../../core/Engine', () => ({
       AiDigestController: {
         fetchMarketOverview: (...args: unknown[]) =>
           mockFetchMarketOverview(...args),
+        fetchFrontPageItem: (...args: unknown[]) =>
+          mockFetchFrontPageItem(...args),
       },
     },
   },
@@ -24,6 +29,29 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockUseSelector = useSelector as jest.Mock;
+
+/**
+ * Configures the two selectors the hook reads: the feature flag and the
+ * deep-linked outdated item id.
+ *
+ * @param options - Selector return overrides.
+ * @param options.enabled - Value for `selectWhatsHappeningEnabled`.
+ * @param options.outdatedItemId - Value for `selectWhatsHappeningOutdatedItemId`.
+ */
+const configureSelectors = ({
+  enabled = true,
+  outdatedItemId = null,
+}: { enabled?: boolean; outdatedItemId?: string | null } = {}) => {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectWhatsHappeningOutdatedItemId) {
+      return outdatedItemId;
+    }
+    if (selector === selectWhatsHappeningEnabled) {
+      return enabled;
+    }
+    return undefined;
+  });
+};
 
 const mockTrend = {
   title: 'Bitcoin ETF inflows hit record high',
@@ -55,8 +83,9 @@ const mockOverview = {
 describe('useWhatsHappening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(true);
+    configureSelectors();
     mockFetchMarketOverview.mockResolvedValue(mockOverview);
+    mockFetchFrontPageItem.mockResolvedValue(null);
   });
 
   it('starts in loading state when enabled', () => {
@@ -213,6 +242,102 @@ describe('useWhatsHappening', () => {
     expect(mockFetchMarketOverview).not.toHaveBeenCalled();
     expect(result.current.items).toHaveLength(0);
     expect(result.current.error).toBeNull();
+  });
+
+  describe('deep-linked outdated front-page item', () => {
+    const mockFrontPage = {
+      id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+      item: {
+        title: 'Older headline that dropped out of the report',
+        description: 'An older market overview item fetched by id.',
+        category: 'regulatory' as const,
+        impact: 'negative' as const,
+        relatedAssets: [
+          {
+            symbol: 'ETH',
+            name: 'Ethereum',
+            caip19: ['eip155:1/slip44:60'],
+          },
+        ],
+        articles: [],
+      },
+      ctaTitle: 'CTA title',
+      ctaDescription: 'CTA description',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    };
+
+    it('prepends the fetched item first, flagged outdated, before the latest items', async () => {
+      configureSelectors({ outdatedItemId: mockFrontPage.id });
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).toHaveBeenCalledWith(mockFrontPage.id);
+      expect(result.current.items[0].isOutdated).toBe(true);
+      expect(result.current.items[0].id).toBe(`front-page-${mockFrontPage.id}`);
+      expect(result.current.items[0].title).toBe(mockFrontPage.item.title);
+      expect(result.current.items[0].date).toBe(mockFrontPage.createdAt);
+      expect(result.current.items[1].title).toBe(mockTrend.title);
+      expect(result.current.items[1].isOutdated).toBeUndefined();
+    });
+
+    it('keeps the total capped at the limit with the outdated item first', async () => {
+      configureSelectors({ outdatedItemId: mockFrontPage.id });
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue({
+        ...mockOverview,
+        trends: [mockTrend, mockTrend],
+      });
+
+      const { result } = renderHook(() => useWhatsHappening(2));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(2);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('shows the outdated item even when the market overview is empty', async () => {
+      configureSelectors({ outdatedItemId: mockFrontPage.id });
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('falls back to the latest items when the front-page fetch fails', async () => {
+      configureSelectors({ outdatedItemId: mockFrontPage.id });
+      mockFetchFrontPageItem.mockRejectedValue(new Error('boom'));
+
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('falls back to the latest items when the front page is not found', async () => {
+      configureSelectors({ outdatedItemId: mockFrontPage.id });
+      mockFetchFrontPageItem.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+    });
+
+    it('does not fetch a front-page item when no deep-linked id is set', async () => {
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -1,8 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import type { MarketOverview } from '@metamask/ai-controllers';
+import type {
+  MarketOverview,
+  MarketOverviewFrontPage,
+} from '@metamask/ai-controllers';
 import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import { selectWhatsHappeningOutdatedItemId } from '../../../../reducers/whatsHappeningDeeplink';
 import type { WhatsHappeningItem } from '../types';
 
 /**
@@ -42,6 +46,45 @@ const mapTrendsToItems = (
     articles: trend.articles,
   }));
 
+const mapFrontPageToItem = (
+  frontPage: MarketOverviewFrontPage,
+): WhatsHappeningItem => ({
+  id: `front-page-${frontPage.id}`,
+  title: frontPage.item.title,
+  description: frontPage.item.description,
+  date: frontPage.createdAt,
+  category: frontPage.item.category,
+  impact: frontPage.item.impact,
+  relatedAssets: frontPage.item.relatedAssets,
+  articles: frontPage.item.articles,
+  isOutdated: true,
+});
+
+/**
+ * Fetches the deep-linked "outdated" front-page item, if any.
+ *
+ * @param outdatedItemId - The front-page item id from the deep link, or `null`.
+ * @returns The mapped outdated item, or `null` when there is none / on failure.
+ */
+const fetchOutdatedItem = async (
+  outdatedItemId: string | null,
+): Promise<WhatsHappeningItem | null> => {
+  if (!outdatedItemId) {
+    return null;
+  }
+
+  try {
+    const frontPage =
+      await Engine.context.AiDigestController.fetchFrontPageItem(
+        outdatedItemId,
+      );
+    return frontPage ? mapFrontPageToItem(frontPage) : null;
+  } catch {
+    // Non-fatal: fall back to rendering just the latest market overview items.
+    return null;
+  }
+};
+
 /**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
@@ -57,6 +100,7 @@ export const useWhatsHappening = (
   options?: UseWhatsHappeningOptions,
 ): UseWhatsHappeningResult => {
   const isFeatureEnabled = useSelector(selectWhatsHappeningEnabled);
+  const outdatedItemId = useSelector(selectWhatsHappeningOutdatedItemId);
   const isHookEnabled = options?.enabled ?? true;
   const isActive = isFeatureEnabled && isHookEnabled;
 
@@ -78,12 +122,17 @@ export const useWhatsHappening = (
     try {
       const data =
         await Engine.context.AiDigestController.fetchMarketOverview();
+      const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
 
-      if (data === null) {
-        setItems([]);
-      } else {
-        setItems(mapTrendsToItems(data, limit));
-      }
+      // When a deep link supplied an id, prepend that (older) front-page item
+      // as the first "outdated" card, keeping the total capped at `limit`.
+      const outdatedItem = await fetchOutdatedItem(outdatedItemId);
+
+      setItems(
+        outdatedItem
+          ? [outdatedItem, ...baseItems].slice(0, limit)
+          : baseItems,
+      );
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to fetch trending items',
@@ -92,7 +141,7 @@ export const useWhatsHappening = (
     } finally {
       setIsLoading(false);
     }
-  }, [isActive, limit]);
+  }, [isActive, limit, outdatedItemId]);
 
   const refresh = useCallback(async () => {
     await fetchItems();

--- a/app/components/UI/WhatsHappening/types.ts
+++ b/app/components/UI/WhatsHappening/types.ts
@@ -18,4 +18,10 @@ export interface WhatsHappeningItem {
   impact?: 'positive' | 'negative' | 'neutral';
   relatedAssets: RelatedAsset[];
   articles: Article[];
+  /**
+   * When true, this item was fetched by id from the front-page endpoint (an
+   * older item no longer in the latest market overview) and is rendered first
+   * in the carousel with an "Outdated" label.
+   */
+  isOutdated?: boolean;
 }

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
@@ -1,6 +1,12 @@
 import NavigationService from '../../../../NavigationService';
 import Routes from '../../../../../constants/navigation/Routes';
 import DevLogger from '../../../../SDKConnect/utils/DevLogger';
+import ReduxService from '../../../../redux';
+import {
+  setWhatsHappeningOutdatedItemId,
+  clearWhatsHappeningOutdatedItemId,
+} from '../../../../../reducers/whatsHappeningDeeplink';
+import { EXPLORE_TAB_INDEX } from '../../../../../constants/navigation/exploreTabIndices';
 import { WhatsHappeningSource } from '../../../../../components/UI/WhatsHappening/constants';
 import { handleWhatsHappeningUrl } from '../handleWhatsHappeningUrl';
 
@@ -14,33 +20,88 @@ jest.mock('../../../../SDKConnect/utils/DevLogger', () => ({
   log: jest.fn(),
 }));
 
+jest.mock('../../../../redux', () => ({
+  __esModule: true,
+  default: {
+    store: {
+      dispatch: jest.fn(),
+    },
+  },
+}));
+
 describe('handleWhatsHappeningUrl', () => {
   const mockNavigate = NavigationService.navigation.navigate as jest.Mock;
+  const mockDispatch = ReduxService.store.dispatch as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('navigates to WhatsHappeningDetailView from a deeplink source', () => {
-    handleWhatsHappeningUrl();
+  describe('without an id', () => {
+    it('navigates to WhatsHappeningDetailView from a deeplink source', () => {
+      handleWhatsHappeningUrl();
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
-      source: WhatsHappeningSource.Deeplink,
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
+        source: WhatsHappeningSource.Deeplink,
+      });
+    });
+
+    it('clears any previously stored outdated item id', () => {
+      handleWhatsHappeningUrl();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        clearWhatsHappeningOutdatedItemId(),
+      );
+    });
+
+    it('falls back to wallet home on navigation errors', () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation error');
+      });
+
+      handleWhatsHappeningUrl();
+
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+      expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handleWhatsHappeningUrl] Failed to handle deeplink:',
+        expect.any(Error),
+      );
     });
   });
 
-  it('falls back to wallet home on navigation errors', () => {
-    mockNavigate.mockImplementationOnce(() => {
-      throw new Error('Navigation error');
+  describe('with an id', () => {
+    const id = 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+
+    it('stores the id so the carousel can render the outdated item', () => {
+      handleWhatsHappeningUrl({ id });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setWhatsHappeningOutdatedItemId(id),
+      );
     });
 
-    handleWhatsHappeningUrl();
+    it('opens the Explore "Now" tab where the carousel lives', () => {
+      handleWhatsHappeningUrl({ id });
 
-    expect(mockNavigate).toHaveBeenCalledTimes(2);
-    expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
-    expect(DevLogger.log).toHaveBeenCalledWith(
-      '[handleWhatsHappeningUrl] Failed to handle deeplink:',
-      expect.any(Error),
-    );
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRENDING_VIEW, {
+        initialTab: EXPLORE_TAB_INDEX.NOW,
+        source: WhatsHappeningSource.Deeplink,
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.WHATS_HAPPENING_DETAIL,
+        expect.anything(),
+      );
+    });
+
+    it('falls back to wallet home on navigation errors', () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation error');
+      });
+
+      handleWhatsHappeningUrl({ id });
+
+      expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
+    });
   });
 });

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -762,7 +762,8 @@ async function handleUniversalLink({
       break;
     }
     case SUPPORTED_ACTIONS.WHATS_HAPPENING: {
-      handleWhatsHappeningUrl();
+      const { params: whatsHappeningParams } = extractURLParams(urlObj.href);
+      handleWhatsHappeningUrl({ id: whatsHappeningParams?.id });
       break;
     }
     case SUPPORTED_ACTIONS.TOP_TRADERS: {

--- a/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
@@ -1,7 +1,21 @@
 import NavigationService from '../../../NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
+import ReduxService from '../../../redux';
+import {
+  setWhatsHappeningOutdatedItemId,
+  clearWhatsHappeningOutdatedItemId,
+} from '../../../../reducers/whatsHappeningDeeplink';
+import { EXPLORE_TAB_INDEX } from '../../../../constants/navigation/exploreTabIndices';
 import { WhatsHappeningSource } from '../../../../components/UI/WhatsHappening/constants';
+
+interface HandleWhatsHappeningUrlParams {
+  /**
+   * Optional market overview front-page item id. When present, the carousel
+   * renders this (older) item first with an "Outdated" label.
+   */
+  id?: string;
+}
 
 const navigateToFallback = () => {
   NavigationService.navigation.navigate(Routes.WALLET.HOME);
@@ -13,13 +27,32 @@ const navigateToFallback = () => {
  * Supported URL formats:
  * - https://link.metamask.io/whats-happening
  * - metamask://whats-happening
+ * - https://link.metamask.io/whats-happening?id=<uuid>
+ * - metamask://whats-happening?id=<uuid>
  *
- * Deeplinks always open the first card.
+ * Without an `id`, opens the What's Happening detail view on the first card.
+ * With an `id`, stores the id in Redux so the What's Happening carousel fetches
+ * that front-page item and renders it first with an "Outdated" label, then
+ * opens the Explore "Now" tab where the carousel lives.
  */
-export const handleWhatsHappeningUrl = () => {
-  DevLogger.log('[handleWhatsHappeningUrl] Starting deeplink handling');
+export const handleWhatsHappeningUrl = ({
+  id,
+}: HandleWhatsHappeningUrlParams = {}) => {
+  DevLogger.log('[handleWhatsHappeningUrl] Starting deeplink handling', { id });
 
   try {
+    if (id) {
+      ReduxService.store.dispatch(setWhatsHappeningOutdatedItemId(id));
+      NavigationService.navigation.navigate(Routes.TRENDING_VIEW, {
+        initialTab: EXPLORE_TAB_INDEX.NOW,
+        source: WhatsHappeningSource.Deeplink,
+      });
+      return;
+    }
+
+    // No id: clear any previously deep-linked outdated item and open the
+    // detail view on the first card, preserving the original behavior.
+    ReduxService.store.dispatch(clearWhatsHappeningOutdatedItemId());
     NavigationService.navigation.navigate(Routes.WHATS_HAPPENING_DETAIL, {
       source: WhatsHappeningSource.Deeplink,
     });

--- a/app/core/DeeplinkManager/types/deepLink.types.ts
+++ b/app/core/DeeplinkManager/types/deepLink.types.ts
@@ -65,6 +65,11 @@ export interface DeeplinkUrlParams {
   // Home-specific parameters
   previewToken?: string;
 
+  // What's Happening-specific parameters
+  // Id of a market overview front-page item to render as the first, "outdated"
+  // card of the What's Happening carousel.
+  id?: string;
+
   // Note: All properties are explicitly defined above
 }
 

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -46,6 +46,7 @@ import moneyBalanceReducer from '../core/redux/slices/moneyBalance';
 import rewardsReducer, { RewardsState } from './rewards';
 import { isTestEnvironment } from '../util/test/utils';
 import attributionReducer from '../core/redux/slices/attribution';
+import whatsHappeningDeeplinkReducer from './whatsHappeningDeeplink';
 
 /**
  * Infer state from a reducer
@@ -136,6 +137,9 @@ export interface RootState {
   rewards: RewardsState;
   networkConnectionBanner: NetworkConnectionBannerState;
   attribution: StateFromReducer<typeof attributionReducer>;
+  whatsHappeningDeeplink: StateFromReducer<
+    typeof whatsHappeningDeeplinkReducer
+  >;
 }
 
 const baseReducers = {
@@ -193,6 +197,7 @@ if (isTestEnvironment) {
 const rootReducer = combineReducers<RootState, any>({
   ...baseReducers,
   attribution: attributionReducer,
+  whatsHappeningDeeplink: whatsHappeningDeeplinkReducer,
 });
 
 export default rootReducer;

--- a/app/reducers/whatsHappeningDeeplink/index.test.ts
+++ b/app/reducers/whatsHappeningDeeplink/index.test.ts
@@ -1,0 +1,68 @@
+import reducer, {
+  initialState,
+  setWhatsHappeningOutdatedItemId,
+  clearWhatsHappeningOutdatedItemId,
+  selectWhatsHappeningOutdatedItemId,
+} from '.';
+import type { RootState } from '..';
+
+describe('whatsHappeningDeeplink reducer', () => {
+  it('returns the initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toStrictEqual(initialState);
+    expect(initialState.outdatedItemId).toBeNull();
+  });
+
+  it('sets the outdated item id', () => {
+    const state = reducer(
+      initialState,
+      setWhatsHappeningOutdatedItemId('abc-123'),
+    );
+
+    expect(state.outdatedItemId).toBe('abc-123');
+  });
+
+  it('overwrites an existing id', () => {
+    const state = reducer(
+      { outdatedItemId: 'old' },
+      setWhatsHappeningOutdatedItemId('new'),
+    );
+
+    expect(state.outdatedItemId).toBe('new');
+  });
+
+  it('accepts null via the setter', () => {
+    const state = reducer(
+      { outdatedItemId: 'abc' },
+      setWhatsHappeningOutdatedItemId(null),
+    );
+
+    expect(state.outdatedItemId).toBeNull();
+  });
+
+  it('clears the outdated item id', () => {
+    const state = reducer(
+      { outdatedItemId: 'abc-123' },
+      clearWhatsHappeningOutdatedItemId(),
+    );
+
+    expect(state.outdatedItemId).toBeNull();
+  });
+});
+
+describe('selectWhatsHappeningOutdatedItemId', () => {
+  it('selects the outdated item id from state', () => {
+    const state = {
+      whatsHappeningDeeplink: { outdatedItemId: 'xyz' },
+    } as unknown as RootState;
+
+    expect(selectWhatsHappeningOutdatedItemId(state)).toBe('xyz');
+  });
+
+  it('returns null when no item id is set', () => {
+    const state = {
+      whatsHappeningDeeplink: { outdatedItemId: null },
+    } as unknown as RootState;
+
+    expect(selectWhatsHappeningOutdatedItemId(state)).toBeNull();
+  });
+});

--- a/app/reducers/whatsHappeningDeeplink/index.ts
+++ b/app/reducers/whatsHappeningDeeplink/index.ts
@@ -1,0 +1,52 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '..';
+
+/**
+ * State for the What's Happening deep link.
+ *
+ * Holds the id of a market overview "front page" item that a
+ * `whats-happening?id=<uuid>` deep link asked us to surface. The What's
+ * Happening carousel renders this item — fetched from the front-page endpoint —
+ * as its first card with an "Outdated" label. `null` when there is none.
+ */
+export interface WhatsHappeningDeeplinkState {
+  outdatedItemId: string | null;
+}
+
+export const initialState: WhatsHappeningDeeplinkState = {
+  outdatedItemId: null,
+};
+
+const whatsHappeningDeeplinkSlice = createSlice({
+  name: 'whatsHappeningDeeplink',
+  initialState,
+  reducers: {
+    setWhatsHappeningOutdatedItemId: (
+      state,
+      action: PayloadAction<string | null>,
+    ) => {
+      state.outdatedItemId = action.payload;
+    },
+    clearWhatsHappeningOutdatedItemId: (state) => {
+      state.outdatedItemId = null;
+    },
+  },
+});
+
+export const {
+  setWhatsHappeningOutdatedItemId,
+  clearWhatsHappeningOutdatedItemId,
+} = whatsHappeningDeeplinkSlice.actions;
+
+/**
+ * Selects the id of the deep-linked "outdated" front-page item to surface in
+ * the What's Happening carousel, or `null` when there is none.
+ *
+ * @param state - The Redux root state.
+ * @returns The outdated front-page item id, or `null`.
+ */
+export const selectWhatsHappeningOutdatedItemId = (
+  state: RootState,
+): string | null => state.whatsHappeningDeeplink.outdatedItemId;
+
+export default whatsHappeningDeeplinkSlice.reducer;

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -81,6 +81,9 @@ const initialRootState: RootState = {
   attribution: {
     attribution: null,
   },
+  whatsHappeningDeeplink: {
+    outdatedItemId: null,
+  },
 };
 
 if (isTestEnvironment) {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10183,6 +10183,7 @@
   "whats_happening": {
     "title": "What's happening",
     "ai": "AI",
+    "outdated": "Outdated",
     "impact": {
       "bullish": "Bullish",
       "bearish": "Bearish",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "@metamask/account-tree-controller": "^7.5.0",
     "@metamask/accounts-controller": "^39.0.2",
     "@metamask/address-book-controller": "^7.1.2",
-    "@metamask/ai-controllers": "^0.7.0",
+    "@metamask/ai-controllers": "patch:@metamask/ai-controllers@npm%3A0.7.0#~/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch",
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,7 +7958,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:^0.7.0":
+"@metamask/ai-controllers@npm:0.7.0":
   version: 0.7.0
   resolution: "@metamask/ai-controllers@npm:0.7.0"
   dependencies:
@@ -7967,6 +7967,18 @@ __metadata:
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.9.0"
   checksum: 10/129d02a26595f16362c6bb1905ef3885b369529eb0a174da46ed7add5fd1d6ffa4d00ba29e09f7583ef70a299dc99f33c82efc45eeea08ab7e5e712c4a3dc11d
+  languageName: node
+  linkType: hard
+
+"@metamask/ai-controllers@patch:@metamask/ai-controllers@npm%3A0.7.0#~/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch":
+  version: 0.7.0
+  resolution: "@metamask/ai-controllers@patch:@metamask/ai-controllers@npm%3A0.7.0#~/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch::version=0.7.0&hash=e9b953"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+  checksum: 10/1690904d9db42bd86a694fa613a2eeb4f3bfd6d5fef7f60abea60fb2f60de8d08d072bc23fd37e820e23bd23d1768bed866a1f7735e1cc6b52cd38b4fa6d9ed7
   languageName: node
   linkType: hard
 
@@ -35488,7 +35500,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^7.5.0"
     "@metamask/accounts-controller": "npm:^39.0.2"
     "@metamask/address-book-controller": "npm:^7.1.2"
-    "@metamask/ai-controllers": "npm:^0.7.0"
+    "@metamask/ai-controllers": "patch:@metamask/ai-controllers@npm%3A0.7.0#~/.yarn/patches/@metamask-ai-controllers-npm-0.7.0-5c88e9c9d3.patch"
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"


### PR DESCRIPTION
## Description

Adds support for a `whats-happening?id=<uuid>` deep link that surfaces an older market overview item — one that has since dropped out of the latest report — as the **first card** of the What's Happening carousel, labelled **"Outdated"**.

The market overview endpoint only returns the latest items, so older "What's happening" items can't be rendered today. A new digest-API endpoint, `GET /api/v1/market-overview/front-page/:id`, returns a single item (same schema as a market overview item) by id. This PR consumes it end to end.

### Frontend

- **New `whatsHappeningDeeplink` Redux slice** holding the deep-linked `outdatedItemId`, wired into the root reducer.
- **`handleWhatsHappeningUrl`** now accepts an optional `id`: when present it stores the id in Redux and opens the Explore "Now" tab (where the carousel lives); without an id it keeps the original behavior (opens the detail view on the first card). **`handleUniversalLink`** reads the `id` query param and forwards it.
- **`useWhatsHappening`** reads the deep-linked id, fetches the item via `AiDigestController.fetchFrontPageItem`, and prepends it (flagged `isOutdated`) as the first card, keeping the total capped at the display limit. A failed/missing front-page fetch is non-fatal — it falls back to the latest items.
- **`WhatsHappeningCard`** renders an "Outdated" badge for outdated items (new `whats_happening.outdated` locale string).

### Core dependency (temporary patch)

`AiDigestController.fetchFrontPageItem` does not exist in the published `@metamask/ai-controllers@0.7.0` yet, so this PR includes a **temporary yarn patch** (`.yarn/patches/@metamask-ai-controllers-npm-0.7.0-*.patch`) adding the method + `MarketOverviewFrontPage` type to the installed `dist`. This mirrors the core PR and should be removed once a preview build is published and the `package.json` version bumped.

## Related

- Core PR: MetaMask/core#9394 (adds `fetchFrontPageItem` to `@metamask/ai-controllers`)

## Manual testing

1. `metamask://whats-happening?id=<valid-front-page-uuid>` → lands on the Explore "Now" tab; the What's Happening carousel shows the fetched item first with an "Outdated" badge.
2. `metamask://whats-happening` (no id) → opens the detail view on the first card, as before.
3. A bad/unknown id (404) → carousel renders the latest items only, no crash.

## Pre-merge checklist

- [x] Unit tests added/updated and passing (hook, card, reducer, deep-link handler)
- [x] `yarn lint:tsc` passes (only pre-existing, unrelated generated-file errors remain)
- [ ] Replace the temporary patch with the published `@metamask/ai-controllers` preview build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deeplink routing and Redux plus a vendored dependency patch; behavior is guarded by non-fatal fetch fallbacks and existing feature flags.
> 
> **Overview**
> Adds **`whats-happening?id=<uuid>`** deep links so an older market overview front-page item can appear as the **first carousel card** with an **"Outdated"** badge, even after it drops off the latest report.
> 
> A new **`whatsHappeningDeeplink`** Redux slice stores the deep-linked id. **`handleWhatsHappeningUrl`** branches on `id`: with an id it dispatches the id and opens Explore **"Now"**; without an id it clears any stored id and keeps opening the detail view. **`handleUniversalLink`** forwards the `id` query param.
> 
> **`useWhatsHappening`** calls **`AiDigestController.fetchFrontPageItem`** when an id is set, prepends the mapped item (`isOutdated: true`), and keeps the list capped at the limit; front-page fetch failures fall back to the normal overview feed. **`WhatsHappeningCard`** shows the localized Outdated label.
> 
> Until **`@metamask/ai-controllers`** ships **`fetchFrontPageItem`**, the PR applies a **temporary Yarn patch** on `0.7.0` (mirroring MetaMask/core#9394).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c920f9fa7f6557e378aa2fb507d28e5485caf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->