### PR TITLE
fix: swaps select controller fields memoization

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -20,7 +20,12 @@ import { act, waitFor } from '@testing-library/react-native';
 import { BigNumber } from 'ethers';
 import { SolScope } from '@metamask/keyring-api';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
+import {
+  selectBridgeFeatureFlags as selectAppBridgeFeatureFlags,
+  selectBridgeQuotes as selectAppBridgeQuotes,
+  selectControllerFields,
+  setSourceAmount,
+} from '../../../../../core/redux/slices/bridge';
 
 jest.mock('../../utils/quoteUtils', () => ({
   isQuoteExpired: jest.fn(),
@@ -86,6 +91,12 @@ jest.mock('../../../../../util/notifications/methods/common', () => ({
 describe('useBridgeQuoteData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    selectControllerFields.clearCache();
+    selectControllerFields.memoizedResultFunc.clearCache();
+    selectAppBridgeQuotes.clearCache();
+    selectAppBridgeQuotes.memoizedResultFunc.clearCache();
+    selectAppBridgeFeatureFlags.clearCache();
+    selectAppBridgeFeatureFlags.memoizedResultFunc.clearCache();
     (isQuoteExpired as jest.Mock).mockReturnValue(false);
     (getQuoteRefreshRate as jest.Mock).mockReturnValue(5000);
     (shouldRefreshQuote as jest.Mock).mockReturnValue(false);
@@ -1089,6 +1100,8 @@ describe('useBridgeQuoteData', () => {
     });
 
     recommendedQuote = secondMockQuote;
+    selectAppBridgeQuotes.clearCache();
+    selectAppBridgeQuotes.memoizedResultFunc.clearCache();
     act(() => {
       store.dispatch(setSourceAmount('2'));
     });

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -4,6 +4,10 @@ import Engine from '../../../../../core/Engine';
 import { createBridgeTestState } from '../../testUtils';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { RequestStatus } from '@metamask/bridge-controller';
+import {
+  selectBridgeQuotes,
+  selectControllerFields,
+} from '../../../../../core/redux/slices/bridge';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -38,6 +42,10 @@ describe('useBridgeQuoteEvents', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    selectControllerFields.clearCache();
+    selectControllerFields.memoizedResultFunc.clearCache();
+    selectBridgeQuotes.clearCache();
+    selectBridgeQuotes.memoizedResultFunc.clearCache();
   });
 
   it.each([

--- a/app/core/redux/slices/bridge/index.perf-test.tsx
+++ b/app/core/redux/slices/bridge/index.perf-test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { Provider, useSelector } from 'react-redux';
+import { act } from '@testing-library/react-native';
+import { measureRenders } from 'reassure';
+import { cloneDeep } from 'lodash';
+import configureStore from '../../../../util/test/configureStore';
+import { initialState as mockRootState } from '../../../../components/UI/Bridge/_mocks_/initialState';
+import {
+  selectBatchSellQuotes,
+  selectBatchSellTrades,
+  selectBridgeQuotes,
+  setSourceAmount,
+} from '.';
+
+const store = configureStore(cloneDeep(mockRootState));
+
+const ProvidersWrapper: React.ComponentType<{
+  children: React.ReactElement;
+}> = ({ children }) => <Provider store={store}>{children}</Provider>;
+
+function BridgeQuoteSelectorPerfHarness() {
+  useSelector(selectBridgeQuotes);
+  useSelector(selectBatchSellQuotes);
+  useSelector(selectBatchSellTrades);
+
+  return <Text>Bridge quote selector perf</Text>;
+}
+
+test('Bridge quote selector unrelated update performance', async () => {
+  const scenario = async () => {
+    act(() => {
+      for (let index = 0; index < 25; index++) {
+        store.dispatch(setSourceAmount(String(index)));
+      }
+    });
+  };
+
+  await measureRenders(<BridgeQuoteSelectorPerfHarness />, {
+    scenario,
+    wrapper: ProvidersWrapper,
+  });
+}, 30000);

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -961,6 +961,32 @@ describe('bridge slice', () => {
       selectBatchSellTrades.resetRecomputations();
     });
 
+    it('updates controller fields when analytics opt-in changes', () => {
+      const mockState = cloneDeep(mockRootState) as unknown as RootState;
+      mockState.engine.backgroundState.AnalyticsController = {
+        ...mockState.engine.backgroundState.AnalyticsController,
+        optedIn: false,
+        analyticsId: 'test-analytics-id',
+      };
+
+      expect(selectControllerFields(mockState).participateInMetaMetrics).toBe(
+        false,
+      );
+
+      const controllerFieldsRecomputations =
+        selectControllerFields.recomputations();
+
+      const optedInState = cloneDeep(mockState);
+      optedInState.engine.backgroundState.AnalyticsController.optedIn = true;
+
+      expect(
+        selectControllerFields(optedInState).participateInMetaMetrics,
+      ).toBe(true);
+      expect(selectControllerFields.recomputations()).toBe(
+        controllerFieldsRecomputations + 1,
+      );
+    });
+
     it('does not recompute when unrelated bridge UI state changes', () => {
       const mockState = cloneDeep(mockRootState) as unknown as RootState;
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -33,7 +33,10 @@ import reducer, {
   selectBatchSellDestStablecoinsByChain,
   selectHardwareWalletsSwaps,
   updateHardwareWalletsSwaps,
+  selectBridgeQuotes,
   selectBatchSellQuotes,
+  selectBatchSellTrades,
+  selectControllerFields,
   selectBatchSellSlippages,
   setBatchSellTokenSlippage,
   setBatchSellTokenSlippages,
@@ -947,6 +950,56 @@ describe('bridge slice', () => {
       const result = selectBatchSellQuotes(mockState as unknown as RootState);
 
       expect(result.recommendedQuotes).toHaveLength(2);
+    });
+  });
+
+  describe('bridge controller quote selectors', () => {
+    beforeEach(() => {
+      selectControllerFields.resetRecomputations();
+      selectBridgeQuotes.resetRecomputations();
+      selectBatchSellQuotes.resetRecomputations();
+      selectBatchSellTrades.resetRecomputations();
+    });
+
+    it('does not recompute when unrelated bridge UI state changes', () => {
+      const mockState = cloneDeep(mockRootState) as unknown as RootState;
+
+      selectBridgeQuotes(mockState);
+      selectBatchSellQuotes(mockState);
+      selectBatchSellTrades(mockState);
+
+      const controllerFieldsRecomputations =
+        selectControllerFields.recomputations();
+      const bridgeQuotesRecomputations = selectBridgeQuotes.recomputations();
+      const batchSellQuotesRecomputations =
+        selectBatchSellQuotes.recomputations();
+      const batchSellTradesRecomputations =
+        selectBatchSellTrades.recomputations();
+
+      const unrelatedState = {
+        ...mockState,
+        bridge: {
+          ...mockState.bridge,
+          sourceAmount: '1',
+        },
+      } as RootState;
+
+      selectBridgeQuotes(unrelatedState);
+      selectBatchSellQuotes(unrelatedState);
+      selectBatchSellTrades(unrelatedState);
+
+      expect(selectControllerFields.recomputations()).toBe(
+        controllerFieldsRecomputations,
+      );
+      expect(selectBridgeQuotes.recomputations()).toBe(
+        bridgeQuotesRecomputations,
+      );
+      expect(selectBatchSellQuotes.recomputations()).toBe(
+        batchSellQuotesRecomputations,
+      );
+      expect(selectBatchSellTrades.recomputations()).toBe(
+        batchSellTradesRecomputations,
+      );
     });
   });
 

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -39,7 +39,6 @@ import {
   hardwareWalletsSwapsReducer,
   initialHardwareWalletsSwapsState,
 } from '../../../../components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.state';
-import { analytics } from '../../../../util/analytics/analytics';
 import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
 import { getTokenExchangeRate } from '../../../../components/UI/Bridge/utils/exchange-rates';
 import {
@@ -56,6 +55,7 @@ import { normalizeTokenAddress } from '../../../../components/UI/Bridge/utils/to
 import { isStockRwaBridgeToken } from '../../../../components/UI/Bridge/utils/isStockRwaBridgeToken';
 import { selectRWAEnabledFlag } from '../../../../selectors/featureFlagController/rwa';
 import { BridgeTokenMetadata } from '../../../../components/UI/Bridge/constants/tokens';
+import { selectAnalyticsEnabled } from '../../../../selectors/analyticsController';
 
 export const selectBridgeControllerState = (state: RootState) =>
   state.engine.backgroundState?.BridgeController;
@@ -712,6 +712,7 @@ export const selectControllerFields = createSelector(
   getCurrencyRateControllerCurrencyRates,
   getCurrencyRateControllerCurrentCurrency,
   selectBridgeConfig,
+  selectAnalyticsEnabled,
   (
     bridgeControllerState,
     gasFeeEstimatesByChainId,
@@ -720,6 +721,7 @@ export const selectControllerFields = createSelector(
     currencyRates,
     currentCurrency,
     bridgeConfig,
+    isAnalyticsEnabled,
   ) => ({
     ...bridgeControllerState,
     gasFeeEstimatesByChainId,
@@ -728,7 +730,7 @@ export const selectControllerFields = createSelector(
     marketData,
     currencyRates,
     currentCurrency,
-    participateInMetaMetrics: analytics.isEnabled(),
+    participateInMetaMetrics: Boolean(isAnalyticsEnabled),
     remoteFeatureFlags: {
       bridgeConfig,
     },

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import { RootState } from '../../../../reducers';
+import type { RootState } from '../../../../reducers';
 import {
   Hex,
   CaipChainId,
@@ -692,7 +692,7 @@ export const selectIsGasIncludedSTXSendBundleSupported = (state: RootState) =>
 export const selectIsGasIncluded7702Supported = (state: RootState) =>
   state.bridge.isGasIncluded7702Supported;
 
-const selectControllerFields = (state: RootState) => ({
+export const selectControllerFields = (state: RootState) => ({
   ...state.engine.backgroundState.BridgeController,
   gasFeeEstimatesByChainId:
     state.engine.backgroundState.GasFeeController.gasFeeEstimatesByChainId ??

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -692,27 +692,48 @@ export const selectIsGasIncludedSTXSendBundleSupported = (state: RootState) =>
 export const selectIsGasIncluded7702Supported = (state: RootState) =>
   state.bridge.isGasIncluded7702Supported;
 
-export const selectControllerFields = (state: RootState) => ({
-  ...state.engine.backgroundState.BridgeController,
-  gasFeeEstimatesByChainId:
-    state.engine.backgroundState.GasFeeController.gasFeeEstimatesByChainId ??
-    {},
-  ...{
-    conversionRates: getMultichainAssetsRatesControllerConversionRates(state),
-    historicalPrices: {},
-  },
-  ...{
-    marketData: getTokenRatesControllerMarketData(state),
-  },
-  ...{
-    currencyRates: getCurrencyRateControllerCurrencyRates(state),
-    currentCurrency: getCurrencyRateControllerCurrentCurrency(state),
-  },
-  participateInMetaMetrics: analytics.isEnabled(),
-  remoteFeatureFlags: {
-    bridgeConfig: selectRemoteFeatureFlags(state).bridgeConfig,
-  },
-});
+const EMPTY_GAS_FEE_ESTIMATES_BY_CHAIN_ID = {};
+const EMPTY_HISTORICAL_PRICES = {};
+
+const selectGasFeeEstimatesByChainIdForBridge = (state: RootState) =>
+  state.engine.backgroundState.GasFeeController.gasFeeEstimatesByChainId ??
+  EMPTY_GAS_FEE_ESTIMATES_BY_CHAIN_ID;
+
+const selectBridgeConfig = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => remoteFeatureFlags.bridgeConfig,
+);
+
+export const selectControllerFields = createSelector(
+  selectBridgeControllerState,
+  selectGasFeeEstimatesByChainIdForBridge,
+  getMultichainAssetsRatesControllerConversionRates,
+  getTokenRatesControllerMarketData,
+  getCurrencyRateControllerCurrencyRates,
+  getCurrencyRateControllerCurrentCurrency,
+  selectBridgeConfig,
+  (
+    bridgeControllerState,
+    gasFeeEstimatesByChainId,
+    conversionRates,
+    marketData,
+    currencyRates,
+    currentCurrency,
+    bridgeConfig,
+  ) => ({
+    ...bridgeControllerState,
+    gasFeeEstimatesByChainId,
+    conversionRates,
+    historicalPrices: EMPTY_HISTORICAL_PRICES,
+    marketData,
+    currencyRates,
+    currentCurrency,
+    participateInMetaMetrics: analytics.isEnabled(),
+    remoteFeatureFlags: {
+      bridgeConfig,
+    },
+  }),
+);
 
 export const selectBridgeQuotes = createSelector(
   selectControllerFields,

--- a/app/selectors/bridgeController/index.test.ts
+++ b/app/selectors/bridgeController/index.test.ts
@@ -1,0 +1,41 @@
+import { cloneDeep } from 'lodash';
+import { initialState as mockRootState } from '../../components/UI/Bridge/_mocks_/initialState';
+import type { RootState } from '../../reducers';
+import { selectControllerFields } from '../../core/redux/slices/bridge';
+import { selectMinSolBalance } from '.';
+
+describe('bridgeController selectors', () => {
+  describe('selectMinSolBalance', () => {
+    beforeEach(() => {
+      selectControllerFields.resetRecomputations();
+      selectMinSolBalance.resetRecomputations();
+    });
+
+    it('does not recompute when unrelated bridge UI state changes', () => {
+      const mockState = cloneDeep(mockRootState) as unknown as RootState;
+
+      selectMinSolBalance(mockState);
+
+      const controllerFieldsRecomputations =
+        selectControllerFields.recomputations();
+      const minSolBalanceRecomputations = selectMinSolBalance.recomputations();
+
+      const unrelatedState = {
+        ...mockState,
+        bridge: {
+          ...mockState.bridge,
+          sourceAmount: '1',
+        },
+      } as RootState;
+
+      selectMinSolBalance(unrelatedState);
+
+      expect(selectControllerFields.recomputations()).toBe(
+        controllerFieldsRecomputations,
+      );
+      expect(selectMinSolBalance.recomputations()).toBe(
+        minSolBalanceRecomputations,
+      );
+    });
+  });
+});

--- a/app/selectors/bridgeController/index.ts
+++ b/app/selectors/bridgeController/index.ts
@@ -1,17 +1,10 @@
 import { createSelector } from 'reselect';
-import { RootState } from '../../reducers';
+import type { RootState } from '../../reducers';
 import {
-  BridgeControllerState,
+  type BridgeControllerState,
   selectMinimumBalanceForRentExemptionInSOL,
 } from '@metamask/bridge-controller';
-import { selectRemoteFeatureFlags } from '../featureFlagController';
-import { analytics } from '../../util/analytics/analytics';
-import {
-  getCurrencyRateControllerCurrencyRates,
-  getCurrencyRateControllerCurrentCurrency,
-  getMultichainAssetsRatesControllerConversionRates,
-  getTokenRatesControllerMarketData,
-} from '../assets/assets-migration';
+import { selectControllerFields } from '../../core/redux/slices/bridge';
 
 export const selectBridgeControllerState = (state: RootState) =>
   state.engine.backgroundState.BridgeController;
@@ -22,31 +15,8 @@ export const selectQuoteRequest = createSelector(
     bridgeControllerState.quoteRequest[0],
 );
 
-// Create the BridgeAppState selector following the same pattern as in bridge slice
-export const selectBridgeAppState = (state: RootState) => ({
-  ...state.engine.backgroundState.BridgeController,
-  gasFeeEstimatesByChainId:
-    state.engine.backgroundState.GasFeeController.gasFeeEstimatesByChainId ??
-    {},
-  ...{
-    conversionRates: getMultichainAssetsRatesControllerConversionRates(state),
-    historicalPrices: {},
-  },
-  ...{
-    marketData: getTokenRatesControllerMarketData(state),
-  },
-  ...{
-    currencyRates: getCurrencyRateControllerCurrencyRates(state),
-    currentCurrency: getCurrencyRateControllerCurrentCurrency(state),
-  },
-  participateInMetaMetrics: analytics.isEnabled(),
-  remoteFeatureFlags: {
-    bridgeConfig: selectRemoteFeatureFlags(state).bridgeConfig,
-  },
-});
-
 // Use the official bridge controller selector
 export const selectMinSolBalance = createSelector(
-  selectBridgeAppState,
+  selectControllerFields,
   (bridgeAppState) => selectMinimumBalanceForRentExemptionInSOL(bridgeAppState),
 );


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR resolves the fresh-object selector memoization issues tracked in [#31369](https://github.com/MetaMask/metamask-mobile/issues/31369) and [#31268](https://github.com/MetaMask/metamask-mobile/issues/31268). It removes the duplicate `selectBridgeAppState` selector and routes `selectMinSolBalance` through the shared Bridge `selectControllerFields` selector. It then memoizes `selectControllerFields` so Bridge quote selectors receive a stable input object when unrelated Bridge UI state changes.

The change prevents `selectBridgeQuotes`, `selectBatchSellQuotes`, `selectBatchSellTrades`, and `selectMinSolBalance` from recomputing when state such as `bridge.sourceAmount` changes without changing the controller-derived inputs. Unit tests now assert recomputation counts directly, and a Reassure selector subscription scenario shows the redundant render count dropping from `2` to `1`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31369
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31268

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - this PR changes selector memoization and automated performance/test coverage only.

Validated with:

```bash
yarn jest app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts app/core/redux/slices/bridge/index.test.ts app/selectors/bridgeController/index.test.ts
REASSURE=true yarn reassure --branch
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - no visual UI changes.

### **After**

N/A - no visual UI changes.

#### Reassure Performance Comparison Report

- **Current**: bddfb377b1b62652918ee18a937dc7e6b884b15e - 2026-07-06 20:09:49Z
- **Baseline**: swaps-4669-selectControllerFields (b1152bf77367b674e3bee6402117a18dd8c2ab9c) - 2026-07-03 20:37:55Z

##### Significant Changes To Duration

| Name                                               | Type   | Duration                               | Count                 |
| -------------------------------------------------- | ------ | -------------------------------------- | --------------------- |
| Bridge quote selector unrelated update performance | render | 0.2 ms → 0.1 ms (-0.1 ms, -36.6%) 🟢🟢 | 2 → 1 (-1, -50.0%) 🟢 |

<details>
<summary>Show details</summary>

| Name                                               | Type   | Duration                                                                                                                                                                                                                                                                                                                              | Count                                                                                                                                                                                                                              |
| -------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Bridge quote selector unrelated update performance | render | **Baseline**<br/>Mean: 0.2 ms<br/>Stdev: 0.0 ms (23.1%)<br/>Runs: 0.2 0.2 0.2 0.2 0.2 0.1 0.1 0.2 0.2 0.1<br/>Warmup runs: 2308.6<br/>Removed outliers: (none)<br/><br/>**Current**<br/>Mean: 0.1 ms<br/>Stdev: 0.0 ms (15.0%)<br/>Runs: 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1<br/>Warmup runs: 2468.9<br/>Removed outliers: (none) | **Baseline**<br/>Mean: 2<br/>Stdev: 0 (0.0%)<br/>Runs: 2 2 2 2 2 2 2 2 2 2<br/>Render issues:<br/>- Redundant updates: 1 (1)<br/><br/>**Current**<br/>Mean: 1<br/>Stdev: 0 (0.0%)<br/>Runs: 1 1 1 1 1 1 1 1 1 1<br/>Render issues: |

</details>

##### Render Count Changes

| Name                                               | Type   | Duration                               | Count                 |
| -------------------------------------------------- | ------ | -------------------------------------- | --------------------- |
| Bridge quote selector unrelated update performance | render | 0.2 ms → 0.1 ms (-0.1 ms, -36.6%) 🟢🟢 | 2 → 1 (-1, -50.0%) 🟢 |

##### Render Issues

*There are no entries*

##### Added Entries

*There are no entries*

##### Removed Entries

*There are no entries*

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Selector memoization and test-only performance coverage; no user-facing behavior or security-sensitive logic changes beyond deriving analytics opt-in from Redux instead of the analytics util.
> 
> **Overview**
> Fixes Bridge quote selector memoization by turning **`selectControllerFields`** into a proper `createSelector` with granular Redux inputs, instead of building a new object on every read.
> 
> **`selectMinSolBalance`** now depends on the shared **`selectControllerFields`**; the duplicate **`selectBridgeAppState`** in `bridgeController` is removed. **`participateInMetaMetrics`** comes from **`selectAnalyticsEnabled`** rather than **`analytics.isEnabled()`**, and stable empty constants are used for default gas/historical price objects.
> 
> Tests assert quote-related selectors do not recompute when unrelated Bridge UI state (e.g. **`sourceAmount`**) changes, hook tests clear selector caches in **`beforeEach`**, and a Reassure scenario tracks fewer redundant renders on unrelated updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b748c044977159e7117a3de522a0ab05ba7be047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->