### PR TITLE
feat(predict): add buy-button override and cardPressDisabled (RWDS-1435 2/4)

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
@@ -460,6 +460,16 @@ describe('PredictCryptoUpDownMarketCard', () => {
     });
   });
 
+  it('does not navigate when cardPressDisabled is true', () => {
+    renderCard(createMarket(), { cardPressDisabled: true });
+
+    fireEvent.press(
+      screen.getByTestId(PredictCryptoUpDownMarketCardSelectorsIDs.CARD),
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('includes transactionActiveAbTests when navigating to the live market details', () => {
     renderCard(createMarket(), { transactionActiveAbTests });
 

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -50,6 +50,7 @@ import {
   type PredictMarket,
   type PredictOutcome,
   type PredictOutcomeToken,
+  type PredictMarketBuyButtonPress,
   type PriceQuery,
 } from '../../types';
 import type {
@@ -174,10 +175,11 @@ interface PredictCryptoUpDownMarketCardProps {
    * output isn't displayed.
    */
   isCarousel?: boolean;
+  cardPressDisabled?: boolean;
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
   predictFeedTab?: string;
   predictScreen?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -1097,6 +1099,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
   testID,
   entryPoint: propEntryPoint,
   isCarousel = false,
+  cardPressDisabled,
   onCardPress,
   onBuyButtonPress,
   predictFeedTab,
@@ -1228,6 +1231,10 @@ const PredictCryptoUpDownMarketCard: React.FC<
       : undefined;
 
   const handleCardPress = useCallback(() => {
+    if (cardPressDisabled) {
+      return;
+    }
+
     onCardPress?.();
     navigateToMarketDetails(
       {
@@ -1243,6 +1250,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
       { throughRoot: true },
     );
   }, [
+    cardPressDisabled,
     cardTitle,
     imageUrl,
     navigateToMarketDetails,
@@ -1265,7 +1273,16 @@ const PredictCryptoUpDownMarketCard: React.FC<
         return;
       }
 
-      onBuyButtonPress?.(selectedMarket.id);
+      const handledExternally =
+        onBuyButtonPress?.({
+          market: selectedMarket,
+          outcome: selectedOutcome,
+          outcomeToken: token,
+        }) === true;
+      if (handledExternally) {
+        return;
+      }
+
       executeGuardedAction(
         () => {
           openBuySheet({

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
@@ -8,6 +8,9 @@ import {
   PredictMarket as PredictMarketType,
 } from '../../types';
 import PredictMarket from './';
+import PredictMarketSingle from '../PredictMarketSingle';
+import PredictMarketMultiple from '../PredictMarketMultiple';
+import PredictMarketSportCard from '../PredictMarketSportCard';
 import PredictCryptoUpDownMarketCard from '../PredictCryptoUpDownMarketCard';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
@@ -342,5 +345,64 @@ describe('PredictMarket', () => {
 
     expect(getByTestId('predict-market-multiple')).toBeOnTheScreen();
     expect(queryByTestId('predict-market-sport-card')).toBeNull();
+  });
+
+  it('passes sponsored buy handler props to the selected child card', () => {
+    const onBuyButtonPress = jest.fn(() => true);
+
+    setupPredictMarketTest(mockSingleMarket, {
+      cardPressDisabled: true,
+      onBuyButtonPress,
+    });
+
+    expect(PredictMarketSingle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cardPressDisabled: true,
+        onBuyButtonPress,
+      }),
+      undefined,
+    );
+  });
+
+  it('passes sponsored buy handler props to multi-outcome and sport cards', () => {
+    const onBuyButtonPress = jest.fn(() => true);
+
+    setupPredictMarketTest(mockMultipleMarket, {
+      cardPressDisabled: true,
+      onBuyButtonPress,
+    });
+    expect(PredictMarketMultiple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cardPressDisabled: true,
+        onBuyButtonPress,
+      }),
+      undefined,
+    );
+
+    setupPredictMarketTest(mockNflMarket, {
+      cardPressDisabled: true,
+      onBuyButtonPress,
+    });
+
+    expect(PredictMarketSportCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cardPressDisabled: true,
+        onBuyButtonPress,
+      }),
+      undefined,
+    );
+
+    setupPredictMarketTest(mockCryptoUpDownMarket, {
+      cardPressDisabled: true,
+      onBuyButtonPress,
+    });
+
+    expect(PredictCryptoUpDownMarketCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cardPressDisabled: true,
+        onBuyButtonPress,
+      }),
+      undefined,
+    );
   });
 });

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { PredictMarket as PredictMarketType } from '../../types';
+import {
+  PredictMarket as PredictMarketType,
+  type PredictMarketBuyButtonPress,
+} from '../../types';
 import { PredictEntryPoint } from '../../types/navigation';
 import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
@@ -16,10 +19,11 @@ interface PredictMarketProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   isCarousel?: boolean;
+  cardPressDisabled?: boolean;
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
   /** Active feed tab key forwarded to trade analytics (e.g. "trending", "world-cup"). */
   predictFeedTab?: string;
   /** Screen context forwarded to trade analytics (e.g. "world_cup"). */
@@ -30,6 +34,7 @@ interface PredictMarketProps {
 const PredictMarket: React.FC<PredictMarketProps> = ({
   market,
   testID,
+  cardPressDisabled,
   entryPoint: propEntryPoint,
   isCarousel = false,
   onCardPress,
@@ -48,6 +53,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
         testID={testID}
         entryPoint={entryPoint}
         isCarousel={isCarousel}
+        cardPressDisabled={cardPressDisabled}
         onCardPress={onCardPress}
         onBuyButtonPress={onBuyButtonPress}
         predictFeedTab={predictFeedTab}
@@ -64,6 +70,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
         testID={testID}
         entryPoint={entryPoint}
         isCarousel={isCarousel}
+        cardPressDisabled={cardPressDisabled}
         onCardPress={onCardPress}
         onBuyButtonPress={onBuyButtonPress}
         predictFeedTab={predictFeedTab}
@@ -80,6 +87,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
         testID={testID}
         entryPoint={entryPoint}
         isCarousel={isCarousel}
+        cardPressDisabled={cardPressDisabled}
         onCardPress={onCardPress}
         onBuyButtonPress={onBuyButtonPress}
         predictFeedTab={predictFeedTab}
@@ -95,6 +103,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
       testID={testID}
       entryPoint={entryPoint}
       isCarousel={isCarousel}
+      cardPressDisabled={cardPressDisabled}
       onCardPress={onCardPress}
       onBuyButtonPress={onBuyButtonPress}
       predictFeedTab={predictFeedTab}

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
@@ -180,6 +180,27 @@ describe('PredictMarketMultiple', () => {
     });
   });
 
+  it('calls buy handler instead of opening the buy sheet when it returns true', () => {
+    const onBuyButtonPress = jest.fn(() => true);
+    const { UNSAFE_getAllByType } = renderWithProvider(
+      <PredictMarketMultiple
+        market={mockMarket}
+        onBuyButtonPress={onBuyButtonPress}
+      />,
+      { state: initialState },
+    );
+
+    const buttons = UNSAFE_getAllByType(Button);
+    fireEvent.press(buttons[0]);
+
+    expect(onBuyButtonPress).toHaveBeenCalledWith({
+      market: mockMarket,
+      outcome: mockMarket.outcomes[0],
+      outcomeToken: mockMarket.outcomes[0].tokens[0],
+    });
+    expect(mockOpenBuySheet).not.toHaveBeenCalled();
+  });
+
   it('handle missing or invalid market data gracefully', () => {
     const marketWithMissingData: PredictMarket = {
       ...mockMarket,
@@ -369,6 +390,21 @@ describe('PredictMarketMultiple', () => {
         image: mockMarket.image,
       },
     });
+  });
+
+  it('does not navigate to market details when card press is disabled', () => {
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketMultiple
+        market={mockMarket}
+        cardPressDisabled
+        testID="predict-market-multiple-card"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('predict-market-multiple-card'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('checks eligibility before balance for Yes button', () => {

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -34,6 +34,7 @@ import {
   Recurrence,
   PredictOutcome,
   PredictOutcomeToken,
+  type PredictMarketBuyButtonPress,
 } from '../../types';
 import {
   PredictNavigationParamList,
@@ -51,10 +52,11 @@ interface PredictMarketMultipleProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   isCarousel?: boolean;
+  cardPressDisabled?: boolean;
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
   predictFeedTab?: string;
   predictScreen?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -63,6 +65,7 @@ interface PredictMarketMultipleProps {
 const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   market,
   testID,
+  cardPressDisabled,
   entryPoint: propEntryPoint,
   isCarousel = false,
   onCardPress,
@@ -138,7 +141,12 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
     outcome: PredictOutcome,
     outcomeToken: PredictOutcomeToken,
   ) => {
-    onBuyButtonPress?.(market.id);
+    const handledExternally =
+      onBuyButtonPress?.({ market, outcome, outcomeToken }) === true;
+    if (handledExternally) {
+      return;
+    }
+
     executeGuardedAction(
       () => {
         openBuySheet({
@@ -168,6 +176,10 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
     <TouchableOpacity
       testID={testID}
       onPress={() => {
+        if (cardPressDisabled) {
+          return;
+        }
+
         onCardPress?.();
         navigation.navigate(Routes.PREDICT.ROOT, {
           screen: Routes.PREDICT.MARKET_DETAILS,

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from '@testing-library/react-native';
 import React from 'react';
 import { Alert } from 'react-native';
+import Button from '../../../../../component-library/components/Buttons/Button';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import {
@@ -183,6 +184,26 @@ describe('PredictMarketSingle', () => {
     });
   });
 
+  it('calls buy handler instead of opening the buy sheet when it returns true', () => {
+    const onBuyButtonPress = jest.fn(() => true);
+    const { UNSAFE_getAllByType } = renderWithProvider(
+      <PredictMarketSingle
+        market={mockMarket}
+        onBuyButtonPress={onBuyButtonPress}
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(UNSAFE_getAllByType(Button)[0]);
+
+    expect(onBuyButtonPress).toHaveBeenCalledWith({
+      market: mockMarket,
+      outcome: mockOutcome,
+      outcomeToken: mockOutcome.tokens[0],
+    });
+    expect(mockOpenBuySheet).not.toHaveBeenCalled();
+  });
+
   it('handle missing or invalid market data gracefully', () => {
     const invalidOutcome: PredictOutcome = {
       ...mockOutcome,
@@ -341,6 +362,21 @@ describe('PredictMarketSingle', () => {
         image: mockMarket.image,
       },
     });
+  });
+
+  it('does not navigate to market details when card press is disabled', () => {
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketSingle
+        market={mockMarket}
+        cardPressDisabled
+        testID="predict-market-single-card"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('predict-market-single-card'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('forwards predictFeedTab and predictScreen to market details navigation', () => {

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -23,6 +23,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import {
   PredictMarket as PredictMarketType,
   PredictOutcomeToken,
+  type PredictMarketBuyButtonPress,
 } from '../../types';
 import {
   PredictNavigationParamList,
@@ -129,10 +130,11 @@ interface PredictMarketSingleProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   isCarousel?: boolean;
+  cardPressDisabled?: boolean;
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
   predictFeedTab?: string;
   predictScreen?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -141,6 +143,7 @@ interface PredictMarketSingleProps {
 const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   market,
   testID,
+  cardPressDisabled,
   entryPoint: propEntryPoint,
   isCarousel = false,
   onCardPress,
@@ -189,7 +192,12 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   const yesPercentage = getYesPercentage();
 
   const handleBuy = (token: PredictOutcomeToken) => {
-    onBuyButtonPress?.(market.id);
+    const handledExternally =
+      onBuyButtonPress?.({ market, outcome, outcomeToken: token }) === true;
+    if (handledExternally) {
+      return;
+    }
+
     executeGuardedAction(
       () => {
         openBuySheet({
@@ -214,6 +222,10 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
     <TouchableOpacity
       testID={testID}
       onPress={() => {
+        if (cardPressDisabled) {
+          return;
+        }
+
         onCardPress?.();
         navigation.navigate(Routes.PREDICT.ROOT, {
           screen: Routes.PREDICT.MARKET_DETAILS,

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -402,6 +402,21 @@ describe('PredictMarketSportCard', () => {
     );
   });
 
+  it('does not navigate to market details when card press is disabled', () => {
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketSportCard
+        market={mockMarket}
+        testID="sport-market-card"
+        cardPressDisabled
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('sport-market-card'));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('explicit entry point takes priority over trending session', () => {
     mockIsFromTrending.mockReturnValue(true);
 
@@ -439,7 +454,11 @@ describe('PredictMarketSportCard', () => {
 
     fireEvent.press(getByTestId('sport-market-card-home-button'));
 
-    expect(onBuyButtonPress).toHaveBeenCalledWith(mockMarket.id);
+    expect(onBuyButtonPress).toHaveBeenCalledWith({
+      market: mockMarket,
+      outcome: mockMarket.outcomes[0],
+      outcomeToken: mockMarket.outcomes[0].tokens[0],
+    });
     expect(mockOpenBuySheet).toHaveBeenCalledWith(
       expect.objectContaining({
         market: mockMarket,
@@ -447,6 +466,27 @@ describe('PredictMarketSportCard', () => {
         entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
       }),
     );
+  });
+
+  it('calls buy handler instead of opening the buy sheet when it returns true', () => {
+    const onBuyButtonPress = jest.fn(() => true);
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketSportCard
+        market={mockMarket}
+        testID="sport-market-card"
+        onBuyButtonPress={onBuyButtonPress}
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('sport-market-card-home-button'));
+
+    expect(onBuyButtonPress).toHaveBeenCalledWith({
+      market: mockMarket,
+      outcome: mockMarket.outcomes[0],
+      outcomeToken: mockMarket.outcomes[0].tokens[0],
+    });
+    expect(mockOpenBuySheet).not.toHaveBeenCalled();
   });
 
   it('renders close button and calls onDismiss without navigating', () => {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -36,6 +36,7 @@ import {
   PredictOutcome,
   PredictOutcomeToken,
   PredictSportTeam,
+  type PredictMarketBuyButtonPress,
 } from '../../types';
 import {
   PredictEntryPoint,
@@ -53,10 +54,11 @@ interface PredictMarketSportCardProps {
   entryPoint?: PredictEntryPoint;
   onDismiss?: () => void;
   isCarousel?: boolean;
+  cardPressDisabled?: boolean;
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
   predictFeedTab?: string;
   predictScreen?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -201,6 +203,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
   entryPoint: propEntryPoint,
   onDismiss,
   isCarousel,
+  cardPressDisabled,
   onCardPress,
   onBuyButtonPress,
   predictFeedTab,
@@ -237,6 +240,10 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
   );
 
   const handleCardPress = useCallback(() => {
+    if (cardPressDisabled) {
+      return;
+    }
+
     onCardPress?.();
     navigation.navigate(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_DETAILS,
@@ -254,6 +261,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
     });
   }, [
     market,
+    cardPressDisabled,
     navigation,
     onCardPress,
     predictFeedTab,
@@ -264,7 +272,16 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
 
   const handleBuy = useCallback(
     (item: SportOutcomeButtonItem) => {
-      onBuyButtonPress?.(market.id);
+      const handledExternally =
+        onBuyButtonPress?.({
+          market,
+          outcome: item.outcome,
+          outcomeToken: item.token,
+        }) === true;
+      if (handledExternally) {
+        return;
+      }
+
       executeGuardedAction(
         () => {
           openBuySheet({

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -342,6 +342,20 @@ export type PredictOutcomeToken = {
   buyPrice?: number;
 };
 
+export type PredictMarketBuyButtonPressParams = {
+  market: PredictMarket;
+  outcome: PredictOutcome;
+  outcomeToken: PredictOutcomeToken;
+};
+
+/**
+ * Called when the user taps a buy button (before the betslip opens).
+ * Return `true` to handle the buy flow externally and skip the default sheet.
+ */
+export type PredictMarketBuyButtonPress = (
+  params: PredictMarketBuyButtonPressParams,
+) => boolean | void;
+
 export interface PredictActivity {
   id: string;
   providerId: string;

--- a/app/components/Views/TrendingView/feeds/predictions/PredictionRowItem.tsx
+++ b/app/components/Views/TrendingView/feeds/predictions/PredictionRowItem.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PredictMarket from '../../../../UI/Predict/components/PredictMarket';
 import PredictMarketRowItem from '../../../../UI/Predict/components/PredictMarketRowItem';
-import type { PredictMarket as PredictMarketType } from '../../../../UI/Predict/types';
+import type {
+  PredictMarket as PredictMarketType,
+  PredictMarketBuyButtonPress,
+} from '../../../../UI/Predict/types';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 
 interface PredictionCarouselRowItemProps {
@@ -10,7 +13,7 @@ interface PredictionCarouselRowItemProps {
   /** Called synchronously before the card's navigation press fires. */
   onCardPress?: () => void;
   /** Called when the user taps a buy button (before betslip opens). */
-  onBuyButtonPress?: (marketId: string) => void;
+  onBuyButtonPress?: PredictMarketBuyButtonPress;
 }
 
 /** Carousel-style market card used inside Explore home tabs. */

--- a/app/components/Views/TrendingView/feeds/predictions/PredictionsCarouselSection.tsx
+++ b/app/components/Views/TrendingView/feeds/predictions/PredictionsCarouselSection.tsx
@@ -53,12 +53,12 @@ const PredictionsCarouselSection: React.FC<PredictionsCarouselSectionProps> = ({
             item_clicked: item.id,
           })
         }
-        onBuyButtonPress={(marketId) =>
+        onBuyButtonPress={({ market }) =>
           trackExploreInteracted({
             interaction_type: 'prediction_voted',
             tab_name: tabName,
             section_name: sectionName,
-            item_clicked: marketId,
+            item_clicked: market.id,
           })
         }
       />

--- a/app/components/Views/TrendingView/tabs/SportsTab.tsx
+++ b/app/components/Views/TrendingView/tabs/SportsTab.tsx
@@ -178,12 +178,12 @@ const SportsTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
                 item_clicked: item.id,
               })
             }
-            onBuyButtonPress={(marketId) =>
+            onBuyButtonPress={({ market }) =>
               trackExploreInteracted({
                 interaction_type: 'prediction_voted',
                 tab_name: 'Sports',
                 section_name: sectionName,
-                item_clicked: marketId,
+                item_clicked: market.id,
               })
             }
           />


### PR DESCRIPTION
## Description

Part **2/4** of RWDS-1435 (First Predict On Us). Adds a reusable buy-button override and `cardPressDisabled` to Predict market cards so a sponsored carousel can drive its own buy flow and disable card-body navigation while keeping outcome buttons active.

Stacked PRs (merge in order):
1. [#32857](https://github.com/MetaMask/metamask-mobile/pull/32857) — Rewards CMS/API + flag foundation ✅ merged
2. [#32858](https://github.com/MetaMask/metamask-mobile/pull/32858) — Predict buy-button + cardPressDisabled (**this PR**, base `main`)
3. [#32859](https://github.com/MetaMask/metamask-mobile/pull/32859) — First Predict On Us Rewards UI
4. [#32860](https://github.com/MetaMask/metamask-mobile/pull/32860) — Onboarding integration

## Changes

- Add `PredictMarketBuyButtonPress` and a richer `onBuyButtonPress({ market, outcome, outcomeToken })` across Predict card variants (single, multiple, sport, crypto up/down). Returning `true` skips the default Predict buy sheet so a caller can handle the buy externally.
- Add `cardPressDisabled` so card-body taps can be disabled while outcome buttons stay active.
- Update Trending/Explore call sites for the new callback shape.

## Testing

- `yarn jest app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx`
- `yarn jest app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx`
- `yarn jest app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx`
- `yarn jest app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx`
- `yarn jest app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared Predict buy and navigation path across all market card types; behavior stays backward-compatible when new props are omitted, but a buggy external handler could block the default buy sheet.
> 
> **Overview**
> Adds **Predict card hooks** so a parent (e.g. a sponsored “First Predict On Us” carousel) can control navigation and buying without forking each card variant.
> 
> **`cardPressDisabled`** is threaded through `PredictMarket` into single, multiple, sport, and crypto up/down cards. When set, tapping the card body no longer opens market details; outcome buy buttons still work.
> 
> **`onBuyButtonPress`** is now typed as `PredictMarketBuyButtonPress` and receives `{ market, outcome, outcomeToken }` instead of only `marketId`. If the callback returns **`true`**, the default Predict buy sheet is skipped so the caller can run its own flow; otherwise behavior is unchanged.
> 
> Explore Trending carousel analytics were updated to read `market.id` from the new callback shape. Unit tests cover disabled card press, external buy handling, and prop forwarding from `PredictMarket`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d056e53b66bb134ba42588581c0643c54395c3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->