### PR TITLE
fix: agentic qrlogin screen teardown and dev/uat url

### DIFF
--- a/app/components/Views/AgenticCliApproval/AgenticCliApprovalService.test.ts
+++ b/app/components/Views/AgenticCliApproval/AgenticCliApprovalService.test.ts
@@ -81,16 +81,16 @@ describe('AgenticCliApprovalService', () => {
   });
 
   describe('getApprovalHost', () => {
-    it('returns the test dashboard host for development builds', () => {
+    it('returns the develop developer dashboard host for development builds', () => {
       mockGetBuildType.mockReturnValue('development');
 
-      expect(getApprovalHost()).toBe('https://test-dashboard.web3auth.io');
+      expect(getApprovalHost()).toBe('https://develop-developer.metamask.io');
     });
 
-    it('returns the dev dashboard host for UAT builds', () => {
+    it('returns the staging developer dashboard host for UAT builds', () => {
       mockGetBuildType.mockReturnValue('main_uat');
 
-      expect(getApprovalHost()).toBe('https://dev-dashboard.web3auth.io');
+      expect(getApprovalHost()).toBe('https://staging-developer.metamask.io');
     });
 
     it('returns the developer dashboard host for production builds', () => {
@@ -99,10 +99,10 @@ describe('AgenticCliApprovalService', () => {
       expect(getApprovalHost()).toBe('https://developer.metamask.io');
     });
 
-    it('returns the test dashboard host for dev channel builds', () => {
+    it('returns the develop developer dashboard host for dev channel builds', () => {
       mockGetBuildType.mockReturnValue('main_dev');
 
-      expect(getApprovalHost()).toBe('https://test-dashboard.web3auth.io');
+      expect(getApprovalHost()).toBe('https://develop-developer.metamask.io');
     });
   });
 
@@ -312,7 +312,7 @@ describe('AgenticCliApprovalService', () => {
       expect(new URL(url).searchParams.get('mimirSignature')).toBe(
         'sig/with+chars',
       );
-      expect(new URL(url).host).toBe('test-dashboard.web3auth.io');
+      expect(new URL(url).host).toBe('develop-developer.metamask.io');
     });
   });
 

--- a/app/components/Views/AgenticCliApproval/AgenticCliApprovalService.ts
+++ b/app/components/Views/AgenticCliApproval/AgenticCliApprovalService.ts
@@ -25,8 +25,8 @@ const APPROVAL_PAGE_PATH_PATTERN = /^\/agentic\/[a-zA-Z0-9/_-]+$/;
 const CLI_DASHBOARD_TOKEN_PATH = '/api/v2/mm-qr-login/token';
 
 const AGENTIC_CLI_APPROVAL_HOST = {
-  dev: 'https://test-dashboard.web3auth.io',
-  uat: 'https://dev-dashboard.web3auth.io',
+  dev: 'https://develop-developer.metamask.io',
+  uat: 'https://staging-developer.metamask.io',
   prod: 'https://developer.metamask.io',
 } as const;
 
@@ -41,6 +41,8 @@ interface CliDashboardTokenResponse {
 const ALLOWED_ORIGIN_PATTERNS: RegExp[] = [
   /^https:\/\/link\.metamask\.io$/,
   /^https:\/\/developer\.metamask\.io$/,
+  /^https:\/\/develop-developer\.metamask\.io$/,
+  /^https:\/\/staging-developer\.metamask\.io$/,
   /^https:\/\/test-dashboard\.web3auth\.io$/,
   /^https:\/\/dev-dashboard\.web3auth\.io$/,
   /^https:\/\/auth\.web3auth\.io$/,

--- a/app/components/Views/AgenticCliDashboardWebview/AgenticCliDashboardWebviewService.ts
+++ b/app/components/Views/AgenticCliDashboardWebview/AgenticCliDashboardWebviewService.ts
@@ -15,6 +15,8 @@ const ALLOWED_ORIGIN_PATTERNS: RegExp[] = [
   /^https:\/\/auth\.web3auth\.io$/,
   /^https:\/\/[a-z0-9-]+\.cx\.metamask\.io$/,
   /^https:\/\/developer\.metamask\.io$/,
+  /^https:\/\/develop-developer\.metamask\.io$/,
+  /^https:\/\/staging-developer\.metamask\.io$/,
 ];
 
 /** Non-prod dashboard hosts used when `MM_DEV_API_ENV=dev`. */
@@ -207,7 +209,7 @@ export const AgenticCliDashboardWebviewService = {
         completeRequest(requestId, (pending) =>
           pending.reject(new Error('Dashboard approval timed out.')),
         );
-        dismissOpenWebview();
+        // dismissOpenWebview();
       }, WEBVIEW_TIMEOUT_MS);
 
       pendingRequests.set(requestId, {

--- a/app/components/Views/AgenticCliDashboardWebview/AgenticCliDashboardWebviewService.ts
+++ b/app/components/Views/AgenticCliDashboardWebview/AgenticCliDashboardWebviewService.ts
@@ -209,7 +209,7 @@ export const AgenticCliDashboardWebviewService = {
         completeRequest(requestId, (pending) =>
           pending.reject(new Error('Dashboard approval timed out.')),
         );
-        // dismissOpenWebview();
+        dismissOpenWebview();
       }, WEBVIEW_TIMEOUT_MS);
 
       pendingRequests.set(requestId, {

--- a/app/components/Views/AgenticCliDashboardWebview/index.test.tsx
+++ b/app/components/Views/AgenticCliDashboardWebview/index.test.tsx
@@ -8,6 +8,7 @@ import Logger from '../../../util/Logger';
 const mockGoBack = jest.fn();
 const mockSetOptions = jest.fn();
 const mockUseParams = jest.fn();
+const mockBeforeRemoveCallback = { current: null as (() => void) | null };
 const mockBuildWebViewUrl =
   AgenticCliDashboardWebviewService.buildWebViewUrl as jest.Mock;
 const mockParseEvent =
@@ -31,6 +32,12 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     goBack: mockGoBack,
     setOptions: mockSetOptions,
+    addListener: (event: string, callback: () => void) => {
+      if (event === 'beforeRemove') {
+        mockBeforeRemoveCallback.current = callback;
+      }
+      return jest.fn();
+    },
   }),
 }));
 
@@ -130,6 +137,7 @@ describe('AgenticCliDashboardWebview', () => {
   beforeEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
+    mockBeforeRemoveCallback.current = null;
     jest.replaceProperty(Platform, 'OS', 'ios');
     mockUseParams.mockReturnValue(params);
     mockBuildWebViewUrl.mockReturnValue(
@@ -177,6 +185,43 @@ describe('AgenticCliDashboardWebview', () => {
       expect(mockResolve).toHaveBeenCalledWith('request-1', 'cli-token'),
     );
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects the pending request when beforeRemove fires without prior completion', async () => {
+    render(<AgenticCliDashboardWebview />);
+    await waitFor(() =>
+      expect(mockBeforeRemoveCallback.current).toEqual(expect.any(Function)),
+    );
+
+    act(() => {
+      mockBeforeRemoveCallback.current?.();
+    });
+
+    expect(mockReject).toHaveBeenCalledWith(
+      'request-1',
+      expect.objectContaining({ message: 'Dashboard approval closed.' }),
+    );
+    expect(mockReject).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reject again when beforeRemove fires after approval', async () => {
+    render(<AgenticCliDashboardWebview />);
+    await waitFor(() => expect(mockWebViewProps).toHaveBeenCalled());
+    mockParseEvent.mockReturnValue({ type: 'approved', cliToken: 'cli-token' });
+
+    act(() => {
+      getLatestWebViewProps().onMessage({
+        nativeEvent: { data: 'message' },
+      });
+    });
+
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      mockBeforeRemoveCallback.current?.();
+    });
+
+    expect(mockReject).not.toHaveBeenCalled();
   });
 
   it('rejects and closes when the dashboard posts close', async () => {

--- a/app/components/Views/AgenticCliDashboardWebview/index.tsx
+++ b/app/components/Views/AgenticCliDashboardWebview/index.tsx
@@ -110,6 +110,15 @@ const AgenticCliDashboardWebview: React.FC = () => {
     );
   }, [close, navigation]);
 
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      if (completedRef.current) return;
+      rejectOnce(DASHBOARD_CLOSED_MESSAGE);
+    });
+
+    return unsubscribe;
+  }, [navigation, rejectOnce]);
+
   const handleMessage = useCallback(
     (messageEvent: WebViewMessageEvent) => {
       const event = AgenticCliDashboardWebviewService.parseEvent(

--- a/app/components/Views/AgenticCliDashboardWebview/index.tsx
+++ b/app/components/Views/AgenticCliDashboardWebview/index.tsx
@@ -110,13 +110,6 @@ const AgenticCliDashboardWebview: React.FC = () => {
     );
   }, [close, navigation]);
 
-  useEffect(
-    () => () => {
-      rejectOnce(DASHBOARD_CLOSED_MESSAGE);
-    },
-    [rejectOnce],
-  );
-
   const handleMessage = useCallback(
     (messageEvent: WebViewMessageEvent) => {
       const event = AgenticCliDashboardWebviewService.parseEvent(

--- a/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
@@ -236,7 +236,7 @@ describe('AgenticCliQrLoginService', () => {
     expect(setStage).toHaveBeenCalledWith('send-auth-token-to-cli');
   });
 
-  it('uses dev auth API and test dashboard for main_dev builds', async () => {
+  it('uses dev auth API and develop dashboard for main_dev builds', async () => {
     const { handleAgenticCliQrLogin } = loadAgenticCliQrLogin('main_dev');
     const conn = createMockConnection();
 
@@ -253,12 +253,12 @@ describe('AgenticCliQrLoginService', () => {
       expect.any(Object),
     );
     expect(AgenticCliDashboardWebviewService.open).toHaveBeenCalledWith({
-      dashboardUrl: 'https://test-dashboard.web3auth.io/agentic/login',
+      dashboardUrl: 'https://develop-developer.metamask.io/agentic/login',
       dashboardToken: 'dashboard-token',
     });
   });
 
-  it('uses UAT auth API and UAT dashboard for main_uat builds', async () => {
+  it('uses dev auth API and staging dashboard for main_uat builds', async () => {
     const { handleAgenticCliQrLogin } = loadAgenticCliQrLogin('main_uat');
     const conn = createMockConnection();
 
@@ -275,7 +275,30 @@ describe('AgenticCliQrLoginService', () => {
       expect.any(Object),
     );
     expect(AgenticCliDashboardWebviewService.open).toHaveBeenCalledWith({
-      dashboardUrl: 'https://dev-dashboard.web3auth.io/agentic/login',
+      dashboardUrl: 'https://staging-developer.metamask.io/agentic/login',
+      dashboardToken: 'dashboard-token',
+    });
+  });
+
+  it('uses prod auth API when MM_DEV_API_ENV is prod', async () => {
+    process.env.MM_DEV_API_ENV = 'prod';
+    const { handleAgenticCliQrLogin } = loadAgenticCliQrLogin('main_prod');
+    const conn = createMockConnection();
+
+    await handleAgenticCliQrLogin({
+      connReq: mockConnectionRequest({ name: 'agentic-cli' }),
+      conn,
+      setStage: jest.fn(),
+      cleanupConnection: jest.fn().mockResolvedValue(undefined),
+    });
+
+    expect(mockGetEnvUrls).toHaveBeenCalledWith('prd');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://authentication.api.cx.metamask.io/api/v2/mm-qr-login/token',
+      expect.any(Object),
+    );
+    expect(AgenticCliDashboardWebviewService.open).toHaveBeenCalledWith({
+      dashboardUrl: 'https://developer.metamask.io/agentic/login',
       dashboardToken: 'dashboard-token',
     });
   });

--- a/app/core/AgenticCli/agenticCliConfig.ts
+++ b/app/core/AgenticCli/agenticCliConfig.ts
@@ -7,11 +7,11 @@ export const CLI_DASHBOARD_TOKEN_PATH = '/api/v2/mm-qr-login/token';
 export const ENGINE_READY_POLL_MS = 250;
 
 export const DASHBOARD_WEBVIEW_URL_BY_ENV: Record<string, string> = {
-  main_dev: 'https://test-dashboard.web3auth.io/agentic/login',
-  main_uat: 'https://dev-dashboard.web3auth.io/agentic/login',
+  main_dev: 'https://develop-developer.metamask.io/agentic/login',
+  main_uat: 'https://staging-developer.metamask.io/agentic/login',
   main_prod: 'https://developer.metamask.io/agentic/login',
-  flask_dev: 'https://test-dashboard.web3auth.io/agentic/login',
-  flask_uat: 'https://dev-dashboard.web3auth.io/agentic/login',
+  flask_dev: 'https://develop-developer.metamask.io/agentic/login',
+  flask_uat: 'https://staging-developer.metamask.io/agentic/login',
   flask_prod: 'https://developer.metamask.io/agentic/login',
 };
 


### PR DESCRIPTION

## **Description**

<!-- mms-check: type=text required=true -->

This PR hardens the Agentic CLI QR login dashboard WebView flow and updates non-prod dashboard hosts.

1. **Screen teardown cleanup** — Replaced a `useEffect` cleanup keyed on `rejectOnce` with a React Navigation `beforeRemove` listener. The old cleanup also ran when unrelated dependencies changed (e.g. when `webViewUrl` was set), which made it look like the screen unmounted before approve was processed. `beforeRemove` runs only when the screen is actually removed (header back, swipe dismiss, hardware back, `goBack` after approve), and rejects the pending `open()` promise unless approval already completed.

2. **Timeout dismissal** — Re-enabled `dismissOpenWebview()` when the dashboard approval request times out so the modal is popped after rejection.

3. **Dev/UAT dashboard URLs** — Pointed dev and UAT Agentic CLI approval/dashboard WebViews from legacy Web3Auth hosts to `develop-developer.metamask.io` and `staging-developer.metamask.io`, with matching origin allowlist updates. Production URLs are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Agentic CLI dashboard approval not rejecting the pending request when the WebView is dismissed before completion.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Agentic CLI QR login dashboard WebView

  Scenario: Approve dashboard connection
    Given a dev or UAT build with Agentic CLI QR login enabled
    And the wallet is unlocked
    When the user scans an Agentic CLI connect QR code
    And approves the connection in the dashboard WebView
    Then the WebView closes
    And the CLI connection completes successfully

  Scenario: Dismiss dashboard WebView before approving
    Given the Agentic CLI dashboard WebView is open
    When the user swipes to dismiss the modal (or presses hardware back on Android)
    Then the WebView closes
    And the pending dashboard approval promise is rejected (CLI link does not hang)

  Scenario: Header back dismisses dashboard WebView
    Given the Agentic CLI dashboard WebView is open
    When the user taps the header back button
    Then the WebView closes
    And the pending request is rejected once (no double reject)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebView teardown and which origins/hosts load for Agentic CLI in dev/UAT; wrong behavior could hang or prematurely abort CLI linking, but production URLs are unchanged.
> 
> **Overview**
> Fixes Agentic CLI dashboard WebView teardown so dismissing the screen does not reject the pending approval at the wrong time, and moves dev/UAT dashboard traffic to MetaMask developer hosts.
> 
> **Dashboard dismiss handling** — Replaces a `useEffect` cleanup tied to `rejectOnce` with a React Navigation `beforeRemove` listener that rejects the pending `open()` promise only when the screen is actually removed and approval has not completed. New component tests cover dismiss-before-approve and no double-reject after success.
> 
> **Non-prod URLs and allowlists** — Dev and UAT builds now use `develop-developer.metamask.io` and `staging-developer.metamask.io` instead of legacy Web3Auth dashboard hosts in `agenticCliConfig`, `AgenticCliApprovalService`, and related tests. WebView origin allowlists add those hosts so in-app navigation stays permitted. Production `developer.metamask.io` is unchanged.
> 
> **QR login tests** — Expectations and copy align with the new hosts; adds coverage for `MM_DEV_API_ENV=prod` using the production auth API and dashboard URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620bbc647b1c220e12c80e9003cc7b6d1750711f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->