### PR TITLE
chore(cla): allowlist mm-token-exchange-service[bot]

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,6 +24,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla.html'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent,Copilot,cursor[bot]'
+          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent,Copilot,cursor[bot],mm-token-exchange-service[bot]'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
## Summary

- Adds `mm-token-exchange-service[bot]` to the CLA signature bot's allowlist in `.github/workflows/cla.yml`, alongside the other exempted internal bot accounts (`dependabot[bot]`, `metamaskbot`, `crowdin-bot`, etc.)
- Fixes the CLA check failing on PRs authored by that bot, e.g. https://github.com/MetaMask/metamask-mobile/pull/32841#issuecomment-4896477647

## Test plan

- [ ] Confirm the CLA check passes on #32841 (or a new PR authored by `mm-token-exchange-service[bot]`) after this merges

Made with [Cursor](https://cursor.com)