### PR TITLE
fix(predict): show retryable error instead of $0 when balance fails to load

### DIFF
--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -646,6 +646,117 @@ describe('PredictBalance', () => {
     });
   });
 
+  describe('when balance fails to load', () => {
+    it('displays a retryable error state instead of $0 when the fetch fails with no cached data', () => {
+      // Arrange
+      mockUsePredictBalance.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+        refetch: jest.fn(),
+      });
+
+      // Act
+      const { getByTestId, getByText, queryByText } = renderWithProvider(
+        <PredictBalance />,
+        { state: initialState },
+      );
+
+      // Assert
+      expect(getByTestId(PREDICT_BALANCE_TEST_IDS.ERROR)).toBeOnTheScreen();
+      expect(
+        getByText(strings('predict.balance_error.title')),
+      ).toBeOnTheScreen();
+      expect(
+        getByText(strings('predict.balance_error.description')),
+      ).toBeOnTheScreen();
+      expect(queryByText(/\$0/)).not.toBeOnTheScreen();
+    });
+
+    it('calls refetch when the retry button is pressed', () => {
+      // Arrange
+      const mockRefetch = jest.fn();
+      mockUsePredictBalance.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+        refetch: mockRefetch,
+      });
+
+      // Act
+      const { getByTestId } = renderWithProvider(<PredictBalance />, {
+        state: initialState,
+      });
+      fireEvent.press(getByTestId(PREDICT_BALANCE_TEST_IDS.RETRY_BUTTON));
+
+      // Assert
+      expect(mockRefetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('displays the loading skeleton while a retry is in flight', () => {
+      // Arrange
+      mockUsePredictBalance.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: true,
+        refetch: jest.fn(),
+      });
+
+      // Act
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <PredictBalance />,
+        { state: initialState },
+      );
+
+      // Assert
+      expect(getByTestId(PREDICT_BALANCE_TEST_IDS.SKELETON)).toBeOnTheScreen();
+      expect(queryByTestId(PREDICT_BALANCE_TEST_IDS.ERROR)).toBeNull();
+    });
+
+    it('displays the last known balance when a background refetch fails', () => {
+      // Arrange — stale data beats an error state
+      mockUsePredictBalance.mockReturnValue({
+        data: 42.5,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+        refetch: jest.fn(),
+      });
+
+      // Act
+      const { getByText, queryByTestId } = renderWithProvider(
+        <PredictBalance />,
+        { state: initialState },
+      );
+
+      // Assert
+      expect(getByText(/\$42\.50/)).toBeOnTheScreen();
+      expect(queryByTestId(PREDICT_BALANCE_TEST_IDS.ERROR)).toBeNull();
+    });
+
+    it('hides the title in the error state when hideTitle is true', () => {
+      // Arrange
+      mockUsePredictBalance.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+        refetch: jest.fn(),
+      });
+
+      // Act
+      const { queryByText } = renderWithProvider(<PredictBalance hideTitle />, {
+        state: initialState,
+      });
+
+      // Assert
+      expect(queryByText(strings('wallet.predict'))).toBeNull();
+    });
+  });
+
   describe('balance refresh', () => {
     it('component renders with adding funds state when deposit is pending', () => {
       // Arrange - set up pending deposit to test the adding funds UI

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.testIds.ts
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.testIds.ts
@@ -1,6 +1,8 @@
 export const PREDICT_BALANCE_TEST_IDS = {
   SKELETON: 'predict-balance-card-skeleton',
   CARD: 'predict-balance-card',
+  ERROR: 'predict-balance-card-error',
+  RETRY_BUTTON: 'predict-balance-retry-button',
   POSITIONS_BUTTON: 'predict-balance-positions-button',
   WITHDRAW_BUTTON: 'predict-balance-withdraw-button',
   WITHDRAW_UNAVAILABLE_SHEET: 'predict-withdraw-unavailable-sheet',

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -4,6 +4,7 @@ import {
   BoxJustifyContent,
   Spinner,
   Text,
+  TextVariant,
   TitleHub,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -31,6 +32,11 @@ import Button, {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { USDC_SYMBOL, USDC_TOKEN_ICON_URL } from '@metamask/perps-controller';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
@@ -69,7 +75,17 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
   const queryClient = useQueryClient();
-  const { data: balance = 0, isLoading } = usePredictBalance();
+  const {
+    data: balanceData,
+    isLoading,
+    isError,
+    isFetching,
+    refetch,
+  } = usePredictBalance();
+  const balance = balanceData ?? 0;
+  // Only treat the fetch failure as fatal when there is no cached balance to
+  // show — rendering a stale balance beats rendering an error (or a fake $0).
+  const hasBalanceLoadError = isError && balanceData === undefined;
   const { deposit, isDepositPending } = usePredictDeposit();
   const { withdraw } = usePredictWithdraw();
   const { executeGuardedAction } = usePredictActionGuard({
@@ -141,6 +157,10 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({
     navigation.navigate(Routes.PREDICT.POSITIONS);
   }, [navigation]);
 
+  const handleRetryBalance = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
   const handleWithdraw = useCallback(() => {
     if (!walletType) {
       return;
@@ -159,7 +179,7 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({
     withdraw,
   ]);
 
-  if (isLoading) {
+  if (isLoading || (hasBalanceLoadError && isFetching)) {
     return (
       <Box twClassName="px-4 gap-3" testID={PREDICT_BALANCE_TEST_IDS.SKELETON}>
         <Box twClassName="gap-2">
@@ -181,6 +201,49 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({
             style={tw.style('rounded-xl flex-1')}
           />
         </Box>
+      </Box>
+    );
+  }
+
+  if (hasBalanceLoadError) {
+    return (
+      <Box
+        twClassName="px-4"
+        testID={PREDICT_BALANCE_TEST_IDS.ERROR}
+        onLayout={(layoutEvent) => {
+          const { height } = layoutEvent.nativeEvent.layout;
+          onLayout?.(height);
+        }}
+      >
+        {!hideTitle && (
+          <Text variant={TextVariant.HeadingLg} twClassName="text-default">
+            {strings('wallet.predict')}
+          </Text>
+        )}
+        <Box twClassName="items-center gap-2 py-4">
+          <Icon
+            name={IconName.Warning}
+            size={IconSize.Xl}
+            color={IconColor.Muted}
+          />
+          <Text variant={TextVariant.HeadingMd} twClassName="text-default">
+            {strings('predict.balance_error.title')}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-alternative text-center"
+          >
+            {strings('predict.balance_error.description')}
+          </Text>
+        </Box>
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Lg}
+          label={strings('predict.balance_error.retry')}
+          onPress={handleRetryBalance}
+          style={tw.style('w-full')}
+          testID={PREDICT_BALANCE_TEST_IDS.RETRY_BUTTON}
+        />
       </Box>
     );
   }

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -41,6 +41,7 @@ import {
 } from '../types';
 import {
   getDefaultPredictControllerState,
+  OPTIMISTIC_BALANCE_MAX_AGE_MS,
   PredictController,
   PredictControllerMessenger,
   type PredictControllerState,
@@ -6262,6 +6263,38 @@ describe('PredictController', () => {
       });
     });
 
+    it('clears cached balance and invalidates account state after confirmed withdrawals', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictWithdraw,
+          status: TransactionStatus.confirmed,
+          from: accountAddress,
+        });
+
+        // Cache entries can be keyed by checksummed addresses — seed one to
+        // verify the case-insensitive cleanup.
+        const checksummedAddress =
+          accountAddress.slice(0, 2) + accountAddress.slice(2).toUpperCase();
+        controller.updateStateForTesting((state) => {
+          state.balances[checksummedAddress] = {
+            balance: 250,
+            validUntil: Date.now() + 60_000,
+          };
+        });
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as { transactionMeta: TransactionMeta });
+
+        await Promise.resolve();
+
+        expect(
+          mockPolymarketProvider.invalidateAccountState,
+        ).toHaveBeenCalledWith(accountAddress);
+        expect(controller.state.balances[checksummedAddress]).toBeUndefined();
+      });
+    });
+
     it('invalidates account state and syncs deposit-wallet balance allowance after confirmed deposits', async () => {
       await withController(async ({ controller, messenger }) => {
         const transactionMeta = createPredictTransactionMeta({
@@ -8925,7 +8958,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('sets validUntil to 5 seconds in future for BUY orders', async () => {
+    it('holds optimistic balance for the settlement safety window for BUY orders', async () => {
       const preview = createMockOrderPreview({ side: Side.BUY });
       const mockResult = {
         success: true as const,
@@ -8951,7 +8984,9 @@ describe('PredictController', () => {
             controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
-          expect(updatedBalance.validUntil).toBe(now + 5000);
+          expect(updatedBalance.validUntil).toBe(
+            now + OPTIMISTIC_BALANCE_MAX_AGE_MS,
+          );
         },
         {
           state: {
@@ -9001,7 +9036,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('sets validUntil to 5 seconds in future for SELL orders', async () => {
+    it('holds optimistic balance for the settlement safety window for SELL orders', async () => {
       const preview = createMockOrderPreview({ side: Side.SELL });
       const mockResult = {
         success: true as const,
@@ -9027,13 +9062,80 @@ describe('PredictController', () => {
             controller.state.balances[
               '0x1234567890123456789012345678901234567890'
             ];
-          expect(updatedBalance.validUntil).toBe(now + 5000);
+          expect(updatedBalance.validUntil).toBe(
+            now + OPTIMISTIC_BALANCE_MAX_AGE_MS,
+          );
         },
         {
           state: {
             balances: {
               '0x1234567890123456789012345678901234567890':
                 createMockPredictBalance(),
+            },
+          },
+        },
+      );
+    });
+
+    it('skips optimistic balance update when there is no cached balance baseline', async () => {
+      const preview = createMockOrderPreview({ side: Side.BUY });
+      const mockResult = {
+        success: true as const,
+        response: {
+          id: 'order-123',
+          spentAmount: '50',
+          receivedAmount: '100',
+        },
+      };
+      mockPolymarketProvider.placeOrder.mockResolvedValue(mockResult);
+
+      await withController(async ({ controller }) => {
+        // Act
+        await controller.placeOrder({
+          preview,
+        });
+
+        // Assert — no baseline means no optimistic entry; the next
+        // getBalance call must fetch the real value from chain.
+        expect(
+          controller.state.balances[
+            '0x1234567890123456789012345678901234567890'
+          ],
+        ).toBeUndefined();
+      });
+    });
+
+    it('clamps optimistic BUY balance at zero when spend exceeds the cached baseline', async () => {
+      const preview = createMockOrderPreview({ side: Side.BUY });
+      const mockResult = {
+        success: true as const,
+        response: {
+          id: 'order-123',
+          spentAmount: '50',
+          receivedAmount: '100',
+        },
+      };
+      mockPolymarketProvider.placeOrder.mockResolvedValue(mockResult);
+
+      await withController(
+        async ({ controller }) => {
+          // Act
+          await controller.placeOrder({
+            preview,
+          });
+
+          // Assert
+          const updatedBalance =
+            controller.state.balances[
+              '0x1234567890123456789012345678901234567890'
+            ];
+          expect(updatedBalance.balance).toBe(0);
+        },
+        {
+          state: {
+            balances: {
+              '0x1234567890123456789012345678901234567890':
+                createMockPredictBalance({ balance: 40 }),
             },
           },
         },

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -461,6 +461,16 @@ const HIGHLIGHT_SERIES_PAST_WINDOW_MS = 60 * 60 * 1000;
 const HIGHLIGHT_SERIES_FUTURE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
+ * How long an optimistic balance (set right after an order fills) stays
+ * authoritative. Settlement happens off-device on Polygon, so there is no
+ * local tx-confirmed event for it — this window is a safety cap generously
+ * sized to outlast settlement, and any confirmed Predict transaction event
+ * (deposit, withdraw, claim) clears the cached balance early so a fresh
+ * on-chain value is fetched.
+ */
+export const OPTIMISTIC_BALANCE_MAX_AGE_MS = 30 * 1000;
+
+/**
  * PredictController - Protocol-agnostic prediction markets trading controller
  *
  * Provides a unified interface for prediction markets trading across multiple protocols.
@@ -1606,7 +1616,12 @@ export class PredictController extends BaseController<
 
       const { spentAmount, receivedAmount } = result.response;
 
-      const cachedBalance = this.state.balances[signer.address]?.balance ?? 0;
+      const cachedBalanceEntry = this.state.balances[signer.address];
+      const cachedBalance = cachedBalanceEntry?.balance ?? 0;
+      // Without a known baseline, an optimistic delta would produce a bogus
+      // (possibly negative) balance — leave the cache empty so the next read
+      // fetches the real value from chain instead.
+      const hasBalanceBaseline = cachedBalanceEntry !== undefined;
       let realAmountUsd = amountUsd;
       let realSharePrice = sharePrice;
       try {
@@ -1615,26 +1630,35 @@ export class PredictController extends BaseController<
           realAmountUsd = parseFloat(spentAmount);
           realSharePrice = parseFloat(spentAmount) / parseFloat(receivedAmount);
 
-          // Optimistically update balance
-          this.update((state) => {
-            state.balances[signer.address] = {
-              balance: cachedBalance - (realAmountUsd + totalFee),
-              // valid for 5 seconds (since it takes some time to reflect balance on-chain)
-              validUntil: Date.now() + 5000,
-            };
-          });
+          if (hasBalanceBaseline) {
+            // Optimistically update balance. Held until a confirmed
+            // transaction event clears it, capped so it can't outlive
+            // on-chain settlement.
+            this.update((state) => {
+              state.balances[signer.address] = {
+                balance: Math.max(
+                  0,
+                  cachedBalance - (realAmountUsd + totalFee),
+                ),
+                validUntil: Date.now() + OPTIMISTIC_BALANCE_MAX_AGE_MS,
+              };
+            });
+          }
         } else {
           realAmountUsd = parseFloat(receivedAmount);
           realSharePrice = parseFloat(receivedAmount) / parseFloat(spentAmount);
 
-          // Optimistically update balance
-          this.update((state) => {
-            state.balances[signer.address] = {
-              balance: cachedBalance + realAmountUsd,
-              // valid for 5 seconds (since it takes some time to reflect balance on-chain)
-              validUntil: Date.now() + 5000,
-            };
-          });
+          if (hasBalanceBaseline) {
+            // Optimistically update balance. Held until a confirmed
+            // transaction event clears it, capped so it can't outlive
+            // on-chain settlement.
+            this.update((state) => {
+              state.balances[signer.address] = {
+                balance: cachedBalance + realAmountUsd,
+                validUntil: Date.now() + OPTIMISTIC_BALANCE_MAX_AGE_MS,
+              };
+            });
+          }
         }
       } catch (_e) {
         // If we can't get real share price, continue without it
@@ -2843,12 +2867,27 @@ export class PredictController extends BaseController<
       this.clearPendingDepositForAddress({ address });
     }
 
+    if (status === 'confirmed') {
+      // Any confirmed Predict transaction changes on-chain funds and possibly
+      // wallet deployment — drop the cached account state and balance so the
+      // next read fetches fresh values instead of stale or optimistic ones.
+      this.provider.invalidateAccountState(address);
+      this.update((state) => {
+        // Balance entries may be keyed by checksummed addresses (signer
+        // address) while `address` is lowercased — match case-insensitively.
+        for (const key of Object.keys(state.balances)) {
+          if (key.toLowerCase() === address.toLowerCase()) {
+            delete state.balances[key];
+          }
+        }
+      });
+    }
+
     let depositWalletSyncPromise: Promise<void> | undefined;
     if (
       (type === 'deposit' || type === 'depositAndOrder') &&
       status === 'confirmed'
     ) {
-      this.provider.invalidateAccountState(address);
       depositWalletSyncPromise = this.syncDepositWalletBalanceAllowanceIfNeeded(
         {
           transactionMeta,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -15,7 +15,11 @@ import {
 import type { OrderPreview } from '../types';
 import { Side, type PredictActivity, type PredictPosition } from '../../types';
 import type { PredictFeatureFlags } from '../../types/flags';
-import { PolymarketProvider } from './PolymarketProvider';
+import {
+  ACCOUNT_STATE_CACHE_TTL_MS,
+  ACCOUNT_STATE_NOT_DEPLOYED_CACHE_TTL_MS,
+  PolymarketProvider,
+} from './PolymarketProvider';
 import { OrderType, SignatureType } from './types';
 import {
   executeDepositWalletBatch,
@@ -830,6 +834,74 @@ describe('PolymarketProvider', () => {
     await expect(
       createProvider().getAccountState({ ownerAddress: signer.address }),
     ).rejects.toThrow('Failed to fetch Polymarket activity');
+  });
+
+  it('serves cached account state within the TTL without refetching', async () => {
+    const provider = createProvider();
+
+    const first = await provider.getAccountState({
+      ownerAddress: signer.address,
+    });
+    const second = await provider.getAccountState({
+      ownerAddress: signer.address,
+    });
+
+    expect(second).toEqual(first);
+    expect(mockIsSmartContractAddress).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches account state once the deployed-wallet TTL expires', async () => {
+    const provider = createProvider();
+    const start = 1_700_000_000_000;
+    // The global test setup replaces Date.now with a jest.fn — reassign (and
+    // restore) rather than spyOn, since mockRestore would wipe the global mock.
+    const originalDateNow = Date.now;
+    Date.now = jest.fn(() => start);
+
+    try {
+      await provider.getAccountState({ ownerAddress: signer.address });
+
+      Date.now = jest.fn(() => start + ACCOUNT_STATE_CACHE_TTL_MS + 1);
+      await provider.getAccountState({ ownerAddress: signer.address });
+
+      expect(mockIsSmartContractAddress).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it('expires not-deployed account states on the shorter TTL', async () => {
+    mockIsSmartContractAddress.mockResolvedValue(false);
+    const provider = createProvider();
+    const start = 1_700_000_000_000;
+    const originalDateNow = Date.now;
+    Date.now = jest.fn(() => start);
+
+    try {
+      const accountState = await provider.getAccountState({
+        ownerAddress: signer.address,
+      });
+      expect(accountState.isDeployed).toBe(false);
+      expect(mockResolveDepositWalletAddress).toHaveBeenCalledTimes(1);
+
+      // Still cached within the not-deployed TTL.
+      Date.now = jest.fn(
+        () => start + ACCOUNT_STATE_NOT_DEPLOYED_CACHE_TTL_MS - 1,
+      );
+      await provider.getAccountState({ ownerAddress: signer.address });
+      expect(mockResolveDepositWalletAddress).toHaveBeenCalledTimes(1);
+
+      // Expired past the not-deployed TTL — must refetch.
+      Date.now = jest.fn(
+        () => start + ACCOUNT_STATE_NOT_DEPLOYED_CACHE_TTL_MS + 1,
+      );
+      await provider.getAccountState({ ownerAddress: signer.address });
+      expect(mockResolveDepositWalletAddress).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 
   describe('getActivity', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -279,6 +279,20 @@ const isTransientPriceHistoryError = (error: Error): boolean =>
     error.message,
   );
 
+/**
+ * TTL for cached account states. Deployed wallets are stable, so a longer TTL
+ * is safe; a "not deployed" result is expected to change (e.g. right after a
+ * first deposit) and must expire quickly so a transient RPC failure or race
+ * can't pin a stale state indefinitely.
+ */
+export const ACCOUNT_STATE_CACHE_TTL_MS = 5 * 60 * 1000;
+export const ACCOUNT_STATE_NOT_DEPLOYED_CACHE_TTL_MS = 30 * 1000;
+
+interface CachedAccountState {
+  accountState: AccountState;
+  expiresAt: number;
+}
+
 export class PolymarketProvider implements PredictProvider {
   readonly providerId = POLYMARKET_PROVIDER_ID;
   readonly name = 'Polymarket';
@@ -286,7 +300,7 @@ export class PolymarketProvider implements PredictProvider {
   readonly #getFeatureFlags: () => PredictFeatureFlags;
 
   #apiKeysByProtocolAddress: Map<string, ApiKeyCreds> = new Map();
-  #accountStateByAddress: Map<string, AccountState> = new Map();
+  #accountStateByAddress: Map<string, CachedAccountState> = new Map();
   #safeAddressesWithZeroLegacyUsdceBalance = new Set<string>();
   #lastBuyOrderTimestampByAddress: Map<string, number> = new Map();
   #buyOrderInProgressByAddress: Map<string, boolean> = new Map();
@@ -310,18 +324,32 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   #getCachedAccountState(ownerAddress: string): AccountState | undefined {
-    return this.#accountStateByAddress.get(
-      this.#getAccountStateCacheKey(ownerAddress),
-    );
+    const cacheKey = this.#getAccountStateCacheKey(ownerAddress);
+    const cached = this.#accountStateByAddress.get(cacheKey);
+
+    if (!cached) {
+      return undefined;
+    }
+
+    if (cached.expiresAt <= Date.now()) {
+      this.#accountStateByAddress.delete(cacheKey);
+      return undefined;
+    }
+
+    return cached.accountState;
   }
 
   #setCachedAccountState(
     ownerAddress: string,
     accountState: AccountState,
   ): void {
+    const ttl = accountState.isDeployed
+      ? ACCOUNT_STATE_CACHE_TTL_MS
+      : ACCOUNT_STATE_NOT_DEPLOYED_CACHE_TTL_MS;
+
     this.#accountStateByAddress.set(
       this.#getAccountStateCacheKey(ownerAddress),
-      accountState,
+      { accountState, expiresAt: Date.now() + ttl },
     );
   }
 

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx
@@ -218,6 +218,13 @@ describe('PredictFeed', () => {
     (
       Engine.context.PredictController.searchMarkets as jest.Mock
     ).mockResolvedValue({ markets: [], totalResults: 0 });
+    // Re-establish getBalance: spying on it in a test and calling mockRestore()
+    // wipes the shared Engine mock's implementation (spyOn returns the existing
+    // jest.fn), which would make the balance query resolve undefined → error
+    // state instead of the balance card.
+    (
+      Engine.context.PredictController.getBalance as jest.Mock
+    ).mockResolvedValue(0);
   });
 
   describe('search interaction', () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2615,6 +2615,11 @@
     "markets_won": "Markets won",
     "won_markets_text": "Won {{count}} market{{s}}",
     "available_balance": "Available balance",
+    "balance_error": {
+      "title": "Couldn't load your balance",
+      "description": "Your funds are safe. Check your connection and try again.",
+      "retry": "Retry"
+    },
     "portfolio": {
       "available_amount": "{{amount}} available",
       "value_accessibility": "Portfolio value, {{value}}",


### PR DESCRIPTION
## **Description**

When the Predict balance or account-state fetch fails (transient Polygon RPC / Polymarket hiccup), the balance card rendered `$0.00` with no error or retry — users read this as their funds vanishing, and it became the dominant Predict support theme on Intercom this week.

Three fixes, matching the three root causes:

1. **Retryable error state instead of $0** — `PredictBalance` no longer defaults a failed query to `0`. When the fetch errors with no cached data it renders a "Couldn't load your balance" card ("Your funds are safe. Check your connection and try again.") with a Retry button. Stale cached data still wins over the error card, and the skeleton shows while a retry is in flight.
2. **Account-state cache TTL + broader invalidation** — `PolymarketProvider`'s `#accountStateByAddress` cache had no TTL and was only invalidated on deposit confirm, so a stale "not deployed" safe-address could be pinned indefinitely. Entries now expire (5 min for deployed wallets, 30 s for not-deployed — the state most likely to change right after a first deposit), and any confirmed Predict transaction (deposit, depositAndOrder, withdraw, claim) invalidates both the account state and the cached balance.
3. **Optimistic balance no longer expires before settlement** — the post-order optimistic balance used a fixed 5 s window, shorter than Polygon settlement, so balances flapped back to stale on-chain values. CLOB settlement has no local tx-confirmed event, so the window is now a 30 s safety cap (`OPTIMISTIC_BALANCE_MAX_AGE_MS`), cleared early by confirmed transaction events. Also fixes two latent bugs in that path: a buy with no cached baseline previously wrote a negative balance (`0 − spent`) into state — it now skips the optimistic write so the next read fetches from chain — and buy balances are clamped at zero.

Verification that ran: `yarn jest` on the three touched suites (62 provider, 414 controller, PredictBalance component tests all passing), `yarn eslint` on changed files (no new issues), `yarn lint:tsc` (no new errors). Not yet run on a device/simulator — the error card layout is covered by component tests but hasn't been eyeballed, hence draft.

## **Changelog**

CHANGELOG entry: Fixed the Predict balance showing $0.00 when it failed to load; it now shows a retryable "Couldn't load your balance" state and keeps balances accurate around order settlement.

## **Related issues**

Refs: no Jira ticket — raised from an Intercom support-theme bug report ("Balance shows $0 when it fails to load (looks like funds disappeared)").

## **Manual testing steps**

```gherkin
Feature: Predict balance error handling

  Scenario: balance fetch fails with no cached data
    Given the device has no network connectivity (or Polygon RPC is unreachable)
    And the app has no cached Predict balance

    When user opens the Predict tab
    Then a "Couldn't load your balance" card with a Retry button is shown instead of $0.00

  Scenario: user retries after connectivity returns
    Given the "Couldn't load your balance" card is visible

    When user restores connectivity and taps Retry
    Then the loading skeleton is shown and the real balance appears

  Scenario: balance stays consistent after placing an order
    Given user has a funded Predict balance

    When user buys a position and waits ~10 seconds
    Then the balance reflects the spent amount and does not flap back to the pre-order value
```

## **Screenshots/Recordings**

### **Before**

N/A - regression path requires a forced network failure; before-state is the `$0.00` render described above.

### **After**

N/A - not yet captured on a simulator; error-state rendering is asserted in `PredictBalance.test.tsx`. Will attach a recording before marking ready for review.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches displayed balances and controller/provider caching around deposits, withdrawals, and orders; changes are defensive but affect fund-related UI and refresh timing.
> 
> **Overview**
> Fixes Predict balance UX and cache behavior when fetches fail or settle slowly, so users no longer see a misleading **$0.00** when the real issue is connectivity or stale data.
> 
> **`PredictBalance`** now treats a failed query as fatal only when there is no cached `balanceData`. In that case it shows a retryable error card (new `predict.balance_error` copy), calls `refetch` from Retry, shows the skeleton while `isFetching`, and still prefers last-known balance over the error when stale data exists.
> 
> **`PolymarketProvider`** adds expiring account-state cache entries (5 minutes for deployed wallets, 30 seconds for not-deployed). **`PredictController`** invalidates account state and clears cached balances (case-insensitive keys) on **any** confirmed Predict transaction, extends post-order optimistic balance to **`OPTIMISTIC_BALANCE_MAX_AGE_MS` (30s)**, skips optimistic updates without a cached baseline, and clamps buy optimistic balances at zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a431e446793fa825c7d98873768ce64cd20f2bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->