### PR TITLE
fix: Refine DS legacy toast to match iOS style

### DIFF
--- a/app/component-library/components/Toast/Toast.constants.ts
+++ b/app/component-library/components/Toast/Toast.constants.ts
@@ -1,10 +1,18 @@
-/* eslint-disable import-x/prefer-default-export */
+import type { WithSpringConfig } from 'react-native-reanimated';
 
-// External dependencies.
-import { AvatarAccountType } from '../Avatars/Avatar/variants/AvatarAccount';
+export const visibilityDuration = 2750;
 
-export const TEST_ACCOUNT_ADDRESS =
-  '0x10e08af911f2e489480fb2855b24771745d0198b50f5c55891369844a8c57092';
-export const TEST_NETWORK_IMAGE_URL =
-  'https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880';
-export const TEST_AVATAR_TYPE = AvatarAccountType.JazzIcon;
+export const TOAST_TOP_PADDING = 8;
+
+/**
+ * Spring tuned to approximate iOS system banner motion.
+ *
+ * UIKit reference: `animate(withDuration: 0.5, usingSpringWithDamping: 0.7,
+ * initialSpringVelocity: 1)`
+ *
+ * SwiftUI reference: `.snappy` / `.smooth` with minimal bounce.
+ */
+export const TOAST_SPRING_CONFIG: WithSpringConfig = {
+  dampingRatio: 0.85,
+  duration: 500,
+};

--- a/app/component-library/components/Toast/Toast.constants.ts
+++ b/app/component-library/components/Toast/Toast.constants.ts
@@ -5,6 +5,21 @@ export const visibilityDuration = 2750;
 export const TOAST_TOP_PADDING = 8;
 
 /**
+ * BannerBase-aligned spacing (design-system Box tokens; 1 unit = 4px).
+ * @see https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BannerBase/BannerBase.tsx
+ */
+export const TOAST_PADDING_VERTICAL = 12;
+export const TOAST_PADDING_BOTTOM_WITH_ACTION = 16;
+export const TOAST_PADDING_HORIZONTAL = 16;
+export const TOAST_PADDING_RIGHT_WITH_CLOSE_ICON = 8;
+export const TOAST_ROW_GAP = 16;
+/** Circular background for icon toasts when `backgroundColor` is set (24px icon inside). */
+export const TOAST_ICON_BACKGROUND_SIZE = 32;
+export const TOAST_ACTION_MARGIN_TOP = 8;
+export const TOAST_DESCRIPTION_MARGIN_TOP = 2;
+export const TOAST_CLOSE_MARGIN_TOP = -4;
+
+/**
  * Spring tuned to approximate iOS system banner motion.
  *
  * UIKit reference: `animate(withDuration: 0.5, usingSpringWithDamping: 0.7,

--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -19,7 +19,7 @@ const styleSheet = (params: { theme: Theme }) => {
       position: 'absolute',
       width: toastWidth,
       left: marginWidth,
-      bottom: 0,
+      top: 0,
       backgroundColor: colors.background.section,
       borderWidth: 1,
       borderColor: colors.border.muted,

--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -1,9 +1,20 @@
 // Third party dependencies.
 import { StyleSheet, Dimensions } from 'react-native';
-import { Theme } from '../../../util/theme/models';
+import { AppThemeKey, Theme } from '../../../util/theme/models';
+
+import {
+  TOAST_ACTION_MARGIN_TOP,
+  TOAST_CLOSE_MARGIN_TOP,
+  TOAST_DESCRIPTION_MARGIN_TOP,
+  TOAST_PADDING_BOTTOM_WITH_ACTION,
+  TOAST_PADDING_HORIZONTAL,
+  TOAST_PADDING_RIGHT_WITH_CLOSE_ICON,
+  TOAST_PADDING_VERTICAL,
+  TOAST_ICON_BACKGROUND_SIZE,
+  TOAST_ROW_GAP,
+} from './Toast.constants';
 
 const marginWidth = 16;
-const padding = 12;
 const toastWidth = Dimensions.get('window').width - marginWidth * 2;
 
 /**
@@ -13,37 +24,60 @@ const toastWidth = Dimensions.get('window').width - marginWidth * 2;
  */
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
-  const { colors } = theme;
+  const { colors, shadows } = theme;
   return StyleSheet.create({
     base: {
       position: 'absolute',
       width: toastWidth,
       left: marginWidth,
       top: 0,
-      backgroundColor: colors.background.section,
+      backgroundColor:
+        theme.themeAppearance === AppThemeKey.light
+          ? colors.background.default
+          : colors.background.section,
+      ...(theme.themeAppearance === AppThemeKey.light ? shadows.size.md : {}),
       borderWidth: 1,
       borderColor: colors.border.muted,
-      borderRadius: 12,
-      padding,
+      borderRadius: 16,
+      paddingTop: TOAST_PADDING_VERTICAL,
+      paddingBottom: TOAST_PADDING_VERTICAL,
+      paddingLeft: TOAST_PADDING_HORIZONTAL,
+      paddingRight: TOAST_PADDING_HORIZONTAL,
       flexDirection: 'row',
       alignItems: 'flex-start',
-    },
-    avatar: {
-      marginTop: -4,
-      marginRight: 16,
+      gap: TOAST_ROW_GAP,
     },
     labelsContainer: {
       flex: 1,
       justifyContent: 'flex-start',
     },
+    startAccessoryContainer: {
+      alignSelf: 'flex-start',
+    },
+    iconBackground: {
+      width: TOAST_ICON_BACKGROUND_SIZE,
+      height: TOAST_ICON_BACKGROUND_SIZE,
+      borderRadius: TOAST_ICON_BACKGROUND_SIZE / 2,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    baseWithActionButton: {
+      paddingBottom: TOAST_PADDING_BOTTOM_WITH_ACTION,
+    },
+    baseWithCloseIconButton: {
+      paddingRight: TOAST_PADDING_RIGHT_WITH_CLOSE_ICON,
+    },
     label: {
       color: colors.text.default,
     },
     description: {
-      marginTop: 4,
+      marginTop: TOAST_DESCRIPTION_MARGIN_TOP,
     },
     actionButton: {
-      marginTop: 8,
+      marginTop: TOAST_ACTION_MARGIN_TOP,
+    },
+    closeButton: {
+      marginTop: TOAST_CLOSE_MARGIN_TOP,
     },
   });
 };

--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -106,6 +106,31 @@ describe('Toast', () => {
     expect(screen.getByText('Test description')).toBeOnTheScreen();
   });
 
+  it('hides toast with customTopOffset when closeToast is called', async () => {
+    const toastOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'Offset toast' }],
+      hasNoTimeout: true,
+      customTopOffset: 24,
+    };
+
+    render(<Toast ref={toastRef} />);
+
+    await act(async () => {
+      toastRef.current?.showToast(toastOptions);
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByText('Offset toast')).toBeOnTheScreen();
+
+    await act(async () => {
+      toastRef.current?.closeToast();
+      jest.runAllTimers();
+    });
+
+    expect(screen.queryByText('Offset toast')).toBeNull();
+  });
+
   it('hides toast when closeToast is called', async () => {
     const toastOptions: ToastOptions = {
       variant: ToastVariants.Plain,

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -27,8 +27,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // External dependencies.
 import Avatar, { AvatarSize, AvatarVariant } from '../Avatars/Avatar';
+import Icon, { IconSize } from '../Icons/Icon';
 import Text, { TextColor, TextVariant } from '../Texts/Text';
-import Button, { ButtonVariants } from '../Buttons/Button';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  IconName as DsIconName,
+} from '@metamask/design-system-react-native';
 
 // Internal dependencies.
 import {
@@ -49,12 +55,24 @@ import {
   visibilityDuration,
 } from './Toast.constants';
 import { useStyles } from '../../hooks';
+import { ButtonProps, ButtonVariants } from '../Buttons/Button/Button.types';
 import ButtonIcon from '../Buttons/ButtonIcon';
+import { ButtonIconSizes } from '../Buttons/ButtonIcon/ButtonIcon.types';
 
 const screenHeight = Dimensions.get('window').height;
 
 const getHiddenTranslateY = (height: number, offset: number) =>
   -(height + offset);
+
+const mapLegacyButtonVariant = (variant?: ButtonVariants): ButtonVariant => {
+  if (variant === ButtonVariants.Secondary) {
+    return ButtonVariant.Secondary;
+  }
+  if (variant === ButtonVariants.Link) {
+    return ButtonVariant.Secondary;
+  }
+  return ButtonVariant.Primary;
+};
 
 /**
  * @deprecated Please update your code to use `Toast` from `@metamask/design-system-react-native`.
@@ -76,9 +94,23 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateYProgress.value + topOffset }],
   }));
+  const hasCloseIconButton =
+    toastOptions?.closeButtonOptions?.variant === ButtonIconVariant.Icon;
   const baseStyle: StyleProp<ViewStyle> = useMemo(
-    () => [styles.base, animatedStyle],
-    [styles.base, animatedStyle],
+    () => [
+      styles.base,
+      toastOptions?.linkButtonOptions && styles.baseWithActionButton,
+      hasCloseIconButton && styles.baseWithCloseIconButton,
+      animatedStyle,
+    ],
+    [
+      styles.base,
+      styles.baseWithActionButton,
+      styles.baseWithCloseIconButton,
+      animatedStyle,
+      toastOptions?.linkButtonOptions,
+      hasCloseIconButton,
+    ],
   );
 
   const resetState = () => setToastOptions(undefined);
@@ -152,19 +184,62 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
     }
   };
 
-  const renderLabel = (labelOptions: ToastLabelOptions) => (
+  const renderInlineLabelSegments = (segments: ToastLabelOptions) => (
     <Text variant={TextVariant.BodyMD}>
-      {labelOptions.map(({ label, isBold }, index) => (
+      {segments.map(({ label, isBold }, index) => (
         <Text
           key={`toast-label-${index}`}
-          variant={isBold ? TextVariant.BodyMDBold : TextVariant.BodyMD}
-          style={styles.label}
+          variant={
+            isBold === false ? TextVariant.BodySM : TextVariant.BodyMDMedium
+          }
+          color={isBold === false ? TextColor.Alternative : undefined}
+          style={isBold === false ? undefined : styles.label}
         >
           {label}
         </Text>
       ))}
     </Text>
   );
+
+  const renderLabel = (labelOptions: ToastLabelOptions) => {
+    const descriptionSplitIndex = labelOptions.findIndex(
+      (option, index) => index > 0 && option.label === '\n',
+    );
+
+    if (descriptionSplitIndex === -1) {
+      return renderInlineLabelSegments(labelOptions);
+    }
+
+    const titleOptions = labelOptions.slice(0, descriptionSplitIndex);
+    const descriptionLabelOptions = labelOptions.slice(
+      descriptionSplitIndex + 1,
+    );
+
+    return (
+      <>
+        {titleOptions.length > 0
+          ? renderInlineLabelSegments(titleOptions)
+          : null}
+        {descriptionLabelOptions.length > 0 ? (
+          <Text
+            variant={TextVariant.BodySM}
+            color={TextColor.Alternative}
+            style={styles.description}
+          >
+            {descriptionLabelOptions.map(({ label }, index) => (
+              <Text
+                key={`toast-description-label-${index}`}
+                variant={TextVariant.BodySM}
+                color={TextColor.Alternative}
+              >
+                {label}
+              </Text>
+            ))}
+          </Text>
+        ) : null}
+      </>
+    );
+  };
 
   const renderDescription = (descriptionOptions?: ToastDescriptionOptions) =>
     descriptionOptions && (
@@ -180,12 +255,13 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const renderActionButton = (linkButtonOptions?: ToastLinkButtonOptions) =>
     linkButtonOptions && (
       <Button
-        variant={ButtonVariants.Secondary}
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Sm}
         onPress={linkButtonOptions.onPress}
-        labelTextVariant={TextVariant.BodyMD}
-        label={linkButtonOptions.label}
         style={styles.actionButton}
-      />
+      >
+        {linkButtonOptions.label}
+      </Button>
     );
 
   const renderCloseButton = (closeButtonOptions?: ToastCloseButtonOptions) => {
@@ -194,17 +270,23 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
         <ButtonIcon
           onPress={() => closeButtonOptions?.onPress?.()}
           iconName={closeButtonOptions?.iconName}
+          size={ButtonIconSizes.Md}
+          style={styles.closeButton}
         />
       );
     }
+    const legacyCloseButton = closeButtonOptions as ButtonProps;
+
     return (
       <Button
-        variant={ButtonVariants.Primary}
-        onPress={() => closeButtonOptions?.onPress()}
-        label={closeButtonOptions?.label}
-        endIconName={closeButtonOptions?.endIconName}
-        style={closeButtonOptions?.style}
-      />
+        variant={mapLegacyButtonVariant(legacyCloseButton.variant)}
+        size={ButtonSize.Sm}
+        onPress={() => legacyCloseButton.onPress?.()}
+        endIconName={legacyCloseButton.endIconName as DsIconName | undefined}
+        style={legacyCloseButton.style}
+      >
+        {legacyCloseButton.label}
+      </Button>
     );
   };
 
@@ -223,7 +305,6 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
             // should receive avatar type as props
             type={accountAvatarType}
             size={AvatarSize.Md}
-            style={styles.avatar}
           />
         );
       }
@@ -234,8 +315,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
             variant={AvatarVariant.Network}
             name={networkName}
             imageSource={networkImageSource}
-            size={AvatarSize.Md}
-            style={styles.avatar}
+            size={AvatarSize.Sm}
           />
         );
       }
@@ -246,21 +326,26 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
             variant={AvatarVariant.Favicon}
             imageSource={appIconSource}
             size={AvatarSize.Md}
-            style={styles.avatar}
           />
         );
       }
       case ToastVariants.Icon: {
         const { iconName, iconColor, backgroundColor } = toastOptions;
-        return (
-          <Avatar
-            variant={AvatarVariant.Icon}
-            name={iconName}
-            iconColor={iconColor}
-            backgroundColor={backgroundColor}
-            style={styles.avatar}
-          />
+        const icon = (
+          <Icon name={iconName} size={IconSize.Lg} color={iconColor} />
         );
+        const hasIconBackground =
+          backgroundColor != null && backgroundColor !== 'transparent';
+
+        if (hasIconBackground) {
+          return (
+            <View style={[styles.iconBackground, { backgroundColor }]}>
+              {icon}
+            </View>
+          );
+        }
+
+        return icon;
       }
     }
   };
@@ -276,10 +361,15 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
 
     const isStartAccessoryValid =
       startAccessory != null && React.isValidElement(startAccessory);
+    const leadingAccessory = isStartAccessoryValid
+      ? startAccessory
+      : renderAvatar();
 
     return (
       <>
-        {isStartAccessoryValid ? startAccessory : renderAvatar()}
+        {leadingAccessory ? (
+          <View style={styles.startAccessoryContainer}>{leadingAccessory}</View>
+        ) : null}
         <View
           style={styles.labelsContainer}
           testID={ToastSelectorsIDs.CONTAINER}

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -21,7 +21,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withDelay,
-  withTiming,
+  withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -43,14 +43,18 @@ import {
 } from './Toast.types';
 import styleSheet from './Toast.styles';
 import { ToastSelectorsIDs } from './ToastModal.testIds';
-import { TAB_BAR_HEIGHT } from '../Navigation/TabBar/TabBar.constants';
+import {
+  TOAST_SPRING_CONFIG,
+  TOAST_TOP_PADDING,
+  visibilityDuration,
+} from './Toast.constants';
 import { useStyles } from '../../hooks';
 import ButtonIcon from '../Buttons/ButtonIcon';
 
-const visibilityDuration = 2750;
-const animationDuration = 250;
-const bottomPadding = 36;
 const screenHeight = Dimensions.get('window').height;
+
+const getHiddenTranslateY = (height: number, offset: number) =>
+  -(height + offset);
 
 /**
  * @deprecated Please update your code to use `Toast` from `@metamask/design-system-react-native`.
@@ -63,14 +67,14 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const [toastOptions, setToastOptions] = useState<ToastOptions | undefined>(
     undefined,
   );
-  const { bottom: bottomNotchSpacing } = useSafeAreaInsets();
-  const translateYProgress = useSharedValue(screenHeight);
+  const { top: topInset } = useSafeAreaInsets();
+  const toastHeight = useSharedValue(screenHeight);
+  const translateYProgress = useSharedValue(-screenHeight);
   const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const customOffset = toastOptions?.customBottomOffset ?? 0;
+  const topOffset =
+    toastOptions?.customTopOffset ?? toastOptions?.customBottomOffset ?? 0;
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateY: translateYProgress.value - TAB_BAR_HEIGHT - customOffset },
-    ],
+    transform: [{ translateY: translateYProgress.value + topOffset }],
   }));
   const baseStyle: StyleProp<ViewStyle> = useMemo(
     () => [styles.base, animatedStyle],
@@ -101,9 +105,9 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   };
 
   const closeToast = () => {
-    translateYProgress.value = withTiming(
-      screenHeight,
-      { duration: animationDuration },
+    translateYProgress.value = withSpring(
+      getHiddenTranslateY(toastHeight.value, topOffset),
+      TOAST_SPRING_CONFIG,
       () => {
         runOnJS(resetState)();
       },
@@ -118,24 +122,27 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const onAnimatedViewLayout = (e: LayoutChangeEvent) => {
     if (toastOptions) {
       const { height } = e.nativeEvent.layout;
-      const translateYToValue = -(bottomPadding + bottomNotchSpacing);
+      const hiddenTranslateY = getHiddenTranslateY(height, topOffset);
+      const visibleTranslateY = topInset + TOAST_TOP_PADDING;
 
-      translateYProgress.value = height;
+      toastHeight.value = height;
+      translateYProgress.value = hiddenTranslateY;
 
       if (toastOptions.hasNoTimeout) {
-        translateYProgress.value = withTiming(translateYToValue, {
-          duration: animationDuration,
-        });
+        translateYProgress.value = withSpring(
+          visibleTranslateY,
+          TOAST_SPRING_CONFIG,
+        );
       } else {
-        translateYProgress.value = withTiming(
-          translateYToValue,
-          { duration: animationDuration },
+        translateYProgress.value = withSpring(
+          visibleTranslateY,
+          TOAST_SPRING_CONFIG,
           () => {
             translateYProgress.value = withDelay(
               visibilityDuration,
-              withTiming(
-                height,
-                { duration: animationDuration },
+              withSpring(
+                hiddenTranslateY,
+                TOAST_SPRING_CONFIG,
                 runOnJS(resetState),
               ),
             );

--- a/app/component-library/components/Toast/Toast.types.ts
+++ b/app/component-library/components/Toast/Toast.types.ts
@@ -52,6 +52,12 @@ interface BaseToastVariants {
   linkButtonOptions?: ToastLinkButtonOptions;
   closeButtonOptions?: ToastCloseButtonOptions;
   startAccessory?: ReactElement;
+  /** Extra offset from the top of the screen (below the safe area). */
+  customTopOffset?: number;
+  /**
+   * @deprecated Use `customTopOffset`. Previously applied offset from the bottom;
+   * retained for backward compatibility during top-placement migration.
+   */
   customBottomOffset?: number;
 }
 


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The legacy design-system `Toast` component still used a bottom-positioned timing animation, which did not match the iOS-style top toast behavior used in newer surfaces.

This PR moves the legacy `Toast` to top placement with Reanimated spring enter/exit animations, extracts shared spring constants into `Toast.constants.ts`, adds `customTopOffset` support, and extends unit tests to cover the updated animation behavior.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated legacy toast notifications to use iOS-style top spring animation

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Legacy Toast iOS-style top animation

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user sees a legacy toast animate in from the top
    Given a feature triggers the legacy Toast component (e.g. Perps toast)

    When the toast is shown
    Then it should slide in from the top with a spring animation
    And it should respect the device safe area inset

  Scenario: user dismisses a legacy toast
    Given a legacy toast is visible

    When user taps the close button or the toast auto-dismisses
    Then the toast should spring out upward and disappear

  Scenario: user sees a persistent legacy toast
    Given a toast is shown with no timeout

    When the toast is displayed
    Then it should remain visible at the top until manually dismissed
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->