### PR TITLE
docs(analytics): TRAM-3658 — document amount_destination=0 placeholder on headless Ramps Order Proposed

### DIFF
--- a/app/components/UI/Ramp/hooks/useFiatFunnelMetrics.test.ts
+++ b/app/components/UI/Ramp/hooks/useFiatFunnelMetrics.test.ts
@@ -104,7 +104,9 @@ describe('useFiatFunnelMetrics', () => {
       expect(payloadFor('RAMPS_ORDER_PROPOSED')).toEqual({
         ...EXPECTED_BASE,
         amount_source: 100,
-        amount_destination: 0, // no quote yet at amount-commit
+        // TRAM-3658: 0 = quote-pending sentinel, not zero crypto (see
+        // docs/readme/headless-ramps-analytics.md).
+        amount_destination: 0,
         payment_method_id: PM_ID,
         currency_destination: 'eip155:1/slip44:60',
         currency_source: 'USD',

--- a/app/components/UI/Ramp/hooks/useFiatFunnelMetrics.ts
+++ b/app/components/UI/Ramp/hooks/useFiatFunnelMetrics.ts
@@ -148,6 +148,10 @@ export function useFiatFunnelMetrics(
   }, [rampSurface, baseProps, trackEvent]);
 
   // RAMPS_ORDER_PROPOSED (amount committed, pre-quote). Imperative.
+  // TRAM-3658 Option A: amount_destination stays schema-required; send 0 when
+  // no quote yet ("quote pending", not zero crypto). Analysts: see
+  // docs/readme/headless-ramps-analytics.md — use RAMPS_ORDER_SELECTED for
+  // crypto-out / fees / exchange_rate.
   const trackAmountCommitted = useCallback(() => {
     if (!rampSurface) return;
 
@@ -157,7 +161,6 @@ export function useFiatFunnelMetrics(
     trackEvent('RAMPS_ORDER_PROPOSED', {
       ...baseProps,
       amount_source: amount,
-      // Crypto-out is known only once a quote arrives; 0 at amount-commit.
       amount_destination: toNumber(rampsQuote?.quote?.amountOut),
       payment_method_id: selectedPaymentMethodId ?? '',
       currency_destination: assetId ?? '',

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -199,6 +199,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         ramp_type: 'HEADLESS',
         ramp_surface: session.params?.rampSurface,
         amount_source: Number(quote?.fiatAmount ?? session.params?.amount ?? 0),
+        // TRAM-3658: 0 when quote unavailable; see docs/readme/headless-ramps-analytics.md
         amount_destination: 0,
         payment_method_id: selectedPaymentMethod?.id || '',
         region: regionIsoCode,

--- a/app/components/UI/Ramp/types/depositAnalytics.ts
+++ b/app/components/UI/Ramp/types/depositAnalytics.ts
@@ -65,12 +65,23 @@ interface RampsRegionSelected {
   is_authenticated: boolean;
 }
 
+/**
+ * Amount committed / order intent. On HEADLESS (TRAM-3623) this fires at
+ * fiat amount-commit, before the provider quote returns.
+ *
+ * `amount_destination` semantics (TRAM-3658, Option A): required in the Segment
+ * schema; the headless client sends `0` as a sentinel for "quote not yet
+ * returned" — not zero crypto. Use `RAMPS_ORDER_SELECTED` (post-quote) for
+ * real crypto-out, fees, and exchange_rate. See
+ * `docs/readme/headless-ramps-analytics.md`.
+ */
 interface RampsOrderProposed {
   quote_session_id?: string;
   ramp_type: 'DEPOSIT' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
+  /** HEADLESS pre-quote: `0` = quote pending (TRAM-3658). DEPOSIT: crypto out. */
   amount_destination: number;
   payment_method_id: string;
   region: string;

--- a/docs/readme/headless-ramps-analytics.md
+++ b/docs/readme/headless-ramps-analytics.md
@@ -1,0 +1,64 @@
+# Headless Ramps Analytics
+
+Analytics guidance for the headless Money / "Add funds" deposit funnel (TRAM-3623). Client emitters live in `app/components/UI/Ramp/hooks/useFiatFunnelMetrics.ts` and are wired into MetaMask Pay via `useFiatFunnelMetricsAdapter`.
+
+## Funnel events (HEADLESS)
+
+| Event | When it fires | `amount_destination` |
+| ----- | ------------- | -------------------- |
+| `RAMPS_SCREEN_VIEWED` | Amount-input screen mounts | — |
+| `RAMPS_ORDER_PROPOSED` | User commits fiat amount (Done on amount input), **before** quote returns | **Placeholder `0`** (see below) |
+| `RAMPS_ORDER_SELECTED` | Provider quote arrives | Quote `amountOut` |
+| `RAMPS_CONTINUE_BUTTON_CLICKED` | User taps Continue / Add Funds | — |
+| `RAMPS_TRANSACTION_CONFIRMED` | Checkout completes (headless host) | Quote `amountOut` |
+
+Filter headless rows with `ramp_type = 'HEADLESS'` and slice by `ramp_surface` (`money_account`, `perps`, `prediction`).
+
+## `amount_destination = 0` on `RAMPS_ORDER_PROPOSED` (TRAM-3658)
+
+### Decision: Option A (shipped)
+
+Keep `amount_destination` **required** in the Segment schema (`ramps-order-proposed.yaml`) and send a best-effort **`0`** from the client when the event fires at amount-commit time, before the provider quote returns.
+
+Option B (make `amount_destination` optional in the schema) was declined to avoid another Segment-schema edit. The client already sends `0`, which validates against both `required: true` and `required: false`.
+
+### Semantics
+
+On the headless surface, `RAMPS_ORDER_PROPOSED` fires when the user commits a fiat amount (`trackAmountCommitted` in `useFiatFunnelMetrics`). At that instant:
+
+- `amount_source` — known (committed fiat in)
+- `payment_method_id`, `region`, `chain_id`, `currency_destination`, `currency_source`, `is_authenticated` — known
+- `amount_destination` — **not yet known**; no quote has returned
+
+The client sends `amount_destination: 0` as a **sentinel meaning "quote pending"**, not "user will receive zero crypto."
+
+If a quote is already cached when the user commits (e.g. re-commit after editing amount), the emitter may send the cached `amountOut` instead. Treat **`0` on `ramp_type = 'HEADLESS'`** as the canonical pre-quote placeholder.
+
+### Analyst query guidance
+
+Do **not** use `amount_destination` from `RAMPS_ORDER_PROPOSED` for:
+
+- Averages or sums of crypto received
+- Revenue / volume in destination asset
+- Exchange-rate math (use `exchange_rate` on `RAMPS_ORDER_SELECTED` instead)
+
+**Recommended patterns:**
+
+1. **Funnel volume (fiat in):** use `amount_source` on `RAMPS_ORDER_PROPOSED` or `RAMPS_ORDER_SELECTED`.
+2. **Crypto out / fees / rate:** use `RAMPS_ORDER_SELECTED`, `RAMPS_TRANSACTION_CONFIRMED`, or terminal transaction events.
+3. **Exclude placeholder rows:** `amount_destination > 0` OR `event = 'Ramps Order Selected'` when aggregating crypto-out.
+4. **Proposed → Selected conversion:** count events; do not join on `amount_destination`.
+
+### Native DEPOSIT comparison
+
+The legacy native Deposit flow fires `RAMPS_ORDER_PROPOSED` later in the journey (after quote / auth steps), so `amount_destination` is usually populated. Headless is intentionally earlier (amount-commit) to measure upstream drop-off (see TRAM-3623 funnel analysis).
+
+## Schema reference
+
+- Segment event: `libraries/events/metamask-mobile-ramps/deposit/ramps-order-proposed.yaml`
+- Schema PR (HEADLESS / `ramp_surface`): Consensys/segment-schema#621
+- Funnel implementation: MetaMask/metamask-mobile#31716
+
+## Open item
+
+Analytics-owner sign-off (Amitabh Aggarwal): confirm documented `0` placeholder is acceptable for Preset / Mixpanel funnels and that downstream dashboards filter correctly.

--- a/docs/readme/headless-ramps-analytics.md
+++ b/docs/readme/headless-ramps-analytics.md
@@ -59,6 +59,6 @@ The legacy native Deposit flow fires `RAMPS_ORDER_PROPOSED` later in the journey
 - Schema PR (HEADLESS / `ramp_surface`): Consensys/segment-schema#621
 - Funnel implementation: MetaMask/metamask-mobile#31716
 
-## Open item
+## Analytics owner sign-off (TRAM-3658)
 
-Analytics-owner sign-off (Amitabh Aggarwal): confirm documented `0` placeholder is acceptable for Preset / Mixpanel funnels and that downstream dashboards filter correctly.
+Confirmed by Amitabh Aggarwal (analytics owner): documented `0` placeholder is acceptable for Preset / Mixpanel funnels; downstream reports and dashboards will not misread `amount_destination = 0` on `RAMPS_ORDER_PROPOSED` as zero crypto (e.g. averaging across the funnel). Option A is validated — no schema or client change required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Spike for [TRAM-3658](https://consensyssoftware.atlassian.net/browse/TRAM-3658): validate **Option A** for `amount_destination` on headless `Ramps Order Proposed`.

The headless Money / "Add funds" funnel (TRAM-3623) fires `Ramps Order Proposed` at **amount-commit time**, before the provider quote returns. At that instant `amount_destination` has no real value, so the client sends a best-effort `0`. The Segment schema marks `amount_destination` as `required: true`.

**Option A (chosen):** keep the field required; document that `0` means "quote not yet returned," not "zero crypto."

**Option B (declined):** make `amount_destination` optional in `segment-schema` — no client change needed either way.

## What changed

- Added [`docs/readme/headless-ramps-analytics.md`](docs/readme/headless-ramps-analytics.md) with:
  - Headless funnel event timing table
  - `amount_destination = 0` placeholder semantics (TRAM-3658)
  - Analyst query guidance (use `RAMPS_ORDER_SELECTED` for crypto-out; do not average `amount_destination` on Proposed)
  - Option B trade-off recorded for posterity
- Code comments on `RampsOrderProposed`, `useFiatFunnelMetrics.trackAmountCommitted`, and `useTransakRouting` failure payload cross-referencing the doc

No runtime behavior change — implementation already shipped in #31716.

## Spike outcome

**Option A validated.** Analytics owner (Amitabh Aggarwal) confirmed downstream Preset/Mixpanel reports will not misread `amount_destination = 0` on `Ramps Order Proposed`. No further schema or client work required.

## Risk

Low — documentation and comments only.

## Verification

```bash
yarn jest app/components/UI/Ramp/hooks/useFiatFunnelMetrics.test.ts
```

22/22 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cb98aa3-9312-4b45-b8f1-cb5c77bff286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cb98aa3-9312-4b45-b8f1-cb5c77bff286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TRAM-3658]: https://consensyssoftware.atlassian.net/browse/TRAM-3658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ