### PR TITLE
fix: cursor should not be visible on MM Pay transaction page when keyboard is not visible

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -289,6 +289,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             isLoading={isPrefillPending}
             onPress={handleAmountPress}
             disabled={!hasPaymentOption}
+            showCursor={isKeyboardVisible}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -107,17 +107,25 @@ describe('CustomAmount', () => {
     expect(getByText('123.45')).toBeOnTheScreen();
   });
 
-  it('renders blinking cursor when not disabled', () => {
+  it('renders blinking cursor when showCursor is true', () => {
     const { getByTestId } = renderWithProvider(
-      <CustomAmount amountFiat="100" />,
+      <CustomAmount amountFiat="100" showCursor />,
     );
 
     expect(getByTestId('custom-amount-cursor')).toBeOnTheScreen();
   });
 
+  it('does not render cursor when showCursor is false', () => {
+    const { queryByTestId } = renderWithProvider(
+      <CustomAmount amountFiat="100" showCursor={false} />,
+    );
+
+    expect(queryByTestId('custom-amount-cursor')).toBeNull();
+  });
+
   it('does not render cursor when disabled', () => {
     const { queryByTestId } = renderWithProvider(
-      <CustomAmount amountFiat="100" disabled />,
+      <CustomAmount amountFiat="100" disabled showCursor />,
     );
 
     expect(queryByTestId('custom-amount-cursor')).toBeNull();
@@ -125,7 +133,7 @@ describe('CustomAmount', () => {
 
   it('does not render cursor when loading', () => {
     const { queryByTestId } = renderWithProvider(
-      <CustomAmount amountFiat="100" isLoading />,
+      <CustomAmount amountFiat="100" isLoading showCursor />,
     );
 
     expect(queryByTestId('custom-amount-cursor')).toBeNull();

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -22,6 +22,7 @@ export interface CustomAmountProps {
   hasAlert?: boolean;
   isLoading?: boolean;
   onPress?: () => void;
+  showCursor?: boolean;
 }
 
 export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
@@ -32,6 +33,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
     hasAlert = false,
     isLoading,
     onPress,
+    showCursor = true,
   } = props;
 
   const { isHeadlessBuyInProgress } = useConfirmationContext();
@@ -51,7 +53,8 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   });
 
   const showLoader = isLoading || (isMaxAmount && isQuotesLoading);
-  const cursorOpacity = useBlinkingCursor(!disabled && !showLoader);
+  const cursorVisible = showCursor && !disabled && !showLoader;
+  const cursorOpacity = useBlinkingCursor(cursorVisible);
 
   if (showLoader) {
     return <CustomAmountSkeleton />;
@@ -69,7 +72,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
       >
         {formattedAmount}
       </Text>
-      {!disabled && (
+      {cursorVisible && (
         <Animated.View
           testID="custom-amount-cursor"
           style={[styles.cursor, { opacity: cursorOpacity }]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Cursor should not be visible on MM Pay transaction page when keyboard is not visible

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1642

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized confirmation UI behavior with a backward-compatible default prop and updated unit tests; no payment, auth, or data-path changes.
> 
> **Overview**
> Fixes the MM Pay custom amount field showing a blinking input cursor after the user dismisses the amount keyboard (e.g. after **Done**), when only the confirm/summary UI is visible.
> 
> **`CustomAmount`** now accepts an optional **`showCursor`** prop (default **`true`**) and only shows the blinking cursor when **`showCursor`** is set and the field is not disabled or in a loading state. **`CustomAmountInfo`** passes **`showCursor={isKeyboardVisible}`** so the cursor appears only while the deposit keyboard is open.
> 
> Unit tests were updated to assert cursor behavior via **`showCursor`** instead of inferring it from disabled/loading alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a698d40660921d5b1751f466ed091178c3361f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->