### PR TITLE
fix: show enriched swap data for native-token swaps in activity list and details cp-8.2.0

### DIFF
--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -809,6 +809,64 @@ describe('ActivityList', () => {
     );
   });
 
+  it('keeps the quote-enriched local swap row over a bare confirmed contractInteraction copy', () => {
+    const swapHash = '0xswap';
+    const localSwap = {
+      type: 'swap',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 7,
+      hash: swapHash,
+      data: {
+        sourceToken: { direction: 'out', symbol: 'POL', decimals: 18 },
+        destinationToken: { direction: 'in', symbol: 'USDT', decimals: 6 },
+      },
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: {
+            chainId: '0x1',
+            hash: swapHash,
+            id: 'swap-id',
+            txParams: { from: '0xevm', nonce: '0xb' },
+          },
+        },
+      },
+    };
+    // Indexer hasn't classified the swap yet — the confirmed copy is a bare
+    // contract call with the same hash.
+    const confirmedSwapContractCall = {
+      type: 'contractInteraction',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 7,
+      hash: swapHash,
+      data: { from: '0xevm', to: '0xrouter' },
+      raw: {
+        type: 'apiEvmTransaction',
+        data: { chainId: 1, from: '0xevm', hash: swapHash, nonce: 11 },
+      },
+    };
+    (useLocalActivityItems as jest.Mock).mockReturnValue([localSwap]);
+    (useTransactionsQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ data: [confirmedSwapContractCall] }] },
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isInitialLoading: false,
+      refetch: mockRefetch,
+    });
+
+    render(<ActivityList header={<></>} />);
+
+    // One row, and it's the typed swap (with both tokens) — the bare confirmed
+    // "contractInteraction" copy is deduped away, not the reverse.
+    expect(screen.getAllByTestId(`row-${swapHash}`)).toHaveLength(1);
+    expect(screen.getByTestId(`row-kind-${swapHash}`)).toHaveTextContent(
+      'swap',
+    );
+  });
+
   it('navigates to transaction details when a confirmed row is pressed', async () => {
     render(<ActivityList header={<></>} />);
 

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -349,6 +349,13 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           .map((item) => item.hash?.toLowerCase())
           .filter(Boolean) as string[],
       );
+      const confirmedItemByHash = new Map<string, ActivityListItem>();
+      for (const confirmed of allConfirmedForConfiguredChains) {
+        const hash = confirmed.hash?.toLowerCase();
+        if (hash && !confirmedItemByHash.has(hash)) {
+          confirmedItemByHash.set(hash, confirmed);
+        }
+      }
 
       const localDomainKindHashes = new Set(
         localActivityItems
@@ -370,6 +377,22 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           .filter(Boolean) as string[],
       );
 
+      const localWinsHashes = new Set(localDomainKindHashes);
+      for (const localItem of localActivityItems) {
+        if (localItem.raw?.type !== 'localTransaction') continue;
+        const hash = localItem.raw.data.primaryTransaction.hash?.toLowerCase();
+        if (!hash) continue;
+        const confirmed = confirmedItemByHash.get(hash);
+        if (!confirmed) continue;
+        const localOutCategorizesConfirmed =
+          confirmed.type !== localItem.type &&
+          localItem.type !== 'contractInteraction' &&
+          localItem.type !== 'swapIncomplete';
+        if (localOutCategorizesConfirmed) {
+          localWinsHashes.add(hash);
+        }
+      }
+
       // localActivityItems are already mapped from TransactionMeta via the adapter;
       // here we apply the same chain-filter and EVM-confirmed dedup that existed before.
       const filteredLocalItems = localActivityItems.filter((item) => {
@@ -388,10 +411,9 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
 
         // Dedup against confirmed by hash — bridge txns are exempt from nonce dedup
         const hash = tx.hash?.toLowerCase();
-        // Domain-specific local kinds win over the generic confirmed copy.
-        const isLocalDomainKind = !!hash && localDomainKindHashes.has(hash);
-        if (hash && confirmedHashes.has(hash) && !isLocalDomainKind)
-          return false;
+        // Local copies that out-categorize their confirmed copy win over it.
+        const localWins = !!hash && localWinsHashes.has(hash);
+        if (hash && confirmedHashes.has(hash) && !localWins) return false;
 
         // Nonce dedup: skip local if a confirmed tx has the same nonce+from+chain
         // (bridge txns exempt, as they may have same nonce as their approval)
@@ -399,7 +421,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           tx,
           bridgeHistoryValues,
         );
-        if (!isBridgeTx && !isLocalDomainKind) {
+        if (!isBridgeTx && !localWins) {
           const nonce = tx.txParams?.nonce;
           const from = tx.txParams?.from?.toLowerCase();
           if (nonce !== undefined && nonce !== null && from) {
@@ -451,12 +473,14 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
 
       const nonEvmItems = mapNonEvmTransactions(filteredNonEvmForMalicious);
 
+      // Drop confirmed copies whose local copy won above, so the winning local
+      // copy isn't rendered alongside a duplicate confirmed row.
       const confirmedEvmItems =
-        localDomainKindHashes.size === 0
+        localWinsHashes.size === 0
           ? allConfirmedForConfiguredChains
           : allConfirmedForConfiguredChains.filter((item) => {
               const hash = item.hash?.toLowerCase();
-              return !(hash && localDomainKindHashes.has(hash));
+              return !(hash && localWinsHashes.has(hash));
             });
 
       return {

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
@@ -258,4 +258,94 @@ describe('useLocalActivityItems', () => {
       },
     });
   });
+
+  it('enriches a swap from the bridge quote when the TransactionMeta has no legacy swap fields', () => {
+    // Unified swaps keep token metadata in the quote, not on the TransactionMeta,
+    // so on-device fields are absent — the row would otherwise be swapIncomplete.
+    selectorState.bridgeHistory = {
+      'swap-id': {
+        quote: {
+          srcChainId: '0x89',
+          destChainId: '0x89',
+          srcAsset: {
+            symbol: 'POL',
+            decimals: 18,
+            assetId: 'eip155:137/slip44:966',
+          },
+          destAsset: {
+            symbol: 'USDT',
+            decimals: 6,
+            assetId:
+              'eip155:137/erc20:0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+          },
+          srcTokenAmount: '1000000000000000000',
+          destTokenAmount: '900000',
+        },
+      },
+    };
+    selectorState.localTransactions = [
+      makeTx({
+        hash: '0xnativeswap',
+        id: 'swap-id',
+        type: TransactionType.swap,
+        txParams: { from, nonce: '0x3', to: usdc, value: '0x1' },
+      } as Partial<TransactionMeta>),
+    ];
+
+    const { result } = renderHook(() => useLocalActivityItems());
+
+    // Resolves to a full swap (not swapIncomplete) with tokens + amounts from the quote.
+    expect(result.current[0]).toMatchObject({
+      type: 'swap',
+      data: {
+        sourceToken: {
+          direction: 'out',
+          symbol: 'POL',
+          decimals: 18,
+          amount: '1000000000000000000',
+        },
+        destinationToken: {
+          direction: 'in',
+          symbol: 'USDT',
+          decimals: 6,
+          amount: '900000',
+        },
+      },
+    });
+  });
+
+  it('prefers the bridge quote over legacy TransactionMeta swap fields', () => {
+    selectorState.bridgeHistory = {
+      'swap-id': {
+        quote: {
+          srcChainId: '0x89',
+          destChainId: '0x89',
+          srcAsset: { symbol: 'POL', decimals: 18 },
+          destAsset: { symbol: 'USDT', decimals: 6 },
+          srcTokenAmount: '1000000000000000000',
+          destTokenAmount: '900000',
+        },
+      },
+    };
+    selectorState.localTransactions = [
+      makeTx({
+        // Stale/partial legacy fields; the quote is authoritative.
+        destinationTokenSymbol: 'STALE',
+        sourceTokenSymbol: 'STALE',
+        hash: '0xnativeswap',
+        id: 'swap-id',
+        type: TransactionType.swap,
+        txParams: { from, nonce: '0x4', to: usdc, value: '0x1' },
+      } as Partial<TransactionMeta>),
+    ];
+
+    const { result } = renderHook(() => useLocalActivityItems());
+
+    expect(result.current[0]).toMatchObject({
+      data: {
+        sourceToken: { symbol: 'POL', amount: '1000000000000000000' },
+        destinationToken: { symbol: 'USDT', amount: '900000' },
+      },
+    });
+  });
 });

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
@@ -9,9 +9,11 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { Hex } from '@metamask/utils';
 import { selectLocalTransactions } from '../../../../selectors/transactionController';
 import { selectBridgeHistoryForAccount } from '../../../../selectors/bridgeStatusController';
+import { findBridgeHistoryItem } from '../../../../util/bridge/findBridgeHistoryItem';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { selectAllTokens } from '../../../../selectors/tokensController';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../selectors/multichainAccounts/accountTreeController';
@@ -161,12 +163,56 @@ function getBridgeActivityStatus(
 }
 
 /**
- * Derives source+destination token enrichment from swap metadata stored on TransactionMeta.
+ * Builds a {@link TokenAmount} from a bridge/swaps quote asset. Requires only a
+ * symbol (so it still resolves a leg whose atomic amount isn't populated yet);
+ * amount/decimals/assetId are included when present.
+ */
+function tokenFromQuoteAsset(
+  direction: TokenAmount['direction'],
+  asset: { symbol?: string; decimals?: number; assetId?: string } | undefined,
+  amount: string | undefined,
+): TokenAmount | undefined {
+  if (!asset?.symbol) {
+    return undefined;
+  }
+  return {
+    direction,
+    symbol: asset.symbol,
+    ...(amount ? { amount } : {}),
+    ...(asset.decimals === undefined ? {} : { decimals: asset.decimals }),
+    ...(asset.assetId ? { assetId: asset.assetId } : {}),
+  };
+}
+
+/**
+ * Derives source+destination token enrichment for a swap.
+ *
+ * Unified swaps store their token metadata in the bridge/swaps quote, not on the
+ * legacy TransactionMeta fields, so on-device resolution (`sourceTokenSymbol` /
+ * `swapMetaData` / native fallback) can miss a leg — most visibly a native
+ * destination — leaving the row as `swapIncomplete` (empty "You received", no
+ * fees, no "Swap again") until the indexer backfills a full copy. Prefer the
+ * quote (symbol always, amount/decimals/assetId when present) so the row resolves
+ * to a complete swap immediately and reactively; fall back to the legacy
+ * on-device fields for older SwapsController transactions with no bridge quote.
  */
 function getSwapTokenEnrichment(
   tx: TransactionMeta,
   nativeSymbol: string | undefined,
+  bridgeHistoryItem: BridgeHistoryItem | undefined,
 ): { sourceToken?: TokenAmount; destinationToken?: TokenAmount } {
+  const quote = bridgeHistoryItem?.quote;
+  const quoteSourceToken = tokenFromQuoteAsset(
+    'out',
+    quote?.srcAsset,
+    quote?.srcTokenAmount,
+  );
+  const quoteDestinationToken = tokenFromQuoteAsset(
+    'in',
+    quote?.destAsset,
+    quote?.destTokenAmount ?? quote?.minDestTokenAmount,
+  );
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const meta = tx as any;
   const srcSymbol: string | undefined =
@@ -179,16 +225,19 @@ function getSwapTokenEnrichment(
     srcSymbol ??
     (meta.destinationTokenAddress && nativeSymbol ? nativeSymbol : undefined);
 
-  if (!effectiveSrcSymbol && !dstSymbol) return {};
-
-  const sourceToken: TokenAmount | undefined = effectiveSrcSymbol
+  const legacySourceToken: TokenAmount | undefined = effectiveSrcSymbol
     ? { direction: 'out', symbol: effectiveSrcSymbol }
     : undefined;
-  const destinationToken: TokenAmount | undefined = dstSymbol
+  const legacyDestinationToken: TokenAmount | undefined = dstSymbol
     ? { direction: 'in', symbol: dstSymbol }
     : undefined;
 
-  return { sourceToken, destinationToken };
+  // The quote is strictly richer than the legacy symbol-only fallback, so it
+  // wins when present.
+  return {
+    sourceToken: quoteSourceToken ?? legacySourceToken,
+    destinationToken: quoteDestinationToken ?? legacyDestinationToken,
+  };
 }
 
 export function useLocalActivityItems(): ActivityListItem[] {
@@ -246,6 +295,15 @@ export function useLocalActivityItems(): ActivityListItem[] {
         }
       }
 
+      // Bridge/swaps history item for this tx — carries the quote used to
+      // enrich swap tokens (and status) when the local TransactionMeta doesn't.
+      const bridgeHistoryItem = findBridgeHistoryItem({
+        bridgeHistory,
+        transactionMetaId: tx.id,
+        transactionActionId: tx.actionId,
+        transactionHash: tx.hash,
+      });
+
       // Bridge activity status override
       const activityStatus = getBridgeActivityStatus(tx, bridgeHistory);
 
@@ -253,6 +311,7 @@ export function useLocalActivityItems(): ActivityListItem[] {
       const { sourceToken, destinationToken } = getSwapTokenEnrichment(
         tx,
         nativeAssetSymbol,
+        bridgeHistoryItem,
       );
 
       const isEarliestNonce = computeIsEarliestNonce(tx, transactionMetaList);


### PR DESCRIPTION
## **Description**

Swaps involving a **native token** (e.g. POL → USDT, LINK → POL on Polygon) rendered broken in two places on the redesigned Activity screen, until the app was force-closed:

- **Details screen:** a bare "Swapped" — no "You sent / You received" header, no Network fee / Total, and no "Swap again" button.
- **List row:** a generic swap icon with no token avatars and no amounts.

**Root cause:** modern MetaMask swaps go through the unified bridge/swaps infrastructure, which stores the token metadata (both assets + amounts) in the **BridgeStatusController quote** — not on the local `TransactionMeta`'s legacy swap fields (`sourceTokenSymbol` / `destinationTokenSymbol` / `swapMetaData`). The on-device adapter read those legacy fields, found nothing (most visibly for a native leg, which has no explicit symbol there), and produced a `swapIncomplete` item. The details screen already keeps the more-categorized copy (via `useActivityDetailsItem`), but the list's local-vs-confirmed dedup dropped the local copy whenever a confirmed copy shared the hash — and a freshly-confirmed swap is first returned by the indexer as a bare `contractInteraction`.

**Fix (two coordinated parts):**

- **`useLocalActivityItems`** — enrich swap tokens from the bridge quote (symbol-first, with amount/decimals/assetId when present), so a swap resolves to a complete item immediately. Fixes the details screen and gives the list a real swap to render. Falls back to the legacy on-device fields for older SwapsController transactions with no quote.
- **`ActivityList`** — make the local-vs-confirmed dedup keep the more-categorized local copy (e.g. an enriched local `swap` over a bare confirmed `contractInteraction`) and drop the duplicate confirmed row, mirroring `useActivityDetailsItem`'s precedence so the list row and details screen resolve to the same copy.

Because the quote is in Redux from the moment the swap is made, both screens now heal **reactively** (no force-close). Once the indexer classifies the confirmed copy as a real swap, the types match and the confirmed copy (with actual on-chain amounts) wins again automatically.

## **Changelog**

CHANGELOG entry: Fixed swaps into a native token (e.g. POL, ETH) showing incomplete details and activity list rows until the app was restarted.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-998

## **Manual testing steps**

```gherkin
Feature: Native-token swap enrichment in the redesigned Activity

  Background:
    Given the activity redesign flag is on

  Scenario: Swap into a native token shows complete details immediately
    Given I perform a swap whose destination is a native token (e.g. LINK -> POL on Polygon)
    When the transaction confirms and I open it from the Activity list
    Then the details show "You sent" / "You received" with both tokens and amounts,
      the network fee / total, and the "Swap again" button
    And I did not have to force-close the app

  Scenario: Swap from a native token shows an enriched list row
    Given I perform a swap whose source is a native token (e.g. POL -> USDT on Polygon)
    When it appears in the Activity list
    Then the row shows both token avatars and the sent/received amounts
      (matching an already-indexed swap), not a generic icon with no amounts

  Scenario: ERC-20 -> ERC-20 swaps and other rows are unaffected
    Given existing swap, bridge, send, and contract-interaction activity
    Then they render exactly as before
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/c7226ff3-efba-4c92-a412-bac84b7ac9f7

### **Before**

https://github.com/user-attachments/assets/bf0322f1-9b66-44a9-99ca-ccd8b67bb570

### **After**

https://github.com/user-attachments/assets/824faee1-b02a-40a5-afbd-15e7f10c2c34


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches activity list merge/dedup logic and swap enrichment paths used on every EVM activity render; behavior is scoped to swaps and hash collisions, with tests but no auth or payment changes.
> 
> **Overview**
> Fixes **incomplete native-token swaps** on the redesigned Activity list and details until restart, by enriching local rows from Redux bridge quote data and aligning list dedup with details precedence.
> 
> **`useLocalActivityItems`** resolves swap `sourceToken` / `destinationToken` from the **BridgeStatusController quote** (via `findBridgeHistoryItem`), with symbol-first support and amounts/decimals/assetId when available; legacy `TransactionMeta` swap fields remain a fallback. That turns unified swaps that lacked on-device symbols (especially a native leg) from `swapIncomplete` into a full **`swap`** as soon as the user submits.
> 
> **`ActivityList`** broadens local-vs-confirmed dedup: besides the existing domain kinds (staking, smart-account upgrade, etc.), any local item that **out-categorizes** the confirmed copy by type (e.g. local `swap` vs confirmed `contractInteraction`) **wins**; the duplicate confirmed row is filtered out so list and details show the same enriched copy.
> 
> Tests cover quote enrichment, quote-over-legacy preference, and the swap-over-contractInteraction dedup case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf3d408352129500ef5b780a03fd6cf0dfff4a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->