### PR TITLE
fix: pure black TransactionNotification modal colors

### DIFF
--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -24,6 +24,10 @@ import BigNumber from 'bignumber.js';
 import { collectibleContractsSelector } from '../../../../reducers/collectibles';
 import { useTheme } from '../../../../util/theme';
 import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../util/theme/themeUtils';
+import {
   selectChainId,
   selectTickerByChainId,
 } from '../../../../selectors/networkController';
@@ -41,8 +45,10 @@ const WINDOW_WIDTH = Dimensions.get('window').width;
 const ACTION_CANCEL = 'cancel';
 const ACTION_SPEEDUP = 'speedup';
 
-const createStyles = (colors) =>
-  StyleSheet.create({
+const createStyles = (theme) => {
+  const { colors } = theme;
+
+  return StyleSheet.create({
     absoluteFill: {
       ...StyleSheet.absoluteFillObject,
     },
@@ -94,12 +100,17 @@ const createStyles = (colors) =>
     modalContainer: {
       width: '90%',
       borderRadius: 10,
-      backgroundColor: colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
+      ...(isPureBlackEnabled && {
+        borderWidth: 1,
+        borderColor: colors.border.muted,
+      }),
     },
     elevatedView: {
       backgroundColor: importedColors.transparent,
     },
   });
+};
 
 function TransactionNotification(props) {
   const {
@@ -127,8 +138,8 @@ function TransactionNotification(props) {
   const actionXAnimated = useSharedValue(0);
   const detailsAnimated = useSharedValue(0);
 
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const theme = useTheme();
+  const styles = createStyles(theme);
 
   const detailsFadeIn = useCallback(async () => {
     setTransactionDetailsIsVisible(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

When `MM_PURE_BLACK_PREVIEW=true` and the app is in dark mode, the transaction details modal opened from a transaction notification toast used `background.default`, which collapses into the pure-black screen background (`#000000`).

This PR updates `TransactionNotification` so the details and speed-up/cancel modal shells use `getElevatedSurfaceColor()` for the background and add a `border.muted` outline when pure black is enabled, keeping the sheet visibly separated from the overlay.

**Scope:** `app/components/UI/Notification/TransactionNotification/index.js` only.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-800](https://consensyssoftware.atlassian.net/browse/TMCU-800)

## **Manual testing steps**

```gherkin
Feature: Transaction notification modal in pure-black dark mode

  Scenario: Transaction details modal stays elevated after tapping a toast
    Given MM_PURE_BLACK_PREVIEW="true" in .js.env
    And the app theme is set to Dark
    And the wallet is on Sepolia testnet

    When I send a small amount of SepoliaETH to my own address
    And I tap the transaction notification toast when it appears
    Then the transaction details modal uses an elevated background
    And the modal shows a muted border against the pure-black overlay
```

## **Screenshots/Recordings**

### **Before**

Modal background blended into the pure-black overlay; no border separation.

<img width="420" alt="Screenshot 2026-07-08 at 1 25 46 PM" src="https://github.com/user-attachments/assets/74947bba-8e86-40d8-8f7b-ce972140b307" />


### **After**

Transaction details modal (`Send SepoliaETH`) with elevated surface and muted border when tapping a submitted transaction toast (screenshot attached in PR comments).

<img width="420" alt="Screenshot 2026-07-08 at 12 50 49 PM" src="https://github.com/user-attachments/assets/a7a651f6-ede5-46e6-a5ec-cc75e1c8fa6e" />

https://github.com/user-attachments/assets/333ef954-d7c1-4b3d-8dfc-332e9aa6d8a2

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b084601f-b8cf-4531-a34e-66b90677bafb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b084601f-b8cf-4531-a34e-66b90677bafb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-800]: https://consensyssoftware.atlassian.net/browse/TMCU-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
