### PR TITLE
feat(whats-happening): support fetching an outdated front-page item (1/2)

### DIFF
--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -323,6 +323,21 @@ describe('useWhatsHappening', () => {
       expect(result.current.items[0].isOutdated).toBeUndefined();
     });
 
+    it('shows the outdated item and clears error when overview throws but front-page fetch succeeds', async () => {
+      mockFetchMarketOverview.mockRejectedValue(new Error('Network error'));
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+      expect(result.current.items[0].id).toBe(`front-page-${mockFrontPage.id}`);
+      expect(result.current.error).toBeNull();
+    });
+
     it('does not fetch a front-page item when no deep-linked id is set', async () => {
       const { result } = renderHook(() => useWhatsHappening());
       await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -4,8 +4,8 @@ import {
   isWhatsHappeningSectionVisible,
   useWhatsHappening,
 } from './useWhatsHappening';
-
 const mockFetchMarketOverview = jest.fn();
+const mockFetchFrontPageItem = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   __esModule: true,
@@ -14,6 +14,8 @@ jest.mock('../../../../core/Engine', () => ({
       AiDigestController: {
         fetchMarketOverview: (...args: unknown[]) =>
           mockFetchMarketOverview(...args),
+        fetchFrontPageItem: (...args: unknown[]) =>
+          mockFetchFrontPageItem(...args),
       },
     },
   },
@@ -24,6 +26,18 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockUseSelector = useSelector as jest.Mock;
+
+/**
+ * Configures the feature-flag selector the hook reads. The deep-linked
+ * outdated item id is now passed via the hook's `outdatedItemId` option, not
+ * a selector.
+ *
+ * @param options - Selector return overrides.
+ * @param options.enabled - Value for `selectWhatsHappeningEnabled`.
+ */
+const configureSelectors = ({ enabled = true }: { enabled?: boolean } = {}) => {
+  mockUseSelector.mockReturnValue(enabled);
+};
 
 const mockTrend = {
   title: 'Bitcoin ETF inflows hit record high',
@@ -55,8 +69,9 @@ const mockOverview = {
 describe('useWhatsHappening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(true);
+    configureSelectors();
     mockFetchMarketOverview.mockResolvedValue(mockOverview);
+    mockFetchFrontPageItem.mockResolvedValue(null);
   });
 
   it('starts in loading state when enabled', () => {
@@ -213,6 +228,107 @@ describe('useWhatsHappening', () => {
     expect(mockFetchMarketOverview).not.toHaveBeenCalled();
     expect(result.current.items).toHaveLength(0);
     expect(result.current.error).toBeNull();
+  });
+
+  describe('deep-linked outdated front-page item', () => {
+    const mockFrontPage = {
+      id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+      item: {
+        title: 'Older headline that dropped out of the report',
+        description: 'An older market overview item fetched by id.',
+        category: 'regulatory' as const,
+        impact: 'negative' as const,
+        relatedAssets: [
+          {
+            symbol: 'ETH',
+            name: 'Ethereum',
+            caip19: ['eip155:1/slip44:60'],
+          },
+        ],
+        articles: [],
+      },
+      ctaTitle: 'CTA title',
+      ctaDescription: 'CTA description',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    };
+
+    it('prepends the fetched item first, flagged outdated, before the latest items', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).toHaveBeenCalledWith(mockFrontPage.id);
+      expect(result.current.items[0].isOutdated).toBe(true);
+      expect(result.current.items[0].id).toBe(`front-page-${mockFrontPage.id}`);
+      expect(result.current.items[0].title).toBe(mockFrontPage.item.title);
+      expect(result.current.items[0].date).toBe(mockFrontPage.createdAt);
+      expect(result.current.items[1].title).toBe(mockTrend.title);
+      expect(result.current.items[1].isOutdated).toBeUndefined();
+    });
+
+    it('keeps the total capped at the limit with the outdated item first', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue({
+        ...mockOverview,
+        trends: [mockTrend, mockTrend],
+      });
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(2, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(2);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('shows the outdated item even when the market overview is empty', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue(null);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('falls back to the latest items when the front-page fetch fails', async () => {
+      mockFetchFrontPageItem.mockRejectedValue(new Error('boom'));
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('falls back to the latest items when the front page is not found', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(null);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+    });
+
+    it('does not fetch a front-page item when no deep-linked id is set', async () => {
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import type { MarketOverview } from '@metamask/ai-controllers';
+import type {
+  MarketOverview,
+  MarketOverviewFrontPage,
+} from '@metamask/ai-controllers';
 import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import type { WhatsHappeningItem } from '../types';
@@ -18,6 +21,12 @@ export interface UseWhatsHappeningResult {
 export interface UseWhatsHappeningOptions {
   /** When false, skips fetching (for parents that supply their own feed). */
   enabled?: boolean;
+  /**
+   * A market overview front-page item id to fetch and prepend as the first,
+   * "outdated" card. Supplied by the What's Happening deep link; only the
+   * detail view passes it, so the Explore/Perps carousels are unaffected.
+   */
+  outdatedItemId?: string | null;
 }
 
 export const isWhatsHappeningSectionVisible = ({
@@ -42,6 +51,45 @@ const mapTrendsToItems = (
     articles: trend.articles,
   }));
 
+const mapFrontPageToItem = (
+  frontPage: MarketOverviewFrontPage,
+): WhatsHappeningItem => ({
+  id: `front-page-${frontPage.id}`,
+  title: frontPage.item.title,
+  description: frontPage.item.description,
+  date: frontPage.createdAt,
+  category: frontPage.item.category,
+  impact: frontPage.item.impact,
+  relatedAssets: frontPage.item.relatedAssets,
+  articles: frontPage.item.articles,
+  isOutdated: true,
+});
+
+/**
+ * Fetches the deep-linked "outdated" front-page item, if any.
+ *
+ * @param outdatedItemId - The front-page item id from the deep link, or `null`.
+ * @returns The mapped outdated item, or `null` when there is none / on failure.
+ */
+const fetchOutdatedItem = async (
+  outdatedItemId: string | null,
+): Promise<WhatsHappeningItem | null> => {
+  if (!outdatedItemId) {
+    return null;
+  }
+
+  try {
+    const frontPage =
+      await Engine.context.AiDigestController.fetchFrontPageItem(
+        outdatedItemId,
+      );
+    return frontPage ? mapFrontPageToItem(frontPage) : null;
+  } catch {
+    // Non-fatal: fall back to rendering just the latest market overview items.
+    return null;
+  }
+};
+
 /**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
@@ -57,6 +105,7 @@ export const useWhatsHappening = (
   options?: UseWhatsHappeningOptions,
 ): UseWhatsHappeningResult => {
   const isFeatureEnabled = useSelector(selectWhatsHappeningEnabled);
+  const outdatedItemId = options?.outdatedItemId ?? null;
   const isHookEnabled = options?.enabled ?? true;
   const isActive = isFeatureEnabled && isHookEnabled;
 
@@ -78,12 +127,15 @@ export const useWhatsHappening = (
     try {
       const data =
         await Engine.context.AiDigestController.fetchMarketOverview();
+      const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
 
-      if (data === null) {
-        setItems([]);
-      } else {
-        setItems(mapTrendsToItems(data, limit));
-      }
+      // When a deep link supplied an id, prepend that (older) front-page item
+      // as the first "outdated" card, keeping the total capped at `limit`.
+      const outdatedItem = await fetchOutdatedItem(outdatedItemId);
+
+      setItems(
+        outdatedItem ? [outdatedItem, ...baseItems].slice(0, limit) : baseItems,
+      );
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to fetch trending items',
@@ -92,7 +144,7 @@ export const useWhatsHappening = (
     } finally {
       setIsLoading(false);
     }
-  }, [isActive, limit]);
+  }, [isActive, limit, outdatedItemId]);
 
   const refresh = useCallback(async () => {
     await fetchItems();

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -124,26 +124,35 @@ export const useWhatsHappening = (
     setIsLoading(true);
     setError(null);
 
+    let overviewError: string | null = null;
+    let baseItems: WhatsHappeningItem[] = [];
+
     try {
       const data =
         await Engine.context.AiDigestController.fetchMarketOverview();
-      const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
+      baseItems = data === null ? [] : mapTrendsToItems(data, limit);
+    } catch (err) {
+      overviewError =
+        err instanceof Error ? err.message : 'Failed to fetch trending items';
+    }
 
-      // When a deep link supplied an id, prepend that (older) front-page item
-      // as the first "outdated" card, keeping the total capped at `limit`.
-      const outdatedItem = await fetchOutdatedItem(outdatedItemId);
+    // Always attempt to fetch the deep-linked outdated item — it has its own
+    // internal try/catch and never throws. This must run even when the overview
+    // request threw so that deep links are never left with an empty error state
+    // when the front-page item would load successfully.
+    const outdatedItem = await fetchOutdatedItem(outdatedItemId);
 
+    if (outdatedItem || baseItems.length > 0) {
       setItems(
         outdatedItem ? [outdatedItem, ...baseItems].slice(0, limit) : baseItems,
       );
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to fetch trending items',
-      );
+    } else {
+      // Both fetches produced nothing; surface the overview error if present.
       setItems([]);
-    } finally {
-      setIsLoading(false);
+      setError(overviewError);
     }
+
+    setIsLoading(false);
   }, [isActive, limit, outdatedItemId]);
 
   const refresh = useCallback(async () => {

--- a/app/components/UI/WhatsHappening/types.ts
+++ b/app/components/UI/WhatsHappening/types.ts
@@ -18,4 +18,10 @@ export interface WhatsHappeningItem {
   impact?: 'positive' | 'negative' | 'neutral';
   relatedAssets: RelatedAsset[];
   articles: Article[];
+  /**
+   * When true, this item was fetched by id from the front-page endpoint (an
+   * older item no longer in the latest market overview) and is rendered first
+   * in the carousel with an "Outdated" label.
+   */
+  isOutdated?: boolean;
 }

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
@@ -199,6 +199,49 @@ describe('WhatsHappeningExpandedCard', () => {
     expect(screen.queryByText('AI')).toBeNull();
   });
 
+  it('renders the Outdated badge when the item is outdated', () => {
+    const item = { ...baseItem, isOutdated: true };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="deeplink"
+      />,
+    );
+    expect(screen.getByText('Outdated')).toBeOnTheScreen();
+  });
+
+  it('does not render the Outdated badge by default', () => {
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={baseItem}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="homepage"
+      />,
+    );
+    expect(screen.queryByText('Outdated')).toBeNull();
+  });
+
+  it('renders the Outdated badge and AI pill even when impact is undefined', () => {
+    const item = { ...baseItem, impact: undefined, isOutdated: true };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="deeplink"
+      />,
+    );
+    expect(screen.getByText('Outdated')).toBeOnTheScreen();
+    expect(screen.getByText('AI')).toBeOnTheScreen();
+    expect(screen.queryByText('Bullish')).toBeNull();
+  });
+
   it('renders the single Related Assets section header when relatedAssets is non-empty', () => {
     const item = { ...baseItem, relatedAssets: [perpsOnlyAsset] };
     renderWithProvider(

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
@@ -139,8 +139,8 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
             style={tw.style('flex-1')}
             contentContainerStyle={tw.style('pt-7 px-5 pb-5 gap-4')}
           >
-            {/* Tag row: AI pill + impact badge */}
-            {item.impact && (
+            {/* Tag row: AI pill + impact badge + outdated badge */}
+            {(item.impact || item.isOutdated) && (
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
@@ -182,13 +182,26 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
                   )}
                 </Pressable>
 
-                <Box
-                  twClassName={`${impactBgClass} rounded px-2 py-1 self-start border border-transparent`}
-                >
-                  <Text variant={TextVariant.BodySm} color={impactTextColor}>
-                    {impactLabel}
-                  </Text>
-                </Box>
+                {item.impact ? (
+                  <Box
+                    twClassName={`${impactBgClass} rounded px-2 py-1 self-start border border-transparent`}
+                  >
+                    <Text variant={TextVariant.BodySm} color={impactTextColor}>
+                      {impactLabel}
+                    </Text>
+                  </Box>
+                ) : null}
+
+                {item.isOutdated ? (
+                  <Box twClassName="bg-warning-muted rounded px-2 py-1 self-start border border-transparent">
+                    <Text
+                      variant={TextVariant.BodySm}
+                      color={TextColor.WarningDefault}
+                    >
+                      {strings('whats_happening.outdated')}
+                    </Text>
+                  </Box>
+                ) : null}
               </Box>
             )}
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10187,6 +10187,7 @@
   "whats_happening": {
     "title": "What's happening",
     "ai": "AI",
+    "outdated": "Outdated",
     "impact": {
       "bullish": "Bullish",
       "bearish": "Bearish",

--- a/package.json
+++ b/package.json
@@ -169,12 +169,6 @@
       "prettier --write"
     ]
   },
-  "previewBuilds": {
-    "@metamask/ai-controllers": {
-      "type": "non-breaking",
-      "previewVersion": "0.7.0-preview-8980fa5"
-    }
-  },
   "resolutions": {
     "@metamask/perps-controller": "^9.0.0",
     "@metamask/network-controller": "34.0.0",
@@ -248,7 +242,7 @@
     "@metamask/account-tree-controller": "^7.5.0",
     "@metamask/accounts-controller": "^39.0.2",
     "@metamask/address-book-controller": "^7.1.2",
-    "@metamask/ai-controllers": "^0.7.0",
+    "@metamask/ai-controllers": "^0.8.0",
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,12 @@
       "prettier --write"
     ]
   },
+  "previewBuilds": {
+    "@metamask/ai-controllers": {
+      "type": "non-breaking",
+      "previewVersion": "0.7.0-preview-8980fa5"
+    }
+  },
   "resolutions": {
     "@metamask/perps-controller": "^9.0.0",
     "@metamask/network-controller": "34.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,15 +7958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:@metamask-previews/ai-controllers@0.7.0-preview-8980fa5":
-  version: 0.7.0-preview-8980fa5
-  resolution: "@metamask-previews/ai-controllers@npm:0.7.0-preview-8980fa5"
+"@metamask/ai-controllers@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@metamask/ai-controllers@npm:0.8.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/0b4405a6c5a8aed033f630c380594036b411a29e6f1393c1fbc625743fb813e25e0230a0a6fee937c711704964dda1c75331db15c955626049695ad9230e58e9
+  checksum: 10/a3afa17519d91d72b8c4cf4d85540d59c02b11a95e8dd55799448e49f89cd577a63c72016f9b88e8430173327f5d4f55743b897e3760940b07806f04815de5f2
   languageName: node
   linkType: hard
 
@@ -35488,7 +35488,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^7.5.0"
     "@metamask/accounts-controller": "npm:^39.0.2"
     "@metamask/address-book-controller": "npm:^7.1.2"
-    "@metamask/ai-controllers": "npm:^0.7.0"
+    "@metamask/ai-controllers": "npm:^0.8.0"
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,15 +7958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@metamask/ai-controllers@npm:0.7.0"
+"@metamask/ai-controllers@npm:@metamask-previews/ai-controllers@0.7.0-preview-8980fa5":
+  version: 0.7.0-preview-8980fa5
+  resolution: "@metamask-previews/ai-controllers@npm:0.7.0-preview-8980fa5"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-  checksum: 10/129d02a26595f16362c6bb1905ef3885b369529eb0a174da46ed7add5fd1d6ffa4d00ba29e09f7583ef70a299dc99f33c82efc45eeea08ab7e5e712c4a3dc11d
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/0b4405a6c5a8aed033f630c380594036b411a29e6f1393c1fbc625743fb813e25e0230a0a6fee937c711704964dda1c75331db15c955626049695ad9230e58e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

**PR 1 of 3 (stacked).** Adds the data + presentation layer for surfacing an older market-overview "What's Happening" item — one that has dropped out of the latest report — in the expanded detail view.

**Reason for the change:** the market-overview endpoint only returns the latest items, so an older "What's Happening" item can no longer be shown. `@metamask/ai-controllers@0.8.0` adds `fetchFrontPageItem`, which fetches a single item by id.

**What this PR does (inert on its own):**
- Bumps `@metamask/ai-controllers` `^0.7.0` → `^0.8.0` (ships `fetchFrontPageItem` + the `MarketOverviewFrontPage` type).
- `useWhatsHappening` accepts an `outdatedItemId` option: it fetches that item via `AiDigestController.fetchFrontPageItem` and prepends it flagged `isOutdated` (capped at the display limit; non-fatal on 404/error).
- Adds `WhatsHappeningItem.isOutdated` and an "Outdated" badge in `WhatsHappeningExpandedCard` (+ the `whats_happening.outdated` locale string).

No surface passes `outdatedItemId` yet, so there is no user-facing change until the wiring in PR 2.

**Stack:** 1/3 this PR · 2/3 #32881 (deep-link wiring) · 3/3 #32900 (dedupe + badge refinement).

## **Changelog**

CHANGELOG entry: null

<!-- Inert on its own; the user-facing entry lives on #32881. -->

## **Related issues**

Refs: MetaMask/core#9394

## **Manual testing steps**

N/A — this PR is inert on its own (no surface passes `outdatedItemId` yet), so there is nothing to exercise in the UI. The logic is covered by unit tests for `useWhatsHappening` and `WhatsHappeningExpandedCard`; end-to-end steps live on #32881.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — no user-facing change in this PR.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature-flagged feed logic with graceful fallbacks and unit tests; no user-facing wiring in this PR and no auth or payment paths touched.
> 
> **Overview**
> Adds support for showing a **What's Happening** item that no longer appears in the latest market overview—intended for deep links in a follow-up PR.
> 
> **`@metamask/ai-controllers`** is bumped to **^0.8.0** so the app can call **`fetchFrontPageItem`**. **`useWhatsHappening`** accepts an optional **`outdatedItemId`**: it loads that front-page record, maps it with **`isOutdated: true`**, and **prepends** it before current trends while still honoring the item **limit**. Front-page failures are **non-fatal**; if the overview fails but the outdated item loads, the UI shows that item **without** surfacing the overview error.
> 
> **`WhatsHappeningItem`** gains optional **`isOutdated`**, and **`WhatsHappeningExpandedCard`** shows an **"Outdated"** badge (including when impact is missing). No caller passes **`outdatedItemId`** yet, so behavior is unchanged until wiring lands in PR 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e467b90ce0b11e8738fd7bba9431ce509221cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->