### PR TITLE
feat(assets): add selectTokenWatchlistEnabled feature flag selector

### DIFF
--- a/app/components/UI/assets/selectors/featureFlags.test.ts
+++ b/app/components/UI/assets/selectors/featureFlags.test.ts
@@ -1,0 +1,111 @@
+import type { Json } from '@metamask/utils';
+import {
+  ASSET_GLOBAL_WATCHLIST_FLAG_KEY,
+  selectTokenWatchlistEnabled,
+} from './featureFlags';
+// eslint-disable-next-line import-x/no-namespace
+import * as remoteFeatureFlagModule from '../../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('7.73.0'),
+}));
+
+jest.mock(
+  '../../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
+describe('selectTokenWatchlistEnabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mockHasMinimumRequiredVersion?.mockRestore();
+  });
+
+  it('exposes the LaunchDarkly flag key for registry alignment', () => {
+    expect(ASSET_GLOBAL_WATCHLIST_FLAG_KEY).toBe('assets-global-watchlist-v1');
+  });
+
+  const testCases: {
+    name: string;
+    state: Record<string, Json>;
+    hasMinimumVersion: boolean;
+    expected: boolean;
+  }[] = [
+    {
+      name: 'returns true when enabled is true and minimum version passes',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: true, minimumVersion: '7.73' },
+        },
+      },
+      hasMinimumVersion: true,
+      expected: true,
+    },
+    {
+      name: 'returns true for direct version-gated shape (no wrapper)',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '7.73',
+        },
+      },
+      hasMinimumVersion: true,
+      expected: true,
+    },
+    {
+      name: 'returns false when enabled is false',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: false, minimumVersion: '7.73' },
+        },
+      },
+      hasMinimumVersion: true,
+      expected: false,
+    },
+    {
+      name: 'returns false when minimum version requirement fails',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { enabled: true, minimumVersion: '99.0.0' },
+        },
+      },
+      hasMinimumVersion: false,
+      expected: false,
+    },
+    {
+      name: 'returns false when flag is missing',
+      state: {},
+      hasMinimumVersion: true,
+      expected: false,
+    },
+    {
+      name: 'returns false for malformed payload',
+      state: {
+        [ASSET_GLOBAL_WATCHLIST_FLAG_KEY]: {
+          value: { variant: 'enabled', minimumVersion: '7.73' },
+        },
+      },
+      hasMinimumVersion: true,
+      expected: false,
+    },
+  ];
+
+  it.each(testCases)('$name', ({ state, hasMinimumVersion, expected }) => {
+    mockHasMinimumRequiredVersion.mockReturnValue(hasMinimumVersion);
+    expect(selectTokenWatchlistEnabled.resultFunc(state)).toStrictEqual(
+      expected,
+    );
+  });
+});

--- a/app/components/UI/assets/selectors/featureFlags.ts
+++ b/app/components/UI/assets/selectors/featureFlags.ts
@@ -1,0 +1,22 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
+import {
+  validatedVersionGatedFeatureFlag,
+  VersionGatedFeatureFlag,
+} from '../../../../util/remoteFeatureFlag';
+
+export const ASSET_GLOBAL_WATCHLIST_FLAG_KEY = 'assets-global-watchlist-v1';
+
+/**
+ * Whether the global token watchlist feature is enabled for the current
+ * client.
+ */
+export const selectTokenWatchlistEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags?.[
+      ASSET_GLOBAL_WATCHLIST_FLAG_KEY
+    ] as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Introduces a version-gated remote feature flag selector for the upcoming global token Watchlist feature, owned by the Assets team. The selector reads the LaunchDarkly flag `assets-global-watchlist-v1` from `RemoteFeatureFlagController` state and returns `true` only when both:

1. The remote payload has `enabled: true`, and
2. The currently running app version satisfies the configured `minimumVersion` (via the existing `validatedVersionGatedFeatureFlag` helper).

It supports both runtime shapes already used elsewhere in the app:

- Direct: `{ enabled: true, minimumVersion: '7.73' }`
- Progressive rollout wrapper: `{ value: { enabled: true, minimumVersion: '7.73' } }`

The file is placed under the new Assets CO path so it lives with the rest of the Watchlist work:

- `app/components/UI/assets/selectors/featureFlags.ts`
- `app/components/UI/assets/selectors/featureFlags.test.ts`

This matches the CODEOWNERS pattern `app/*/*/assets/**` → `@MetaMask/metamask-assets`.

This PR only wires the selector; consumers (Token Details star icon, Homepage section, full-screen Watchlist view, Swap/Bridge pill, Explore trending) will land in follow-up PRs per the tech spec.

**Note:** These files were originally introduced in #30336 and mistakenly removed in #30803 (cleanup of deprecated code). This PR re-introduces them as they are actively needed by the in-progress watchlist feature work (#30338, #30339).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [ASSETS-3114](https://consensyssoftware.atlassian.net/browse/ASSETS-3114)

Tech Spec: [WatchList Tech Spec - Technical Breakdown & Tasks → 3.1 Feature Flags](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/401467637802/WatchList+Tech+Spec+-+Technical+Breakdown+Tasks#3.1.-Feature-Flags)

## **Manual testing steps**

Automated coverage:

```
yarn jest app/components/UI/assets/selectors/featureFlags.test.ts --coverage=false
# 7 passed
```

## **Screenshots/Recordings**

N/A — no UI changes; logic-only selector with full test coverage.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72defb2f-b0e3-42ce-80d2-fb8acab8d5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72defb2f-b0e3-42ce-80d2-fb8acab8d5e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3114]: https://consensyssoftware.atlassian.net/browse/ASSETS-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ