### PR TITLE
ci: re-enable Namespace shadow CI (iOS-only) behind NAMESPACE_SHADOW_AUTO_DISPATCH

### DIFF
--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -160,8 +160,4 @@ jobs:
             fi
             echo
             echo "_Shadow CI runs **fire-and-forget**: it does not appear in this PR's checks and never blocks the merge queue. Benchmark data is collected by \`scripts/namespace-benchmark.sh\`._"
-            if [ "${{ vars.NAMESPACE_SHADOW_AUTO_DISPATCH }}" != "true" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-              echo
-              echo "_Auto-dispatch is **disabled** (NAMESPACE_SHADOW_AUTO_DISPATCH ≠ true). Use workflow_dispatch on this workflow or ci.yml._"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -1,11 +1,6 @@
 name: CI (Namespace shadow)
 
-# On-demand dispatcher for Namespace shadow runs (INFRA-3631 / INFRA-3678).
-#
-# Automatic triggers (pull_request, push to main, hourly schedule) are disabled:
-# the Phase 5d benchmark is complete (INFRA-3631) and the failure investigation
-# is closed (INFRA-3652). The workflow is retained for on-demand runs only
-# (e.g. INFRA-3639 swap testing) via manual workflow_dispatch.
+# Dispatcher for Namespace shadow runs (INFRA-3631 / INFRA-3678).
 #
 # It dispatches `ci.yml` as a separate `workflow_dispatch` run with
 # `runner_provider=namespace` (not `workflow_call`), so shadow runs live in the
@@ -13,12 +8,27 @@ name: CI (Namespace shadow)
 # token-exchange, and dispatch steps use continue-on-error so this job's own
 # check always concludes success even when the dispatch cannot run.
 #
+# Shadow runs are iOS-only: ci.yml skips Android and Linux-only jobs when
+# runner_provider is namespace (see the BITRISE/NAMESPACE-SHADOW markers there),
+# mirroring the Bitrise shadow benchmark scope.
+#
 # Authentication: Token Exchange Service (same pattern as triage-forwarder.yml —
 # OIDC → POST /api/exchange/token). Prerequisites:
 #   - Actions variable TOKEN_EXCHANGE_URL (already used elsewhere, e.g. triage-forwarder).
 #   - Rego policy mm-metamask-mobile-namespace-shadow-ci-token-exchange in
 #     token-exchange-service (matches the OIDC `workflow_ref` claim).
+#
+# Auto-dispatch gate: set repo Actions variable NAMESPACE_SHADOW_AUTO_DISPATCH=true
+# to dispatch on PR/push. Default (unset/false) = manual workflow_dispatch only.
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/CODEOWNERS"
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +43,13 @@ jobs:
   dispatch-shadow:
     name: "[shadow] Dispatch"
     runs-on: ubuntu-latest
-    # Manual dispatch only. If pull_request triggers are ever restored, re-add a
-    # fork-PR guard here so OIDC/token exchange never runs for untrusted forks.
+    # Fork PRs use head.repo != github.repository — skip (no shadow, no token exchange).
+    # PR/push auto-dispatch requires NAMESPACE_SHADOW_AUTO_DISPATCH=true; workflow_dispatch always runs.
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     steps:
       - name: Get OIDC token for token-exchange-service
         id: oidc
@@ -145,4 +160,8 @@ jobs:
             fi
             echo
             echo "_Shadow CI runs **fire-and-forget**: it does not appear in this PR's checks and never blocks the merge queue. Benchmark data is collected by \`scripts/namespace-benchmark.sh\`._"
+            if [ "${{ vars.NAMESPACE_SHADOW_AUTO_DISPATCH }}" != "true" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+              echo
+              echo "_Auto-dispatch is **disabled** (NAMESPACE_SHADOW_AUTO_DISPATCH ≠ true). Use workflow_dispatch on this workflow or ci.yml._"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,8 @@ jobs:
   dedupe:
     name: Dedupe
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     steps:
@@ -213,8 +213,8 @@ jobs:
   git-safe-dependencies:
     name: Run `@lavamoat/git-safe-dependencies`
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     steps:
@@ -255,8 +255,8 @@ jobs:
   scripts:
     name: Run `${{ matrix.scripts }}`
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     strategy:
@@ -314,8 +314,8 @@ jobs:
   js-bundle-size-check:
     name: JS bundle size check
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     permissions:
@@ -627,8 +627,8 @@ jobs:
   check-workflows:
     name: Check workflows
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     steps:
@@ -649,8 +649,8 @@ jobs:
   prepare-ci-js-deps:
     name: Prepare CI JS dependencies
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
     steps:
@@ -676,8 +676,8 @@ jobs:
   unit-tests:
     name: Unit tests (${{ matrix.shard }})
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
       - prepare-ci-js-deps
@@ -751,8 +751,8 @@ jobs:
   merge-unit-and-component-view-tests:
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     needs: [prepare-ci-js-deps, unit-tests, component-view-tests]
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ github.event_name != 'merge_group' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ github.event_name != 'merge_group' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -933,8 +933,8 @@ jobs:
   component-view-tests:
     name: Component view tests
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     needs:
       - get_requirements
       - prepare-ci-js-deps
@@ -1050,10 +1050,11 @@ jobs:
     # ai_performance_test_tags == '[]'  → AI ran and found no perf-relevant changes: skip.
     # ai_performance_test_tags == ''    → conservative fallback (AI failed) or run-performance-tests label: run all tests.
     # ai_performance_test_tags == '[…]' → specific tags selected: run those tests.
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
+        inputs.runner_provider != 'namespace' &&
         github.event_name == 'pull_request' &&
         !cancelled() &&
         (
@@ -1081,10 +1082,11 @@ jobs:
 
   build-android-apks:
     name: 'Build Android APKs'
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
+        inputs.runner_provider != 'namespace' &&
         !cancelled() &&
         needs.get_requirements.outputs.android_e2e_needed == 'true' &&
         !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
@@ -1157,10 +1159,11 @@ jobs:
 
   e2e-smoke-tests-android:
     name: 'Android E2E Smoke Tests'
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
+        inputs.runner_provider != 'namespace' &&
         !cancelled() &&
         needs.build-android-apks.result == 'success' &&
         (needs.prepare-e2e-timings.result == 'success' || needs.prepare-e2e-timings.result == 'failure' || needs.prepare-e2e-timings.result == 'skipped')
@@ -1235,10 +1238,11 @@ jobs:
 
   appium-smoke-tests-android:
     name: 'Appium Smoke Tests (Android)'
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
+        inputs.runner_provider != 'namespace' &&
         !cancelled() &&
         needs.build-android-apks.result == 'success'
       }}
@@ -1321,8 +1325,8 @@ jobs:
   report-fixture-validation:
     name: 'Report Fixture Validation'
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ inputs.runner_provider != 'bitrise' && !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
     needs: [validate-e2e-fixtures]
     permissions:
       pull-requests: write
@@ -1362,8 +1366,8 @@ jobs:
     name: SonarCloud analysis
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     needs: merge-unit-and-component-view-tests
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ inputs.runner_provider != 'bitrise' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -1430,8 +1434,8 @@ jobs:
     name: SonarCloud quality gate status
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     needs: sonar-cloud
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ inputs.runner_provider != 'bitrise' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -1506,7 +1510,7 @@ jobs:
   cleanup-ci-js-deps:
     name: Delete CI JS deps artifact
     runs-on: ubuntu-latest
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
     if: ${{ always() && inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
     needs:
       - unit-tests
@@ -1540,8 +1544,8 @@ jobs:
     name: Check all jobs pass
     # Run the aggregate gate even when optional dependencies are skipped.
     # The composite action decides which skipped jobs are acceptable.
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ always() && !cancelled() && inputs.runner_provider != 'bitrise' }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ always() && !cancelled() && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     needs:
       - get_requirements
@@ -1588,8 +1592,8 @@ jobs:
     name: Log merge group failure
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     # Only run this job if the merge group event fails, skip on forks
-    # BITRISE-SHADOW: skip for iOS-only benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ inputs.runner_provider != 'bitrise' && github.event_name == 'merge_group' && failure() }}
+    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && github.event_name == 'merge_group' && failure() }}
     needs:
       - check-all-jobs-pass
     steps:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Re-enables Namespace shadow CI runs so we can resume the Namespace runner evaluation, using the same gating pattern already in place for the Bitrise shadow (`ci-bitrise-shadow.yml` / `BITRISE_SHADOW_AUTO_DISPATCH`).

**What is the reason for the change?**

The Namespace shadow dispatcher (`ci-namespace-shadow.yml`) had its automatic triggers removed after the Phase 5d benchmark closed (INFRA-3631/INFRA-3652), leaving it `workflow_dispatch`-only. We now want to run Namespace shadow E2E again, but with the safer kill-switch mechanism the Bitrise shadow introduced later, and with the same reduced iOS-only scope.

**What is the improvement/solution?**

1. **`ci-namespace-shadow.yml`** — restores the `pull_request` + `push` (main) triggers, gated behind a new repo Actions variable `NAMESPACE_SHADOW_AUTO_DISPATCH` (mirror of `BITRISE_SHADOW_AUTO_DISPATCH`):
   - Unset/false (default): nothing auto-dispatches; manual `workflow_dispatch` still works.
   - `true`: PR/push events dispatch a shadow `ci.yml` run with `runner_provider=namespace`.
   - Fork PRs never dispatch (no OIDC/token exchange for untrusted forks).
   - The OIDC → token-exchange → dispatch steps are unchanged (proven against the existing `mm-metamask-mobile-namespace-shadow-ci-token-exchange` policy).
2. **`ci.yml`** — extends every `BITRISE-SHADOW` iOS-only skip condition to also cover `runner_provider == 'namespace'` (markers renamed to `BITRISE/NAMESPACE-SHADOW`). A Namespace shadow run now executes exactly the same job set as a Bitrise shadow run: `get_requirements`, `check-diff`, `native-build-fingerprint`, `smart-e2e-selection`, `prepare-e2e-timings`, `build-ios-apps`, `ios-tests-ready`, `e2e-smoke-tests-ios`, `validate-e2e-fixtures` (and `appium-smoke-tests-ios` on main push/schedule). Android jobs and all Linux-only quality jobs (lint, unit tests, sonar, etc.) are skipped.

Shadow runs remain fire-and-forget and never interfere with the real CI run on a PR: everything that posts PR comments/statuses (`check-diff` post-status, `smart-e2e-selection` post-comment, `report-fixture-validation`, SonarCloud, `check-all-jobs-pass`) is excluded for shadow providers, and artifact uploads are scoped to the shadow run itself.

**Rollout:** merging this PR changes nothing by itself — `NAMESPACE_SHADOW_AUTO_DISPATCH` already exists and is currently set to `false`, so auto-dispatch stays off until greenlit.

1. (Recommended) After merge, trigger one manual `workflow_dispatch` of "CI (Namespace shadow)" from `main` to confirm the token exchange still works and the dispatched `ci.yml` run executes only the iOS-only job set.
2. Greenlight — enable auto-dispatch on PR/push:

   ```bash
   gh variable set NAMESPACE_SHADOW_AUTO_DISPATCH --body true --repo MetaMask/metamask-mobile
   ```

3. Kill switch — disable again at any time (no code PR needed):

   ```bash
   gh variable set NAMESPACE_SHADOW_AUTO_DISPATCH --body false --repo MetaMask/metamask-mobile
   ```

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — no Jira ticket yet (will be created and linked/added to the title later). Related prior work: INFRA-3631 / INFRA-3678 (Namespace shadow), INFRA-3679 (Bitrise shadow gate pattern).

## **Manual testing steps**

```gherkin
Feature: Namespace shadow CI dispatch gate

  Scenario: auto-dispatch disabled by default
    Given NAMESPACE_SHADOW_AUTO_DISPATCH is unset or not "true"
    When a pull request is opened or synchronized, or a commit is pushed to main
    Then the "[shadow] Dispatch" job is skipped and no shadow ci.yml run is created

  Scenario: manual dispatch always works
    Given any value of NAMESPACE_SHADOW_AUTO_DISPATCH
    When a maintainer triggers "CI (Namespace shadow)" via workflow_dispatch
    Then a ci.yml run is dispatched with runner_provider=namespace
    And only the iOS-only job set runs (iOS build + iOS E2E smoke + fixture validation)
    And Android, lint, unit-test, Sonar and PR-comment/status jobs are skipped

  Scenario: auto-dispatch enabled
    Given NAMESPACE_SHADOW_AUTO_DISPATCH is set to "true"
    When a same-repo pull request is opened or synchronized
    Then a shadow ci.yml run is dispatched on the PR branch (fire-and-forget, not in PR checks)
    And fork PRs never dispatch

  Scenario: validation
    Given the two modified workflow files
    When actionlint runs against them
    Then no errors are reported (verified locally)
```

## **Screenshots/Recordings**

N/A — CI workflow change only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration and OIDC/token-exchange dispatch paths for shadow runs; mis-gating could skip needed jobs or trigger extra runs, but default auto-dispatch stays off and fork PRs are blocked.
> 
> **Overview**
> **Re-enables automatic Namespace shadow CI** using the same kill-switch pattern as Bitrise shadow, without changing default behavior until `NAMESPACE_SHADOW_AUTO_DISPATCH=true`.
> 
> `ci-namespace-shadow.yml` again listens on **PR** and **main push** (with doc-only `paths-ignore`), but the dispatch job only runs when **`NAMESPACE_SHADOW_AUTO_DISPATCH`** is `true` or the workflow is started manually. **Fork PRs** are excluded from auto-dispatch. Comments document that shadow runs are **iOS-only**.
> 
> In **`ci.yml`**, every job that was skipped for `runner_provider == 'bitrise'` is now also skipped for **`runner_provider == 'namespace'`** (Android, Linux lint/tests, Sonar, aggregate gates, performance/Android E2E, etc.), so a Namespace shadow dispatch runs the same reduced **iOS benchmark** job set as Bitrise shadow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013209de291aef538a8fa458d55639a304e2a81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->