### PR TITLE
feat(rewards): wire First Predict On Us into onboarding (RWDS-1435 4/4)

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -110,6 +110,8 @@ import DefaultSettings from '../../Views/OnboardingSuccess/DefaultSettings';
 import OnboardingGeneralSettings from '../../Views/OnboardingSuccess/OnboardingGeneralSettings';
 import OnboardingAssetsSettings from '../../Views/OnboardingSuccess/OnboardingAssetsSettings';
 import OnboardingSecuritySettings from '../../Views/OnboardingSuccess/OnboardingSecuritySettings';
+import FirstPredictOnUsSplashScreen from '../../UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen';
+import FirstPredictOnUsOrderSheet from '../../UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet';
 import BasicFunctionalityModal from '../../UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal';
 import PermittedNetworksInfoSheet from '../../Views/AccountPermissions/PermittedNetworksInfoSheet/PermittedNetworksInfoSheet';
 import NFTAutoDetectionModal from '../../../../app/components/Views/NFTAutoDetectionModal/NFTAutoDetectionModal';
@@ -379,6 +381,23 @@ const OnboardingNav = () => {
         name={Routes.ONBOARDING.WALLET_CREATION_ERROR}
         component={WalletCreationError}
         options={{ headerShown: false }}
+      />
+      <NativeStack.Screen
+        name={Routes.ONBOARDING.FIRST_PREDICT_ON_US_SPLASH}
+        component={FirstPredictOnUsSplashScreen}
+        options={{
+          headerShown: false,
+          gestureEnabled: false,
+        }}
+      />
+      <NativeStack.Screen
+        name={Routes.ONBOARDING.FIRST_PREDICT_ON_US_ORDER_SHEET}
+        component={FirstPredictOnUsOrderSheet}
+        options={{
+          headerShown: false,
+          presentation: 'transparentModal',
+          contentStyle: { backgroundColor: importedColors.transparent },
+        }}
       />
     </NativeStack.Navigator>
   );

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsMarketsCarousel.test.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsMarketsCarousel.test.tsx
@@ -6,9 +6,11 @@ import { FEATURED_CAROUSEL_TEST_IDS } from '../../../Predict/components/Featured
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { markFirstPredictionOnUsOutcomeOpened } from '../../../../../reducers/rewards';
 import FirstPredictOnUsMarketsCarousel from './FirstPredictOnUsMarketsCarousel';
 
 const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockAddProperties = jest.fn();
 const mockBuild = jest.fn(() => ({ name: 'event' }));
@@ -22,6 +24,11 @@ const mockCreateEventBuilder = jest.fn(() => ({
 jest.mock('../../../Predict/components/PredictMarket', () =>
   jest.fn(() => null),
 );
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
 
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
@@ -204,6 +211,12 @@ describe('FirstPredictOnUsMarketsCarousel', () => {
       market_id: '1',
       outcome: 'Yes',
     });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markFirstPredictionOnUsOutcomeOpened({
+        marketId: '1',
+        outcome: 'Yes',
+      }),
+    );
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.ONBOARDING.FIRST_PREDICT_ON_US_ORDER_SHEET,
       {

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsMarketsCarousel.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsMarketsCarousel.tsx
@@ -8,9 +8,11 @@ import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { FlashList } from '@shopify/flash-list';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { markFirstPredictionOnUsOutcomeOpened } from '../../../../../reducers/rewards';
 import type {
   PredictMarket,
   PredictMarketBuyButtonPress,
@@ -42,6 +44,7 @@ const FirstPredictOnUsMarketsCarousel: React.FC<
   usdAmount,
 }) => {
   const tw = useTailwind();
+  const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const navigation =
     useNavigation<NavigationProp<ReactNavigation.RootParamList>>();
@@ -96,6 +99,13 @@ const FirstPredictOnUsMarketsCarousel: React.FC<
           })
           .build(),
       );
+      dispatch(
+        markFirstPredictionOnUsOutcomeOpened({
+          marketId,
+          outcome,
+        }),
+      );
+
       navigation.navigate(Routes.ONBOARDING.FIRST_PREDICT_ON_US_ORDER_SHEET, {
         confirmLabel,
         selectedOrder: params,
@@ -108,6 +118,7 @@ const FirstPredictOnUsMarketsCarousel: React.FC<
     [
       confirmLabel,
       createEventBuilder,
+      dispatch,
       navigation,
       trackEvent,
       tradeDescriptionTemplate,

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet.test.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet.test.tsx
@@ -4,6 +4,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { markFirstPredictionOnUsOrderConfirmed } from '../../../../../reducers/rewards';
 import { usePredictOrderPreview } from '../../../Predict/hooks/usePredictOrderPreview';
 import { Recurrence, Side, type PredictMarket } from '../../../Predict/types';
 import { useFirstPredictOnUsOrder } from '../../hooks/useFirstPredictOnUsOrder';
@@ -12,6 +13,7 @@ import FirstPredictOnUsOrderSheet, {
 } from './FirstPredictOnUsOrderSheet';
 
 const mockSubmitOrder = jest.fn();
+const mockDispatch = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockAddProperties = jest.fn();
 const mockBuild = jest.fn(() => ({ name: 'event' }));
@@ -32,6 +34,11 @@ jest.mock('../../../Predict/hooks/usePredictOrderPreview', () => ({
 
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
 }));
 
 jest.mock(
@@ -248,7 +255,7 @@ describe('FirstPredictOnUsOrderSheet', () => {
     ).toBeOnTheScreen();
   });
 
-  it('tracks confirmed order and submits on confirm', async () => {
+  it('tracks confirmed order, updates support state, and submits on confirm', async () => {
     mockSubmitOrder.mockResolvedValueOnce(undefined);
     const { getByTestId } = renderWithParams();
 
@@ -264,6 +271,13 @@ describe('FirstPredictOnUsOrderSheet', () => {
       outcome: 'Yes',
       status: 'confirmed',
     });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markFirstPredictionOnUsOrderConfirmed({
+        marketId: 'market-1',
+        outcome: 'Yes',
+      }),
+    );
+
     await waitFor(() => {
       expect(mockSubmitOrder).toHaveBeenCalledWith({
         amountUsd: 5,

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsOrderSheet.tsx
@@ -22,9 +22,11 @@ import {
   type NavigationProp,
   type RouteProp,
 } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { markFirstPredictionOnUsOrderConfirmed } from '../../../../../reducers/rewards';
 import { usePredictOrderPreview } from '../../../Predict/hooks/usePredictOrderPreview';
 import {
   Side,
@@ -62,6 +64,7 @@ type FirstPredictOnUsOrderSheetRoute = RouteProp<
 
 const FirstPredictOnUsOrderSheet: React.FC = () => {
   const tw = useTailwind();
+  const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const navigation =
     useNavigation<NavigationProp<ReactNavigation.RootParamList>>();
@@ -110,6 +113,13 @@ const FirstPredictOnUsOrderSheet: React.FC = () => {
         })
         .build(),
     );
+    dispatch(
+      markFirstPredictionOnUsOrderConfirmed({
+        marketId,
+        outcome,
+      }),
+    );
+
     try {
       await submitOrder({
         amountUsd: usdAmount,
@@ -123,7 +133,7 @@ const FirstPredictOnUsOrderSheet: React.FC = () => {
     } catch {
       // The hook owns error state for the sheet.
     }
-  }, [createEventBuilder, onClose, params, submitOrder, trackEvent]);
+  }, [createEventBuilder, dispatch, onClose, params, submitOrder, trackEvent]);
 
   if (!params) {
     return null;

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen.test.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen.test.tsx
@@ -4,11 +4,16 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { ONBOARDING_SUCCESS_FLOW } from '../../../../../constants/onboarding';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import {
+  markFirstPredictionOnUsOfferViewed,
+  markFirstPredictionOnUsSkipped,
+} from '../../../../../reducers/rewards';
 import type { FirstPredictOnUsDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import type { PredictMarket } from '../../../Predict/types';
 import FirstPredictOnUsSplashScreen from './FirstPredictOnUsSplashScreen';
 
 const mockReset = jest.fn();
+const mockDispatch = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockBuild = jest.fn(() => ({ name: 'event' }));
 const mockCreateEventBuilder = jest.fn(() => ({
@@ -55,6 +60,11 @@ jest.mock('@react-navigation/native', () => {
     }),
   };
 });
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
 
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
@@ -123,16 +133,19 @@ describe('FirstPredictOnUsSplashScreen', () => {
     ).toBeOnTheScreen();
   });
 
-  it('tracks the viewed event on mount', () => {
+  it('tracks the viewed event and marks offer viewed on mount', () => {
     renderWithParams();
 
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.FIRST_PREDICTION_ON_US_VIEWED,
     );
     expect(mockTrackEvent).toHaveBeenCalledWith({ name: 'event' });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markFirstPredictionOnUsOfferViewed(),
+    );
   });
 
-  it('tracks skip and resets to OnboardingSuccess', () => {
+  it('tracks skip, marks skipped, and resets to OnboardingSuccess', () => {
     const { getByTestId } = renderWithParams();
 
     fireEvent.press(getByTestId('first-predict-on-us-splash-skip'));
@@ -140,6 +153,7 @@ describe('FirstPredictOnUsSplashScreen', () => {
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.FIRST_PREDICTION_ON_US_SKIPPED,
     );
+    expect(mockDispatch).toHaveBeenCalledWith(markFirstPredictionOnUsSkipped());
     expect(mockReset).toHaveBeenCalledWith(expectedSuccessReset);
   });
 

--- a/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen.tsx
+++ b/app/components/UI/Rewards/components/FirstPredictOnUs/FirstPredictOnUsSplashScreen.tsx
@@ -5,10 +5,15 @@ import {
   type NavigationProp,
   type RouteProp,
 } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { ONBOARDING_SUCCESS_FLOW } from '../../../../../constants/onboarding';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import {
+  markFirstPredictionOnUsOfferViewed,
+  markFirstPredictionOnUsSkipped,
+} from '../../../../../reducers/rewards';
 import type { FirstPredictOnUsDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import type { PredictMarket } from '../../../Predict/types';
 import FirstPredictOnUsSplashLayout from './FirstPredictOnUsSplashLayout';
@@ -41,6 +46,7 @@ const FirstPredictOnUsSplashScreen: React.FC = () => {
     useNavigation<NavigationProp<ReactNavigation.RootParamList>>();
   const route = useRoute<FirstPredictOnUsSplashRoute>();
   const params = route.params;
+  const dispatch = useDispatch();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const onClose = useCallback(() => {
@@ -68,8 +74,9 @@ const FirstPredictOnUsSplashScreen: React.FC = () => {
         MetaMetricsEvents.FIRST_PREDICTION_ON_US_SKIPPED,
       ).build(),
     );
+    dispatch(markFirstPredictionOnUsSkipped());
     onClose();
-  }, [createEventBuilder, onClose, trackEvent]);
+  }, [createEventBuilder, dispatch, onClose, trackEvent]);
 
   useEffect(() => {
     if (!params) {
@@ -82,7 +89,8 @@ const FirstPredictOnUsSplashScreen: React.FC = () => {
         MetaMetricsEvents.FIRST_PREDICTION_ON_US_VIEWED,
       ).build(),
     );
-  }, [createEventBuilder, onClose, params, trackEvent]);
+    dispatch(markFirstPredictionOnUsOfferViewed());
+  }, [createEventBuilder, dispatch, onClose, params, trackEvent]);
 
   if (!params) {
     return null;

--- a/app/components/UI/Rewards/utils/resolveFirstPredictOnUs.test.ts
+++ b/app/components/UI/Rewards/utils/resolveFirstPredictOnUs.test.ts
@@ -1,0 +1,340 @@
+import Engine from '../../../../core/Engine';
+import { store } from '../../../../store';
+import { Recurrence, type PredictMarket } from '../../Predict/types';
+import { selectRewardsFirstPredictOnUsEnabled } from '../../../../selectors/featureFlagController/rewardsFirstPredictOnUs';
+import { selectFirstPredictOnUsOfferViewed } from '../../../../reducers/rewards/selectors';
+import {
+  resolveFirstPredictOnUsMarkets,
+  resolveFirstPredictOnUsLaunch,
+} from './resolveFirstPredictOnUs';
+
+jest.mock('../../../../core/Engine', () => ({
+  controllerMessenger: {
+    call: jest.fn(),
+  },
+  context: {
+    PredictController: {
+      getMarket: jest.fn(),
+      refreshEligibility: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
+}));
+
+jest.mock(
+  '../../../../selectors/featureFlagController/rewardsFirstPredictOnUs',
+  () => ({
+    selectRewardsFirstPredictOnUsEnabled: jest.fn(),
+  }),
+);
+
+jest.mock('../../../../reducers/rewards/selectors', () => ({
+  selectFirstPredictOnUsOfferViewed: jest.fn(),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+const mockGetMarket = Engine.context.PredictController
+  .getMarket as jest.MockedFunction<
+  typeof Engine.context.PredictController.getMarket
+>;
+const mockRefreshEligibility = Engine.context.PredictController
+  .refreshEligibility as jest.MockedFunction<
+  typeof Engine.context.PredictController.refreshEligibility
+>;
+const mockCall = Engine.controllerMessenger.call as jest.MockedFunction<
+  typeof Engine.controllerMessenger.call
+>;
+const mockGetState = store.getState as jest.MockedFunction<
+  typeof store.getState
+>;
+const mockFeatureEnabled =
+  selectRewardsFirstPredictOnUsEnabled as jest.MockedFunction<
+    typeof selectRewardsFirstPredictOnUsEnabled
+  >;
+const mockAlreadyShown =
+  selectFirstPredictOnUsOfferViewed as jest.MockedFunction<
+    typeof selectFirstPredictOnUsOfferViewed
+  >;
+
+const buildMarket = (
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket => ({
+  id: '30615',
+  providerId: 'polymarket',
+  slug: 'spain-vs-england',
+  title: 'Spain vs England',
+  description: 'Spain vs England',
+  image: 'https://example.com/image.png',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['world-cup'],
+  liquidity: 1000,
+  volume: 9100,
+  outcomes: [
+    {
+      id: '0xabc',
+      providerId: 'polymarket',
+      marketId: '30615',
+      title: 'Moneyline',
+      groupItemTitle: 'Moneyline',
+      description: 'Moneyline',
+      image: 'https://example.com/image.png',
+      status: 'open',
+      active: true,
+      acceptingOrders: true,
+      volume: 9100,
+      liquidity: 1000,
+      tokens: [
+        { id: 'token-1', title: 'ESP', price: 0.5 },
+        { id: 'token-2', title: 'ENG', price: 0.5 },
+      ],
+    },
+    {
+      id: '0xdef',
+      providerId: 'polymarket',
+      marketId: '30615',
+      title: 'Spread',
+      groupItemTitle: 'Spread',
+      description: 'Spread',
+      image: 'https://example.com/image.png',
+      status: 'open',
+      active: true,
+      acceptingOrders: true,
+      volume: 100,
+      liquidity: 200,
+      tokens: [{ id: 'token-3', title: 'ESP -1.5', price: 0.25 }],
+    },
+  ],
+  ...overrides,
+});
+
+describe('resolveFirstPredictOnUsMarkets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty result without calling the controller for no refs', async () => {
+    const result = await resolveFirstPredictOnUsMarkets([]);
+
+    expect(mockGetMarket).not.toHaveBeenCalled();
+    expect(result).toEqual({ markets: [], failedCount: 0 });
+  });
+
+  it('returns the full market when conditionId is omitted', async () => {
+    mockGetMarket.mockResolvedValueOnce(buildMarket());
+
+    const result = await resolveFirstPredictOnUsMarkets([{ eventId: '30615' }]);
+
+    expect(mockGetMarket).toHaveBeenCalledWith({ marketId: '30615' });
+    expect(result.markets).toHaveLength(1);
+    expect(result.markets[0].outcomes).toHaveLength(2);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('filters each market to the configured conditionId', async () => {
+    mockGetMarket.mockResolvedValueOnce(buildMarket());
+
+    const result = await resolveFirstPredictOnUsMarkets([
+      { eventId: '30615', conditionId: '0xabc' },
+    ]);
+
+    expect(result.markets).toHaveLength(1);
+    expect(result.markets[0].outcomes).toEqual([
+      expect.objectContaining({ id: '0xabc' }),
+    ]);
+    expect(result.failedCount).toBe(0);
+  });
+
+  it('falls back to the parent market image when a filtered outcome has no image', async () => {
+    const marketImage = 'https://example.com/parent-market.png';
+    mockGetMarket.mockResolvedValueOnce(
+      buildMarket({
+        image: marketImage,
+        outcomes: [
+          {
+            id: '0xabc',
+            providerId: 'polymarket',
+            marketId: '30615',
+            title: 'Moneyline',
+            groupItemTitle: 'Moneyline',
+            description: 'Moneyline',
+            image: '',
+            status: 'open',
+            active: true,
+            acceptingOrders: true,
+            volume: 9100,
+            liquidity: 1000,
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.5 },
+              { id: 'token-2', title: 'No', price: 0.5 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const result = await resolveFirstPredictOnUsMarkets([
+      { eventId: '30615', conditionId: '0xabc' },
+    ]);
+
+    expect(result.markets[0].outcomes[0].image).toBe(marketImage);
+  });
+
+  it('drops failed or unmatched market refs and counts them', async () => {
+    mockGetMarket
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(buildMarket({ id: '30616' }));
+
+    const result = await resolveFirstPredictOnUsMarkets([
+      { eventId: '30615', conditionId: '0xabc' },
+      { eventId: '30616', conditionId: 'missing-condition' },
+    ]);
+
+    expect(result.markets).toEqual([]);
+    expect(result.failedCount).toBe(2);
+  });
+
+  it('requests every configured market ref from the backend payload', async () => {
+    mockGetMarket.mockResolvedValue(buildMarket());
+
+    await resolveFirstPredictOnUsMarkets([
+      { eventId: '1', conditionId: '0xabc' },
+      { eventId: '2', conditionId: '0xabc' },
+      { eventId: '3', conditionId: '0xabc' },
+      { eventId: '4', conditionId: '0xabc' },
+    ]);
+
+    expect(mockGetMarket).toHaveBeenCalledTimes(4);
+    expect(mockGetMarket).toHaveBeenCalledWith({ marketId: '4' });
+  });
+});
+
+describe('resolveFirstPredictOnUsLaunch', () => {
+  const content = {
+    name: 'First Predict On Us',
+    image: null,
+    localizedText: {},
+    usdAmount: 5,
+    markets: [{ eventId: '30615', conditionId: '0xabc' }],
+    termsUrl: null,
+  };
+
+  const setEligibility = (eligibility: unknown) => {
+    mockGetState.mockReturnValue({
+      engine: { backgroundState: { PredictController: { eligibility } } },
+    } as never);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFeatureEnabled.mockReturnValue(true);
+    mockAlreadyShown.mockReturnValue(false);
+    setEligibility({ eligible: true, country: 'US' });
+    mockRefreshEligibility.mockResolvedValue(undefined as never);
+    mockCall.mockResolvedValue(content as never);
+    mockGetMarket.mockResolvedValue(buildMarket());
+  });
+
+  it('resolves content and markets when all gates pass', async () => {
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(mockRefreshEligibility).toHaveBeenCalled();
+    expect(mockGetMarket).toHaveBeenCalledWith({ marketId: '30615' });
+    expect(result?.content).toBe(content);
+    expect(result?.markets).toHaveLength(1);
+    expect(result?.markets[0].outcomes).toEqual([
+      expect.objectContaining({ id: '0xabc' }),
+    ]);
+  });
+
+  it('returns null and skips network when the splash was already shown', async () => {
+    mockAlreadyShown.mockReturnValue(true);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockRefreshEligibility).not.toHaveBeenCalled();
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('returns null and skips network when the feature flag is disabled', async () => {
+    mockFeatureEnabled.mockReturnValue(false);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockRefreshEligibility).not.toHaveBeenCalled();
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('returns null when Predict is geo-ineligible', async () => {
+    setEligibility({ eligible: false, country: 'GB' });
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no country has resolved', async () => {
+    setEligibility({ eligible: true, country: undefined });
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no CMS content is returned', async () => {
+    mockCall.mockResolvedValue(null as never);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockGetMarket).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the CMS content has no markets', async () => {
+    mockCall.mockResolvedValue({ ...content, markets: [] } as never);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+    expect(mockGetMarket).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no markets resolve', async () => {
+    mockGetMarket.mockRejectedValue(new Error('network') as never);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when resolution rejects', async () => {
+    mockCall.mockRejectedValue(new Error('network down') as never);
+
+    const result = await resolveFirstPredictOnUsLaunch();
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when resolution exceeds the timeout', async () => {
+    mockGetMarket.mockImplementation(
+      () => new Promise(() => undefined) as never,
+    );
+
+    const result = await resolveFirstPredictOnUsLaunch(10);
+
+    expect(result).toBeNull();
+  });
+});

--- a/app/components/UI/Rewards/utils/resolveFirstPredictOnUs.ts
+++ b/app/components/UI/Rewards/utils/resolveFirstPredictOnUs.ts
@@ -1,0 +1,211 @@
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+import { store } from '../../../../store';
+import type { RootState } from '../../../../reducers';
+import { selectRewardsFirstPredictOnUsEnabled } from '../../../../selectors/featureFlagController/rewardsFirstPredictOnUs';
+import { selectFirstPredictOnUsOfferViewed } from '../../../../reducers/rewards/selectors';
+import type {
+  FirstPredictOnUsDto,
+  PredictMarketRef,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+import type { PredictMarket } from '../../Predict/types';
+
+// ============================================================================
+// Market resolution
+// ============================================================================
+
+/**
+ * Narrow a resolved market to a single outcome (condition) when the backend
+ * ref specifies a `conditionId`. Falls back to the market image when an
+ * outcome image is missing. Returns null when the condition can't be matched.
+ */
+export function filterMarketToConditionId(
+  market: PredictMarket,
+  conditionId: string,
+): PredictMarket | null {
+  const outcomes = market.outcomes.filter(
+    (outcome) => outcome.id === conditionId,
+  );
+  if (outcomes.length === 0) {
+    return null;
+  }
+
+  return {
+    ...market,
+    outcomes: outcomes.map((outcome) => ({
+      ...outcome,
+      image: outcome.image || market.image,
+    })),
+  };
+}
+
+/**
+ * Resolve a single backend market ref into a full Predict market via
+ * `PredictController.getMarket`, applying condition filtering when present.
+ */
+export async function resolveMarketRef(
+  ref: PredictMarketRef,
+): Promise<PredictMarket | null> {
+  const market = await Engine.context.PredictController.getMarket({
+    marketId: ref.eventId,
+  });
+
+  if (!ref.conditionId) {
+    return market;
+  }
+
+  return filterMarketToConditionId(market, ref.conditionId);
+}
+
+export interface ResolvedFirstPredictOnUsMarkets {
+  markets: PredictMarket[];
+  failedCount: number;
+}
+
+/**
+ * Resolve every backend market ref concurrently. Individual failures are
+ * tolerated: the resolved subset is returned alongside a `failedCount` so
+ * callers can decide whether the result is usable.
+ */
+export async function resolveFirstPredictOnUsMarkets(
+  refs: PredictMarketRef[],
+): Promise<ResolvedFirstPredictOnUsMarkets> {
+  if (refs.length === 0) {
+    return { markets: [], failedCount: 0 };
+  }
+
+  const results = await Promise.allSettled(refs.map(resolveMarketRef));
+
+  const markets: PredictMarket[] = [];
+  let failedCount = 0;
+
+  results.forEach((result) => {
+    if (result.status === 'fulfilled' && result.value) {
+      markets.push(result.value);
+    } else {
+      failedCount++;
+    }
+  });
+
+  return { markets, failedCount };
+}
+
+// ============================================================================
+// Launch gating
+// ============================================================================
+
+/**
+ * Maximum time we spend resolving eligibility, content, and markets before
+ * abandoning the launch. Keeps a hung network request from blocking onboarding.
+ */
+export const FIRST_PREDICT_ON_US_RESOLVE_TIMEOUT_MS = 5000;
+
+export interface ResolvedFirstPredictOnUsLaunch {
+  content: FirstPredictOnUsDto;
+  markets: PredictMarket[];
+}
+
+const withTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('First Predict On Us launch resolution timed out'));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
+
+/**
+ * Read Predict geo eligibility, refreshing it first so onboarding decisions use
+ * a fresh value rather than whatever happened to be cached.
+ */
+const resolveEligibility = async (): Promise<boolean> => {
+  try {
+    await Engine.context.PredictController.refreshEligibility();
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      'resolveFirstPredictOnUs: eligibility refresh failed',
+    );
+  }
+
+  const eligibility = (store.getState() as RootState).engine.backgroundState
+    .PredictController?.eligibility;
+
+  return Boolean(eligibility?.eligible && eligibility?.country);
+};
+
+const resolve = async (): Promise<ResolvedFirstPredictOnUsLaunch | null> => {
+  const state = store.getState() as RootState;
+
+  // Static gates first: feature flag + one-time persisted guard.
+  if (!selectRewardsFirstPredictOnUsEnabled(state)) {
+    return null;
+  }
+  if (selectFirstPredictOnUsOfferViewed(state)) {
+    return null;
+  }
+
+  // Predict geo eligibility.
+  const isEligible = await resolveEligibility();
+
+  if (!isEligible) {
+    return null;
+  }
+
+  // CMS content (1-minute cached in the controller).
+  const content = (await Engine.controllerMessenger.call(
+    'RewardsController:getFirstPredictOnUs',
+  )) as FirstPredictOnUsDto | null;
+
+  if (!content) {
+    return null;
+  }
+
+  const refs = content.markets ?? [];
+  if (refs.length === 0) {
+    return null;
+  }
+
+  // Resolve the referenced Predict markets. Individual failures are tolerated;
+  // we only require at least one usable market.
+  const { markets } = await resolveFirstPredictOnUsMarkets(refs);
+
+  if (markets.length === 0) {
+    return null;
+  }
+
+  return { content, markets };
+};
+
+/**
+ * Off-screen gating for the First Predict On Us onboarding splash.
+ *
+ * Runs all checks (feature flag, one-time guard, Predict geo eligibility, CMS
+ * content, market resolution) before the splash is ever rendered, bounded by a
+ * timeout. Returns the resolved content + markets when the splash should be
+ * shown as an onboarding step, or `null` when it should be skipped.
+ *
+ * The caller is responsible for marking the persisted guard and navigating.
+ */
+export async function resolveFirstPredictOnUsLaunch(
+  timeoutMs: number = FIRST_PREDICT_ON_US_RESOLVE_TIMEOUT_MS,
+): Promise<ResolvedFirstPredictOnUsLaunch | null> {
+  try {
+    return await withTimeout(resolve(), timeoutMs);
+  } catch (error) {
+    Logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      'resolveFirstPredictOnUs: failed to resolve splash content',
+    );
+    return null;
+  }
+}

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -59,6 +59,11 @@ jest.mock('@metamask/key-tree', () => ({
   mnemonicPhraseToBytes: jest.fn((_phrase) => new Uint8Array([1, 2, 3])),
 }));
 
+const mockResolveFirstPredictOnUsLaunch = jest.fn();
+jest.mock('../../UI/Rewards/utils/resolveFirstPredictOnUs', () => ({
+  resolveFirstPredictOnUsLaunch: () => mockResolveFirstPredictOnUsLaunch(),
+}));
+
 import ChoosePassword from './index.tsx';
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
 import {
@@ -980,6 +985,160 @@ describe('ChoosePassword', () => {
       });
 
       mockNewWalletAndKeychain.mockRestore();
+    });
+
+    it('resets to the First Predict On Us splash as a flat onboarding step when the campaign resolves (no questionnaire)', async () => {
+      mockEligibility.shouldShowQuestionnaire = false;
+
+      const firstPredictContent = {
+        name: 'First Predict On Us',
+        image: null,
+        localizedText: {},
+        usdAmount: 5,
+        markets: [{ eventId: '30615', conditionId: '0xabc' }],
+        termsUrl: null,
+      };
+      const firstPredictMarkets = [{ id: '30615', outcomes: [] }];
+      mockResolveFirstPredictOnUsLaunch.mockResolvedValue({
+        content: firstPredictContent,
+        markets: firstPredictMarkets,
+      });
+
+      (
+        Authentication.requestBiometricsAccessControlForIOS as jest.Mock
+      ).mockResolvedValue({
+        currentAuthType: 'biometrics',
+        availableBiometryType: 'faceID',
+      });
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+      jest
+        .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
+        .mockResolvedValue(undefined);
+
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+        oauthLoginSuccess: true,
+        provider: 'google',
+      };
+
+      try {
+        const component = renderWithProviders(<ChoosePassword />);
+        await fillAndSubmitForm(component);
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        await waitFor(() => {
+          expect(mockNavigation.reset).toHaveBeenCalledWith({
+            index: 0,
+            routes: [
+              {
+                name: 'FirstPredictOnUsSplash',
+                params: {
+                  content: firstPredictContent,
+                  markets: firstPredictMarkets,
+                  successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+                },
+              },
+            ],
+          });
+        });
+      } finally {
+        mockEligibility.shouldShowQuestionnaire = true;
+        mockResolveFirstPredictOnUsLaunch.mockReset();
+        mockNewWalletAndKeychain.mockRestore();
+      }
+    });
+
+    it('resets to the First Predict On Us splash from the questionnaire onComplete when the campaign resolves', async () => {
+      mockEligibility.shouldShowQuestionnaire = true;
+
+      const firstPredictContent = {
+        name: 'First Predict On Us',
+        image: null,
+        localizedText: {},
+        usdAmount: 5,
+        markets: [{ eventId: '30615', conditionId: '0xabc' }],
+        termsUrl: null,
+      };
+      const firstPredictMarkets = [{ id: '30615', outcomes: [] }];
+      mockResolveFirstPredictOnUsLaunch.mockResolvedValue({
+        content: firstPredictContent,
+        markets: firstPredictMarkets,
+      });
+
+      (
+        Authentication.requestBiometricsAccessControlForIOS as jest.Mock
+      ).mockResolvedValue({
+        currentAuthType: 'biometrics',
+        availableBiometryType: 'faceID',
+      });
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+      jest
+        .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
+        .mockResolvedValue(undefined);
+
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+        oauthLoginSuccess: true,
+        provider: 'google',
+      };
+
+      try {
+        const component = renderWithProviders(<ChoosePassword />);
+        await fillAndSubmitForm(component);
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        // Splash is shown after the survey: it is triggered by the
+        // questionnaire's onComplete callback, not directly on wallet creation.
+        let questionnaireOnComplete: (() => void) | undefined;
+        await waitFor(() => {
+          const call = mockNavigation.navigate.mock.calls.find(
+            ([routeName]) =>
+              routeName === Routes.ONBOARDING.INTEREST_QUESTIONNAIRE,
+          );
+          expect(call).toBeDefined();
+          questionnaireOnComplete = call?.[1]?.onComplete;
+          expect(questionnaireOnComplete).toEqual(expect.any(Function));
+        });
+
+        await act(async () => {
+          await questionnaireOnComplete?.();
+        });
+
+        await waitFor(() => {
+          expect(mockNavigation.reset).toHaveBeenCalledWith({
+            index: 0,
+            routes: [
+              {
+                name: 'FirstPredictOnUsSplash',
+                params: {
+                  content: firstPredictContent,
+                  markets: firstPredictMarkets,
+                  successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+                },
+              },
+            ],
+          });
+        });
+      } finally {
+        mockResolveFirstPredictOnUsLaunch.mockReset();
+        mockNewWalletAndKeychain.mockRestore();
+      }
     });
 
     it('navigates to the support article when the learn more link is pressed', async () => {

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, act, fireEvent, waitFor } from '@testing-library/react-native';
+import {
+  render,
+  act,
+  fireEvent,
+  waitFor,
+  screen,
+} from '@testing-library/react-native';
 import configureMockStore from 'redux-mock-store';
 import {
   ONBOARDING,
@@ -178,7 +184,7 @@ jest.mock('../../../util/device', () => ({
   isMediumDevice: jest.fn(),
 }));
 
-const mockEligibility = {
+let mockEligibility = {
   shouldShowQuestionnaire: true,
   variantName: 'treatment',
   isActive: true,
@@ -214,10 +220,7 @@ const mockRunAfterInteractions = jest.fn().mockImplementation((cb) => {
     cancel: jest.fn(),
   };
 });
-jest
-  .spyOn(InteractionManager, 'runAfterInteractions')
-  .mockImplementation(mockRunAfterInteractions);
-
+InteractionManager.runAfterInteractions = mockRunAfterInteractions;
 const mockStore = configureMockStore();
 const createInitialState = (geolocationLocation = 'GB') => ({
   user: {
@@ -299,10 +302,13 @@ const renderWithProviders = (ui: React.ReactElement) =>
   );
 
 /** Waits for async work triggered by componentDidMount to settle. */
-const waitForInit = () =>
-  act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 100));
+const waitForInit = async () => {
+  await waitFor(() => {
+    expect(
+      screen.getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+    ).toBeOnTheScreen();
   });
+};
 
 /** Returns all primary form elements by testID in one call. */
 const getFormElements = (
@@ -375,6 +381,11 @@ describe('ChoosePassword', () => {
     mockTrackOnboarding.mockClear();
     store = mockStore(createInitialState());
     ReduxService.store = store as unknown as ReduxStore;
+    mockEligibility = {
+      shouldShowQuestionnaire: true,
+      variantName: 'treatment',
+      isActive: true,
+    };
     mockRefreshGeolocation.mockResolvedValue('GB');
     (Authentication.getType as jest.Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-deprecated -- getType still returns PASSCODE
@@ -397,11 +408,13 @@ describe('ChoosePassword', () => {
     };
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders correctly', async () => {
     const component = renderWithProviders(<ChoosePassword />);
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await waitForInit();
     expect(
       component.getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
     ).toBeOnTheScreen();
@@ -410,9 +423,7 @@ describe('ChoosePassword', () => {
   describe('UI State', () => {
     it('shows FoxRiveLoaderAnimation and hides form inputs during loading', async () => {
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       await fillAndSubmitForm(component);
 
@@ -474,9 +485,7 @@ describe('ChoosePassword', () => {
       mockNewWalletAndKeychain.mockReturnValue(walletCreationPromise);
 
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       // Initially the form is visible and the loader is absent
       expect(
@@ -509,9 +518,7 @@ describe('ChoosePassword', () => {
 
     it('helper text is always visible below the password field', async () => {
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
       const helperText = strings('choose_password.must_be_at_least', {
         number: 8,
       });
@@ -525,7 +532,6 @@ describe('ChoosePassword', () => {
           ),
           'ValidPassword123',
         );
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
       expect(component.getByText(helperText)).toBeOnTheScreen();
@@ -533,18 +539,14 @@ describe('ChoosePassword', () => {
 
     it('helper text remains visible after blurring the password field with a short password', async () => {
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
       const { passwordInput } = getFormElements(component);
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'short');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
       await act(async () => {
         fireEvent(passwordInput, 'blur');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
       expect(
@@ -556,19 +558,15 @@ describe('ChoosePassword', () => {
 
     it('helper text remains visible after refocusing the password field', async () => {
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
       const { passwordInput } = getFormElements(component);
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'short');
         fireEvent(passwordInput, 'blur');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
       await act(async () => {
         fireEvent(passwordInput, 'focus');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
       expect(
@@ -597,9 +595,7 @@ describe('ChoosePassword', () => {
   describe('Form Validation', () => {
     it('shows a password mismatch error when passwords differ', async () => {
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       await fillForm(component, 'Test123456!', 'DifferentPassword123!');
 
@@ -687,9 +683,7 @@ describe('ChoosePassword', () => {
   describe('Navigation', () => {
     it('back button navigates to the previous screen', async () => {
       const { getByTestId } = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       const backButton = getByTestId(ChoosePasswordSelectorsIDs.BACK_BUTTON_ID);
       await act(async () => {
@@ -714,7 +708,6 @@ describe('ChoosePassword', () => {
       mockNavigation.setParams.mockClear();
 
       await fillAndSubmitForm(component, 'StrongPassword123!@#');
-      await waitForInit();
 
       await waitFor(() => {
         expect(mockNavigation.replace).toHaveBeenCalledWith(
@@ -923,20 +916,18 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockNavigation.reset).toHaveBeenCalledWith({
-        routes: [
-          {
-            name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
-            params: expect.objectContaining({
-              metricsEnabled: true,
-              error: passcodeError,
-            }),
-          },
-        ],
+      await waitFor(() => {
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          routes: [
+            {
+              name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
+              params: expect.objectContaining({
+                metricsEnabled: true,
+                error: passcodeError,
+              }),
+            },
+          ],
+        });
       });
 
       jest.spyOn(Device, 'isIos').mockRestore();
@@ -968,10 +959,6 @@ describe('ChoosePassword', () => {
 
       const component = renderWithProviders(<ChoosePassword />);
       await fillAndSubmitForm(component);
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
 
       await waitFor(() => {
         expect(mockNavigation.navigate).toHaveBeenCalledWith(
@@ -1029,10 +1016,6 @@ describe('ChoosePassword', () => {
       try {
         const component = renderWithProviders(<ChoosePassword />);
         await fillAndSubmitForm(component);
-
-        await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 200));
-        });
 
         await waitFor(() => {
           expect(mockNavigation.reset).toHaveBeenCalledWith({
@@ -1098,10 +1081,6 @@ describe('ChoosePassword', () => {
       try {
         const component = renderWithProviders(<ChoosePassword />);
         await fillAndSubmitForm(component);
-
-        await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 200));
-        });
 
         // Splash is shown after the survey: it is triggered by the
         // questionnaire's onComplete callback, not directly on wallet creation.
@@ -1341,9 +1320,7 @@ describe('ChoosePassword', () => {
         oauthLoginSuccess: true,
       };
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       // OAuth users do not need the checkbox to enable submission
       await fillForm(component, 'Test1234', 'Test1234', false);
@@ -1359,9 +1336,7 @@ describe('ChoosePassword', () => {
         oauthLoginSuccess: false,
       };
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       // Passwords match and are long enough but checkbox is not checked
       await fillForm(component, 'Test1234', 'Test1234', false);
@@ -1376,9 +1351,7 @@ describe('ChoosePassword', () => {
         [PREVIOUS_SCREEN]: ONBOARDING,
       };
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       await fillForm(component, 'Test1234', 'Test1234', false);
 
@@ -1398,9 +1371,7 @@ describe('ChoosePassword', () => {
       };
 
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       expect(() =>
         component.getByText(/Use this for wallet recovery/),
@@ -1425,9 +1396,7 @@ describe('ChoosePassword', () => {
       };
 
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       expect(() =>
         component.getByText(/If you lose this password/),
@@ -1731,15 +1700,13 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
+      await waitFor(() => {
+        expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
+        expect(mockCaptureException).toHaveBeenCalled();
+        expect(mockTrackEvent).not.toHaveBeenLastCalledWith(
+          expect.objectContaining({ name: 'Error Screen Viewed' }),
+        );
       });
-
-      expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
-      expect(mockCaptureException).toHaveBeenCalled();
-      expect(mockTrackEvent).not.toHaveBeenLastCalledWith(
-        expect.objectContaining({ name: 'Error Screen Viewed' }),
-      );
 
       mockNewWalletAndKeychain.mockRestore();
     });
@@ -1764,27 +1731,25 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockCaptureException).toHaveBeenCalledWith(walletError, {
-        tags: {
-          view: 'ChoosePassword',
-          context: 'Wallet creation failed - auto reported',
-        },
-      });
-      expect(mockNavigation.reset).toHaveBeenCalledWith({
-        routes: [
-          {
-            name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
-            params: expect.objectContaining({
-              metricsEnabled: true,
-              error: walletError,
-              accountType: AccountType.MetamaskGoogle,
-            }),
+      await waitFor(() => {
+        expect(mockCaptureException).toHaveBeenCalledWith(walletError, {
+          tags: {
+            view: 'ChoosePassword',
+            context: 'Wallet creation failed - auto reported',
           },
-        ],
+        });
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          routes: [
+            {
+              name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
+              params: expect.objectContaining({
+                metricsEnabled: true,
+                error: walletError,
+                accountType: AccountType.MetamaskGoogle,
+              }),
+            },
+          ],
+        });
       });
 
       mockComponentAuthenticationType.mockReset();
@@ -1813,26 +1778,24 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockCaptureException).toHaveBeenCalledWith(walletError, {
-        tags: {
-          view: 'ChoosePassword',
-          context: 'Wallet creation failed - auto reported',
-        },
-      });
-      expect(mockNavigation.reset).toHaveBeenCalledWith({
-        routes: [
-          {
-            name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
-            params: expect.objectContaining({
-              metricsEnabled: true,
-              error: walletError,
-            }),
+      await waitFor(() => {
+        expect(mockCaptureException).toHaveBeenCalledWith(walletError, {
+          tags: {
+            view: 'ChoosePassword',
+            context: 'Wallet creation failed - auto reported',
           },
-        ],
+        });
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          routes: [
+            {
+              name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
+              params: expect.objectContaining({
+                metricsEnabled: true,
+                error: walletError,
+              }),
+            },
+          ],
+        });
       });
 
       mockComponentAuthenticationType.mockReset();
@@ -1916,18 +1879,16 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockTrace).toHaveBeenCalledWith({
-        name: TraceName.OnboardingPasswordSetupError,
-        op: TraceOperation.OnboardingUserJourney,
-        parentContext: mockOnboardingTraceCtx,
-        tags: { errorMessage: testError.toString() },
-      });
-      expect(mockEndTrace).toHaveBeenCalledWith({
-        name: TraceName.OnboardingPasswordSetupError,
+      await waitFor(() => {
+        expect(mockTrace).toHaveBeenCalledWith({
+          name: TraceName.OnboardingPasswordSetupError,
+          op: TraceOperation.OnboardingUserJourney,
+          parentContext: mockOnboardingTraceCtx,
+          tags: { errorMessage: testError.toString() },
+        });
+        expect(mockEndTrace).toHaveBeenCalledWith({
+          name: TraceName.OnboardingPasswordSetupError,
+        });
       });
     });
 
@@ -1945,17 +1906,15 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockTrace).not.toHaveBeenCalledWith(
-        expect.objectContaining({
+      await waitFor(() => {
+        expect(mockTrace).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: TraceName.OnboardingPasswordSetupError,
+          }),
+        );
+        expect(mockEndTrace).not.toHaveBeenCalledWith({
           name: TraceName.OnboardingPasswordSetupError,
-        }),
-      );
-      expect(mockEndTrace).not.toHaveBeenCalledWith({
-        name: TraceName.OnboardingPasswordSetupError,
+        });
       });
     });
 
@@ -1989,22 +1948,20 @@ describe('ChoosePassword', () => {
 
       await fillAndSubmitForm(component, 'StrongPassword123!');
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(mockTrace).toHaveBeenCalledWith({
-        name: TraceName.OnboardingPasswordSetupAttempt,
-        op: TraceOperation.OnboardingUserJourney,
-        parentContext: mockOnboardingTraceCtx,
-      });
-      expect(mockTrace).not.toHaveBeenCalledWith(
-        expect.objectContaining({
+      await waitFor(() => {
+        expect(mockTrace).toHaveBeenCalledWith({
+          name: TraceName.OnboardingPasswordSetupAttempt,
+          op: TraceOperation.OnboardingUserJourney,
+          parentContext: mockOnboardingTraceCtx,
+        });
+        expect(mockTrace).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: TraceName.OnboardingPasswordSetupError,
+          }),
+        );
+        expect(mockEndTrace).not.toHaveBeenCalledWith({
           name: TraceName.OnboardingPasswordSetupError,
-        }),
-      );
-      expect(mockEndTrace).not.toHaveBeenCalledWith({
-        name: TraceName.OnboardingPasswordSetupError,
+        });
       });
     });
   });
@@ -2019,9 +1976,7 @@ describe('ChoosePassword', () => {
       };
 
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       const passwordInput = component.getByTestId(
         ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
@@ -2035,15 +1990,12 @@ describe('ChoosePassword', () => {
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'StrongPass123!');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
       await act(async () => {
         fireEvent.changeText(confirmPasswordInput, 'StrongPass123!');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
       await act(async () => {
         fireEvent.press(checkbox);
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
       const submitButton = component.getByTestId(
@@ -2076,9 +2028,7 @@ describe('ChoosePassword', () => {
       };
 
       const component = renderWithProviders(<ChoosePassword />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await waitForInit();
 
       const passwordInput = component.getByTestId(
         ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
@@ -2089,11 +2039,9 @@ describe('ChoosePassword', () => {
 
       await act(async () => {
         fireEvent.changeText(passwordInput, 'StrongPass123!');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
       await act(async () => {
         fireEvent.changeText(confirmPasswordInput, 'StrongPass123!');
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
       const submitButton = component.getByTestId(
@@ -2140,10 +2088,6 @@ describe('ChoosePassword', () => {
       const component = renderWithProviders(<ChoosePassword />);
       await waitForInit();
       await fillAndSubmitForm(component, VALID_PASSWORD, VALID_PASSWORD, false);
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
 
       await waitFor(() => {
         expect(mockNavigation.navigate).toHaveBeenCalledWith(
@@ -2223,10 +2167,8 @@ describe('ChoosePassword', () => {
 
       const component = renderWithProviders(<ChoosePassword />);
 
-      // Wait for the geolocation refresh to settle (reject → isGeolocationResolved = true)
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      });
+      // Wait for geolocation refresh to settle (reject → isGeolocationResolved = true)
+      await waitForInit();
 
       await fillForm(component, VALID_PASSWORD, VALID_PASSWORD, false);
 

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -105,6 +105,11 @@ import { selectGeolocationLocation } from '../../../selectors/geolocationControl
 import { getDefaultMarketingOptInChecked } from '../../../util/onboarding/getDefaultMarketingOptInChecked';
 import { selectOnboardingAccountType } from '../../../selectors/onboarding';
 import { useOnboardingInterestQuestionnaireEligibility } from '../../../hooks/useOnboardingInterestQuestionnaireEligibility';
+import {
+  resolveFirstPredictOnUsLaunch,
+  type ResolvedFirstPredictOnUsLaunch,
+} from '../../UI/Rewards/utils/resolveFirstPredictOnUs';
+import { markFirstPredictionOnUsOfferViewed } from '../../../reducers/rewards';
 
 interface KeyringState {
   type: string;
@@ -197,6 +202,11 @@ const ChoosePassword = () => {
   // Flag to know if password in keyring was set or not
   const keyringControllerPasswordSet = useRef(false);
   const foxRiveLoaderRef = useRef<FoxRiveLoaderAnimationRef>(null);
+  // Off-screen resolution of the First Predict On Us onboarding splash. Kicked
+  // off early (for social login) so the result is typically ready by the time
+  // the wallet is created and we navigate into the success flow.
+  const firstPredictOnUsLaunchRef =
+    useRef<Promise<ResolvedFirstPredictOnUsLaunch | null> | null>(null);
 
   const reduxAccountType = useSelector(selectOnboardingAccountType);
   const { shouldShowQuestionnaire } =
@@ -206,6 +216,13 @@ const ChoosePassword = () => {
     () => route.params?.oauthLoginSuccess,
     [route.params?.oauthLoginSuccess],
   );
+
+  useEffect(() => {
+    if (!isSocialLoginUser || firstPredictOnUsLaunchRef.current) {
+      return;
+    }
+    firstPredictOnUsLaunchRef.current = resolveFirstPredictOnUsLaunch();
+  }, [isSocialLoginUser]);
 
   useEffect(() => {
     if (!isSocialLoginUser) {
@@ -421,7 +438,34 @@ const ChoosePassword = () => {
     [password, recreateVault, dispatch],
   );
 
-  const onContinueNavigation = useCallback(() => {
+  const onContinueNavigation = useCallback(async () => {
+    // The First Predict On Us splash is a flat onboarding step shown after any
+    // survey and before the "wallet ready" success screen. Its off-screen gating
+    // was kicked off on mount; if it resolved we reset to the splash (which
+    // dismisses forward to OnboardingSuccess). Otherwise we reset straight to
+    // the success flow. The flow stays linear either way.
+    const firstPredictOnUsLaunch = firstPredictOnUsLaunchRef.current
+      ? await firstPredictOnUsLaunchRef.current
+      : null;
+
+    if (firstPredictOnUsLaunch) {
+      dispatch(markFirstPredictionOnUsOfferViewed());
+      navigation.reset({
+        index: 0,
+        routes: [
+          {
+            name: Routes.ONBOARDING.FIRST_PREDICT_ON_US_SPLASH,
+            params: {
+              content: firstPredictOnUsLaunch.content,
+              markets: firstPredictOnUsLaunch.markets,
+              successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+            },
+          },
+        ],
+      });
+      return;
+    }
+
     navigation.reset({
       index: 0,
       routes: [
@@ -436,7 +480,7 @@ const ChoosePassword = () => {
         },
       ],
     });
-  }, [navigation]);
+  }, [navigation, dispatch]);
 
   const handlePostWalletCreation = useCallback(
     async (authType: AuthData, isMarketingOptedIn: boolean) => {
@@ -506,7 +550,7 @@ const ChoosePassword = () => {
           ...(accountType && { accountType }),
         });
       } else {
-        onContinueNavigation();
+        await onContinueNavigation();
       }
     },
     [

--- a/app/components/Views/OnboardingSuccess/index.test.tsx
+++ b/app/components/Views/OnboardingSuccess/index.test.tsx
@@ -458,9 +458,11 @@ describe('OnboardingSuccess', () => {
         successFlow: ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
       };
       const { getByTestId } = renderWithProvider(<OnboardingSuccess />);
-      expect(
-        getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
-      ).toBeOnTheScreen();
+      return waitFor(() => {
+        expect(
+          getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+        ).toBeOnTheScreen();
+      });
     });
 
     it('fails to add networks to the network controller but renders the component', () => {
@@ -468,9 +470,11 @@ describe('OnboardingSuccess', () => {
         Engine.context.NetworkController.addNetwork as jest.Mock
       ).mockRejectedValue(new Error('Failed to add network'));
       const { getByTestId } = renderWithProvider(<OnboardingSuccess />);
-      expect(
-        getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
-      ).toBeOnTheScreen();
+      return waitFor(() => {
+        expect(
+          getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+        ).toBeOnTheScreen();
+      });
     });
   });
 
@@ -480,10 +484,11 @@ describe('OnboardingSuccess', () => {
         successFlow: ONBOARDING_SUCCESS_FLOW.NO_BACKED_UP_SRP,
       };
       const { getByTestId } = renderWithProvider(<OnboardingSuccess />);
-
-      expect(
-        getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
-      ).toBeOnTheScreen();
+      return waitFor(() => {
+        expect(
+          getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+        ).toBeOnTheScreen();
+      });
     });
 
     it('dispatches ResetNavigationToHome action when done button is pressed', async () => {
@@ -491,7 +496,9 @@ describe('OnboardingSuccess', () => {
         successFlow: ONBOARDING_SUCCESS_FLOW.NO_BACKED_UP_SRP,
       };
       const { getByTestId } = renderWithProvider(<OnboardingSuccess />);
-      const button = getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON);
+      const button = await waitFor(() =>
+        getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+      );
       fireEvent.press(button);
       expect(mockDiscoverAccounts).toHaveBeenCalled();
 
@@ -500,6 +507,27 @@ describe('OnboardingSuccess', () => {
           skipInitialBalanceWait: true,
         }),
       );
+      await waitFor(() => {
+        expect(mockNavigationDispatch).toHaveBeenCalledWith(
+          ResetNavigationToHome,
+        );
+      });
+    });
+  });
+
+  describe('first predict on us splash flow', () => {
+    it('resets to HomeNav when Done is pressed after the gate completes', async () => {
+      mockRouteParams = {
+        successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+      };
+
+      const { getByTestId } = renderWithProvider(<OnboardingSuccess />);
+      const button = await waitFor(() =>
+        getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON),
+      );
+
+      fireEvent.press(button);
+
       await waitFor(() => {
         expect(mockNavigationDispatch).toHaveBeenCalledWith(
           ResetNavigationToHome,

--- a/app/components/Views/OnboardingSuccess/index.test.tsx
+++ b/app/components/Views/OnboardingSuccess/index.test.tsx
@@ -160,6 +160,10 @@ describe('OnboardingSuccessComponent', () => {
     setupSelectorMocks();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders correctly when successFlow is BACKED_UP_SRP', () => {
     const { getByTestId } = renderWithProvider(
       <OnboardingSuccessComponent
@@ -309,27 +313,30 @@ describe('OnboardingSuccessComponent', () => {
     const loggerSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {
       // Do nothing
     });
-    mockDiscoverAccounts.mockRejectedValueOnce(new Error('discovery failed'));
-    const onDone = jest.fn();
-    const { getByTestId } = renderWithProvider(
-      <OnboardingSuccessComponent
-        onDone={onDone}
-        successFlow={ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE}
-      />,
-    );
-    fireEvent.press(getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON));
-
-    await waitFor(() => {
-      expect(onDone).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(loggerSpy).toHaveBeenCalledWith(
-        expect.any(Error),
-        'OnboardingSuccess: discoverAccounts failed',
+    try {
+      mockDiscoverAccounts.mockRejectedValueOnce(new Error('discovery failed'));
+      const onDone = jest.fn();
+      const { getByTestId } = renderWithProvider(
+        <OnboardingSuccessComponent
+          onDone={onDone}
+          successFlow={ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE}
+        />,
       );
-    });
-    loggerSpy.mockRestore();
-    mockDiscoverAccounts.mockResolvedValue(0);
+      fireEvent.press(getByTestId(OnboardingSuccessSelectorIDs.DONE_BUTTON));
+
+      await waitFor(() => {
+        expect(onDone).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(loggerSpy).toHaveBeenCalledWith(
+          expect.any(Error),
+          'OnboardingSuccess: discoverAccounts failed',
+        );
+      });
+    } finally {
+      loggerSpy.mockRestore();
+      mockDiscoverAccounts.mockResolvedValue(0);
+    }
   });
 
   it('does not mark steps eligible for SETTINGS_BACKUP flow when Done is pressed', () => {
@@ -450,6 +457,10 @@ describe('OnboardingSuccess', () => {
     setupSelectorMocks();
     mockDiscoverAccounts.mockResolvedValue(0);
     mockRouteParams = {};
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe('route params successFlow is IMPORT_FROM_SEED_PHRASE', () => {

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -78,6 +78,12 @@ import rewardsReducer, {
   setVersionGuardError,
   dismissCampaignOutcomeToast,
   subscribeCampaignReminder,
+  markFirstPredictionOnUsOfferViewed,
+  markFirstPredictionOnUsSkipped,
+  markFirstPredictionOnUsOutcomeOpened,
+  markFirstPredictionOnUsOrderConfirmed,
+  markFirstPredictionOnUsOrderExecuted,
+  markFirstPredictionOnUsOrderFailed,
   RewardsState,
 } from '.';
 import { OnboardingStep } from './types';
@@ -2068,6 +2074,15 @@ describe('rewardsReducer', () => {
         optinAllowedForGeo: true,
         optinAllowedForGeoLoading: false,
         hideUnlinkedAccountsBanner: true,
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: true,
+          marketId: null,
+          outcome: null,
+          orderStatus: null,
+          predictAccountAddress: null,
+          transactionHash: null,
+        },
         hideCurrentAccountNotOptedInBanner: [
           {
             accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
@@ -2204,6 +2219,15 @@ describe('rewardsReducer', () => {
         optinAllowedForGeo: true,
         optinAllowedForGeoLoading: false,
         hideUnlinkedAccountsBanner: true,
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: true,
+          marketId: null,
+          outcome: null,
+          orderStatus: null,
+          predictAccountAddress: null,
+          transactionHash: null,
+        },
         hideCurrentAccountNotOptedInBanner: [
           {
             accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
@@ -2303,6 +2327,8 @@ describe('rewardsReducer', () => {
         unlockedRewards: persistedRewardsState.unlockedRewards,
         hideUnlinkedAccountsBanner:
           persistedRewardsState.hideUnlinkedAccountsBanner,
+        firstPredictionOnUsInteraction:
+          persistedRewardsState.firstPredictionOnUsInteraction,
         hideCurrentAccountNotOptedInBanner:
           persistedRewardsState.hideCurrentAccountNotOptedInBanner,
         // These fields are restored from persisted state
@@ -2488,6 +2514,15 @@ describe('rewardsReducer', () => {
           },
         ],
         hideUnlinkedAccountsBanner: true,
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: true,
+          marketId: null,
+          outcome: null,
+          orderStatus: null,
+          predictAccountAddress: null,
+          transactionHash: null,
+        },
         hideCurrentAccountNotOptedInBanner: [
           {
             accountGroupId: 'keyring:wallet1/1' as AccountGroupId,
@@ -7065,6 +7100,164 @@ describe('ondoCampaignDeposits', () => {
 
       expect(state.vipSplashAccepted).toEqual({
         'old-sub': true,
+      });
+    });
+  });
+
+  describe('setCandidateSubscriptionId — preserves firstPredictionOnUsInteraction', () => {
+    it('preserves the interaction trail when subscription ID changes', () => {
+      const stateWithInteraction: RewardsState = {
+        ...initialState,
+        candidateSubscriptionId: 'old-sub',
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: false,
+          marketId: 'market-1',
+          outcome: 'Yes',
+          orderStatus: 'executed',
+          predictAccountAddress: '0xabc',
+          transactionHash: '0xhash',
+        },
+      };
+
+      const state = rewardsReducer(
+        stateWithInteraction,
+        setCandidateSubscriptionId('new-sub'),
+      );
+
+      expect(state.firstPredictionOnUsInteraction).toEqual({
+        offerViewed: true,
+        skipped: false,
+        marketId: 'market-1',
+        outcome: 'Yes',
+        orderStatus: 'executed',
+        predictAccountAddress: '0xabc',
+        transactionHash: '0xhash',
+      });
+    });
+  });
+
+  describe('First Prediction On Us interaction actions', () => {
+    it('marks the offer as viewed', () => {
+      const state = rewardsReducer(
+        initialState,
+        markFirstPredictionOnUsOfferViewed(),
+      );
+
+      expect(state.firstPredictionOnUsInteraction.offerViewed).toBe(true);
+    });
+
+    it('marks the offer as skipped', () => {
+      const state = rewardsReducer(
+        initialState,
+        markFirstPredictionOnUsSkipped(),
+      );
+
+      expect(state.firstPredictionOnUsInteraction.skipped).toBe(true);
+    });
+
+    it('records outcome opened details and clears prior order evidence', () => {
+      const seeded: RewardsState = {
+        ...initialState,
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: false,
+          marketId: 'old-market',
+          outcome: 'No',
+          orderStatus: 'executed',
+          predictAccountAddress: '0xold',
+          transactionHash: '0xoldhash',
+        },
+      };
+
+      const state = rewardsReducer(
+        seeded,
+        markFirstPredictionOnUsOutcomeOpened({
+          marketId: 'market-1',
+          outcome: 'Yes',
+        }),
+      );
+
+      expect(state.firstPredictionOnUsInteraction).toEqual({
+        offerViewed: true,
+        skipped: false,
+        marketId: 'market-1',
+        outcome: 'Yes',
+        orderStatus: null,
+        predictAccountAddress: null,
+        transactionHash: null,
+      });
+    });
+
+    it('records confirmed order status', () => {
+      const state = rewardsReducer(
+        initialState,
+        markFirstPredictionOnUsOrderConfirmed({
+          marketId: 'market-1',
+          outcome: 'Yes',
+        }),
+      );
+
+      expect(state.firstPredictionOnUsInteraction).toMatchObject({
+        skipped: false,
+        marketId: 'market-1',
+        outcome: 'Yes',
+        orderStatus: 'confirmed',
+      });
+    });
+
+    it('records executed order status with account and transaction evidence', () => {
+      const state = rewardsReducer(
+        initialState,
+        markFirstPredictionOnUsOrderExecuted({
+          marketId: 'market-1',
+          outcome: 'Yes',
+          predictAccountAddress: '0xabc',
+          transactionHash: '0xhash',
+        }),
+      );
+
+      expect(state.firstPredictionOnUsInteraction).toEqual({
+        offerViewed: false,
+        skipped: false,
+        marketId: 'market-1',
+        outcome: 'Yes',
+        orderStatus: 'executed',
+        predictAccountAddress: '0xabc',
+        transactionHash: '0xhash',
+      });
+    });
+
+    it('records failed order status and clears account evidence', () => {
+      const seeded: RewardsState = {
+        ...initialState,
+        firstPredictionOnUsInteraction: {
+          offerViewed: true,
+          skipped: false,
+          marketId: 'market-1',
+          outcome: 'Yes',
+          orderStatus: 'confirmed',
+          predictAccountAddress: '0xabc',
+          transactionHash: '0xhash',
+        },
+      };
+
+      const state = rewardsReducer(
+        seeded,
+        markFirstPredictionOnUsOrderFailed({
+          marketId: 'market-1',
+          outcome: 'Yes',
+        }),
+      );
+
+      expect(state.firstPredictionOnUsInteraction).toEqual({
+        offerViewed: true,
+        skipped: false,
+        marketId: 'market-1',
+        outcome: 'Yes',
+        orderStatus: 'failed',
+        predictAccountAddress: null,
+        transactionHash: null,
       });
     });
   });

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -80,6 +80,32 @@ export interface BulkLinkState {
   initialSubscriptionId: string | null;
 }
 
+export type FirstPredictionOnUsOrderStatus =
+  | 'confirmed'
+  | 'executed'
+  | 'failed';
+
+export interface FirstPredictionOnUsInteraction {
+  offerViewed: boolean;
+  skipped: boolean;
+  marketId: string | null;
+  outcome: string | null;
+  orderStatus: FirstPredictionOnUsOrderStatus | null;
+  predictAccountAddress: string | null;
+  transactionHash: string | null;
+}
+
+export const initialFirstPredictionOnUsInteraction: FirstPredictionOnUsInteraction =
+  {
+    offerViewed: false,
+    skipped: false,
+    marketId: null,
+    outcome: null,
+    orderStatus: null,
+    predictAccountAddress: null,
+    transactionHash: null,
+  };
+
 export interface RewardsState {
   activeTab: 'overview' | 'campaigns' | 'activity';
   seasonStatusLoading: boolean;
@@ -245,6 +271,12 @@ export interface RewardsState {
 
   // Subscribed campaign start reminders (keyed by `${subscriptionId}:${campaignId}`)
   subscribedCampaignReminders: Record<string, boolean>;
+
+  // Customer-support trail for First Prediction On Us. Included in exported
+  // state logs so support can see whether the user viewed, skipped, or
+  // predicted — and the predict account / tx hash when a real order executes.
+  // `offerViewed` is also the one-time guard that prevents re-showing the splash.
+  firstPredictionOnUsInteraction: FirstPredictionOnUsInteraction;
 }
 
 /**
@@ -373,6 +405,8 @@ export const initialState: RewardsState = {
   dismissedCampaignOutcomeToasts: {},
 
   subscribedCampaignReminders: {},
+
+  firstPredictionOnUsInteraction: initialFirstPredictionOnUsInteraction,
 };
 
 interface RehydrateAction extends Action<'persist/REHYDRATE'> {
@@ -553,6 +587,7 @@ const rewardsSlice = createSlice({
           bulkLink: state.bulkLink,
           dismissedCampaignOutcomeToasts: state.dismissedCampaignOutcomeToasts,
           subscribedCampaignReminders: state.subscribedCampaignReminders,
+          firstPredictionOnUsInteraction: state.firstPredictionOnUsInteraction,
           vipSplashAccepted: state.vipSplashAccepted,
           vipRefereeSplashAccepted: state.vipRefereeSplashAccepted,
           versionGuardMinimumMobileVersion:
@@ -1252,6 +1287,67 @@ const rewardsSlice = createSlice({
       );
       state.subscribedCampaignReminders[key] = true;
     },
+
+    markFirstPredictionOnUsOfferViewed: (state) => {
+      state.firstPredictionOnUsInteraction.offerViewed = true;
+    },
+
+    markFirstPredictionOnUsSkipped: (state) => {
+      state.firstPredictionOnUsInteraction.skipped = true;
+    },
+
+    markFirstPredictionOnUsOutcomeOpened: (
+      state,
+      action: PayloadAction<{ marketId: string; outcome: string }>,
+    ) => {
+      state.firstPredictionOnUsInteraction.skipped = false;
+      state.firstPredictionOnUsInteraction.marketId = action.payload.marketId;
+      state.firstPredictionOnUsInteraction.outcome = action.payload.outcome;
+      state.firstPredictionOnUsInteraction.orderStatus = null;
+      state.firstPredictionOnUsInteraction.predictAccountAddress = null;
+      state.firstPredictionOnUsInteraction.transactionHash = null;
+    },
+
+    markFirstPredictionOnUsOrderConfirmed: (
+      state,
+      action: PayloadAction<{ marketId: string; outcome: string }>,
+    ) => {
+      state.firstPredictionOnUsInteraction.skipped = false;
+      state.firstPredictionOnUsInteraction.marketId = action.payload.marketId;
+      state.firstPredictionOnUsInteraction.outcome = action.payload.outcome;
+      state.firstPredictionOnUsInteraction.orderStatus = 'confirmed';
+    },
+
+    markFirstPredictionOnUsOrderExecuted: (
+      state,
+      action: PayloadAction<{
+        marketId: string;
+        outcome: string;
+        predictAccountAddress: string;
+        transactionHash: string;
+      }>,
+    ) => {
+      state.firstPredictionOnUsInteraction.skipped = false;
+      state.firstPredictionOnUsInteraction.marketId = action.payload.marketId;
+      state.firstPredictionOnUsInteraction.outcome = action.payload.outcome;
+      state.firstPredictionOnUsInteraction.orderStatus = 'executed';
+      state.firstPredictionOnUsInteraction.predictAccountAddress =
+        action.payload.predictAccountAddress;
+      state.firstPredictionOnUsInteraction.transactionHash =
+        action.payload.transactionHash;
+    },
+
+    markFirstPredictionOnUsOrderFailed: (
+      state,
+      action: PayloadAction<{ marketId: string; outcome: string }>,
+    ) => {
+      state.firstPredictionOnUsInteraction.skipped = false;
+      state.firstPredictionOnUsInteraction.marketId = action.payload.marketId;
+      state.firstPredictionOnUsInteraction.outcome = action.payload.outcome;
+      state.firstPredictionOnUsInteraction.orderStatus = 'failed';
+      state.firstPredictionOnUsInteraction.predictAccountAddress = null;
+      state.firstPredictionOnUsInteraction.transactionHash = null;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -1322,6 +1418,11 @@ const rewardsSlice = createSlice({
 
               subscribedCampaignReminders:
                 action.payload.rewards.subscribedCampaignReminders ?? {},
+
+              firstPredictionOnUsInteraction: {
+                ...initialFirstPredictionOnUsInteraction,
+                ...action.payload.rewards.firstPredictionOnUsInteraction,
+              },
 
               // Bulk link state - preserve interrupted status for resume capability
               bulkLink: {
@@ -1433,6 +1534,12 @@ export const {
   setPendingDeeplink,
   dismissCampaignOutcomeToast,
   subscribeCampaignReminder,
+  markFirstPredictionOnUsOfferViewed,
+  markFirstPredictionOnUsSkipped,
+  markFirstPredictionOnUsOutcomeOpened,
+  markFirstPredictionOnUsOrderConfirmed,
+  markFirstPredictionOnUsOrderExecuted,
+  markFirstPredictionOnUsOrderFailed,
 } = rewardsSlice.actions;
 
 export default rewardsSlice.reducer;

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -465,6 +465,10 @@ export const selectSubscribedCampaignReminders = (
   state.rewards.subscribedCampaignReminders ??
   initialState.subscribedCampaignReminders;
 
+export const selectFirstPredictOnUsOfferViewed = (state: RootState): boolean =>
+  state.rewards.firstPredictionOnUsInteraction?.offerViewed ??
+  initialState.firstPredictionOnUsInteraction.offerViewed;
+
 export const selectIsCampaignOutcomeToastDismissed =
   (
     subscriptionId: string | undefined,


### PR DESCRIPTION
## Description

Wires **First Predict On Us** into seedless onboarding (RWDS-1435 4/4): launch orchestration, navigation registration, and persisted Rewards state.

### Analytics & support state

Builds on PR 3/4 (#32859) Segment events and adds customer-support state persistence:

- Replaces `firstPredictOnUsSplashShown` with `firstPredictionOnUsInteraction` (`offerViewed`, `skipped`, market/outcome, order status, predict account, tx hash)
- `offerViewed` is the one-time splash guard
- UI dispatches support-state updates alongside Segment events
- Predict account address / tx hash reserved for real order wiring (not sent to Segment)

Schema: [segment-schema#684](https://github.com/Consensys/segment-schema/pull/684)  
Parent: https://github.com/MetaMask/metamask-mobile/pull/32688  
Base: `rwds-1435/3-rewards-ui` (#32859)

## Test plan

- [ ] Unit tests for resolve util, rewards reducer, and ChoosePassword wiring pass
- [ ] Eligible social-login user sees splash once; `offerViewed` prevents re-show
- [ ] Skip sets `skipped: true` in Rewards state and appears in exported state logs
- [ ] Outcome open / order confirm update interaction trail with market and outcome

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-wallet seedless onboarding navigation path and introduces Predict market resolution plus persisted interaction state, but launch is heavily gated and failures/timeouts skip the splash safely.
> 
> **Overview**
> Wires **First Predict On Us** into seedless onboarding as an optional step after wallet creation (and after the interest questionnaire when shown).
> 
> **Launch orchestration:** New `resolveFirstPredictOnUsLaunch` runs off-screen with a timeout, checking the feature flag, persisted `offerViewed`, Predict geo eligibility, Rewards CMS content, and resolving Predict markets from backend refs (optional `conditionId` filtering). `ChoosePassword` starts this resolution early for social-login users and, on continue, **resets** to the splash with resolved content/markets or falls through to the existing onboarding success flow.
> 
> **Navigation:** Onboarding stack registers the splash (non-gestural) and transparent-modal order sheet routes.
> 
> **Support state:** Rewards Redux gains persisted `firstPredictionOnUsInteraction` (viewed, skipped, market/outcome, order status, predict account, tx hash) with actions dispatched alongside existing Segment events from the splash, carousel, and order sheet. `offerViewed` is the one-time re-show guard.
> 
> Tests cover the resolver, reducer, ChoosePassword navigation paths, and UI dispatch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7b72b0dc67cf61f27a9e437465022855d3fe46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->