### PR TITLE
fix: Refine Base Notification toast to match iOS style

### DIFF
--- a/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
@@ -1,19 +1,25 @@
-import { StyleSheet } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
+
+const marginWidth = 16;
+const notificationWidth = Dimensions.get('window').width - marginWidth * 2;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
   const { colors } = theme;
 
   return StyleSheet.create({
-    floatingBackground: {
+    base: {
+      position: 'absolute',
+      top: 0,
+      left: marginWidth,
+      width: notificationWidth,
       backgroundColor: colors.background.section,
-      marginHorizontal: 16,
       borderRadius: 8,
       borderWidth: 1,
       borderColor: colors.border.muted,
     },
-    defaultFlashFloating: {
+    content: {
       padding: 16,
       flexDirection: 'row',
       flex: 1,

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
@@ -1,12 +1,20 @@
 import { Dimensions, StyleSheet } from 'react-native';
-import { Theme } from '../../../util/theme/models';
+import { AppThemeKey, Theme } from '../../../util/theme/models';
+import {
+  TOAST_CLOSE_MARGIN_TOP,
+  TOAST_DESCRIPTION_MARGIN_TOP,
+  TOAST_PADDING_HORIZONTAL,
+  TOAST_PADDING_RIGHT_WITH_CLOSE_ICON,
+  TOAST_PADDING_VERTICAL,
+  TOAST_ROW_GAP,
+} from '../../components/Toast/Toast.constants';
 
 const marginWidth = 16;
 const notificationWidth = Dimensions.get('window').width - marginWidth * 2;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
-  const { colors } = theme;
+  const { colors, shadows } = theme;
 
   return StyleSheet.create({
     base: {
@@ -14,32 +22,46 @@ const styleSheet = (params: { theme: Theme }) => {
       top: 0,
       left: marginWidth,
       width: notificationWidth,
-      backgroundColor: colors.background.section,
-      borderRadius: 8,
+      backgroundColor:
+        theme.themeAppearance === AppThemeKey.light
+          ? colors.background.default
+          : colors.background.section,
+      ...(theme.themeAppearance === AppThemeKey.light ? shadows.size.md : {}),
+      borderRadius: 16,
       borderWidth: 1,
       borderColor: colors.border.muted,
-    },
-    content: {
-      padding: 16,
+      paddingTop: TOAST_PADDING_VERTICAL,
+      paddingBottom: TOAST_PADDING_VERTICAL,
+      paddingLeft: TOAST_PADDING_HORIZONTAL,
+      paddingRight: TOAST_PADDING_HORIZONTAL,
       flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: TOAST_ROW_GAP,
+    },
+    baseWithCloseIconButton: {
+      paddingRight: TOAST_PADDING_RIGHT_WITH_CLOSE_ICON,
+    },
+    pressableContent: {
       flex: 1,
-      borderRadius: 8,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: TOAST_ROW_GAP,
     },
     flashLabel: {
       flex: 1,
-      flexDirection: 'column',
-    },
-    flashText: {
-      flex: 1,
-      lineHeight: 18,
+      justifyContent: 'flex-start',
     },
     flashTitle: {
-      flex: 1,
-      marginBottom: 2,
-      lineHeight: 18,
+      color: colors.text.default,
     },
-    flashIcon: {
-      marginRight: 15,
+    flashText: {
+      marginTop: TOAST_DESCRIPTION_MARGIN_TOP,
+    },
+    startAccessoryContainer: {
+      alignSelf: 'flex-start',
+    },
+    closeButton: {
+      marginTop: TOAST_CLOSE_MARGIN_TOP,
     },
   });
 };

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.types.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.types.ts
@@ -30,4 +30,12 @@ export interface BaseNotificationProps {
   onPress?: () => void;
   onHide?: () => void;
   autoDismiss?: boolean;
+  /** When false the notification is not rendered. Defaults to true. */
+  isVisible?: boolean;
+  /** Called after the exit spring animation completes. */
+  onDismissComplete?: () => void;
+  /** Auto-dismiss delay in ms. Defaults to Toast visibilityDuration (2750ms). */
+  dismissDuration?: number;
+  /** When true, the notification stays visible until manually dismissed. */
+  persistUntilDismiss?: boolean;
 }

--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
 import BaseNotification, { getDescription } from './';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { strings } from '../../../../locales/i18n';
@@ -85,18 +85,30 @@ describe('BaseNotification', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the close affordance when autoDismiss is true', () => {
+  it('invokes onHide when the close affordance is pressed', async () => {
+    jest.useFakeTimers();
     const onHide = jest.fn();
     const { getByTestId } = renderWithProvider(
       <BaseNotification
         status="success"
         data={defaultData}
         autoDismiss
+        persistUntilDismiss
         onHide={onHide}
       />,
     );
-    fireEvent.press(getByTestId('base-notification-close'));
+
+    fireEvent(getByTestId('base-notification-container'), 'layout', {
+      nativeEvent: { layout: { height: 100, width: 300, x: 0, y: 0 } },
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('base-notification-close'));
+      jest.runAllTimers();
+    });
+
     expect(onHide).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
   describe('EIP-7702 transactions (without nonce)', () => {

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -164,12 +164,22 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const dismissDurationMs = dismissDuration ?? visibilityDuration;
 
   const topOffset = 0;
+  const hasCloseIconButton = autoDismiss;
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateYProgress.value + topOffset }],
   }));
   const baseStyle: StyleProp<ViewStyle> = useMemo(
-    () => [styles.base, animatedStyle],
-    [styles.base, animatedStyle],
+    () => [
+      styles.base,
+      hasCloseIconButton && styles.baseWithCloseIconButton,
+      animatedStyle,
+    ],
+    [
+      styles.base,
+      styles.baseWithCloseIconButton,
+      animatedStyle,
+      hasCloseIconButton,
+    ],
   );
 
   const runExitAnimation = useCallback(
@@ -262,15 +272,16 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
       testID="base-notification-container"
     >
       <TouchableOpacity
-        style={styles.content}
+        style={styles.pressableContent}
         onPress={onPress}
         activeOpacity={0.8}
+        disabled={!onPress}
       >
-        <View style={styles.flashIcon}>{getIcon(status)}</View>
+        <View style={styles.startAccessoryContainer}>{getIcon(status)}</View>
         <View style={styles.flashLabel}>
           <Text
             variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Bold}
+            fontWeight={FontWeight.Medium}
             color={TextColor.TextDefault}
             style={styles.flashTitle}
             testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
@@ -279,21 +290,22 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
           </Text>
           <Text
             variant={TextVariant.BodySm}
-            color={TextColor.TextDefault}
+            color={TextColor.TextAlternative}
             style={styles.flashText}
           >
             {!description ? getDescription(status, safeData) : description}
           </Text>
         </View>
-        {autoDismiss && (
-          <ButtonIcon
-            iconName={IconName.Close}
-            size={ButtonIconSize.Md}
-            onPress={handleManualDismiss}
-            testID="base-notification-close"
-          />
-        )}
       </TouchableOpacity>
+      {autoDismiss && (
+        <ButtonIcon
+          iconName={IconName.Close}
+          size={ButtonIconSize.Md}
+          onPress={handleManualDismiss}
+          style={styles.closeButton}
+          testID="base-notification-close"
+        />
+      )}
     </Animated.View>
   );
 };

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -1,5 +1,21 @@
-import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useMemo, useRef } from 'react';
+import {
+  Dimensions,
+  LayoutChangeEvent,
+  StyleProp,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  cancelAnimation,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Text,
   TextVariant,
@@ -15,10 +31,14 @@ import {
   ButtonIconSize,
 } from '@metamask/design-system-react-native';
 
-import { baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import { useStyles } from '../../hooks';
 import { ToastSelectorsIDs } from '../../components/Toast/ToastModal.testIds';
+import {
+  TOAST_SPRING_CONFIG,
+  TOAST_TOP_PADDING,
+  visibilityDuration,
+} from '../../components/Toast/Toast.constants';
 
 import styleSheet from './BaseNotification.styles';
 import {
@@ -26,6 +46,11 @@ import {
   BaseNotificationProps,
   BaseNotificationStatus,
 } from './BaseNotification.types';
+
+const screenHeight = Dimensions.get('window').height;
+
+const getHiddenTranslateY = (height: number, offset: number) =>
+  -(height + offset);
 
 export const getIcon = (status: BaseNotificationStatus | undefined) => {
   switch (status) {
@@ -73,7 +98,7 @@ const getTitle = (
     case 'pending_withdrawal':
       return strings('notifications.pending_withdrawal_title');
     case 'success': {
-      const parsed = nonce != null ? parseInt(String(nonce)) : NaN;
+      const parsed = nonce != null ? parseInt(String(nonce), 10) : NaN;
       if (!Number.isNaN(parsed)) {
         return strings('notifications.success_title', { nonce: parsed });
       }
@@ -88,7 +113,7 @@ const getTitle = (
     case 'received':
       return strings('notifications.received_title', { amount, assetType });
     case 'speedup': {
-      const parsed = nonce != null ? parseInt(String(nonce)) : NaN;
+      const parsed = nonce != null ? parseInt(String(nonce), 10) : NaN;
       if (!Number.isNaN(parsed)) {
         return strings('notifications.speedup_title', { nonce: parsed });
       }
@@ -123,49 +148,153 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   onPress,
   onHide,
   autoDismiss = false,
+  isVisible = true,
+  onDismissComplete,
+  dismissDuration,
+  persistUntilDismiss = false,
 }) => {
   const { styles } = useStyles(styleSheet, {});
+  const { top: topInset } = useSafeAreaInsets();
   const safeData: BaseNotificationData = data ?? {};
   const { description = null, title = null } = safeData;
 
+  const notificationHeight = useSharedValue(screenHeight);
+  const translateYProgress = useSharedValue(-screenHeight);
+  const hasEnteredRef = useRef(false);
+  const dismissDurationMs = dismissDuration ?? visibilityDuration;
+
+  const topOffset = 0;
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateYProgress.value + topOffset }],
+  }));
+  const baseStyle: StyleProp<ViewStyle> = useMemo(
+    () => [styles.base, animatedStyle],
+    [styles.base, animatedStyle],
+  );
+
+  const runExitAnimation = useCallback(
+    (onComplete?: () => void) => {
+      const hiddenTranslateY = getHiddenTranslateY(
+        notificationHeight.value,
+        topOffset,
+      );
+
+      translateYProgress.value = withSpring(
+        hiddenTranslateY,
+        TOAST_SPRING_CONFIG,
+        () => {
+          if (onComplete) {
+            runOnJS(onComplete)();
+          }
+        },
+      );
+    },
+    [notificationHeight, topOffset, translateYProgress],
+  );
+
+  const handleDismissComplete = useCallback(() => {
+    onDismissComplete?.();
+  }, [onDismissComplete]);
+
+  const handleManualDismiss = useCallback(() => {
+    cancelAnimation(translateYProgress);
+    runExitAnimation(() => {
+      onHide?.();
+      handleDismissComplete();
+    });
+  }, [handleDismissComplete, onHide, runExitAnimation, translateYProgress]);
+
+  const onAnimatedViewLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (!isVisible || hasEnteredRef.current) {
+        return;
+      }
+
+      hasEnteredRef.current = true;
+      const { height } = event.nativeEvent.layout;
+      const hiddenTranslateY = getHiddenTranslateY(height, topOffset);
+      const visibleTranslateY = topInset + TOAST_TOP_PADDING;
+
+      notificationHeight.value = height;
+      translateYProgress.value = hiddenTranslateY;
+
+      if (persistUntilDismiss) {
+        translateYProgress.value = withSpring(
+          visibleTranslateY,
+          TOAST_SPRING_CONFIG,
+        );
+        return;
+      }
+
+      translateYProgress.value = withSpring(
+        visibleTranslateY,
+        TOAST_SPRING_CONFIG,
+        () => {
+          translateYProgress.value = withDelay(
+            dismissDurationMs,
+            withSpring(hiddenTranslateY, TOAST_SPRING_CONFIG, () => {
+              runOnJS(handleDismissComplete)();
+            }),
+          );
+        },
+      );
+    },
+    [
+      dismissDurationMs,
+      handleDismissComplete,
+      isVisible,
+      notificationHeight,
+      persistUntilDismiss,
+      topInset,
+      topOffset,
+      translateYProgress,
+    ],
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+
   return (
-    <View style={baseStyles.flexGrow}>
-      <View style={styles.floatingBackground}>
-        <TouchableOpacity
-          style={styles.defaultFlashFloating}
-          onPress={onPress}
-          activeOpacity={0.8}
-        >
-          <View style={styles.flashIcon}>{getIcon(status)}</View>
-          <View style={styles.flashLabel}>
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              color={TextColor.TextDefault}
-              style={styles.flashTitle}
-              testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
-            >
-              {!title ? getTitle(status, safeData) : title}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextDefault}
-              style={styles.flashText}
-            >
-              {!description ? getDescription(status, safeData) : description}
-            </Text>
-          </View>
-          {autoDismiss && (
-            <ButtonIcon
-              iconName={IconName.Close}
-              size={ButtonIconSize.Md}
-              onPress={onHide}
-              testID="base-notification-close"
-            />
-          )}
-        </TouchableOpacity>
-      </View>
-    </View>
+    <Animated.View
+      onLayout={onAnimatedViewLayout}
+      style={baseStyle}
+      testID="base-notification-container"
+    >
+      <TouchableOpacity
+        style={styles.content}
+        onPress={onPress}
+        activeOpacity={0.8}
+      >
+        <View style={styles.flashIcon}>{getIcon(status)}</View>
+        <View style={styles.flashLabel}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Bold}
+            color={TextColor.TextDefault}
+            style={styles.flashTitle}
+            testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
+          >
+            {!title ? getTitle(status, safeData) : title}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextDefault}
+            style={styles.flashText}
+          >
+            {!description ? getDescription(status, safeData) : description}
+          </Text>
+        </View>
+        {autoDismiss && (
+          <ButtonIcon
+            iconName={IconName.Close}
+            size={ButtonIconSize.Md}
+            onPress={handleManualDismiss}
+            testID="base-notification-close"
+          />
+        )}
+      </TouchableOpacity>
+    </Animated.View>
   );
 };
 

--- a/app/components/UI/Notification/SimpleNotification/index.js
+++ b/app/components/UI/Notification/SimpleNotification/index.js
@@ -1,62 +1,32 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import Animated from 'react-native-reanimated';
 import BaseNotification from '../../../../component-library/components-temp/BaseNotification';
-import Device from '../../../../util/device';
-import ElevatedView from 'react-native-elevated-view';
-import { colors as importedColors } from '../../../../styles/common';
-
-const styles = StyleSheet.create({
-  modalTypeViewBrowser: {
-    bottom: Device.isIphoneX() ? 70 : 60,
-  },
-  elevatedView: {
-    backgroundColor: importedColors.transparent,
-  },
-  notificationContainer: {
-    position: 'absolute',
-    bottom: 0,
-    paddingBottom: Device.isIphoneX() ? 20 : 10,
-    left: 0,
-    right: 0,
-    backgroundColor: importedColors.transparent,
-  },
-});
 
 function SimpleNotification({
-  isInBrowserView,
-  notificationAnimated,
   hideCurrentNotification,
+  onDismissComplete,
+  dismissDuration,
   currentNotification,
 }) {
   return (
-    <Animated.View
-      style={[
-        styles.notificationContainer,
-        isInBrowserView && styles.modalTypeViewBrowser,
-        { transform: [{ translateY: notificationAnimated }] },
-      ]}
-    >
-      <ElevatedView style={styles.elevatedView} elevation={100}>
-        <BaseNotification
-          status={currentNotification.status}
-          data={{
-            title: currentNotification.title,
-            description: currentNotification.description,
-          }}
-          onHide={hideCurrentNotification}
-        />
-      </ElevatedView>
-    </Animated.View>
+    <BaseNotification
+      status={currentNotification.status}
+      data={{
+        title: currentNotification.title,
+        description: currentNotification.description,
+      }}
+      onHide={hideCurrentNotification}
+      onDismissComplete={onDismissComplete}
+      dismissDuration={dismissDuration}
+    />
   );
 }
 
 SimpleNotification.propTypes = {
-  isInBrowserView: PropTypes.bool,
-  notificationAnimated: PropTypes.object,
   currentNotification: PropTypes.object,
   hideCurrentNotification: PropTypes.func,
+  onDismissComplete: PropTypes.func,
+  dismissDuration: PropTypes.number,
 };
 
 export default SimpleNotification;

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -2,23 +2,18 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { StyleSheet, View, Text, Dimensions } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useSharedValue } from 'react-native-reanimated';
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
 import { renderFromWei, fastSplit } from '../../../../util/number';
 import { validateTransactionActionBalance } from '../../../../util/transactions';
-import {
-  fontStyles,
-  colors as importedColors,
-} from '../../../../styles/common';
+import { fontStyles } from '../../../../styles/common';
 import decodeTransaction from '../../TransactionElement/utils';
 import TransactionActionContent from '../../TransactionActionModal/TransactionActionContent';
 import ActionContent from '../../ActionModal/ActionContent';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import TransactionDetails from '../../TransactionElement/TransactionDetails';
 import BaseNotification from '../../../../component-library/components-temp/BaseNotification';
-import Device from '../../../../util/device';
-import ElevatedView from 'react-native-elevated-view';
 import { CANCEL_RATE, SPEED_UP_RATE } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
 import { collectibleContractsSelector } from '../../../../reducers/collectibles';
@@ -60,17 +55,6 @@ const createStyles = (colors) =>
       color: colors.text.default,
       ...fontStyles.bold,
     },
-    notification: {
-      position: 'absolute',
-      bottom: 0,
-      paddingBottom: Device.isIphoneX() ? 20 : 10,
-      left: 0,
-      right: 0,
-      backgroundColor: importedColors.transparent,
-    },
-    modalTypeViewBrowser: {
-      bottom: Device.isIphoneX() ? 70 : 60,
-    },
     closeIcon: {
       paddingTop: 4,
       position: 'absolute',
@@ -96,18 +80,15 @@ const createStyles = (colors) =>
       borderRadius: 10,
       backgroundColor: colors.background.default,
     },
-    elevatedView: {
-      backgroundColor: importedColors.transparent,
-    },
   });
 
 function TransactionNotification(props) {
   const {
     accounts,
     currentNotification,
-    isInBrowserView,
-    notificationAnimated,
     onClose,
+    onDismissComplete,
+    dismissDuration,
     transactions,
     animatedTimingStart,
     smartTransactions,
@@ -286,28 +267,18 @@ function TransactionNotification(props) {
 
   return (
     <>
-      <Animated.View
-        style={[
-          styles.notification,
-          isInBrowserView && styles.modalTypeViewBrowser,
-          {
-            transform: [{ translateY: notificationAnimated }],
-          },
-        ]}
-      >
-        <ElevatedView style={styles.elevatedView} elevation={100}>
-          <BaseNotification
-            status={currentNotification.status}
-            data={{
-              ...tx?.txParams,
-              ...currentNotification.transaction,
-              title: transactionElement?.notificationKey,
-            }}
-            onPress={detailsFadeIn}
-            onHide={onCloseNotification}
-          />
-        </ElevatedView>
-      </Animated.View>
+      <BaseNotification
+        status={currentNotification.status}
+        data={{
+          ...tx?.txParams,
+          ...currentNotification.transaction,
+          title: transactionElement?.notificationKey,
+        }}
+        onPress={detailsFadeIn}
+        onHide={onCloseNotification}
+        onDismissComplete={onDismissComplete}
+        dismissDuration={dismissDuration}
+      />
       {transactionDetailsIsVisible && (
         <View style={styles.modalsContainer}>
           <View style={[styles.modalOverlay]}>
@@ -369,9 +340,9 @@ function TransactionNotification(props) {
 }
 
 TransactionNotification.propTypes = {
-  isInBrowserView: PropTypes.bool,
-  notificationAnimated: PropTypes.object,
   onClose: PropTypes.func,
+  onDismissComplete: PropTypes.func,
+  dismissDuration: PropTypes.number,
   animatedTimingStart: PropTypes.func,
   currentNotification: PropTypes.object,
   swapsTransactions: PropTypes.object,

--- a/app/components/UI/Notification/index.js
+++ b/app/components/UI/Notification/index.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useNavigationState } from '@react-navigation/native';
 import {
   removeCurrentNotification,
   hideCurrentNotification,
@@ -11,18 +10,10 @@ import TransactionNotification from './TransactionNotification';
 import SimpleNotification from './SimpleNotification';
 import { currentNotificationSelector } from '../../../reducers/notification';
 
-import { findRouteNameFromNavigatorState } from '../../../util/general';
 import usePrevious from '../../hooks/usePrevious';
-import {
-  useSharedValue,
-  withTiming,
-  Easing,
-  runOnJS,
-} from 'react-native-reanimated';
+import { withTiming, Easing, runOnJS } from 'react-native-reanimated';
 
 const { TRANSACTION, SIMPLE } = NotificationTypes;
-
-const BROWSER_ROUTE = 'BrowserView';
 
 function Notification({
   currentNotification,
@@ -30,9 +21,6 @@ function Notification({
   hideCurrentNotification,
   removeCurrentNotification,
 }) {
-  const notificationAnimated = useSharedValue(200);
-  const routes = useNavigationState((state) => state.routes);
-
   const prevNotificationIsVisible = usePrevious(currentNotificationIsVisible);
 
   const animatedTimingStart = useCallback((animatedRef, toValue, callback) => {
@@ -43,44 +31,22 @@ function Notification({
     );
   }, []);
 
-  const isInBrowserView = useMemo(
-    () => findRouteNameFromNavigatorState(routes) === BROWSER_ROUTE,
-    [routes],
-  );
-
   useEffect(
     () => () => {
-      animatedTimingStart(notificationAnimated, 200, removeCurrentNotification);
       hideCurrentNotification();
+      removeCurrentNotification();
     },
-    [
-      notificationAnimated,
-      animatedTimingStart,
-      hideCurrentNotification,
-      removeCurrentNotification,
-    ],
+    [hideCurrentNotification, removeCurrentNotification],
   );
 
   useEffect(() => {
     if (!prevNotificationIsVisible && currentNotificationIsVisible) {
-      animatedTimingStart(notificationAnimated, 0);
       hideCurrentNotification();
-      setTimeout(() => {
-        animatedTimingStart(
-          notificationAnimated,
-          200,
-          removeCurrentNotification,
-        );
-      }, currentNotification.autodismiss || 5000);
     }
   }, [
-    animatedTimingStart,
     hideCurrentNotification,
-    removeCurrentNotification,
     currentNotificationIsVisible,
     prevNotificationIsVisible,
-    currentNotification.autodismiss,
-    notificationAnimated,
   ]);
 
   if (!currentNotification?.type) return null;
@@ -88,8 +54,8 @@ function Notification({
     return (
       <TransactionNotification
         onClose={hideCurrentNotification}
-        isInBrowserView={isInBrowserView}
-        notificationAnimated={notificationAnimated}
+        onDismissComplete={removeCurrentNotification}
+        dismissDuration={currentNotification.autodismiss}
         animatedTimingStart={animatedTimingStart}
         currentNotification={currentNotification}
       />
@@ -97,8 +63,9 @@ function Notification({
   if (currentNotification.type === SIMPLE)
     return (
       <SimpleNotification
-        isInBrowserView={isInBrowserView}
-        notificationAnimated={notificationAnimated}
+        onDismissComplete={removeCurrentNotification}
+        dismissDuration={currentNotification.autodismiss}
+        hideCurrentNotification={hideCurrentNotification}
         currentNotification={currentNotification}
       />
     );

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -11,9 +11,8 @@ import {
   BackHandler,
   ScrollView,
   InteractionManager,
-  Animated,
-  Easing,
   Platform,
+  View,
 } from 'react-native';
 import { captureException } from '@sentry/react-native';
 import { colors as importedColors } from '../../../styles/common';
@@ -22,7 +21,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import FadeOutOverlay from '../../UI/FadeOutOverlay';
 import Device from '../../../util/device';
 import BaseNotification from '../../../component-library/components-temp/BaseNotification';
-import ElevatedView from 'react-native-elevated-view';
 import { loadingSet, loadingUnset } from '../../../actions/user';
 import {
   saveOnboardingEvent as saveEvent,
@@ -209,7 +207,8 @@ const Onboarding = () => {
     startFoxAnimation: undefined,
   });
 
-  const notificationAnimated = useRef(new Animated.Value(100)).current;
+  const [onboardingNotificationVisible, setOnboardingNotificationVisible] =
+    useState(false);
 
   const onboardingTraceCtx = useRef<TraceContext>(undefined);
   const socialLoginTraceCtx = useRef<TraceContext>(undefined);
@@ -227,19 +226,6 @@ const Onboarding = () => {
   const mounted = useRef<boolean>(false);
   const hasCheckedVaultBackup = useRef<boolean>(false);
   const warningCallback = useRef<() => boolean>(() => true);
-  const notificationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const animatedTimingStart = useCallback(
-    (animatedRef: Animated.Value, toValue: number): void => {
-      Animated.timing(animatedRef, {
-        toValue,
-        duration: 500,
-        easing: Easing.linear,
-        useNativeDriver: true,
-      }).start();
-    },
-    [],
-  );
 
   const disableBackPress = useCallback((): void => {
     // Disable back press
@@ -248,12 +234,9 @@ const Onboarding = () => {
   }, []);
 
   const showNotification = useCallback((): void => {
-    animatedTimingStart(notificationAnimated, 0);
-    notificationTimer.current = setTimeout(() => {
-      animatedTimingStart(notificationAnimated, 200);
-    }, 4000);
+    setOnboardingNotificationVisible(true);
     disableBackPress();
-  }, [animatedTimingStart, notificationAnimated, disableBackPress]);
+  }, [disableBackPress]);
 
   const updateNavBar = useCallback((): void => {
     navigation.setOptions({
@@ -1105,27 +1088,23 @@ const Onboarding = () => {
           };
 
       return (
-        <Animated.View
-          style={[
-            tw.style('flex-row items-end', { flex: 0.1 }),
-            { transform: [{ translateY: notificationAnimated }] },
-          ]}
+        <View
+          style={tw.style('absolute top-0 left-0 right-0', { zIndex: 999 })}
+          pointerEvents="box-none"
         >
-          <ElevatedView
-            style={tw.style(
-              'absolute bottom-0 left-0 right-0 bg-transparent',
-              Device.isIphoneX() ? 'pb-5' : 'pb-[10px]',
-            )}
-            elevation={100}
-          >
-            <BaseNotification status="success" data={notificationData} />
-          </ElevatedView>
-        </Animated.View>
+          <BaseNotification
+            isVisible={onboardingNotificationVisible}
+            dismissDuration={4000}
+            onDismissComplete={() => setOnboardingNotificationVisible(false)}
+            status="success"
+            data={notificationData}
+          />
+        </View>
       );
     }, [
       route?.params?.delete,
       route?.params?.showErrorReportSentToast,
-      notificationAnimated,
+      onboardingNotificationVisible,
       tw,
     ]);
 
@@ -1156,9 +1135,6 @@ const Onboarding = () => {
 
     return () => {
       mounted.current = false;
-      if (notificationTimer.current) {
-        clearTimeout(notificationTimer.current);
-      }
       unsetLoading();
       InteractionManager.runAfterInteractions(PreventScreenshot.allow);
     };


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Top-of-screen notifications (`BaseNotification`) previously lacked the iOS-style spring animation used elsewhere in the app, and consumer components duplicated visibility and dismiss logic.

This PR adds Reanimated spring enter/exit animations with safe-area-aware top placement to `BaseNotification`, reuses shared toast animation constants, and simplifies `SimpleNotification`, `TransactionNotification`, the notification root, and onboarding notification usage to rely on the component's built-in visibility lifecycle.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated top notification toasts to use iOS-style spring animation

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: BaseNotification iOS-style top toast animation

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user sees a transaction notification animate in from the top
    Given a transaction is submitted or confirmed

    When the transaction notification appears
    Then the notification should slide in from the top with a spring animation
    And the notification should respect the device safe area inset

  Scenario: user dismisses a notification
    Given a top notification is visible

    When user taps the dismiss control
    Then the notification should spring out upward and disappear

  Scenario: user sees onboarding notification
    Given I am on the onboarding flow where a notification is shown

    When the notification is displayed
    Then it should appear at the top with the same spring animation behavior
```

## **Screenshots/Recordings**

### **Before**

### **After**

### **Swap and Send**
Uses BaseNotification

<table>
  <tr>
    <td align="center" valign="top"><strong>Before</strong><br>
    <video src="https://github.com/user-attachments/assets/6111536e-f649-431f-81ec-ef67d7958a21" controls width="320"></video></td>
    <td align="center" valign="top"><strong>After</strong><br>
    <video src="https://github.com/user-attachments/assets/85c417c8-91d6-4ea0-bb4b-3d5afe79f098" controls width="320"></video></td>
  </tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->