### PR TITLE
fix(notifications): use back arrow instead of close icon in header

### DIFF
--- a/app/components/Views/Notifications/index.tsx
+++ b/app/components/Views/Notifications/index.tsx
@@ -124,9 +124,8 @@ const NotificationsView = ({
       <HeaderCompactStandard
         title={strings('app_settings.notifications_title')}
         titleProps={{ testID: NotificationMenuViewSelectorsIDs.TITLE }}
-        startButtonIconProps={{
-          iconName: IconName.Close,
-          onPress: handleClose,
+        onBack={handleClose}
+        backButtonProps={{
           testID: NotificationMenuViewSelectorsIDs.CLOSE_BUTTON,
         }}
         endButtonIconProps={[


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Notifications list screen used an X (close) icon for the header start button, which is inconsistent with other sub-screens that use a back arrow for navigation. This change switches the header to `HeaderCompactStandard`'s `onBack` prop so it renders the standard back arrow (`IconName.ArrowLeft`). Navigation behavior is unchanged: tap still calls `goBack()` when possible, otherwise navigates to the wallet home screen.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Notifications screen header to use a back arrow instead of a close icon

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Notifications header back navigation

  Scenario: user opens Notifications and navigates back
    Given the user is logged in with notifications enabled
    And the user is on the wallet home screen

    When user opens the Notifications screen from the bell icon
    Then the header shows a back arrow (not an X) on the left
    And tapping the back arrow returns to the previous screen

  Scenario: user opens Notifications without a back stack
    Given the user opens Notifications without navigation history

    When user taps the back arrow in the header
    Then the app navigates to the wallet home screen
```

Unit tests: `yarn jest app/components/Views/Notifications/index.test.tsx`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="410" height="806" alt="Screenshot 2026-07-07 at 4 28 38 PM" src="https://github.com/user-attachments/assets/1a2d8315-3db4-4a4a-b7f0-6682d9fc1984" />
header showed an X icon in the top-left of the Notifications screen.

### **After**
<img width="407" height="822" alt="Screenshot 2026-07-07 at 4 23 05 PM" src="https://github.com/user-attachments/assets/0e0a4e25-d1ef-4242-8617-fb3dc13ff7ed" />
header shows the standard back arrow in the top-left; navigation behavior unchanged.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-screen header API swap with no logic changes beyond icon affordance; low blast radius.
> 
> **Overview**
> The Notifications list header no longer uses a custom **close (X)** start button via `startButtonIconProps`. It now uses `HeaderCompactStandard`'s **`onBack`** with **`backButtonProps`**, so the left control shows the standard **back arrow** like other sub-screens.
> 
> **`handleClose`** is unchanged: `goBack()` when the stack allows it, otherwise navigate to wallet home. Settings on the right and existing test IDs (including `CLOSE_BUTTON` on the back control) are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91399a9adaa32e51e0794066ad680f91b5e07bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->