### PR TITLE
fix: now tab - ordering regression cp-8.2.0

### DIFF
--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -65,11 +65,6 @@ import {
   useWhatsHappening,
 } from '../../../UI/WhatsHappening/hooks';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
-import { useABTest } from '../../../../hooks';
-import {
-  WHATS_HAPPENING_EXPLORE_AB_KEY,
-  WHATS_HAPPENING_EXPLORE_VARIANTS,
-} from '../abTestConfig';
 
 interface PerpsBlockProps {
   refresh: TabProps['refresh'];
@@ -215,10 +210,6 @@ const NowTabContent: React.FC<TabProps> = ({
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const isWhatsHappeningEnabled = useSelector(selectWhatsHappeningEnabled);
-  const { variant: whatsHappeningExploreVariant } = useABTest(
-    WHATS_HAPPENING_EXPLORE_AB_KEY,
-    WHATS_HAPPENING_EXPLORE_VARIANTS,
-  );
 
   const whatsHappening = useWhatsHappening(MAX_ITEMS_DISPLAYED);
   const refreshWhatsHappening = whatsHappening.refresh;
@@ -290,50 +281,31 @@ const NowTabContent: React.FC<TabProps> = ({
 
   const sections = useMemo((): ExploreSectionItem[] => {
     const items: ExploreSectionItem[] = [];
-    const whFirst = whatsHappeningExploreVariant.whatsHappeningBeforePredict;
 
-    const whatsHappeningSection: ExploreSectionItem = {
-      key: 'wh',
-      content: (
-        <WhatsHappeningSection
-          source={WhatsHappeningSource.Explore}
-          feed={whatsHappening}
-          tabName="Now"
-          sectionName="whats_happening"
-        />
-      ),
-    };
-
-    const predictionsSection: ExploreSectionItem = {
-      key: 'predict',
-      content: (
-        <PredictionsCarouselSection
-          feed={displayedPredictions}
-          tabName="Now"
-          sectionName="predictions_trending"
-          title={
-            worldCupPredictions.isEnabled
-              ? strings('predict.world_cup.predictions_title')
-              : strings('wallet.predict')
-          }
-          testIdPrefix="predict-market-row-item"
-          idPrefix="predictions"
-          onViewAll={() =>
-            worldCupPredictions.isEnabled
-              ? navigateToExploreWorldCupPredictions(navigation)
-              : navigateToExplorePredictionsList(navigation, 'trending')
-          }
-          isEnabled={isPredictEnabled}
-        />
-      ),
-    };
-
-    if (whFirst) {
-      if (showWhatsHappening) items.push(whatsHappeningSection);
-      if (showPredictions) items.push(predictionsSection);
-    } else {
-      if (showPredictions) items.push(predictionsSection);
-      if (showWhatsHappening) items.push(whatsHappeningSection);
+    if (showPredictions) {
+      items.push({
+        key: 'predict',
+        content: (
+          <PredictionsCarouselSection
+            feed={displayedPredictions}
+            tabName="Now"
+            sectionName="predictions_trending"
+            title={
+              worldCupPredictions.isEnabled
+                ? strings('predict.world_cup.predictions_title')
+                : strings('wallet.predict')
+            }
+            testIdPrefix="predict-market-row-item"
+            idPrefix="predictions"
+            onViewAll={() =>
+              worldCupPredictions.isEnabled
+                ? navigateToExploreWorldCupPredictions(navigation)
+                : navigateToExplorePredictionsList(navigation, 'trending')
+            }
+            isEnabled={isPredictEnabled}
+          />
+        ),
+      });
     }
 
     if (showCryptoMovers) {
@@ -394,6 +366,20 @@ const NowTabContent: React.FC<TabProps> = ({
       });
     }
 
+    if (showWhatsHappening) {
+      items.push({
+        key: 'wh',
+        content: (
+          <WhatsHappeningSection
+            source={WhatsHappeningSource.Explore}
+            feed={whatsHappening}
+            tabName="Now"
+            sectionName="whats_happening"
+          />
+        ),
+      });
+    }
+
     if (showStocks) {
       items.push({
         key: 'stocks',
@@ -423,7 +409,6 @@ const NowTabContent: React.FC<TabProps> = ({
 
     return items;
   }, [
-    whatsHappeningExploreVariant.whatsHappeningBeforePredict,
     showWhatsHappening,
     showPredictions,
     showCryptoMovers,


### PR DESCRIPTION
## **Description**

UI regression.

The Explore > "Now Tab" order was decided here [ASSETS-3405](https://consensyssoftware.atlassian.net/browse/ASSETS-3405) / https://github.com/MetaMask/metamask-mobile/pull/31993

However this change unintended re-introduced the ordering: https://github.com/MetaMask/metamask-mobile/pull/32561

This PR re-applies changes on https://github.com/MetaMask/metamask-mobile/pull/31993, with tests

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: now tab - ordering regression cp-8.2.0

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32897

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[ASSETS-3405]: https://consensyssoftware.atlassian.net/browse/ASSETS-3405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only section ordering on Explore Now; no auth, data, or API changes.
> 
> **Overview**
> Fixes an Explore **Now** tab layout regression by dropping the **Whats Happening vs Predictions** A/B ordering experiment from `NowTab` and using a single, fixed section stack again.
> 
> **Predictions** stays at the top when shown, followed by **crypto movers**, **perps**, then **What's Happening** (after perps, before **stocks**). The `useABTest` hook and `whatsHappeningBeforePredict` branching are removed from section assembly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d1ed3787f4288a19282cbf49239a3c39cd0bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->