### PR TITLE
feat: register withdraw destination token in unified assets state

### DIFF
--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -37,6 +37,7 @@ import { usePredictBalanceTokenFilter } from '../../../../../UI/Predict/hooks/us
 
 const mockAddTokens = jest.fn().mockResolvedValue(undefined);
 const mockRenderNoFeeTag = jest.fn(() => null);
+const mockEnsurePayToken = jest.fn().mockResolvedValue(undefined);
 const mockFindNetworkClientIdByChainId = jest
   .fn()
   .mockReturnValue('network-client-1');

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -38,6 +38,7 @@ import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaym
 import { usePredictBalanceTokenFilter } from '../../../../../UI/Predict/hooks/usePredictBalanceTokenFilter';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
 import { usePayWithNoFeeToken } from '../../../hooks/pay/usePayWithNoFeeToken';
+import { useEnsurePayToken } from '../../../hooks/tokens/useEnsurePayToken';
 
 interface PayWithModalParams {
   /**
@@ -85,6 +86,7 @@ export function PayWithModal() {
     isPredictContext,
     isPredictContext ? resetSelectedPaymentToken : undefined,
   );
+  const ensurePayToken = useEnsurePayToken();
 
   const isMoneyAccount = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountDeposit,
@@ -183,6 +185,18 @@ export function PayWithModal() {
           } catch {
             // Network not configured — skip
           }
+
+          // Adding via TokensController only covers legacy metadata. Ensure the
+          // token is also registered in unified assets state, so the pay
+          // controller can resolve it (otherwise it throws "Payment token not
+          // found").
+          await ensurePayToken({
+            address: token.address as Hex,
+            chainId: token.chainId as Hex,
+            symbol: token.symbol,
+            decimals: token.decimals,
+            name: token.name,
+          });
         }
 
         setPayToken({
@@ -196,6 +210,7 @@ export function PayWithModal() {
     [
       close,
       dismissOnSelectCount,
+      ensurePayToken,
       isPredictContext,
       isWithdraw,
       navigation,

--- a/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.test.ts
@@ -2,6 +2,7 @@ import { act } from '@testing-library/react-native';
 import { merge } from 'lodash';
 import Engine from '../../../../../core/Engine';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
 import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
@@ -9,6 +10,7 @@ import {
   accountMock,
   otherControllersMock,
 } from '../../__mocks__/controllers/other-controllers-mock';
+import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useEnsurePayToken } from './useEnsurePayToken';
 
 jest.mock('../../../../../core/Engine', () => ({
@@ -40,12 +42,21 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../selectors/accountsController'),
+  selectInternalAccountByAddresses: jest.fn(() => () => []),
+}));
+
 jest.mock('../../../../../selectors/networkController', () => ({
   ...jest.requireActual('../../../../../selectors/networkController'),
   selectNetworkConfigurations: jest.fn(() => ({})),
 }));
 
+jest.mock('../transactions/useTransactionAccountOverride');
+
 const ACCOUNT_ID_MOCK = 'mock-account-id';
+const OVERRIDE_ACCOUNT_ID_MOCK = 'mock-override-account-id';
+const OVERRIDE_ADDRESS_MOCK = '0xOverrideAddress';
 const TOKEN_ADDRESS_MOCK =
   '0x55d398326f99059fF775485246999027B3197955' as const;
 const CHAIN_ID_MOCK = '0x38' as const; // BNB
@@ -103,6 +114,10 @@ describe('useEnsurePayToken', () => {
     (selectNetworkConfigurations as unknown as jest.Mock).mockReturnValue({
       [CHAIN_ID_MOCK]: { nativeCurrency: 'BNB' },
     });
+    jest.mocked(useTransactionAccountOverride).mockReturnValue(undefined);
+    (selectInternalAccountByAddresses as unknown as jest.Mock).mockReturnValue(
+      () => [],
+    );
   });
 
   describe('unified assets state', () => {
@@ -173,6 +188,50 @@ describe('useEnsurePayToken', () => {
 
       await expect(runEnsure()).resolves.toBeUndefined();
       expect(mockGetAssets).toHaveBeenCalled();
+    });
+
+    it('registers the token under the transaction pay account override when set', async () => {
+      jest
+        .mocked(useTransactionAccountOverride)
+        .mockReturnValue(OVERRIDE_ADDRESS_MOCK);
+      (
+        selectInternalAccountByAddresses as unknown as jest.Mock
+      ).mockReturnValue(() => [
+        {
+          id: OVERRIDE_ACCOUNT_ID_MOCK,
+          address: OVERRIDE_ADDRESS_MOCK,
+          type: 'eip155:eoa',
+        },
+      ]);
+
+      await runEnsure();
+
+      expect(mockAddCustomAsset).toHaveBeenCalledWith(
+        OVERRIDE_ACCOUNT_ID_MOCK,
+        expect.any(String),
+        expect.anything(),
+      );
+      expect(mockGetAssets).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: OVERRIDE_ACCOUNT_ID_MOCK })],
+        expect.anything(),
+      );
+    });
+
+    it('falls back to the selected account when the override address has no matching account', async () => {
+      jest
+        .mocked(useTransactionAccountOverride)
+        .mockReturnValue(OVERRIDE_ADDRESS_MOCK);
+      (
+        selectInternalAccountByAddresses as unknown as jest.Mock
+      ).mockReturnValue(() => []);
+
+      await runEnsure();
+
+      expect(mockAddCustomAsset).toHaveBeenCalledWith(
+        ACCOUNT_ID_MOCK,
+        expect.any(String),
+        expect.anything(),
+      );
     });
   });
 

--- a/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.test.ts
@@ -1,0 +1,209 @@
+import { act } from '@testing-library/react-native';
+import { merge } from 'lodash';
+import Engine from '../../../../../core/Engine';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+import {
+  accountMock,
+  otherControllersMock,
+} from '../../__mocks__/controllers/other-controllers-mock';
+import { useEnsurePayToken } from './useEnsurePayToken';
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    AssetsController: {
+      addCustomAsset: jest.fn(),
+      getAssets: jest.fn(),
+    },
+    TokenRatesController: {
+      updateExchangeRates: jest.fn(),
+    },
+  },
+}));
+
+jest.mock(
+  '../../../../../selectors/featureFlagController/assetsUnifyState',
+  () => ({
+    selectIsAssetsUnifyStateEnabled: jest.fn(() => false),
+  }),
+);
+
+jest.mock(
+  '../../../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    ...jest.requireActual(
+      '../../../../../selectors/multichainAccounts/accountTreeController',
+    ),
+    selectSelectedAccountGroupEvmInternalAccount: jest.fn(() => null),
+  }),
+);
+
+jest.mock('../../../../../selectors/networkController', () => ({
+  ...jest.requireActual('../../../../../selectors/networkController'),
+  selectNetworkConfigurations: jest.fn(() => ({})),
+}));
+
+const ACCOUNT_ID_MOCK = 'mock-account-id';
+const TOKEN_ADDRESS_MOCK =
+  '0x55d398326f99059fF775485246999027B3197955' as const;
+const CHAIN_ID_MOCK = '0x38' as const; // BNB
+const SYMBOL_MOCK = 'USDT';
+const DECIMALS_MOCK = 18;
+const NAME_MOCK = 'Tether USD';
+
+function renderEnsurePayToken() {
+  return renderHookWithProvider(() => useEnsurePayToken(), {
+    state: merge({}, otherControllersMock),
+  });
+}
+
+async function runEnsure(overrides: Partial<Record<string, unknown>> = {}) {
+  const { result } = renderEnsurePayToken();
+
+  await act(async () => {
+    await result.current({
+      address: TOKEN_ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      symbol: SYMBOL_MOCK,
+      decimals: DECIMALS_MOCK,
+      name: NAME_MOCK,
+      ...overrides,
+    });
+  });
+}
+
+describe('useEnsurePayToken', () => {
+  const mockAddCustomAsset = jest.mocked(
+    Engine.context.AssetsController.addCustomAsset,
+  );
+  const mockGetAssets = jest.mocked(Engine.context.AssetsController.getAssets);
+  const mockUpdateExchangeRates = jest.mocked(
+    Engine.context.TokenRatesController.updateExchangeRates,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockAddCustomAsset.mockResolvedValue(undefined);
+    mockGetAssets.mockResolvedValue({});
+    mockUpdateExchangeRates.mockResolvedValue(undefined);
+
+    (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+    (
+      selectSelectedAccountGroupEvmInternalAccount as unknown as jest.Mock
+    ).mockReturnValue({
+      id: ACCOUNT_ID_MOCK,
+      address: accountMock,
+      type: 'eip155:eoa',
+    });
+    (selectNetworkConfigurations as unknown as jest.Mock).mockReturnValue({
+      [CHAIN_ID_MOCK]: { nativeCurrency: 'BNB' },
+    });
+  });
+
+  describe('unified assets state', () => {
+    beforeEach(() => {
+      (selectIsAssetsUnifyStateEnabled as unknown as jest.Mock).mockReturnValue(
+        true,
+      );
+    });
+
+    it('registers the token via addCustomAsset', async () => {
+      await runEnsure();
+
+      expect(mockAddCustomAsset).toHaveBeenCalledWith(
+        ACCOUNT_ID_MOCK,
+        expect.stringContaining('erc20'),
+        {
+          address: TOKEN_ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          decimals: DECIMALS_MOCK,
+          name: NAME_MOCK,
+          symbol: SYMBOL_MOCK,
+        },
+      );
+    });
+
+    it('falls back to symbol when name is missing', async () => {
+      await runEnsure({ name: undefined });
+
+      expect(mockAddCustomAsset).toHaveBeenCalledWith(
+        ACCOUNT_ID_MOCK,
+        expect.any(String),
+        expect.objectContaining({ name: SYMBOL_MOCK }),
+      );
+    });
+
+    it('refreshes the price via getAssets', async () => {
+      await runEnsure();
+
+      expect(mockGetAssets).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: ACCOUNT_ID_MOCK })],
+        expect.objectContaining({
+          dataTypes: ['price'],
+          forceUpdate: true,
+          assetsForPriceUpdate: [expect.stringContaining('erc20')],
+        }),
+      );
+    });
+
+    it('does not use the legacy TokenRatesController path', async () => {
+      await runEnsure();
+
+      expect(mockUpdateExchangeRates).not.toHaveBeenCalled();
+    });
+
+    it('skips registration and price when there is no EVM account', async () => {
+      (
+        selectSelectedAccountGroupEvmInternalAccount as unknown as jest.Mock
+      ).mockReturnValue(null);
+
+      await runEnsure();
+
+      expect(mockAddCustomAsset).not.toHaveBeenCalled();
+      expect(mockGetAssets).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when addCustomAsset rejects', async () => {
+      mockAddCustomAsset.mockRejectedValue(new Error('boom'));
+
+      await expect(runEnsure()).resolves.toBeUndefined();
+      expect(mockGetAssets).toHaveBeenCalled();
+    });
+  });
+
+  describe('legacy assets state', () => {
+    it('refreshes the rate via TokenRatesController.updateExchangeRates', async () => {
+      await runEnsure();
+
+      expect(mockUpdateExchangeRates).toHaveBeenCalledWith([
+        { chainId: CHAIN_ID_MOCK, nativeCurrency: 'BNB' },
+      ]);
+    });
+
+    it('does not use the unified path', async () => {
+      await runEnsure();
+
+      expect(mockAddCustomAsset).not.toHaveBeenCalled();
+      expect(mockGetAssets).not.toHaveBeenCalled();
+    });
+
+    it('skips the rate refresh when the chain has no native currency', async () => {
+      (selectNetworkConfigurations as unknown as jest.Mock).mockReturnValue({});
+
+      await runEnsure();
+
+      expect(mockUpdateExchangeRates).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when updateExchangeRates rejects', async () => {
+      mockUpdateExchangeRates.mockRejectedValue(new Error('boom'));
+
+      await expect(runEnsure()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.ts
@@ -4,10 +4,12 @@ import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import type { Caip19AssetId } from '@metamask/assets-controller';
 import { Hex, createProjectLogger } from '@metamask/utils';
 import Engine from '../../../../../core/Engine';
+import { selectInternalAccountByAddresses } from '../../../../../selectors/accountsController';
 import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { toAssetId } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 
 const log = createProjectLogger('pay-token-ensure');
 
@@ -28,6 +30,12 @@ export interface EnsurePayTokenParams {
  * user does not already hold) must be registered there via `addCustomAsset`.
  * The token's fiat rate is also refreshed best-effort. Failures are logged and
  * swallowed so token selection is never blocked.
+ *
+ * The token must be registered under the same account the pay controller
+ * uses to resolve the transaction: the transaction's pay account override
+ * when set, otherwise the globally selected account. Using the wrong account
+ * (e.g. always the globally selected one) can leave the token unresolved
+ * when an override is active.
  */
 export function useEnsurePayToken(): (
   token: EnsurePayTokenParams,
@@ -35,7 +43,17 @@ export function useEnsurePayToken(): (
   const isAssetsUnifyStateEnabled = useSelector(
     selectIsAssetsUnifyStateEnabled,
   );
-  const evmAccount = useSelector(selectSelectedAccountGroupEvmInternalAccount);
+  const selectedEvmAccount = useSelector(
+    selectSelectedAccountGroupEvmInternalAccount,
+  );
+  const accountOverride = useTransactionAccountOverride();
+  const getInternalAccountsByAddresses = useSelector(
+    selectInternalAccountByAddresses,
+  );
+  const overrideAccount = accountOverride
+    ? getInternalAccountsByAddresses([accountOverride])[0]
+    : undefined;
+  const evmAccount = overrideAccount ?? selectedEvmAccount;
   const networkConfigurations = useSelector(selectNetworkConfigurations);
 
   return useCallback(

--- a/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useEnsurePayToken.ts
@@ -1,0 +1,106 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import type { Caip19AssetId } from '@metamask/assets-controller';
+import { Hex, createProjectLogger } from '@metamask/utils';
+import Engine from '../../../../../core/Engine';
+import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+import { toAssetId } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+
+const log = createProjectLogger('pay-token-ensure');
+
+export interface EnsurePayTokenParams {
+  address: Hex;
+  chainId: Hex;
+  symbol: string;
+  decimals: number;
+  name?: string;
+}
+
+/**
+ * Returns a callback that ensures a token can be resolved by the pay
+ * controller before it is selected as a receive/pay token.
+ *
+ * In unified assets state the pay controller reads token metadata from
+ * AssetsController, so a freshly-selected withdraw destination token (one the
+ * user does not already hold) must be registered there via `addCustomAsset`.
+ * The token's fiat rate is also refreshed best-effort. Failures are logged and
+ * swallowed so token selection is never blocked.
+ */
+export function useEnsurePayToken(): (
+  token: EnsurePayTokenParams,
+) => Promise<void> {
+  const isAssetsUnifyStateEnabled = useSelector(
+    selectIsAssetsUnifyStateEnabled,
+  );
+  const evmAccount = useSelector(selectSelectedAccountGroupEvmInternalAccount);
+  const networkConfigurations = useSelector(selectNetworkConfigurations);
+
+  return useCallback(
+    async ({
+      address,
+      chainId,
+      symbol,
+      decimals,
+      name,
+    }: EnsurePayTokenParams) => {
+      const { AssetsController, TokenRatesController } = Engine.context;
+      const caipChainId = toEvmCaipChainId(chainId);
+      const caipAssetType = toAssetId(address, caipChainId);
+
+      // Register the token in unified assets state so the pay controller can
+      // resolve its metadata (legacy metadata is added by the caller via
+      // TokensController.addTokens).
+      if (
+        isAssetsUnifyStateEnabled &&
+        evmAccount?.id &&
+        caipAssetType &&
+        AssetsController?.addCustomAsset
+      ) {
+        try {
+          await AssetsController.addCustomAsset(
+            evmAccount.id,
+            caipAssetType as Caip19AssetId,
+            { address, chainId, decimals, name: name ?? symbol, symbol },
+          );
+        } catch (error) {
+          log('addCustomAsset failed', { address, chainId, error });
+        }
+      }
+
+      // Refresh the token's fiat/market rate (best-effort). When unavailable
+      // for the token's chain, the pay controller resolves without it for
+      // post-quote/withdraw destinations.
+      try {
+        if (isAssetsUnifyStateEnabled) {
+          if (evmAccount && caipAssetType && AssetsController?.getAssets) {
+            await AssetsController.getAssets([evmAccount], {
+              chainIds: [caipChainId],
+              dataTypes: ['price'],
+              forceUpdate: true,
+              assetsForPriceUpdate: [caipAssetType as Caip19AssetId],
+            });
+          }
+          return;
+        }
+
+        const nativeCurrency = networkConfigurations?.[chainId]?.nativeCurrency;
+
+        if (nativeCurrency && TokenRatesController?.updateExchangeRates) {
+          await TokenRatesController.updateExchangeRates([
+            { chainId, nativeCurrency },
+          ]);
+        }
+      } catch (error) {
+        log('Failed to refresh pay token fiat rate', {
+          address,
+          chainId,
+          error,
+        });
+      }
+    },
+    [isAssetsUnifyStateEnabled, evmAccount, networkConfigurations],
+  );
+}


### PR DESCRIPTION
## **Description**

When a user picks a withdraw destination token they don't already hold (for example, a token on a chain they don't use), the pay controller needs that token's metadata to select it. The app already adds the token to the old `TokensController` for this, but if unified assets state is turned on, the pay controller reads token metadata from `AssetsController` instead, so the token would not be found there.

This adds a `useEnsurePayToken` hook that also registers the token in `AssetsController` (via `addCustomAsset`) and refreshes its price, so token selection keeps working if and when unified assets state is turned on for more users. The `assetsUnifyState` flag is off in production today, so this is a forward-looking safety net, not an active bug fix.

This came out of investigating a "Payment token not found" error on Predict withdraw (see https://github.com/MetaMask/metamask-mobile/pull/32703, which fixes the same error for the case that does affect production today: a missing fiat rate, fixed upstream in `@metamask/transaction-pay-controller`). This PR covers the separate, dev-only-today case for when unified assets state is enabled.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: internal Slack investigation of Predict withdraw "Payment token not found" error

## **Manual testing steps**

~~~gherkin
Feature: Withdraw to a token you don't hold, with unified assets state on

  Scenario: pick a token you don't already have
    Given the assetsUnifyState flag is turned on
    And a Predict or Perps account with money to withdraw
    And you don't hold the destination token yet
    When you open the withdraw screen
    And tap "Receive" then "Other assets"
    And pick that token
    Then the token is selected without an error
~~~

I have not manually tested this on a device yet, since it only matters once the `assetsUnifyState` flag is turned on, which it is not in production today.

## **Screenshots/Recordings**

N/A - this only changes internal token-registration logic, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to pay-with token selection with swallowed errors; unified path is behind a disabled feature flag today, with legacy behavior unchanged aside from optional rate refresh.
> 
> **Overview**
> Adds **`useEnsurePayToken`** so choosing a withdraw/receive token in **PayWithModal** also registers it in unified **`AssetsController`** (not only legacy **`TokensController.addTokens`**), avoiding **"Payment token not found"** when `assetsUnifyState` is on.
> 
> When unified assets are enabled, the hook **`addCustomAsset`**s the token under the pay account (transaction override when set, else selected EVM account), then best-effort refreshes price via **`getAssets`**. With unified assets off, it only triggers legacy **`TokenRatesController.updateExchangeRates`**; failures are logged and never block selection.
> 
> **PayWithModal** awaits this hook after adding legacy token metadata and before **`setPayToken`**. Unit tests cover both flag paths, account override, and error swallowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04e05c74782ef17a3af814736aba131b1c6ded4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->