### PR TITLE
perf(bridge): hoist token selector shared state out of rows

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -10,10 +10,6 @@ import {
 } from '../../testUtils/fixtures';
 import { BridgeTokenSelector } from './BridgeTokenSelector';
 import { tokenToIncludeAsset } from '../../utils/tokenUtils';
-import {
-  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
-  TokenSelectorBalanceLayoutVariant,
-} from '../TokenSelectorItem.abTestConfig';
 
 let mockBridgeFeatureFlags: {
   chainRanking?: { chainId: CaipChainId; name?: string }[];
@@ -25,8 +21,6 @@ let mockBridgeFeatureFlags: {
   ],
   chains: {},
 };
-
-let mockRWAEnabled = false;
 
 interface MockBridgeState {
   sourceToken: ReturnType<typeof createMockToken> | null;
@@ -132,20 +126,11 @@ jest.mock('../../../../../selectors/networkController', () => ({
 }));
 
 jest.mock('../../../../../selectors/featureFlagController/rwa', () => ({
-  selectRWAEnabledFlag: jest.fn(() => mockRWAEnabled),
-}));
-
-const mockUseABTest = jest.fn(() => ({
-  variant:
-    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
-      TokenSelectorBalanceLayoutVariant.Control
-    ],
-  variantName: 'control',
-  isActive: false,
+  selectRWAEnabledFlag: jest.fn(() => false),
 }));
 
 jest.mock('../../../../../hooks', () => ({
-  useABTest: () => mockUseABTest(),
+  useABTest: () => ({ variant: undefined }),
 }));
 
 // Use a getter to access mockBridgeFeatureFlags at runtime (after variable is defined)
@@ -488,39 +473,31 @@ jest.mock('../SkeletonItem', () => ({
   },
 }));
 
-interface MockTokenSelectorItemProps {
-  token: {
-    symbol: string;
-    address: string;
-    chainId: string;
-    isVerified?: boolean;
-  };
-  onPress: (token: {
-    symbol: string;
-    address: string;
-    chainId: string;
-  }) => void;
-  children?: React.ReactNode;
-  isNoFeeAsset?: boolean;
-  showStockBadge?: boolean;
-  balanceLayoutConfigOverride?: {
-    showTokenBalanceFirst: boolean;
-    removeTickerFromTokenBalance: boolean;
-  };
-}
-
-const mockTokenSelectorItemPropsBySymbol: Record<
-  string,
-  MockTokenSelectorItemProps[]
-> = {};
-
 jest.mock('../TokenSelectorItem', () => ({
-  TokenSelectorItem: (props: MockTokenSelectorItemProps) => {
-    const { token, onPress, children } = props;
+  TokenSelectorItem: ({
+    token,
+    onPress,
+    children,
+    isNoFeeAsset,
+    showStockBadge,
+  }: {
+    token: {
+      symbol: string;
+      address: string;
+      chainId: string;
+      isVerified?: boolean;
+    };
+    onPress: (token: {
+      symbol: string;
+      address: string;
+      chainId: string;
+    }) => void;
+    children?: React.ReactNode;
+    isNoFeeAsset?: boolean;
+    showStockBadge?: boolean;
+  }) => {
     const { createElement } = jest.requireActual('react');
     const { TouchableOpacity, Text, View } = jest.requireActual('react-native');
-
-    (mockTokenSelectorItemPropsBySymbol[token.symbol] ||= []).push(props);
 
     return createElement(
       TouchableOpacity,
@@ -533,10 +510,10 @@ jest.mock('../TokenSelectorItem', () => ({
             'verified',
           )
         : null,
-      props.isNoFeeAsset
+      isNoFeeAsset
         ? createElement(Text, { testID: `no-fee-${token.symbol}` }, 'No fee')
         : null,
-      props.showStockBadge
+      showStockBadge
         ? createElement(Text, { testID: `stock-${token.symbol}` }, 'Stock')
         : null,
       createElement(View, null, children),
@@ -558,19 +535,6 @@ const resetMocks = () => {
     ],
     chains: {},
   };
-  mockRWAEnabled = false;
-  mockUseABTest.mockClear();
-  mockUseABTest.mockReturnValue({
-    variant:
-      TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
-        TokenSelectorBalanceLayoutVariant.Control
-      ],
-    variantName: 'control',
-    isActive: false,
-  });
-  Object.keys(mockTokenSelectorItemPropsBySymbol).forEach(
-    (symbol) => delete mockTokenSelectorItemPropsBySymbol[symbol],
-  );
   mockPopularTokensState = {
     popularTokens: [
       createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' }),
@@ -736,10 +700,7 @@ describe('BridgeTokenSelector', () => {
         <BridgeTokenSelector />,
         store,
       );
-      await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
-      expect(mockTokenSelectorItemPropsBySymbol.USDC.at(-1)?.isNoFeeAsset).toBe(
-        true,
-      );
+      await waitFor(() => expect(getByTestId('no-fee-USDC')).toBeTruthy());
 
       mockRouteParams = { type: 'dest' };
       rerender(
@@ -747,10 +708,7 @@ describe('BridgeTokenSelector', () => {
           <BridgeTokenSelector />
         </Provider>,
       );
-      await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
-      expect(mockTokenSelectorItemPropsBySymbol.USDC.at(-1)?.isNoFeeAsset).toBe(
-        true,
-      );
+      await waitFor(() => expect(getByTestId('no-fee-USDC')).toBeTruthy());
     });
 
     it('passes verified popular tokens through to selector rows', async () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -10,13 +10,23 @@ import {
 } from '../../testUtils/fixtures';
 import { BridgeTokenSelector } from './BridgeTokenSelector';
 import { tokenToIncludeAsset } from '../../utils/tokenUtils';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutVariant,
+} from '../TokenSelectorItem.abTestConfig';
 
-let mockBridgeFeatureFlags = {
+let mockBridgeFeatureFlags: {
+  chainRanking?: { chainId: CaipChainId; name?: string }[];
+  chains?: Record<string, { noFeeAssets?: string[] }>;
+} = {
   chainRanking: [
-    { chainId: MOCK_CHAIN_IDS.ethereum },
-    { chainId: MOCK_CHAIN_IDS.polygon },
+    { chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' },
+    { chainId: MOCK_CHAIN_IDS.polygon, name: 'Polygon' },
   ],
+  chains: {},
 };
+
+let mockRWAEnabled = false;
 
 interface MockBridgeState {
   sourceToken: ReturnType<typeof createMockToken> | null;
@@ -119,6 +129,23 @@ jest.mock('../../../../../selectors/networkController', () => ({
     '0x1': { name: 'Ethereum Mainnet', chainId: '0x1' },
     '0x89': { name: 'Polygon', chainId: '0x89' },
   })),
+}));
+
+jest.mock('../../../../../selectors/featureFlagController/rwa', () => ({
+  selectRWAEnabledFlag: jest.fn(() => mockRWAEnabled),
+}));
+
+const mockUseABTest = jest.fn(() => ({
+  variant:
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+      TokenSelectorBalanceLayoutVariant.Control
+    ],
+  variantName: 'control',
+  isActive: false,
+}));
+
+jest.mock('../../../../../hooks', () => ({
+  useABTest: () => mockUseABTest(),
 }));
 
 // Use a getter to access mockBridgeFeatureFlags at runtime (after variable is defined)
@@ -461,27 +488,40 @@ jest.mock('../SkeletonItem', () => ({
   },
 }));
 
+interface MockTokenSelectorItemProps {
+  token: {
+    symbol: string;
+    address: string;
+    chainId: string;
+    isVerified?: boolean;
+  };
+  onPress: (token: {
+    symbol: string;
+    address: string;
+    chainId: string;
+  }) => void;
+  children?: React.ReactNode;
+  isNoFeeAsset?: boolean;
+  showStockBadge?: boolean;
+  balanceLayoutConfigOverride?: {
+    showTokenBalanceFirst: boolean;
+    removeTickerFromTokenBalance: boolean;
+  };
+}
+
+const mockTokenSelectorItemPropsBySymbol: Record<
+  string,
+  MockTokenSelectorItemProps[]
+> = {};
+
 jest.mock('../TokenSelectorItem', () => ({
-  TokenSelectorItem: ({
-    token,
-    onPress,
-    children,
-  }: {
-    token: {
-      symbol: string;
-      address: string;
-      chainId: string;
-      isVerified?: boolean;
-    };
-    onPress: (token: {
-      symbol: string;
-      address: string;
-      chainId: string;
-    }) => void;
-    children?: React.ReactNode;
-  }) => {
+  TokenSelectorItem: (props: MockTokenSelectorItemProps) => {
+    const { token, onPress, children } = props;
     const { createElement } = jest.requireActual('react');
     const { TouchableOpacity, Text, View } = jest.requireActual('react-native');
+
+    (mockTokenSelectorItemPropsBySymbol[token.symbol] ||= []).push(props);
+
     return createElement(
       TouchableOpacity,
       { onPress: () => onPress(token), testID: `token-${token.symbol}` },
@@ -492,6 +532,12 @@ jest.mock('../TokenSelectorItem', () => ({
             { testID: `verified-${token.symbol}` },
             'verified',
           )
+        : null,
+      props.isNoFeeAsset
+        ? createElement(Text, { testID: `no-fee-${token.symbol}` }, 'No fee')
+        : null,
+      props.showStockBadge
+        ? createElement(Text, { testID: `stock-${token.symbol}` }, 'Stock')
         : null,
       createElement(View, null, children),
     );
@@ -507,10 +553,24 @@ const resetMocks = () => {
   mockRouteParams = { type: 'source' };
   mockBridgeFeatureFlags = {
     chainRanking: [
-      { chainId: MOCK_CHAIN_IDS.ethereum },
-      { chainId: MOCK_CHAIN_IDS.polygon },
+      { chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' },
+      { chainId: MOCK_CHAIN_IDS.polygon, name: 'Polygon' },
     ],
+    chains: {},
   };
+  mockRWAEnabled = false;
+  mockUseABTest.mockClear();
+  mockUseABTest.mockReturnValue({
+    variant:
+      TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+        TokenSelectorBalanceLayoutVariant.Control
+      ],
+    variantName: 'control',
+    isActive: false,
+  });
+  Object.keys(mockTokenSelectorItemPropsBySymbol).forEach(
+    (symbol) => delete mockTokenSelectorItemPropsBySymbol[symbol],
+  );
   mockPopularTokensState = {
     popularTokens: [
       createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' }),
@@ -677,6 +737,10 @@ describe('BridgeTokenSelector', () => {
         store,
       );
       await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
+      expect(mockTokenSelectorItemPropsBySymbol.USDC.at(-1)?.isNoFeeAsset).toBe(
+        true,
+      );
+
       mockRouteParams = { type: 'dest' };
       rerender(
         <Provider store={store}>
@@ -684,6 +748,9 @@ describe('BridgeTokenSelector', () => {
         </Provider>,
       );
       await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
+      expect(mockTokenSelectorItemPropsBySymbol.USDC.at(-1)?.isNoFeeAsset).toBe(
+        true,
+      );
     });
 
     it('passes verified popular tokens through to selector rows', async () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -27,6 +27,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch';
 import {
   selectAllowedChainRanking,
+  selectBridgeFeatureFlags,
   selectTokenSelectorNetworkFilter,
   setIsSelectingToken,
   setTokenSelectorNetworkFilter,
@@ -63,6 +64,15 @@ import { createStyles } from './BridgeTokenSelector.styles';
 import Engine from '../../../../../core/Engine';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { useInitialBridgeTokens } from '../../hooks/useInitialBridgeTokens';
+import { selectRWAEnabledFlag } from '../../../../../selectors/featureFlagController/rwa';
+import { isStockRwaBridgeToken } from '../../utils/isStockRwaBridgeToken';
+import { useABTest } from '../../../../../hooks';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutConfig,
+  TokenSelectorBalanceLayoutVariant,
+} from '../TokenSelectorItem.abTestConfig';
 
 export interface BridgeTokenSelectorRouteParams {
   type: TokenSelectorType;
@@ -71,6 +81,59 @@ export interface BridgeTokenSelectorRouteParams {
 const MIN_SEARCH_LENGTH = 3;
 const ESTIMATED_ITEM_HEIGHT = 68; // container paddingVertical(4×2) + itemWrapper paddingVertical(10×2) + AvatarSize.Lg(40px)
 const LOAD_MORE_DISTANCE_THRESHOLD = 300; // Distance from bottom to trigger load
+
+interface BridgeTokenSelectorRowProps {
+  token: BridgeToken;
+  isSelected: boolean;
+  isNoFeeAsset: boolean;
+  showStockBadge: boolean;
+  balanceLayoutConfig: TokenSelectorBalanceLayoutConfig;
+  onTokenPress: (token: BridgeToken) => void;
+  onInfoPress: (token: BridgeToken) => void;
+}
+
+const BridgeTokenSelectorRow = React.memo(
+  ({
+    token,
+    isSelected,
+    isNoFeeAsset,
+    showStockBadge,
+    balanceLayoutConfig,
+    onTokenPress,
+    onInfoPress,
+  }: BridgeTokenSelectorRowProps) => {
+    const handleInfoPress = useCallback(() => {
+      onInfoPress(token);
+    }, [onInfoPress, token]);
+
+    const networkImageSource = useMemo(
+      () =>
+        getNetworkImageSource({
+          chainId: token.chainId,
+        }),
+      [token.chainId],
+    );
+
+    return (
+      <TokenSelectorItem
+        token={token}
+        isSelected={isSelected}
+        onPress={onTokenPress}
+        networkImageSource={networkImageSource}
+        isNoFeeAsset={isNoFeeAsset}
+        showStockBadge={showStockBadge}
+        balanceLayoutConfigOverride={balanceLayoutConfig}
+      >
+        <ButtonIcon
+          iconName={IconName.Info}
+          size={ButtonIconSize.Sm}
+          onPress={handleInfoPress}
+          iconProps={{ color: IconColor.IconAlternative }}
+        />
+      </TokenSelectorItem>
+    );
+  },
+);
 
 export const BridgeTokenSelector: React.FC = () => {
   const navigation = useNavigation();
@@ -104,6 +167,17 @@ export const BridgeTokenSelector: React.FC = () => {
   );
 
   const enabledChainRanking = useSelector(selectAllowedChainRanking);
+  const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
+  const isRWAEnabled = useSelector(selectRWAEnabledFlag);
+  const { variant: balanceLayoutConfig } = useABTest(
+    TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  );
+  const tokenBalanceLayoutConfig =
+    balanceLayoutConfig ??
+    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+      TokenSelectorBalanceLayoutVariant.Control
+    ];
 
   // Use custom hook for token selection
   const { handleTokenPress, selectedToken } = useTokenSelection(
@@ -264,6 +338,27 @@ export const BridgeTokenSelector: React.FC = () => {
     searchString,
   ]);
 
+  const getIsNoFeeAsset = useCallback(
+    (token: BridgeToken) => {
+      const routeNoFee =
+        route.params?.type === TokenSelectorType.Source
+          ? token.noFee?.isSource
+          : token.noFee?.isDestination;
+
+      if (routeNoFee) {
+        return true;
+      }
+
+      const caipChainId = formatChainIdToCaip(token.chainId);
+      return (
+        bridgeFeatureFlags.chains?.[caipChainId]?.noFeeAssets?.includes(
+          token.address,
+        ) ?? false
+      );
+    },
+    [bridgeFeatureFlags.chains, route.params?.type],
+  );
+
   // Re-trigger search when chain IDs change if there's an active search
   useEffect(() => {
     if (shouldResearchAfterChainChange.current && isValidSearch) {
@@ -377,38 +472,29 @@ export const BridgeTokenSelector: React.FC = () => {
         return <SkeletonItem />;
       }
 
-      const isNoFeeAsset =
-        route.params?.type === TokenSelectorType.Source
-          ? item.noFee?.isSource
-          : item.noFee?.isDestination;
+      const isSelected =
+        selectedToken?.address === item.address &&
+        selectedToken?.chainId === item.chainId;
+
       return (
-        <TokenSelectorItem
+        <BridgeTokenSelectorRow
           token={item}
-          isSelected={
-            selectedToken &&
-            selectedToken.address === item.address &&
-            selectedToken.chainId === item.chainId
-          }
-          onPress={handleTokenPress}
-          networkImageSource={getNetworkImageSource({
-            chainId: item.chainId,
-          })}
-          isNoFeeAsset={isNoFeeAsset}
-        >
-          <ButtonIcon
-            iconName={IconName.Info}
-            size={ButtonIconSize.Sm}
-            onPress={() => handleInfoButtonPress(item)}
-            iconProps={{ color: IconColor.IconAlternative }}
-          />
-        </TokenSelectorItem>
+          isSelected={isSelected}
+          onTokenPress={handleTokenPress}
+          onInfoPress={handleInfoButtonPress}
+          isNoFeeAsset={getIsNoFeeAsset(item)}
+          showStockBadge={isStockRwaBridgeToken(item, isRWAEnabled)}
+          balanceLayoutConfig={tokenBalanceLayoutConfig}
+        />
       );
     },
     [
       selectedToken,
       handleTokenPress,
-      route.params?.type,
       handleInfoButtonPress,
+      getIsNoFeeAsset,
+      isRWAEnabled,
+      tokenBalanceLayoutConfig,
     ],
   );
 

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -4,21 +4,27 @@ import { Text as RNText, View } from 'react-native';
 import { TokenSelectorItem, getSecurityTag } from './TokenSelectorItem';
 import { SecurityDataType } from '../types';
 import { ethers } from 'ethers';
-import { useABTest } from '../../../../hooks';
 import { createMockTokenWithBalance } from '../testUtils/fixtures';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutVariant,
+} from './TokenSelectorItem.abTestConfig';
 import {
   TOKEN_BALANCE_LOADING,
   TOKEN_BALANCE_LOADING_UPPERCASE,
   TOKEN_RATE_UNDEFINED,
 } from '../../Tokens/constants';
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => []),
-}));
+jest.mock('../../shared/StockBadge', () => {
+  const { createElement } = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
 
-jest.mock('../../../../hooks', () => ({
-  useABTest: jest.fn(),
-}));
+  return {
+    __esModule: true,
+    default: ({ token }: { token: { symbol: string } }) =>
+      createElement(Text, { testID: `stock-badge-${token.symbol}` }, 'Stock'),
+  };
+});
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => {
@@ -186,18 +192,9 @@ jest.mock('../../../../component-library/components/Tags/Tag', () => {
 
 describe('TokenSelectorItem', () => {
   const mockOnPress = jest.fn();
-  const mockUseABTest = jest.mocked(useABTest);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseABTest.mockReturnValue({
-      variant: {
-        showTokenBalanceFirst: false,
-        removeTickerFromTokenBalance: false,
-      },
-      variantName: 'control',
-      isActive: false,
-    });
   });
 
   describe('rendering', () => {
@@ -733,7 +730,15 @@ describe('TokenSelectorItem', () => {
       });
 
       const controlRender = render(
-        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          balanceLayoutConfigOverride={
+            TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+              TokenSelectorBalanceLayoutVariant.Control
+            ]
+          }
+        />,
       );
       expect(controlRender.getByText('50 USDC')).toBeOnTheScreen();
 
@@ -746,15 +751,6 @@ describe('TokenSelectorItem', () => {
     });
 
     it('shows token balance first without the ticker in the treatment layout', () => {
-      mockUseABTest.mockReturnValue({
-        variant: {
-          showTokenBalanceFirst: true,
-          removeTickerFromTokenBalance: true,
-        },
-        variantName: 'treatment',
-        isActive: true,
-      });
-
       const token = createMockTokenWithBalance({
         balance: '50.0',
         balanceFiat: '$500',
@@ -762,7 +758,15 @@ describe('TokenSelectorItem', () => {
       });
 
       const treatmentRender = render(
-        <TokenSelectorItem token={token} onPress={mockOnPress} />,
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          balanceLayoutConfigOverride={
+            TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+              TokenSelectorBalanceLayoutVariant.Treatment
+            ]
+          }
+        />,
       );
       expect(treatmentRender.getByText('50')).toBeOnTheScreen();
       expect(treatmentRender.queryByText('50 USDC')).not.toBeOnTheScreen();

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   StyleSheet,
   ImageSourcePropType,
@@ -7,7 +7,6 @@ import {
   StyleProp,
   TextStyle,
 } from 'react-native';
-import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import { getAssetTestId } from '../../../../../tests/selectors/Wallet/WalletView.selectors';
 import TagBase, {
@@ -33,21 +32,16 @@ import StockBadge from '../../shared/StockBadge';
 import { useStyles } from '../../../../component-library/hooks';
 import { Theme } from '../../../../util/theme/models';
 import { BridgeToken, SecurityDataType } from '../types';
-import { RootState } from '../../../../reducers';
 import { fontStyles } from '../../../../styles/common';
 import {
   TOKEN_BALANCE_LOADING,
   TOKEN_BALANCE_LOADING_UPPERCASE,
   TOKEN_RATE_UNDEFINED,
 } from '../../Tokens/constants';
-import { selectNoFeeAssets } from '../../../../core/redux/slices/bridge';
 import Tag from '../../../../component-library/components/Tags/Tag';
 import { ACCOUNT_TYPE_LABELS } from '../../../../constants/account-type-labels';
 import { formatTokenBalance, getTokenImageSource } from '../utils';
-import { useRWAToken } from '../hooks/useRWAToken';
-import { useABTest } from '../../../../hooks';
 import {
-  TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
   TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
   TokenSelectorBalanceLayoutConfig,
   TokenSelectorBalanceLayoutVariant,
@@ -180,6 +174,7 @@ interface TokenSelectorItemProps {
   shouldShowBalance?: boolean;
   children?: React.ReactNode;
   isNoFeeAsset?: boolean;
+  showStockBadge?: boolean;
   secondaryRowContent?: React.ReactNode;
   tokenBalanceTextProps?: Partial<BalanceTextProps>;
   balanceLayoutConfigOverride?: TokenSelectorBalanceLayoutConfig;
@@ -287,6 +282,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   shouldShowBalance = true,
   children,
   isNoFeeAsset = false,
+  showStockBadge = false,
   secondaryRowContent,
   tokenBalanceTextProps,
   balanceLayoutConfigOverride,
@@ -299,21 +295,12 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   const { styles } = useStyles(createStyles, {
     isSelected: shouldShowSelectedStyle,
   });
-  const { variant } = useABTest(
-    TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
-    TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
-  );
-  const noFeeAssets = useSelector((state: RootState) =>
-    selectNoFeeAssets(state, token.chainId),
-  );
-
-  const showNoFeeBadge = isNoFeeAsset || noFeeAssets?.includes(token.address);
+  const showNoFeeBadge = isNoFeeAsset;
 
   const fiatValue = token.balanceFiat;
 
   const selectedVariant =
     balanceLayoutConfigOverride ??
-    variant ??
     TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
       TokenSelectorBalanceLayoutVariant.Control
     ];
@@ -328,7 +315,20 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
 
   const isNative = token.address === ethers.constants.AddressZero;
 
-  const { isStockToken } = useRWAToken();
+  const handlePress = useCallback(() => {
+    onPress(token);
+  }, [onPress, token]);
+
+  const tokenImageSource = useMemo(
+    () =>
+      getTokenImageSource(
+        token.symbol,
+        token.image,
+        token.address,
+        token.chainId,
+      ),
+    [token.address, token.chainId, token.image, token.symbol],
+  );
 
   const fiatBalance = shouldShowBalance ? fiatValue : undefined;
   const tokenBalance = shouldShowBalance ? cryptoBalance : undefined;
@@ -341,12 +341,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   const tokenAvatar = (
     <AvatarToken
       name={token.symbol}
-      imageSource={getTokenImageSource(
-        token.symbol,
-        token.image,
-        token.address,
-        token.chainId,
-      )}
+      imageSource={tokenImageSource}
       size={AvatarSize.Lg}
       testID={
         isNative ? `network-logo-${token.symbol}` : `token-logo-${token.symbol}`
@@ -365,7 +360,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
 
       <TouchableOpacity
         key={token.address}
-        onPress={() => onPress(token)}
+        onPress={handlePress}
         style={[
           styles.itemWrapper,
           shouldIncludeChildrenInPressTarget && styles.itemWrapperWithChildren,
@@ -557,7 +552,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
                 />
               )}
             </Box>
-            {isStockToken(token as BridgeToken) && <StockBadge token={token} />}
+            {showStockBadge && <StockBadge token={token} />}
           </Box>
         </Box>
         {shouldIncludeChildrenInPressTarget && children ? (


### PR DESCRIPTION
## **Description**

`TokenSelectorItem` was wrapped in `React.memo`, but each visible row still ran screen-level hooks and Redux selectors (`useABTest`, `selectNoFeeAssets`, `useRWAToken`) and recreated unstable props during render. On long bridge/swaps token lists, that duplicated subscriptions and work across every visible row.

This change makes `TokenSelectorItem` a pure memoized row that receives shared decisions as props (`isNoFeeAsset`, `showStockBadge`, `balanceLayoutConfigOverride`) and hoists A/B layout, no-fee, and RWA resolution into `BridgeTokenSelector`. A memoized `BridgeTokenSelectorRow` stabilizes the info-button child and network image source passed into each row.

Related ticket: SWAPS-4670.

BEFORE:
{
  "BridgeTokenSelector.render": 11,
  "TokenSelectorItem.render": 253,
  "TokenSelectorItem.useABTest": 253,
  "TokenSelectorItem.selectNoFeeAssets": 209,
  "TokenSelectorItem.useRWAToken": 253
}

AFTER:
{
  "BridgeTokenSelector.render": 13,
  "TokenSelectorItem.render": 226,
  "BridgeTokenSelector.useABTest": 13,
  "BridgeTokenSelector.selectBridgeFeatureFlags": 22,
  "BridgeTokenSelector.selectRWAEnabledFlag": 22
}

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/issues/31368

## **Manual testing steps**

```gherkin
Feature: Bridge token selector row performance refactor

  Background:
    Given I am logged into MetaMask Mobile
    And I have a wallet with multiple bridge-eligible tokens

  Scenario: token selector renders badges and balance layout correctly
    Given I open the bridge or swaps token selector
    When I scroll through the token list
    Then tokens with no-fee eligibility show the no-fee badge when applicable
    And stock RWA tokens show the stock badge when the RWA flag is enabled
    And balance layout matches the active A/B variant (fiat-first control or token-balance-first treatment)

  Scenario: token selector search and selection still work
    Given I open the bridge or swaps token selector
    When I search for a token with at least 3 characters
    Then matching tokens appear in the list
    When I select a token
    Then the selector closes or advances as before
    And the info button still opens token details for the tapped row
```

## **Screenshots/Recordings**

### **Before**

N/A — internal performance refactor with no intended visual change.

### **After**

N/A — internal performance refactor with no intended visual change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance refactor with logic moved to the parent; no-fee and badge behavior should match when callers pass the same resolved props, with regression coverage in bridge selector and `TokenSelectorItem` tests.
> 
> **Overview**
> **Hoists per-row work to the bridge token selector screen** so long lists no longer run `useABTest`, Redux no-fee selectors, and RWA hooks on every visible row.
> 
> `BridgeTokenSelector` now resolves balance layout once via `useABTest`, reads `selectBridgeFeatureFlags` and `selectRWAEnabledFlag`, and computes **`getIsNoFeeAsset`** from route type (`token.noFee` plus `bridgeFeatureFlags.chains[caip].noFeeAssets`). It passes **`isNoFeeAsset`**, **`showStockBadge`** (`isStockRwaBridgeToken`), and **`balanceLayoutConfigOverride`** into a new memoized **`BridgeTokenSelectorRow`**, which stabilizes network image and info-button callbacks before rendering `TokenSelectorItem`.
> 
> **`TokenSelectorItem`** becomes a leaner presentational row: it drops those hooks/selectors, shows the no-fee badge only from **`isNoFeeAsset`**, and shows **`StockBadge`** only when **`showStockBadge`** is true. Tests now drive A/B layout via **`balanceLayoutConfigOverride`** and mock the new parent-level flags and row props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911cd17409210428c39d62f0b1a3e8e6ae1e8121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->