### PR TITLE
feat(whats-happening): open an outdated front-page item from a deep link (2/3)

### DIFF
--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -4,8 +4,8 @@ import {
   isWhatsHappeningSectionVisible,
   useWhatsHappening,
 } from './useWhatsHappening';
-
 const mockFetchMarketOverview = jest.fn();
+const mockFetchFrontPageItem = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   __esModule: true,
@@ -14,6 +14,8 @@ jest.mock('../../../../core/Engine', () => ({
       AiDigestController: {
         fetchMarketOverview: (...args: unknown[]) =>
           mockFetchMarketOverview(...args),
+        fetchFrontPageItem: (...args: unknown[]) =>
+          mockFetchFrontPageItem(...args),
       },
     },
   },
@@ -24,6 +26,18 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockUseSelector = useSelector as jest.Mock;
+
+/**
+ * Configures the feature-flag selector the hook reads. The deep-linked
+ * outdated item id is now passed via the hook's `outdatedItemId` option, not
+ * a selector.
+ *
+ * @param options - Selector return overrides.
+ * @param options.enabled - Value for `selectWhatsHappeningEnabled`.
+ */
+const configureSelectors = ({ enabled = true }: { enabled?: boolean } = {}) => {
+  mockUseSelector.mockReturnValue(enabled);
+};
 
 const mockTrend = {
   title: 'Bitcoin ETF inflows hit record high',
@@ -55,8 +69,9 @@ const mockOverview = {
 describe('useWhatsHappening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockReturnValue(true);
+    configureSelectors();
     mockFetchMarketOverview.mockResolvedValue(mockOverview);
+    mockFetchFrontPageItem.mockResolvedValue(null);
   });
 
   it('starts in loading state when enabled', () => {
@@ -213,6 +228,107 @@ describe('useWhatsHappening', () => {
     expect(mockFetchMarketOverview).not.toHaveBeenCalled();
     expect(result.current.items).toHaveLength(0);
     expect(result.current.error).toBeNull();
+  });
+
+  describe('deep-linked outdated front-page item', () => {
+    const mockFrontPage = {
+      id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+      item: {
+        title: 'Older headline that dropped out of the report',
+        description: 'An older market overview item fetched by id.',
+        category: 'regulatory' as const,
+        impact: 'negative' as const,
+        relatedAssets: [
+          {
+            symbol: 'ETH',
+            name: 'Ethereum',
+            caip19: ['eip155:1/slip44:60'],
+          },
+        ],
+        articles: [],
+      },
+      ctaTitle: 'CTA title',
+      ctaDescription: 'CTA description',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    };
+
+    it('prepends the fetched item first, flagged outdated, before the latest items', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).toHaveBeenCalledWith(mockFrontPage.id);
+      expect(result.current.items[0].isOutdated).toBe(true);
+      expect(result.current.items[0].id).toBe(`front-page-${mockFrontPage.id}`);
+      expect(result.current.items[0].title).toBe(mockFrontPage.item.title);
+      expect(result.current.items[0].date).toBe(mockFrontPage.createdAt);
+      expect(result.current.items[1].title).toBe(mockTrend.title);
+      expect(result.current.items[1].isOutdated).toBeUndefined();
+    });
+
+    it('keeps the total capped at the limit with the outdated item first', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue({
+        ...mockOverview,
+        trends: [mockTrend, mockTrend],
+      });
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(2, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(2);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('shows the outdated item even when the market overview is empty', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue(null);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
+    it('falls back to the latest items when the front-page fetch fails', async () => {
+      mockFetchFrontPageItem.mockRejectedValue(new Error('boom'));
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('falls back to the latest items when the front page is not found', async () => {
+      mockFetchFrontPageItem.mockResolvedValue(null);
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBeUndefined();
+    });
+
+    it('does not fetch a front-page item when no deep-linked id is set', async () => {
+      const { result } = renderHook(() => useWhatsHappening());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockFetchFrontPageItem).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -269,51 +269,6 @@ describe('useWhatsHappening', () => {
       expect(result.current.items[1].isOutdated).toBeUndefined();
     });
 
-    it('dedupes a latest-feed item that shares the outdated item title', async () => {
-      const duplicateTrend = { ...mockTrend, title: mockFrontPage.item.title };
-      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
-      mockFetchMarketOverview.mockResolvedValue({
-        ...mockOverview,
-        trends: [duplicateTrend, mockTrend],
-      });
-
-      const { result } = renderHook(() =>
-        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
-      );
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-      // The title appears exactly once — as the outdated (first) card.
-      const withTitle = result.current.items.filter(
-        (item) => item.title === mockFrontPage.item.title,
-      );
-      expect(withTitle).toHaveLength(1);
-      expect(result.current.items[0].isOutdated).toBe(true);
-      // The non-duplicate latest item is still present.
-      expect(
-        result.current.items.some((item) => item.title === mockTrend.title),
-      ).toBe(true);
-    });
-
-    it('dedupes case- and whitespace-insensitively', async () => {
-      const noisyDuplicate = {
-        ...mockTrend,
-        title: `  ${mockFrontPage.item.title.replace(/ /gu, '   ').toUpperCase()}  `,
-      };
-      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
-      mockFetchMarketOverview.mockResolvedValue({
-        ...mockOverview,
-        trends: [noisyDuplicate],
-      });
-
-      const { result } = renderHook(() =>
-        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
-      );
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-      expect(result.current.items).toHaveLength(1);
-      expect(result.current.items[0].isOutdated).toBe(true);
-    });
-
     it('keeps the total capped at the limit with the outdated item first', async () => {
       mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
       mockFetchMarketOverview.mockResolvedValue({

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.test.ts
@@ -269,6 +269,51 @@ describe('useWhatsHappening', () => {
       expect(result.current.items[1].isOutdated).toBeUndefined();
     });
 
+    it('dedupes a latest-feed item that shares the outdated item title', async () => {
+      const duplicateTrend = { ...mockTrend, title: mockFrontPage.item.title };
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue({
+        ...mockOverview,
+        trends: [duplicateTrend, mockTrend],
+      });
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      // The title appears exactly once — as the outdated (first) card.
+      const withTitle = result.current.items.filter(
+        (item) => item.title === mockFrontPage.item.title,
+      );
+      expect(withTitle).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+      // The non-duplicate latest item is still present.
+      expect(
+        result.current.items.some((item) => item.title === mockTrend.title),
+      ).toBe(true);
+    });
+
+    it('dedupes case- and whitespace-insensitively', async () => {
+      const noisyDuplicate = {
+        ...mockTrend,
+        title: `  ${mockFrontPage.item.title.replace(/ /gu, '   ').toUpperCase()}  `,
+      };
+      mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
+      mockFetchMarketOverview.mockResolvedValue({
+        ...mockOverview,
+        trends: [noisyDuplicate],
+      });
+
+      const { result } = renderHook(() =>
+        useWhatsHappening(5, { outdatedItemId: mockFrontPage.id }),
+      );
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(result.current.items[0].isOutdated).toBe(true);
+    });
+
     it('keeps the total capped at the limit with the outdated item first', async () => {
       mockFetchFrontPageItem.mockResolvedValue(mockFrontPage);
       mockFetchMarketOverview.mockResolvedValue({

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -91,44 +91,6 @@ const fetchOutdatedItem = async (
 };
 
 /**
- * Derives a dedupe key from an item title. Market overview items have no id,
- * so the title is our only stable identifier. Normalized (trimmed, lower-cased,
- * whitespace-collapsed) so trivial formatting differences still match.
- *
- * @param title - The item title.
- * @returns A normalized key for equality comparison.
- */
-const getTitleKey = (title: string): string =>
-  title.trim().toLowerCase().replace(/\s+/gu, ' ');
-
-/**
- * Prepends the deep-linked "outdated" item as the first card, removing any
- * latest-feed item with the same title. A front-page item can be recent enough
- * to also appear in the market overview; without this it would render twice.
- *
- * @param outdatedItem - The outdated item to prepend, or `null`.
- * @param baseItems - The latest market overview items.
- * @param limit - Maximum number of items to return.
- * @returns The items to render, capped at `limit`.
- */
-const prependOutdatedItem = (
-  outdatedItem: WhatsHappeningItem | null,
-  baseItems: WhatsHappeningItem[],
-  limit: number,
-): WhatsHappeningItem[] => {
-  if (!outdatedItem) {
-    return baseItems;
-  }
-
-  const outdatedKey = getTitleKey(outdatedItem.title);
-  const deduped = baseItems.filter(
-    (item) => getTitleKey(item.title) !== outdatedKey,
-  );
-
-  return [outdatedItem, ...deduped].slice(0, limit);
-};
-
-/**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
  * Calls `AiDigestController.fetchMarketOverview()` (which handles caching
@@ -168,11 +130,12 @@ export const useWhatsHappening = (
       const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
 
       // When a deep link supplied an id, prepend that (older) front-page item
-      // as the first "outdated" card, de-duplicated by title against the
-      // latest feed and capped at `limit`.
+      // as the first "outdated" card, keeping the total capped at `limit`.
       const outdatedItem = await fetchOutdatedItem(outdatedItemId);
 
-      setItems(prependOutdatedItem(outdatedItem, baseItems, limit));
+      setItems(
+        outdatedItem ? [outdatedItem, ...baseItems].slice(0, limit) : baseItems,
+      );
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to fetch trending items',

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import type { MarketOverview } from '@metamask/ai-controllers';
+import type {
+  MarketOverview,
+  MarketOverviewFrontPage,
+} from '@metamask/ai-controllers';
 import Engine from '../../../../core/Engine';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import type { WhatsHappeningItem } from '../types';
@@ -18,6 +21,12 @@ export interface UseWhatsHappeningResult {
 export interface UseWhatsHappeningOptions {
   /** When false, skips fetching (for parents that supply their own feed). */
   enabled?: boolean;
+  /**
+   * A market overview front-page item id to fetch and prepend as the first,
+   * "outdated" card. Supplied by the What's Happening deep link; only the
+   * detail view passes it, so the Explore/Perps carousels are unaffected.
+   */
+  outdatedItemId?: string | null;
 }
 
 export const isWhatsHappeningSectionVisible = ({
@@ -42,6 +51,45 @@ const mapTrendsToItems = (
     articles: trend.articles,
   }));
 
+const mapFrontPageToItem = (
+  frontPage: MarketOverviewFrontPage,
+): WhatsHappeningItem => ({
+  id: `front-page-${frontPage.id}`,
+  title: frontPage.item.title,
+  description: frontPage.item.description,
+  date: frontPage.createdAt,
+  category: frontPage.item.category,
+  impact: frontPage.item.impact,
+  relatedAssets: frontPage.item.relatedAssets,
+  articles: frontPage.item.articles,
+  isOutdated: true,
+});
+
+/**
+ * Fetches the deep-linked "outdated" front-page item, if any.
+ *
+ * @param outdatedItemId - The front-page item id from the deep link, or `null`.
+ * @returns The mapped outdated item, or `null` when there is none / on failure.
+ */
+const fetchOutdatedItem = async (
+  outdatedItemId: string | null,
+): Promise<WhatsHappeningItem | null> => {
+  if (!outdatedItemId) {
+    return null;
+  }
+
+  try {
+    const frontPage =
+      await Engine.context.AiDigestController.fetchFrontPageItem(
+        outdatedItemId,
+      );
+    return frontPage ? mapFrontPageToItem(frontPage) : null;
+  } catch {
+    // Non-fatal: fall back to rendering just the latest market overview items.
+    return null;
+  }
+};
+
 /**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
@@ -57,6 +105,7 @@ export const useWhatsHappening = (
   options?: UseWhatsHappeningOptions,
 ): UseWhatsHappeningResult => {
   const isFeatureEnabled = useSelector(selectWhatsHappeningEnabled);
+  const outdatedItemId = options?.outdatedItemId ?? null;
   const isHookEnabled = options?.enabled ?? true;
   const isActive = isFeatureEnabled && isHookEnabled;
 
@@ -78,12 +127,15 @@ export const useWhatsHappening = (
     try {
       const data =
         await Engine.context.AiDigestController.fetchMarketOverview();
+      const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
 
-      if (data === null) {
-        setItems([]);
-      } else {
-        setItems(mapTrendsToItems(data, limit));
-      }
+      // When a deep link supplied an id, prepend that (older) front-page item
+      // as the first "outdated" card, keeping the total capped at `limit`.
+      const outdatedItem = await fetchOutdatedItem(outdatedItemId);
+
+      setItems(
+        outdatedItem ? [outdatedItem, ...baseItems].slice(0, limit) : baseItems,
+      );
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to fetch trending items',
@@ -92,7 +144,7 @@ export const useWhatsHappening = (
     } finally {
       setIsLoading(false);
     }
-  }, [isActive, limit]);
+  }, [isActive, limit, outdatedItemId]);
 
   const refresh = useCallback(async () => {
     await fetchItems();

--- a/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
+++ b/app/components/UI/WhatsHappening/hooks/useWhatsHappening.ts
@@ -91,6 +91,44 @@ const fetchOutdatedItem = async (
 };
 
 /**
+ * Derives a dedupe key from an item title. Market overview items have no id,
+ * so the title is our only stable identifier. Normalized (trimmed, lower-cased,
+ * whitespace-collapsed) so trivial formatting differences still match.
+ *
+ * @param title - The item title.
+ * @returns A normalized key for equality comparison.
+ */
+const getTitleKey = (title: string): string =>
+  title.trim().toLowerCase().replace(/\s+/gu, ' ');
+
+/**
+ * Prepends the deep-linked "outdated" item as the first card, removing any
+ * latest-feed item with the same title. A front-page item can be recent enough
+ * to also appear in the market overview; without this it would render twice.
+ *
+ * @param outdatedItem - The outdated item to prepend, or `null`.
+ * @param baseItems - The latest market overview items.
+ * @param limit - Maximum number of items to return.
+ * @returns The items to render, capped at `limit`.
+ */
+const prependOutdatedItem = (
+  outdatedItem: WhatsHappeningItem | null,
+  baseItems: WhatsHappeningItem[],
+  limit: number,
+): WhatsHappeningItem[] => {
+  if (!outdatedItem) {
+    return baseItems;
+  }
+
+  const outdatedKey = getTitleKey(outdatedItem.title);
+  const deduped = baseItems.filter(
+    (item) => getTitleKey(item.title) !== outdatedKey,
+  );
+
+  return [outdatedItem, ...deduped].slice(0, limit);
+};
+
+/**
  * Hook to fetch trending "What's Happening" items for the carousel.
  *
  * Calls `AiDigestController.fetchMarketOverview()` (which handles caching
@@ -130,12 +168,11 @@ export const useWhatsHappening = (
       const baseItems = data === null ? [] : mapTrendsToItems(data, limit);
 
       // When a deep link supplied an id, prepend that (older) front-page item
-      // as the first "outdated" card, keeping the total capped at `limit`.
+      // as the first "outdated" card, de-duplicated by title against the
+      // latest feed and capped at `limit`.
       const outdatedItem = await fetchOutdatedItem(outdatedItemId);
 
-      setItems(
-        outdatedItem ? [outdatedItem, ...baseItems].slice(0, limit) : baseItems,
-      );
+      setItems(prependOutdatedItem(outdatedItem, baseItems, limit));
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to fetch trending items',

--- a/app/components/UI/WhatsHappening/types.ts
+++ b/app/components/UI/WhatsHappening/types.ts
@@ -18,4 +18,10 @@ export interface WhatsHappeningItem {
   impact?: 'positive' | 'negative' | 'neutral';
   relatedAssets: RelatedAsset[];
   articles: Article[];
+  /**
+   * When true, this item was fetched by id from the front-page endpoint (an
+   * older item no longer in the latest market overview) and is rendered first
+   * in the carousel with an "Outdated" label.
+   */
+  isOutdated?: boolean;
 }

--- a/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.tsx
@@ -60,6 +60,11 @@ const DEFAULT_INITIAL_INDEX = 0;
 interface WhatsHappeningDetailParams {
   initialIndex?: number;
   source: WhatsHappeningSourceValue;
+  /**
+   * A market overview front-page item id from the deep link. When present, that
+   * (older) item is fetched and shown first, flagged "Outdated".
+   */
+  outdatedItemId?: string;
 }
 
 const WhatsHappeningDetailView = () => {
@@ -71,9 +76,12 @@ const WhatsHappeningDetailView = () => {
   const initialIndex = route.params?.initialIndex ?? DEFAULT_INITIAL_INDEX;
   const source: WhatsHappeningSourceValue =
     route.params?.source ?? WhatsHappeningSource.Unknown;
+  const outdatedItemId = route.params?.outdatedItemId;
 
-  const { items, isLoading, error, refresh } =
-    useWhatsHappening(MAX_ITEMS_DISPLAYED);
+  const { items, isLoading, error, refresh } = useWhatsHappening(
+    MAX_ITEMS_DISPLAYED,
+    { outdatedItemId },
+  );
 
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [cardHeight, setCardHeight] = useState(0);

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
@@ -199,6 +199,49 @@ describe('WhatsHappeningExpandedCard', () => {
     expect(screen.queryByText('AI')).toBeNull();
   });
 
+  it('renders the Outdated badge when the item is outdated', () => {
+    const item = { ...baseItem, isOutdated: true };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="deeplink"
+      />,
+    );
+    expect(screen.getByText('Outdated')).toBeOnTheScreen();
+  });
+
+  it('does not render the Outdated badge by default', () => {
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={baseItem}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="homepage"
+      />,
+    );
+    expect(screen.queryByText('Outdated')).toBeNull();
+  });
+
+  it('renders the Outdated badge and AI pill even when impact is undefined', () => {
+    const item = { ...baseItem, impact: undefined, isOutdated: true };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="deeplink"
+      />,
+    );
+    expect(screen.getByText('Outdated')).toBeOnTheScreen();
+    expect(screen.getByText('AI')).toBeOnTheScreen();
+    expect(screen.queryByText('Bullish')).toBeNull();
+  });
+
   it('renders the single Related Assets section header when relatedAssets is non-empty', () => {
     const item = { ...baseItem, relatedAssets: [perpsOnlyAsset] };
     renderWithProvider(

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
@@ -139,8 +139,8 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
             style={tw.style('flex-1')}
             contentContainerStyle={tw.style('pt-7 px-5 pb-5 gap-4')}
           >
-            {/* Tag row: AI pill + impact badge */}
-            {item.impact && (
+            {/* Tag row: AI pill + impact badge + outdated badge */}
+            {(item.impact || item.isOutdated) && (
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
@@ -182,13 +182,26 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
                   )}
                 </Pressable>
 
-                <Box
-                  twClassName={`${impactBgClass} rounded px-2 py-1 self-start border border-transparent`}
-                >
-                  <Text variant={TextVariant.BodySm} color={impactTextColor}>
-                    {impactLabel}
-                  </Text>
-                </Box>
+                {item.impact ? (
+                  <Box
+                    twClassName={`${impactBgClass} rounded px-2 py-1 self-start border border-transparent`}
+                  >
+                    <Text variant={TextVariant.BodySm} color={impactTextColor}>
+                      {impactLabel}
+                    </Text>
+                  </Box>
+                ) : null}
+
+                {item.isOutdated ? (
+                  <Box twClassName="bg-warning-muted rounded px-2 py-1 self-start border border-transparent">
+                    <Text
+                      variant={TextVariant.BodySm}
+                      color={TextColor.WarningDefault}
+                    >
+                      {strings('whats_happening.outdated')}
+                    </Text>
+                  </Box>
+                ) : null}
               </Box>
             )}
 

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -1308,7 +1308,32 @@ describe('handleUniversalLink', () => {
       });
 
       expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
-      expect(handleWhatsHappeningUrl).toHaveBeenCalledWith();
+      expect(handleWhatsHappeningUrl).toHaveBeenCalledWith({ id: undefined });
+      expect(handled).toHaveBeenCalled();
+    });
+
+    it('forwards the id query param to _handleWhatsHappening', async () => {
+      const id = 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+      const whatsHappeningUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.WHATS_HAPPENING}?id=${id}`;
+      const whatsHappeningUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: whatsHappeningUrl,
+        pathname: `/${ACTIONS.WHATS_HAPPENING}`,
+        search: `?id=${id}`,
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: whatsHappeningUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: whatsHappeningUrl,
+        source: 'test-source',
+      });
+
+      expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
+      expect(handleWhatsHappeningUrl).toHaveBeenCalledWith({ id });
       expect(handled).toHaveBeenCalled();
     });
   });

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleWhatsHappeningUrl.test.ts
@@ -21,26 +21,69 @@ describe('handleWhatsHappeningUrl', () => {
     jest.clearAllMocks();
   });
 
-  it('navigates to WhatsHappeningDetailView from a deeplink source', () => {
-    handleWhatsHappeningUrl();
+  describe('without an id', () => {
+    it('opens the detail view on the first card', () => {
+      handleWhatsHappeningUrl();
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
-      source: WhatsHappeningSource.Deeplink,
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
+        source: WhatsHappeningSource.Deeplink,
+        initialIndex: 0,
+      });
+    });
+
+    it('does not pass an outdatedItemId', () => {
+      handleWhatsHappeningUrl();
+
+      const [, params] = mockNavigate.mock.calls[0];
+      expect(params).not.toHaveProperty('outdatedItemId');
+    });
+
+    it('falls back to wallet home on navigation errors', () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation error');
+      });
+
+      handleWhatsHappeningUrl();
+
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+      expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handleWhatsHappeningUrl] Failed to handle deeplink:',
+        expect.any(Error),
+      );
     });
   });
 
-  it('falls back to wallet home on navigation errors', () => {
-    mockNavigate.mockImplementationOnce(() => {
-      throw new Error('Navigation error');
+  describe('with an id', () => {
+    const id = 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d';
+
+    it('opens the detail view with the outdatedItemId param', () => {
+      handleWhatsHappeningUrl({ id });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WHATS_HAPPENING_DETAIL, {
+        source: WhatsHappeningSource.Deeplink,
+        initialIndex: 0,
+        outdatedItemId: id,
+      });
     });
 
-    handleWhatsHappeningUrl();
+    it('does not navigate to the Explore/Trending view', () => {
+      handleWhatsHappeningUrl({ id });
 
-    expect(mockNavigate).toHaveBeenCalledTimes(2);
-    expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
-    expect(DevLogger.log).toHaveBeenCalledWith(
-      '[handleWhatsHappeningUrl] Failed to handle deeplink:',
-      expect.any(Error),
-    );
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.TRENDING_VIEW,
+        expect.anything(),
+      );
+    });
+
+    it('falls back to wallet home on navigation errors', () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation error');
+      });
+
+      handleWhatsHappeningUrl({ id });
+
+      expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET.HOME);
+    });
   });
 });

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -762,7 +762,8 @@ async function handleUniversalLink({
       break;
     }
     case SUPPORTED_ACTIONS.WHATS_HAPPENING: {
-      handleWhatsHappeningUrl();
+      const { params: whatsHappeningParams } = extractURLParams(urlObj.href);
+      handleWhatsHappeningUrl({ id: whatsHappeningParams?.id });
       break;
     }
     case SUPPORTED_ACTIONS.TOP_TRADERS: {

--- a/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleWhatsHappeningUrl.ts
@@ -3,6 +3,14 @@ import Routes from '../../../../constants/navigation/Routes';
 import DevLogger from '../../../SDKConnect/utils/DevLogger';
 import { WhatsHappeningSource } from '../../../../components/UI/WhatsHappening/constants';
 
+interface HandleWhatsHappeningUrlParams {
+  /**
+   * Optional market overview front-page item id. When present, the expanded
+   * detail view renders this (older) item first with an "Outdated" label.
+   */
+  id?: string;
+}
+
 const navigateToFallback = () => {
   NavigationService.navigation.navigate(Routes.WALLET.HOME);
 };
@@ -13,15 +21,23 @@ const navigateToFallback = () => {
  * Supported URL formats:
  * - https://link.metamask.io/whats-happening
  * - metamask://whats-happening
+ * - https://link.metamask.io/whats-happening?id=<uuid>
+ * - metamask://whats-happening?id=<uuid>
  *
- * Deeplinks always open the first card.
+ * Opens the What's Happening expanded detail view. Without an `id` it opens on
+ * the first (latest) card; with an `id` it passes that front-page item id to
+ * the detail view, which fetches it and shows it first, flagged "Outdated".
  */
-export const handleWhatsHappeningUrl = () => {
-  DevLogger.log('[handleWhatsHappeningUrl] Starting deeplink handling');
+export const handleWhatsHappeningUrl = ({
+  id,
+}: HandleWhatsHappeningUrlParams = {}) => {
+  DevLogger.log('[handleWhatsHappeningUrl] Starting deeplink handling', { id });
 
   try {
     NavigationService.navigation.navigate(Routes.WHATS_HAPPENING_DETAIL, {
       source: WhatsHappeningSource.Deeplink,
+      initialIndex: 0,
+      ...(id ? { outdatedItemId: id } : {}),
     });
   } catch (error) {
     DevLogger.log(

--- a/app/core/DeeplinkManager/types/deepLink.types.ts
+++ b/app/core/DeeplinkManager/types/deepLink.types.ts
@@ -65,6 +65,11 @@ export interface DeeplinkUrlParams {
   // Home-specific parameters
   previewToken?: string;
 
+  // What's Happening-specific parameters
+  // Id of a market overview front-page item to render as the first, "outdated"
+  // card of the What's Happening expanded view.
+  id?: string;
+
   // Note: All properties are explicitly defined above
 }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10187,6 +10187,7 @@
   "whats_happening": {
     "title": "What's happening",
     "ai": "AI",
+    "outdated": "Outdated",
     "impact": {
       "bullish": "Bullish",
       "bearish": "Bearish",

--- a/package.json
+++ b/package.json
@@ -169,12 +169,6 @@
       "prettier --write"
     ]
   },
-  "previewBuilds": {
-    "@metamask/ai-controllers": {
-      "type": "non-breaking",
-      "previewVersion": "0.7.0-preview-8980fa5"
-    }
-  },
   "resolutions": {
     "@metamask/perps-controller": "^9.0.0",
     "@metamask/network-controller": "34.0.0",
@@ -248,7 +242,7 @@
     "@metamask/account-tree-controller": "^7.5.0",
     "@metamask/accounts-controller": "^39.0.2",
     "@metamask/address-book-controller": "^7.1.2",
-    "@metamask/ai-controllers": "^0.7.0",
+    "@metamask/ai-controllers": "^0.8.0",
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -169,6 +169,12 @@
       "prettier --write"
     ]
   },
+  "previewBuilds": {
+    "@metamask/ai-controllers": {
+      "type": "non-breaking",
+      "previewVersion": "0.7.0-preview-8980fa5"
+    }
+  },
   "resolutions": {
     "@metamask/perps-controller": "^9.0.0",
     "@metamask/network-controller": "34.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,15 +7958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:@metamask-previews/ai-controllers@0.7.0-preview-8980fa5":
-  version: 0.7.0-preview-8980fa5
-  resolution: "@metamask-previews/ai-controllers@npm:0.7.0-preview-8980fa5"
+"@metamask/ai-controllers@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@metamask/ai-controllers@npm:0.8.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/0b4405a6c5a8aed033f630c380594036b411a29e6f1393c1fbc625743fb813e25e0230a0a6fee937c711704964dda1c75331db15c955626049695ad9230e58e9
+  checksum: 10/a3afa17519d91d72b8c4cf4d85540d59c02b11a95e8dd55799448e49f89cd577a63c72016f9b88e8430173327f5d4f55743b897e3760940b07806f04815de5f2
   languageName: node
   linkType: hard
 
@@ -35488,7 +35488,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^7.5.0"
     "@metamask/accounts-controller": "npm:^39.0.2"
     "@metamask/address-book-controller": "npm:^7.1.2"
-    "@metamask/ai-controllers": "npm:^0.7.0"
+    "@metamask/ai-controllers": "npm:^0.8.0"
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,15 +7958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ai-controllers@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@metamask/ai-controllers@npm:0.7.0"
+"@metamask/ai-controllers@npm:@metamask-previews/ai-controllers@0.7.0-preview-8980fa5":
+  version: 0.7.0-preview-8980fa5
+  resolution: "@metamask-previews/ai-controllers@npm:0.7.0-preview-8980fa5"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-  checksum: 10/129d02a26595f16362c6bb1905ef3885b369529eb0a174da46ed7add5fd1d6ffa4d00ba29e09f7583ef70a299dc99f33c82efc45eeea08ab7e5e712c4a3dc11d
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/0b4405a6c5a8aed033f630c380594036b411a29e6f1393c1fbc625743fb813e25e0230a0a6fee937c711704964dda1c75331db15c955626049695ad9230e58e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

**PR 2 of 3 (stacked on #32911).** Wires the What's Happening deep link end to end so it can open a specific (older) item by id.

**Reason for the change:** users can receive a link to a specific "What's Happening" item that may no longer be in the latest feed. Tapping it should take them straight to that item.

**What this PR does:**
- `handleWhatsHappeningUrl` accepts an optional `id`. With an id it opens the expanded detail view passing `outdatedItemId` (without one it opens on the first card, as before).
- `handleUniversalLink` reads the `?id=` query param; `DeeplinkUrlParams` gains `id`.
- `WhatsHappeningDetailView` reads the `outdatedItemId` route param and passes it to `useWhatsHappening`, so the fetched item shows first, flagged "Outdated". Scoped to the deep link — the Explore/Perps carousels are unaffected.

**Note on the revert commit:** this branch briefly carried the dedup logic, which has since moved to its own PR (#32900). Force-pushing is disabled in this environment, so the dedup commit was undone with a revert commit rather than a history rewrite — the net diff of this PR is wiring only.

**Stack:** 1/3 #32911 (data + presentation) · 2/3 this PR · 3/3 #32900 (dedupe + badge refinement).


https://github.com/user-attachments/assets/6e565970-2acd-4b81-88c9-e3da546c8f2b



## **Changelog**

CHANGELOG entry: Added support for opening a specific "What's Happening" item from a deep link (e.g. `metamask://whats-happening?id=<id>`); the item opens in the expanded view and is labelled "Outdated" when it is no longer in the latest feed.

## **Related issues**

Refs: #32911

## **Manual testing steps**

```gherkin
Feature: Open a What's Happening item from a deep link

  Scenario: user opens a deep link with an item id
    Given the "What's Happening" feature is enabled
    And the digest API returns an item for that id
    When the user opens metamask://whats-happening?id=<uuid>
    Then the app opens the What's Happening expanded view
    And that item is shown first

  Scenario: user opens the deep link without an id
    Given the "What's Happening" feature is enabled
    When the user opens metamask://whats-happening
    Then the app opens the What's Happening expanded view on the first (latest) card
```

## **Screenshots/Recordings**

### **Before**

N/A — the deep link previously always opened the first card.

### **After**

_To attach: a simulator recording of `metamask://whats-happening?id=<uuid>` opening the expanded view on the target item._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped feature wiring with graceful API fallbacks and broad test coverage; no auth or payment paths touched.
> 
> **Overview**
> **What's Happening** deep links can now target a specific older item via `?id=<uuid>`. Universal link handling reads that query param and passes it through `handleWhatsHappeningUrl` as `outdatedItemId` on the detail route.
> 
> The detail view forwards `outdatedItemId` into `useWhatsHappening`, which optionally calls `AiDigestController.fetchFrontPageItem`, maps the result with `isOutdated: true`, and **prepends** it to the latest feed while keeping the list capped at `limit`. Fetch failures are non-fatal and fall back to the normal overview-only feed; carousels that do not pass the option are unchanged.
> 
> The expanded card shows an **Outdated** badge (new copy in `en.json`), including when impact is missing. `@metamask/ai-controllers` is bumped to **^0.8.0** for the front-page API types/method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb0f8fb1a565f97dad937a8e4d7c333734ef4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->