### PR TITLE
fix: restore SLB chart horizontal scroll for historical positions

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1025,6 +1025,57 @@ function getApproxBarDurationSec(bars) {
 
 
 /**
+ * How long (ms) to keep re-asserting the centered visible range for a
+ * historical frame. A one-shot \`setVisibleRange\` issued during the post-load
+ * settle is overridden by TradingView's default "scroll to latest" positioning,
+ * so we re-apply every animation frame for this window — the same thing the
+ * animated focusTime slide does implicitly, which a single auto-center call did
+ * not. Kept short so it never fights a real user gesture.
+ */
+const CENTER_HOLD_MS = 700;
+/** Bumped on each hold so a newer center / fresh series cancels an in-flight hold. */
+let centerHoldGeneration = 0;
+/**
+ * Re-asserts \`setVisibleRange({ from, to })\` every animation frame for
+ * {@link CENTER_HOLD_MS}, defeating TradingView's post-load scroll-to-latest
+ * that clobbers a single call. Generation- and data-guarded so a newer center
+ * or a fresh series stops it; no-ops once the widget is torn down.
+ *
+ * Deliberately omits the \`{ percentRightMargin: 0 }\` option: passing it makes
+ * TradingView anchor to the latest candle and ignore an older from/to, so a
+ * historical frame (an old position's trades) would snap back to "today".
+ */
+function holdCenteredVisibleRange(chart, fromSec, toSec) {
+    centerHoldGeneration += 1;
+    const gen = centerHoldGeneration;
+    const dataGeneration = getOhlcvGeneration();
+    const startTs = Date.now();
+    const apply = () => {
+        if (gen !== centerHoldGeneration)
+            return;
+        if (dataGeneration !== getOhlcvGeneration())
+            return;
+        if (!getWidget() || !isChartReady())
+            return;
+        try {
+            chart.setVisibleRange({ from: fromSec, to: toSec });
+        }
+        catch {
+            // setVisibleRange can throw every frame while the chart is mid-teardown;
+            // swallow silently so the hold window doesn't spam errors to RN.
+        }
+        if (Date.now() - startTs < CENTER_HOLD_MS) {
+            try {
+                requestAnimationFrame(apply);
+            }
+            catch {
+                setTimeout(apply, 16);
+            }
+        }
+    };
+    apply();
+}
+/**
  * Centers the viewport on the SLB trade window after a data load.
  *
  * Called from ohlcvIngestion's \`applyVisibleRange\` when \`slbMode\` is active.
@@ -1053,8 +1104,24 @@ function slbCenterViewport(chart) {
         const barPadSec = getApproxBarDurationSec(data) * 2;
         const fromSec = Math.floor(fromMs / 1000) - barPadSec;
         const toSec = Math.ceil(toMs / 1000) + barPadSec;
+        // A frame whose right edge sits before the latest loaded bar is a historical
+        // position (an old, closed trade range). TradingView's post-load
+        // scroll-to-latest clobbers a single \`setVisibleRange\`, and
+        // \`percentRightMargin: 0\` re-anchors it to the latest candle — together they
+        // snap the viewport back to "today" and push the trades off-screen. Re-assert
+        // the range across the settle window (without that option) so the historical
+        // frame sticks. A frame ending at/after the latest bar is the trailing window:
+        // TV doesn't fight it, so a single anchored call is enough.
+        const lastBar = data.at(-1);
+        const lastBarSec = lastBar != null ? Math.floor(lastBar.time / 1000) : null;
+        const isHistoricalFrame = lastBarSec != null && Math.ceil(toMs / 1000) < lastBarSec;
         try {
-            chart.setVisibleRange({ from: fromSec, to: toSec }, { percentRightMargin: 0 });
+            if (isHistoricalFrame) {
+                holdCenteredVisibleRange(chart, fromSec, toSec);
+            }
+            else {
+                chart.setVisibleRange({ from: fromSec, to: toSec }, { percentRightMargin: 0 });
+            }
             setSlbCenteringPending(false);
         }
         catch (error) {
@@ -1062,6 +1129,10 @@ function slbCenterViewport(chart) {
         }
     };
     subscription.subscribe(null, onLoaded);
+}
+/** Test-only: reset the center-hold generation counter between cases. */
+function __resetSocialLeaderboardForTests() {
+    centerHoldGeneration = 0;
 }
 /**
  * Schedules SLB viewport centering after the initial chart-ready event.

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/__tests__/socialLeaderboard.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/__tests__/socialLeaderboard.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  __resetSocialLeaderboardForTests,
+  slbCenterViewport,
+  slbHandleGetBars,
+  slbScheduleInitialCentering,
+} from '../index';
+import {
+  __resetStateForTests,
+  bumpOhlcvGeneration,
+  setChartReady,
+  setOhlcvData,
+  setSlbCenteringPending,
+  setSlbMode,
+  setVisibleFromMs,
+  setVisibleToMs,
+  setWidget,
+} from '../../../core/state';
+import type {
+  OHLCVBar,
+  TVActiveChart,
+  TVChartingLibraryWidget,
+  TVSubscription,
+} from '../../../core/types';
+
+// One bar per hour; last bar at t = 10h so a trade window ending well before it
+// is a "historical frame" and a window ending at it is a "trailing frame".
+const HOUR_MS = 60 * 60 * 1000;
+const bars: OHLCVBar[] = Array.from({ length: 11 }, (_, i) => ({
+  time: i * HOUR_MS,
+  open: 1,
+  high: 1,
+  low: 1,
+  close: 1 + i,
+}));
+const LAST_BAR_MS = 10 * HOUR_MS;
+
+interface SetRangeCall {
+  range: { from: number; to: number };
+  options?: { percentRightMargin?: number };
+}
+
+interface StubChart {
+  chart: TVActiveChart;
+  setRangeCalls: SetRangeCall[];
+  /** Fire the onDataLoaded subscribers, simulating TradingView's load event. */
+  fireDataLoaded: () => void;
+}
+
+function makeStubChart(): StubChart {
+  const setRangeCalls: SetRangeCall[] = [];
+  const subscribers: (() => void)[] = [];
+  const subscription: TVSubscription = {
+    subscribe: (_scope, cb) => {
+      subscribers.push(cb as () => void);
+    },
+    unsubscribe: (_scope, cb) => {
+      const idx = subscribers.indexOf(cb as () => void);
+      if (idx >= 0) subscribers.splice(idx, 1);
+    },
+  };
+  const chart = {
+    onDataLoaded: () => subscription,
+    setVisibleRange: (
+      range: { from: number; to: number },
+      options?: { percentRightMargin?: number },
+    ) => {
+      setRangeCalls.push({ range: { ...range }, options });
+    },
+  } as unknown as TVActiveChart;
+  return {
+    chart,
+    setRangeCalls,
+    fireDataLoaded: () => subscribers.slice().forEach((cb) => cb()),
+  };
+}
+
+function installWidget(chart: TVActiveChart): TVChartingLibraryWidget {
+  const widget = {
+    activeChart: () => chart,
+  } as unknown as TVChartingLibraryWidget;
+  setWidget(widget);
+  setChartReady(true);
+  return widget;
+}
+
+describe('slbCenterViewport', () => {
+  beforeEach(() => {
+    __resetStateForTests();
+    __resetSocialLeaderboardForTests();
+    setOhlcvData(bars);
+    setSlbMode(true);
+    setSlbCenteringPending(true);
+    jest.useFakeTimers();
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(Date.now()), 16);
+        return 0;
+      });
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('no-ops when slbMode is off', () => {
+    setSlbMode(false);
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    expect(stub.setRangeCalls).toHaveLength(0);
+  });
+
+  it('no-ops when centering is not pending', () => {
+    setSlbCenteringPending(false);
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    expect(stub.setRangeCalls).toHaveLength(0);
+  });
+
+  it('no-ops when visible bounds are missing', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(null);
+    setVisibleToMs(null);
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    expect(stub.setRangeCalls).toHaveLength(0);
+  });
+
+  it('trailing frame: a single anchored setVisibleRange after data load', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    // Trade window ends at the latest bar → trailing frame.
+    setVisibleFromMs(8 * HOUR_MS);
+    setVisibleToMs(LAST_BAR_MS);
+
+    slbCenterViewport(stub.chart);
+    expect(stub.setRangeCalls).toHaveLength(0); // waits for onDataLoaded
+
+    stub.fireDataLoaded();
+    jest.advanceTimersByTime(1000);
+
+    // Exactly one call, anchored with percentRightMargin: 0, and no hold loop.
+    expect(stub.setRangeCalls).toHaveLength(1);
+    expect(stub.setRangeCalls[0].options).toEqual({ percentRightMargin: 0 });
+  });
+
+  it('historical frame: re-asserts the range across the hold window without percentRightMargin', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    // Trade window ends well before the latest bar → historical frame.
+    setVisibleFromMs(1 * HOUR_MS);
+    setVisibleToMs(3 * HOUR_MS);
+
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+
+    // First assertion fires synchronously; more arrive across the hold window.
+    expect(stub.setRangeCalls.length).toBeGreaterThanOrEqual(1);
+    jest.advanceTimersByTime(1000);
+    expect(stub.setRangeCalls.length).toBeGreaterThan(1);
+
+    // The historical-frame path must NOT pass percentRightMargin (it would
+    // re-anchor the viewport to the latest candle).
+    stub.setRangeCalls.forEach((call) => {
+      expect(call.options).toBeUndefined();
+    });
+
+    // The framed range covers the trade window (1h..3h in seconds), not "today".
+    const first = stub.setRangeCalls[0].range;
+    expect(first.from).toBeLessThan(1 * 60 * 60);
+    expect(first.to).toBeGreaterThanOrEqual(3 * 60 * 60);
+    expect(first.to).toBeLessThan(LAST_BAR_MS / 1000);
+  });
+
+  it('historical frame: the hold loop stops re-asserting after the hold window', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(1 * HOUR_MS);
+    setVisibleToMs(3 * HOUR_MS);
+
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    jest.advanceTimersByTime(2000);
+    const settled = stub.setRangeCalls.length;
+    jest.advanceTimersByTime(2000);
+    expect(stub.setRangeCalls.length).toBe(settled);
+  });
+
+  it('historical frame: a stale data generation cancels the hold', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(1 * HOUR_MS);
+    setVisibleToMs(3 * HOUR_MS);
+
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    const before = stub.setRangeCalls.length;
+
+    // A fresh series arrives mid-hold → the in-flight hold must stop.
+    bumpOhlcvGeneration();
+    jest.advanceTimersByTime(1000);
+    expect(stub.setRangeCalls.length).toBe(before);
+  });
+
+  it('drops the framing when the data generation changed before the load event', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(1 * HOUR_MS);
+    setVisibleToMs(3 * HOUR_MS);
+
+    slbCenterViewport(stub.chart);
+    bumpOhlcvGeneration(); // superseded before onDataLoaded fires
+    stub.fireDataLoaded();
+    jest.advanceTimersByTime(1000);
+    expect(stub.setRangeCalls).toHaveLength(0);
+  });
+
+  it('clears the centering-pending flag after framing', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(8 * HOUR_MS);
+    setVisibleToMs(LAST_BAR_MS);
+
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+
+    // A second invocation should now no-op (pending was cleared).
+    stub.setRangeCalls.length = 0;
+    slbCenterViewport(stub.chart);
+    stub.fireDataLoaded();
+    jest.advanceTimersByTime(1000);
+    expect(stub.setRangeCalls).toHaveLength(0);
+  });
+});
+
+describe('slbScheduleInitialCentering', () => {
+  beforeEach(() => {
+    __resetStateForTests();
+    __resetSocialLeaderboardForTests();
+    setOhlcvData(bars);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('no-ops when slbMode is off', () => {
+    setSlbMode(false);
+    expect(() => slbScheduleInitialCentering()).not.toThrow();
+  });
+
+  it('no-ops when the widget is not ready', () => {
+    setSlbMode(true);
+    setSlbCenteringPending(true);
+    expect(() => slbScheduleInitialCentering()).not.toThrow();
+  });
+});
+
+describe('slbHandleGetBars', () => {
+  beforeEach(() => {
+    __resetStateForTests();
+  });
+
+  it('returns false and does not respond when slbMode is off', () => {
+    setSlbMode(false);
+    const onResult = jest.fn();
+    expect(slbHandleGetBars(onResult)).toBe(false);
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it('signals noData and returns true when slbMode is on', () => {
+    setSlbMode(true);
+    const onResult = jest.fn();
+    expect(slbHandleGetBars(onResult)).toBe(true);
+    expect(onResult).toHaveBeenCalledWith([], { noData: true });
+  });
+});

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/index.ts
@@ -55,6 +55,61 @@ import { getApproxBarDurationSec } from '../../core/timeUtils';
 import type { TVActiveChart } from '../../core/types';
 
 /**
+ * How long (ms) to keep re-asserting the centered visible range for a
+ * historical frame. A one-shot `setVisibleRange` issued during the post-load
+ * settle is overridden by TradingView's default "scroll to latest" positioning,
+ * so we re-apply every animation frame for this window — the same thing the
+ * animated focusTime slide does implicitly, which a single auto-center call did
+ * not. Kept short so it never fights a real user gesture.
+ */
+const CENTER_HOLD_MS = 700;
+
+/** Bumped on each hold so a newer center / fresh series cancels an in-flight hold. */
+let centerHoldGeneration = 0;
+
+/**
+ * Re-asserts `setVisibleRange({ from, to })` every animation frame for
+ * {@link CENTER_HOLD_MS}, defeating TradingView's post-load scroll-to-latest
+ * that clobbers a single call. Generation- and data-guarded so a newer center
+ * or a fresh series stops it; no-ops once the widget is torn down.
+ *
+ * Deliberately omits the `{ percentRightMargin: 0 }` option: passing it makes
+ * TradingView anchor to the latest candle and ignore an older from/to, so a
+ * historical frame (an old position's trades) would snap back to "today".
+ */
+function holdCenteredVisibleRange(
+  chart: TVActiveChart,
+  fromSec: number,
+  toSec: number,
+): void {
+  centerHoldGeneration += 1;
+  const gen = centerHoldGeneration;
+  const dataGeneration = getOhlcvGeneration();
+  const startTs = Date.now();
+
+  const apply = (): void => {
+    if (gen !== centerHoldGeneration) return;
+    if (dataGeneration !== getOhlcvGeneration()) return;
+    if (!getWidget() || !isChartReady()) return;
+    try {
+      chart.setVisibleRange({ from: fromSec, to: toSec });
+    } catch {
+      // setVisibleRange can throw every frame while the chart is mid-teardown;
+      // swallow silently so the hold window doesn't spam errors to RN.
+    }
+    if (Date.now() - startTs < CENTER_HOLD_MS) {
+      try {
+        requestAnimationFrame(apply);
+      } catch {
+        setTimeout(apply, 16);
+      }
+    }
+  };
+
+  apply();
+}
+
+/**
  * Centers the viewport on the SLB trade window after a data load.
  *
  * Called from ohlcvIngestion's `applyVisibleRange` when `slbMode` is active.
@@ -85,11 +140,28 @@ export function slbCenterViewport(chart: TVActiveChart): void {
     const fromSec = Math.floor(fromMs / 1000) - barPadSec;
     const toSec = Math.ceil(toMs / 1000) + barPadSec;
 
+    // A frame whose right edge sits before the latest loaded bar is a historical
+    // position (an old, closed trade range). TradingView's post-load
+    // scroll-to-latest clobbers a single `setVisibleRange`, and
+    // `percentRightMargin: 0` re-anchors it to the latest candle — together they
+    // snap the viewport back to "today" and push the trades off-screen. Re-assert
+    // the range across the settle window (without that option) so the historical
+    // frame sticks. A frame ending at/after the latest bar is the trailing window:
+    // TV doesn't fight it, so a single anchored call is enough.
+    const lastBar = data.at(-1);
+    const lastBarSec = lastBar != null ? Math.floor(lastBar.time / 1000) : null;
+    const isHistoricalFrame =
+      lastBarSec != null && Math.ceil(toMs / 1000) < lastBarSec;
+
     try {
-      chart.setVisibleRange(
-        { from: fromSec, to: toSec },
-        { percentRightMargin: 0 },
-      );
+      if (isHistoricalFrame) {
+        holdCenteredVisibleRange(chart, fromSec, toSec);
+      } else {
+        chart.setVisibleRange(
+          { from: fromSec, to: toSec },
+          { percentRightMargin: 0 },
+        );
+      }
       setSlbCenteringPending(false);
     } catch (error) {
       reportErrorToRN(error);
@@ -97,6 +169,11 @@ export function slbCenterViewport(chart: TVActiveChart): void {
   };
 
   subscription.subscribe(null, onLoaded);
+}
+
+/** Test-only: reset the center-hold generation counter between cases. */
+export function __resetSocialLeaderboardForTests(): void {
+  centerHoldGeneration = 0;
 }
 
 /**


### PR DESCRIPTION
## Description

The chart-logic refactor (#32564) ported the Social Leaderboard (SLB) viewport-centering from the monolithic `chartLogic.js` into the modular `overlays/socialLeaderboard/slbCenterViewport`, but dropped the **historical-frame handling** the legacy code relied on. This introduced a regression on the trader position chart (`TraderAdvancedChart.tsx`): when the chart renders it no longer **horizontally scrolls to put the trader's trades in view** for older/closed positions.

### Root cause

The port issued a single call:

```js
chart.setVisibleRange({ from, to }, { percentRightMargin: 0 });
```

For a position whose trades predate the latest loaded candle (a historical/closed position — the exact case that needs a leftward scroll), this does two things the legacy code explicitly worked around:

1. **A one-shot `setVisibleRange` doesn't stick** — TradingView's post-load "scroll to latest" positioning clobbers it.
2. **`percentRightMargin: 0` re-anchors to the latest candle** and ignores an older `from`/`to`.

Together they snap the viewport back to "today" and push the trades off-screen.

Two related behaviors kept working, which is why this was scoped to the initial framing only:
- **Correct time-period selection** is computed RN-side (`TraderAdvancedChart`), untouched by the refactor.
- **Tap-to-focus** (`overlays/focusTime`) still works because it re-asserts the range across an animation loop and omits `percentRightMargin` — precisely the pattern the legacy auto-center used and the port dropped.

### Fix

Restore the legacy behavior in `slbCenterViewport`:
- Detect a **historical frame** (trade window ending before the latest loaded bar).
- For historical frames, re-assert `setVisibleRange({ from, to })` every animation frame across a short hold window (`CENTER_HOLD_MS = 700`), **without** `percentRightMargin`, so the framing sticks against TradingView's scroll-to-latest. Generation- and data-guarded so a newer center or a fresh series cancels an in-flight hold.
- **Trailing frames** (recent/open positions, window ending at/after the latest bar) keep the single anchored call — TradingView doesn't fight those.

Regenerated `chartLogicString.ts` (the runtime bundle) via `yarn build:advanced-chart-webview`.

## Changes

- `webview/src/overlays/socialLeaderboard/index.ts` — historical-frame detection + hold loop.
- `webview/src/overlays/socialLeaderboard/__tests__/socialLeaderboard.test.ts` — new tests (historical hold, trailing single-call, generation cancellation, guards).
- `webview/chartLogicString.ts` — regenerated bundle.

## Testing

- `yarn jest app/components/UI/Charts/AdvancedChart/webview/src/` → **497 passed** (incl. 13 new SLB tests).
- `yarn eslint` on changed files → clean.
- `tsc --noEmit -p tsconfig.webview.json` → clean.
- Bundle regenerated and verified to contain the new logic.

## Manual QA checklist

- [ ] Open a trader position with **older/closed** trades → chart scrolls left to frame the trades on load.
- [ ] Open a position with **recent/open** trades → trailing window still frames correctly.
- [ ] Tap a trade row → chart still slides/centers on that trade.
- [ ] Switch time periods → still selects the correct period and reframes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to `slbMode` in the Social Leaderboard overlay; trailing-frame behavior is unchanged and coverage is added via unit tests.
> 
> **Overview**
> Fixes a regression where **Social Leaderboard / trader position** charts stopped scrolling to frame **older closed positions** on load: a single `setVisibleRange` with `percentRightMargin: 0` was overridden by TradingView’s post-load scroll-to-latest.
> 
> **`slbCenterViewport`** now treats a trade window that ends **before the latest loaded bar** as a **historical frame**. For those frames it runs **`holdCenteredVisibleRange`**: re-applies `setVisibleRange` on each animation frame for ~700ms **without** `percentRightMargin`, with generation and OHLCV guards so new data or teardown cancels the loop. **Trailing** windows (ending at/after the latest bar) still use one anchored `setVisibleRange` call.
> 
> Adds **`socialLeaderboard.test.ts`** for historical vs trailing behavior, hold cancellation, and guards; regenerates **`chartLogicString.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a51e5081354e85698613a7825eda9b78939b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->