### PR TITLE
fix: pure black migrate HardwareWalletBottomSheet to MMDS BottomSheet

### DIFF
--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
@@ -1,12 +1,3 @@
-// Mock dependencies
-jest.mock('../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      background: { default: '#FFFFFF' },
-    },
-  }),
-}));
-
 // Mutable state objects for tests to manipulate
 const mockConnectionState: Record<string, unknown> = { status: 'disconnected' };
 const mockDeviceSelection = {
@@ -62,35 +53,31 @@ const mockLastBottomSheetOnCloseRef = {
 };
 
 // Mock bottom sheet
-jest.mock(
-  '../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const React = jest.requireActual('react');
-    const { View } = jest.requireActual('react-native');
-    return {
-      __esModule: true,
-      default: React.forwardRef(
-        (
-          {
-            children,
-            testID,
-            onClose,
-          }: {
-            children: React.ReactNode;
-            testID?: string;
-            onClose?: () => void;
-          },
-          _ref: React.Ref<unknown>,
-        ) => {
-          // Test double: capture BottomSheet onClose for assertions (not production UI).
-          // eslint-disable-next-line react-compiler/react-compiler -- intentional mock side effect
-          mockLastBottomSheetOnCloseRef.current = onClose;
-          return <View testID={testID}>{children}</View>;
+jest.mock('@metamask/design-system-react-native', () => {
+  const React = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    BottomSheet: React.forwardRef(
+      (
+        {
+          children,
+          testID,
+          onClose,
+        }: {
+          children: React.ReactNode;
+          testID?: string;
+          onClose?: () => void;
         },
-      ),
-    };
-  },
-);
+        _ref: React.Ref<unknown>,
+      ) => {
+        // Test double: capture BottomSheet onClose for assertions (not production UI).
+        // eslint-disable-next-line react-compiler/react-compiler -- intentional mock side effect
+        mockLastBottomSheetOnCloseRef.current = onClose;
+        return <View testID={testID}>{children}</View>;
+      },
+    ),
+  };
+});
 
 import React from 'react';
 import { act, render } from '@testing-library/react-native';

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
@@ -1,11 +1,7 @@
-import React, { useMemo, useRef, useCallback, useEffect } from 'react';
-import { StyleSheet } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../component-library/components/BottomSheets/BottomSheet';
-
-import { useTheme } from '../../../../util/theme';
+import React, { useMemo, useCallback, useEffect } from 'react';
+import {
+  BottomSheet,
+} from '@metamask/design-system-react-native';
 
 import {
   HardwareWalletType,
@@ -28,13 +24,6 @@ import DevLogger from '../../../SDKConnect/utils/DevLogger';
 
 export const HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID =
   'hardware-wallet-bottom-sheet';
-
-const createStyles = (colors: { background: { default: string } }) =>
-  StyleSheet.create({
-    bottomSheet: {
-      backgroundColor: colors.background.default,
-    },
-  });
 
 export interface HardwareWalletBottomSheetProps {
   connectionState: HardwareWalletConnectionState;
@@ -92,10 +81,6 @@ export const HardwareWalletBottomSheet: React.FC<
   onCTAClicked,
   onRetryQrScan,
 }) => {
-  const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
-
-  const bottomSheetRef = useRef<BottomSheetRef>(null);
   const [openQrScannerOnMount, setOpenQrScannerOnMount] = React.useState(false);
 
   const { devices, selectedDevice, isScanning } = deviceSelection;
@@ -268,19 +253,12 @@ export const HardwareWalletBottomSheet: React.FC<
     return null;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return (
-    <GestureHandlerRootView style={StyleSheet.absoluteFill}>
-      <BottomSheet
-        ref={bottomSheetRef}
-        testID={HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID}
-        isFullscreen={false}
-        onClose={handleClose}
-        shouldNavigateBack={false}
-        style={styles.bottomSheet}
-      >
-        {renderContent()}
-      </BottomSheet>
-    </GestureHandlerRootView>
+    <BottomSheet
+      testID={HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID}
+      onClose={handleClose}
+    >
+      {renderContent()}
+    </BottomSheet>
   );
 };

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo, useCallback, useEffect } from 'react';
-import {
-  BottomSheet,
-} from '@metamask/design-system-react-native';
+import { BottomSheet } from '@metamask/design-system-react-native';
 
 import {
   HardwareWalletType,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Replaces the deprecated component-library `BottomSheet` in `HardwareWalletBottomSheet` with the design-system `BottomSheet` from `@metamask/design-system-react-native`, and removes the manual `backgroundColor` override.

The legacy sheet forced `colors.background.default` (`bg-default`) onto the surface. Under Pure Black dark mode, elevated surfaces like bottom sheets should use `bg-alternative` instead. That mismatch caused visible elevation/clash issues during hardware wallet connection flows (device selection, awaiting confirmation, errors, etc.).

This change lets the design-system component own sheet surface styling and removes the now-unnecessary `GestureHandlerRootView` wrapper (the app root already provides one).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-803

## **Manual testing steps**

```gherkin
Feature: Hardware wallet bottom sheet Pure Black styling

  Scenario: Ledger connection sheet renders with correct elevated surface
    Given the app is running with Pure Black dark mode enabled
    And a Ledger hardware wallet connection flow is triggered

    When the HardwareWalletBottomSheet appears (scanning, connecting, awaiting confirmation, or error)
    Then the sheet background uses the elevated surface color (bg-alternative)
    And there are no black bands or bg-default clashes against the sheet surface
```

N/A for full device QA in this environment — unit tests updated and passing.

## **Screenshots/Recordings**

### **Before / After**

Before: Manual `backgroundColor: colors.background.default` on legacy BottomSheet
After: DS `BottomSheet` with no custom background styling.

<img width="350" alt="Screenshot 2026-07-08 at 2 17 10 PM" src="https://github.com/user-attachments/assets/58f1d01d-76a1-4ebe-a7da-025e459e9085" />
<img width="350" alt="Screenshot 2026-07-08 at 2 12 40 PM" src="https://github.com/user-attachments/assets/962c2524-c0bf-46a1-a059-c66b4c5ce12d" />

### Before

https://github.com/user-attachments/assets/9424024e-582e-4af1-ace6-b0ad15be1a5c

### After

https://github.com/user-attachments/assets/02ff9550-2023-4e83-99aa-35a887a645f7

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7372dd8-14f7-415b-95ad-95711b682c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7372dd8-14f7-415b-95ad-95711b682c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

