### PR TITLE
feat: remove Social Leaderboard position PnL arrows

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -82,25 +82,23 @@ describe('PositionRow', () => {
     expect(screen.getByText('$2,259.96')).toBeOnTheScreen();
   });
 
-  it('renders an up triangle with the unsigned percent on the bottom-right (no absolute PnL)', () => {
+  it('renders a plus sign with the percent on the bottom-right (no absolute PnL)', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    // Direction lives in the caret, so the percent is unsigned.
-    expect(screen.getByText('▲')).toBeOnTheScreen();
-    expect(screen.getByText('182.00%')).toBeOnTheScreen();
-    expect(screen.queryByText('+182.00%')).toBeNull();
+    expect(screen.getByText('+182.00%')).toBeOnTheScreen();
+    expect(screen.queryByText('▲')).toBeNull();
+    expect(screen.queryByText('▼')).toBeNull();
+    expect(screen.queryByText('182.00%')).toBeNull();
     expect(screen.queryByText('+$1,059.96 (+182%)')).toBeNull();
     expect(screen.queryByText('+$1,059.96')).toBeNull();
   });
 
-  it('colors the percent to match the up triangle for a winning position', () => {
+  it('colors the signed percent for a winning position', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    const triangleColor = colorOf(screen.getByText('▲'));
-    const percentColor = colorOf(screen.getByText('182.00%'));
+    const percentColor = colorOf(screen.getByText('+182.00%'));
     expect(percentColor).toBeDefined();
-    expect(percentColor).toBe(triangleColor);
   });
 
-  it('renders a down triangle with the unsigned percent for a losing open position', () => {
+  it('renders a minus sign with the percent for a losing open position', () => {
     const position = {
       ...basePosition,
       pnlValueUsd: -250,
@@ -108,20 +106,19 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('▼')).toBeOnTheScreen();
-    expect(screen.getByText('25.00%')).toBeOnTheScreen();
-    expect(screen.queryByText('-25.00%')).toBeNull();
+    expect(screen.getByText('-25.00%')).toBeOnTheScreen();
+    expect(screen.queryByText('▲')).toBeNull();
+    expect(screen.queryByText('▼')).toBeNull();
+    expect(screen.queryByText('25.00%')).toBeNull();
     expect(screen.queryByText('-$250.00 (-25%)')).toBeNull();
   });
 
-  it('colors the percent to match the down triangle for a losing position', () => {
+  it('colors the signed percent for a losing position', () => {
     const position = { ...basePosition, pnlValueUsd: -250, pnlPercent: -25 };
 
     renderWithProvider(<PositionRow position={position} />);
-    const triangleColor = colorOf(screen.getByText('▼'));
-    const percentColor = colorOf(screen.getByText('25.00%'));
+    const percentColor = colorOf(screen.getByText('-25.00%'));
     expect(percentColor).toBeDefined();
-    expect(percentColor).toBe(triangleColor);
   });
 
   it('renders the percent even when pnlValueUsd is missing', () => {
@@ -131,7 +128,7 @@ describe('PositionRow', () => {
     } as unknown as Position;
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('182.00%')).toBeOnTheScreen();
+    expect(screen.getByText('+182.00%')).toBeOnTheScreen();
   });
 
   it('renders dash when pnlPercent is null', () => {
@@ -157,7 +154,7 @@ describe('PositionRow', () => {
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders a neutral minus and unsigned 0% when unrealized PnL is zero', () => {
+  it('renders signed 0% without a direction arrow when unrealized PnL is zero', () => {
     const position = {
       ...basePosition,
       pnlValueUsd: 0,
@@ -165,10 +162,9 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    // U+2212 minus glyph (not a triangle) for break-even, then unsigned 0%.
-    expect(screen.getByText('−')).toBeOnTheScreen();
-    expect(screen.getByText('0.00%')).toBeOnTheScreen();
-    expect(screen.queryByText('+0.00%')).toBeNull();
+    expect(screen.getByText('+0.00%')).toBeOnTheScreen();
+    expect(screen.queryByText('▲')).toBeNull();
+    expect(screen.queryByText('▼')).toBeNull();
     expect(screen.queryByText('$0.00 (+0%)')).toBeNull();
   });
 
@@ -262,12 +258,13 @@ describe('PositionRow', () => {
       expect(screen.getByText('Apr 15 at 2:00 pm')).toBeOnTheScreen();
     });
 
-    it('renders realized PnL percent as unsigned magnitude (sign comes from caret)', () => {
+    it('renders realized PnL percent with a plus sign', () => {
       renderWithProvider(<PositionRow position={closedPosition} />);
 
       // realizedPnl (300) / boughtUsd (1200) * 100 = 25%
-      expect(screen.getByText('25.00%')).toBeOnTheScreen();
-      expect(screen.queryByText('+25%')).toBeNull();
+      expect(screen.getByText('+25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
 
     it('renders dash for PnL when boughtUsd is zero', () => {
@@ -278,14 +275,15 @@ describe('PositionRow', () => {
       expect(screen.getByText('—')).toBeOnTheScreen();
     });
 
-    it('renders negative realized PnL percent as unsigned magnitude', () => {
+    it('renders negative realized PnL percent with a minus sign', () => {
       const position = { ...closedPosition, realizedPnl: -300 };
 
       renderWithProvider(<PositionRow position={position} />);
 
       // -300 / 1200 * 100 = -25%
-      expect(screen.getByText('25.00%')).toBeOnTheScreen();
-      expect(screen.queryByText('-25.00%')).toBeNull();
+      expect(screen.getByText('-25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
 
     it('uses realized PnL percent even when pnlPercent is 0', () => {
@@ -293,18 +291,18 @@ describe('PositionRow', () => {
 
       renderWithProvider(<PositionRow position={position} />);
 
-      expect(screen.getByText('25.00%')).toBeOnTheScreen();
+      expect(screen.getByText('+25.00%')).toBeOnTheScreen();
     });
 
-    it('renders break-even realized PnL with a neutral minus and 0% percent', () => {
+    it('renders break-even realized PnL with signed 0% percent', () => {
       const position = { ...closedPosition, realizedPnl: 0, boughtUsd: 1200 };
 
       renderWithProvider(<PositionRow position={position} />);
 
       expect(screen.getByText('$0.00')).toBeOnTheScreen();
-      // U+2212 minus glyph, not a hyphen
-      expect(screen.getByText('−')).toBeOnTheScreen();
-      expect(screen.getByText('0.00%')).toBeOnTheScreen();
+      expect(screen.getByText('+0.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
 
     it('renders realized PnL value when boughtUsd is zero (percent null)', () => {
@@ -404,7 +402,7 @@ describe('PositionRow', () => {
       expect(screen.queryByText('1.50B ETH')).not.toBeOnTheScreen();
     });
 
-    it('renders an up triangle with a colored, unsigned percent for a winning closed perp (matching spot)', () => {
+    it('renders a plus sign with a colored percent for a winning closed perp', () => {
       const closedPerp = {
         ...perpPosition,
         currentValueUSD: 0,
@@ -415,13 +413,13 @@ describe('PositionRow', () => {
 
       renderWithProvider(<PositionRow position={closedPerp} isClosed />);
 
-      // 300 / 1200 * 100 = 25%, rendered unsigned with the caret carrying direction.
-      expect(screen.getByText('▲')).toBeOnTheScreen();
-      expect(screen.getByText('25.00%')).toBeOnTheScreen();
-      expect(screen.queryByText('+25%')).toBeNull();
+      // 300 / 1200 * 100 = 25%
+      expect(screen.getByText('+25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
 
-    it('renders a down triangle with a colored, unsigned percent for a losing closed perp', () => {
+    it('renders a minus sign with a colored percent for a losing closed perp', () => {
       const closedPerp = {
         ...perpPosition,
         currentValueUSD: 0,
@@ -432,18 +430,17 @@ describe('PositionRow', () => {
 
       renderWithProvider(<PositionRow position={closedPerp} isClosed />);
 
-      expect(screen.getByText('▼')).toBeOnTheScreen();
-      expect(screen.getByText('25.00%')).toBeOnTheScreen();
-      expect(screen.queryByText('-25.00%')).toBeNull();
+      expect(screen.getByText('-25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
 
-    it('renders the directional triangle with an unsigned percent for an open perp', () => {
+    it('renders the plus sign with the percent for an open perp', () => {
       renderWithProvider(<PositionRow position={perpPosition} />);
 
-      // Open positions now match closed: caret carries direction, percent is unsigned.
-      expect(screen.getByText('▲')).toBeOnTheScreen();
-      expect(screen.getByText('182.00%')).toBeOnTheScreen();
-      expect(screen.queryByText('+182.00%')).toBeNull();
+      expect(screen.getByText('+182.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -114,33 +114,20 @@ const PositionRowComponent: React.FC<PositionRowProps> = ({
     </Text>
   );
 
-  // All positions — open and closed, perp and spot — render a directional
-  // triangle (▲/▼) alongside an unsigned percentage, both colored by direction
-  // (green up / red down). A break-even position shows a neutral minus and a
-  // neutral percentage. The sign lives in the caret, so the percent is unsigned.
+  // All positions — open and closed, perp and spot — render the PnL direction
+  // as a signed percentage, colored by profit/loss direction.
+  const signedDisplayPnlPercent =
+    hasPnlPercent && pnlSignSource != null && !isPnlZero
+      ? Math.abs(displayPnlPercent) * (isPnlPositive ? 1 : -1)
+      : displayPnlPercent;
   const bottomRight = (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      gap={1}
+    <Text
+      variant={TextVariant.BodySm}
+      twClassName={pnlColorClass}
+      color={pnlColorClass ? undefined : TextColor.TextAlternative}
     >
-      {!hasPnlPercent ? null : isPnlZero ? (
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {'−'}
-        </Text>
-      ) : (
-        <Text variant={TextVariant.BodySm} twClassName={pnlColorClass}>
-          {isPnlPositive ? '▲' : '▼'}
-        </Text>
-      )}
-      <Text
-        variant={TextVariant.BodySm}
-        twClassName={pnlColorClass}
-        color={pnlColorClass ? undefined : TextColor.TextAlternative}
-      >
-        {formatPercent(displayPnlPercent, { showSign: false })}
-      </Text>
-    </Box>
+      {formatPercent(signedDisplayPnlPercent)}
+    </Text>
   );
 
   const content = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the separate up/down triangle indicator from Social Leaderboard position rows
- Render open and closed position PnL percentages with explicit `+`/`-` signs instead
- Update PositionRow coverage for spot and perp open/closed signed percent rendering



<img width="2561" height="2757" alt="SCR-20260707-pgbu" src="https://github.com/user-attachments/assets/00561e92-6e21-47f2-9a9f-32cfaa18ab34" />


<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1783435311848059?thread_ts=1783435311.848059&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-a5240368-ce5f-5227-b948-951a2f7c610a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5240368-ce5f-5227-b948-951a2f7c610a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

