### PR TITLE
fix(permissions): restore safe area on dapp connect modal

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
@@ -31,7 +31,7 @@ import { ConnectionProps } from '../../../../../core/SDKConnect/Connection';
 import MultichainAccountSelectorList from '../../../../../component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList';
 import { AccountGroupWithInternalAccounts } from '../../../../../selectors/multichainAccounts/accounts.type';
 import { selectAccountGroups } from '../../../../../selectors/multichainAccounts/accountTreeController';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
 
@@ -60,6 +60,7 @@ const MultichainAccountConnectMultiSelector = ({
   hostname,
   connection,
 }: MultichainAccountConnectMultiSelectorProps) => {
+  const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { isRenderedAsBottomSheet });
   const navigation = useNavigation();
   const [selectedAccountGroupIdsSet, setSelectedAccountGroupIdsSet] = useState<
@@ -164,7 +165,12 @@ const MultichainAccountConnectMultiSelector = ({
   );
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View
+      style={[
+        styles.safeArea,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
       <View style={styles.container}>
         <SheetHeader
           title={screenTitle || strings('accounts.connect_accounts_title')}
@@ -189,7 +195,7 @@ const MultichainAccountConnectMultiSelector = ({
         )}
         <View style={styles.body}>{renderCtaButtons()}</View>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnectMultiSelector/MultichainAccountConnectMultiSelector.tsx
@@ -62,6 +62,13 @@ const MultichainAccountConnectMultiSelector = ({
 }: MultichainAccountConnectMultiSelectorProps) => {
   const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { isRenderedAsBottomSheet });
+  const safeAreaContainerStyle = useMemo(
+    () => [
+      styles.safeArea,
+      { paddingTop: insets.top, paddingBottom: insets.bottom },
+    ],
+    [styles.safeArea, insets.top, insets.bottom],
+  );
   const navigation = useNavigation();
   const [selectedAccountGroupIdsSet, setSelectedAccountGroupIdsSet] = useState<
     Set<AccountGroupId>
@@ -165,12 +172,7 @@ const MultichainAccountConnectMultiSelector = ({
   );
 
   return (
-    <View
-      style={[
-        styles.safeArea,
-        { paddingTop: insets.top, paddingBottom: insets.bottom },
-      ]}
-    >
+    <View style={safeAreaContainerStyle}>
       <View style={styles.container}>
         <SheetHeader
           title={screenTitle || strings('accounts.connect_accounts_title')}

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { ImageSourcePropType, TouchableOpacity, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import { useNavigation } from '@react-navigation/native';
 import StyledButton from '../../../UI/StyledButton';
@@ -126,6 +126,7 @@ const MultichainPermissionsSummary = ({
   showPermissionsOnly = false,
   isMaliciousDapp = false,
 }: MultichainPermissionsSummaryProps) => {
+  const insets = useSafeAreaInsets();
   const nonTabView = showAccountsOnly || showPermissionsOnly;
   const { colors } = useTheme();
   const { styles } = useStyles(styleSheet, {});
@@ -568,7 +569,12 @@ const MultichainPermissionsSummary = ({
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View
+      style={[
+        styles.safeArea,
+        { paddingTop: insets.top, paddingBottom: insets.bottom },
+      ]}
+    >
       <View style={styles.mainContainer}>
         <View style={styles.contentContainer}>
           {renderHeader()}
@@ -698,7 +704,7 @@ const MultichainPermissionsSummary = ({
           )}
         </View>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -130,6 +130,13 @@ const MultichainPermissionsSummary = ({
   const nonTabView = showAccountsOnly || showPermissionsOnly;
   const { colors } = useTheme();
   const { styles } = useStyles(styleSheet, {});
+  const safeAreaContainerStyle = useMemo(
+    () => [
+      styles.safeArea,
+      { paddingTop: insets.top, paddingBottom: insets.bottom },
+    ],
+    [styles.safeArea, insets.top, insets.bottom],
+  );
   const navigation = useNavigation();
   const { navigate } = navigation;
   const providerConfig = useSelector(selectProviderConfig);
@@ -569,12 +576,7 @@ const MultichainPermissionsSummary = ({
   };
 
   return (
-    <View
-      style={[
-        styles.safeArea,
-        { paddingTop: insets.top, paddingBottom: insets.bottom },
-      ]}
-    >
+    <View style={safeAreaContainerStyle}>
       <View style={styles.mainContainer}>
         <View style={styles.contentContainer}>
           {renderHeader()}


### PR DESCRIPTION
## **Description**

The dApp connect permissions modal (`MultichainPermissionsSummary`) is presented through nested `transparentModal` navigators (`ROOT_MODAL_FLOW` → `ACCOUNT_CONNECT`). On iOS, `SafeAreaView` in that presentation context resolves zero top/bottom insets, so the connect UI bleeds under the status bar and home indicator.

This change replaces `SafeAreaView` with explicit `useSafeAreaInsets()` padding on the connect summary and edit-accounts screens, matching the pattern already used by `AccountSelector` in the same modal flow.

## **Changelog**

CHANGELOG entry: Fixed dApp connect view content bleeding under the status bar and home indicator on iOS

## **Related issues**

Refs: [TMCU-997](https://consensyssoftware.atlassian.net/browse/TMCU-997)

## **Manual testing steps**

```gherkin
Feature: dApp connect safe area

  Scenario: connect view respects safe area in browser
    Given the user is on iOS with the in-app browser open
    And the user navigates to a dApp such as https://www.curve.finance
    When the user triggers a wallet connection request
    Then the connect modal header clears the status bar
    And the Cancel and Connect buttons sit above the home indicator

  Scenario: edit accounts screen respects safe area
    Given the connect modal is visible
    When the user taps "Edit accounts"
    Then the account selector header and action buttons respect top and bottom safe areas
```

## **Screenshots/Recordings**

### **Before**

<img width="300" src="https://github.com/user-attachments/assets/7eeadf45-c161-4933-a2d0-03805eb75570" />


### **After**
<img width="300" src="https://github.com/user-attachments/assets/e75dd5bf-db51-4d3c-b212-07a7fd6eb82c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-997]: https://consensyssoftware.atlassian.net/browse/TMCU-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation-layer padding changes with no auth, permissions, or data-flow changes.
> 
> **Overview**
> Fixes **iOS layout** in nested `transparentModal` dApp connect flows where `SafeAreaView` reported **zero** top/bottom insets, so headers and CTAs could sit under the status bar and home indicator.
> 
> **`MultichainPermissionsSummary`** and **`MultichainAccountConnectMultiSelector`** now use **`useSafeAreaInsets()`** with a memoized outer **`View`** that applies `paddingTop` / `paddingBottom` on top of existing `styles.safeArea`, aligned with **`AccountSelector`** in the same modal stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e440a462d571198107288e3061162d26970be02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->