### PR TITLE
fix(activity): correctly label lending withdrawals and remove the Money type filter

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -41,12 +41,15 @@ describeForPlatforms('ActivityScreen', () => {
       await findByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_SHEET),
     ).toBeOnTheScreen();
 
-    fireEvent.press(await findByTestId(optionTestId(ActivityTypeFilter.Money)));
+    fireEvent.press(
+      await findByTestId(optionTestId(ActivityTypeFilter.MetamaskCard)),
+    );
 
     // The label renders on both the in-list chip and its pinned copy.
     await waitFor(() => {
       expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Money)).length,
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.MetamaskCard))
+          .length,
       ).toBeGreaterThan(0);
     });
   });
@@ -98,15 +101,18 @@ describeForPlatforms('ActivityScreen', () => {
       ).toBeGreaterThan(0);
     });
 
-    // User manually switches to Money.
+    // User manually switches to MetaMask Card.
     fireEvent.press(getByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP));
-    fireEvent.press(await findByTestId(optionTestId(ActivityTypeFilter.Money)));
+    fireEvent.press(
+      await findByTestId(optionTestId(ActivityTypeFilter.MetamaskCard)),
+    );
 
     // The re-apply effect is keyed on the param value (which didn't change), so
     // the manual selection sticks instead of snapping back to Perps.
     await waitFor(() => {
       expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Money)).length,
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.MetamaskCard))
+          .length,
       ).toBeGreaterThan(0);
     });
   });

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.test.tsx
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.test.tsx
@@ -115,11 +115,6 @@ describe('ActivityEmptyState', () => {
     expect(mockGoToBuy).toHaveBeenCalledTimes(1);
 
     cleanup();
-    render(<ActivityEmptyState typeFilter={ActivityTypeFilter.Money} />);
-    fireEvent.press(screen.getByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE));
-    await waitFor(() => expect(mockInitiateDeposit).toHaveBeenCalledTimes(1));
-
-    cleanup();
     render(<ActivityEmptyState typeFilter={ActivityTypeFilter.MetamaskCard} />);
     fireEvent.press(screen.getByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE));
     expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT);

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.tsx
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.tsx
@@ -8,14 +8,12 @@ import {
 import { Box, TabEmptyState } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
-import Logger from '../../../../../util/Logger';
 import { selectAddressHasTokenBalances } from '../../../../../selectors/tokenBalancesController';
 import ActivityEmptyDarkIcon from '../../../../../images/activity-empty-dark.svg';
 import ActivityEmptyLightIcon from '../../../../../images/activity-empty-light.svg';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { useMoneyAccountDeposit } from '../../../../UI/Money/hooks/useMoneyAccount';
 import { ActivityScreenSelectorsIDs } from '../../ActivityScreen.testIds';
 import { ActivityTypeFilter } from '../../types';
 import {
@@ -41,7 +39,6 @@ const ActivityEmptyState: React.FC<ActivityEmptyStateProps> = ({
   const designSystemTheme = useDesignSystemTheme();
   const navigation = useNavigation();
   const { goToBuy } = useRampNavigation();
-  const { initiateDeposit } = useMoneyAccountDeposit();
   const hasFunds = useSelector(selectAddressHasTokenBalances);
 
   const Icon =
@@ -75,21 +72,13 @@ const ActivityEmptyState: React.FC<ActivityEmptyStateProps> = ({
           screen: Routes.PERPS.MARKET_LIST,
         });
         return;
-      case ActivityEmptyStateAction.TransferToMoney:
-        initiateDeposit().catch((error) => {
-          Logger.error(error as Error, {
-            message:
-              '[ActivityEmptyState] Money deposit failed to initiate from empty state',
-          });
-        });
-        return;
       case ActivityEmptyStateAction.OpenMetamaskCard:
         navigation.navigate(Routes.CARD.ROOT);
         return;
       default:
         return;
     }
-  }, [emptyState.action, navigation, goToBuy, initiateDeposit]);
+  }, [emptyState.action, navigation, goToBuy]);
 
   return (
     <Box

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.test.ts
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.test.ts
@@ -65,34 +65,6 @@ describe('getActivityEmptyState', () => {
     });
   });
 
-  describe('Money filter', () => {
-    it('returns funded copy + TransferToMoney when hasFunds is true', () => {
-      expect(
-        getActivityEmptyState({
-          filter: ActivityTypeFilter.Money,
-          hasFunds: true,
-        }),
-      ).toEqual({
-        descriptionKey: 'activity_view.empty_state.money_funded.description',
-        actionLabelKey: 'activity_view.empty_state.money_funded.action',
-        action: ActivityEmptyStateAction.TransferToMoney,
-      });
-    });
-
-    it('returns unfunded copy + TransferToMoney when hasFunds is false', () => {
-      expect(
-        getActivityEmptyState({
-          filter: ActivityTypeFilter.Money,
-          hasFunds: false,
-        }),
-      ).toEqual({
-        descriptionKey: 'activity_view.empty_state.money_unfunded.description',
-        actionLabelKey: 'activity_view.empty_state.money_unfunded.action',
-        action: ActivityEmptyStateAction.TransferToMoney,
-      });
-    });
-  });
-
   describe('Filters that override hasFunds (themed copy regardless of balance)', () => {
     it.each([true, false])(
       'Predictions returns themed copy + MakePrediction (hasFunds=%s)',

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.ts
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.ts
@@ -88,21 +88,6 @@ export function getActivityEmptyState({
         action: ActivityEmptyStateAction.AddFunds,
       };
 
-    case ActivityTypeFilter.Money:
-      return hasFunds
-        ? {
-            descriptionKey:
-              'activity_view.empty_state.money_funded.description',
-            actionLabelKey: 'activity_view.empty_state.money_funded.action',
-            action: ActivityEmptyStateAction.TransferToMoney,
-          }
-        : {
-            descriptionKey:
-              'activity_view.empty_state.money_unfunded.description',
-            actionLabelKey: 'activity_view.empty_state.money_unfunded.action',
-            action: ActivityEmptyStateAction.TransferToMoney,
-          };
-
     case ActivityTypeFilter.MetamaskCard:
       // TODO: confirm card empty state copy with product
       return {

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.ts
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/empty-states.ts
@@ -10,7 +10,6 @@ export enum ActivityEmptyStateAction {
   AddFunds = 'addFunds',
   MakePrediction = 'makePrediction',
   BrowsePerpsMarkets = 'browsePerpsMarkets',
-  TransferToMoney = 'transferToMoney',
   OpenMetamaskCard = 'openMetamaskCard',
 }
 

--- a/app/components/Views/ActivityScreen/components/ActivityTypeFilterSheet/ActivityTypeFilterSheet.test.tsx
+++ b/app/components/Views/ActivityScreen/components/ActivityTypeFilterSheet/ActivityTypeFilterSheet.test.tsx
@@ -65,11 +65,11 @@ describe('ActivityTypeFilterSheet', () => {
     );
 
     const props = lastProps();
-    expect(props.getLabel(ActivityTypeFilter.Money)).toBe(
-      strings(ACTIVITY_TYPE_FILTER_LABEL_KEY[ActivityTypeFilter.Money]),
+    expect(props.getLabel(ActivityTypeFilter.MetamaskCard)).toBe(
+      strings(ACTIVITY_TYPE_FILTER_LABEL_KEY[ActivityTypeFilter.MetamaskCard]),
     );
-    expect(props.getOptionTestID(ActivityTypeFilter.Money)).toBe(
-      `${ActivityScreenSelectorsIDs.TYPE_FILTER_OPTION_PREFIX}${ActivityTypeFilter.Money}`,
+    expect(props.getOptionTestID(ActivityTypeFilter.MetamaskCard)).toBe(
+      `${ActivityScreenSelectorsIDs.TYPE_FILTER_OPTION_PREFIX}${ActivityTypeFilter.MetamaskCard}`,
     );
   });
 

--- a/app/components/Views/ActivityScreen/components/ActivityTypeFilterSheet/ActivityTypeFilterSheet.tsx
+++ b/app/components/Views/ActivityScreen/components/ActivityTypeFilterSheet/ActivityTypeFilterSheet.tsx
@@ -17,7 +17,6 @@ export const ACTIVITY_TYPE_FILTER_LABEL_KEY: Record<
   [ActivityTypeFilter.Perps]: 'activity_view.type_filter.perps',
   [ActivityTypeFilter.Predictions]: 'activity_view.type_filter.predictions',
   [ActivityTypeFilter.MetamaskCard]: 'activity_view.type_filter.metamask_card',
-  [ActivityTypeFilter.Money]: 'activity_view.type_filter.money',
 };
 
 export interface ActivityTypeFilterSheetProps {

--- a/app/components/Views/ActivityScreen/types.test.ts
+++ b/app/components/Views/ActivityScreen/types.test.ts
@@ -5,6 +5,7 @@ import {
   PERPS_ACTIVITY_FILTER_KINDS,
   PERPS_ACTIVITY_FILTER_ORDER,
   PerpsActivityFilter,
+  activityKindMatchesTypeFilter,
   getPerpsSubFilterKinds,
   resolveInitialActivityTypeFilter,
 } from './types';
@@ -84,6 +85,22 @@ describe('getPerpsSubFilterKinds', () => {
         'trades' as unknown as PerpsActivityFilter,
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('activityKindMatchesTypeFilter', () => {
+  it('groups lending deposit and withdrawal under Transactions, not Money', () => {
+    for (const kind of [
+      'lendingDeposit',
+      'lendingWithdrawal',
+    ] as ActivityKind[]) {
+      expect(
+        activityKindMatchesTypeFilter(kind, ActivityTypeFilter.Transactions),
+      ).toBe(true);
+      expect(
+        activityKindMatchesTypeFilter(kind, ActivityTypeFilter.Money),
+      ).toBe(false);
+    }
   });
 });
 

--- a/app/components/Views/ActivityScreen/types.test.ts
+++ b/app/components/Views/ActivityScreen/types.test.ts
@@ -89,17 +89,15 @@ describe('getPerpsSubFilterKinds', () => {
 });
 
 describe('activityKindMatchesTypeFilter', () => {
-  it('groups lending deposit and withdrawal under Transactions, not Money', () => {
+  it('groups lending and mUSD-bonus kinds under Transactions (the Money bucket is removed)', () => {
     for (const kind of [
       'lendingDeposit',
       'lendingWithdrawal',
+      'claimMusdBonus',
     ] as ActivityKind[]) {
       expect(
         activityKindMatchesTypeFilter(kind, ActivityTypeFilter.Transactions),
       ).toBe(true);
-      expect(
-        activityKindMatchesTypeFilter(kind, ActivityTypeFilter.Money),
-      ).toBe(false);
     }
   });
 });
@@ -145,9 +143,9 @@ describe('resolveInitialActivityTypeFilter', () => {
   it('prefers an explicit initialTypeFilter over legacy redirect hints', () => {
     expect(
       resolveInitialActivityTypeFilter({
-        initialTypeFilter: ActivityTypeFilter.Money,
+        initialTypeFilter: ActivityTypeFilter.Predictions,
         redirectToPerpsTransactions: true,
       }),
-    ).toBe(ActivityTypeFilter.Money);
+    ).toBe(ActivityTypeFilter.Predictions);
   });
 });

--- a/app/components/Views/ActivityScreen/types.ts
+++ b/app/components/Views/ActivityScreen/types.ts
@@ -13,7 +13,6 @@ export enum ActivityTypeFilter {
   Perps = 'perps',
   Predictions = 'predictions',
   MetamaskCard = 'metamaskCard',
-  Money = 'money',
 }
 
 /**
@@ -124,6 +123,7 @@ export const ACTIVITY_TYPE_FILTER_KINDS: Record<
     'unstake',
     'lendingDeposit',
     'lendingWithdrawal',
+    'claimMusdBonus',
   ]),
   [ActivityTypeFilter.BuySell]: new Set<ActivityKind>(['buy', 'sell']),
   // Derived from the Perps sub-buckets — see PERPS_ACTIVITY_FILTER_KINDS.
@@ -136,7 +136,6 @@ export const ACTIVITY_TYPE_FILTER_KINDS: Record<
     'predictionPlaced',
   ]),
   [ActivityTypeFilter.MetamaskCard]: new Set<ActivityKind>([]),
-  [ActivityTypeFilter.Money]: new Set<ActivityKind>(['claimMusdBonus']),
 };
 
 // TODO: re-enable `ActivityTypeFilter.All` once the data sources are unified
@@ -149,7 +148,6 @@ export const ACTIVITY_TYPE_FILTER_ORDER: ActivityTypeFilter[] = [
   ActivityTypeFilter.Perps,
   ActivityTypeFilter.Predictions,
   ActivityTypeFilter.MetamaskCard,
-  ActivityTypeFilter.Money,
 ];
 
 export function activityKindMatchesTypeFilter(

--- a/app/components/Views/ActivityScreen/types.ts
+++ b/app/components/Views/ActivityScreen/types.ts
@@ -119,11 +119,11 @@ export const ACTIVITY_TYPE_FILTER_KINDS: Record<
     'nftBuy',
     'nftMint',
     'nftSell',
-    // Earn/Staking (ETH pooled staking deposit / claim / unstake). Lumped under
-    // Transactions for now — they have no dedicated bucket yet.
     'deposit',
     'claim',
     'unstake',
+    'lendingDeposit',
+    'lendingWithdrawal',
   ]),
   [ActivityTypeFilter.BuySell]: new Set<ActivityKind>(['buy', 'sell']),
   // Derived from the Perps sub-buckets — see PERPS_ACTIVITY_FILTER_KINDS.
@@ -136,11 +136,7 @@ export const ACTIVITY_TYPE_FILTER_KINDS: Record<
     'predictionPlaced',
   ]),
   [ActivityTypeFilter.MetamaskCard]: new Set<ActivityKind>([]),
-  [ActivityTypeFilter.Money]: new Set<ActivityKind>([
-    'claimMusdBonus',
-    'lendingDeposit',
-    'lendingWithdrawal',
-  ]),
+  [ActivityTypeFilter.Money]: new Set<ActivityKind>(['claimMusdBonus']),
 };
 
 // TODO: re-enable `ActivityTypeFilter.All` once the data sources are unified

--- a/app/util/activity-adapters/adapters/local-transaction.test.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.test.ts
@@ -820,6 +820,55 @@ describe('mapLocalTransaction', () => {
     });
   });
 
+  it('maps a typed lendingWithdraw transaction from the received token transfer', () => {
+    // Mobile tags lending withdrawals with TransactionType.lendingWithdraw, so
+    // the explicit case (not the contractInteraction heuristic) must classify it.
+    const transaction = {
+      chainId: base,
+      hash: '0x26f4911467b538702c0945e4ec5e303de44c0c1c174897141d1b548ea3161795',
+      status: TransactionStatus.confirmed,
+      time: 1779912434153,
+      type: TransactionType.lendingWithdraw,
+      txParams: {
+        from,
+        to: baseAavePool,
+        data: '0x69328dec000000000000000000000000833589fcd6edb6e08f4c7c32d4f71b54bda029130000000000000000000000000000000000000000000000000000000000030d400000000000000000000000009bed78535d6a03a955f1504aadba974d9a29e292',
+      },
+      txReceipt: {
+        logs: [
+          {
+            address: baseUsdc,
+            data: '0x0000000000000000000000000000000000000000000000000000000000030d40',
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x0000000000000000000000004e65fe4dba92790696d040ac24aa414708f5c0ab',
+              '0x0000000000000000000000009bed78535d6a03a955f1504aadba974d9a29e292',
+            ],
+          },
+        ],
+      },
+    } as unknown as Partial<TransactionMeta>;
+
+    expect(
+      withoutRaw(mapLocalTransaction(makeGroup(transaction))),
+    ).toStrictEqual({
+      type: 'lendingWithdrawal',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1779912434153,
+      hash: '0x26f4911467b538702c0945e4ec5e303de44c0c1c174897141d1b548ea3161795',
+      data: {
+        destinationToken: {
+          amount: '200000',
+          assetId: toAssetId(baseUsdc, 'eip155:8453'),
+          decimals: 6,
+          direction: 'in',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
   it('maps an EIP-7702 upgrade (authorizationList) to a smart account upgrade activity with the gas shown as a native amount', () => {
     const transaction = {
       chainId: mainnet,

--- a/app/util/activity-adapters/adapters/local-transaction.test.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.test.ts
@@ -869,6 +869,84 @@ describe('mapLocalTransaction', () => {
     });
   });
 
+  it('maps a typed lendingWithdraw with no matching transfer log to a withdrawal without a destination token', () => {
+    const otherRecipient =
+      '0x0000000000000000000000001111111111111111111111111111111111111111';
+    const transaction = {
+      chainId: base,
+      hash: '0x9c1b7c1d9d2b3a4c5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c',
+      status: TransactionStatus.confirmed,
+      time: 1779912434153,
+      type: TransactionType.lendingWithdraw,
+      txParams: {
+        from,
+        to: baseAavePool,
+        data: '0x69328dec',
+      },
+      txReceipt: {
+        logs: [
+          // Log with no topics — exercises the missing event-topic / `to` branch.
+          {
+            address: baseUsdc,
+            data: '0x0000000000000000000000000000000000000000000000000000000000030d40',
+            topics: [],
+          },
+          // A Transfer to someone other than the sender — not the received token.
+          {
+            address: baseUsdc,
+            data: '0x0000000000000000000000000000000000000000000000000000000000030d40',
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x0000000000000000000000004e65fe4dba92790696d040ac24aa414708f5c0ab',
+              otherRecipient,
+            ],
+          },
+        ],
+      },
+    } as unknown as Partial<TransactionMeta>;
+
+    expect(
+      withoutRaw(mapLocalTransaction(makeGroup(transaction))),
+    ).toStrictEqual({
+      type: 'lendingWithdrawal',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1779912434153,
+      hash: '0x9c1b7c1d9d2b3a4c5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c',
+      data: {
+        destinationToken: undefined,
+      },
+    });
+  });
+
+  it('maps a typed lendingWithdraw with no receipt logs to a withdrawal without a destination token', () => {
+    const transaction = {
+      chainId: base,
+      hash: '0x5a6b7c8d9e0f10213243546576879a0b1c2d3e4f5061728394a5b6c7d8e9f001',
+      status: TransactionStatus.confirmed,
+      time: 1779912434153,
+      type: TransactionType.lendingWithdraw,
+      txParams: {
+        from,
+        to: baseAavePool,
+        data: '0x69328dec',
+      },
+    } as unknown as Partial<TransactionMeta>;
+
+    expect(
+      withoutRaw(mapLocalTransaction(makeGroup(transaction))),
+    ).toStrictEqual({
+      type: 'lendingWithdrawal',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1779912434153,
+      hash: '0x5a6b7c8d9e0f10213243546576879a0b1c2d3e4f5061728394a5b6c7d8e9f001',
+      data: {
+        destinationToken: undefined,
+      },
+    });
+  });
+
   it('maps an EIP-7702 upgrade (authorizationList) to a smart account upgrade activity with the gas shown as a native amount', () => {
     const transaction = {
       chainId: mainnet,

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -254,6 +254,32 @@ export function mapLocalTransaction(
   const from = initialTransaction.txParams.from ?? '';
   const to = initialTransaction.txParams.to ?? '';
   const methodId = initialTransaction.txParams.data?.slice(0, 10);
+  // A lending withdrawal returns the underlying token to the sender; find that
+  // Transfer log to build the received (destination) token.
+  const getLendingWithdrawalDestinationToken = () => {
+    const fromAddress = from.toLowerCase();
+    const receivedTokenLog = (initialTransaction.txReceipt?.logs ?? []).find(
+      ({ topics: [eventTopic, , logTo] = [] }) => {
+        const toAddress = logTo
+          ? `0x${logTo.slice(-40)}`.toLowerCase()
+          : undefined;
+
+        return (
+          eventTopic?.toLowerCase() === environment.tokenTransferLogTopicHash &&
+          toAddress === fromAddress
+        );
+      },
+    );
+
+    return receivedTokenLog
+      ? getContractToken({
+          amount: BigInt(String(receivedTokenLog.data)).toString(),
+          transaction: initialTransaction,
+          direction: 'in',
+          contractAddress: receivedTokenLog.address,
+        })
+      : undefined;
+  };
   const getDirectWrappedTokenActivity = (): ActivityListItem | undefined => {
     if (!methodId) {
       return undefined;
@@ -678,6 +704,20 @@ export function mapLocalTransaction(
         },
       };
 
+    case TransactionType.lendingWithdraw:
+      return {
+        type: 'lendingWithdrawal',
+        chainId,
+        status,
+        timestamp,
+        hash,
+        raw: { type: 'localTransaction', data: transactionGroup },
+        data: {
+          destinationToken: getLendingWithdrawalDestinationToken(),
+          ...(fees ? { fees } : {}),
+        },
+      };
+
     case TransactionType.stakingDeposit:
       return {
         type: 'deposit',
@@ -793,28 +833,6 @@ export function mapLocalTransaction(
       }
 
       if (isWithdrawContractInteraction) {
-        const fromAddress = from.toLowerCase();
-        const receivedTokenLog = (
-          initialTransaction.txReceipt?.logs ?? []
-        ).find(({ topics: [eventTopic, , logTo] = [] }) => {
-          const toAddress = logTo
-            ? `0x${logTo.slice(-40)}`.toLowerCase()
-            : undefined;
-
-          return (
-            eventTopic?.toLowerCase() ===
-              environment.tokenTransferLogTopicHash && toAddress === fromAddress
-          );
-        });
-        const destinationToken = receivedTokenLog
-          ? getContractToken({
-              amount: BigInt(String(receivedTokenLog.data)).toString(),
-              transaction: initialTransaction,
-              direction: 'in',
-              contractAddress: receivedTokenLog.address,
-            })
-          : undefined;
-
         return {
           type: 'lendingWithdrawal',
           chainId,
@@ -823,7 +841,7 @@ export function mapLocalTransaction(
           hash,
           raw: { type: 'localTransaction', data: transactionGroup },
           data: {
-            destinationToken,
+            destinationToken: getLendingWithdrawalDestinationToken(),
             ...(fees ? { fees } : {}),
           },
         };

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -254,8 +254,7 @@ export function mapLocalTransaction(
   const from = initialTransaction.txParams.from ?? '';
   const to = initialTransaction.txParams.to ?? '';
   const methodId = initialTransaction.txParams.data?.slice(0, 10);
-  // A lending withdrawal returns the underlying token to the sender; find that
-  // Transfer log to build the received (destination) token.
+
   const getLendingWithdrawalDestinationToken = () => {
     const fromAddress = from.toLowerCase();
     const receivedTokenLog = (initialTransaction.txReceipt?.logs ?? []).find(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3101,8 +3101,7 @@
       "buy_sell": "Buy/Sell",
       "perps": "Perps",
       "predictions": "Predictions",
-      "metamask_card": "Card",
-      "money": "Money"
+      "metamask_card": "Card"
     },
     "perps_filter": {
       "title": "Perps",
@@ -3142,14 +3141,6 @@
       "buy_sell": {
         "description": "Add funds to your wallet to get started.",
         "action": "Add funds"
-      },
-      "money_funded": {
-        "description": "You've got funds—put them to work in MetaMask Money.",
-        "action": "Transfer funds"
-      },
-      "money_unfunded": {
-        "description": "Transfer to MetaMask Money and unlock all it has to offer.",
-        "action": "Transfer funds"
       },
       "metamask_card": {
         "description": "Manage your MetaMask Card and spend crypto anywhere.",


### PR DESCRIPTION
## **Description**

Two related activity-redesign fixes for lending (Aave stablecoin) transactions.

**1. Lending withdrawals were labeled "Smart contract interaction."**
Mobile tags withdrawal txs with `TransactionType.lendingWithdraw`, but the shared activity adapter only recognized withdrawals via the `contractInteraction` + method-id heuristic — the deposit had a dedicated `case`, the withdrawal did not, so typed withdrawals fell through to the generic label. Added `case TransactionType.lendingWithdraw`, reusing a shared `getLendingWithdrawalDestinationToken()` helper (also used by the existing heuristic) to build the received token from the ERC-20 `Transfer` log. Deposits were unaffected — they're tagged `lendingDeposit` and already have a matching case.

Confirmed against `metamask-extension`: it never tags lending txs with a specific type, so it relies purely on the heuristic. Mobile diverges by producing typed lending txs (the confirmation flow depends on the type), so the adapter must handle those types — a justified divergence.

**2. Type-filter cleanup.**
Lending deposit/withdrawal now live under the **Transactions** filter (alongside staking). The **Money** type filter is removed entirely: its only remaining kind (`claimMusdBonus`) folds into Transactions, and the `Money` enum value, its sheet label, and its empty state are dropped so it no longer appears in the "Types" sheet.

Lending is EVM-only (Aave V3 on eip155 chains) and flows through the EVM `TransactionController`, so this all lives in the EVM local-transaction adapter; non-EVM activity has a separate adapter and is unaffected.

## **Changelog**

CHANGELOG entry: Fixed lending withdrawals showing as "Smart contract interaction" in Activity, and grouped lending activity under the Transactions filter (removed the Money filter).

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1003

## **Manual testing steps**

```gherkin
Feature: Lending activity labeling and filtering (activity redesign)

  Scenario: Lending withdrawal is labeled correctly
    Given the activity redesign flag is on
    And I withdraw from Aave stablecoin lending (e.g. USDC)
    When I open the Activity list
    Then the row reads "Lending withdrawal USDC" (not "Smart contract interaction")

  Scenario: Lending activity appears under Transactions
    Given I have lending deposits and withdrawals
    When I set the Type filter to "Transactions"
    Then the lending deposit and withdrawal rows are shown

  Scenario: The Money filter is gone
    When I open the Activity "Types" filter sheet
    Then there is no "Money" option
    And any former Money activity (e.g. Claimed mUSD bonus) shows under "Transactions"
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/1eee072c-876d-40d4-b07a-222f6852902c

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches activity classification and filter bucketing for lending/Money flows; behavior change is localized to Activity UI and the EVM transaction adapter with solid test coverage.
> 
> **Overview**
> Fixes **lending withdrawal** rows showing as generic smart contract interactions by handling **`TransactionType.lendingWithdraw`** in the EVM local-transaction adapter and mapping them to **`lendingWithdrawal`**, with received tokens parsed from ERC-20 **Transfer** logs via a shared **`getLendingWithdrawalDestinationToken()`** helper (also used by the existing contract-interaction heuristic).
> 
> Removes the **Money** Activity type filter entirely: **`lendingDeposit`**, **`lendingWithdrawal`**, and **`claimMusdBonus`** now group under **Transactions**; the enum value, sheet option, Money empty state, and **Transfer to Money** CTA are dropped. Tests and **en.json** strings are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 025a8e3a9f689fb5edb63ad2182fd87609966dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->