### PR TITLE
chore: adds value Pills to QuickBuy amount selection

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
@@ -92,6 +92,7 @@ const buildController = (
     description: 'bridge.price_impact_info_description',
   },
   isPriceImpactError: false,
+  isPresetAddFundsMode: false,
   buttonError: null,
   hasValidAmount: false,
   isConfirmDisabled: false,
@@ -207,6 +208,27 @@ describe('QuickBuyProvider — handleBuy', () => {
     expect(setActiveScreen).not.toHaveBeenCalled();
     expect(handleConfirm).not.toHaveBeenCalled();
   });
+
+  it('calls handleConfirm when isPriceImpactError=true but isPresetAddFundsMode=true', async () => {
+    const handleConfirm = jest.fn().mockResolvedValue(undefined);
+    (useQuickBuyController as jest.Mock).mockReturnValue(
+      buildController({
+        isPriceImpactError: true,
+        isPresetAddFundsMode: true,
+        handleConfirm,
+      }),
+    );
+
+    const setActiveScreen = jest.fn();
+    const ctx = renderProvider(featuresWithModal, setActiveScreen);
+
+    await act(async () => {
+      await ctx.current.handleBuy();
+    });
+
+    expect(handleConfirm).toHaveBeenCalledTimes(1);
+    expect(setActiveScreen).not.toHaveBeenCalled();
+  });
 });
 
 describe('QuickBuyProvider — isConfirmDisabled', () => {
@@ -238,6 +260,19 @@ describe('QuickBuyProvider — isConfirmDisabled', () => {
     );
 
     const ctx = renderProvider(featuresWithModal);
+    expect(ctx.current.isConfirmDisabled).toBe(false);
+  });
+
+  it('is false when isPresetAddFundsMode=true even with a price impact error', () => {
+    (useQuickBuyController as jest.Mock).mockReturnValue(
+      buildController({
+        isConfirmDisabled: false,
+        isPriceImpactError: true,
+        isPresetAddFundsMode: true,
+      }),
+    );
+
+    const ctx = renderProvider(featuresWithoutModal);
     expect(ctx.current.isConfirmDisabled).toBe(false);
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
@@ -100,6 +100,8 @@ const buildController = (
   handleClose: jest.fn(),
   handleSliderChange: jest.fn(),
   handleSliderDragEnd: jest.fn(),
+  handleQuickAmountPress: jest.fn(),
+  usdToCurrentCurrencyRate: undefined,
   handleAmountAreaPress: jest.fn(),
   handleAmountChange: jest.fn(),
   handleToggleAmountDisplay: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.tsx
@@ -48,10 +48,11 @@ export const QuickBuyProvider: React.FC<QuickBuyProviderProps> = ({
   children,
 }) => {
   const controller = useQuickBuyController(target, onClose, analyticsContext);
-  const { isPriceImpactError, handleConfirm } = controller;
+  const { isPriceImpactError, isPresetAddFundsMode, handleConfirm } =
+    controller;
 
   const handleBuy = useCallback(async () => {
-    if (isPriceImpactError) {
+    if (!isPresetAddFundsMode && isPriceImpactError) {
       // We guard here to ensure no high-impact trade ever silently proceeds.
       if (features.highPriceImpactModal) {
         setActiveScreen('priceImpactConfirm');
@@ -61,6 +62,7 @@ export const QuickBuyProvider: React.FC<QuickBuyProviderProps> = ({
     await handleConfirm();
   }, [
     features.highPriceImpactModal,
+    isPresetAddFundsMode,
     isPriceImpactError,
     handleConfirm,
     setActiveScreen,
@@ -70,7 +72,9 @@ export const QuickBuyProvider: React.FC<QuickBuyProviderProps> = ({
   // high-impact quote, since there is no other safeguard in place.
   const isConfirmDisabled =
     controller.isConfirmDisabled ||
-    (isPriceImpactError && !features.highPriceImpactModal);
+    (!isPresetAddFundsMode &&
+      isPriceImpactError &&
+      !features.highPriceImpactModal);
 
   const value: QuickBuyContextValue = {
     ...controller,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -219,6 +219,7 @@ const buildHookResult = (
     description: 'bridge.price_impact_info_description',
   },
   isPriceImpactError: false,
+  isPresetAddFundsMode: false,
   buttonError: null,
   hasValidAmount: false,
   isConfirmDisabled: true,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -227,6 +227,8 @@ const buildHookResult = (
   handleClose: jest.fn(),
   handleSliderChange: jest.fn(),
   handleSliderDragEnd: jest.fn(),
+  handleQuickAmountPress: jest.fn(),
+  usdToCurrentCurrencyRate: undefined,
   handleAmountAreaPress: jest.fn(),
   handleAmountChange: jest.fn(),
   handleToggleAmountDisplay: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -243,6 +243,8 @@ const buildHookResult = (
   handleClose: jest.fn(),
   handleSliderChange: jest.fn(),
   handleSliderDragEnd: jest.fn(),
+  handleQuickAmountPress: jest.fn(),
+  usdToCurrentCurrencyRate: undefined,
   handleAmountAreaPress: jest.fn(),
   handleAmountChange: jest.fn(),
   handleToggleAmountDisplay: jest.fn(),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -235,6 +235,7 @@ const buildHookResult = (
     description: 'bridge.price_impact_info_description',
   },
   isPriceImpactError: false,
+  isPresetAddFundsMode: false,
   buttonError: null,
   hasValidAmount: false,
   isConfirmDisabled: true,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
@@ -19,6 +19,7 @@ export const QuickBuyEventProperties = {
   MARKET_CAP: 'market_cap',
   PAY_WITH_TOKEN: 'pay_with_token',
   PRESET_VALUE: 'preset_value',
+  SLIDER_PERCENT: 'slider_percent',
   PREVIOUS_PAY_WITH_TOKEN: 'previous_pay_with_token',
   PREVIOUS_RECEIVE_TOKEN: 'previous_receive_token',
   PREVIOUS_SLIPPAGE: 'previous_slippage',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
@@ -18,6 +18,7 @@ export const QuickBuyEventProperties = {
   LATENCY_MS: 'latency_ms',
   MARKET_CAP: 'market_cap',
   PAY_WITH_TOKEN: 'pay_with_token',
+  PRESET_VALUE: 'preset_value',
   PREVIOUS_PAY_WITH_TOKEN: 'previous_pay_with_token',
   PREVIOUS_RECEIVE_TOKEN: 'previous_receive_token',
   PREVIOUS_SLIPPAGE: 'previous_slippage',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
@@ -15,6 +15,16 @@ jest.mock('./QuickBuyPercentageSlider', () => ({
   QuickBuyPercentageSlider: () => null,
 }));
 
+jest.mock('./QuickBuyQuickAmounts', () => {
+  const ReactMock = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactMock.createElement(Text, { testID: 'quick-buy-quick-amounts' }),
+  };
+});
+
 jest.mock('./QuickBuyTokenIcon', () => ({
   __esModule: true,
   default: () => null,
@@ -78,5 +88,23 @@ describe('QuickBuyActionFooter', () => {
     render(<QuickBuyActionFooter />);
     expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
     expect(screen.getByText('confirm-button:loading')).toBeOnTheScreen();
+  });
+
+  it('renders quick-amount pills when the feature flag is enabled', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      features: { payWithSheet: true, quickAmountPills: true },
+    });
+    render(<QuickBuyActionFooter />);
+    expect(screen.getByTestId('quick-buy-quick-amounts')).toBeOnTheScreen();
+  });
+
+  it('hides quick-amount pills when the feature flag is disabled', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      features: { payWithSheet: true, quickAmountPills: false },
+    });
+    render(<QuickBuyActionFooter />);
+    expect(screen.queryByTestId('quick-buy-quick-amounts')).toBeNull();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -19,6 +19,7 @@ import QuickBuyBanners from '../QuickBuyBanners';
 import QuickBuyConfirmButton from '../QuickBuyConfirmButton';
 import { useQuickBuyContext } from '../useQuickBuyContext';
 import { QuickBuyPercentageSlider } from './QuickBuyPercentageSlider';
+import QuickBuyQuickAmounts from './QuickBuyQuickAmounts';
 import QuickBuyTokenIcon from './QuickBuyTokenIcon';
 
 const QuickBuyActionFooter: React.FC = () => {
@@ -58,6 +59,12 @@ const QuickBuyActionFooter: React.FC = () => {
           onDragEnd={handleSliderDragEnd}
         />
       </Box>
+
+      {features.quickAmountPills ? (
+        <Box twClassName="pb-3">
+          <QuickBuyQuickAmounts />
+        </Box>
+      ) : null}
 
       {/* Pay with / Receive with row */}
       <Box

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import QuickBuyQuickAmounts from './QuickBuyQuickAmounts';
+import { useQuickBuyContext } from '../useQuickBuyContext';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+
+jest.mock('../useQuickBuyContext', () => ({
+  useQuickBuyContext: jest.fn(),
+}));
+
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../utils/quickBuyQuickAmounts', () => ({
+  getBuyQuickAmounts: jest.fn(() => [
+    { value: 500, label: '$500', isUsdFallback: false },
+    { value: 1500, label: '$1,500', isUsdFallback: false },
+    { value: 2500, label: '$2,500', isUsdFallback: false },
+    { value: 3500, label: '$3,500', isUsdFallback: false },
+  ]),
+  SELL_QUICK_PERCENTAGES: [25, 50, 75, 100],
+}));
+
+const mockPlayImpact = jest.fn();
+
+jest.mock('../../../../../../../util/haptics', () => ({
+  ...jest.requireActual<typeof import('../../../../../../../util/haptics')>(
+    '../../../../../../../util/haptics',
+  ),
+  useHaptics: jest.fn(),
+}));
+
+const baseContext = {
+  tradeMode: 'buy' as const,
+  currentCurrency: 'USD',
+  usdToCurrentCurrencyRate: 1,
+  hasSourcePrice: true,
+  isSliderDisabled: false,
+  handleQuickAmountPress: jest.fn(),
+  handleSliderChange: jest.fn(),
+  handleSliderDragEnd: jest.fn(),
+};
+
+describe('QuickBuyQuickAmounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useHaptics as jest.Mock).mockReturnValue({
+      playImpact: mockPlayImpact,
+    });
+    (useQuickBuyContext as jest.Mock).mockReturnValue(baseContext);
+  });
+
+  it('renders buy pills and commits the tapped fiat amount', async () => {
+    renderWithProvider(<QuickBuyQuickAmounts />);
+
+    expect(screen.getByText('$500')).toBeOnTheScreen();
+    expect(screen.getByText('$3,500')).toBeOnTheScreen();
+
+    fireEvent.press(screen.getByText('$1,500'));
+
+    await waitFor(() => {
+      expect(mockPlayImpact).toHaveBeenCalledWith(
+        ImpactMoment.QuickAmountSelection,
+      );
+      expect(baseContext.handleQuickAmountPress).toHaveBeenCalledWith(1500);
+    });
+  });
+
+  it('renders sell percentage pills and commits via the slider handlers', async () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      tradeMode: 'sell',
+    });
+
+    renderWithProvider(<QuickBuyQuickAmounts />);
+
+    expect(screen.getByText('25%')).toBeOnTheScreen();
+    expect(
+      screen.getByText('social_leaderboard.quick_buy.max'),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(screen.getByText('75%'));
+
+    await waitFor(() => {
+      expect(baseContext.handleSliderChange).toHaveBeenCalledWith(75);
+      expect(baseContext.handleSliderDragEnd).toHaveBeenCalledWith(75);
+    });
+  });
+
+  it('uses only handleSliderChange for unpriced sell sources', async () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      tradeMode: 'sell',
+      hasSourcePrice: false,
+    });
+
+    renderWithProvider(<QuickBuyQuickAmounts />);
+
+    fireEvent.press(screen.getByText('50%'));
+
+    await waitFor(() => {
+      expect(baseContext.handleSliderChange).toHaveBeenCalledWith(50);
+      expect(baseContext.handleSliderDragEnd).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
@@ -15,10 +15,10 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
 
 jest.mock('../utils/quickBuyQuickAmounts', () => ({
   getBuyQuickAmounts: jest.fn(() => [
-    { value: 500, label: '$500', isUsdFallback: false },
-    { value: 1500, label: '$1,500', isUsdFallback: false },
-    { value: 2500, label: '$2,500', isUsdFallback: false },
-    { value: 3500, label: '$3,500', isUsdFallback: false },
+    { value: 10, label: '$10', presetTierUsd: 10 },
+    { value: 50, label: '$50', presetTierUsd: 50 },
+    { value: 100, label: '$100', presetTierUsd: 100 },
+    { value: 250, label: '$250', presetTierUsd: 250 },
   ]),
   SELL_QUICK_PERCENTAGES: [25, 50, 75, 100],
 }));
@@ -55,16 +55,16 @@ describe('QuickBuyQuickAmounts', () => {
   it('renders buy pills and commits the tapped fiat amount', async () => {
     renderWithProvider(<QuickBuyQuickAmounts />);
 
-    expect(screen.getByText('$500')).toBeOnTheScreen();
-    expect(screen.getByText('$3,500')).toBeOnTheScreen();
+    expect(screen.getByText('$10')).toBeOnTheScreen();
+    expect(screen.getByText('$250')).toBeOnTheScreen();
 
-    fireEvent.press(screen.getByText('$1,500'));
+    fireEvent.press(screen.getByText('$50'));
 
     await waitFor(() => {
       expect(mockPlayImpact).toHaveBeenCalledWith(
         ImpactMoment.QuickAmountSelection,
       );
-      expect(baseContext.handleQuickAmountPress).toHaveBeenCalledWith(1500);
+      expect(baseContext.handleQuickAmountPress).toHaveBeenCalledWith(50, 50);
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
@@ -1,0 +1,107 @@
+import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, { useCallback } from 'react';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../../../../../component-library/components/Buttons/Button';
+import { TextVariant } from '../../../../../../../component-library/components/Texts/Text';
+import { strings } from '../../../../../../../../locales/i18n';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
+import { useQuickBuyContext } from '../useQuickBuyContext';
+import {
+  getBuyQuickAmounts,
+  SELL_QUICK_PERCENTAGES,
+} from '../utils/quickBuyQuickAmounts';
+
+/**
+ * Shared pill chrome.
+ * ButtonSize.Md (40px) matches the Figma height; px-2 overrides the default
+ * 16px horizontal padding so all four labels fit on one row without clipping.
+ */
+const QUICK_AMOUNT_PILL_PROPS = {
+  variant: ButtonVariants.Secondary,
+  size: ButtonSize.Md,
+  labelTextVariant: TextVariant.BodySMMedium,
+} as const;
+
+const QuickBuyQuickAmounts: React.FC = () => {
+  const tw = useTailwind();
+  const { playImpact } = useHaptics();
+  const {
+    tradeMode,
+    currentCurrency,
+    usdToCurrentCurrencyRate,
+    hasSourcePrice,
+    isSliderDisabled,
+    handleQuickAmountPress,
+    handleSliderChange,
+    handleSliderDragEnd,
+  } = useQuickBuyContext();
+
+  const handleSellPercentPress = useCallback(
+    (percent: number) => {
+      playImpact(ImpactMoment.QuickAmountSelection);
+      if (!hasSourcePrice) {
+        handleSliderChange(percent);
+        return;
+      }
+      handleSliderChange(percent);
+      handleSliderDragEnd(percent);
+    },
+    [hasSourcePrice, handleSliderChange, handleSliderDragEnd, playImpact],
+  );
+
+  const handleBuyAmountPress = useCallback(
+    (value: number) => {
+      playImpact(ImpactMoment.QuickAmountSelection);
+      handleQuickAmountPress(value);
+    },
+    [handleQuickAmountPress, playImpact],
+  );
+
+  if (tradeMode === 'sell') {
+    return (
+      <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2 py-1">
+        {SELL_QUICK_PERCENTAGES.map((percent) => (
+          <Button
+            key={percent}
+            {...QUICK_AMOUNT_PILL_PROPS}
+            label={
+              percent === 100
+                ? strings('social_leaderboard.quick_buy.max')
+                : `${percent}%`
+            }
+            onPress={() => handleSellPercentPress(percent)}
+            isDisabled={isSliderDisabled}
+            style={tw.style('min-w-0 flex-1 px-2')}
+            testID={`quick-buy-sell-pill-${percent}`}
+          />
+        ))}
+      </Box>
+    );
+  }
+
+  const buyAmounts = getBuyQuickAmounts(
+    currentCurrency,
+    usdToCurrentCurrencyRate,
+  );
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2 py-1">
+      {buyAmounts.map((option) => (
+        <Button
+          key={option.label}
+          {...QUICK_AMOUNT_PILL_PROPS}
+          label={option.label}
+          onPress={() => handleBuyAmountPress(option.value)}
+          isDisabled={isSliderDisabled}
+          style={tw.style('min-w-0 flex-1 px-2')}
+          testID={`quick-buy-buy-pill-${option.value}`}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default QuickBuyQuickAmounts;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
@@ -53,9 +53,9 @@ const QuickBuyQuickAmounts: React.FC = () => {
   );
 
   const handleBuyAmountPress = useCallback(
-    (value: number) => {
+    (value: number, presetTierUsd: number) => {
       playImpact(ImpactMoment.QuickAmountSelection);
-      handleQuickAmountPress(value);
+      handleQuickAmountPress(value, presetTierUsd);
     },
     [handleQuickAmountPress, playImpact],
   );
@@ -91,13 +91,15 @@ const QuickBuyQuickAmounts: React.FC = () => {
     <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2 py-1">
       {buyAmounts.map((option) => (
         <Button
-          key={option.label}
+          key={option.presetTierUsd}
           {...QUICK_AMOUNT_PILL_PROPS}
           label={option.label}
-          onPress={() => handleBuyAmountPress(option.value)}
+          onPress={() =>
+            handleBuyAmountPress(option.value, option.presetTierUsd)
+          }
           isDisabled={isSliderDisabled}
           style={tw.style('min-w-0 flex-1 px-2')}
-          testID={`quick-buy-buy-pill-${option.value}`}
+          testID={`quick-buy-buy-pill-${option.presetTierUsd}`}
         />
       ))}
     </Box>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/features.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/features.ts
@@ -8,4 +8,5 @@ export const TOP_TRADERS_QUICK_BUY_FEATURES: QuickBuyFeatures = {
   payWithSheet: true,
   highPriceImpactModal: true,
   fiatCryptoToggle: true,
+  quickAmountPills: true,
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
@@ -21,6 +21,7 @@ jest.mock('../analytics', () => ({
     AMOUNT_USD: 'amount_usd',
     AMOUNT_SELECTION_METHOD: 'amount_selection_method',
     PAY_WITH_TOKEN: 'pay_with_token',
+    PRESET_VALUE: 'preset_value',
     RECEIVE_TOKEN: 'receive_token',
     INTERACTION_TYPE: 'interaction_type',
     QUOTE_INDEX: 'quote_index',
@@ -39,6 +40,7 @@ jest.mock('../analytics', () => ({
     AMOUNT_SELECTION_METHOD: {
       CUSTOM_INPUT: 'custom_input',
       SLIDER: 'slider',
+      PRESET: 'preset',
     },
     INTERACTION_TYPE: {
       QUOTE_SELECTED: 'quote_selected',
@@ -127,6 +129,28 @@ describe('useQuickBuyAnalytics', () => {
       expect(mockTrack).toHaveBeenCalledWith(
         MetaMetricsEvents.SOCIAL_QUICK_BUY_AMOUNT_SELECTED,
         expect.objectContaining({ slider_percent: 25 }),
+      );
+    });
+
+    it('includes preset_value when provided', () => {
+      const { result } = renderHook(() => useQuickBuyAnalytics(TRADER, CAIP19));
+
+      act(() => {
+        result.current.trackAmountSelected(
+          50,
+          QuickBuyEventValues.AMOUNT_SELECTION_METHOD.PRESET,
+          'USDC',
+          undefined,
+          undefined,
+          50,
+        );
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.SOCIAL_QUICK_BUY_AMOUNT_SELECTED,
+        expect.objectContaining({
+          [QuickBuyEventProperties.PRESET_VALUE]: 50,
+        }),
       );
     });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
@@ -22,6 +22,7 @@ jest.mock('../analytics', () => ({
     AMOUNT_SELECTION_METHOD: 'amount_selection_method',
     PAY_WITH_TOKEN: 'pay_with_token',
     PRESET_VALUE: 'preset_value',
+    SLIDER_PERCENT: 'slider_percent',
     RECEIVE_TOKEN: 'receive_token',
     INTERACTION_TYPE: 'interaction_type',
     QUOTE_INDEX: 'quote_index',
@@ -128,7 +129,9 @@ describe('useQuickBuyAnalytics', () => {
 
       expect(mockTrack).toHaveBeenCalledWith(
         MetaMetricsEvents.SOCIAL_QUICK_BUY_AMOUNT_SELECTED,
-        expect.objectContaining({ slider_percent: 25 }),
+        expect.objectContaining({
+          [QuickBuyEventProperties.SLIDER_PERCENT]: 25,
+        }),
       );
     });
 
@@ -165,7 +168,7 @@ describe('useQuickBuyAnalytics', () => {
       });
 
       const call = mockTrack.mock.calls[0][1];
-      expect(call).not.toHaveProperty('slider_percent');
+      expect(call).not.toHaveProperty(QuickBuyEventProperties.SLIDER_PERCENT);
     });
 
     it('is a no-op when traderAddress is empty', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
@@ -103,7 +103,9 @@ export function useQuickBuyAnalytics(
         ...(receiveToken
           ? { [QuickBuyEventProperties.RECEIVE_TOKEN]: receiveToken }
           : {}),
-        ...(sliderPercent != null ? { slider_percent: sliderPercent } : {}),
+        ...(sliderPercent != null
+          ? { [QuickBuyEventProperties.SLIDER_PERCENT]: sliderPercent }
+          : {}),
         ...(presetValue != null
           ? { [QuickBuyEventProperties.PRESET_VALUE]: presetValue }
           : {}),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
@@ -33,6 +33,7 @@ export function useQuickBuyAnalytics(
     payWithToken?: string,
     sliderPercent?: number,
     receiveToken?: string,
+    presetValue?: number,
   ) => void;
   trackTradeModeToggled: (tradeType: 'buy' | 'sell') => void;
   trackQuoteSelected: (quoteIndex: number, quoteCount: number) => void;
@@ -86,6 +87,7 @@ export function useQuickBuyAnalytics(
       payWithToken?: string,
       sliderPercent?: number,
       receiveToken?: string,
+      presetValue?: number,
     ) => {
       if (!resolvedTraderAddress || !caip19) return;
       lastTrackedAmountRef.current = String(amountUsd);
@@ -102,6 +104,9 @@ export function useQuickBuyAnalytics(
           ? { [QuickBuyEventProperties.RECEIVE_TOKEN]: receiveToken }
           : {}),
         ...(sliderPercent != null ? { slider_percent: sliderPercent } : {}),
+        ...(presetValue != null
+          ? { [QuickBuyEventProperties.PRESET_VALUE]: presetValue }
+          : {}),
       });
       dismissStageRef.current =
         QuickBuyEventValues.DISMISS_STAGE.AMOUNT_SELECTION;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -1,4 +1,7 @@
-import { isNonEvmChainId } from '@metamask/bridge-controller';
+import {
+  isNonEvmChainId,
+  formatChainIdToCaip,
+} from '@metamask/bridge-controller';
 import type { Hex } from '@metamask/utils';
 import {
   useCallback,
@@ -87,6 +90,7 @@ import { useTheme } from '../../../../../../../util/theme';
 import { calcTokenValue } from '../../../../../../../util/transactions';
 import { useRefreshSmartTransactionsLiveness } from '../../../../../../hooks/useRefreshSmartTransactionsLiveness';
 import { toAssetId } from '../../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import { useRampNavigation } from '../../../../../../UI/Ramp/hooks/useRampNavigation';
 import { useHasSufficientGas } from '../../../../../../UI/Bridge/hooks/useHasSufficientGas';
 import { useInitialSlippage } from '../../../../../../UI/Bridge/hooks/useInitialSlippage';
 import useIsInsufficientBalance from '../../../../../../UI/Bridge/hooks/useInsufficientBalance';
@@ -222,7 +226,7 @@ export interface UseQuickBuyControllerResult {
   handleSliderChange: (percent: number) => void;
   handleSliderDragEnd: (percent: number) => void;
   /** Buy-mode preset fiat pill tap — commits amount and fetches quote immediately. */
-  handleQuickAmountPress: (fiatValue: number) => void;
+  handleQuickAmountPress: (fiatValue: number, presetTierUsd?: number) => void;
   /** USD → user display currency rate for fallback pill conversion. */
   usdToCurrentCurrencyRate: number | undefined;
   handleAmountAreaPress: () => void;
@@ -241,6 +245,7 @@ export function useQuickBuyController(
   const dispatch = useDispatch();
   const theme = useTheme();
   const { toastRef } = useContext(ToastContext);
+  const { goToBuy } = useRampNavigation();
 
   const traderAddress = analyticsContext?.traderAddress ?? '';
   const caip19 = useMemo(
@@ -287,6 +292,8 @@ export function useQuickBuyController(
     useState<QuickBuyAmountDisplayMode>('fiat');
   const [sliderPercent, setSliderPercent] = useState(0);
   const lastSliderPercentRef = useRef(0);
+  const [isPresetAddFundsMode, setIsPresetAddFundsMode] = useState(false);
+  const hasAppliedOpenDefaultRef = useRef(false);
   // Deduplicates consecutive handleSliderDragEnd calls with the same
   // user-currency amount (can happen when Tap + Pan both fire onEnd for a pure
   // tap gesture).
@@ -970,6 +977,7 @@ export function useQuickBuyController(
   // gesture, not on every pixel of movement.
   const handleSliderChange = useCallback(
     (percent: number) => {
+      setIsPresetAddFundsMode(false);
       const rounded = Math.round(percent);
       if (rounded === lastSliderPercentRef.current) {
         return;
@@ -1015,6 +1023,7 @@ export function useQuickBuyController(
   // and fires analytics exactly once per interaction.
   const handleSliderDragEnd = useCallback(
     (percent: number) => {
+      setIsPresetAddFundsMode(false);
       const rounded = Math.round(percent);
       const nextFiat =
         rounded === 0 || maxSpendFiat <= 0
@@ -1071,7 +1080,7 @@ export function useQuickBuyController(
   );
 
   const handleQuickAmountPress = useCallback(
-    (fiatValue: number) => {
+    (fiatValue: number, presetTierUsd?: number) => {
       if (!Number.isFinite(fiatValue) || fiatValue <= 0) {
         return;
       }
@@ -1079,6 +1088,10 @@ export function useQuickBuyController(
       lastInputMethodRef.current =
         QuickBuyEventValues.AMOUNT_SELECTION_METHOD.PRESET;
       setIsMaxSourceAmount(false);
+
+      const exceedsBalance =
+        tradeMode === 'buy' && maxSpendFiat > 0 && fiatValue > maxSpendFiat;
+      setIsPresetAddFundsMode(exceedsBalance);
 
       const nextFiat = fiatValue.toFixed(FIAT_INPUT_DECIMALS);
       lastCommittedFiatRef.current = nextFiat;
@@ -1092,13 +1105,16 @@ export function useQuickBuyController(
       setSliderPercent(nextSliderPercent);
       lastSliderPercentRef.current = nextSliderPercent;
 
-      setImmediateFetchToken((token) => token + 1);
+      if (!exceedsBalance) {
+        setImmediateFetchToken((token) => token + 1);
+      }
       trackAmountSelected(
         toAmountUsd(fiatValue),
         QuickBuyEventValues.AMOUNT_SELECTION_METHOD.PRESET,
         tradeMode === 'buy' ? sourceToken?.symbol : undefined,
         undefined,
         tradeMode === 'sell' ? destToken?.symbol : undefined,
+        presetTierUsd,
       );
     },
     [
@@ -1111,6 +1127,18 @@ export function useQuickBuyController(
       lastInputMethodRef,
     ],
   );
+
+  // Default the slider to 50% once per sheet open when spendable balance is known.
+  useEffect(() => {
+    if (hasAppliedOpenDefaultRef.current) {
+      return;
+    }
+    if (!hasSourcePrice || maxSpendFiat <= 0) {
+      return;
+    }
+    hasAppliedOpenDefaultRef.current = true;
+    handleSliderDragEnd(50);
+  }, [hasSourcePrice, maxSpendFiat, handleSliderDragEnd]);
 
   const handleAmountAreaPress = useCallback(() => {
     // Priced flows are fiat-first, so typing in fiat keeps the keyboard digits
@@ -1133,6 +1161,7 @@ export function useQuickBuyController(
     setQuotedFiatAmount('');
     setSourceAmountTokens('');
     setIsMaxSourceAmount(false);
+    setIsPresetAddFundsMode(false);
     setSliderPercent(0);
     lastSliderPercentRef.current = 0;
     lastCommittedFiatRef.current = '';
@@ -1213,6 +1242,7 @@ export function useQuickBuyController(
 
   const handleAmountChange = useCallback(
     (text: string) => {
+      setIsPresetAddFundsMode(false);
       lastInputMethodRef.current =
         QuickBuyEventValues.AMOUNT_SELECTION_METHOD.CUSTOM_INPUT;
       const cleaned = dotAndCommaDecimalFormatter(text).replace(/[^0-9.]/g, '');
@@ -1273,6 +1303,18 @@ export function useQuickBuyController(
   ]);
 
   const handleConfirm = useCallback(async () => {
+    if (isPresetAddFundsMode && tradeMode === 'buy' && sourceToken) {
+      const assetId = toAssetId(
+        sourceToken.address,
+        formatChainIdToCaip(sourceToken.chainId),
+      );
+      if (assetId) {
+        await goToBuy({ assetId }, { buyFlowOrigin: 'tokenInfo' });
+      }
+      handleClose();
+      return;
+    }
+
     if (!activeQuote || !walletAddress) return;
 
     // `amount_usd` is contractually USD; the entered amount is in the user's
@@ -1443,6 +1485,9 @@ export function useQuickBuyController(
       dispatch(setIsSubmittingTx(false));
     }
   }, [
+    isPresetAddFundsMode,
+    goToBuy,
+    handleClose,
     activeQuote,
     walletAddress,
     stxEnabled,
@@ -1453,7 +1498,7 @@ export function useQuickBuyController(
     isNonEvmSourced,
     isEvmNonEvmBridge,
     isNonEvmNonEvmBridge,
-    sourceToken?.chainId,
+    sourceToken,
     destToken?.chainId,
     fiatAmountNumber,
     toAmountUsd,
@@ -1464,7 +1509,6 @@ export function useQuickBuyController(
     tradeMode,
     destToken?.symbol,
     target.tokenSymbol,
-    sourceToken?.symbol,
     trackTradeSubmitted,
     trackTradeCompleted,
     markTradeSubmitted,
@@ -1574,25 +1618,26 @@ export function useQuickBuyController(
   // receive estimate are not blanked every refresh tick.
   const isBlockingQuoteLoad = isQuoteLoading && !hasUsableQuoteOnScreen;
 
-  const isConfirmDisabled =
-    !hasValidAmount ||
-    isAmountUncommitted ||
-    isSetupLoading ||
-    !sourceToken ||
-    !destToken ||
-    isDestinationAddressMissing ||
-    !activeQuote ||
-    hasQuoteMismatch ||
-    isPendingQuoteRefresh ||
-    isQuoteRequestStale ||
-    isBlockingQuoteLoad ||
-    hasInsufficientBalance ||
-    isNetworkFeeUnavailable ||
-    hasInsufficientGas ||
-    isSubmittingTx ||
-    hasError ||
-    isHardwareSolanaBlocked ||
-    !walletAddress;
+  const isConfirmDisabled = isPresetAddFundsMode
+    ? !hasValidAmount || isSetupLoading || !sourceToken || isSubmittingTx
+    : !hasValidAmount ||
+      isAmountUncommitted ||
+      isSetupLoading ||
+      !sourceToken ||
+      !destToken ||
+      isDestinationAddressMissing ||
+      !activeQuote ||
+      hasQuoteMismatch ||
+      isPendingQuoteRefresh ||
+      isQuoteRequestStale ||
+      isBlockingQuoteLoad ||
+      hasInsufficientBalance ||
+      isNetworkFeeUnavailable ||
+      hasInsufficientGas ||
+      isSubmittingTx ||
+      hasError ||
+      isHardwareSolanaBlocked ||
+      !walletAddress;
 
   const isTotalLoading =
     hasValidAmount &&
@@ -1601,12 +1646,14 @@ export function useQuickBuyController(
   const isConfirmLoading = isSubmittingTx;
 
   let buttonError: QuickBuyButtonError | null = null;
-  if (hasInsufficientBalance || isNetworkFeeUnavailable) {
-    buttonError = 'insufficient_balance';
-  } else if (hasInsufficientGas) {
-    buttonError = 'insufficient_gas';
-  } else if (hasError) {
-    buttonError = 'no_quotes';
+  if (!isPresetAddFundsMode) {
+    if (hasInsufficientBalance || isNetworkFeeUnavailable) {
+      buttonError = 'insufficient_balance';
+    } else if (hasInsufficientGas) {
+      buttonError = 'insufficient_gas';
+    } else if (hasError) {
+      buttonError = 'no_quotes';
+    }
   }
 
   let confirmButtonState: 'idle' | 'loading' | 'success' = 'idle';
@@ -1615,12 +1662,15 @@ export function useQuickBuyController(
   }
 
   const getButtonLabel = useCallback(() => {
+    if (isPresetAddFundsMode) {
+      return strings('social_leaderboard.quick_buy.add_funds');
+    }
     if (buttonError) return strings(BUTTON_ERROR_LABELS[buttonError]);
     if (isSubmittingTx) return strings('bridge.submitting_transaction');
     return tradeMode === 'sell'
       ? strings('social_leaderboard.trader_position.sell')
       : strings('social_leaderboard.trader_position.buy');
-  }, [buttonError, isSubmittingTx, tradeMode]);
+  }, [buttonError, isPresetAddFundsMode, isSubmittingTx, tradeMode]);
 
   return {
     hiddenInputRef,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -215,6 +215,8 @@ export interface UseQuickBuyControllerResult {
   isHardwareSolanaBlocked: boolean;
   priceImpactViewData: ReturnType<typeof usePriceImpactViewData>;
   isPriceImpactError: boolean;
+  /** True when a buy pill amount exceeds balance and the CTA routes to Ramp. */
+  isPresetAddFundsMode: boolean;
   // button state (priority-encoded; the Buy button surfaces at most one)
   buttonError: QuickBuyButtonError | null;
   hasValidAmount: boolean;
@@ -1308,9 +1310,10 @@ export function useQuickBuyController(
         sourceToken.address,
         formatChainIdToCaip(sourceToken.chainId),
       );
-      if (assetId) {
-        await goToBuy({ assetId }, { buyFlowOrigin: 'tokenInfo' });
+      if (!assetId) {
+        return;
       }
+      await goToBuy({ assetId }, { buyFlowOrigin: 'tokenInfo' });
       handleClose();
       return;
     }
@@ -1729,6 +1732,7 @@ export function useQuickBuyController(
     isHardwareSolanaBlocked,
     priceImpactViewData,
     isPriceImpactError,
+    isPresetAddFundsMode,
     buttonError,
     hasValidAmount,
     isConfirmDisabled,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -221,6 +221,10 @@ export interface UseQuickBuyControllerResult {
   handleClose: () => void;
   handleSliderChange: (percent: number) => void;
   handleSliderDragEnd: (percent: number) => void;
+  /** Buy-mode preset fiat pill tap — commits amount and fetches quote immediately. */
+  handleQuickAmountPress: (fiatValue: number) => void;
+  /** USD → user display currency rate for fallback pill conversion. */
+  usdToCurrentCurrencyRate: number | undefined;
   handleAmountAreaPress: () => void;
   handleAmountChange: (text: string) => void;
   handleToggleAmountDisplay: () => void;
@@ -491,6 +495,25 @@ export function useQuickBuyController(
     },
     [sourceToken?.chainId, networkConfigurations, currencyRates],
   );
+
+  const usdToCurrentCurrencyRate = useMemo(() => {
+    const nativeCurrency = sourceToken?.chainId
+      ? networkConfigurations[sourceToken.chainId]?.nativeCurrency
+      : undefined;
+    const evmChainCurrencyEntry = nativeCurrency
+      ? currencyRates?.[nativeCurrency]
+      : undefined;
+    const fallbackEvmCurrencyEntry = Object.values(currencyRates ?? {}).find(
+      (entry) => entry?.conversionRate && entry?.usdConversionRate,
+    );
+    const currencyEntry = evmChainCurrencyEntry ?? fallbackEvmCurrencyEntry;
+    const conversionRate = currencyEntry?.conversionRate;
+    const usdConversionRate = currencyEntry?.usdConversionRate;
+    if (!conversionRate || !usdConversionRate) {
+      return undefined;
+    }
+    return conversionRate / usdConversionRate;
+  }, [sourceToken?.chainId, networkConfigurations, currencyRates]);
 
   // BridgeController.fetchQuotes does not start gas fee polling, so estimates
   // for the source chain may be missing when selectBridgeQuotesBase enriches
@@ -1044,6 +1067,48 @@ export function useQuickBuyController(
       tradeMode,
       toAmountUsd,
       trackAmountSelected,
+    ],
+  );
+
+  const handleQuickAmountPress = useCallback(
+    (fiatValue: number) => {
+      if (!Number.isFinite(fiatValue) || fiatValue <= 0) {
+        return;
+      }
+
+      lastInputMethodRef.current =
+        QuickBuyEventValues.AMOUNT_SELECTION_METHOD.PRESET;
+      setIsMaxSourceAmount(false);
+
+      const nextFiat = fiatValue.toFixed(FIAT_INPUT_DECIMALS);
+      lastCommittedFiatRef.current = nextFiat;
+      setFiatAmount(nextFiat);
+      setQuotedFiatAmount(nextFiat);
+
+      const nextSliderPercent =
+        maxSpendFiat > 0
+          ? Math.min(100, Math.round((fiatValue / maxSpendFiat) * 100))
+          : 0;
+      setSliderPercent(nextSliderPercent);
+      lastSliderPercentRef.current = nextSliderPercent;
+
+      setImmediateFetchToken((token) => token + 1);
+      trackAmountSelected(
+        toAmountUsd(fiatValue),
+        QuickBuyEventValues.AMOUNT_SELECTION_METHOD.PRESET,
+        tradeMode === 'buy' ? sourceToken?.symbol : undefined,
+        undefined,
+        tradeMode === 'sell' ? destToken?.symbol : undefined,
+      );
+    },
+    [
+      maxSpendFiat,
+      sourceToken?.symbol,
+      destToken?.symbol,
+      tradeMode,
+      toAmountUsd,
+      trackAmountSelected,
+      lastInputMethodRef,
     ],
   );
 
@@ -1622,6 +1687,8 @@ export function useQuickBuyController(
     handleClose,
     handleSliderChange,
     handleSliderDragEnd,
+    handleQuickAmountPress,
+    usdToCurrentCurrencyRate,
     handleAmountAreaPress,
     handleAmountChange,
     handleToggleAmountDisplay,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/types.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/types.ts
@@ -32,6 +32,8 @@ export interface QuickBuyFeatures {
   payWithSheet: boolean;
   highPriceImpactModal: boolean;
   fiatCryptoToggle: boolean;
+  /** Fixed fiat / percentage quick-amount pills below the slider. */
+  quickAmountPills?: boolean;
 }
 
 /** Stable-token destination candidates for the Sell "Receive with" picker. */

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -766,7 +766,11 @@ describe('useQuickBuyController', () => {
         options: [sourceWithRate],
       });
       const onClose = jest.fn();
-      (toAssetId as jest.Mock).mockReturnValueOnce(undefined);
+      (toAssetId as jest.Mock).mockImplementation((address: string) =>
+        address === sourceWithRate.address
+          ? undefined
+          : 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+      );
 
       const { result } = renderHook(() =>
         useQuickBuyController(createTarget(), onClose),

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -756,6 +756,34 @@ describe('useQuickBuyController', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
+    it('does not close the sheet when pay-with asset id cannot be resolved', async () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: '100000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 2000 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+      const onClose = jest.fn();
+      (toAssetId as jest.Mock).mockReturnValueOnce(undefined);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), onClose),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(250, 250);
+      });
+
+      await act(async () => {
+        await result.current.handleConfirm();
+      });
+
+      expect(mockGoToBuy).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
     it('exposes usdToCurrentCurrencyRate from native currency rates', () => {
       (selectCurrencyRates as unknown as jest.Mock).mockReturnValue({
         ETH: { conversionRate: 1000, usdConversionRate: 1200 },

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -31,6 +31,7 @@ import Logger from '../../../../../../util/Logger';
 import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
 import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
 import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
+import { toAssetId } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import {
@@ -74,12 +75,23 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockTrackAmountSelected = jest.fn();
+const mockGoToBuy = jest.fn().mockResolvedValue(undefined);
 const mockTrackTradeSubmitted = jest.fn();
 const mockTrackTradeCompleted = jest.fn();
 const mockTrackQuoteSelected = jest.fn();
 const mockTrackPayWithSelected = jest.fn();
 const mockTrackReceiveTokenSelected = jest.fn();
 const mockTrackSlippageChanged = jest.fn();
+
+jest.mock('../../../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
+  toAssetId: jest.fn(
+    () => 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+  ),
+}));
+
+jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: () => ({ goToBuy: mockGoToBuy }),
+}));
 
 jest.mock('./hooks/useQuickBuyAnalytics', () => ({
   useQuickBuyAnalytics: () => ({
@@ -452,6 +464,10 @@ const setupDefaultMocks = () => {
   (buildQuickBuyToastOptions as jest.Mock).mockImplementation(
     (kind: string) => ({ kind }),
   );
+  (toAssetId as jest.Mock).mockReturnValue(
+    'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+  );
+  mockGoToBuy.mockResolvedValue(undefined);
 };
 
 describe('useQuickBuyController', () => {
@@ -568,6 +584,7 @@ describe('useQuickBuyController', () => {
       const { result } = renderHook(() =>
         useQuickBuyController(createTarget(), jest.fn()),
       );
+      mockTrackAmountSelected.mockClear();
 
       act(() => {
         result.current.handleSliderChange(48);
@@ -577,6 +594,26 @@ describe('useQuickBuyController', () => {
 
       expect(result.current.sliderPercent).toBe(51);
       expect(mockTrackAmountSelected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sheet open defaults', () => {
+    it('defaults the slider to 50% when spendable balance is available', () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '100',
+        atomicBalance: '100000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 1 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.sliderPercent).toBe(50);
+      expect(Number(result.current.fiatAmount)).toBe(50);
     });
   });
 
@@ -594,6 +631,7 @@ describe('useQuickBuyController', () => {
       const { result } = renderHook(() =>
         useQuickBuyController(createTarget(), jest.fn()),
       );
+      mockTrackAmountSelected.mockClear();
 
       act(() => {
         result.current.handleSliderChange(48);
@@ -647,16 +685,22 @@ describe('useQuickBuyController', () => {
       );
 
       act(() => {
-        result.current.handleQuickAmountPress(500);
+        result.current.handleQuickAmountPress(50, 50);
       });
 
-      expect(result.current.fiatAmount).toBe('500.00');
-      expect(result.current.sliderPercent).toBe(25);
-      expect(mockTrackAmountSelected).toHaveBeenCalledTimes(1);
-      expect(mockTrackAmountSelected.mock.calls[0][1]).toBe('preset');
+      expect(result.current.fiatAmount).toBe('50.00');
+      expect(result.current.sliderPercent).toBe(3);
+      expect(mockTrackAmountSelected).toHaveBeenCalledWith(
+        expect.any(Number),
+        'preset',
+        expect.any(String),
+        undefined,
+        undefined,
+        50,
+      );
     });
 
-    it('still sets amounts above the available balance for insufficient-funds handling', () => {
+    it('enables Add Funds when a pill exceeds the available balance', () => {
       (useLatestBalance as jest.Mock).mockReturnValue({
         displayBalance: '0.1',
         atomicBalance: '100000000000000000',
@@ -671,11 +715,45 @@ describe('useQuickBuyController', () => {
       );
 
       act(() => {
-        result.current.handleQuickAmountPress(3500);
+        result.current.handleQuickAmountPress(250, 250);
       });
 
-      expect(result.current.fiatAmount).toBe('3500.00');
+      expect(result.current.fiatAmount).toBe('250.00');
       expect(result.current.sliderPercent).toBe(100);
+      expect(result.current.getButtonLabel()).toBe(
+        'social_leaderboard.quick_buy.add_funds',
+      );
+      expect(result.current.isConfirmDisabled).toBe(false);
+    });
+
+    it('routes to Ramp buy when Add Funds is confirmed', async () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: '100000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 2000 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+      const onClose = jest.fn();
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), onClose),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(250, 250);
+      });
+
+      await act(async () => {
+        await result.current.handleConfirm();
+      });
+
+      expect(mockGoToBuy).toHaveBeenCalledWith(
+        expect.objectContaining({ assetId: expect.any(String) }),
+        { buyFlowOrigin: 'tokenInfo' },
+      );
+      expect(onClose).toHaveBeenCalled();
     });
 
     it('exposes usdToCurrentCurrencyRate from native currency rates', () => {
@@ -710,6 +788,7 @@ describe('useQuickBuyController', () => {
       const { result } = renderHook(() =>
         useQuickBuyController(createTarget(), jest.fn()),
       );
+      mockTrackAmountSelected.mockClear();
 
       act(() => {
         result.current.handleAmountChange('20');

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -631,6 +631,66 @@ describe('useQuickBuyController', () => {
     });
   });
 
+  describe('handleQuickAmountPress', () => {
+    it('commits the fiat amount, syncs the slider, and tracks PRESET analytics', () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '10',
+        atomicBalance: '10000000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 200 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(500);
+      });
+
+      expect(result.current.fiatAmount).toBe('500.00');
+      expect(result.current.sliderPercent).toBe(25);
+      expect(mockTrackAmountSelected).toHaveBeenCalledTimes(1);
+      expect(mockTrackAmountSelected.mock.calls[0][1]).toBe('preset');
+    });
+
+    it('still sets amounts above the available balance for insufficient-funds handling', () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: '100000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 2000 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(3500);
+      });
+
+      expect(result.current.fiatAmount).toBe('3500.00');
+      expect(result.current.sliderPercent).toBe(100);
+    });
+
+    it('exposes usdToCurrentCurrencyRate from native currency rates', () => {
+      (selectCurrencyRates as unknown as jest.Mock).mockReturnValue({
+        ETH: { conversionRate: 1000, usdConversionRate: 1200 },
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.usdToCurrentCurrencyRate).toBeCloseTo(1000 / 1200);
+    });
+  });
+
   describe('user-currency (non-USD)', () => {
     it('formats the headline in the user currency while emitting amount_usd in USD', () => {
       // EUR display currency; native ETH worth €1,000 / $1,200 → USD = EUR * 1.2.

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -644,6 +644,13 @@ describe('useQuickBuyController', () => {
 
       expect(result.current.sliderPercent).toBe(51);
       expect(mockTrackAmountSelected).toHaveBeenCalledTimes(1);
+      expect(mockTrackAmountSelected).toHaveBeenCalledWith(
+        expect.any(Number),
+        'slider',
+        expect.any(String),
+        51,
+        undefined,
+      );
     });
 
     it('deduplicates identical commit values (Tap + Pan double-fire guard)', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.test.ts
@@ -1,0 +1,118 @@
+import {
+  formatCurrency,
+  getCurrencySymbol,
+} from '../../../../../../UI/Bridge/utils/currencyUtils';
+import {
+  CURATED_QUICK_BUY_AMOUNTS,
+  formatQuickBuyPillLabel,
+  getBuyQuickAmounts,
+  USD_QUICK_BUY_BASE,
+} from './quickBuyQuickAmounts';
+
+jest.mock('../../../../../../UI/Bridge/utils/currencyUtils', () => ({
+  formatCurrency: jest.fn(
+    (amount: number, currency: string) => `${currency}:${amount}`,
+  ),
+  getCurrencySymbol: jest.fn((currency: string) => `$${currency}`),
+}));
+
+describe('quickBuyQuickAmounts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('formatQuickBuyPillLabel', () => {
+    it('uses full currency formatting for standard-magnitude currencies', () => {
+      expect(formatQuickBuyPillLabel(500, 'USD')).toBe('USD:500');
+      expect(formatCurrency).toHaveBeenCalledWith(500, 'USD', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+        useGrouping: false,
+      });
+    });
+
+    it('uses compact K labels for BRL amounts at or above the threshold', () => {
+      expect(formatQuickBuyPillLabel(2500, 'BRL')).toBe('$BRL2.5K');
+      expect(formatQuickBuyPillLabel(12500, 'BRL')).toBe('$BRL12.5K');
+      expect(formatCurrency).not.toHaveBeenCalled();
+    });
+
+    it('uses compact K/M labels for CNY, JPY, INR, and KRW', () => {
+      expect(formatQuickBuyPillLabel(3500, 'CNY')).toBe('$CNY3.5K');
+      expect(formatQuickBuyPillLabel(25000, 'CNY')).toBe('$CNY25K');
+      expect(formatQuickBuyPillLabel(75000, 'JPY')).toBe('$JPY75K');
+      expect(formatQuickBuyPillLabel(125000, 'INR')).toBe('$INR125K');
+      expect(formatQuickBuyPillLabel(700000, 'KRW')).toBe('$KRW700K');
+      expect(formatQuickBuyPillLabel(3500000, 'KRW')).toBe('$KRW3.5M');
+    });
+  });
+
+  describe('getBuyQuickAmounts', () => {
+    it('returns curated amounts for supported currencies without conversion', () => {
+      const options = getBuyQuickAmounts('EUR', 0.92);
+
+      expect(options).toHaveLength(4);
+      expect(options[0]).toEqual({
+        value: 500,
+        label: 'EUR:500',
+        isUsdFallback: false,
+      });
+      expect(options.map((option) => option.value)).toEqual(
+        Array.from(CURATED_QUICK_BUY_AMOUNTS.EUR ?? []),
+      );
+      expect(formatCurrency).toHaveBeenCalledWith(500, 'EUR', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+        useGrouping: false,
+      });
+    });
+
+    it('returns compact labels for high-magnitude curated currencies', () => {
+      const jpy = getBuyQuickAmounts('JPY', undefined);
+      const brl = getBuyQuickAmounts('BRL', undefined);
+
+      expect(jpy[0]).toEqual({
+        value: 75000,
+        label: '$JPY75K',
+        isUsdFallback: false,
+      });
+      expect(brl[2]).toEqual({
+        value: 12500,
+        label: '$BRL12.5K',
+        isUsdFallback: false,
+      });
+      expect(getCurrencySymbol).toHaveBeenCalledWith('JPY');
+    });
+
+    it('normalizes lowercase currency codes against the curated table', () => {
+      const options = getBuyQuickAmounts('jpy', undefined);
+
+      expect(options[0]?.value).toBe(75000);
+      expect(options[0]?.label).toBe('$JPY75K');
+      expect(options[0]?.isUsdFallback).toBe(false);
+    });
+
+    it('falls back to USD labels with converted values for unlisted currencies', () => {
+      const options = getBuyQuickAmounts('SEK', 10.5);
+
+      expect(options).toHaveLength(USD_QUICK_BUY_BASE.length);
+      expect(options[0]).toEqual({
+        value: 500 * 10.5,
+        label: 'USD:500',
+        isUsdFallback: true,
+      });
+      expect(formatCurrency).toHaveBeenCalledWith(500, 'USD', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+        useGrouping: false,
+      });
+    });
+
+    it('uses a 1:1 multiplier when the USD conversion rate is unavailable', () => {
+      const options = getBuyQuickAmounts('SEK', undefined);
+
+      expect(options[0]?.value).toBe(500);
+      expect(options[0]?.isUsdFallback).toBe(true);
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.test.ts
@@ -3,9 +3,9 @@ import {
   getCurrencySymbol,
 } from '../../../../../../UI/Bridge/utils/currencyUtils';
 import {
-  CURATED_QUICK_BUY_AMOUNTS,
   formatQuickBuyPillLabel,
   getBuyQuickAmounts,
+  snapToNiceFiatAmount,
   USD_QUICK_BUY_BASE,
 } from './quickBuyQuickAmounts';
 
@@ -21,98 +21,105 @@ describe('quickBuyQuickAmounts', () => {
     jest.clearAllMocks();
   });
 
+  describe('snapToNiceFiatAmount', () => {
+    it('returns USD tiers unchanged at a 1:1 rate', () => {
+      expect(snapToNiceFiatAmount(10, 'USD')).toBe(10);
+      expect(snapToNiceFiatAmount(50, 'USD')).toBe(50);
+      expect(snapToNiceFiatAmount(100, 'USD')).toBe(100);
+      expect(snapToNiceFiatAmount(250, 'USD')).toBe(250);
+    });
+
+    it('snaps EUR conversions to round local amounts', () => {
+      expect(snapToNiceFiatAmount(9.2, 'EUR')).toBe(10);
+      expect(snapToNiceFiatAmount(46, 'EUR')).toBe(50);
+    });
+
+    it('snaps JPY to whole yen', () => {
+      expect(snapToNiceFiatAmount(1487, 'JPY')).toBe(1500);
+      expect(snapToNiceFiatAmount(37500, 'JPY')).toBe(50000);
+    });
+
+    it('snaps IDR to whole rupiah', () => {
+      expect(snapToNiceFiatAmount(160_000, 'IDR')).toBe(150_000);
+    });
+  });
+
   describe('formatQuickBuyPillLabel', () => {
     it('uses full currency formatting for standard-magnitude currencies', () => {
-      expect(formatQuickBuyPillLabel(500, 'USD')).toBe('USD:500');
-      expect(formatCurrency).toHaveBeenCalledWith(500, 'USD', {
+      expect(formatQuickBuyPillLabel(10, 'USD')).toBe('USD:10');
+      expect(formatCurrency).toHaveBeenCalledWith(10, 'USD', {
         minimumFractionDigits: 0,
         maximumFractionDigits: 0,
         useGrouping: false,
       });
     });
 
-    it('uses compact K labels for BRL amounts at or above the threshold', () => {
-      expect(formatQuickBuyPillLabel(2500, 'BRL')).toBe('$BRL2.5K');
-      expect(formatQuickBuyPillLabel(12500, 'BRL')).toBe('$BRL12.5K');
+    it('uses compact K labels for high-magnitude JPY amounts', () => {
+      expect(formatQuickBuyPillLabel(1500, 'JPY')).toBe('$JPY1.5K');
+      expect(formatQuickBuyPillLabel(15000, 'JPY')).toBe('$JPY15K');
       expect(formatCurrency).not.toHaveBeenCalled();
     });
 
-    it('uses compact K/M labels for CNY, JPY, INR, and KRW', () => {
-      expect(formatQuickBuyPillLabel(3500, 'CNY')).toBe('$CNY3.5K');
-      expect(formatQuickBuyPillLabel(25000, 'CNY')).toBe('$CNY25K');
-      expect(formatQuickBuyPillLabel(75000, 'JPY')).toBe('$JPY75K');
-      expect(formatQuickBuyPillLabel(125000, 'INR')).toBe('$INR125K');
-      expect(formatQuickBuyPillLabel(700000, 'KRW')).toBe('$KRW700K');
-      expect(formatQuickBuyPillLabel(3500000, 'KRW')).toBe('$KRW3.5M');
+    it('uses compact K/M labels for IDR and KRW', () => {
+      expect(formatQuickBuyPillLabel(200_000, 'IDR')).toBe('$IDR200K');
+      expect(formatQuickBuyPillLabel(3_500_000, 'KRW')).toBe('$KRW3.5M');
+      expect(getCurrencySymbol).toHaveBeenCalledWith('IDR');
     });
   });
 
   describe('getBuyQuickAmounts', () => {
-    it('returns curated amounts for supported currencies without conversion', () => {
-      const options = getBuyQuickAmounts('EUR', 0.92);
+    it('returns four USD tiers at a 1:1 rate', () => {
+      const options = getBuyQuickAmounts('USD', 1);
 
       expect(options).toHaveLength(4);
-      expect(options[0]).toEqual({
-        value: 500,
-        label: 'EUR:500',
-        isUsdFallback: false,
-      });
-      expect(options.map((option) => option.value)).toEqual(
-        Array.from(CURATED_QUICK_BUY_AMOUNTS.EUR ?? []),
+      expect(options.map((option) => option.presetTierUsd)).toEqual(
+        Array.from(USD_QUICK_BUY_BASE),
       );
-      expect(formatCurrency).toHaveBeenCalledWith(500, 'EUR', {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-        useGrouping: false,
-      });
-    });
-
-    it('returns compact labels for high-magnitude curated currencies', () => {
-      const jpy = getBuyQuickAmounts('JPY', undefined);
-      const brl = getBuyQuickAmounts('BRL', undefined);
-
-      expect(jpy[0]).toEqual({
-        value: 75000,
-        label: '$JPY75K',
-        isUsdFallback: false,
-      });
-      expect(brl[2]).toEqual({
-        value: 12500,
-        label: '$BRL12.5K',
-        isUsdFallback: false,
-      });
-      expect(getCurrencySymbol).toHaveBeenCalledWith('JPY');
-    });
-
-    it('normalizes lowercase currency codes against the curated table', () => {
-      const options = getBuyQuickAmounts('jpy', undefined);
-
-      expect(options[0]?.value).toBe(75000);
-      expect(options[0]?.label).toBe('$JPY75K');
-      expect(options[0]?.isUsdFallback).toBe(false);
-    });
-
-    it('falls back to USD labels with converted values for unlisted currencies', () => {
-      const options = getBuyQuickAmounts('SEK', 10.5);
-
-      expect(options).toHaveLength(USD_QUICK_BUY_BASE.length);
       expect(options[0]).toEqual({
-        value: 500 * 10.5,
-        label: 'USD:500',
-        isUsdFallback: true,
+        value: 10,
+        label: 'USD:10',
+        presetTierUsd: 10,
       });
-      expect(formatCurrency).toHaveBeenCalledWith(500, 'USD', {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-        useGrouping: false,
+      expect(options[3]).toEqual({
+        value: 250,
+        label: 'USD:250',
+        presetTierUsd: 250,
       });
+    });
+
+    it('converts and snaps EUR amounts from the USD anchor', () => {
+      const options = getBuyQuickAmounts('EUR', 0.92);
+
+      expect(options[0]?.value).toBe(10);
+      expect(options[1]?.value).toBe(50);
+      expect(options[0]?.presetTierUsd).toBe(10);
+      expect(options[0]?.label).toBe('EUR:10');
+    });
+
+    it('converts and snaps JPY amounts with compact labels at higher tiers', () => {
+      const options = getBuyQuickAmounts('JPY', 150);
+
+      expect(options[0]).toEqual({
+        value: 1500,
+        label: '$JPY1.5K',
+        presetTierUsd: 10,
+      });
+      expect(options[3]?.value).toBe(50000);
+      expect(options[3]?.label).toBe('$JPY50K');
+    });
+
+    it('normalizes lowercase currency codes', () => {
+      const options = getBuyQuickAmounts('jpy', 150);
+
+      expect(options[0]?.value).toBe(1500);
+      expect(options[0]?.label).toBe('$JPY1.5K');
     });
 
     it('uses a 1:1 multiplier when the USD conversion rate is unavailable', () => {
       const options = getBuyQuickAmounts('SEK', undefined);
 
-      expect(options[0]?.value).toBe(500);
-      expect(options[0]?.isUsdFallback).toBe(true);
+      expect(options[0]?.value).toBe(10);
+      expect(options[0]?.presetTierUsd).toBe(10);
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.ts
@@ -4,10 +4,32 @@ import {
 } from '../../../../../../UI/Bridge/utils/currencyUtils';
 
 /** USD anchor set for buy quick-amount pills (Swap Next Figma). */
-export const USD_QUICK_BUY_BASE = [500, 1500, 2500, 3500] as const;
+export const USD_QUICK_BUY_BASE = [10, 50, 100, 250] as const;
 
 /** Sell quick-amount pills as balance percentages; 100 maps to the "Max" label. */
 export const SELL_QUICK_PERCENTAGES = [25, 50, 75, 100] as const;
+
+const NICE_AMOUNT_MULTIPLIERS = [1, 1.5, 2, 2.5, 5, 10] as const;
+
+/** Fiat codes that display without fractional units (ISO 4217 minor units = 0). */
+const ZERO_DECIMAL_CURRENCIES = new Set([
+  'BIF',
+  'CLP',
+  'DJF',
+  'GNF',
+  'IDR',
+  'JPY',
+  'KMF',
+  'KRW',
+  'PYG',
+  'RWF',
+  'UGX',
+  'VND',
+  'VUV',
+  'XAF',
+  'XOF',
+  'XPF',
+]);
 
 /**
  * Currencies whose pill amounts use larger magnitudes and need compact K/M
@@ -19,41 +41,63 @@ const COMPACT_PILL_LABEL_CURRENCIES = new Set([
   'JPY',
   'INR',
   'KRW',
+  'IDR',
 ]);
 
 /** Minimum magnitude before a compact-pill currency switches from full to K/M. */
 const COMPACT_PILL_LABEL_THRESHOLD = 1_000;
 
-/**
- * Hand-tuned buy pill amounts per currency. Values are already in that
- * currency's units — no conversion on tap. Currencies not listed here fall
- * back to USD-labeled pills with live USD→user-currency conversion.
- */
-const CURRENCIES_WITH_USD_MAGNITUDE = [
-  'EUR',
-  'GBP',
-  'CHF',
-  'CAD',
-  'AUD',
-] as const;
-export const CURATED_QUICK_BUY_AMOUNTS: Record<string, readonly number[]> = {
-  USD: USD_QUICK_BUY_BASE,
-  ...Object.fromEntries(
-    CURRENCIES_WITH_USD_MAGNITUDE.map((code) => [code, USD_QUICK_BUY_BASE]),
-  ),
-  BRL: [2500, 7500, 12500, 17500],
-  CNY: [3500, 10000, 17500, 25000],
-  JPY: [75000, 200000, 350000, 500000],
-  INR: [40000, 125000, 200000, 300000],
-  KRW: [700000, 2000000, 3500000, 5000000],
-};
-
-/** Intl options for pill labels — no grouping separators so "$3500" fits in-row. */
+/** Intl options for pill labels — no grouping separators so "$250" fits in-row. */
 const PILL_LABEL_CURRENCY_OPTIONS: Intl.NumberFormatOptions = {
   minimumFractionDigits: 0,
   maximumFractionDigits: 0,
   useGrouping: false,
 };
+
+function getCurrencyFractionDigits(currency: string): number {
+  return ZERO_DECIMAL_CURRENCIES.has(currency.toUpperCase()) ? 0 : 2;
+}
+
+/**
+ * Snaps a converted fiat amount to the nearest "nice" value (1/2/5/10 × 10^n)
+ * so pill labels stay round across currencies. Label and committed value both
+ * use this result.
+ */
+export function snapToNiceFiatAmount(value: number, currency: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return value;
+  }
+
+  const fractionDigits = getCurrencyFractionDigits(currency);
+
+  if (value < 1) {
+    const factor = 10 ** fractionDigits;
+    return Math.round(value * factor) / factor;
+  }
+
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+
+  let bestDiff = Infinity;
+  let bestCandidate = NICE_AMOUNT_MULTIPLIERS[0] * magnitude;
+
+  for (const multiplier of NICE_AMOUNT_MULTIPLIERS) {
+    const candidate = multiplier * magnitude;
+    const diff = Math.abs(candidate - value);
+    if (diff < bestDiff || (diff === bestDiff && candidate > bestCandidate)) {
+      bestDiff = diff;
+      bestCandidate = candidate;
+    }
+  }
+
+  let result = bestCandidate;
+  if (fractionDigits === 0) {
+    result = Math.round(result);
+  } else {
+    result = Math.round(result * 100) / 100;
+  }
+
+  return result;
+}
 
 function formatPillCurrency(value: number, currency: string): string {
   return formatCurrency(value, currency, PILL_LABEL_CURRENCY_OPTIONS);
@@ -81,9 +125,8 @@ function formatCompactMagnitude(value: number): string {
 
 /**
  * Pill label for a buy quick-amount. Uses compact K/M notation for
- * high-magnitude currencies (BRL, CNY, JPY, INR, KRW) so labels fit in the
- * pill row. The committed `value` is always the full amount — only display
- * is abbreviated. Hermes does not support `Intl` `notation: 'compact'`.
+ * high-magnitude currencies so labels fit in the pill row. The committed
+ * `value` is always the full amount — only display is abbreviated.
  */
 export function formatQuickBuyPillLabel(
   value: number,
@@ -104,10 +147,10 @@ export function formatQuickBuyPillLabel(
 export interface BuyQuickAmountOption {
   /** Amount in the user's display currency (committed to `fiatAmount`). */
   value: number;
-  /** Pill label — curated currencies use `currentCurrency`; fallback uses USD. */
+  /** Pill label in the user's display currency. */
   label: string;
-  /** True when the pill is USD-labeled but the value is converted locally. */
-  isUsdFallback: boolean;
+  /** USD anchor tier for analytics (`preset_value`). */
+  presetTierUsd: number;
 }
 
 /**
@@ -115,24 +158,13 @@ export interface BuyQuickAmountOption {
  *
  * @param currentCurrency - User's selected fiat currency code (e.g. `EUR`).
  * @param usdToCurrentRate - Multiplier to convert USD → `currentCurrency`
- * (`conversionRate / usdConversionRate`). When undefined, fallback pills
- * use a 1:1 multiplier so taps still set a numeric amount.
+ * (`conversionRate / usdConversionRate`). When undefined, uses a 1:1 multiplier.
  */
 export function getBuyQuickAmounts(
   currentCurrency: string,
   usdToCurrentRate: number | undefined,
 ): BuyQuickAmountOption[] {
   const normalizedCurrency = currentCurrency.toUpperCase();
-  const curated = CURATED_QUICK_BUY_AMOUNTS[normalizedCurrency];
-
-  if (curated) {
-    return curated.map((value) => ({
-      value,
-      label: formatQuickBuyPillLabel(value, normalizedCurrency),
-      isUsdFallback: false,
-    }));
-  }
-
   const rate =
     usdToCurrentRate !== undefined &&
     Number.isFinite(usdToCurrentRate) &&
@@ -140,12 +172,16 @@ export function getBuyQuickAmounts(
       ? usdToCurrentRate
       : 1;
 
-  return USD_QUICK_BUY_BASE.map((usdValue) => {
-    const value = usdValue * rate;
+  return USD_QUICK_BUY_BASE.map((presetTierUsd) => {
+    const raw = presetTierUsd * rate;
+    const value =
+      normalizedCurrency === 'USD'
+        ? presetTierUsd
+        : snapToNiceFiatAmount(raw, normalizedCurrency);
     return {
       value,
-      label: formatPillCurrency(usdValue, 'USD'),
-      isUsdFallback: true,
+      label: formatQuickBuyPillLabel(value, normalizedCurrency),
+      presetTierUsd,
     };
   });
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/quickBuyQuickAmounts.ts
@@ -1,0 +1,151 @@
+import {
+  formatCurrency,
+  getCurrencySymbol,
+} from '../../../../../../UI/Bridge/utils/currencyUtils';
+
+/** USD anchor set for buy quick-amount pills (Swap Next Figma). */
+export const USD_QUICK_BUY_BASE = [500, 1500, 2500, 3500] as const;
+
+/** Sell quick-amount pills as balance percentages; 100 maps to the "Max" label. */
+export const SELL_QUICK_PERCENTAGES = [25, 50, 75, 100] as const;
+
+/**
+ * Currencies whose pill amounts use larger magnitudes and need compact K/M
+ * labels so four pills fit in a single row without truncation.
+ */
+const COMPACT_PILL_LABEL_CURRENCIES = new Set([
+  'BRL',
+  'CNY',
+  'JPY',
+  'INR',
+  'KRW',
+]);
+
+/** Minimum magnitude before a compact-pill currency switches from full to K/M. */
+const COMPACT_PILL_LABEL_THRESHOLD = 1_000;
+
+/**
+ * Hand-tuned buy pill amounts per currency. Values are already in that
+ * currency's units — no conversion on tap. Currencies not listed here fall
+ * back to USD-labeled pills with live USD→user-currency conversion.
+ */
+const CURRENCIES_WITH_USD_MAGNITUDE = [
+  'EUR',
+  'GBP',
+  'CHF',
+  'CAD',
+  'AUD',
+] as const;
+export const CURATED_QUICK_BUY_AMOUNTS: Record<string, readonly number[]> = {
+  USD: USD_QUICK_BUY_BASE,
+  ...Object.fromEntries(
+    CURRENCIES_WITH_USD_MAGNITUDE.map((code) => [code, USD_QUICK_BUY_BASE]),
+  ),
+  BRL: [2500, 7500, 12500, 17500],
+  CNY: [3500, 10000, 17500, 25000],
+  JPY: [75000, 200000, 350000, 500000],
+  INR: [40000, 125000, 200000, 300000],
+  KRW: [700000, 2000000, 3500000, 5000000],
+};
+
+/** Intl options for pill labels — no grouping separators so "$3500" fits in-row. */
+const PILL_LABEL_CURRENCY_OPTIONS: Intl.NumberFormatOptions = {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+  useGrouping: false,
+};
+
+function formatPillCurrency(value: number, currency: string): string {
+  return formatCurrency(value, currency, PILL_LABEL_CURRENCY_OPTIONS);
+}
+
+function formatCompactMagnitude(value: number): string {
+  const abs = Math.abs(value);
+
+  if (abs >= 1_000_000) {
+    const compact = abs / 1_000_000;
+    const formatted =
+      compact % 1 === 0 ? String(compact) : String(Number(compact.toFixed(1)));
+    return `${formatted}M`;
+  }
+
+  if (abs >= 1_000) {
+    const compact = abs / 1_000;
+    const formatted =
+      compact % 1 === 0 ? String(compact) : String(Number(compact.toFixed(1)));
+    return `${formatted}K`;
+  }
+
+  return String(abs);
+}
+
+/**
+ * Pill label for a buy quick-amount. Uses compact K/M notation for
+ * high-magnitude currencies (BRL, CNY, JPY, INR, KRW) so labels fit in the
+ * pill row. The committed `value` is always the full amount — only display
+ * is abbreviated. Hermes does not support `Intl` `notation: 'compact'`.
+ */
+export function formatQuickBuyPillLabel(
+  value: number,
+  currency: string,
+): string {
+  const normalizedCurrency = currency.toUpperCase();
+  const shouldUseCompact =
+    COMPACT_PILL_LABEL_CURRENCIES.has(normalizedCurrency) &&
+    Math.abs(value) >= COMPACT_PILL_LABEL_THRESHOLD;
+
+  if (!shouldUseCompact) {
+    return formatPillCurrency(value, normalizedCurrency);
+  }
+
+  return `${getCurrencySymbol(normalizedCurrency)}${formatCompactMagnitude(value)}`;
+}
+
+export interface BuyQuickAmountOption {
+  /** Amount in the user's display currency (committed to `fiatAmount`). */
+  value: number;
+  /** Pill label — curated currencies use `currentCurrency`; fallback uses USD. */
+  label: string;
+  /** True when the pill is USD-labeled but the value is converted locally. */
+  isUsdFallback: boolean;
+}
+
+/**
+ * Builds buy-side quick-amount pill options for the user's display currency.
+ *
+ * @param currentCurrency - User's selected fiat currency code (e.g. `EUR`).
+ * @param usdToCurrentRate - Multiplier to convert USD → `currentCurrency`
+ * (`conversionRate / usdConversionRate`). When undefined, fallback pills
+ * use a 1:1 multiplier so taps still set a numeric amount.
+ */
+export function getBuyQuickAmounts(
+  currentCurrency: string,
+  usdToCurrentRate: number | undefined,
+): BuyQuickAmountOption[] {
+  const normalizedCurrency = currentCurrency.toUpperCase();
+  const curated = CURATED_QUICK_BUY_AMOUNTS[normalizedCurrency];
+
+  if (curated) {
+    return curated.map((value) => ({
+      value,
+      label: formatQuickBuyPillLabel(value, normalizedCurrency),
+      isUsdFallback: false,
+    }));
+  }
+
+  const rate =
+    usdToCurrentRate !== undefined &&
+    Number.isFinite(usdToCurrentRate) &&
+    usdToCurrentRate > 0
+      ? usdToCurrentRate
+      : 1;
+
+  return USD_QUICK_BUY_BASE.map((usdValue) => {
+    const value = usdValue * rate;
+    return {
+      value,
+      label: formatPillCurrency(usdValue, 'USD'),
+      isUsdFallback: true,
+    };
+  });
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1152,6 +1152,7 @@
       "buy_label": "Buy",
       "sell_label": "Sell",
       "receive": "Receive",
+      "max": "Max",
       "toast_pending_buy": "Buying {{amount}} of {{symbol}} with {{counter}}",
       "toast_pending_sell": "Selling {{amount}} of {{symbol}} for {{counter}}",
       "toast_complete_buy": "Bought {{amount}} of {{symbol}} with {{counter}}",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1153,6 +1153,7 @@
       "sell_label": "Sell",
       "receive": "Receive",
       "max": "Max",
+      "add_funds": "Add funds",
       "toast_pending_buy": "Buying {{amount}} of {{symbol}} with {{counter}}",
       "toast_pending_sell": "Selling {{amount}} of {{symbol}} for {{counter}}",
       "toast_complete_buy": "Bought {{amount}} of {{symbol}} with {{counter}}",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

- Adds to Buy side quick-amount pills ($10 / $50 / $100 / $250) with runtime USD conversion and nice-number snapping for non-USD currencies
- Defaults the amount slider to 50% when the QuickBuy sheet opens
- When a buy pill exceeds pay-with balance, show an enabled **Add funds** CTA that routes to Ramp `goToBuy` for the selected "pay with" token.
- Sell side stays with % amount pills

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 17 38" src="https://github.com/user-attachments/assets/11d61f2f-4720-49d7-997b-315634cd54ef" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 18 25" src="https://github.com/user-attachments/assets/645dbb24-e636-42eb-a8c8-f1d6ddf8d2b2" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 18 38" src="https://github.com/user-attachments/assets/12cc591e-0cd8-4657-8d6e-819dcd8b21e5" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 22 00" src="https://github.com/user-attachments/assets/a04eaa85-670b-40f5-ae69-24e57e43a45a" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 20 58" src="https://github.com/user-attachments/assets/468b664b-f804-4898-8805-49db014b4efc" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 10 23 00" src="https://github.com/user-attachments/assets/131ada1b-9d95-4524-93f9-690f6f85de44" />


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: NA

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trade confirmation, CTA enablement, and price-impact guards, and adds Ramp navigation when presets exceed balance—important for funds UX but covered by tests.
> 
> **Overview**
> Adds **quick-amount pills** to Social Quick Buy (behind `quickAmountPills`, on for Top Traders): buy mode shows USD-anchored fiat tiers converted to the user’s currency with rounded labels; sell mode shows 25/50/75/Max % pills wired to the slider.
> 
> **Sheet open** now commits **50%** of spendable balance once pricing is available. **Preset buy taps** commit amount, sync the slider, and track `preset` analytics with `preset_value`.
> 
> When a buy preset **exceeds pay-with balance**, the flow enters **`isPresetAddFundsMode`**: CTA shows **Add funds**, skips quote/insufficient-balance gates and high price-impact blocking, and **`handleConfirm`** routes to Ramp **`goToBuy`** for the pay-with token then closes the sheet.
> 
> New copy: `max`, `add_funds`. Broad unit tests cover pills, footer flag, currency utils, context, controller, and analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d97ef7ef70b2f6df5867dec20288bf1430e70059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->