### PR TITLE
fix: remove tsc check from registry updates

### DIFF
--- a/tests/feature-flags/sync-production-flags.test.ts
+++ b/tests/feature-flags/sync-production-flags.test.ts
@@ -5,12 +5,7 @@ jest.mock('prettier', () => ({
   },
 }));
 
-jest.mock('child_process', () => ({
-  execFileSync: jest.fn(),
-}));
-
 /* eslint-disable import-x/no-nodejs-modules -- Node.js script for CI/sync */
-import { execFileSync } from 'child_process';
 import fs from 'fs';
 import {
   getProductionRemoteFlagApiResponse,
@@ -429,14 +424,7 @@ describe('findDuplicateRegistryKeys', () => {
 });
 
 describe('validateRegistryFile', () => {
-  const mockedExecFileSync = execFileSync as unknown as jest.Mock;
-
-  beforeEach(() => {
-    mockedExecFileSync.mockReset();
-  });
-
-  it('returns empty array for valid content with no duplicates and clean tsc', () => {
-    mockedExecFileSync.mockReturnValue('');
+  it('returns empty array for valid content with no duplicates', () => {
     const content = `
   flagA: {
     name: 'flagA',
@@ -449,7 +437,6 @@ describe('validateRegistryFile', () => {
   });
 
   it('returns duplicate key errors', () => {
-    mockedExecFileSync.mockReturnValue('');
     const content = `
   flagA: {
     name: 'flagA',
@@ -461,80 +448,6 @@ describe('validateRegistryFile', () => {
     const errors = validateRegistryFile(content);
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0]).toContain('flagA');
-  });
-
-  it('returns TypeScript errors from tsc', () => {
-    const tsError =
-      'feature-flag-registry.ts(10,3): error TS1117: Duplicate property';
-    mockedExecFileSync.mockImplementation(() => {
-      const err = new Error('tsc failed') as Error & { stdout: string };
-      err.stdout = tsError;
-      throw err;
-    });
-    const content = `
-  flagA: {
-    name: 'flagA',
-  },
-`;
-    const errors = validateRegistryFile(content);
-    expect(errors).toContainEqual(expect.stringContaining('error TS1117'));
-  });
-
-  it('catches chained TypeScript errors from imported files', () => {
-    const chainedError =
-      'node_modules/@metamask/utils/types.d.ts(5,1): error TS2305: Module has no exported member';
-    mockedExecFileSync.mockImplementation(() => {
-      const err = new Error('tsc failed') as Error & { stdout: string };
-      err.stdout = chainedError;
-      throw err;
-    });
-    const content = `
-  flagA: {
-    name: 'flagA',
-  },
-`;
-    const errors = validateRegistryFile(content);
-    expect(errors).toContainEqual(expect.stringContaining('error TS2305'));
-  });
-
-  it('reports error when tsc fails to spawn with no output', () => {
-    mockedExecFileSync.mockImplementation(() => {
-      const err = new Error('ENOENT') as Error & {
-        stdout: string;
-        stderr: string;
-      };
-      err.stdout = '';
-      err.stderr = '';
-      throw err;
-    });
-    const content = `
-  flagA: {
-    name: 'flagA',
-  },
-`;
-    const errors = validateRegistryFile(content);
-    expect(errors).toContainEqual(expect.stringContaining('tsc failed to run'));
-  });
-
-  it('reports error when tsc exits with non-TS diagnostic output', () => {
-    mockedExecFileSync.mockImplementation(() => {
-      const err = new Error('tsc failed') as Error & {
-        stdout: string;
-        stderr: string;
-      };
-      err.stdout = 'Some unexpected compiler crash output';
-      err.stderr = '';
-      throw err;
-    });
-    const content = `
-  flagA: {
-    name: 'flagA',
-  },
-`;
-    const errors = validateRegistryFile(content);
-    expect(errors).toContainEqual(
-      expect.stringContaining('tsc exited with an error'),
-    );
   });
 });
 

--- a/tests/feature-flags/sync-production-flags.ts
+++ b/tests/feature-flags/sync-production-flags.ts
@@ -22,8 +22,6 @@
  */
 
 // eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
-import { execFileSync } from 'child_process';
-// eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
 import fs from 'fs';
 // eslint-disable-next-line import-x/no-nodejs-modules -- Node.js script for CI/sync
 import path from 'path';
@@ -469,33 +467,6 @@ export function validateRegistryFile(content: string): string[] {
   const duplicates = findDuplicateRegistryKeys(content);
   errors.push(...duplicates);
 
-  const rootDir = path.resolve(__dirname, '../..');
-  try {
-    execFileSync(
-      path.resolve(rootDir, 'node_modules/.bin/tsc'),
-      ['--noEmit', '-p', path.resolve(rootDir, 'tsconfig.json')],
-      { encoding: 'utf-8', stdio: 'pipe', cwd: rootDir },
-    );
-  } catch (err: unknown) {
-    const stdout = (err as { stdout?: string }).stdout ?? '';
-    const stderr = (err as { stderr?: string }).stderr ?? '';
-    if (!stdout && !stderr) {
-      errors.push('tsc failed to run (no output — binary may be missing)');
-    } else {
-      const output = stdout || stderr;
-      const tsErrors = output
-        .split('\n')
-        .filter((line: string) => line.includes('error TS'));
-      if (tsErrors.length > 0) {
-        errors.push(...tsErrors);
-      } else {
-        errors.push(
-          `tsc exited with an error but no TS diagnostics found: ${output.trim().split('\n')[0]}`,
-        );
-      }
-    }
-  }
-
   return errors;
 }
 
@@ -746,12 +717,14 @@ export async function updateRegistryFile(result: SyncResult): Promise<void> {
 
   const validationErrors = validateRegistryFile(finalContent);
   if (validationErrors.length > 0) {
-    console.error(c.red('\n✗ Post-write validation failed:'));
+    console.warn(c.yellow('\n⚠ Post-write validation warnings:'));
     for (const err of validationErrors) {
-      console.error(c.red(`  - ${err}`));
+      console.warn(c.yellow(`  - ${err}`));
     }
-    throw new Error(
-      `Registry file has ${validationErrors.length} validation error(s)`,
+    console.warn(
+      c.yellow(
+        'The registry file was written but has validation issues that need manual attention.',
+      ),
     );
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Removes the tsc check on FF registry update as this is done in CI already

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: 

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

NA

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->
N/A

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling change to the sync script and its tests only; no runtime app or auth paths affected.
> 
> **Overview**
> **Removes the post-update `tsc --noEmit` check** from the production feature-flag sync script (`validateRegistryFile` / `updateRegistryFile`), since TypeScript is already validated in CI.
> 
> `validateRegistryFile` now only reports **duplicate registry keys** via `findDuplicateRegistryKeys`; the `child_process` / `execFileSync` import and all tsc error parsing are gone.
> 
> After `feature-flags:sync:update` writes the registry, **duplicate-key issues are warnings** (yellow console output) instead of failing the run with a thrown error. Tests drop the `child_process` mock and the cases that asserted tsc failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888a769dd0f2418f3093a4b3126d1566109a05f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->