### PR TITLE
chore(rewards): remove dead rewardsEnabled feature flag references

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -49,18 +49,7 @@ const navigation = {
 
 const mockInitialState = {
   engine: {
-    backgroundState: {
-      ...backgroundState,
-      RemoteFeatureFlagController: {
-        remoteFeatureFlags: {
-          rewardsEnabled: {
-            enabled: true,
-            minimumVersion: '0.0.1',
-          },
-        },
-        cacheTimestamp: 0,
-      },
-    },
+    backgroundState,
   },
 };
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
@@ -130,7 +130,7 @@ describe('usePerpsOrderFees', () => {
           selectorStr.includes('rewards') ||
           selectorStr.includes('Rewards')
         ) {
-          return true; // rewardsEnabled
+          return true; // rewards-related selectors default to enabled
         }
         if (
           selectorStr.includes('address') ||

--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -6,7 +6,6 @@ import type { Json } from '@metamask/utils';
  * in app/selectors/featureFlagController/
  */
 export enum FeatureFlagNames {
-  rewardsEnabled = 'rewardsEnabled',
   otaUpdatesEnabled = 'otaUpdatesEnabled',
   fullPageAccountList = 'fullPageAccountList',
   assetsDefiPositionsEnabled = 'assetsDefiPositionsEnabled',

--- a/tests/component-view/stateFixture.ts
+++ b/tests/component-view/stateFixture.ts
@@ -40,11 +40,6 @@ export const defaultFeatureFlags: Record<string, unknown> = {
     featureVersion: null,
     minimumVersion: null,
   },
-  rewardsEnabled: {
-    enabled: false,
-    featureVersion: null,
-    minimumVersion: null,
-  },
   rewardsAnnouncementModalEnabled: {
     enabled: false,
     featureVersion: null,


### PR DESCRIPTION
## **Description**

The remote `rewardsEnabled` flag still exists in production client-config, but the mobile app no longer reads it. Rewards gating in `RewardsController` uses `basicFunctionalityEnabled`, and VIP uses `vipProgramEnabled`.

This PR removes leftover client-side references that implied `rewardsEnabled` still controlled rewards behavior:

- `FeatureFlagNames.rewardsEnabled` dev-override enum entry (no selector implementation)
- Unused `rewardsEnabled` default in component-view test fixtures
- Stale `rewardsEnabled` remote-flag mock in `TabBar` tests
- Misleading comment in `usePerpsOrderFees` tests

The feature flag registry entry is intentionally kept so E2E mocks and drift checks stay aligned with production client-config.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (internal cleanup)

## **Manual testing steps**

N/A — test-only and dead-code cleanup; no runtime behavior change.

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)