### PR TITLE
feat(perps): instrument user-perceived CUF spans with lifecycle context

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -360,7 +360,11 @@ const PerpsHomeView = ({
   const entryCufTags = useMemo(() => buildPerpsCufStartTags(), []);
   usePerpsMeasurement({
     traceName: TraceName.PerpsEntryToLiveMarketList,
-    conditions: [!isAnyLoading],
+    // The variant endData reads orders.length, so — unlike the screen-load
+    // metric above, which deliberately ignores orders for speed — this span
+    // must wait for the orders stream too, or a user with open orders is
+    // misrecorded as empty/position.
+    conditions: [!isAnyLoading, !isLoading.orders],
     tags: entryCufTags,
     endData: entryCufEndData,
   });

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -347,6 +347,14 @@ const PerpsHomeView = ({
     conditions: [!isAnyLoading],
   });
 
+  const entryCufVariant = hasPositions
+    ? PERPS_CUF_VARIANT.POSITION
+    : PERPS_CUF_VARIANT.EMPTY;
+  const entryCufEndData = {
+    [PERPS_CUF_TAG.VARIANT]:
+      orders.length > 0 ? PERPS_CUF_VARIANT.ORDER : entryCufVariant,
+  };
+
   // Entry CUF: enter Perps -> live market list. Starts at mount; launch-context
   // tag splits cold from warm p75. Captured at mount so the tag is the launch
   // context, not the post-settle value.
@@ -355,13 +363,7 @@ const PerpsHomeView = ({
     traceName: TraceName.PerpsEntryToLiveMarketList,
     conditions: [!isAnyLoading],
     tags: entryCufTags,
-    endData: {
-      [PERPS_CUF_TAG.VARIANT]: hasPositions
-        ? PERPS_CUF_VARIANT.POSITION
-        : orders.length > 0
-          ? PERPS_CUF_VARIANT.ORDER
-          : PERPS_CUF_VARIANT.EMPTY,
-    },
+    endData: entryCufEndData,
   });
 
   // After the entry renders, later in-session flows are warm.

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -97,6 +97,9 @@ import Reanimated, { SharedValue } from 'react-native-reanimated';
 import { useDiscoveryScrollManager } from '../../../Predict/hooks/useDiscoveryScrollManager';
 import styleSheet from './PerpsHomeView.styles';
 import { TraceName } from '../../../../../util/trace';
+import { markPerpsForegroundSettled } from '../../utils/perpsLifecycleContext';
+import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
+import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
@@ -343,6 +346,30 @@ const PerpsHomeView = ({
     traceName: TraceName.PerpsMarketListView, // Keep same trace name for consistency
     conditions: [!isAnyLoading],
   });
+
+  // Entry CUF: enter Perps -> live market list. Starts at mount; launch-context
+  // tag splits cold from warm p75. Captured at mount so the tag is the launch
+  // context, not the post-settle value.
+  const entryCufTags = useMemo(() => buildPerpsCufStartTags(), []);
+  usePerpsMeasurement({
+    traceName: TraceName.PerpsEntryToLiveMarketList,
+    conditions: [!isAnyLoading],
+    tags: entryCufTags,
+    endData: {
+      [PERPS_CUF_TAG.VARIANT]: hasPositions
+        ? PERPS_CUF_VARIANT.POSITION
+        : orders.length > 0
+          ? PERPS_CUF_VARIANT.ORDER
+          : PERPS_CUF_VARIANT.EMPTY,
+    },
+  });
+
+  // After the entry renders, later in-session flows are warm.
+  useEffect(() => {
+    if (!isAnyLoading) {
+      markPerpsForegroundSettled();
+    }
+  }, [isAnyLoading]);
 
   // Reset section tracking when screen comes into focus
   // This ensures sections can be tracked again when navigating back to the screen

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -97,7 +97,6 @@ import Reanimated, { SharedValue } from 'react-native-reanimated';
 import { useDiscoveryScrollManager } from '../../../Predict/hooks/useDiscoveryScrollManager';
 import styleSheet from './PerpsHomeView.styles';
 import { TraceName } from '../../../../../util/trace';
-import { markPerpsForegroundSettled } from '../../utils/perpsLifecycleContext';
 import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
 import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import {
@@ -364,14 +363,9 @@ const PerpsHomeView = ({
     conditions: [!isAnyLoading],
     tags: entryCufTags,
     endData: entryCufEndData,
+    // Entry surface: settle the foreground so later flows read as warm.
+    marksForegroundSettled: true,
   });
-
-  // After the entry renders, later in-session flows are warm.
-  useEffect(() => {
-    if (!isAnyLoading) {
-      markPerpsForegroundSettled();
-    }
-  }, [isAnyLoading]);
 
   // Reset section tracking when screen comes into focus
   // This ensures sections can be tracked again when navigating back to the screen

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -360,11 +360,16 @@ const PerpsHomeView = ({
   const entryCufTags = useMemo(() => buildPerpsCufStartTags(), []);
   usePerpsMeasurement({
     traceName: TraceName.PerpsEntryToLiveMarketList,
+    // endConditions (not the simple `conditions` API): this span must measure
+    // mount -> live data. The simple API auto-resets whenever its first
+    // condition is false, which for a readiness flag means the span restarts on
+    // every render during loading and under-reports the true latency. Using
+    // endConditions starts at mount and never resets.
     // The variant endData reads orders.length, so — unlike the screen-load
     // metric above, which deliberately ignores orders for speed — this span
     // must wait for the orders stream too, or a user with open orders is
     // misrecorded as empty/position.
-    conditions: [!isAnyLoading, !isLoading.orders],
+    endConditions: [!isAnyLoading, !isLoading.orders],
     tags: entryCufTags,
     endData: entryCufEndData,
   });

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -363,8 +363,6 @@ const PerpsHomeView = ({
     conditions: [!isAnyLoading],
     tags: entryCufTags,
     endData: entryCufEndData,
-    // Entry surface: settle the foreground so later flows read as warm.
-    marksForegroundSettled: true,
   });
 
   // Reset section tracking when screen comes into focus

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -112,6 +112,8 @@ import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import { usePerpsMarketStats } from '../../hooks/usePerpsMarketStats';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
+import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
+import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
 import { usePerpsTPSLUpdate } from '../../hooks/usePerpsTPSLUpdate';
 import { useStopLossPrompt } from '../../hooks/useStopLossPrompt';
@@ -585,6 +587,27 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       symbol: market?.symbol,
       hasMarketStats: !!marketStats,
       loadingStates: { isLoadingHistory, isLoadingPosition },
+    },
+  });
+
+  // Market detail CUF: open -> stats + live price. Chart and top-of-book keep
+  // their own spans. Tags captured at mount for per-context p75.
+  const marketDetailCufTags = useMemo(() => buildPerpsCufStartTags(), []);
+  usePerpsMeasurement({
+    traceName: TraceName.PerpsMarketDetailLive,
+    conditions: [
+      !!market,
+      !!marketStats,
+      !isLoadingHistory,
+      !isLoadingPosition,
+      !!currentPrice,
+    ],
+    tags: marketDetailCufTags,
+    endData: {
+      [PERPS_CUF_TAG.VARIANT]:
+        !!account?.totalBalance && parseFloat(account.totalBalance) > 0
+          ? PERPS_CUF_VARIANT.FUNDED
+          : PERPS_CUF_VARIANT.UNFUNDED,
     },
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -601,6 +601,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       !isLoadingHistory,
       !isLoadingPosition,
       !!currentPrice,
+      // The funded/unfunded endData tag reads account.totalBalance, so the span
+      // must not end until the account stream has loaded — otherwise a funded
+      // user is misrecorded as unfunded while account is still loading.
+      !isLoadingAccount,
     ],
     tags: marketDetailCufTags,
     endData: {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -609,8 +609,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
           ? PERPS_CUF_VARIANT.FUNDED
           : PERPS_CUF_VARIANT.UNFUNDED,
     },
-    // Direct entry (deeplink / homepage card) settles the foreground here.
-    marksForegroundSettled: true,
   });
 
   // Track asset screen viewed event - declarative (main's event name)

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -595,7 +595,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const marketDetailCufTags = useMemo(() => buildPerpsCufStartTags(), []);
   usePerpsMeasurement({
     traceName: TraceName.PerpsMarketDetailLive,
-    conditions: [
+    // endConditions (not the simple `conditions` API), which would auto-reset
+    // while the first condition is false and restart the span on every render
+    // during hydration — under-reporting open-to-live-detail latency.
+    endConditions: [
       !!market,
       !!marketStats,
       !isLoadingHistory,

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -609,6 +609,8 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
           ? PERPS_CUF_VARIANT.FUNDED
           : PERPS_CUF_VARIANT.UNFUNDED,
     },
+    // Direct entry (deeplink / homepage card) settles the foreground here.
+    marksForegroundSettled: true,
   });
 
   // Track asset screen viewed event - declarative (main's event name)

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -472,10 +472,13 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const tradePageCufTags = useMemo(() => buildPerpsCufStartTags(), []);
   usePerpsMeasurement({
     traceName: TraceName.PerpsTradePageRender,
+    // endConditions (not the simple `conditions` API), which would auto-reset
+    // while the first condition is false and restart the span before readiness
+    // flips — making the reported trade-page render duration falsely faster.
     // The funded/unfunded endData reads account.totalBalance, so gate on account
     // freshness (!isLoadingAccount), not just presence — a present-but-stale
     // account would otherwise misclassify a funded user as unfunded.
-    conditions: [isDataReady, !!currentPrice, !!account, !isLoadingAccount],
+    endConditions: [isDataReady, !!currentPrice, !!account, !isLoadingAccount],
     tags: tradePageCufTags,
     endData: {
       [PERPS_CUF_TAG.VARIANT]:

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -124,6 +124,8 @@ import { usePerpsMaxSlippage } from '../../hooks/usePerpsMaxSlippage';
 import { useIsPerpsBalanceSelected } from '../../hooks/useIsPerpsBalanceSelected';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
+import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
+import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
 import { usePerpsSavePendingConfig } from '../../hooks/usePerpsSavePendingConfig';
 import {
@@ -464,6 +466,20 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   usePerpsMeasurement({
     traceName: TraceName.PerpsOrderView,
     conditions: [isDataReady, !!currentPrice, !!account],
+  });
+
+  // Trade page CUF: order form ready with live price + account. Tags at mount.
+  const tradePageCufTags = useMemo(() => buildPerpsCufStartTags(), []);
+  usePerpsMeasurement({
+    traceName: TraceName.PerpsTradePageRender,
+    conditions: [isDataReady, !!currentPrice, !!account],
+    tags: tradePageCufTags,
+    endData: {
+      [PERPS_CUF_TAG.VARIANT]:
+        !!account?.totalBalance && parseFloat(account.totalBalance) > 0
+          ? PERPS_CUF_VARIANT.FUNDED
+          : PERPS_CUF_VARIANT.UNFUNDED,
+    },
   });
 
   const assetData = useMemo(() => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -472,7 +472,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   const tradePageCufTags = useMemo(() => buildPerpsCufStartTags(), []);
   usePerpsMeasurement({
     traceName: TraceName.PerpsTradePageRender,
-    conditions: [isDataReady, !!currentPrice, !!account],
+    // The funded/unfunded endData reads account.totalBalance, so gate on account
+    // freshness (!isLoadingAccount), not just presence — a present-but-stale
+    // account would otherwise misclassify a funded user as unfunded.
+    conditions: [isDataReady, !!currentPrice, !!account, !isLoadingAccount],
     tags: tradePageCufTags,
     endData: {
       [PERPS_CUF_TAG.VARIANT]:

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -480,8 +480,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           ? PERPS_CUF_VARIANT.FUNDED
           : PERPS_CUF_VARIANT.UNFUNDED,
     },
-    // Direct entry (deeplink) settles the foreground here.
-    marksForegroundSettled: true,
   });
 
   const assetData = useMemo(() => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -476,7 +476,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     tags: tradePageCufTags,
     endData: {
       [PERPS_CUF_TAG.VARIANT]:
-        !!account?.totalBalance && parseFloat(account.totalBalance) > 0
+        !!account?.totalBalance && Number.parseFloat(account.totalBalance) > 0
           ? PERPS_CUF_VARIANT.FUNDED
           : PERPS_CUF_VARIANT.UNFUNDED,
     },

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -480,6 +480,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           ? PERPS_CUF_VARIANT.FUNDED
           : PERPS_CUF_VARIANT.UNFUNDED,
     },
+    // Direct entry (deeplink) settles the foreground here.
+    marksForegroundSettled: true,
   });
 
   const assetData = useMemo(() => {

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -31,6 +31,7 @@ export const PERPS_CUF_END_REASON = {
   POSITION_NOT_FOUND: 'position_not_found',
   POSITION_FETCH_ERROR: 'position_fetch_error',
   ORDER_FAILED: 'order_failed',
+  REQUEST_FAILED: 'request_failed',
   EXCEPTION: 'exception',
   STREAM_TIMEOUT: 'stream_timeout',
 } as const;

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -1,0 +1,39 @@
+/** Sentry tag / span-attribute keys for Perps CUF spans. */
+export const PERPS_CUF_TAG = {
+  FEATURE: 'feature',
+  LIFECYCLE_CONTEXT: 'lifecycle_context',
+  VARIANT: 'variant',
+  DIRECTION: 'direction',
+  ORDER_TYPE: 'order_type',
+  SUCCESS: 'success',
+  REASON: 'reason',
+  TOAST_TO_POSITION_MS: 'toast_to_position_ms',
+  BOUNDARY: 'boundary',
+} as const;
+
+/** Which surface closed the place-order CUF span. */
+export const PERPS_CUF_BOUNDARY = {
+  STREAM: 'stream',
+  POLL_FALLBACK: 'poll_fallback',
+} as const;
+
+/** Account/flow variant tag values. */
+export const PERPS_CUF_VARIANT = {
+  EMPTY: 'empty',
+  POSITION: 'position',
+  ORDER: 'order',
+  FUNDED: 'funded',
+  UNFUNDED: 'unfunded',
+} as const;
+
+/** Terminal reasons for the place-order CUF span. */
+export const PERPS_CUF_END_REASON = {
+  POSITION_NOT_FOUND: 'position_not_found',
+  POSITION_FETCH_ERROR: 'position_fetch_error',
+  ORDER_FAILED: 'order_failed',
+  EXCEPTION: 'exception',
+  STREAM_TIMEOUT: 'stream_timeout',
+} as const;
+
+/** How long the place-order span may wait for the position stream to close it. */
+export const PERPS_CUF_STREAM_TIMEOUT_MS = 30000;

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -34,6 +34,12 @@ export const PERPS_CUF_END_REASON = {
   STREAM_TIMEOUT: 'stream_timeout',
   /** A newer operation of the same flow replaced this one before it confirmed. */
   SUPERSEDED: 'superseded',
+  /** The stream was reset (disconnect / account or network switch) before the
+   * confirmation arrived, so the op was abandoned rather than confirmed. */
+  DISCONNECTED: 'disconnected',
+  /** The controller request never settled (hung) before the watchdog fired —
+   * distinct from a settled request whose stream render never arrived. */
+  CONTROLLER_TIMEOUT: 'controller_timeout',
 } as const;
 
 /** How long the place-order span may wait for the position stream to close it. */

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -7,14 +7,14 @@ export const PERPS_CUF_TAG = {
   ORDER_TYPE: 'order_type',
   SUCCESS: 'success',
   REASON: 'reason',
-  TOAST_TO_POSITION_MS: 'toast_to_position_ms',
+  /** Signed ms between confirmation toast and position render; positive = position rendered after the toast. */
+  TOAST_POSITION_DELTA_MS: 'toast_position_delta_ms',
   BOUNDARY: 'boundary',
 } as const;
 
 /** Which surface closed the place-order CUF span. */
 export const PERPS_CUF_BOUNDARY = {
   STREAM: 'stream',
-  POLL_FALLBACK: 'poll_fallback',
 } as const;
 
 /** Account/flow variant tag values. */
@@ -28,8 +28,6 @@ export const PERPS_CUF_VARIANT = {
 
 /** Terminal reasons for the place-order CUF span. */
 export const PERPS_CUF_END_REASON = {
-  POSITION_NOT_FOUND: 'position_not_found',
-  POSITION_FETCH_ERROR: 'position_fetch_error',
   ORDER_FAILED: 'order_failed',
   REQUEST_FAILED: 'request_failed',
   EXCEPTION: 'exception',
@@ -38,3 +36,9 @@ export const PERPS_CUF_END_REASON = {
 
 /** How long the place-order span may wait for the position stream to close it. */
 export const PERPS_CUF_STREAM_TIMEOUT_MS = 30000;
+
+/**
+ * How long the success path waits for the stream to render the position
+ * before unblocking the confirmation toast without it.
+ */
+export const PERPS_CUF_STREAM_CONFIRM_RACE_MS = 1000;

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -32,6 +32,8 @@ export const PERPS_CUF_END_REASON = {
   REQUEST_FAILED: 'request_failed',
   EXCEPTION: 'exception',
   STREAM_TIMEOUT: 'stream_timeout',
+  /** A newer operation of the same flow replaced this one before it confirmed. */
+  SUPERSEDED: 'superseded',
 } as const;
 
 /** How long the place-order span may wait for the position stream to close it. */

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -15,6 +15,7 @@ import {
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
   watchPerpsCufPositionClosed,
+  acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -171,6 +172,13 @@ export const usePerpsClosePosition = (
         DevLogger.log('usePerpsClosePosition: Close result', result);
 
         if (result.success) {
+          // Controller accepted the close: only now may a stream shrink/absence
+          // complete the CUF as a success. If the position already shrank while
+          // the request was in flight, that render instant was recorded and the
+          // span ends at it here.
+          if (closeCufOpId) {
+            acceptPerpsCufRequest(closeCufOpId);
+          }
           // Market order immediately fills or fails
           // Limit orders aren't guaranteed to fill immediately, so we don't display "close position success" toast for them.
           // Note: We only support market close for now but keeping check for future limit close support.

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -14,7 +14,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
-  watchPerpsCufPositionChanged,
+  watchPerpsCufPositionClosed,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -79,7 +79,7 @@ export const usePerpsClosePosition = (
         closeCufOpId = startPerpsCufTrace({
           name: TraceName.PerpsClosePositionToConfirmation,
         });
-        watchPerpsCufPositionChanged(closeCufOpId, position);
+        watchPerpsCufPositionClosed(closeCufOpId, position);
         endPerpsCufTraceAfter(
           {
             id: closeCufOpId,

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -74,17 +74,15 @@ export const usePerpsClosePosition = (
       // Confirmation CUF (market close): ends when the stream shows the
       // position reduced or absent. Limit closes rest until filled, so their
       // confirmation is not a render-latency measurement.
+      let closeCufOpId: string | undefined;
       if (orderType === 'market') {
-        startPerpsCufTrace({
+        closeCufOpId = startPerpsCufTrace({
           name: TraceName.PerpsClosePositionToConfirmation,
         });
-        watchPerpsCufPositionChanged(
-          TraceName.PerpsClosePositionToConfirmation,
-          position,
-        );
+        watchPerpsCufPositionChanged(closeCufOpId, position);
         endPerpsCufTraceAfter(
           {
-            name: TraceName.PerpsClosePositionToConfirmation,
+            id: closeCufOpId,
             data: {
               [PERPS_CUF_TAG.SUCCESS]: false,
               [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
@@ -226,25 +224,29 @@ export const usePerpsClosePosition = (
 
           // Rejected request, not an exception: classify before the throw so
           // the catch's EXCEPTION end no-ops (matches TPSL/cancel paths).
-          endPerpsCufTrace({
-            name: TraceName.PerpsClosePositionToConfirmation,
-            data: {
-              [PERPS_CUF_TAG.SUCCESS]: false,
-              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
-            },
-          });
+          if (closeCufOpId) {
+            endPerpsCufTrace({
+              id: closeCufOpId,
+              data: {
+                [PERPS_CUF_TAG.SUCCESS]: false,
+                [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
+              },
+            });
+          }
           throw new Error(errorMessage);
         }
 
         return result;
       } catch (err) {
-        endPerpsCufTrace({
-          name: TraceName.PerpsClosePositionToConfirmation,
-          data: {
-            [PERPS_CUF_TAG.SUCCESS]: false,
-            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
-          },
-        });
+        if (closeCufOpId) {
+          endPerpsCufTrace({
+            id: closeCufOpId,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+            },
+          });
+        }
         const closeError =
           err instanceof Error
             ? err

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -9,6 +9,18 @@ import {
   type TrackingData,
 } from '@metamask/perps-controller';
 import { handlePerpsError } from '../utils/translatePerpsError';
+import { TraceName } from '../../../../util/trace';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTrace,
+  endPerpsCufTraceAfter,
+  watchPerpsCufPositionChanged,
+} from '../utils/perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_END_REASON,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsTrading } from './usePerpsTrading';
 
@@ -58,6 +70,29 @@ export const usePerpsClosePosition = (
         slippage,
       } = params;
       const isFullClose = size === undefined || size === '';
+
+      // Confirmation CUF (market close): ends when the stream shows the
+      // position reduced or absent. Limit closes rest until filled, so their
+      // confirmation is not a render-latency measurement.
+      if (orderType === 'market') {
+        startPerpsCufTrace({
+          name: TraceName.PerpsClosePositionToConfirmation,
+        });
+        watchPerpsCufPositionChanged(
+          TraceName.PerpsClosePositionToConfirmation,
+          position,
+        );
+        endPerpsCufTraceAfter(
+          {
+            name: TraceName.PerpsClosePositionToConfirmation,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+            },
+          },
+          PERPS_CUF_STREAM_TIMEOUT_MS,
+        );
+      }
 
       try {
         setIsClosing(true);
@@ -194,6 +229,13 @@ export const usePerpsClosePosition = (
 
         return result;
       } catch (err) {
+        endPerpsCufTrace({
+          name: TraceName.PerpsClosePositionToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+          },
+        });
         const closeError =
           err instanceof Error
             ? err

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -224,6 +224,15 @@ export const usePerpsClosePosition = (
             fallbackMessage: strings('perps.close_position.error_unknown'),
           });
 
+          // Rejected request, not an exception: classify before the throw so
+          // the catch's EXCEPTION end no-ops (matches TPSL/cancel paths).
+          endPerpsCufTrace({
+            name: TraceName.PerpsClosePositionToConfirmation,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
+            },
+          });
           throw new Error(errorMessage);
         }
 

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.ts
@@ -13,7 +13,7 @@ import { TraceName } from '../../../../util/trace';
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
-  endPerpsCufTraceAfter,
+  endPerpsCufRequestAfter,
   watchPerpsCufPositionClosed,
   acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
@@ -76,19 +76,15 @@ export const usePerpsClosePosition = (
       // position reduced or absent. Limit closes rest until filled, so their
       // confirmation is not a render-latency measurement.
       let closeCufOpId: string | undefined;
+      let controllerSettled = false;
       if (orderType === 'market') {
         closeCufOpId = startPerpsCufTrace({
           name: TraceName.PerpsClosePositionToConfirmation,
         });
         watchPerpsCufPositionClosed(closeCufOpId, position);
-        endPerpsCufTraceAfter(
-          {
-            id: closeCufOpId,
-            data: {
-              [PERPS_CUF_TAG.SUCCESS]: false,
-              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-            },
-          },
+        endPerpsCufRequestAfter(
+          closeCufOpId,
+          () => controllerSettled,
           PERPS_CUF_STREAM_TIMEOUT_MS,
         );
       }
@@ -168,6 +164,8 @@ export const usePerpsClosePosition = (
           // Pass live position to avoid getPositions() API call (prevents 429 rate limiting)
           position,
         });
+
+        controllerSettled = true;
 
         DevLogger.log('usePerpsClosePosition: Close result', result);
 

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
@@ -173,6 +173,46 @@ describe('usePerpsMeasurement', () => {
       );
     });
 
+    it('does not reset or restart across loading re-renders (measures mount -> ready)', () => {
+      jest.clearAllMocks();
+
+      // Simulate a CUF span: start at mount, several re-renders while the first
+      // end-condition is still false (loading), then readiness. The span must
+      // start exactly once and never end as `reset`, so its duration spans the
+      // whole mount -> ready window rather than restarting near readiness.
+      const { rerender } = renderHook(
+        ({ endConditions }) =>
+          usePerpsMeasurement({
+            traceName: TraceName.PerpsEntryToLiveMarketList,
+            endConditions,
+            // Fresh endData ref each render (as the real views pass), which
+            // forces the effect to re-run every render.
+            endData: { variant: 'empty' },
+          }),
+        { initialProps: { endConditions: [false, false] } },
+      );
+
+      // Re-render repeatedly while still loading (new array each time).
+      rerender({ endConditions: [false, false] });
+      rerender({ endConditions: [true, false] });
+      rerender({ endConditions: [false, false] });
+
+      // Started once, never reset.
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).not.toHaveBeenCalled();
+
+      // Readiness: ends once as a success.
+      rerender({ endConditions: [true, true] });
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.PerpsEntryToLiveMarketList,
+          data: { success: true, variant: 'empty' },
+        }),
+      );
+    });
+
     it('should wait for start conditions before beginning measurement', () => {
       jest.clearAllMocks();
 

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
@@ -2,6 +2,11 @@ import { renderHook } from '@testing-library/react-native';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { TraceName, TraceOperation } from '../../../../util/trace';
 import { usePerpsMeasurement } from './usePerpsMeasurement';
+import {
+  getPerpsLifecycleContext,
+  resetPerpsLifecycleContextForTests,
+  PERPS_LIFECYCLE_CONTEXT,
+} from '../utils/perpsLifecycleContext';
 
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
   DevLogger: {
@@ -333,6 +338,39 @@ describe('usePerpsMeasurement', () => {
 
       // Should only call trace once (no restart without reset)
       expect(mockTrace).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('marksForegroundSettled', () => {
+    beforeEach(() => {
+      resetPerpsLifecycleContextForTests();
+    });
+
+    it('settles the foreground when an entry span completes (any entry surface)', () => {
+      expect(getPerpsLifecycleContext()).toBe(
+        PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+      );
+
+      // Immediate completion (no conditions) with the entry flag set.
+      renderHook(() =>
+        usePerpsMeasurement({
+          traceName: TraceName.PerpsOrderView,
+          marksForegroundSettled: true,
+        }),
+      );
+
+      // Later in-session flows now read as warm — even though Home never rendered.
+      expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+    });
+
+    it('does not settle the foreground for non-entry spans', () => {
+      renderHook(() =>
+        usePerpsMeasurement({ traceName: TraceName.PerpsOrderView }),
+      );
+
+      expect(getPerpsLifecycleContext()).toBe(
+        PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+      );
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.test.ts
@@ -21,6 +21,9 @@ jest.mock('../../../../util/trace', () => ({
     PerpsPositionDetailsView: 'Perps Position Details View',
     PerpsOrderView: 'Perps Order View',
     PerpsClosePositionView: 'Perps Close Position View',
+    PerpsEntryToLiveMarketList: 'Perps Entry To Live Market List',
+    PerpsMarketDetailLive: 'Perps Market Detail Live',
+    PerpsTradePageRender: 'Perps Trade Page Render',
   },
   TraceOperation: {
     PerpsOperation: 'perps.operation',
@@ -341,27 +344,29 @@ describe('usePerpsMeasurement', () => {
     });
   });
 
-  describe('marksForegroundSettled', () => {
+  describe('foreground settle on entry render', () => {
     beforeEach(() => {
       resetPerpsLifecycleContextForTests();
     });
 
-    it('settles the foreground when an entry span completes (any entry surface)', () => {
-      expect(getPerpsLifecycleContext()).toBe(
-        PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
-      );
+    it.each([
+      TraceName.PerpsEntryToLiveMarketList,
+      TraceName.PerpsMarketDetailLive,
+      TraceName.PerpsTradePageRender,
+    ])(
+      'settles the foreground when the %s entry span completes',
+      (entryTraceName) => {
+        expect(getPerpsLifecycleContext()).toBe(
+          PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+        );
 
-      // Immediate completion (no conditions) with the entry flag set.
-      renderHook(() =>
-        usePerpsMeasurement({
-          traceName: TraceName.PerpsOrderView,
-          marksForegroundSettled: true,
-        }),
-      );
+        // Immediate completion (no conditions) — any entry surface, no opt-in.
+        renderHook(() => usePerpsMeasurement({ traceName: entryTraceName }));
 
-      // Later in-session flows now read as warm — even though Home never rendered.
-      expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
-    });
+        // Later in-session flows now read as warm, regardless of entry path.
+        expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+      },
+    );
 
     it('does not settle the foreground for non-entry spans', () => {
       renderHook(() =>

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
@@ -8,6 +8,7 @@ import {
   TraceOperation,
 } from '../../../../util/trace';
 import { PERFORMANCE_CONFIG } from '@metamask/perps-controller';
+import { markPerpsForegroundSettled } from '../utils/perpsLifecycleContext';
 
 // Static helper functions - moved outside component to avoid recreation
 const allTrue = (conditionArray: boolean[]): boolean =>
@@ -41,6 +42,11 @@ interface MeasurementOptions {
   // completes (e.g. the empty/position/order variant, which depends on loaded
   // data). Queryable in the Sentry spans dataset.
   endData?: Record<string, MeasurementValue>;
+
+  // Set by Perps entry surfaces (Home, Market Details, Order). When this span
+  // completes it marks the foreground settled, so later in-session flows are
+  // tagged `warm` regardless of which surface the user entered through.
+  marksForegroundSettled?: boolean;
 }
 
 /**
@@ -94,6 +100,7 @@ export const usePerpsMeasurement = ({
   debugContext = {},
   tags,
   endData,
+  marksForegroundSettled = false,
 }: MeasurementOptions) => {
   const hasCompleted = useRef(false);
   const previousStartState = useRef(false);
@@ -220,6 +227,13 @@ export const usePerpsMeasurement = ({
       traceStarted.current = false;
 
       hasCompleted.current = true;
+
+      // First entry surface to finish rendering settles the foreground so
+      // later flows in this session are tagged `warm`, regardless of whether
+      // the user entered via Home, a deeplink, or a homepage card.
+      if (marksForegroundSettled) {
+        markPerpsForegroundSettled();
+      }
     }
 
     // Update previous states for edge detection
@@ -234,6 +248,7 @@ export const usePerpsMeasurement = ({
     debugContext,
     tags,
     endData,
+    marksForegroundSettled,
     actualStartConditions,
     actualEndConditions,
   ]);

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
@@ -16,6 +16,8 @@ const allTrue = (conditionArray: boolean[]): boolean =>
 const anyTrue = (conditionArray: boolean[]): boolean =>
   conditionArray.some(Boolean);
 
+type MeasurementValue = string | number | boolean;
+
 interface MeasurementOptions {
   traceName: TraceName;
   op?: TraceOperation; // Optional operation type, defaults to PerpsOperation
@@ -33,12 +35,12 @@ interface MeasurementOptions {
   // Filterable Sentry tags applied at span start (e.g. feature:perps,
   // lifecycle_context). Unlike debugContext (span attributes), these are
   // queryable as tags in Discover/dashboards.
-  tags?: Record<string, string | number | boolean>;
+  tags?: Record<string, MeasurementValue>;
 
   // Span attributes set at span END, for values only known once the flow
   // completes (e.g. the empty/position/order variant, which depends on loaded
   // data). Queryable in the Sentry spans dataset.
-  endData?: Record<string, string | number | boolean>;
+  endData?: Record<string, MeasurementValue>;
 }
 
 /**

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
@@ -8,7 +8,7 @@ import {
   TraceOperation,
 } from '../../../../util/trace';
 import { PERFORMANCE_CONFIG } from '@metamask/perps-controller';
-import { markPerpsForegroundSettled } from '../utils/perpsLifecycleContext';
+import { settlePerpsForegroundOnSpan } from '../utils/perpsLifecycleContext';
 
 // Static helper functions - moved outside component to avoid recreation
 const allTrue = (conditionArray: boolean[]): boolean =>
@@ -42,11 +42,6 @@ interface MeasurementOptions {
   // completes (e.g. the empty/position/order variant, which depends on loaded
   // data). Queryable in the Sentry spans dataset.
   endData?: Record<string, MeasurementValue>;
-
-  // Set by Perps entry surfaces (Home, Market Details, Order). When this span
-  // completes it marks the foreground settled, so later in-session flows are
-  // tagged `warm` regardless of which surface the user entered through.
-  marksForegroundSettled?: boolean;
 }
 
 /**
@@ -100,7 +95,6 @@ export const usePerpsMeasurement = ({
   debugContext = {},
   tags,
   endData,
-  marksForegroundSettled = false,
 }: MeasurementOptions) => {
   const hasCompleted = useRef(false);
   const previousStartState = useRef(false);
@@ -228,12 +222,10 @@ export const usePerpsMeasurement = ({
 
       hasCompleted.current = true;
 
-      // First entry surface to finish rendering settles the foreground so
-      // later flows in this session are tagged `warm`, regardless of whether
-      // the user entered via Home, a deeplink, or a homepage card.
-      if (marksForegroundSettled) {
-        markPerpsForegroundSettled();
-      }
+      // If this span is a Perps entry-surface render, settle the foreground so
+      // later in-session flows read as `warm` — covers every entry path (Home,
+      // deeplink, homepage card) with no per-view opt-in.
+      settlePerpsForegroundOnSpan(traceName);
     }
 
     // Update previous states for edge detection
@@ -248,7 +240,6 @@ export const usePerpsMeasurement = ({
     debugContext,
     tags,
     endData,
-    marksForegroundSettled,
     actualStartConditions,
     actualEndConditions,
   ]);

--- a/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMeasurement.ts
@@ -29,6 +29,16 @@ interface MeasurementOptions {
   resetConditions?: boolean[];
 
   debugContext?: Record<string, unknown>;
+
+  // Filterable Sentry tags applied at span start (e.g. feature:perps,
+  // lifecycle_context). Unlike debugContext (span attributes), these are
+  // queryable as tags in Discover/dashboards.
+  tags?: Record<string, string | number | boolean>;
+
+  // Span attributes set at span END, for values only known once the flow
+  // completes (e.g. the empty/position/order variant, which depends on loaded
+  // data). Queryable in the Sentry spans dataset.
+  endData?: Record<string, string | number | boolean>;
 }
 
 /**
@@ -80,6 +90,8 @@ export const usePerpsMeasurement = ({
   endConditions,
   resetConditions,
   debugContext = {},
+  tags,
+  endData,
 }: MeasurementOptions) => {
   const hasCompleted = useRef(false);
   const previousStartState = useRef(false);
@@ -173,6 +185,7 @@ export const usePerpsMeasurement = ({
         op,
         id: traceId.current,
         data: debugContext as Record<string, string | number | boolean>,
+        ...(tags ? { tags } : {}),
       });
       traceStarted.current = true;
     }
@@ -200,7 +213,7 @@ export const usePerpsMeasurement = ({
       endTrace({
         name: traceName,
         id: traceId.current,
-        data: { success: true },
+        data: { success: true, ...endData },
       });
       traceStarted.current = false;
 
@@ -217,6 +230,8 @@ export const usePerpsMeasurement = ({
     shouldEnd,
     shouldReset,
     debugContext,
+    tags,
+    endData,
     actualStartConditions,
     actualEndConditions,
   ]);

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -413,13 +413,17 @@ describe('usePerpsOrderExecution', () => {
           jest.advanceTimersByTime(PERPS_CUF_STREAM_TIMEOUT_MS);
         });
 
-        // The gesture-anchored fallback closes the span instead of leaking it.
+        // The gesture-anchored fallback closes the span instead of leaking it,
+        // tagged controller_timeout (hung request) not stream_timeout.
         expect(mockEndTrace).toHaveBeenCalledWith(
           expect.objectContaining({
             id: expect.stringContaining(
               TraceName.PerpsPlaceOrderToPositionRendered,
             ),
-            data: expect.objectContaining({ success: false }),
+            data: expect.objectContaining({
+              success: false,
+              reason: 'controller_timeout',
+            }),
           }),
         );
       } finally {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -11,8 +11,12 @@ import { usePerpsTrading } from './usePerpsTrading';
 import {
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
+  resetPerpsCufTraceForTests,
 } from '../utils/perpsCufTrace';
-import { PERPS_CUF_STREAM_TIMEOUT_MS } from '../constants/perpsCufTags';
+import {
+  PERPS_CUF_STREAM_CONFIRM_RACE_MS,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 import { endTrace, TraceName } from '../../../../util/trace';
 
 jest.mock('./usePerpsTrading');
@@ -27,10 +31,18 @@ jest.mock('../../../../util/trace', () => {
 const mockEndTrace = endTrace as jest.Mock;
 const mockGetPositionsSnapshot = jest.fn();
 const mockGetOrdersSnapshot = jest.fn();
+const mockPositionsLastDeliveredAt = jest.fn(() => null as number | null);
+const mockOrdersLastDeliveredAt = jest.fn(() => null as number | null);
 jest.mock('../providers/PerpsStreamManager', () => ({
   usePerpsStream: () => ({
-    positions: { getSnapshot: mockGetPositionsSnapshot },
-    orders: { getSnapshot: mockGetOrdersSnapshot },
+    positions: {
+      getSnapshot: mockGetPositionsSnapshot,
+      getLastDeliveredAt: mockPositionsLastDeliveredAt,
+    },
+    orders: {
+      getSnapshot: mockGetOrdersSnapshot,
+      getLastDeliveredAt: mockOrdersLastDeliveredAt,
+    },
   }),
 }));
 const mockTrack = jest.fn();
@@ -62,10 +74,15 @@ describe('usePerpsOrderExecution', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Clear the CUF singleton's pending map/place-order state so armed ops from
+    // one test can't leak into the next (these tests drive the real module).
+    resetPerpsCufTraceForTests();
     mockTrack.mockClear();
     mockEndTrace.mockClear();
     mockGetPositionsSnapshot.mockReturnValue([]); // Loaded, no positions by default
     mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
+    mockPositionsLastDeliveredAt.mockReturnValue(null);
+    mockOrdersLastDeliveredAt.mockReturnValue(null);
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
     });
@@ -125,6 +142,7 @@ describe('usePerpsOrderExecution', () => {
       // Order already rendered by submit time: the span ends synchronously; the
       // gesture-anchored safety fallback stays pending and no-ops.
       mockGetOrdersSnapshot.mockReturnValue([{ orderId: 'lim1' }]);
+      mockOrdersLastDeliveredAt.mockReturnValue(4242);
       mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
 
       const { result } = renderHook(() =>
@@ -147,6 +165,16 @@ describe('usePerpsOrderExecution', () => {
       // limits that fill before watcher registration are still detected.
       expect(onSuccess).toHaveBeenCalledWith();
       expect(mockGetPositionsSnapshot).toHaveBeenCalledTimes(1);
+      // The already-rested order ends at its stream delivery instant, not now.
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringContaining(
+            TraceName.PerpsPlaceLimitOrderToOrderRendered,
+          ),
+          timestamp: 4242,
+          data: expect.objectContaining({ success: true }),
+        }),
+      );
     });
 
     it('ends immediately when a marketable limit fill rendered before watcher registration', async () => {
@@ -154,6 +182,7 @@ describe('usePerpsOrderExecution', () => {
         .mockReturnValueOnce([]) // pre-submit baseline: loaded, no position
         .mockReturnValue([mockPosition]); // post-submit fill already rendered
       mockGetOrdersSnapshot.mockReturnValue([]);
+      mockPositionsLastDeliveredAt.mockReturnValue(7777);
       mockPlaceOrder.mockImplementation(async () => {
         handlePerpsCufPositionsDelivered([mockPosition]);
         return { success: true, orderId: 'lim1' };
@@ -169,11 +198,13 @@ describe('usePerpsOrderExecution', () => {
         });
       });
 
+      // The already-rendered fill ends at the positions delivery instant.
       expect(mockEndTrace).toHaveBeenCalledWith(
         expect.objectContaining({
           id: expect.stringContaining(
             TraceName.PerpsPlaceLimitOrderToOrderRendered,
           ),
+          timestamp: 7777,
           data: expect.objectContaining({ success: true }),
         }),
       );
@@ -338,6 +369,61 @@ describe('usePerpsOrderExecution', () => {
               TraceName.PerpsPlaceOrderToPositionRendered,
             ),
             data: expect.objectContaining({ success: false }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not let the hung-controller watchdog end after controller success while stream wait continues', async () => {
+      jest.useFakeTimers();
+      try {
+        const onSuccess = jest.fn();
+        mockPlaceOrder.mockResolvedValue({
+          success: true,
+          orderId: 'order123',
+        });
+
+        const { result } = renderHook(() =>
+          usePerpsOrderExecution({ onSuccess }),
+        );
+
+        let placeOrderPromise: Promise<unknown>;
+        await act(async () => {
+          placeOrderPromise = result.current.placeOrder(mockOrderParams);
+          await Promise.resolve();
+        });
+
+        await act(async () => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_CONFIRM_RACE_MS);
+          await Promise.resolve();
+        });
+        await act(async () => {
+          await placeOrderPromise;
+        });
+        expect(onSuccess).toHaveBeenCalledWith();
+        mockEndTrace.mockClear();
+
+        act(() => {
+          jest.advanceTimersByTime(
+            PERPS_CUF_STREAM_TIMEOUT_MS - PERPS_CUF_STREAM_CONFIRM_RACE_MS,
+          );
+        });
+
+        expect(mockEndTrace).not.toHaveBeenCalled();
+
+        await act(async () => {
+          handlePerpsCufPositionsDelivered([mockPosition]);
+          await Promise.resolve();
+        });
+
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringContaining(
+              TraceName.PerpsPlaceOrderToPositionRendered,
+            ),
+            data: expect.objectContaining({ success: true }),
           }),
         );
       } finally {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -393,6 +393,40 @@ describe('usePerpsOrderExecution', () => {
       );
     });
 
+    it('records a negative toast_position_delta_ms when the position renders before the toast', async () => {
+      // Monotonic clock: the stream render instant is captured inside placeOrder
+      // (before the await resolves) and the toast instant after it, so the
+      // signed delta is negative — a positive value would mean the position
+      // rendered AFTER the toast.
+      let clock = 1_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => {
+        clock += 10;
+        return clock;
+      });
+      try {
+        mockPlaceOrderSuccessWithRender();
+
+        const { result } = renderHook(() => usePerpsOrderExecution());
+
+        await act(async () => {
+          await result.current.placeOrder(mockOrderParams);
+        });
+        await waitFor(() => {
+          expect(result.current.isPlacing).toBe(false);
+        });
+
+        const renderCall = mockEndTrace.mock.calls.find((c) =>
+          String(c[0]?.id ?? '').includes(
+            TraceName.PerpsPlaceOrderToPositionRendered,
+          ),
+        );
+        expect(renderCall).toBeDefined();
+        expect(renderCall?.[0]?.data?.toast_position_delta_ms).toBeLessThan(0);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
     it('ends the span via the gesture fallback if the controller never returns', () => {
       jest.useFakeTimers();
       try {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -58,7 +58,6 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 
 describe('usePerpsOrderExecution', () => {
   const mockPlaceOrder = jest.fn();
-  const mockGetPositions = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,10 +65,8 @@ describe('usePerpsOrderExecution', () => {
     mockEndTrace.mockClear();
     mockGetPositionsSnapshot.mockReturnValue([]); // Loaded, no positions by default
     mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
-    mockGetPositions.mockResolvedValue([]); // REST fallback: no positions
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
-      getPositions: mockGetPositions,
     });
   });
 
@@ -251,35 +248,6 @@ describe('usePerpsOrderExecution', () => {
       } finally {
         jest.useRealTimers();
       }
-    });
-  });
-
-  describe('baseline capture at submit', () => {
-    it('fetches positions for a baseline when the cache is not loaded', async () => {
-      mockGetPositionsSnapshot.mockReturnValue(null); // cache not loaded
-      mockGetPositions.mockResolvedValue([]); // REST baseline
-      mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'o1' });
-
-      const { result } = renderHook(() => usePerpsOrderExecution());
-      await act(async () => {
-        await result.current.placeOrder(mockOrderParams);
-      });
-      await waitFor(() => expect(result.current.isPlacing).toBe(false));
-
-      expect(mockGetPositions).toHaveBeenCalled();
-    });
-
-    it('does not fetch positions when the cache is already loaded', async () => {
-      mockGetPositionsSnapshot.mockReturnValue([]); // loaded
-      mockPlaceOrder.mockResolvedValue({ success: true });
-
-      const { result } = renderHook(() => usePerpsOrderExecution());
-      await act(async () => {
-        await result.current.placeOrder(mockOrderParams);
-      });
-      await waitFor(() => expect(result.current.isPlacing).toBe(false));
-
-      expect(mockGetPositions).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -99,6 +99,34 @@ describe('usePerpsOrderExecution', () => {
     });
   };
 
+  describe('limit orders (no position-render CUF)', () => {
+    it('confirms immediately without arming or waiting on the position stream', async () => {
+      const onSuccess = jest.fn();
+      mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
+
+      const { result } = renderHook(() =>
+        usePerpsOrderExecution({ onSuccess }),
+      );
+
+      await act(async () => {
+        await result.current.placeOrder({
+          ...mockOrderParams,
+          orderType: 'limit',
+          price: '10000',
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPlacing).toBe(false);
+      });
+
+      // Resting limit orders confirm on API success; the market baseline
+      // snapshot is never read because the CUF is not armed.
+      expect(onSuccess).toHaveBeenCalledWith();
+      expect(mockGetSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
   describe('successful order placement', () => {
     it('calls onSuccess with the position once the stream renders it', async () => {
       const onSuccess = jest.fn();

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -8,12 +8,19 @@ import {
 } from '@metamask/perps-controller';
 import { usePerpsOrderExecution } from './usePerpsOrderExecution';
 import { usePerpsTrading } from './usePerpsTrading';
-import { handlePerpsCufPositionsDelivered } from '../utils/perpsCufTrace';
+import {
+  handlePerpsCufPositionsDelivered,
+  handlePerpsCufOrdersDelivered,
+} from '../utils/perpsCufTrace';
 
 jest.mock('./usePerpsTrading');
-const mockGetSnapshot = jest.fn();
+const mockGetPositionsSnapshot = jest.fn();
+const mockGetOrdersSnapshot = jest.fn();
 jest.mock('../providers/PerpsStreamManager', () => ({
-  usePerpsStream: () => ({ positions: { getSnapshot: mockGetSnapshot } }),
+  usePerpsStream: () => ({
+    positions: { getSnapshot: mockGetPositionsSnapshot },
+    orders: { getSnapshot: mockGetOrdersSnapshot },
+  }),
 }));
 const mockTrack = jest.fn();
 jest.mock('./usePerpsEventTracking', () => ({
@@ -45,7 +52,8 @@ describe('usePerpsOrderExecution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrack.mockClear();
-    mockGetSnapshot.mockReturnValue(null); // No cached positions by default
+    mockGetPositionsSnapshot.mockReturnValue(null); // No cached positions by default
+    mockGetOrdersSnapshot.mockReturnValue(null); // No cached orders by default
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
     });
@@ -91,17 +99,20 @@ describe('usePerpsOrderExecution', () => {
   const mockPlaceOrderSuccessWithRender = (
     result: Record<string, unknown> = {},
   ) => {
-    mockGetSnapshot.mockReturnValueOnce(null); // pre-order baseline: none
-    mockGetSnapshot.mockReturnValue([mockPosition]);
+    mockGetPositionsSnapshot.mockReturnValueOnce(null); // pre-order baseline: none
+    mockGetPositionsSnapshot.mockReturnValue([mockPosition]);
     mockPlaceOrder.mockImplementation(async () => {
       handlePerpsCufPositionsDelivered([mockPosition]);
       return { success: true, orderId: 'order123', ...result };
     });
   };
 
-  describe('limit orders (no position-render CUF)', () => {
-    it('confirms immediately without arming or waiting on the position stream', async () => {
+  describe('limit orders (order-render CUF, not position-render)', () => {
+    it('confirms immediately and never touches the position matcher', async () => {
       const onSuccess = jest.fn();
+      // Order already rendered by submit time: span ends synchronously, no
+      // fallback timer is scheduled.
+      mockGetOrdersSnapshot.mockReturnValue([{ orderId: 'lim1' }]);
       mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
 
       const { result } = renderHook(() =>
@@ -120,10 +131,41 @@ describe('usePerpsOrderExecution', () => {
         expect(result.current.isPlacing).toBe(false);
       });
 
-      // Resting limit orders confirm on API success; the market baseline
-      // snapshot is never read because the CUF is not armed.
+      // Resting limit orders confirm on API success; the position baseline
+      // snapshot is never read because the position-render CUF is not armed.
       expect(onSuccess).toHaveBeenCalledWith();
-      expect(mockGetSnapshot).not.toHaveBeenCalled();
+      expect(mockGetPositionsSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('ends the order-render span when the resting order renders in the stream', async () => {
+      jest.useFakeTimers();
+      try {
+        mockGetOrdersSnapshot.mockReturnValue([]); // not rendered synchronously
+        mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
+
+        const { result } = renderHook(() => usePerpsOrderExecution());
+
+        await act(async () => {
+          await result.current.placeOrder({
+            ...mockOrderParams,
+            orderType: 'limit',
+            price: '10000',
+          });
+        });
+
+        // Stream renders the resting order -> span ends at the boundary
+        // (before the 30s fallback would fire).
+        act(() => {
+          handlePerpsCufOrdersDelivered([{ orderId: 'lim1' }]);
+        });
+
+        // Flush the scheduled fallback so no timer leaks past the test.
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -12,6 +12,7 @@ import {
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
 } from '../utils/perpsCufTrace';
+import { PERPS_CUF_STREAM_TIMEOUT_MS } from '../constants/perpsCufTags';
 import { endTrace, TraceName } from '../../../../util/trace';
 
 jest.mock('./usePerpsTrading');
@@ -121,8 +122,8 @@ describe('usePerpsOrderExecution', () => {
   describe('limit orders (order-render CUF, not position-render)', () => {
     it('confirms immediately when the resting order is already rendered', async () => {
       const onSuccess = jest.fn();
-      // Order already rendered by submit time: span ends synchronously, no
-      // fallback timer is scheduled.
+      // Order already rendered by submit time: the span ends synchronously; the
+      // gesture-anchored safety fallback stays pending and no-ops.
       mockGetOrdersSnapshot.mockReturnValue([{ orderId: 'lim1' }]);
       mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
 
@@ -278,6 +279,70 @@ describe('usePerpsOrderExecution', () => {
         orderId: 'order123',
       });
       expect(result.current.error).toBeUndefined();
+    });
+
+    it('ends the position-render span at the captured render instant, not when the hook resumes', async () => {
+      mockPlaceOrderSuccessWithRender();
+
+      const { result } = renderHook(() => usePerpsOrderExecution());
+
+      await act(async () => {
+        await result.current.placeOrder(mockOrderParams);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPlacing).toBe(false);
+      });
+
+      // endTrace receives an explicit numeric timestamp (the stream render
+      // instant) plus the toast->position delta, so the span measures
+      // gesture -> actual render rather than gesture -> toast callback.
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringContaining(
+            TraceName.PerpsPlaceOrderToPositionRendered,
+          ),
+          timestamp: expect.any(Number),
+          data: expect.objectContaining({
+            success: true,
+            toast_position_delta_ms: expect.any(Number),
+          }),
+        }),
+      );
+    });
+
+    it('ends the span via the gesture fallback if the controller never returns', () => {
+      jest.useFakeTimers();
+      try {
+        mockGetPositionsSnapshot.mockReturnValue([]);
+        // Controller hangs: the promise never settles, so no per-flow end runs.
+        mockPlaceOrder.mockImplementation(
+          () => new Promise<never>(() => undefined),
+        );
+
+        const { result } = renderHook(() => usePerpsOrderExecution());
+
+        act(() => {
+          // Fire and forget: a hung controller means this never resolves.
+          result.current.placeOrder(mockOrderParams).catch(() => undefined);
+        });
+
+        act(() => {
+          jest.advanceTimersByTime(PERPS_CUF_STREAM_TIMEOUT_MS);
+        });
+
+        // The gesture-anchored fallback closes the span instead of leaking it.
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringContaining(
+              TraceName.PerpsPlaceOrderToPositionRendered,
+            ),
+            data: expect.objectContaining({ success: false }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('calls onSuccess with no args when the stream has not rendered the position yet', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -63,8 +63,8 @@ describe('usePerpsOrderExecution', () => {
     jest.clearAllMocks();
     mockTrack.mockClear();
     mockEndTrace.mockClear();
-    mockGetPositionsSnapshot.mockReturnValue(null); // No cached positions by default
-    mockGetOrdersSnapshot.mockReturnValue(null); // No cached orders by default
+    mockGetPositionsSnapshot.mockReturnValue([]); // Loaded, no positions by default
+    mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
     });
@@ -110,7 +110,7 @@ describe('usePerpsOrderExecution', () => {
   const mockPlaceOrderSuccessWithRender = (
     result: Record<string, unknown> = {},
   ) => {
-    mockGetPositionsSnapshot.mockReturnValueOnce(null); // pre-order baseline: none
+    mockGetPositionsSnapshot.mockReturnValueOnce([]); // pre-order baseline: loaded, none
     mockGetPositionsSnapshot.mockReturnValue([mockPosition]);
     mockPlaceOrder.mockImplementation(async () => {
       handlePerpsCufPositionsDelivered([mockPosition]);
@@ -150,7 +150,7 @@ describe('usePerpsOrderExecution', () => {
 
     it('ends immediately when a marketable limit fill rendered before watcher registration', async () => {
       mockGetPositionsSnapshot
-        .mockReturnValueOnce(null) // pre-submit baseline
+        .mockReturnValueOnce([]) // pre-submit baseline: loaded, no position
         .mockReturnValue([mockPosition]); // post-submit fill already rendered
       mockGetOrdersSnapshot.mockReturnValue([]);
       mockPlaceOrder.mockImplementation(async () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -119,7 +119,7 @@ describe('usePerpsOrderExecution', () => {
   };
 
   describe('limit orders (order-render CUF, not position-render)', () => {
-    it('confirms immediately and never touches the position matcher', async () => {
+    it('confirms immediately when the resting order is already rendered', async () => {
       const onSuccess = jest.fn();
       // Order already rendered by submit time: span ends synchronously, no
       // fallback timer is scheduled.
@@ -142,10 +142,40 @@ describe('usePerpsOrderExecution', () => {
         expect(result.current.isPlacing).toBe(false);
       });
 
-      // Resting limit orders confirm on API success; the position baseline
-      // snapshot is never read because the position-render CUF is not armed.
+      // Limit orders capture a pre-submit position baseline so marketable
+      // limits that fill before watcher registration are still detected.
       expect(onSuccess).toHaveBeenCalledWith();
-      expect(mockGetPositionsSnapshot).not.toHaveBeenCalled();
+      expect(mockGetPositionsSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends immediately when a marketable limit fill rendered before watcher registration', async () => {
+      mockGetPositionsSnapshot
+        .mockReturnValueOnce(null) // pre-submit baseline
+        .mockReturnValue([mockPosition]); // post-submit fill already rendered
+      mockGetOrdersSnapshot.mockReturnValue([]);
+      mockPlaceOrder.mockImplementation(async () => {
+        handlePerpsCufPositionsDelivered([mockPosition]);
+        return { success: true, orderId: 'lim1' };
+      });
+
+      const { result } = renderHook(() => usePerpsOrderExecution());
+
+      await act(async () => {
+        await result.current.placeOrder({
+          ...mockOrderParams,
+          orderType: 'limit',
+          price: '10000',
+        });
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringContaining(
+            TraceName.PerpsPlaceLimitOrderToOrderRendered,
+          ),
+          data: expect.objectContaining({ success: true }),
+        }),
+      );
     });
 
     it('ends the order-render span when the resting order renders in the stream', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -58,6 +58,7 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 
 describe('usePerpsOrderExecution', () => {
   const mockPlaceOrder = jest.fn();
+  const mockGetPositions = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -65,8 +66,10 @@ describe('usePerpsOrderExecution', () => {
     mockEndTrace.mockClear();
     mockGetPositionsSnapshot.mockReturnValue([]); // Loaded, no positions by default
     mockGetOrdersSnapshot.mockReturnValue([]); // Loaded, no orders by default
+    mockGetPositions.mockResolvedValue([]); // REST fallback: no positions
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
+      getPositions: mockGetPositions,
     });
   });
 
@@ -248,6 +251,35 @@ describe('usePerpsOrderExecution', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe('baseline capture at submit', () => {
+    it('fetches positions for a baseline when the cache is not loaded', async () => {
+      mockGetPositionsSnapshot.mockReturnValue(null); // cache not loaded
+      mockGetPositions.mockResolvedValue([]); // REST baseline
+      mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'o1' });
+
+      const { result } = renderHook(() => usePerpsOrderExecution());
+      await act(async () => {
+        await result.current.placeOrder(mockOrderParams);
+      });
+      await waitFor(() => expect(result.current.isPlacing).toBe(false));
+
+      expect(mockGetPositions).toHaveBeenCalled();
+    });
+
+    it('does not fetch positions when the cache is already loaded', async () => {
+      mockGetPositionsSnapshot.mockReturnValue([]); // loaded
+      mockPlaceOrder.mockResolvedValue({ success: true });
+
+      const { result } = renderHook(() => usePerpsOrderExecution());
+      await act(async () => {
+        await result.current.placeOrder(mockOrderParams);
+      });
+      await waitFor(() => expect(result.current.isPlacing).toBe(false));
+
+      expect(mockGetPositions).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -12,8 +12,18 @@ import {
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
 } from '../utils/perpsCufTrace';
+import { endTrace, TraceName } from '../../../../util/trace';
 
 jest.mock('./usePerpsTrading');
+jest.mock('../../../../util/trace', () => {
+  const actual = jest.requireActual('../../../../util/trace');
+  return {
+    ...actual,
+    trace: jest.fn(),
+    endTrace: jest.fn(),
+  };
+});
+const mockEndTrace = endTrace as jest.Mock;
 const mockGetPositionsSnapshot = jest.fn();
 const mockGetOrdersSnapshot = jest.fn();
 jest.mock('../providers/PerpsStreamManager', () => ({
@@ -52,6 +62,7 @@ describe('usePerpsOrderExecution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrack.mockClear();
+    mockEndTrace.mockClear();
     mockGetPositionsSnapshot.mockReturnValue(null); // No cached positions by default
     mockGetOrdersSnapshot.mockReturnValue(null); // No cached orders by default
     (usePerpsTrading as jest.Mock).mockReturnValue({
@@ -334,6 +345,32 @@ describe('usePerpsOrderExecution', () => {
         success: false,
         error: 'Insufficient margin',
       });
+    });
+
+    it('does not close a pending market CUF when a later limit order fails', async () => {
+      mockPlaceOrder.mockResolvedValue({
+        success: false,
+        error: 'Limit failed',
+      });
+
+      handlePerpsCufPositionsDelivered([mockPosition]);
+      mockEndTrace.mockClear();
+
+      const { result } = renderHook(() => usePerpsOrderExecution());
+
+      await act(async () => {
+        await result.current.placeOrder({
+          ...mockOrderParams,
+          orderType: 'limit',
+          price: '10000',
+        });
+      });
+
+      expect(mockEndTrace).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.PerpsPlaceOrderToPositionRendered,
+        }),
+      );
     });
 
     it('tracks failed order with trade_with_token and mm_pay fields when trackingData is set', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -8,8 +8,13 @@ import {
 } from '@metamask/perps-controller';
 import { usePerpsOrderExecution } from './usePerpsOrderExecution';
 import { usePerpsTrading } from './usePerpsTrading';
+import { handlePerpsCufPositionsDelivered } from '../utils/perpsCufTrace';
 
 jest.mock('./usePerpsTrading');
+const mockGetSnapshot = jest.fn();
+jest.mock('../providers/PerpsStreamManager', () => ({
+  usePerpsStream: () => ({ positions: { getSnapshot: mockGetSnapshot } }),
+}));
 const mockTrack = jest.fn();
 jest.mock('./usePerpsEventTracking', () => ({
   usePerpsEventTracking: () => ({ track: mockTrack }),
@@ -36,15 +41,13 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 
 describe('usePerpsOrderExecution', () => {
   const mockPlaceOrder = jest.fn();
-  const mockGetPositions = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrack.mockClear();
-    mockGetPositions.mockResolvedValue([]); // Setup default
+    mockGetSnapshot.mockReturnValue(null); // No cached positions by default
     (usePerpsTrading as jest.Mock).mockReturnValue({
       placeOrder: mockPlaceOrder,
-      getPositions: mockGetPositions,
     });
   });
 
@@ -80,16 +83,28 @@ describe('usePerpsOrderExecution', () => {
     stopLossCount: 0,
   };
 
+  /**
+   * Order succeeds and the position stream renders it: the stream delivery
+   * happens inside placeOrder (after the CUF is armed), and the post-render
+   * snapshot contains the position.
+   */
+  const mockPlaceOrderSuccessWithRender = (
+    result: Record<string, unknown> = {},
+  ) => {
+    mockGetSnapshot.mockReturnValueOnce(null); // pre-order baseline: none
+    mockGetSnapshot.mockReturnValue([mockPosition]);
+    mockPlaceOrder.mockImplementation(async () => {
+      handlePerpsCufPositionsDelivered([mockPosition]);
+      return { success: true, orderId: 'order123', ...result };
+    });
+  };
+
   describe('successful order placement', () => {
-    it('places order and fetches position then calls onSuccess with position', async () => {
+    it('calls onSuccess with the position once the stream renders it', async () => {
       const onSuccess = jest.fn();
       const onError = jest.fn();
 
-      mockPlaceOrder.mockResolvedValue({
-        success: true,
-        orderId: 'order123',
-      });
-      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockPlaceOrderSuccessWithRender();
 
       const { result } = renderHook(() =>
         usePerpsOrderExecution({ onSuccess, onError }),
@@ -104,7 +119,6 @@ describe('usePerpsOrderExecution', () => {
       });
 
       expect(mockPlaceOrder).toHaveBeenCalledWith(mockOrderParams);
-      expect(mockGetPositions).toHaveBeenCalled();
       expect(onSuccess).toHaveBeenCalledWith(mockPosition);
       expect(onError).not.toHaveBeenCalled();
       expect(result.current.lastResult).toEqual({
@@ -114,14 +128,14 @@ describe('usePerpsOrderExecution', () => {
       expect(result.current.error).toBeUndefined();
     });
 
-    it('calls onSuccess with no args when position is not found after order', async () => {
+    it('calls onSuccess with no args when the stream has not rendered the position yet', async () => {
       const onSuccess = jest.fn();
 
       mockPlaceOrder.mockResolvedValue({
         success: true,
         orderId: 'order123',
       });
-      mockGetPositions.mockResolvedValue([]); // No positions
+      // No stream delivery: the confirm race times out and toasts without it.
 
       const { result } = renderHook(() =>
         usePerpsOrderExecution({ onSuccess }),
@@ -136,32 +150,12 @@ describe('usePerpsOrderExecution', () => {
       });
 
       expect(onSuccess).toHaveBeenCalledWith();
-    });
 
-    it('calls onSuccess with no args when position fetch rejects', async () => {
-      const onSuccess = jest.fn();
-      const onError = jest.fn();
-
-      mockPlaceOrder.mockResolvedValue({
-        success: true,
-        orderId: 'order123',
+      // Deliver the late render so the pending stream waiter (and its
+      // timeout) resolves instead of leaking past the test.
+      act(() => {
+        handlePerpsCufPositionsDelivered([mockPosition]);
       });
-      mockGetPositions.mockRejectedValue(new Error('Network error'));
-
-      const { result } = renderHook(() =>
-        usePerpsOrderExecution({ onSuccess, onError }),
-      );
-
-      await act(async () => {
-        await result.current.placeOrder(mockOrderParams);
-      });
-
-      await waitFor(() => {
-        expect(result.current.isPlacing).toBe(false);
-      });
-
-      expect(onSuccess).toHaveBeenCalledWith();
-      expect(onError).not.toHaveBeenCalled();
     });
 
     it('tracks partially filled event with trackingData when filledSize is between 0 and order size', async () => {
@@ -178,12 +172,7 @@ describe('usePerpsOrderExecution', () => {
         },
       };
 
-      mockPlaceOrder.mockResolvedValue({
-        success: true,
-        orderId: 'order123',
-        filledSize: '0.1',
-      });
-      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockPlaceOrderSuccessWithRender({ filledSize: '0.1' });
 
       const { result } = renderHook(() =>
         usePerpsOrderExecution({ onSuccess, onError: jest.fn() }),
@@ -221,12 +210,7 @@ describe('usePerpsOrderExecution', () => {
         },
       };
 
-      mockPlaceOrder.mockResolvedValue({
-        success: true,
-        orderId: 'order123',
-        filledSize: '0.1',
-      });
-      mockGetPositions.mockResolvedValue([mockPosition]);
+      mockPlaceOrderSuccessWithRender({ filledSize: '0.1' });
 
       const { result } = renderHook(() =>
         usePerpsOrderExecution({ onSuccess, onError: jest.fn() }),
@@ -473,7 +457,10 @@ describe('usePerpsOrderExecution', () => {
     it('clears error when a subsequent order placement succeeds', async () => {
       mockPlaceOrder
         .mockResolvedValueOnce({ success: false, error: 'First error' })
-        .mockResolvedValueOnce({ success: true });
+        .mockImplementation(async () => {
+          handlePerpsCufPositionsDelivered([mockPosition]);
+          return { success: true };
+        });
 
       const { result } = renderHook(() => usePerpsOrderExecution());
 
@@ -497,7 +484,7 @@ describe('usePerpsOrderExecution', () => {
 
   describe('without callbacks', () => {
     it('updates lastResult when placeOrder succeeds and no onSuccess provided', async () => {
-      mockPlaceOrder.mockResolvedValue({ success: true });
+      mockPlaceOrderSuccessWithRender();
 
       const { result } = renderHook(() => usePerpsOrderExecution());
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -210,6 +210,57 @@ describe('usePerpsOrderExecution', () => {
       );
     });
 
+    it('ends as a success when a marketable limit fill fully closed the prior position', async () => {
+      jest.useFakeTimers();
+      try {
+        mockGetPositionsSnapshot
+          .mockReturnValueOnce([mockPosition]) // pre-submit baseline: a real hold
+          .mockReturnValue([]); // fill closed it fully -> symbol now absent
+        mockGetOrdersSnapshot.mockReturnValue([]); // filled, so no resting order
+        mockPositionsLastDeliveredAt.mockReturnValue(9999);
+        mockPlaceOrder.mockImplementation(async () => {
+          handlePerpsCufPositionsDelivered([]);
+          return { success: true, orderId: 'lim1' };
+        });
+
+        const { result } = renderHook(() => usePerpsOrderExecution());
+
+        await act(async () => {
+          await result.current.placeOrder({
+            ...mockOrderParams,
+            orderType: 'limit',
+            price: '10000',
+          });
+        });
+
+        // The close-fill is a synchronous render: ends at the delivery instant
+        // as a success, not a stream_timeout via a watcher that missed it.
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringContaining(
+              TraceName.PerpsPlaceLimitOrderToOrderRendered,
+            ),
+            timestamp: 9999,
+            data: expect.objectContaining({ success: true }),
+          }),
+        );
+        // Draining the safety watchdog must not overturn it into a failure.
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+        expect(mockEndTrace).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringContaining(
+              TraceName.PerpsPlaceLimitOrderToOrderRendered,
+            ),
+            data: expect.objectContaining({ success: false }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('does not end immediately when only TP/SL changed during limit submit', async () => {
       jest.useFakeTimers();
       try {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -178,6 +178,47 @@ describe('usePerpsOrderExecution', () => {
       );
     });
 
+    it('does not end immediately when only TP/SL changed during limit submit', async () => {
+      jest.useFakeTimers();
+      try {
+        mockGetPositionsSnapshot
+          .mockReturnValueOnce([
+            {
+              ...mockPosition,
+              takeProfitPrice: '70000',
+            },
+          ])
+          .mockReturnValue([{ ...mockPosition, takeProfitPrice: '71000' }]);
+        mockGetOrdersSnapshot.mockReturnValue([]);
+        mockPlaceOrder.mockResolvedValue({ success: true, orderId: 'lim1' });
+
+        const { result } = renderHook(() => usePerpsOrderExecution());
+
+        await act(async () => {
+          await result.current.placeOrder({
+            ...mockOrderParams,
+            orderType: 'limit',
+            price: '10000',
+          });
+        });
+
+        expect(mockEndTrace).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: expect.stringContaining(
+              TraceName.PerpsPlaceLimitOrderToOrderRendered,
+            ),
+            data: expect.objectContaining({ success: true }),
+          }),
+        );
+
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('ends the order-render span when the resting order renders in the stream', async () => {
       jest.useFakeTimers();
       try {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -268,7 +268,12 @@ export function usePerpsOrderExecution(
                 renderedPosition &&
                 renderedPositionSnapshot !== positionBaselineSnapshot
               ) {
-                // Fill already rendered: end at the positions delivery instant.
+                // Fill already rendered before the watcher armed: end at the
+                // positions channel's last-delivery instant. This is channel-
+                // granular (positions re-deliver on any PnL tick), so it upper-
+                // bounds this symbol's fill instant rather than pinpointing it —
+                // bounded and never optimistic. Rare branch; the normal path
+                // (watcher observes the live delivery) is exact.
                 endCufStreamRendered(stream.positions.getLastDeliveredAt());
               } else {
                 watchPerpsCufLimitRendered(

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -65,7 +65,7 @@ export function usePerpsOrderExecution(
   params: UsePerpsOrderExecutionParams = {},
 ): UsePerpsOrderExecutionReturn {
   const { onSubmitted, onSuccess, onError } = params;
-  const { placeOrder: controllerPlaceOrder } = usePerpsTrading();
+  const { placeOrder: controllerPlaceOrder, getPositions } = usePerpsTrading();
   const { track } = usePerpsEventTracking();
   const stream = usePerpsStream();
 
@@ -89,7 +89,9 @@ export function usePerpsOrderExecution(
       // measure submit -> resting order rendered in the orders stream (no
       // exchange fill-wait time) via PerpsPlaceLimitOrderToOrderRendered. Each
       // start mints a unique op id so overlapping orders never collide.
-      const isMarketOrder = orderParams.orderType === 'market';
+      // Only an explicit limit order takes the order-render path; anything else
+      // (including an omitted orderType) is treated as market.
+      const isMarketOrder = orderParams.orderType !== 'limit';
       const cufOpId = startPerpsCufTrace({
         name: isMarketOrder
           ? TraceName.PerpsPlaceOrderToPositionRendered
@@ -114,10 +116,20 @@ export function usePerpsOrderExecution(
       // cache means "not loaded", not "no position" — pass that through so the
       // matcher captures the baseline from the first delivery instead of
       // assuming absent (which a pre-existing position would falsely satisfy).
-      const positionsCache = stream.positions.getSnapshot();
-      const positionsLoaded = positionsCache !== null;
+      let baselinePositions = stream.positions.getSnapshot();
+      if (baselinePositions === null) {
+        // Cache not loaded (rare cold-start): fetch once so we have a real
+        // pre-order baseline instead of capturing a possibly-already-filled
+        // first stream delivery. Falls back to BASELINE_PENDING if it fails.
+        try {
+          baselinePositions = await getPositions();
+        } catch {
+          baselinePositions = null;
+        }
+      }
+      const positionsLoaded = baselinePositions !== null;
       const positionBaseline =
-        positionsCache?.find((p) => p.symbol === orderParams.symbol) ?? null;
+        baselinePositions?.find((p) => p.symbol === orderParams.symbol) ?? null;
       const positionBaselineSnapshot =
         getPerpsOrderPositionSnapshot(positionBaseline);
       if (isMarketOrder) {
@@ -418,7 +430,15 @@ export function usePerpsOrderExecution(
         setIsPlacing(false);
       }
     },
-    [controllerPlaceOrder, stream, onSubmitted, onSuccess, onError, track],
+    [
+      controllerPlaceOrder,
+      getPositions,
+      stream,
+      onSubmitted,
+      onSuccess,
+      onError,
+      track,
+    ],
   );
 
   return {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -50,6 +50,19 @@ interface UsePerpsOrderExecutionReturn {
 }
 
 type PerpsOrderTrackingValue = string | number | boolean;
+type PerpsOrderPositionSnapshot = Pick<
+  Position,
+  'size' | 'takeProfitPrice' | 'stopLossPrice'
+>;
+
+const getPerpsOrderPositionSnapshot = (
+  position?: PerpsOrderPositionSnapshot | null,
+) =>
+  position
+    ? `${position.size}|${position.takeProfitPrice ?? ''}|${
+        position.stopLossPrice ?? ''
+      }`
+    : undefined;
 
 /**
  * Hook to handle order execution flow
@@ -104,14 +117,16 @@ export function usePerpsOrderExecution(
           [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
           [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
         });
+      // Baseline lets stream matchers tell this order's fill apart from a
+      // position that already existed on this market before submission.
+      const positionBaseline =
+        stream.positions
+          .getSnapshot()
+          ?.find((p) => p.symbol === orderParams.symbol) ?? null;
+      const positionBaselineSnapshot =
+        getPerpsOrderPositionSnapshot(positionBaseline);
       if (isMarketOrder) {
-        // Baseline lets the stream matcher tell the order's fill apart from a
-        // position that already existed on this market before the order.
-        const baseline =
-          stream.positions
-            .getSnapshot()
-            ?.find((p) => p.symbol === orderParams.symbol) ?? null;
-        armPerpsPlaceOrderCuf(cufOpId, orderParams.symbol, baseline);
+        armPerpsPlaceOrderCuf(cufOpId, orderParams.symbol, positionBaseline);
       }
 
       try {
@@ -202,26 +217,38 @@ export function usePerpsOrderExecution(
               // End when the order rests in the orders stream, or — for a
               // marketable limit that fills immediately — when it renders as a
               // new/changed position (baseline tells a fill from a prior hold).
-              const positionBaseline =
-                stream.positions
-                  .getSnapshot()
-                  ?.find((p) => p.symbol === orderParams.symbol) ?? null;
-              watchPerpsCufLimitRendered(
-                cufOpId,
-                orderId,
-                orderParams.symbol,
-                positionBaseline,
-              );
-              endPerpsCufTraceAfter(
-                {
-                  id: cufOpId,
-                  data: {
-                    [PERPS_CUF_TAG.SUCCESS]: false,
-                    [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+              const renderedPosition = stream.positions
+                .getSnapshot()
+                ?.find((p) => p.symbol === orderParams.symbol);
+              const renderedPositionSnapshot =
+                getPerpsOrderPositionSnapshot(renderedPosition);
+              if (
+                renderedPosition &&
+                renderedPositionSnapshot !== positionBaselineSnapshot
+              ) {
+                endCuf({
+                  [PERPS_CUF_TAG.SUCCESS]: true,
+                  [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+                });
+              } else {
+                watchPerpsCufLimitRendered(
+                  cufOpId,
+                  orderId,
+                  orderParams.symbol,
+                  positionBaseline,
+                );
+                endPerpsCufTraceAfter(
+                  {
+                    id: cufOpId,
+                    data: {
+                      [PERPS_CUF_TAG.SUCCESS]: false,
+                      [PERPS_CUF_TAG.REASON]:
+                        PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+                    },
                   },
-                },
-                PERPS_CUF_STREAM_TIMEOUT_MS,
-              );
+                  PERPS_CUF_STREAM_TIMEOUT_MS,
+                );
+              }
             }
           } else {
             // Wait briefly for the stream to render the new/changed position so

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -65,7 +65,7 @@ export function usePerpsOrderExecution(
   params: UsePerpsOrderExecutionParams = {},
 ): UsePerpsOrderExecutionReturn {
   const { onSubmitted, onSuccess, onError } = params;
-  const { placeOrder: controllerPlaceOrder, getPositions } = usePerpsTrading();
+  const { placeOrder: controllerPlaceOrder } = usePerpsTrading();
   const { track } = usePerpsEventTracking();
   const stream = usePerpsStream();
 
@@ -116,20 +116,16 @@ export function usePerpsOrderExecution(
       // cache means "not loaded", not "no position" — pass that through so the
       // matcher captures the baseline from the first delivery instead of
       // assuming absent (which a pre-existing position would falsely satisfy).
-      let baselinePositions = stream.positions.getSnapshot();
-      if (baselinePositions === null) {
-        // Cache not loaded (rare cold-start): fetch once so we have a real
-        // pre-order baseline instead of capturing a possibly-already-filled
-        // first stream delivery. Falls back to BASELINE_PENDING if it fails.
-        try {
-          baselinePositions = await getPositions();
-        } catch {
-          baselinePositions = null;
-        }
-      }
-      const positionsLoaded = baselinePositions !== null;
+      // We deliberately do NOT block order submission on a REST fetch to
+      // resolve an unloaded cache: the fetch would add latency to every
+      // cold-start trade. The only residual is a rare cold-start order whose
+      // fill lands in that very first delivery — it records a stream_timeout
+      // rather than a render duration, which does not corrupt data or affect
+      // the user's flow.
+      const positionsCache = stream.positions.getSnapshot();
+      const positionsLoaded = positionsCache !== null;
       const positionBaseline =
-        baselinePositions?.find((p) => p.symbol === orderParams.symbol) ?? null;
+        positionsCache?.find((p) => p.symbol === orderParams.symbol) ?? null;
       const positionBaselineSnapshot =
         getPerpsOrderPositionSnapshot(positionBaseline);
       if (isMarketOrder) {
@@ -430,15 +426,7 @@ export function usePerpsOrderExecution(
         setIsPlacing(false);
       }
     },
-    [
-      controllerPlaceOrder,
-      getPositions,
-      stream,
-      onSubmitted,
-      onSuccess,
-      onError,
-      track,
-    ],
+    [controllerPlaceOrder, stream, onSubmitted, onSuccess, onError, track],
   );
 
   return {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -20,6 +20,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTrace,
   armPerpsPlaceOrderCuf,
+  isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
 } from '../utils/perpsCufTrace';
 import {
@@ -101,7 +102,7 @@ export function usePerpsOrderExecution(
         stream.positions
           .getSnapshot()
           ?.find((p) => p.symbol === orderParams.symbol) ?? null;
-      armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
+      const cufGeneration = armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
 
       try {
         setIsPlacing(true);
@@ -172,6 +173,7 @@ export function usePerpsOrderExecution(
           // the confirmation toast fires together with it.
           const rendered = await waitForPerpsPlaceOrderPositionRendered(
             PERPS_CUF_STREAM_CONFIRM_RACE_MS,
+            cufGeneration,
           );
           const toastShownAt = Date.now();
           if (rendered) {
@@ -199,7 +201,12 @@ export function usePerpsOrderExecution(
             // Deliberately not awaited: the caller must not block on the span.
             waitForPerpsPlaceOrderPositionRendered(
               PERPS_CUF_STREAM_TIMEOUT_MS,
+              cufGeneration,
             ).then((late) => {
+              // A newer order owns the span now; this continuation is stale.
+              if (!isPerpsPlaceOrderCufCurrent(cufGeneration)) {
+                return;
+              }
               if (late) {
                 endPlaceOrderCuf({
                   [PERPS_CUF_TAG.SUCCESS]: true,

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -22,6 +22,7 @@ import {
   endPerpsCufTraceAfter,
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
+  isPerpsFillRendered,
   waitForPerpsPlaceOrderPositionRendered,
   watchPerpsCufLimitRendered,
 } from '../utils/perpsCufTrace';
@@ -259,19 +260,15 @@ export function usePerpsOrderExecution(
               const renderedPosition = stream.positions
                 .getSnapshot()
                 ?.find((p) => p.symbol === orderParams.symbol);
-              const renderedPositionSnapshot =
-                getPerpsOrderPositionSnapshot(renderedPosition);
-              const baselineExisted = positionBaselineSnapshot !== undefined;
               // A synchronous fill is a position that appeared/changed versus the
               // baseline, OR a pre-existing position now absent because the fill
               // reduced it fully to zero (a marketable limit that closed the
-              // hold). Mirrors placeOrderPositionRendered so the fast path and
-              // the stream matcher agree. Only trusted with a loaded baseline.
+              // hold). Delegates to the same predicate the stream matcher uses,
+              // so the fast path and the matcher cannot drift. Only trusted with
+              // a loaded baseline; otherwise defer to the stream matcher.
               const filledSynchronously =
                 positionsLoaded &&
-                (renderedPosition
-                  ? renderedPositionSnapshot !== positionBaselineSnapshot
-                  : baselineExisted);
+                isPerpsFillRendered(renderedPosition, positionBaselineSnapshot);
               if (filledSynchronously) {
                 // Fill already rendered before the watcher armed: end at the
                 // positions channel's last-delivery instant. This is channel-

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -163,9 +163,11 @@ export function usePerpsOrderExecution(
       let controllerSettled = false;
       setTimeout(() => {
         if (!controllerSettled) {
+          // Distinct from stream_timeout: the controller request itself never
+          // settled, rather than a settled request whose render never arrived.
           endCuf({
             [PERPS_CUF_TAG.SUCCESS]: false,
-            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.CONTROLLER_TIMEOUT,
           });
         }
       }, PERPS_CUF_STREAM_TIMEOUT_MS);

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -19,9 +19,11 @@ import { usePerpsTrading } from './usePerpsTrading';
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
+  endPerpsCufTraceAfter,
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
+  watchPerpsCufOrderPresent,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -101,16 +103,26 @@ export function usePerpsOrderExecution(
           [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
           [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
         });
+      // Limit orders get their own app-responsiveness CUF instead: submit ->
+      // the resting order renders in the live orders stream (no fill wait).
+      const endLimitOrderCuf = (
+        data: Record<string, PerpsOrderTrackingValue>,
+      ) =>
+        endPerpsCufTrace({
+          name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+          data,
+        });
+      const cufStartTags = {
+        [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
+          ? PERPS_EVENT_VALUE.DIRECTION.LONG
+          : PERPS_EVENT_VALUE.DIRECTION.SHORT,
+        [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
+      };
       let cufGeneration = 0;
       if (isMarketOrder) {
         startPerpsCufTrace({
           name: TraceName.PerpsPlaceOrderToPositionRendered,
-          tags: {
-            [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
-              ? PERPS_EVENT_VALUE.DIRECTION.LONG
-              : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-            [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
-          },
+          tags: cufStartTags,
         });
         // Baseline lets the stream matcher tell the order's fill apart from a
         // position that already existed on this market before the order.
@@ -119,6 +131,11 @@ export function usePerpsOrderExecution(
             .getSnapshot()
             ?.find((p) => p.symbol === orderParams.symbol) ?? null;
         cufGeneration = armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
+      } else {
+        startPerpsCufTrace({
+          name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+          tags: cufStartTags,
+        });
       }
 
       try {
@@ -188,8 +205,39 @@ export function usePerpsOrderExecution(
 
           if (!isMarketOrder) {
             // Resting limit order: accepted, no position renders now. Confirm
-            // immediately; the position-render CUF does not apply.
+            // immediately, then end the order-render CUF when the resting
+            // order appears in the stream (or on timeout).
             onSuccess?.();
+            const orderId = result.orderId;
+            if (typeof orderId !== 'string') {
+              endLimitOrderCuf({
+                [PERPS_CUF_TAG.SUCCESS]: false,
+                [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
+              });
+            } else if (
+              stream.orders.getSnapshot()?.some((o) => o.orderId === orderId)
+            ) {
+              // Already rendered between submit and here.
+              endLimitOrderCuf({
+                [PERPS_CUF_TAG.SUCCESS]: true,
+                [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+              });
+            } else {
+              watchPerpsCufOrderPresent(
+                TraceName.PerpsPlaceLimitOrderToOrderRendered,
+                orderId,
+              );
+              endPerpsCufTraceAfter(
+                {
+                  name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+                  data: {
+                    [PERPS_CUF_TAG.SUCCESS]: false,
+                    [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+                  },
+                },
+                PERPS_CUF_STREAM_TIMEOUT_MS,
+              );
+            }
           } else {
             // Wait briefly for the stream to render the new/changed position so
             // the confirmation toast fires together with it.
@@ -238,10 +286,14 @@ export function usePerpsOrderExecution(
         } else {
           const errorMessage =
             result.error || strings('perps.order.error.unknown');
-          endPlaceOrderCuf({
+          // Ends whichever place-order CUF was started (market or limit); the
+          // other is a no-op.
+          const failedData = {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ORDER_FAILED,
-          });
+          };
+          endPlaceOrderCuf(failedData);
+          endLimitOrderCuf(failedData);
           setError(errorMessage);
           DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
 
@@ -280,10 +332,13 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
-        endPlaceOrderCuf({
+        // Ends whichever place-order CUF was started; the other is a no-op.
+        const exceptionData = {
           [PERPS_CUF_TAG.SUCCESS]: false,
           [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
-        });
+        };
+        endPlaceOrderCuf(exceptionData);
+        endLimitOrderCuf(exceptionData);
         const errorObject = ensureError(
           err,
           'usePerpsOrderExecution.placeOrder',

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -23,7 +23,7 @@ import {
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
-  watchPerpsCufOrderPresent,
+  watchPerpsCufLimitRendered,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -199,7 +199,19 @@ export function usePerpsOrderExecution(
                 [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
               });
             } else {
-              watchPerpsCufOrderPresent(cufOpId, orderId);
+              // End when the order rests in the orders stream, or — for a
+              // marketable limit that fills immediately — when it renders as a
+              // new/changed position (baseline tells a fill from a prior hold).
+              const positionBaseline =
+                stream.positions
+                  .getSnapshot()
+                  ?.find((p) => p.symbol === orderParams.symbol) ?? null;
+              watchPerpsCufLimitRendered(
+                cufOpId,
+                orderId,
+                orderParams.symbol,
+                positionBaseline,
+              );
               endPerpsCufTraceAfter(
                 {
                   id: cufOpId,

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -44,6 +44,8 @@ interface UsePerpsOrderExecutionReturn {
   error?: string;
 }
 
+type PerpsOrderTrackingValue = string | number | boolean;
+
 /**
  * Hook to handle order execution flow
  * Manages loading states, success/error handling, and position fetching
@@ -75,7 +77,7 @@ export function usePerpsOrderExecution(
       // check is the position-confirmed proxy.
       let toastAt: number | undefined;
       const endPlaceOrderCuf = (
-        data: Record<string, string | number | boolean>,
+        data: Record<string, PerpsOrderTrackingValue>,
       ) =>
         endPerpsCufTrace({
           name: TraceName.PerpsPlaceOrderToPositionRendered,

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -106,10 +106,16 @@ export function usePerpsOrderExecution(
       const endCuf = (data: Record<string, PerpsOrderTrackingValue>) =>
         endPerpsCufTrace({ id: cufOpId, data });
       const endCufRendered = (renderedAt: number, toastShownAt: number) =>
-        endCuf({
-          [PERPS_CUF_TAG.SUCCESS]: true,
-          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-          [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
+        // End at the captured stream render instant, not when this code runs,
+        // so the span measures gesture -> actual position render.
+        endPerpsCufTrace({
+          id: cufOpId,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: true,
+            [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+            [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
+          },
+          timestamp: renderedAt,
         });
       // Baseline lets stream matchers tell this order's fill apart from a
       // position that already existed on this market before submission. A null
@@ -136,6 +142,22 @@ export function usePerpsOrderExecution(
           positionsLoaded,
         );
       }
+
+      // Safety fallback anchored at the gesture: if the controller never
+      // returns (a hung request), none of the per-flow ends run, so this
+      // guarantees the span is always closed and never leaks in the pending
+      // registry. It is idempotent, so the real end (render or failure) no-ops
+      // it whenever that happens first.
+      endPerpsCufTraceAfter(
+        {
+          id: cufOpId,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+          },
+        },
+        PERPS_CUF_STREAM_TIMEOUT_MS,
+      );
 
       try {
         setIsPlacing(true);

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -110,15 +110,23 @@ export function usePerpsOrderExecution(
           [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
         });
       // Baseline lets stream matchers tell this order's fill apart from a
-      // position that already existed on this market before submission.
+      // position that already existed on this market before submission. A null
+      // cache means "not loaded", not "no position" — pass that through so the
+      // matcher captures the baseline from the first delivery instead of
+      // assuming absent (which a pre-existing position would falsely satisfy).
+      const positionsCache = stream.positions.getSnapshot();
+      const positionsLoaded = positionsCache !== null;
       const positionBaseline =
-        stream.positions
-          .getSnapshot()
-          ?.find((p) => p.symbol === orderParams.symbol) ?? null;
+        positionsCache?.find((p) => p.symbol === orderParams.symbol) ?? null;
       const positionBaselineSnapshot =
         getPerpsOrderPositionSnapshot(positionBaseline);
       if (isMarketOrder) {
-        armPerpsPlaceOrderCuf(cufOpId, orderParams.symbol, positionBaseline);
+        armPerpsPlaceOrderCuf(
+          cufOpId,
+          orderParams.symbol,
+          positionBaseline,
+          positionsLoaded,
+        );
       }
 
       try {
@@ -215,6 +223,9 @@ export function usePerpsOrderExecution(
               const renderedPositionSnapshot =
                 getPerpsOrderPositionSnapshot(renderedPosition);
               if (
+                // Only trust a synchronous fill when we had a real baseline to
+                // compare against; otherwise defer to the stream matcher.
+                positionsLoaded &&
                 renderedPosition &&
                 renderedPositionSnapshot !== positionBaselineSnapshot
               ) {
@@ -228,6 +239,7 @@ export function usePerpsOrderExecution(
                   orderId,
                   orderParams.symbol,
                   positionBaseline,
+                  positionsLoaded,
                 );
                 endPerpsCufTraceAfter(
                   {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -86,65 +86,38 @@ export function usePerpsOrderExecution(
       // limit order would time out or fold exchange fill-wait time into an
       // app-responsiveness metric. Limit orders are intentionally not measured
       // here; a dedicated order-render CUF can be added later if needed.
+      // Market orders measure submit -> position rendered (toast coupled to the
+      // same stream render). Limit orders measure submit -> resting order
+      // rendered in the orders stream (no exchange fill-wait time). Each start
+      // mints a unique op id so overlapping orders never collide.
       const isMarketOrder = orderParams.orderType === 'market';
-      const endPlaceOrderCuf = (
-        data: Record<string, PerpsOrderTrackingValue>,
-      ) =>
-        endPerpsCufTrace({
-          name: TraceName.PerpsPlaceOrderToPositionRendered,
-          data,
-        });
-      const endPlaceOrderRendered = (
-        renderedAt: number,
-        toastShownAt: number,
-      ) =>
-        endPlaceOrderCuf({
+      const cufOpId = startPerpsCufTrace({
+        name: isMarketOrder
+          ? TraceName.PerpsPlaceOrderToPositionRendered
+          : TraceName.PerpsPlaceLimitOrderToOrderRendered,
+        tags: {
+          [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
+            ? PERPS_EVENT_VALUE.DIRECTION.LONG
+            : PERPS_EVENT_VALUE.DIRECTION.SHORT,
+          [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
+        },
+      });
+      const endCuf = (data: Record<string, PerpsOrderTrackingValue>) =>
+        endPerpsCufTrace({ id: cufOpId, data });
+      const endCufRendered = (renderedAt: number, toastShownAt: number) =>
+        endCuf({
           [PERPS_CUF_TAG.SUCCESS]: true,
           [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
           [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
         });
-      // Limit orders get their own app-responsiveness CUF instead: submit ->
-      // the resting order renders in the live orders stream (no fill wait).
-      const endLimitOrderCuf = (
-        data: Record<string, PerpsOrderTrackingValue>,
-      ) =>
-        endPerpsCufTrace({
-          name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
-          data,
-        });
-      const endStartedPlaceOrderCuf = (
-        data: Record<string, PerpsOrderTrackingValue>,
-      ) => {
-        if (isMarketOrder) {
-          endPlaceOrderCuf(data);
-        } else {
-          endLimitOrderCuf(data);
-        }
-      };
-      const cufStartTags = {
-        [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
-          ? PERPS_EVENT_VALUE.DIRECTION.LONG
-          : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-        [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
-      };
-      let cufGeneration = 0;
       if (isMarketOrder) {
-        startPerpsCufTrace({
-          name: TraceName.PerpsPlaceOrderToPositionRendered,
-          tags: cufStartTags,
-        });
         // Baseline lets the stream matcher tell the order's fill apart from a
         // position that already existed on this market before the order.
         const baseline =
           stream.positions
             .getSnapshot()
             ?.find((p) => p.symbol === orderParams.symbol) ?? null;
-        cufGeneration = armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
-      } else {
-        startPerpsCufTrace({
-          name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
-          tags: cufStartTags,
-        });
+        armPerpsPlaceOrderCuf(cufOpId, orderParams.symbol, baseline);
       }
 
       try {
@@ -219,7 +192,7 @@ export function usePerpsOrderExecution(
             onSuccess?.();
             const orderId = result.orderId;
             if (typeof orderId !== 'string') {
-              endLimitOrderCuf({
+              endCuf({
                 [PERPS_CUF_TAG.SUCCESS]: false,
                 [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
               });
@@ -227,18 +200,15 @@ export function usePerpsOrderExecution(
               stream.orders.getSnapshot()?.some((o) => o.orderId === orderId)
             ) {
               // Already rendered between submit and here.
-              endLimitOrderCuf({
+              endCuf({
                 [PERPS_CUF_TAG.SUCCESS]: true,
                 [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
               });
             } else {
-              watchPerpsCufOrderPresent(
-                TraceName.PerpsPlaceLimitOrderToOrderRendered,
-                orderId,
-              );
+              watchPerpsCufOrderPresent(cufOpId, orderId);
               endPerpsCufTraceAfter(
                 {
-                  name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+                  id: cufOpId,
                   data: {
                     [PERPS_CUF_TAG.SUCCESS]: false,
                     [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
@@ -252,11 +222,11 @@ export function usePerpsOrderExecution(
             // the confirmation toast fires together with it.
             const rendered = await waitForPerpsPlaceOrderPositionRendered(
               PERPS_CUF_STREAM_CONFIRM_RACE_MS,
-              cufGeneration,
+              cufOpId,
             );
             const toastShownAt = Date.now();
             if (rendered) {
-              endPlaceOrderRendered(rendered.renderedAt, toastShownAt);
+              endCufRendered(rendered.renderedAt, toastShownAt);
               const position = stream.positions
                 .getSnapshot()
                 ?.find((p) => p.symbol === orderParams.symbol);
@@ -275,16 +245,16 @@ export function usePerpsOrderExecution(
               // Deliberately not awaited: the caller must not block on the span.
               waitForPerpsPlaceOrderPositionRendered(
                 PERPS_CUF_STREAM_TIMEOUT_MS,
-                cufGeneration,
+                cufOpId,
               ).then((late) => {
                 // A newer order owns the span now; this continuation is stale.
-                if (!isPerpsPlaceOrderCufCurrent(cufGeneration)) {
+                if (!isPerpsPlaceOrderCufCurrent(cufOpId)) {
                   return;
                 }
                 if (late) {
-                  endPlaceOrderRendered(late.renderedAt, toastShownAt);
+                  endCufRendered(late.renderedAt, toastShownAt);
                 } else {
-                  endPlaceOrderCuf({
+                  endCuf({
                     [PERPS_CUF_TAG.SUCCESS]: false,
                     [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
                   });
@@ -295,11 +265,10 @@ export function usePerpsOrderExecution(
         } else {
           const errorMessage =
             result.error || strings('perps.order.error.unknown');
-          const failedData = {
+          endCuf({
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ORDER_FAILED,
-          };
-          endStartedPlaceOrderCuf(failedData);
+          });
           setError(errorMessage);
           DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
 
@@ -338,11 +307,10 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
-        const exceptionData = {
+        endCuf({
           [PERPS_CUF_TAG.SUCCESS]: false,
           [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
-        };
-        endStartedPlaceOrderCuf(exceptionData);
+        });
         const errorObject = ensureError(
           err,
           'usePerpsOrderExecution.placeOrder',

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -87,9 +87,10 @@ export function usePerpsOrderExecution(
       // app-responsiveness metric. Limit orders are intentionally not measured
       // here; a dedicated order-render CUF can be added later if needed.
       // Market orders measure submit -> position rendered (toast coupled to the
-      // same stream render). Limit orders measure submit -> resting order
-      // rendered in the orders stream (no exchange fill-wait time). Each start
-      // mints a unique op id so overlapping orders never collide.
+      // same stream render) via PerpsPlaceOrderToPositionRendered. Limit orders
+      // measure submit -> resting order rendered in the orders stream (no
+      // exchange fill-wait time) via PerpsPlaceLimitOrderToOrderRendered. Each
+      // start mints a unique op id so overlapping orders never collide.
       const isMarketOrder = orderParams.orderType === 'market';
       const cufOpId = startPerpsCufTrace({
         name: isMarketOrder

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -112,6 +112,15 @@ export function usePerpsOrderExecution(
           name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
           data,
         });
+      const endStartedPlaceOrderCuf = (
+        data: Record<string, PerpsOrderTrackingValue>,
+      ) => {
+        if (isMarketOrder) {
+          endPlaceOrderCuf(data);
+        } else {
+          endLimitOrderCuf(data);
+        }
+      };
       const cufStartTags = {
         [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
           ? PERPS_EVENT_VALUE.DIRECTION.LONG
@@ -286,14 +295,11 @@ export function usePerpsOrderExecution(
         } else {
           const errorMessage =
             result.error || strings('perps.order.error.unknown');
-          // Ends whichever place-order CUF was started (market or limit); the
-          // other is a no-op.
           const failedData = {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ORDER_FAILED,
           };
-          endPlaceOrderCuf(failedData);
-          endLimitOrderCuf(failedData);
+          endStartedPlaceOrderCuf(failedData);
           setError(errorMessage);
           DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
 
@@ -332,13 +338,11 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
-        // Ends whichever place-order CUF was started; the other is a no-op.
         const exceptionData = {
           [PERPS_CUF_TAG.SUCCESS]: false,
           [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
         };
-        endPlaceOrderCuf(exceptionData);
-        endLimitOrderCuf(exceptionData);
+        endStartedPlaceOrderCuf(exceptionData);
         const errorObject = ensureError(
           err,
           'usePerpsOrderExecution.placeOrder',

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -261,13 +261,18 @@ export function usePerpsOrderExecution(
                 ?.find((p) => p.symbol === orderParams.symbol);
               const renderedPositionSnapshot =
                 getPerpsOrderPositionSnapshot(renderedPosition);
-              if (
-                // Only trust a synchronous fill when we had a real baseline to
-                // compare against; otherwise defer to the stream matcher.
+              const baselineExisted = positionBaselineSnapshot !== undefined;
+              // A synchronous fill is a position that appeared/changed versus the
+              // baseline, OR a pre-existing position now absent because the fill
+              // reduced it fully to zero (a marketable limit that closed the
+              // hold). Mirrors placeOrderPositionRendered so the fast path and
+              // the stream matcher agree. Only trusted with a loaded baseline.
+              const filledSynchronously =
                 positionsLoaded &&
-                renderedPosition &&
-                renderedPositionSnapshot !== positionBaselineSnapshot
-              ) {
+                (renderedPosition
+                  ? renderedPositionSnapshot !== positionBaselineSnapshot
+                  : baselineExisted);
+              if (filledSynchronously) {
                 // Fill already rendered before the watcher armed: end at the
                 // positions channel's last-delivery instant. This is channel-
                 // granular (positions re-deliver on any PnL tick), so it upper-

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -80,6 +80,11 @@ export function usePerpsOrderExecution(
       // Place-order CUF: submit -> matching position rendered by the stream.
       // The confirmation toast is coupled to the same stream render, so the
       // toast<->position delta is measured, not an artifact of a fixed delay.
+      // Market-only by design: the span ends on a position render, so a resting
+      // limit order would time out or fold exchange fill-wait time into an
+      // app-responsiveness metric. Limit orders are intentionally not measured
+      // here; a dedicated order-render CUF can be added later if needed.
+      const isMarketOrder = orderParams.orderType === 'market';
       const endPlaceOrderCuf = (
         data: Record<string, PerpsOrderTrackingValue>,
       ) =>
@@ -87,22 +92,34 @@ export function usePerpsOrderExecution(
           name: TraceName.PerpsPlaceOrderToPositionRendered,
           data,
         });
-      startPerpsCufTrace({
-        name: TraceName.PerpsPlaceOrderToPositionRendered,
-        tags: {
-          [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
-            ? PERPS_EVENT_VALUE.DIRECTION.LONG
-            : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-          [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
-        },
-      });
-      // Baseline lets the stream matcher tell the order's fill apart from a
-      // position that already existed on this market before the order.
-      const baseline =
-        stream.positions
-          .getSnapshot()
-          ?.find((p) => p.symbol === orderParams.symbol) ?? null;
-      const cufGeneration = armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
+      const endPlaceOrderRendered = (
+        renderedAt: number,
+        toastShownAt: number,
+      ) =>
+        endPlaceOrderCuf({
+          [PERPS_CUF_TAG.SUCCESS]: true,
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+          [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]: renderedAt - toastShownAt,
+        });
+      let cufGeneration = 0;
+      if (isMarketOrder) {
+        startPerpsCufTrace({
+          name: TraceName.PerpsPlaceOrderToPositionRendered,
+          tags: {
+            [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
+              ? PERPS_EVENT_VALUE.DIRECTION.LONG
+              : PERPS_EVENT_VALUE.DIRECTION.SHORT,
+            [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
+          },
+        });
+        // Baseline lets the stream matcher tell the order's fill apart from a
+        // position that already existed on this market before the order.
+        const baseline =
+          stream.positions
+            .getSnapshot()
+            ?.find((p) => p.symbol === orderParams.symbol) ?? null;
+        cufGeneration = armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
+      }
 
       try {
         setIsPlacing(true);
@@ -169,58 +186,54 @@ export function usePerpsOrderExecution(
             track(MetaMetricsEvents.PERPS_TRADE_TRANSACTION, partialProps);
           }
 
-          // Wait briefly for the stream to render the new/changed position so
-          // the confirmation toast fires together with it.
-          const rendered = await waitForPerpsPlaceOrderPositionRendered(
-            PERPS_CUF_STREAM_CONFIRM_RACE_MS,
-            cufGeneration,
-          );
-          const toastShownAt = Date.now();
-          if (rendered) {
-            endPlaceOrderCuf({
-              [PERPS_CUF_TAG.SUCCESS]: true,
-              [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-              [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]:
-                rendered.renderedAt - toastShownAt,
-            });
-            const position = stream.positions
-              .getSnapshot()
-              ?.find((p) => p.symbol === orderParams.symbol);
-            DevLogger.log(
-              'usePerpsOrderExecution: Position rendered by stream',
-              rendered.position,
-            );
-            onSuccess?.(position);
-          } else {
-            // Stream quiet: unblock the toast now, end the span when the
-            // position finally renders (or record the miss on timeout).
-            DevLogger.log(
-              'usePerpsOrderExecution: Position not rendered yet, toasting without it',
-            );
+          if (!isMarketOrder) {
+            // Resting limit order: accepted, no position renders now. Confirm
+            // immediately; the position-render CUF does not apply.
             onSuccess?.();
-            // Deliberately not awaited: the caller must not block on the span.
-            waitForPerpsPlaceOrderPositionRendered(
-              PERPS_CUF_STREAM_TIMEOUT_MS,
+          } else {
+            // Wait briefly for the stream to render the new/changed position so
+            // the confirmation toast fires together with it.
+            const rendered = await waitForPerpsPlaceOrderPositionRendered(
+              PERPS_CUF_STREAM_CONFIRM_RACE_MS,
               cufGeneration,
-            ).then((late) => {
-              // A newer order owns the span now; this continuation is stale.
-              if (!isPerpsPlaceOrderCufCurrent(cufGeneration)) {
-                return;
-              }
-              if (late) {
-                endPlaceOrderCuf({
-                  [PERPS_CUF_TAG.SUCCESS]: true,
-                  [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-                  [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]:
-                    late.renderedAt - toastShownAt,
-                });
-              } else {
-                endPlaceOrderCuf({
-                  [PERPS_CUF_TAG.SUCCESS]: false,
-                  [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-                });
-              }
-            });
+            );
+            const toastShownAt = Date.now();
+            if (rendered) {
+              endPlaceOrderRendered(rendered.renderedAt, toastShownAt);
+              const position = stream.positions
+                .getSnapshot()
+                ?.find((p) => p.symbol === orderParams.symbol);
+              DevLogger.log(
+                'usePerpsOrderExecution: Position rendered by stream',
+                rendered.position,
+              );
+              onSuccess?.(position);
+            } else {
+              // Stream quiet: unblock the toast now, end the span when the
+              // position finally renders (or record the miss on timeout).
+              DevLogger.log(
+                'usePerpsOrderExecution: Position not rendered yet, toasting without it',
+              );
+              onSuccess?.();
+              // Deliberately not awaited: the caller must not block on the span.
+              waitForPerpsPlaceOrderPositionRendered(
+                PERPS_CUF_STREAM_TIMEOUT_MS,
+                cufGeneration,
+              ).then((late) => {
+                // A newer order owns the span now; this continuation is stale.
+                if (!isPerpsPlaceOrderCufCurrent(cufGeneration)) {
+                  return;
+                }
+                if (late) {
+                  endPlaceOrderRendered(late.renderedAt, toastShownAt);
+                } else {
+                  endPlaceOrderCuf({
+                    [PERPS_CUF_TAG.SUCCESS]: false,
+                    [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+                  });
+                }
+              });
+            }
           }
         } else {
           const errorMessage =

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -117,6 +117,18 @@ export function usePerpsOrderExecution(
           },
           timestamp: renderedAt,
         });
+      // Limit fast-path end: the confirming order/fill was already present in the
+      // stream cache when we checked, so end at the channel's last delivery
+      // instant rather than now (falls back to now if unavailable).
+      const endCufStreamRendered = (renderedAt: number | null) =>
+        endPerpsCufTrace({
+          id: cufOpId,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: true,
+            [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+          },
+          timestamp: renderedAt ?? undefined,
+        });
       // Baseline lets stream matchers tell this order's fill apart from a
       // position that already existed on this market before submission. A null
       // cache means "not loaded", not "no position" — pass that through so the
@@ -143,21 +155,19 @@ export function usePerpsOrderExecution(
         );
       }
 
-      // Safety fallback anchored at the gesture: if the controller never
-      // returns (a hung request), none of the per-flow ends run, so this
-      // guarantees the span is always closed and never leaks in the pending
-      // registry. It is idempotent, so the real end (render or failure) no-ops
-      // it whenever that happens first.
-      endPerpsCufTraceAfter(
-        {
-          id: cufOpId,
-          data: {
+      // Safety watchdog anchored at the gesture: if the controller never
+      // returns (a hung request), none of the per-flow ends run, so this closes
+      // the span. Once the controller settles, stream-specific waits own the
+      // timeout window and this watchdog must not race them.
+      let controllerSettled = false;
+      setTimeout(() => {
+        if (!controllerSettled) {
+          endCuf({
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-          },
-        },
-        PERPS_CUF_STREAM_TIMEOUT_MS,
-      );
+          });
+        }
+      }, PERPS_CUF_STREAM_TIMEOUT_MS);
 
       try {
         setIsPlacing(true);
@@ -172,6 +182,7 @@ export function usePerpsOrderExecution(
         onSubmitted?.();
 
         const result = await controllerPlaceOrder(orderParams);
+        controllerSettled = true;
         setLastResult(result);
 
         if (result.success) {
@@ -238,11 +249,9 @@ export function usePerpsOrderExecution(
             } else if (
               stream.orders.getSnapshot()?.some((o) => o.orderId === orderId)
             ) {
-              // Already rendered between submit and here.
-              endCuf({
-                [PERPS_CUF_TAG.SUCCESS]: true,
-                [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-              });
+              // Already rested between submit and here: end at the delivery
+              // instant, not now.
+              endCufStreamRendered(stream.orders.getLastDeliveredAt());
             } else {
               // End when the order rests in the orders stream, or — for a
               // marketable limit that fills immediately — when it renders as a
@@ -259,10 +268,8 @@ export function usePerpsOrderExecution(
                 renderedPosition &&
                 renderedPositionSnapshot !== positionBaselineSnapshot
               ) {
-                endCuf({
-                  [PERPS_CUF_TAG.SUCCESS]: true,
-                  [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-                });
+                // Fill already rendered: end at the positions delivery instant.
+                endCufStreamRendered(stream.positions.getLastDeliveredAt());
               } else {
                 watchPerpsCufLimitRendered(
                   cufOpId,
@@ -374,6 +381,7 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
+        controllerSettled = true;
         endCuf({
           [PERPS_CUF_TAG.SUCCESS]: false,
           [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -16,6 +16,19 @@ import {
 import { usePerpsEventTracking } from './usePerpsEventTracking';
 import { usePerpsMeasurement } from './usePerpsMeasurement';
 import { usePerpsTrading } from './usePerpsTrading';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTrace,
+  endPerpsCufTraceAfter,
+  setPerpsPlaceOrderCufSymbol,
+  setPerpsPlaceOrderCufToastShown,
+} from '../utils/perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_END_REASON,
+  PERPS_CUF_BOUNDARY,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 
 interface UsePerpsOrderExecutionParams {
   /** Called when the order has been successfully submitted to the exchange (before position fetch). */
@@ -57,6 +70,42 @@ export function usePerpsOrderExecution(
 
   const placeOrder = useCallback(
     async (orderParams: OrderParams) => {
+      // Place-order CUF: submit -> matching position confirmed. toast delta is
+      // measured against the MSO <=200ms target; the post-submit getPositions
+      // check is the position-confirmed proxy.
+      let toastAt: number | undefined;
+      const endPlaceOrderCuf = (
+        data: Record<string, string | number | boolean>,
+      ) =>
+        endPerpsCufTrace({
+          name: TraceName.PerpsPlaceOrderToPositionRendered,
+          data,
+        });
+      // Used when the poll misses the position: keeps the span open for the
+      // stream boundary but guarantees it closes if the stream never delivers.
+      const schedulePlaceOrderCufTimeout = () =>
+        endPerpsCufTraceAfter(
+          {
+            name: TraceName.PerpsPlaceOrderToPositionRendered,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+            },
+          },
+          PERPS_CUF_STREAM_TIMEOUT_MS,
+        );
+      startPerpsCufTrace({
+        name: TraceName.PerpsPlaceOrderToPositionRendered,
+        tags: {
+          [PERPS_CUF_TAG.DIRECTION]: orderParams.isBuy
+            ? PERPS_EVENT_VALUE.DIRECTION.LONG
+            : PERPS_EVENT_VALUE.DIRECTION.SHORT,
+          [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
+        },
+      });
+      // The position stream ends this span when the matching position renders.
+      setPerpsPlaceOrderCufSymbol(orderParams.symbol);
+
       try {
         setIsPlacing(true);
         setError(undefined);
@@ -71,6 +120,9 @@ export function usePerpsOrderExecution(
 
         const result = await controllerPlaceOrder(orderParams);
         setLastResult(result);
+        // Toast fires on lastResult — stamp it to measure the toast<->position delta.
+        toastAt = Date.now();
+        setPerpsPlaceOrderCufToastShown();
 
         if (result.success) {
           DevLogger.log(
@@ -133,12 +185,22 @@ export function usePerpsOrderExecution(
             );
 
             if (newPosition) {
+              // No-op when the position stream already closed the span.
+              endPlaceOrderCuf({
+                [PERPS_CUF_TAG.SUCCESS]: true,
+                [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.POLL_FALLBACK,
+                [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]:
+                  toastAt !== undefined ? Date.now() - toastAt : -1,
+              });
               DevLogger.log(
                 'usePerpsOrderExecution: Found new position',
                 newPosition,
               );
               onSuccess?.(newPosition);
             } else {
+              // Poll missed the position — leave the span open for the stream
+              // boundary, with a timeout end in case the stream never delivers.
+              schedulePlaceOrderCufTimeout();
               DevLogger.log(
                 'usePerpsOrderExecution: Position not found immediately',
               );
@@ -146,6 +208,7 @@ export function usePerpsOrderExecution(
               onSuccess?.();
             }
           } catch (fetchError) {
+            schedulePlaceOrderCufTimeout();
             DevLogger.log(
               'usePerpsOrderExecution: Error fetching positions after order',
               fetchError,
@@ -156,6 +219,10 @@ export function usePerpsOrderExecution(
         } else {
           const errorMessage =
             result.error || strings('perps.order.error.unknown');
+          endPlaceOrderCuf({
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.ORDER_FAILED,
+          });
           setError(errorMessage);
           DevLogger.log('usePerpsOrderExecution: Order failed', errorMessage);
 
@@ -194,6 +261,10 @@ export function usePerpsOrderExecution(
           onError?.(errorMessage);
         }
       } catch (err) {
+        endPlaceOrderCuf({
+          [PERPS_CUF_TAG.SUCCESS]: false,
+          [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+        });
         const errorObject = ensureError(
           err,
           'usePerpsOrderExecution.placeOrder',

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -19,20 +19,22 @@ import { usePerpsTrading } from './usePerpsTrading';
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
-  endPerpsCufTraceAfter,
-  setPerpsPlaceOrderCufSymbol,
-  setPerpsPlaceOrderCufToastShown,
+  armPerpsPlaceOrderCuf,
+  waitForPerpsPlaceOrderPositionRendered,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
   PERPS_CUF_END_REASON,
   PERPS_CUF_BOUNDARY,
   PERPS_CUF_STREAM_TIMEOUT_MS,
+  PERPS_CUF_STREAM_CONFIRM_RACE_MS,
 } from '../constants/perpsCufTags';
+import { usePerpsStream } from '../providers/PerpsStreamManager';
 
 interface UsePerpsOrderExecutionParams {
-  /** Called when the order has been successfully submitted to the exchange (before position fetch). */
+  /** Called when the order has been successfully submitted to the exchange. */
   onSubmitted?: () => void;
+  /** Called when the position has rendered via the stream (or, on stream timeout, without it). */
   onSuccess?: (position?: Position) => void;
   onError?: (error: string) => void;
 }
@@ -48,14 +50,16 @@ type PerpsOrderTrackingValue = string | number | boolean;
 
 /**
  * Hook to handle order execution flow
- * Manages loading states, success/error handling, and position fetching
+ * Manages loading states, success/error handling, and stream-confirmed
+ * position rendering
  */
 export function usePerpsOrderExecution(
   params: UsePerpsOrderExecutionParams = {},
 ): UsePerpsOrderExecutionReturn {
   const { onSubmitted, onSuccess, onError } = params;
-  const { placeOrder: controllerPlaceOrder, getPositions } = usePerpsTrading();
+  const { placeOrder: controllerPlaceOrder } = usePerpsTrading();
   const { track } = usePerpsEventTracking();
+  const stream = usePerpsStream();
 
   const [isPlacing, setIsPlacing] = useState(false);
   const [lastResult, setLastResult] = useState<OrderResult>();
@@ -72,10 +76,9 @@ export function usePerpsOrderExecution(
 
   const placeOrder = useCallback(
     async (orderParams: OrderParams) => {
-      // Place-order CUF: submit -> matching position confirmed. toast delta is
-      // measured against the MSO <=200ms target; the post-submit getPositions
-      // check is the position-confirmed proxy.
-      let toastAt: number | undefined;
+      // Place-order CUF: submit -> matching position rendered by the stream.
+      // The confirmation toast is coupled to the same stream render, so the
+      // toast<->position delta is measured, not an artifact of a fixed delay.
       const endPlaceOrderCuf = (
         data: Record<string, PerpsOrderTrackingValue>,
       ) =>
@@ -83,19 +86,6 @@ export function usePerpsOrderExecution(
           name: TraceName.PerpsPlaceOrderToPositionRendered,
           data,
         });
-      // Used when the poll misses the position: keeps the span open for the
-      // stream boundary but guarantees it closes if the stream never delivers.
-      const schedulePlaceOrderCufTimeout = () =>
-        endPerpsCufTraceAfter(
-          {
-            name: TraceName.PerpsPlaceOrderToPositionRendered,
-            data: {
-              [PERPS_CUF_TAG.SUCCESS]: false,
-              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-            },
-          },
-          PERPS_CUF_STREAM_TIMEOUT_MS,
-        );
       startPerpsCufTrace({
         name: TraceName.PerpsPlaceOrderToPositionRendered,
         tags: {
@@ -105,8 +95,13 @@ export function usePerpsOrderExecution(
           [PERPS_CUF_TAG.ORDER_TYPE]: orderParams.orderType,
         },
       });
-      // The position stream ends this span when the matching position renders.
-      setPerpsPlaceOrderCufSymbol(orderParams.symbol);
+      // Baseline lets the stream matcher tell the order's fill apart from a
+      // position that already existed on this market before the order.
+      const baseline =
+        stream.positions
+          .getSnapshot()
+          ?.find((p) => p.symbol === orderParams.symbol) ?? null;
+      armPerpsPlaceOrderCuf(orderParams.symbol, baseline);
 
       try {
         setIsPlacing(true);
@@ -122,9 +117,6 @@ export function usePerpsOrderExecution(
 
         const result = await controllerPlaceOrder(orderParams);
         setLastResult(result);
-        // Toast fires on lastResult — stamp it to measure the toast<->position delta.
-        toastAt = Date.now();
-        setPerpsPlaceOrderCufToastShown();
 
         if (result.success) {
           DevLogger.log(
@@ -176,47 +168,52 @@ export function usePerpsOrderExecution(
             track(MetaMetricsEvents.PERPS_TRADE_TRANSACTION, partialProps);
           }
 
-          // Try to fetch the newly created position
-          try {
-            // Add a small delay to ensure the position is available
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-
-            const fetchedPositions = await getPositions();
-            const newPosition = fetchedPositions.find(
-              (p) => p.symbol === orderParams.symbol,
-            );
-
-            if (newPosition) {
-              // No-op when the position stream already closed the span.
-              endPlaceOrderCuf({
-                [PERPS_CUF_TAG.SUCCESS]: true,
-                [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.POLL_FALLBACK,
-                [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]:
-                  toastAt !== undefined ? Date.now() - toastAt : -1,
-              });
-              DevLogger.log(
-                'usePerpsOrderExecution: Found new position',
-                newPosition,
-              );
-              onSuccess?.(newPosition);
-            } else {
-              // Poll missed the position — leave the span open for the stream
-              // boundary, with a timeout end in case the stream never delivers.
-              schedulePlaceOrderCufTimeout();
-              DevLogger.log(
-                'usePerpsOrderExecution: Position not found immediately',
-              );
-              // Still call success, but without position data
-              onSuccess?.();
-            }
-          } catch (fetchError) {
-            schedulePlaceOrderCufTimeout();
+          // Wait briefly for the stream to render the new/changed position so
+          // the confirmation toast fires together with it.
+          const rendered = await waitForPerpsPlaceOrderPositionRendered(
+            PERPS_CUF_STREAM_CONFIRM_RACE_MS,
+          );
+          const toastShownAt = Date.now();
+          if (rendered) {
+            endPlaceOrderCuf({
+              [PERPS_CUF_TAG.SUCCESS]: true,
+              [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+              [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]:
+                rendered.renderedAt - toastShownAt,
+            });
+            const position = stream.positions
+              .getSnapshot()
+              ?.find((p) => p.symbol === orderParams.symbol);
             DevLogger.log(
-              'usePerpsOrderExecution: Error fetching positions after order',
-              fetchError,
+              'usePerpsOrderExecution: Position rendered by stream',
+              rendered.position,
             );
-            // Don't fail the whole operation, just proceed without position data
+            onSuccess?.(position);
+          } else {
+            // Stream quiet: unblock the toast now, end the span when the
+            // position finally renders (or record the miss on timeout).
+            DevLogger.log(
+              'usePerpsOrderExecution: Position not rendered yet, toasting without it',
+            );
             onSuccess?.();
+            // Deliberately not awaited: the caller must not block on the span.
+            waitForPerpsPlaceOrderPositionRendered(
+              PERPS_CUF_STREAM_TIMEOUT_MS,
+            ).then((late) => {
+              if (late) {
+                endPlaceOrderCuf({
+                  [PERPS_CUF_TAG.SUCCESS]: true,
+                  [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+                  [PERPS_CUF_TAG.TOAST_POSITION_DELTA_MS]:
+                    late.renderedAt - toastShownAt,
+                });
+              } else {
+                endPlaceOrderCuf({
+                  [PERPS_CUF_TAG.SUCCESS]: false,
+                  [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+                });
+              }
+            });
           }
         } else {
           const errorMessage =
@@ -337,14 +334,7 @@ export function usePerpsOrderExecution(
         setIsPlacing(false);
       }
     },
-    [
-      controllerPlaceOrder,
-      getPositions,
-      onSubmitted,
-      onSuccess,
-      onError,
-      track,
-    ],
+    [controllerPlaceOrder, stream, onSubmitted, onSuccess, onError, track],
   );
 
   return {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -79,13 +79,6 @@ export function usePerpsOrderExecution(
 
   const placeOrder = useCallback(
     async (orderParams: OrderParams) => {
-      // Place-order CUF: submit -> matching position rendered by the stream.
-      // The confirmation toast is coupled to the same stream render, so the
-      // toast<->position delta is measured, not an artifact of a fixed delay.
-      // Market-only by design: the span ends on a position render, so a resting
-      // limit order would time out or fold exchange fill-wait time into an
-      // app-responsiveness metric. Limit orders are intentionally not measured
-      // here; a dedicated order-render CUF can be added later if needed.
       // Market orders measure submit -> position rendered (toast coupled to the
       // same stream render) via PerpsPlaceOrderToPositionRendered. Limit orders
       // measure submit -> resting order rendered in the orders stream (no

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.ts
@@ -50,19 +50,11 @@ interface UsePerpsOrderExecutionReturn {
 }
 
 type PerpsOrderTrackingValue = string | number | boolean;
-type PerpsOrderPositionSnapshot = Pick<
-  Position,
-  'size' | 'takeProfitPrice' | 'stopLossPrice'
->;
+type PerpsOrderPositionSnapshot = Pick<Position, 'size'>;
 
 const getPerpsOrderPositionSnapshot = (
   position?: PerpsOrderPositionSnapshot | null,
-) =>
-  position
-    ? `${position.size}|${position.takeProfitPrice ?? ''}|${
-        position.stopLossPrice ?? ''
-      }`
-    : undefined;
+) => (position ? position.size : undefined);
 
 /**
  * Hook to handle order execution flow

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -16,7 +16,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
-  watchPerpsCufPositionChanged,
+  watchPerpsCufTpSlChanged,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -58,7 +58,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       const tpslCufOpId = startPerpsCufTrace({
         name: TraceName.PerpsUpdateTPSLToConfirmation,
       });
-      watchPerpsCufPositionChanged(tpslCufOpId, position);
+      watchPerpsCufTpSlChanged(tpslCufOpId, position);
       endPerpsCufTraceAfter(
         {
           id: tpslCufOpId,

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -11,6 +11,18 @@ import {
 } from '@metamask/perps-controller';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
+import { TraceName } from '../../../../util/trace';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTrace,
+  endPerpsCufTraceAfter,
+  watchPerpsCufPositionChanged,
+} from '../utils/perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_END_REASON,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 
 interface UseTPSLUpdateOptions {
   onSuccess?: () => void;
@@ -38,6 +50,24 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
     ): Promise<{ success: boolean }> => {
       setIsUpdating(true);
       DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to true');
+
+      // Confirmation CUF: ends when the stream shows the position's TP/SL
+      // values changed (the optimistic patch renders through the same path).
+      startPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
+      watchPerpsCufPositionChanged(
+        TraceName.PerpsUpdateTPSLToConfirmation,
+        position,
+      );
+      endPerpsCufTraceAfter(
+        {
+          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+          },
+        },
+        PERPS_CUF_STREAM_TIMEOUT_MS,
+      );
 
       try {
         const result = await updatePositionTPSL({
@@ -69,6 +99,13 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           return { success: true };
         }
         DevLogger.log('Failed to update position TP/SL:', result.error);
+        endPerpsCufTrace({
+          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
+          },
+        });
 
         const errorMessage = result.error || strings('perps.errors.unknown');
 
@@ -83,6 +120,13 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
         return { success: false };
       } catch (error) {
+        endPerpsCufTrace({
+          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+          },
+        });
         DevLogger.log('Error updating position TP/SL:', error);
 
         Logger.error(ensureError(error, 'usePerpsTPSLUpdate.handle'), {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -53,14 +53,13 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
 
       // Confirmation CUF: ends when the stream shows the position's TP/SL
       // values changed (the optimistic patch renders through the same path).
-      startPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
-      watchPerpsCufPositionChanged(
-        TraceName.PerpsUpdateTPSLToConfirmation,
-        position,
-      );
+      const tpslCufOpId = startPerpsCufTrace({
+        name: TraceName.PerpsUpdateTPSLToConfirmation,
+      });
+      watchPerpsCufPositionChanged(tpslCufOpId, position);
       endPerpsCufTraceAfter(
         {
-          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          id: tpslCufOpId,
           data: {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
@@ -100,7 +99,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
         }
         DevLogger.log('Failed to update position TP/SL:', result.error);
         endPerpsCufTrace({
-          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          id: tpslCufOpId,
           data: {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
@@ -121,7 +120,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
         return { success: false };
       } catch (error) {
         endPerpsCufTrace({
-          name: TraceName.PerpsUpdateTPSLToConfirmation,
+          id: tpslCufOpId,
           data: {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -15,7 +15,7 @@ import { TraceName } from '../../../../util/trace';
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
-  endPerpsCufTraceAfter,
+  endPerpsCufRequestAfter,
   watchPerpsCufTpSlChanged,
   acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
@@ -60,14 +60,10 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
         name: TraceName.PerpsUpdateTPSLToConfirmation,
       });
       watchPerpsCufTpSlChanged(tpslCufOpId, position);
-      endPerpsCufTraceAfter(
-        {
-          id: tpslCufOpId,
-          data: {
-            [PERPS_CUF_TAG.SUCCESS]: false,
-            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-          },
-        },
+      let controllerSettled = false;
+      endPerpsCufRequestAfter(
+        tpslCufOpId,
+        () => controllerSettled,
         PERPS_CUF_STREAM_TIMEOUT_MS,
       );
 
@@ -79,6 +75,7 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
           trackingData,
           position, // Pass live WebSocket position to avoid REST API fetch (prevents rate limiting)
         });
+        controllerSettled = true;
 
         if (result.success) {
           // Controller accepted the update: open the gate before the optimistic

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -17,6 +17,7 @@ import {
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
   watchPerpsCufTpSlChanged,
+  acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -80,6 +81,11 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
         });
 
         if (result.success) {
+          // Controller accepted the update: open the gate before the optimistic
+          // render so a TP/SL change can complete the CUF as a success. A failed
+          // request never reaches here, so it can't be recorded as a success.
+          acceptPerpsCufRequest(tpslCufOpId);
+
           DevLogger.log('Position TP/SL updated successfully:', result);
 
           // Apply optimistic update immediately for better UX

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.ts
@@ -51,8 +51,10 @@ export function usePerpsTPSLUpdate(options?: UseTPSLUpdateOptions) {
       setIsUpdating(true);
       DevLogger.log('usePerpsTPSLUpdate: Setting isUpdating to true');
 
-      // Confirmation CUF: ends when the stream shows the position's TP/SL
-      // values changed (the optimistic patch renders through the same path).
+      // Confirmation CUF: ends when the live positions stream delivers the
+      // backend-confirmed TP/SL change (that delivery runs the CUF dispatcher).
+      // The optimistic cache patch renders sooner but does not end the span, so
+      // this measures gesture -> confirmed live data, not the optimistic guess.
       const tpslCufOpId = startPerpsCufTrace({
         name: TraceName.PerpsUpdateTPSLToConfirmation,
       });

--- a/app/components/UI/Perps/hooks/usePerpsTrading.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.ts
@@ -41,6 +41,7 @@ import {
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
   watchPerpsCufOrderAbsent,
+  acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -103,6 +104,12 @@ export function usePerpsTrading() {
               [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
             },
           });
+        } else {
+          // Only now may a stream absence complete the span as a success — the
+          // controller accepted the cancel. If the order already vanished while
+          // the request was in flight, the render instant was recorded and the
+          // span ends at it here.
+          acceptPerpsCufRequest(cancelCufOpId);
         }
         return result;
       } catch (error) {

--- a/app/components/UI/Perps/hooks/usePerpsTrading.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.ts
@@ -39,7 +39,7 @@ import { TraceName } from '../../../../util/trace';
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
-  endPerpsCufTraceAfter,
+  endPerpsCufRequestAfter,
   watchPerpsCufOrderAbsent,
   acceptPerpsCufRequest,
 } from '../utils/perpsCufTrace';
@@ -84,18 +84,15 @@ export function usePerpsTrading() {
         name: TraceName.PerpsCancelOrderToConfirmation,
       });
       watchPerpsCufOrderAbsent(cancelCufOpId, params.orderId);
-      endPerpsCufTraceAfter(
-        {
-          id: cancelCufOpId,
-          data: {
-            [PERPS_CUF_TAG.SUCCESS]: false,
-            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
-          },
-        },
+      let controllerSettled = false;
+      endPerpsCufRequestAfter(
+        cancelCufOpId,
+        () => controllerSettled,
         PERPS_CUF_STREAM_TIMEOUT_MS,
       );
       try {
         const result = await controller.cancelOrder(params);
+        controllerSettled = true;
         if (!result?.success) {
           endPerpsCufTrace({
             id: cancelCufOpId,

--- a/app/components/UI/Perps/hooks/usePerpsTrading.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.ts
@@ -35,6 +35,18 @@ import {
   type WithdrawParams,
   type WithdrawResult,
 } from '@metamask/perps-controller';
+import { TraceName } from '../../../../util/trace';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTrace,
+  endPerpsCufTraceAfter,
+  watchPerpsCufOrderAbsent,
+} from '../utils/perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_END_REASON,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 
 /**
  * UI-facing params for fetching markets.
@@ -65,7 +77,45 @@ export function usePerpsTrading() {
   const cancelOrder = useCallback(
     async (params: CancelOrderParams): Promise<CancelOrderResult> => {
       const controller = Engine.context.PerpsController;
-      return controller.cancelOrder(params);
+      // Confirmation CUF: every cancel UI path funnels through here; the span
+      // ends when the stream no longer lists the order.
+      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      watchPerpsCufOrderAbsent(
+        TraceName.PerpsCancelOrderToConfirmation,
+        params.orderId,
+      );
+      endPerpsCufTraceAfter(
+        {
+          name: TraceName.PerpsCancelOrderToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+          },
+        },
+        PERPS_CUF_STREAM_TIMEOUT_MS,
+      );
+      try {
+        const result = await controller.cancelOrder(params);
+        if (!result?.success) {
+          endPerpsCufTrace({
+            name: TraceName.PerpsCancelOrderToConfirmation,
+            data: {
+              [PERPS_CUF_TAG.SUCCESS]: false,
+              [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
+            },
+          });
+        }
+        return result;
+      } catch (error) {
+        endPerpsCufTrace({
+          name: TraceName.PerpsCancelOrderToConfirmation,
+          data: {
+            [PERPS_CUF_TAG.SUCCESS]: false,
+            [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+          },
+        });
+        throw error;
+      }
     },
     [],
   );

--- a/app/components/UI/Perps/hooks/usePerpsTrading.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.ts
@@ -79,14 +79,13 @@ export function usePerpsTrading() {
       const controller = Engine.context.PerpsController;
       // Confirmation CUF: every cancel UI path funnels through here; the span
       // ends when the stream no longer lists the order.
-      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
-      watchPerpsCufOrderAbsent(
-        TraceName.PerpsCancelOrderToConfirmation,
-        params.orderId,
-      );
+      const cancelCufOpId = startPerpsCufTrace({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+      });
+      watchPerpsCufOrderAbsent(cancelCufOpId, params.orderId);
       endPerpsCufTraceAfter(
         {
-          name: TraceName.PerpsCancelOrderToConfirmation,
+          id: cancelCufOpId,
           data: {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
@@ -98,7 +97,7 @@ export function usePerpsTrading() {
         const result = await controller.cancelOrder(params);
         if (!result?.success) {
           endPerpsCufTrace({
-            name: TraceName.PerpsCancelOrderToConfirmation,
+            id: cancelCufOpId,
             data: {
               [PERPS_CUF_TAG.SUCCESS]: false,
               [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.REQUEST_FAILED,
@@ -108,7 +107,7 @@ export function usePerpsTrading() {
         return result;
       } catch (error) {
         endPerpsCufTrace({
-          name: TraceName.PerpsCancelOrderToConfirmation,
+          id: cancelCufOpId,
           data: {
             [PERPS_CUF_TAG.SUCCESS]: false,
             [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,

--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
@@ -13,6 +13,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../services/PerpsConnectionManager');
 
+jest.mock('../utils/perpsLifecycleContext', () => ({
+  initPerpsLifecycleTracking: jest.fn(() => jest.fn()),
+}));
+
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PerpsController: {

--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
@@ -8,6 +8,7 @@ import { selectPerpsEnabledFlag } from '../index';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { ensureError } from '../../../../util/errorUtils';
+import { initPerpsLifecycleTracking } from '../utils/perpsLifecycleContext';
 
 /**
  * Top-level always-on provider for Perps WebSocket connections.
@@ -30,6 +31,9 @@ export const PerpsAlwaysOnProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  // Track AppState so Perps CUF spans can tag lifecycle_context.
+  useEffect(() => initPerpsLifecycleTracking(), []);
 
   useEffect(() => {
     const controller = Engine.context.PerpsController;

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -976,11 +976,17 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
 
         this.cache.set('orders', orders);
         this.notifySubscribers(orders);
-        // Orders just rendered to subscribers — close pending cancel / limit
-        // order-render CUF spans, flushing throttled subscribers first so the
-        // span ends when they actually render, not at throttle-enqueue time.
-        // Skip while paused: notifySubscribers delivered nothing, so nothing
-        // rendered.
+        // Orders confirmed in the live stream — close pending cancel / limit
+        // order-render CUF spans at this delivery instant. The boundary is
+        // stream confirmation (the order is now present/absent in live orders
+        // data), which the always-on prewarm subscription keeps observable even
+        // though the submitting surface (the order form, a confirmations modal)
+        // does not itself subscribe to orders; the initiating screen under that
+        // modal (Market Details / positions / home) does subscribe, so the
+        // flush-on-confirm renders it there at the same instant. Deliberately
+        // NOT gated on a real subscriber: the order form path has none of its
+        // own, so gating would time out a genuine confirmation.
+        // Skip while paused: notifySubscribers delivered nothing.
         if (this.pauseCount === 0) {
           handlePerpsCufOrdersDelivered(orders, () =>
             this.flushThrottledDeliveries(),

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -471,6 +471,9 @@ abstract class StreamChannel<T> {
   }
 
   public clearCache(): void {
+    // End any first-data trace still open, so clearing the cache before first
+    // data doesn't leave a span running until the 5-minute auto-clean.
+    this.endOpenFirstDataTrace();
     // This ensures no timers are orphaned during the disconnect/reconnect cycle
     this.subscribers.forEach((subscriber) => {
       // Clear any pending updates and timers
@@ -1003,14 +1006,16 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
   }
 
   public disconnect() {
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     super.disconnect();
   }
 
   public clearCache(): void {
     // Cleanup pre-warm subscription
     this.cleanupPrewarm();
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     // Call parent clearCache
     super.clearCache();
   }
@@ -1153,14 +1158,16 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
   }
 
   public disconnect() {
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     super.disconnect();
   }
 
   public clearCache(): void {
     // Cleanup pre-warm subscription
     this.cleanupPrewarm();
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     // Call parent clearCache
     super.clearCache();
   }
@@ -1418,14 +1425,16 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
   }
 
   public disconnect() {
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     super.disconnect();
   }
 
   public clearCache(): void {
     // Cleanup pre-warm subscription
     this.cleanupPrewarm();
-    this.firstDataTraceId = undefined;
+    // End (not just drop) any open first-data trace before the base teardown.
+    this.endOpenFirstDataTrace();
     // Call parent clearCache
     super.clearCache();
   }

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -42,6 +42,7 @@ import {
 } from '@metamask/perps-controller/constants/perpsConfig';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import { getE2EMockStreamManager } from '../utils/e2eBridgePerps';
+import { endPerpsPlaceOrderCufOnPositions } from '../utils/perpsCufTrace';
 import { CandleStreamChannel } from './channels/CandleStreamChannel';
 import { getPreloadedData } from '../hooks/stream/hasCachedPerpsData';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -963,6 +964,9 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
 
         this.cache.set('positions', positions);
         this.notifySubscribers(positions);
+        // Positions just rendered to subscribers — close a pending
+        // place-order CUF span at its user-perceived boundary.
+        endPerpsPlaceOrderCufOnPositions(positions);
         this.triggerPersist();
       },
     });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -102,6 +102,11 @@ abstract class StreamChannel<T> {
   // allowing independent callers (tab visibility, controller operations) to
   // pause/resume without clobbering each other.
   protected pauseCount = 0;
+  // Wall-clock instant of the most recent real delivery to subscribers (unset
+  // while paused, since nothing rendered). Lets a caller that reads getSnapshot()
+  // attribute an already-present value to the instant it was delivered rather
+  // than to when the caller happened to look.
+  protected lastDeliveredAt: number | null = null;
   // Retry counter for deferred connect() calls
   protected connectRetryCount = 0;
   // Timer handle for deferConnect so it can be cancelled on disconnect
@@ -114,9 +119,20 @@ abstract class StreamChannel<T> {
       return;
     }
 
+    this.lastDeliveredAt = Date.now();
     this.subscribers.forEach((subscriber) => {
       this.deliverToSubscriber(subscriber, updates);
     });
+  }
+
+  /**
+   * Wall-clock instant of the most recent real delivery on this channel, or null
+   * if nothing has been delivered (or the channel is paused). Used to timestamp a
+   * CUF span end at the delivery instant when the confirming value was already
+   * present by the time the caller checked getSnapshot().
+   */
+  public getLastDeliveredAt(): number | null {
+    return this.lastDeliveredAt;
   }
 
   /**
@@ -138,6 +154,7 @@ abstract class StreamChannel<T> {
       return;
     }
 
+    this.lastDeliveredAt = Date.now();
     // A subscriber registered for multiple changed symbols must be delivered to
     // exactly once per tick (not once per matching symbol).
     const notifiedIds = new Set<string>();

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -433,7 +433,18 @@ abstract class StreamChannel<T> {
       this.wsSubscription = null;
     }
     this.accountAddress = null;
+    // End any first-data trace still open (disconnected before first data), so
+    // it isn't left running until the 5-minute auto-clean as a bogus long span.
+    this.endOpenFirstDataTrace();
     this.wsConnectionStartTime = null;
+  }
+
+  /**
+   * End a first-data ("time to first ...") trace left open at disconnect.
+   * No-op in the base; channels that start such a trace override this.
+   */
+  protected endOpenFirstDataTrace(): void {
+    // Overridden by channels with a first-data trace.
   }
 
   /**
@@ -505,6 +516,18 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
   private prewarmUnsubscribe?: () => void;
   private actualPriceUnsubscribe?: () => void;
   private firstDataTraceId?: string;
+
+  protected endOpenFirstDataTrace(): void {
+    if (this.firstDataTraceId) {
+      endTrace({
+        name: TraceName.PerpsWebSocketFirstPrice,
+        id: this.firstDataTraceId,
+        data: { success: false, reason: 'disconnected' },
+      });
+      this.firstDataTraceId = undefined;
+    }
+  }
+
   private allMarketSymbols: string[] = [];
   // Unique ID per prewarm cycle to detect stale promises and prevent subscription leaks
   private prewarmCycleId: number = 0;
@@ -841,6 +864,17 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
   private prewarmUnsubscribe?: () => void;
   private firstDataTraceId?: string;
 
+  protected endOpenFirstDataTrace(): void {
+    if (this.firstDataTraceId) {
+      endTrace({
+        name: TraceName.PerpsWebSocketFirstOrders,
+        id: this.firstDataTraceId,
+        data: { success: false, reason: 'disconnected' },
+      });
+      this.firstDataTraceId = undefined;
+    }
+  }
+
   protected connect() {
     if (this.wsSubscription) return;
 
@@ -986,6 +1020,17 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
 class PositionStreamChannel extends StreamChannel<Position[] | null> {
   private prewarmUnsubscribe?: () => void;
   private firstDataTraceId?: string;
+
+  protected endOpenFirstDataTrace(): void {
+    if (this.firstDataTraceId) {
+      endTrace({
+        name: TraceName.PerpsWebSocketFirstPositions,
+        id: this.firstDataTraceId,
+        data: { success: false, reason: 'disconnected' },
+      });
+      this.firstDataTraceId = undefined;
+    }
+  }
 
   protected connect() {
     if (this.wsSubscription) return;
@@ -1276,6 +1321,17 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
   private prewarmUnsubscribe?: () => void;
   private firstDataTraceId?: string;
 
+  protected endOpenFirstDataTrace(): void {
+    if (this.firstDataTraceId) {
+      endTrace({
+        name: TraceName.PerpsWebSocketFirstAccount,
+        id: this.firstDataTraceId,
+        data: { success: false, reason: 'disconnected' },
+      });
+      this.firstDataTraceId = undefined;
+    }
+  }
+
   protected connect() {
     if (this.wsSubscription) return;
 
@@ -1508,6 +1564,17 @@ class TopOfBookStreamChannel extends StreamChannel<
     | { bestBid?: string; bestAsk?: string; spread?: string }
     | undefined = undefined;
   private firstDataTraceId?: string;
+
+  protected endOpenFirstDataTrace(): void {
+    if (this.firstDataTraceId) {
+      endTrace({
+        name: TraceName.PerpsWebSocketFirstOrderBook,
+        id: this.firstDataTraceId,
+        data: { success: false, reason: 'disconnected' },
+      });
+      this.firstDataTraceId = undefined;
+    }
+  }
 
   protected connect() {
     if (!this.currentSymbol || this.wsSubscription) {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -130,6 +130,15 @@ abstract class StreamChannel<T> {
    * if nothing has been delivered (or the channel is paused). Used to timestamp a
    * CUF span end at the delivery instant when the confirming value was already
    * present by the time the caller checked getSnapshot().
+   *
+   * Granularity is per-channel, not per-symbol: on a full-snapshot channel like
+   * positions (which re-delivers all symbols on any PnL tick) this is effectively
+   * "the last tick", so it upper-bounds an individual symbol's change instant
+   * rather than pinpointing it. The bound is always >= the span start and <= now,
+   * so a span end using it is bounded and never optimistic — it can only slightly
+   * over-measure, never under-measure. Callers needing the exact per-symbol change
+   * instant should observe the live delivery (as the normal watcher path does),
+   * not read this after the fact.
    */
   public getLastDeliveredAt(): number | null {
     return this.lastDeliveredAt;

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -903,9 +903,13 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
         // Orders just rendered to subscribers — close pending cancel / limit
         // order-render CUF spans, flushing throttled subscribers first so the
         // span ends when they actually render, not at throttle-enqueue time.
-        handlePerpsCufOrdersDelivered(orders, () =>
-          this.flushThrottledDeliveries(),
-        );
+        // Skip while paused: notifySubscribers delivered nothing, so nothing
+        // rendered.
+        if (this.pauseCount === 0) {
+          handlePerpsCufOrdersDelivered(orders, () =>
+            this.flushThrottledDeliveries(),
+          );
+        }
         this.triggerPersist();
       },
     });
@@ -1049,9 +1053,12 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
         // Positions just rendered to subscribers — close any pending CUF span
         // (place/close/TPSL/reconnect) at its user-perceived boundary, flushing
         // throttled subscribers first so the span ends at real render time.
-        handlePerpsCufPositionsDelivered(positions, () =>
-          this.flushThrottledDeliveries(),
-        );
+        // Skip while paused: notifySubscribers delivered nothing.
+        if (this.pauseCount === 0) {
+          handlePerpsCufPositionsDelivered(positions, () =>
+            this.flushThrottledDeliveries(),
+          );
+        }
         this.triggerPersist();
       },
     });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -798,6 +798,10 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           },
         );
 
+        // End any first-price span still open from a prior connect()/prewarm
+        // before overwriting the trace id, or that span is orphaned and ships
+        // bogus first-data telemetry.
+        this.endOpenFirstDataTrace();
         // Start trace for first price measurement (prewarm is the usual
         // price subscription path; connect() covers the no-prewarm case)
         this.firstDataTraceId = uuidv4();

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -42,7 +42,10 @@ import {
 } from '@metamask/perps-controller/constants/perpsConfig';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import { getE2EMockStreamManager } from '../utils/e2eBridgePerps';
-import { endPerpsPlaceOrderCufOnPositions } from '../utils/perpsCufTrace';
+import {
+  handlePerpsCufPositionsDelivered,
+  handlePerpsCufOrdersDelivered,
+} from '../utils/perpsCufTrace';
 import { CandleStreamChannel } from './channels/CandleStreamChannel';
 import { getPreloadedData } from '../hooks/stream/hasCachedPerpsData';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -482,6 +485,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
   private readonly symbols = new Set<string>();
   private prewarmUnsubscribe?: () => void;
   private actualPriceUnsubscribe?: () => void;
+  private firstDataTraceId?: string;
   private allMarketSymbols: string[] = [];
   // Unique ID per prewarm cycle to detect stale promises and prevent subscription leaks
   private prewarmCycleId: number = 0;
@@ -544,9 +548,35 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
       return;
     }
 
+    // Start trace for first price measurement (before subscription)
+    this.firstDataTraceId = uuidv4();
+    trace({
+      name: TraceName.PerpsWebSocketFirstPrice,
+      id: this.firstDataTraceId,
+      op: TraceOperation.PerpsOperation,
+    });
+    this.wsConnectionStartTime = performance.now();
+
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
       symbols: allSymbols,
       callback: (updates: PriceUpdate[]) => {
+        // Track first price data from WebSocket (only once per connection)
+        if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
+          const firstDataDuration =
+            performance.now() - this.wsConnectionStartTime;
+          DevLogger.log(
+            `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First price data received`,
+            { duration: `${firstDataDuration.toFixed(0)}ms` },
+          );
+          endTrace({
+            name: TraceName.PerpsWebSocketFirstPrice,
+            id: this.firstDataTraceId,
+            data: { success: true, duration: firstDataDuration },
+          });
+          this.wsConnectionStartTime = null;
+          this.firstDataTraceId = undefined;
+        }
+
         // Update cache and build price map
         const priceMap: Record<string, PriceUpdate> = {};
         updates.forEach((update) => {
@@ -692,6 +722,16 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           },
         );
 
+        // Start trace for first price measurement (prewarm is the usual
+        // price subscription path; connect() covers the no-prewarm case)
+        this.firstDataTraceId = uuidv4();
+        trace({
+          name: TraceName.PerpsWebSocketFirstPrice,
+          id: this.firstDataTraceId,
+          op: TraceOperation.PerpsOperation,
+        });
+        this.wsConnectionStartTime = performance.now();
+
         // WARNING: Do NOT set includeMarketData: true here. It triggers
         // per-symbol activeAssetCtx subscriptions (N symbols × N DEXs = N²
         // WebSocket connections). assetCtxs (1 per DEX) is always established
@@ -700,6 +740,23 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           symbols: this.allMarketSymbols,
           includeMarketData: false,
           callback: (updates: PriceUpdate[]) => {
+            // Track first price data from WebSocket (only once per prewarm)
+            if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
+              const firstDataDuration =
+                performance.now() - this.wsConnectionStartTime;
+              DevLogger.log(
+                `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First price data received`,
+                { duration: `${firstDataDuration.toFixed(0)}ms` },
+              );
+              endTrace({
+                name: TraceName.PerpsWebSocketFirstPrice,
+                id: this.firstDataTraceId,
+                data: { success: true, duration: firstDataDuration },
+              });
+              this.wsConnectionStartTime = null;
+              this.firstDataTraceId = undefined;
+            }
+
             const priceMap: Record<string, PriceUpdate> = {};
             updates.forEach((update) => {
               const priceUpdate = this.toPriceUpdate(update);
@@ -824,6 +881,8 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
 
         this.cache.set('orders', orders);
         this.notifySubscribers(orders);
+        // Orders just rendered to subscribers — close a pending cancel CUF span.
+        handlePerpsCufOrdersDelivered(orders);
         this.triggerPersist();
       },
     });
@@ -964,9 +1023,9 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
 
         this.cache.set('positions', positions);
         this.notifySubscribers(positions);
-        // Positions just rendered to subscribers — close a pending
-        // place-order CUF span at its user-perceived boundary.
-        endPerpsPlaceOrderCufOnPositions(positions);
+        // Positions just rendered to subscribers — close any pending CUF span
+        // (place/close/TPSL/reconnect) at its user-perceived boundary.
+        handlePerpsCufPositionsDelivered(positions);
         this.triggerPersist();
       },
     });
@@ -1415,6 +1474,7 @@ class TopOfBookStreamChannel extends StreamChannel<
   private cachedTopOfBook:
     | { bestBid?: string; bestAsk?: string; spread?: string }
     | undefined = undefined;
+  private firstDataTraceId?: string;
 
   protected connect() {
     if (!this.currentSymbol || this.wsSubscription) {
@@ -1427,12 +1487,38 @@ class TopOfBookStreamChannel extends StreamChannel<
       symbol: this.currentSymbol,
     });
 
+    // Start trace for first top-of-book measurement (before subscription)
+    this.firstDataTraceId = uuidv4();
+    trace({
+      name: TraceName.PerpsWebSocketFirstOrderBook,
+      id: this.firstDataTraceId,
+      op: TraceOperation.PerpsOperation,
+    });
+    this.wsConnectionStartTime = performance.now();
+
     this.wsSubscription = Engine.context.PerpsController.subscribeToPrices({
       symbols: [this.currentSymbol],
       includeOrderBook: true,
       callback: (updates: PriceUpdate[]) => {
         const update = updates.find((u) => u.symbol === this.currentSymbol);
         if (update) {
+          // Track first top-of-book data (only once per connection)
+          if (this.wsConnectionStartTime !== null && this.firstDataTraceId) {
+            const firstDataDuration =
+              performance.now() - this.wsConnectionStartTime;
+            DevLogger.log(
+              `${PERFORMANCE_CONFIG.LoggingMarkers.WebsocketPerformance} PerpsWS: First order book data received`,
+              { duration: `${firstDataDuration.toFixed(0)}ms` },
+            );
+            endTrace({
+              name: TraceName.PerpsWebSocketFirstOrderBook,
+              id: this.firstDataTraceId,
+              data: { success: true, duration: firstDataDuration },
+            });
+            this.wsConnectionStartTime = null;
+            this.firstDataTraceId = undefined;
+          }
+
           const topOfBook = {
             bestBid: update.bestBid,
             bestAsk: update.bestAsk,

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -197,6 +197,25 @@ abstract class StreamChannel<T> {
   }
 
   /**
+   * Immediately deliver any throttled subscriber's pending update, cancelling
+   * its timer. Used to close CUF confirmations at the instant subscribers
+   * actually render, instead of up to a throttle interval later.
+   */
+  public flushThrottledDeliveries() {
+    this.subscribers.forEach((subscriber) => {
+      if (!subscriber.timer) {
+        return;
+      }
+      clearTimeout(subscriber.timer);
+      subscriber.timer = undefined;
+      if (subscriber.pendingUpdate !== undefined) {
+        subscriber.callback(subscriber.pendingUpdate);
+        subscriber.pendingUpdate = undefined;
+      }
+    });
+  }
+
+  /**
    * Register a subscription's symbols into the reverse index so symbol-scoped
    * dispatch can find it. No-op for subscriptions without symbols.
    */
@@ -881,8 +900,12 @@ class OrderStreamChannel extends StreamChannel<Order[] | null> {
 
         this.cache.set('orders', orders);
         this.notifySubscribers(orders);
-        // Orders just rendered to subscribers — close a pending cancel CUF span.
-        handlePerpsCufOrdersDelivered(orders);
+        // Orders just rendered to subscribers — close pending cancel / limit
+        // order-render CUF spans, flushing throttled subscribers first so the
+        // span ends when they actually render, not at throttle-enqueue time.
+        handlePerpsCufOrdersDelivered(orders, () =>
+          this.flushThrottledDeliveries(),
+        );
         this.triggerPersist();
       },
     });
@@ -1024,8 +1047,11 @@ class PositionStreamChannel extends StreamChannel<Position[] | null> {
         this.cache.set('positions', positions);
         this.notifySubscribers(positions);
         // Positions just rendered to subscribers — close any pending CUF span
-        // (place/close/TPSL/reconnect) at its user-perceived boundary.
-        handlePerpsCufPositionsDelivered(positions);
+        // (place/close/TPSL/reconnect) at its user-perceived boundary, flushing
+        // throttled subscribers first so the span ends at real render time.
+        handlePerpsCufPositionsDelivered(positions, () =>
+          this.flushThrottledDeliveries(),
+        );
         this.triggerPersist();
       },
     });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -200,6 +200,11 @@ abstract class StreamChannel<T> {
    * Immediately deliver any throttled subscriber's pending update, cancelling
    * its timer. Used to close CUF confirmations at the instant subscribers
    * actually render, instead of up to a throttle interval later.
+   *
+   * This is a deliberate throttle bypass, invoked ONLY when a CUF matcher
+   * confirms on a delivery (not on every tick), so the measured render instant
+   * reflects real subscriber delivery. The affected subscribers simply receive
+   * their already-pending update slightly early; no extra work is scheduled.
    */
   public flushThrottledDeliveries() {
     this.subscribers.forEach((subscriber) => {
@@ -853,6 +858,10 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
    * Cleanup pre-warm subscription
    */
   public cleanupPrewarm(): void {
+    // Prewarm starts the first-price trace; end it here too so a soft reconnect
+    // (preserveCaches: true skips clearCache) doesn't leave it open to be
+    // overwritten by the next prewarm.
+    this.endOpenFirstDataTrace();
     if (this.actualPriceUnsubscribe) {
       this.actualPriceUnsubscribe();
       this.actualPriceUnsubscribe = undefined;

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -48,10 +48,11 @@ jest.mock('../../../../store', () => ({
 }));
 
 // Keep the real CUF helpers (reconnect arms a real span) but spy on the
-// teardown clear so tests can assert it fires on hard disconnect only.
+// teardown clear and span end so tests can assert reconnect CUF lifecycle.
 jest.mock('../utils/perpsCufTrace', () => ({
   ...jest.requireActual('../utils/perpsCufTrace'),
   clearPendingPerpsCufTraces: jest.fn(),
+  endPerpsCufTrace: jest.fn(),
 }));
 
 // Mock selectors
@@ -116,12 +117,19 @@ import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectPerpsNetwork } from '../selectors/perpsController';
-import { clearPendingPerpsCufTraces } from '../utils/perpsCufTrace';
+import {
+  clearPendingPerpsCufTraces,
+  endPerpsCufTrace,
+} from '../utils/perpsCufTrace';
+import { TraceName } from '../../../../util/trace';
 
 const mockClearPendingPerpsCufTraces =
   clearPendingPerpsCufTraces as jest.MockedFunction<
     typeof clearPendingPerpsCufTraces
   >;
+const mockEndPerpsCufTrace = endPerpsCufTrace as jest.MockedFunction<
+  typeof endPerpsCufTrace
+>;
 import { TradingReadinessCache } from '@metamask/perps-controller';
 
 // Import PerpsConnectionManager after mocks are set up
@@ -1141,6 +1149,50 @@ describe('PerpsConnectionManager', () => {
 
       // Cleanup
       m.pendingReconnectPromise = null;
+    });
+  });
+
+  describe('performReconnection — CUF lifecycle', () => {
+    beforeEach(async () => {
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      await PerpsConnectionManager.connect();
+      mockClearPendingPerpsCufTraces.mockClear();
+      mockEndPerpsCufTrace.mockClear();
+    });
+
+    it('abandons pending confirmation CUFs before arming the reconnect span', async () => {
+      const m = PerpsConnectionManager as unknown as {
+        performReconnection: () => Promise<void>;
+      };
+
+      await m.performReconnection().catch(() => undefined);
+
+      // The reconnect path (incl. NetInfo offline->online) must clear pending
+      // confirmation CUFs so a stale op can't be ended by the fresh delivery.
+      expect(mockClearPendingPerpsCufTraces).toHaveBeenCalled();
+    });
+
+    it('ends the reconnect span as a failure when reconnection throws', async () => {
+      mockPerpsController.init.mockRejectedValueOnce(
+        new Error('reconnect boom'),
+      );
+      const m = PerpsConnectionManager as unknown as {
+        performReconnection: () => Promise<void>;
+      };
+
+      await m.performReconnection().catch(() => undefined);
+
+      // A failed reconnect abandons its own span immediately (not the 30s
+      // fallback), so a retry's fresh delivery can't end both spans as success.
+      expect(mockEndPerpsCufTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: expect.stringContaining(
+            TraceName.PerpsWebSocketReconnectToFreshData,
+          ),
+          data: expect.objectContaining({ success: false }),
+        }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -47,6 +47,13 @@ jest.mock('../../../../store', () => ({
   },
 }));
 
+// Keep the real CUF helpers (reconnect arms a real span) but spy on the
+// teardown clear so tests can assert it fires on hard disconnect only.
+jest.mock('../utils/perpsCufTrace', () => ({
+  ...jest.requireActual('../utils/perpsCufTrace'),
+  clearPendingPerpsCufTraces: jest.fn(),
+}));
+
 // Mock selectors
 jest.mock('../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountAddress: jest.fn(),
@@ -109,6 +116,12 @@ import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectPerpsNetwork } from '../selectors/perpsController';
+import { clearPendingPerpsCufTraces } from '../utils/perpsCufTrace';
+
+const mockClearPendingPerpsCufTraces =
+  clearPendingPerpsCufTraces as jest.MockedFunction<
+    typeof clearPendingPerpsCufTraces
+  >;
 import { TradingReadinessCache } from '@metamask/perps-controller';
 
 // Import PerpsConnectionManager after mocks are set up
@@ -1142,6 +1155,7 @@ describe('PerpsConnectionManager', () => {
           channel.clearCache.mockClear();
         }
       });
+      mockClearPendingPerpsCufTraces.mockClear();
     });
 
     it('clears all stream channel caches when grace period fires', async () => {
@@ -1170,6 +1184,8 @@ describe('PerpsConnectionManager', () => {
       expect(mockStreamManagerInstance.fills.clearCache).toHaveBeenCalled();
       expect(mockStreamManagerInstance.topOfBook.clearCache).toHaveBeenCalled();
       expect(mockStreamManagerInstance.candles.clearCache).toHaveBeenCalled();
+      // Hard teardown must also abandon pending confirmation CUFs.
+      expect(mockClearPendingPerpsCufTraces).toHaveBeenCalled();
     });
 
     it('resets isPreloading flag so next connect can prewarm', async () => {
@@ -1237,6 +1253,8 @@ describe('PerpsConnectionManager', () => {
       expect(
         mockStreamManagerInstance.marketData.clearCache,
       ).not.toHaveBeenCalled();
+      // Soft resume preserves stream continuity, so pending CUFs are kept.
+      expect(mockClearPendingPerpsCufTraces).not.toHaveBeenCalled();
     });
 
     it('skips disconnection when reference count is still positive', async () => {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -17,6 +17,16 @@ import {
   TraceName,
   TraceOperation,
 } from '../../../../util/trace';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTraceAfter,
+  watchPerpsCufAnyPositions,
+} from '../utils/perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_END_REASON,
+  PERPS_CUF_STREAM_TIMEOUT_MS,
+} from '../constants/perpsCufTags';
 import Logger from '../../../../util/Logger';
 import {
   PERPS_CONSTANTS,
@@ -1002,6 +1012,22 @@ class PerpsConnectionManagerClass {
 
     DevLogger.log(
       'PerpsConnectionManager: Reconnecting with new account/network context',
+    );
+
+    // Freshness CUF: reconnect start -> first fresh positions delivery.
+    startPerpsCufTrace({
+      name: TraceName.PerpsWebSocketReconnectToFreshData,
+    });
+    watchPerpsCufAnyPositions(TraceName.PerpsWebSocketReconnectToFreshData);
+    endPerpsCufTraceAfter(
+      {
+        name: TraceName.PerpsWebSocketReconnectToFreshData,
+        data: {
+          [PERPS_CUF_TAG.SUCCESS]: false,
+          [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,
+        },
+      },
+      PERPS_CUF_STREAM_TIMEOUT_MS,
     );
 
     // Set connecting state immediately to prevent race conditions

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1015,13 +1015,13 @@ class PerpsConnectionManagerClass {
     );
 
     // Freshness CUF: reconnect start -> first fresh positions delivery.
-    startPerpsCufTrace({
+    const reconnectCufOpId = startPerpsCufTrace({
       name: TraceName.PerpsWebSocketReconnectToFreshData,
     });
-    watchPerpsCufAnyPositions(TraceName.PerpsWebSocketReconnectToFreshData);
+    watchPerpsCufAnyPositions(reconnectCufOpId);
     endPerpsCufTraceAfter(
       {
-        name: TraceName.PerpsWebSocketReconnectToFreshData,
+        id: reconnectCufOpId,
         data: {
           [PERPS_CUF_TAG.SUCCESS]: false,
           [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.STREAM_TIMEOUT,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -21,6 +21,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTraceAfter,
   watchPerpsCufAnyPositions,
+  clearPendingPerpsCufTraces,
 } from '../utils/perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -194,6 +195,9 @@ class PerpsConnectionManagerClass {
         streamManager.fills.clearCache();
         streamManager.topOfBook.clearCache();
         streamManager.candles.clearCache();
+        // The confirming streams are reset here, so abandon any pending CUF
+        // confirmation — a stale op must not be ended by the next session.
+        clearPendingPerpsCufTraces();
 
         // Reset throttle so the next data arrival persists immediately
         streamManager.resetDiskCacheThrottles();
@@ -637,6 +641,8 @@ class PerpsConnectionManagerClass {
               streamManager.fills.clearCache();
               streamManager.topOfBook.clearCache();
               streamManager.candles.clearCache();
+              // Streams reset: abandon any pending CUF confirmation.
+              clearPendingPerpsCufTraces();
             }
 
             // Reset state before disconnecting to prevent race conditions
@@ -1061,6 +1067,9 @@ class PerpsConnectionManagerClass {
       streamManager.fills.clearCache();
       streamManager.topOfBook.clearCache();
       streamManager.candles.clearCache();
+      // Streams reset on account/network switch: abandon any pending CUF
+      // confirmation so the next account's first delivery can't falsely end it.
+      clearPendingPerpsCufTraces();
       setMeasurement(
         PerpsMeasurementName.PerpsReconnectionCleanup,
         performance.now() - cleanupStart,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../util/trace';
 import {
   startPerpsCufTrace,
+  endPerpsCufTrace,
   endPerpsCufTraceAfter,
   watchPerpsCufAnyPositions,
   clearPendingPerpsCufTraces,
@@ -659,8 +660,9 @@ class PerpsConnectionManagerClass {
               // delivery would end the stale op as a success with a duration
               // inflated by the background/disconnect gap. Skipped for a
               // preserveCaches soft resume above, where the stream continuity
-              // means the confirming delivery is still legitimate. The reconnect
-              // measurement span is preserved by clearPendingPerpsCufTraces.
+              // means the confirming delivery is still legitimate. No reconnect
+              // measurement span is armed during disconnect (it is armed later
+              // in performReconnection, after its own clear), so none is lost.
               clearPendingPerpsCufTraces();
             }
 
@@ -1039,7 +1041,17 @@ class PerpsConnectionManagerClass {
       'PerpsConnectionManager: Reconnecting with new account/network context',
     );
 
-    // Freshness CUF: reconnect start -> first fresh positions delivery.
+    // Abandon any pending confirmation CUF (and any stale reconnect span) from
+    // the previous session BEFORE arming this reconnection's own span. The
+    // streams are being torn down and resubscribed here, so a stale op must not
+    // be ended by the new subscription's first delivery (which would record a
+    // success with a duration inflated by the offline/reconnect gap). This also
+    // covers reconnect paths that do not route through the identity-change or
+    // hard-disconnect clears — notably NetInfo offline->online.
+    clearPendingPerpsCufTraces();
+
+    // Freshness CUF: reconnect start -> first fresh positions delivery. Armed
+    // AFTER the clear above so it is never abandoned by it.
     const reconnectCufOpId = startPerpsCufTrace({
       name: TraceName.PerpsWebSocketReconnectToFreshData,
     });
@@ -1228,6 +1240,17 @@ class PerpsConnectionManagerClass {
 
       // Clear connection timeout on error
       this.clearConnectionTimeout();
+
+      // Reconnect failed: end its CUF span now as a failure rather than leaving
+      // it open for the 30s fallback — otherwise a retry's fresh positions
+      // delivery could end both this stale span and the new reconnect span.
+      endPerpsCufTrace({
+        id: reconnectCufOpId,
+        data: {
+          [PERPS_CUF_TAG.SUCCESS]: false,
+          [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.EXCEPTION,
+        },
+      });
 
       traceData = {
         success: false,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -654,6 +654,14 @@ class PerpsConnectionManagerClass {
               streamManager.fills.clearCache();
               streamManager.topOfBook.clearCache();
               streamManager.candles.clearCache();
+              // Hard teardown (streams torn down, caches cleared): abandon any
+              // pending confirmation CUF as `disconnected`, or a later reconnect
+              // delivery would end the stale op as a success with a duration
+              // inflated by the background/disconnect gap. Skipped for a
+              // preserveCaches soft resume above, where the stream continuity
+              // means the confirming delivery is still legitimate. The reconnect
+              // measurement span is preserved by clearPendingPerpsCufTraces.
+              clearPendingPerpsCufTraces();
             }
 
             // Reset state before disconnecting to prevent race conditions

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -195,8 +195,11 @@ class PerpsConnectionManagerClass {
         streamManager.fills.clearCache();
         streamManager.topOfBook.clearCache();
         streamManager.candles.clearCache();
-        // The confirming streams are reset here, so abandon any pending CUF
-        // confirmation — a stale op must not be ended by the next session.
+        // Session identity changed (account/network/provider/HIP-3): abandon any
+        // pending confirmation CUF so the NEXT session's first delivery can't
+        // falsely end it against different data. Only here, not on same-account
+        // soft reconnects — there the confirming delivery legitimately arrives
+        // in the resubscribed stream, so clearing would drop a real confirmation.
         clearPendingPerpsCufTraces();
 
         // Reset throttle so the next data arrival persists immediately
@@ -641,8 +644,6 @@ class PerpsConnectionManagerClass {
               streamManager.fills.clearCache();
               streamManager.topOfBook.clearCache();
               streamManager.candles.clearCache();
-              // Streams reset: abandon any pending CUF confirmation.
-              clearPendingPerpsCufTraces();
             }
 
             // Reset state before disconnecting to prevent race conditions
@@ -1067,9 +1068,6 @@ class PerpsConnectionManagerClass {
       streamManager.fills.clearCache();
       streamManager.topOfBook.clearCache();
       streamManager.candles.clearCache();
-      // Streams reset on account/network switch: abandon any pending CUF
-      // confirmation so the next account's first delivery can't falsely end it.
-      clearPendingPerpsCufTraces();
       setMeasurement(
         PerpsMeasurementName.PerpsReconnectionCleanup,
         performance.now() - cleanupStart,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -195,12 +195,6 @@ class PerpsConnectionManagerClass {
         streamManager.fills.clearCache();
         streamManager.topOfBook.clearCache();
         streamManager.candles.clearCache();
-        // Session identity changed (account/network/provider/HIP-3): abandon any
-        // pending confirmation CUF so the NEXT session's first delivery can't
-        // falsely end it against different data. Only here, not on same-account
-        // soft reconnects — there the confirming delivery legitimately arrives
-        // in the resubscribed stream, so clearing would drop a real confirmation.
-        clearPendingPerpsCufTraces();
 
         // Reset throttle so the next data arrival persists immediately
         streamManager.resetDiskCacheThrottles();
@@ -250,6 +244,22 @@ class PerpsConnectionManagerClass {
             );
           });
         }, 50);
+      }
+
+      // Abandon pending CUFs on ANY session-identity change — even while
+      // disconnected, since the tracked identity advances below regardless of
+      // isConnected. Pending close/cancel/TP-SL/place ops and stale reconnect
+      // measurements must not survive into the next session and be falsely
+      // ended by that session's first delivery. Same-account soft reconnects
+      // don't reach here, so their pending confirmations are kept; the new
+      // reconnect measurement starts later inside performReconnection.
+      if (
+        hasAccountChanged ||
+        hasPerpsNetworkChanged ||
+        hasProviderChanged ||
+        hasHip3Changed
+      ) {
+        clearPendingPerpsCufTraces();
       }
 
       // Update tracked values

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -201,6 +201,39 @@ describe('perpsCufTrace', () => {
     );
   });
 
+  it('ends a superseded market place-order op instead of leaking it', () => {
+    const first = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(first, 'BTC');
+
+    // A second market order is placed before the first renders/times out.
+    const second = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(second, 'ETH');
+
+    // The first op is ended (superseded), not left pending forever.
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: first,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.SUCCESS]: false,
+        }),
+      }),
+    );
+    expect(isPerpsPlaceOrderCufCurrent(second)).toBe(true);
+
+    // The second op still ends normally on its own render.
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
+    // (place-order end is owned by the hook via the waiter; the matcher only
+    // records the render — assert the first op is gone from the registry.)
+    endPerpsCufTrace({ id: second });
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: second }),
+    );
+  });
+
   it('resolves the place-order waiter when the armed symbol renders', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -12,9 +12,10 @@ import {
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
-  watchPerpsCufPositionChanged,
+  watchPerpsCufPositionClosed,
+  watchPerpsCufTpSlChanged,
   watchPerpsCufOrderAbsent,
-  watchPerpsCufOrderPresent,
+  watchPerpsCufLimitRendered,
   watchPerpsCufAnyPositions,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
@@ -295,6 +296,36 @@ describe('perpsCufTrace', () => {
     );
   });
 
+  it('resolves when an order-form submit reduces the baseline position to zero', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    // A position existed before the order; the order flips/closes it to zero.
+    armPerpsPlaceOrderCuf(opId, 'BTC', { symbol: 'BTC', size: '0.01' });
+
+    // BTC position now absent from the stream — a real rendered outcome.
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
+    ).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0' } }),
+    );
+  });
+
+  it('does not resolve on absence when no baseline position existed', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC'); // no pre-order position
+
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
+    ).resolves.toBeNull();
+  });
+
   it('ignores deliveries that do not match the armed symbol', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
@@ -351,7 +382,7 @@ describe('perpsCufTrace', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsClosePositionToConfirmation,
     });
-    watchPerpsCufPositionChanged(opId, btc);
+    watchPerpsCufPositionClosed(opId, btc);
 
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
 
@@ -365,11 +396,11 @@ describe('perpsCufTrace', () => {
     );
   });
 
-  it('close span ends on a size change but not on an identical snapshot', () => {
+  it('close span ends on a size change but not on an identical size', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsClosePositionToConfirmation,
     });
-    watchPerpsCufPositionChanged(opId, btc);
+    watchPerpsCufPositionClosed(opId, btc);
 
     handlePerpsCufPositionsDelivered([btc]);
     expect(mockEndTrace).not.toHaveBeenCalled();
@@ -378,16 +409,56 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
+  it('close span is NOT ended by a TP/SL-only change (no size change)', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionClosed(opId, btc);
+
+    // Same size, different take-profit: not a close.
+    handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '80000' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
   it('tpsl span ends when the TP value changes in the stream', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsUpdateTPSLToConfirmation,
     });
-    watchPerpsCufPositionChanged(opId, btc);
+    watchPerpsCufTpSlChanged(opId, btc);
 
     handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
 
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({ id: opId }),
+    );
+  });
+
+  it('tpsl span is NOT ended by a size-only change (partial fill/close)', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsUpdateTPSLToConfirmation,
+    });
+    watchPerpsCufTpSlChanged(opId, btc);
+
+    // Same TP/SL, different size: not a TP/SL update.
+    handlePerpsCufPositionsDelivered([{ ...btc, size: '0.02' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('close and tpsl spans on the same symbol do not cross-end each other', () => {
+    const closeOp = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionClosed(closeOp, btc);
+    const tpslOp = startPerpsCufTrace({
+      name: TraceName.PerpsUpdateTPSLToConfirmation,
+    });
+    watchPerpsCufTpSlChanged(tpslOp, btc);
+
+    // Only TP/SL changed: ends the tpsl span, not the close span.
+    handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tpslOp }),
     );
   });
 
@@ -410,12 +481,32 @@ describe('perpsCufTrace', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
     });
-    watchPerpsCufOrderPresent(opId, 'o-9');
+    watchPerpsCufLimitRendered(opId, 'o-9', 'BTC');
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }]);
     expect(mockEndTrace).not.toHaveBeenCalled();
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-9' }]);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: opId,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+        }),
+      }),
+    );
+  });
+
+  it('limit-order-render span ends when a marketable limit fills into a position', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+    });
+    // No pre-order position baseline: the fill renders a brand-new position.
+    watchPerpsCufLimitRendered(opId, 'o-9', 'BTC');
+
+    // Order never rests; instead a position for the symbol appears.
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         id: opId,
@@ -434,7 +525,7 @@ describe('perpsCufTrace', () => {
     const limitOpId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
     });
-    watchPerpsCufOrderPresent(limitOpId, 'o-2');
+    watchPerpsCufLimitRendered(limitOpId, 'o-2', 'ETH');
 
     // o-1 gone (cancel confirmed) and o-2 present (limit rendered) in the
     // same delivery: both spans end.

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -736,6 +736,23 @@ describe('perpsCufTrace', () => {
     expect(flush).toHaveBeenCalledTimes(1);
   });
 
+  it('flushes only once across repeated deferred ticks before acceptance', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+    const flush = jest.fn();
+
+    // Still gated across three deliveries: DEFERRED_AT is recorded on the first,
+    // so only that tick flushes; later ticks must not re-flush.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+    expect(flush).toHaveBeenCalledTimes(1);
+  });
+
   it('does not flush when no confirmation matches the delivery', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -9,6 +9,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTrace,
   endPerpsCufTraceAfter,
+  endPerpsCufRequestAfter,
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
@@ -202,6 +203,52 @@ describe('perpsCufTrace', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  describe('endPerpsCufRequestAfter (request-flow fallback reason)', () => {
+    it('records controller_timeout when the request never settled', () => {
+      jest.useFakeTimers();
+      try {
+        const opId = startPerpsCufTrace({
+          name: TraceName.PerpsCancelOrderToConfirmation,
+        });
+        endPerpsCufRequestAfter(opId, () => false, 1000);
+        jest.advanceTimersByTime(1000);
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: opId,
+            data: expect.objectContaining({
+              success: false,
+              reason: 'controller_timeout',
+            }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('records stream_timeout when the request settled but no render arrived', () => {
+      jest.useFakeTimers();
+      try {
+        const opId = startPerpsCufTrace({
+          name: TraceName.PerpsCancelOrderToConfirmation,
+        });
+        endPerpsCufRequestAfter(opId, () => true, 1000);
+        jest.advanceTimersByTime(1000);
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: opId,
+            data: expect.objectContaining({
+              success: false,
+              reason: 'stream_timeout',
+            }),
+          }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   it('two overlapping cancels each end independently on their own order', () => {
@@ -601,7 +648,7 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
-  it('preserves the reconnect measurement span when clearing on teardown', () => {
+  it('clears stale reconnect measurement spans on session teardown', () => {
     const reconnectOp = startPerpsCufTrace({
       name: TraceName.PerpsWebSocketReconnectToFreshData,
     });
@@ -614,22 +661,21 @@ describe('perpsCufTrace', () => {
 
     clearPendingPerpsCufTraces();
 
-    // The confirmation op is abandoned; the reconnect measurement survives —
-    // clearing must not end the span that is measuring the reconnection itself.
-    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    // Both the confirmation op and any stale reconnect measurement are
+    // abandoned; the next session must start its own reconnect span after the
+    // teardown clear, not reuse this one.
+    expect(mockEndTrace).toHaveBeenCalledTimes(2);
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({ id: closeOp }),
     );
-    expect(mockEndTrace).not.toHaveBeenCalledWith(
-      expect.objectContaining({ id: reconnectOp }),
-    );
-
-    // Fresh positions still close the reconnect span as a success.
-    mockEndTrace.mockClear();
-    handlePerpsCufPositionsDelivered([]);
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({ id: reconnectOp }),
     );
+
+    // A later fresh delivery from the next session cannot resurrect either op.
+    mockEndTrace.mockClear();
+    handlePerpsCufPositionsDelivered([]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
   it('cancel span ends only once the order id is absent', () => {

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -18,6 +18,7 @@ import {
   watchPerpsCufLimitRendered,
   watchPerpsCufAnyPositions,
   acceptPerpsCufRequest,
+  isPerpsFillRendered,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
   resetPerpsCufTraceForTests,
@@ -47,6 +48,30 @@ describe('perpsCufTrace', () => {
     jest.clearAllMocks();
     resetPerpsLifecycleContextForTests();
     resetPerpsCufTraceForTests();
+  });
+
+  describe('isPerpsFillRendered (shared fill predicate)', () => {
+    const pos = (size: string) => ({ symbol: 'BTC', size });
+
+    it('is a render when a new position appears with no baseline', () => {
+      expect(isPerpsFillRendered(pos('0.1'), undefined)).toBe(true);
+    });
+
+    it('is a render when the position size changed versus the baseline', () => {
+      expect(isPerpsFillRendered(pos('0.2'), '0.1')).toBe(true);
+    });
+
+    it('is NOT a render when the position is unchanged from the baseline', () => {
+      expect(isPerpsFillRendered(pos('0.1'), '0.1')).toBe(false);
+    });
+
+    it('is a render when a pre-existing position is now absent (closed to zero)', () => {
+      expect(isPerpsFillRendered(undefined, '0.1')).toBe(true);
+    });
+
+    it('is NOT a render when absent and no position existed before', () => {
+      expect(isPerpsFillRendered(undefined, undefined)).toBe(false);
+    });
   });
 
   it('starts a span with a unique id and feature + lifecycle_context tags', () => {

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -1,0 +1,141 @@
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
+import {
+  trace,
+  endTrace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import {
+  startPerpsCufTrace,
+  endPerpsCufTrace,
+  setPerpsPlaceOrderCufSymbol,
+  setPerpsPlaceOrderCufToastShown,
+  endPerpsPlaceOrderCufOnPositions,
+} from './perpsCufTrace';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_VARIANT,
+  PERPS_CUF_BOUNDARY,
+} from '../constants/perpsCufTags';
+import {
+  markPerpsForegroundSettled,
+  resetPerpsLifecycleContextForTests,
+  PERPS_LIFECYCLE_CONTEXT,
+} from './perpsLifecycleContext';
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+const mockTrace = trace as jest.Mock;
+const mockEndTrace = endTrace as jest.Mock;
+
+describe('perpsCufTrace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPerpsLifecycleContextForTests();
+    // Drain any span left pending by a previous test.
+    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+    endPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    jest.clearAllMocks();
+  });
+
+  it('starts a span tagged with feature and lifecycle_context', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsEntryToLiveMarketList,
+        id: TraceName.PerpsEntryToLiveMarketList,
+        op: TraceOperation.PerpsOperation,
+        tags: expect.objectContaining({
+          [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
+          [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]:
+            PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+        }),
+      }),
+    );
+  });
+
+  it('merges caller variant tags without dropping the defaults', () => {
+    markPerpsForegroundSettled();
+
+    startPerpsCufTrace({
+      name: TraceName.PerpsEntryToLiveMarketList,
+      tags: { [PERPS_CUF_TAG.VARIANT]: PERPS_CUF_VARIANT.EMPTY },
+    });
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: {
+          [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
+          [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: PERPS_LIFECYCLE_CONTEXT.WARM,
+          [PERPS_CUF_TAG.VARIANT]: PERPS_CUF_VARIANT.EMPTY,
+        },
+      }),
+    );
+  });
+
+  it('ends a started span and defaults the id to the trace name', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+
+    endPerpsCufTrace({
+      name: TraceName.PerpsEntryToLiveMarketList,
+      data: { [PERPS_CUF_TAG.SUCCESS]: true },
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsEntryToLiveMarketList,
+        id: TraceName.PerpsEntryToLiveMarketList,
+        data: { [PERPS_CUF_TAG.SUCCESS]: true },
+      }),
+    );
+  });
+
+  it('end is idempotent: only the first end reaches endTrace', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+
+    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the place-order span from the stream when the symbol arrives', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    setPerpsPlaceOrderCufSymbol('BTC');
+    setPerpsPlaceOrderCufToastShown();
+
+    endPerpsPlaceOrderCufOnPositions([{ symbol: 'ETH' }, { symbol: 'BTC' }]);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsPlaceOrderToPositionRendered,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.SUCCESS]: true,
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+          [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  it('stream end ignores positions that do not match the pending symbol', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    setPerpsPlaceOrderCufSymbol('BTC');
+
+    endPerpsPlaceOrderCufOnPositions([{ symbol: 'ETH' }]);
+    endPerpsPlaceOrderCufOnPositions(null);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('stream end no-ops when no place-order span is pending', () => {
+    endPerpsPlaceOrderCufOnPositions([{ symbol: 'BTC' }]);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
+  endPerpsCufTraceAfter,
   armPerpsPlaceOrderCuf,
   isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
@@ -111,6 +112,65 @@ describe('perpsCufTrace', () => {
     endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
 
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('scheduled fallback ends its own span instance when nothing else does', () => {
+    jest.useFakeTimers();
+    try {
+      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      endPerpsCufTraceAfter(
+        {
+          name: TraceName.PerpsCancelOrderToConfirmation,
+          data: { [PERPS_CUF_TAG.SUCCESS]: false },
+        },
+        1000,
+      );
+
+      jest.advanceTimersByTime(1000);
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.PerpsCancelOrderToConfirmation,
+          data: { [PERPS_CUF_TAG.SUCCESS]: false },
+        }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('stale scheduled fallback does not end a successor span with the same name', () => {
+    jest.useFakeTimers();
+    try {
+      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      endPerpsCufTraceAfter(
+        {
+          name: TraceName.PerpsCancelOrderToConfirmation,
+          data: { [PERPS_CUF_TAG.SUCCESS]: false },
+        },
+        1000,
+      );
+      // The stream ends the first span, then a second cancel starts before
+      // the first span's fallback fires.
+      endPerpsCufTrace({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+        data: { [PERPS_CUF_TAG.SUCCESS]: true },
+      });
+      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      mockEndTrace.mockClear();
+
+      jest.advanceTimersByTime(2000);
+      expect(mockEndTrace).not.toHaveBeenCalled();
+
+      // The successor span is still pending and can complete normally.
+      endPerpsCufTrace({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+        data: { [PERPS_CUF_TAG.SUCCESS]: true },
+      });
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('resolves the place-order waiter when the armed symbol renders', async () => {

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -345,6 +345,56 @@ describe('perpsCufTrace', () => {
     ).resolves.toBeNull();
   });
 
+  it('unloaded cache: a pre-existing position in the first delivery does NOT confirm', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    // Cache not loaded at submit (baselineLoaded=false), user already holds BTC.
+    armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
+
+    // First delivery is the pre-order position, captured as baseline — not a
+    // confirm — so stale stream data can't satisfy the order.
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
+    ).resolves.toBeNull();
+  });
+
+  it('unloaded cache: confirms on a later change after capturing the baseline', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
+    const wait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
+
+    // First delivery = pre-order baseline (0.01), captured, no confirm.
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+    // The order changes the size -> confirm.
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
+
+    await expect(wait).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
+    );
+  });
+
+  it('unloaded cache with no prior position: confirms when the order fills', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
+    const wait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
+
+    // First delivery = empty (no position), captured as absent baseline.
+    handlePerpsCufPositionsDelivered([]);
+    // Order fills -> a new position appears -> confirm.
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+
+    await expect(wait).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
+    );
+  });
+
   it('ignores deliveries that do not match the armed symbol', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -11,6 +11,11 @@ import {
   setPerpsPlaceOrderCufSymbol,
   setPerpsPlaceOrderCufToastShown,
   endPerpsPlaceOrderCufOnPositions,
+  watchPerpsCufPositionChanged,
+  watchPerpsCufOrderAbsent,
+  watchPerpsCufAnyPositions,
+  handlePerpsCufPositionsDelivered,
+  handlePerpsCufOrdersDelivered,
 } from './perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -39,6 +44,10 @@ describe('perpsCufTrace', () => {
     // Drain any span left pending by a previous test.
     endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
     endPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    endPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
+    endPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
+    endPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+    endPerpsCufTrace({ name: TraceName.PerpsWebSocketReconnectToFreshData });
     jest.clearAllMocks();
   });
 
@@ -137,5 +146,81 @@ describe('perpsCufTrace', () => {
     endPerpsPlaceOrderCufOnPositions([{ symbol: 'BTC' }]);
 
     expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  const btc = { symbol: 'BTC', size: '0.01', takeProfitPrice: '70000' };
+
+  it('close span ends when the watched position disappears', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
+    watchPerpsCufPositionChanged(
+      TraceName.PerpsClosePositionToConfirmation,
+      btc,
+    );
+
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsClosePositionToConfirmation,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+        }),
+      }),
+    );
+  });
+
+  it('close span ends on a size change but not on an identical snapshot', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
+    watchPerpsCufPositionChanged(
+      TraceName.PerpsClosePositionToConfirmation,
+      btc,
+    );
+
+    handlePerpsCufPositionsDelivered([btc]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    handlePerpsCufPositionsDelivered([{ ...btc, size: '0.005' }]);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('tpsl span ends when the TP value changes in the stream', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
+    watchPerpsCufPositionChanged(TraceName.PerpsUpdateTPSLToConfirmation, btc);
+
+    handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsUpdateTPSLToConfirmation,
+      }),
+    );
+  });
+
+  it('cancel span ends only once the order id is absent', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+    watchPerpsCufOrderAbsent(TraceName.PerpsCancelOrderToConfirmation, 'o-1');
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-2' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+      }),
+    );
+  });
+
+  it('reconnect span ends on any positions delivery', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsWebSocketReconnectToFreshData });
+    watchPerpsCufAnyPositions(TraceName.PerpsWebSocketReconnectToFreshData);
+
+    handlePerpsCufPositionsDelivered([]);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsWebSocketReconnectToFreshData,
+      }),
+    );
   });
 });

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -14,6 +14,7 @@ import {
   waitForPerpsPlaceOrderPositionRendered,
   watchPerpsCufPositionChanged,
   watchPerpsCufOrderAbsent,
+  watchPerpsCufOrderPresent,
   watchPerpsCufAnyPositions,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
@@ -48,6 +49,7 @@ describe('perpsCufTrace', () => {
     endPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
     endPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
     endPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+    endPerpsCufTrace({ name: TraceName.PerpsPlaceLimitOrderToOrderRendered });
     endPerpsCufTrace({ name: TraceName.PerpsWebSocketReconnectToFreshData });
     jest.clearAllMocks();
   });
@@ -337,6 +339,56 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.PerpsCancelOrderToConfirmation,
+      }),
+    );
+  });
+
+  it('limit-order-render span ends once the order id appears in the stream', () => {
+    startPerpsCufTrace({
+      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+    });
+    watchPerpsCufOrderPresent(
+      TraceName.PerpsPlaceLimitOrderToOrderRendered,
+      'o-9',
+    );
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-9' }]);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+        }),
+      }),
+    );
+  });
+
+  it('cancel and limit-render order spans resolve independently on one delivery', () => {
+    startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+    watchPerpsCufOrderAbsent(TraceName.PerpsCancelOrderToConfirmation, 'o-1');
+    startPerpsCufTrace({
+      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+    });
+    watchPerpsCufOrderPresent(
+      TraceName.PerpsPlaceLimitOrderToOrderRendered,
+      'o-2',
+    );
+
+    // o-1 gone (cancel confirmed) and o-2 present (limit rendered) in the
+    // same delivery: both spans end.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+      }),
+    );
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
       }),
     );
   });

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -721,6 +721,21 @@ describe('perpsCufTrace', () => {
     );
   });
 
+  it('flushes throttled subscribers when a gated match is deferred', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    // Armed but not yet accepted: the match must defer (not end) yet still
+    // flush, so the recorded DEFERRED_AT reflects real subscriber delivery.
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+    const flush = jest.fn();
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+    expect(flush).toHaveBeenCalledTimes(1);
+  });
+
   it('does not flush when no confirmation matches the delivery', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -332,6 +332,21 @@ describe('perpsCufTrace', () => {
     );
   });
 
+  it('resolves a pending-baseline order when the first positions tick contains the symbol', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC', undefined, false);
+
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
+    ).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
+    );
+  });
+
   it('does not resolve on absence when no baseline position existed', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
@@ -345,36 +360,18 @@ describe('perpsCufTrace', () => {
     ).resolves.toBeNull();
   });
 
-  it('unloaded cache: a pre-existing position in the first delivery does NOT confirm', async () => {
+  it('unloaded cache: a present symbol in the first delivery confirms instead of being swallowed as baseline', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
     });
-    // Cache not loaded at submit (baselineLoaded=false), user already holds BTC.
     armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
 
-    // First delivery is the pre-order position, captured as baseline — not a
-    // confirm — so stale stream data can't satisfy the order.
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
 
     await expect(
       waitForPerpsPlaceOrderPositionRendered(5, opId),
-    ).resolves.toBeNull();
-  });
-
-  it('unloaded cache: confirms on a later change after capturing the baseline', async () => {
-    const opId = startPerpsCufTrace({
-      name: TraceName.PerpsPlaceOrderToPositionRendered,
-    });
-    armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
-    const wait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
-
-    // First delivery = pre-order baseline (0.01), captured, no confirm.
-    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
-    // The order changes the size -> confirm.
-    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
-
-    await expect(wait).resolves.toEqual(
-      expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
+    ).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
     );
   });
 

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -18,6 +18,7 @@ import {
   watchPerpsCufAnyPositions,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
+  resetPerpsCufTraceForTests,
 } from './perpsCufTrace';
 import {
   PERPS_CUF_TAG,
@@ -43,24 +44,19 @@ describe('perpsCufTrace', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetPerpsLifecycleContextForTests();
-    // Drain any span left pending by a previous test.
-    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
-    endPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    endPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
-    endPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
-    endPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
-    endPerpsCufTrace({ name: TraceName.PerpsPlaceLimitOrderToOrderRendered });
-    endPerpsCufTrace({ name: TraceName.PerpsWebSocketReconnectToFreshData });
-    jest.clearAllMocks();
+    resetPerpsCufTraceForTests();
   });
 
-  it('starts a span tagged with feature and lifecycle_context', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+  it('starts a span with a unique id and feature + lifecycle_context tags', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsEntryToLiveMarketList,
+    });
 
+    expect(opId).toContain(TraceName.PerpsEntryToLiveMarketList);
     expect(mockTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.PerpsEntryToLiveMarketList,
-        id: TraceName.PerpsEntryToLiveMarketList,
+        id: opId,
         op: TraceOperation.PerpsOperation,
         tags: expect.objectContaining({
           [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
@@ -69,6 +65,16 @@ describe('perpsCufTrace', () => {
         }),
       }),
     );
+  });
+
+  it('mints a distinct id for each start of the same trace name', () => {
+    const a = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    const b = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    expect(a).not.toEqual(b);
   });
 
   it('merges caller variant tags without dropping the defaults', () => {
@@ -90,41 +96,41 @@ describe('perpsCufTrace', () => {
     );
   });
 
-  it('ends a started span and defaults the id to the trace name', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
-
-    endPerpsCufTrace({
+  it('ends a started span by its op id', () => {
+    const opId = startPerpsCufTrace({
       name: TraceName.PerpsEntryToLiveMarketList,
-      data: { [PERPS_CUF_TAG.SUCCESS]: true },
     });
+
+    endPerpsCufTrace({ id: opId, data: { [PERPS_CUF_TAG.SUCCESS]: true } });
 
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.PerpsEntryToLiveMarketList,
-        id: TraceName.PerpsEntryToLiveMarketList,
+        id: opId,
         data: { [PERPS_CUF_TAG.SUCCESS]: true },
       }),
     );
   });
 
   it('end is idempotent: only the first end reaches endTrace', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsEntryToLiveMarketList,
+    });
 
-    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
-    endPerpsCufTrace({ name: TraceName.PerpsEntryToLiveMarketList });
+    endPerpsCufTrace({ id: opId });
+    endPerpsCufTrace({ id: opId });
 
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
-  it('scheduled fallback ends its own span instance when nothing else does', () => {
+  it('scheduled fallback ends its own span when nothing else does', () => {
     jest.useFakeTimers();
     try {
-      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      const opId = startPerpsCufTrace({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+      });
       endPerpsCufTraceAfter(
-        {
-          name: TraceName.PerpsCancelOrderToConfirmation,
-          data: { [PERPS_CUF_TAG.SUCCESS]: false },
-        },
+        { id: opId, data: { [PERPS_CUF_TAG.SUCCESS]: false } },
         1000,
       );
 
@@ -132,7 +138,7 @@ describe('perpsCufTrace', () => {
 
       expect(mockEndTrace).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: TraceName.PerpsCancelOrderToConfirmation,
+          id: opId,
           data: { [PERPS_CUF_TAG.SUCCESS]: false },
         }),
       );
@@ -141,52 +147,71 @@ describe('perpsCufTrace', () => {
     }
   });
 
-  it('stale scheduled fallback does not end a successor span with the same name', () => {
+  it('a superseded op fallback never ends a later op of the same flow', () => {
     jest.useFakeTimers();
     try {
-      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
+      const first = startPerpsCufTrace({
+        name: TraceName.PerpsCancelOrderToConfirmation,
+      });
       endPerpsCufTraceAfter(
-        {
-          name: TraceName.PerpsCancelOrderToConfirmation,
-          data: { [PERPS_CUF_TAG.SUCCESS]: false },
-        },
+        { id: first, data: { [PERPS_CUF_TAG.SUCCESS]: false } },
         1000,
       );
-      // The stream ends the first span, then a second cancel starts before
-      // the first span's fallback fires.
-      endPerpsCufTrace({
+      // The stream ends the first op, then a second cancel starts before the
+      // first op's fallback fires.
+      endPerpsCufTrace({ id: first, data: { [PERPS_CUF_TAG.SUCCESS]: true } });
+      const second = startPerpsCufTrace({
         name: TraceName.PerpsCancelOrderToConfirmation,
-        data: { [PERPS_CUF_TAG.SUCCESS]: true },
       });
-      startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
       mockEndTrace.mockClear();
 
       jest.advanceTimersByTime(2000);
+      // The stale fallback targeted `first`, not `second`.
       expect(mockEndTrace).not.toHaveBeenCalled();
 
-      // The successor span is still pending and can complete normally.
-      endPerpsCufTrace({
-        name: TraceName.PerpsCancelOrderToConfirmation,
-        data: { [PERPS_CUF_TAG.SUCCESS]: true },
-      });
+      endPerpsCufTrace({ id: second, data: { [PERPS_CUF_TAG.SUCCESS]: true } });
       expect(mockEndTrace).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }
   });
 
+  it('two overlapping cancels each end independently on their own order', () => {
+    const opA = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opA, 'o-A');
+    const opB = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opB, 'o-B');
+
+    // o-A cancelled (absent), o-B still resting.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-B' }]);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: opA }),
+    );
+
+    // o-B cancelled too.
+    handlePerpsCufOrdersDelivered([]);
+    expect(mockEndTrace).toHaveBeenCalledTimes(2);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: opB }),
+    );
+  });
+
   it('resolves the place-order waiter when the armed symbol renders', async () => {
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const generation = armPerpsPlaceOrderCuf('BTC');
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC');
 
     handlePerpsCufPositionsDelivered([
       { symbol: 'ETH', size: '1' },
       { symbol: 'BTC', size: '0.01' },
     ]);
-    const rendered = await waitForPerpsPlaceOrderPositionRendered(
-      5,
-      generation,
-    );
+    const rendered = await waitForPerpsPlaceOrderPositionRendered(5, opId);
 
     expect(rendered).toEqual({
       position: { symbol: 'BTC', size: '0.01' },
@@ -195,13 +220,12 @@ describe('perpsCufTrace', () => {
   });
 
   it('resolves a waiter registered before the stream delivers', async () => {
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const generation = armPerpsPlaceOrderCuf('BTC');
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC');
 
-    const pendingWait = waitForPerpsPlaceOrderPositionRendered(
-      1000,
-      generation,
-    );
+    const pendingWait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
 
     await expect(pendingWait).resolves.toEqual(
@@ -211,67 +235,75 @@ describe('perpsCufTrace', () => {
 
   it('does not resolve for a pre-existing position unchanged from the baseline', async () => {
     const existing = { symbol: 'BTC', size: '0.01' };
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const generation = armPerpsPlaceOrderCuf('BTC', existing);
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC', existing);
 
     handlePerpsCufPositionsDelivered([existing]);
 
     await expect(
-      waitForPerpsPlaceOrderPositionRendered(5, generation),
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
     ).resolves.toBeNull();
   });
 
   it('resolves when the armed position changes versus the baseline (add to position)', async () => {
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const generation = armPerpsPlaceOrderCuf('BTC', {
-      symbol: 'BTC',
-      size: '0.01',
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
     });
+    armPerpsPlaceOrderCuf(opId, 'BTC', { symbol: 'BTC', size: '0.01' });
 
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
 
     await expect(
-      waitForPerpsPlaceOrderPositionRendered(5, generation),
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
     ).resolves.toEqual(
       expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
     );
   });
 
   it('ignores deliveries that do not match the armed symbol', async () => {
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const generation = armPerpsPlaceOrderCuf('BTC');
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC');
 
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
     handlePerpsCufPositionsDelivered(null);
 
     await expect(
-      waitForPerpsPlaceOrderPositionRendered(5, generation),
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
     ).resolves.toBeNull();
   });
 
-  it('waiter resolves null when no place-order span is pending', async () => {
-    const generation = armPerpsPlaceOrderCuf('BTC');
-    endPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+  it('waiter resolves null when its place-order span is no longer pending', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC');
+    endPerpsCufTrace({ id: opId });
 
     await expect(
-      waitForPerpsPlaceOrderPositionRendered(5, generation),
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
     ).resolves.toBeNull();
   });
 
   it('superseded waiter goes inert instead of touching the next order', async () => {
-    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    const staleGeneration = armPerpsPlaceOrderCuf('BTC');
-    const staleWait = waitForPerpsPlaceOrderPositionRendered(
-      5,
-      staleGeneration,
-    );
+    const staleOpId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(staleOpId, 'BTC');
+    const staleWait = waitForPerpsPlaceOrderPositionRendered(5, staleOpId);
 
     // A second order re-arms before the first waiter settles.
-    const generation = armPerpsPlaceOrderCuf('ETH');
-    const liveWait = waitForPerpsPlaceOrderPositionRendered(1000, generation);
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'ETH');
+    const liveWait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
 
     await expect(staleWait).resolves.toBeNull();
-    expect(isPerpsPlaceOrderCufCurrent(staleGeneration)).toBe(false);
+    expect(isPerpsPlaceOrderCufCurrent(staleOpId)).toBe(false);
 
     // The stale waiter's timeout must not have cleared the live resolver.
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '2' }]);
@@ -283,17 +315,16 @@ describe('perpsCufTrace', () => {
   const btc = { symbol: 'BTC', size: '0.01', takeProfitPrice: '70000' };
 
   it('close span ends when the watched position disappears', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
-    watchPerpsCufPositionChanged(
-      TraceName.PerpsClosePositionToConfirmation,
-      btc,
-    );
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionChanged(opId, btc);
 
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
 
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: TraceName.PerpsClosePositionToConfirmation,
+        id: opId,
         data: expect.objectContaining({
           [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
         }),
@@ -302,11 +333,10 @@ describe('perpsCufTrace', () => {
   });
 
   it('close span ends on a size change but not on an identical snapshot', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsClosePositionToConfirmation });
-    watchPerpsCufPositionChanged(
-      TraceName.PerpsClosePositionToConfirmation,
-      btc,
-    );
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionChanged(opId, btc);
 
     handlePerpsCufPositionsDelivered([btc]);
     expect(mockEndTrace).not.toHaveBeenCalled();
@@ -316,41 +346,38 @@ describe('perpsCufTrace', () => {
   });
 
   it('tpsl span ends when the TP value changes in the stream', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsUpdateTPSLToConfirmation });
-    watchPerpsCufPositionChanged(TraceName.PerpsUpdateTPSLToConfirmation, btc);
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsUpdateTPSLToConfirmation,
+    });
+    watchPerpsCufPositionChanged(opId, btc);
 
     handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
 
     expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsUpdateTPSLToConfirmation,
-      }),
+      expect.objectContaining({ id: opId }),
     );
   });
 
   it('cancel span ends only once the order id is absent', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
-    watchPerpsCufOrderAbsent(TraceName.PerpsCancelOrderToConfirmation, 'o-1');
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-2' }]);
     expect(mockEndTrace).not.toHaveBeenCalled();
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
     expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsCancelOrderToConfirmation,
-      }),
+      expect.objectContaining({ id: opId }),
     );
   });
 
   it('limit-order-render span ends once the order id appears in the stream', () => {
-    startPerpsCufTrace({
+    const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
     });
-    watchPerpsCufOrderPresent(
-      TraceName.PerpsPlaceLimitOrderToOrderRendered,
-      'o-9',
-    );
+    watchPerpsCufOrderPresent(opId, 'o-9');
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }]);
     expect(mockEndTrace).not.toHaveBeenCalled();
@@ -358,7 +385,7 @@ describe('perpsCufTrace', () => {
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-9' }]);
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+        id: opId,
         data: expect.objectContaining({
           [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
         }),
@@ -367,42 +394,66 @@ describe('perpsCufTrace', () => {
   });
 
   it('cancel and limit-render order spans resolve independently on one delivery', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsCancelOrderToConfirmation });
-    watchPerpsCufOrderAbsent(TraceName.PerpsCancelOrderToConfirmation, 'o-1');
-    startPerpsCufTrace({
+    const cancelOpId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(cancelOpId, 'o-1');
+    const limitOpId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
     });
-    watchPerpsCufOrderPresent(
-      TraceName.PerpsPlaceLimitOrderToOrderRendered,
-      'o-2',
-    );
+    watchPerpsCufOrderPresent(limitOpId, 'o-2');
 
     // o-1 gone (cancel confirmed) and o-2 present (limit rendered) in the
     // same delivery: both spans end.
     handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
 
     expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsCancelOrderToConfirmation,
-      }),
+      expect.objectContaining({ id: cancelOpId }),
     );
     expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
-      }),
+      expect.objectContaining({ id: limitOpId }),
     );
   });
 
   it('reconnect span ends on any positions delivery', () => {
-    startPerpsCufTrace({ name: TraceName.PerpsWebSocketReconnectToFreshData });
-    watchPerpsCufAnyPositions(TraceName.PerpsWebSocketReconnectToFreshData);
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsWebSocketReconnectToFreshData,
+    });
+    watchPerpsCufAnyPositions(opId);
 
     handlePerpsCufPositionsDelivered([]);
 
     expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsWebSocketReconnectToFreshData,
-      }),
+      expect.objectContaining({ id: opId }),
     );
+  });
+
+  it('flushes throttled subscribers before ending a matched confirmation', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+    const flush = jest.fn();
+
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);
+
+    expect(flush).toHaveBeenCalledTimes(1);
+    // Flush happens before the span end.
+    expect(flush.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEndTrace.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not flush when no confirmation matches the delivery', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+    const flush = jest.fn();
+
+    // o-1 still present -> no match -> no flush.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }], flush);
+
+    expect(flush).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -9,6 +9,7 @@ import {
   startPerpsCufTrace,
   endPerpsCufTrace,
   armPerpsPlaceOrderCuf,
+  isPerpsPlaceOrderCufCurrent,
   waitForPerpsPlaceOrderPositionRendered,
   watchPerpsCufPositionChanged,
   watchPerpsCufOrderAbsent,
@@ -114,13 +115,16 @@ describe('perpsCufTrace', () => {
 
   it('resolves the place-order waiter when the armed symbol renders', async () => {
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    armPerpsPlaceOrderCuf('BTC');
+    const generation = armPerpsPlaceOrderCuf('BTC');
 
     handlePerpsCufPositionsDelivered([
       { symbol: 'ETH', size: '1' },
       { symbol: 'BTC', size: '0.01' },
     ]);
-    const rendered = await waitForPerpsPlaceOrderPositionRendered(5);
+    const rendered = await waitForPerpsPlaceOrderPositionRendered(
+      5,
+      generation,
+    );
 
     expect(rendered).toEqual({
       position: { symbol: 'BTC', size: '0.01' },
@@ -130,9 +134,12 @@ describe('perpsCufTrace', () => {
 
   it('resolves a waiter registered before the stream delivers', async () => {
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    armPerpsPlaceOrderCuf('BTC');
+    const generation = armPerpsPlaceOrderCuf('BTC');
 
-    const pendingWait = waitForPerpsPlaceOrderPositionRendered(1000);
+    const pendingWait = waitForPerpsPlaceOrderPositionRendered(
+      1000,
+      generation,
+    );
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
 
     await expect(pendingWait).resolves.toEqual(
@@ -143,36 +150,72 @@ describe('perpsCufTrace', () => {
   it('does not resolve for a pre-existing position unchanged from the baseline', async () => {
     const existing = { symbol: 'BTC', size: '0.01' };
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    armPerpsPlaceOrderCuf('BTC', existing);
+    const generation = armPerpsPlaceOrderCuf('BTC', existing);
 
     handlePerpsCufPositionsDelivered([existing]);
 
-    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, generation),
+    ).resolves.toBeNull();
   });
 
   it('resolves when the armed position changes versus the baseline (add to position)', async () => {
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    armPerpsPlaceOrderCuf('BTC', { symbol: 'BTC', size: '0.01' });
+    const generation = armPerpsPlaceOrderCuf('BTC', {
+      symbol: 'BTC',
+      size: '0.01',
+    });
 
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
 
-    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toEqual(
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, generation),
+    ).resolves.toEqual(
       expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
     );
   });
 
   it('ignores deliveries that do not match the armed symbol', async () => {
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    armPerpsPlaceOrderCuf('BTC');
+    const generation = armPerpsPlaceOrderCuf('BTC');
 
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
     handlePerpsCufPositionsDelivered(null);
 
-    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, generation),
+    ).resolves.toBeNull();
   });
 
   it('waiter resolves null when no place-order span is pending', async () => {
-    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
+    const generation = armPerpsPlaceOrderCuf('BTC');
+    endPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, generation),
+    ).resolves.toBeNull();
+  });
+
+  it('superseded waiter goes inert instead of touching the next order', async () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    const staleGeneration = armPerpsPlaceOrderCuf('BTC');
+    const staleWait = waitForPerpsPlaceOrderPositionRendered(
+      5,
+      staleGeneration,
+    );
+
+    // A second order re-arms before the first waiter settles.
+    const generation = armPerpsPlaceOrderCuf('ETH');
+    const liveWait = waitForPerpsPlaceOrderPositionRendered(1000, generation);
+
+    await expect(staleWait).resolves.toBeNull();
+    expect(isPerpsPlaceOrderCufCurrent(staleGeneration)).toBe(false);
+
+    // The stale waiter's timeout must not have cleared the live resolver.
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '2' }]);
+    await expect(liveWait).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'ETH', size: '2' } }),
+    );
   });
 
   const btc = { symbol: 'BTC', size: '0.01', takeProfitPrice: '70000' };

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -8,9 +8,8 @@ import {
 import {
   startPerpsCufTrace,
   endPerpsCufTrace,
-  setPerpsPlaceOrderCufSymbol,
-  setPerpsPlaceOrderCufToastShown,
-  endPerpsPlaceOrderCufOnPositions,
+  armPerpsPlaceOrderCuf,
+  waitForPerpsPlaceOrderPositionRendered,
   watchPerpsCufPositionChanged,
   watchPerpsCufOrderAbsent,
   watchPerpsCufAnyPositions,
@@ -113,39 +112,67 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
-  it('ends the place-order span from the stream when the symbol arrives', () => {
+  it('resolves the place-order waiter when the armed symbol renders', async () => {
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    setPerpsPlaceOrderCufSymbol('BTC');
-    setPerpsPlaceOrderCufToastShown();
+    armPerpsPlaceOrderCuf('BTC');
 
-    endPerpsPlaceOrderCufOnPositions([{ symbol: 'ETH' }, { symbol: 'BTC' }]);
+    handlePerpsCufPositionsDelivered([
+      { symbol: 'ETH', size: '1' },
+      { symbol: 'BTC', size: '0.01' },
+    ]);
+    const rendered = await waitForPerpsPlaceOrderPositionRendered(5);
 
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.PerpsPlaceOrderToPositionRendered,
-        data: expect.objectContaining({
-          [PERPS_CUF_TAG.SUCCESS]: true,
-          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-          [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]: expect.any(Number),
-        }),
-      }),
+    expect(rendered).toEqual({
+      position: { symbol: 'BTC', size: '0.01' },
+      renderedAt: expect.any(Number),
+    });
+  });
+
+  it('resolves a waiter registered before the stream delivers', async () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    armPerpsPlaceOrderCuf('BTC');
+
+    const pendingWait = waitForPerpsPlaceOrderPositionRendered(1000);
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+
+    await expect(pendingWait).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
     );
   });
 
-  it('stream end ignores positions that do not match the pending symbol', () => {
+  it('does not resolve for a pre-existing position unchanged from the baseline', async () => {
+    const existing = { symbol: 'BTC', size: '0.01' };
     startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
-    setPerpsPlaceOrderCufSymbol('BTC');
+    armPerpsPlaceOrderCuf('BTC', existing);
 
-    endPerpsPlaceOrderCufOnPositions([{ symbol: 'ETH' }]);
-    endPerpsPlaceOrderCufOnPositions(null);
+    handlePerpsCufPositionsDelivered([existing]);
 
-    expect(mockEndTrace).not.toHaveBeenCalled();
+    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
   });
 
-  it('stream end no-ops when no place-order span is pending', () => {
-    endPerpsPlaceOrderCufOnPositions([{ symbol: 'BTC' }]);
+  it('resolves when the armed position changes versus the baseline (add to position)', async () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    armPerpsPlaceOrderCuf('BTC', { symbol: 'BTC', size: '0.01' });
 
-    expect(mockEndTrace).not.toHaveBeenCalled();
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
+
+    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
+    );
+  });
+
+  it('ignores deliveries that do not match the armed symbol', async () => {
+    startPerpsCufTrace({ name: TraceName.PerpsPlaceOrderToPositionRendered });
+    armPerpsPlaceOrderCuf('BTC');
+
+    handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
+    handlePerpsCufPositionsDelivered(null);
+
+    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
+  });
+
+  it('waiter resolves null when no place-order span is pending', async () => {
+    await expect(waitForPerpsPlaceOrderPositionRendered(5)).resolves.toBeNull();
   });
 
   const btc = { symbol: 'BTC', size: '0.01', takeProfitPrice: '70000' };

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -281,6 +281,25 @@ describe('perpsCufTrace', () => {
     ).resolves.toBeNull();
   });
 
+  it('does not resolve when only TP/SL changes versus the baseline', async () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceOrderToPositionRendered,
+    });
+    armPerpsPlaceOrderCuf(opId, 'BTC', {
+      symbol: 'BTC',
+      size: '0.01',
+      takeProfitPrice: '70000',
+    });
+
+    handlePerpsCufPositionsDelivered([
+      { symbol: 'BTC', size: '0.01', takeProfitPrice: '71000' },
+    ]);
+
+    await expect(
+      waitForPerpsPlaceOrderPositionRendered(5, opId),
+    ).resolves.toBeNull();
+  });
+
   it('resolves when the armed position changes versus the baseline (add to position)', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
@@ -506,6 +525,23 @@ describe('perpsCufTrace', () => {
         }),
       }),
     );
+  });
+
+  it('limit-order-render span does NOT end on a TP/SL-only position update', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
+    });
+    watchPerpsCufLimitRendered(opId, 'o-9', 'BTC', {
+      symbol: 'BTC',
+      size: '0.01',
+      takeProfitPrice: '70000',
+    });
+
+    handlePerpsCufPositionsDelivered([
+      { symbol: 'BTC', size: '0.01', takeProfitPrice: '71000' },
+    ]);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
   it('limit-order-render span ends when a marketable limit fills into a position', () => {

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -19,6 +19,7 @@ import {
   watchPerpsCufAnyPositions,
   acceptPerpsCufRequest,
   isPerpsFillRendered,
+  clearPendingPerpsCufTraces,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
   resetPerpsCufTraceForTests,
@@ -571,6 +572,33 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({ id: tpslOp }),
     );
+  });
+
+  it('clears pending confirmations on teardown so the next session cannot end them', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionClosed(opId, btc);
+    acceptPerpsCufRequest(opId);
+
+    clearPendingPerpsCufTraces();
+
+    // Ended exactly once as an abandoned failure...
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: opId,
+        data: expect.objectContaining({
+          success: false,
+          reason: 'disconnected',
+        }),
+      }),
+    );
+
+    // ...and a later delivery matching its old criteria cannot resurrect it.
+    mockEndTrace.mockClear();
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
   it('cancel span ends only once the order id is absent', () => {

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -409,6 +409,17 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
+  it('close span is NOT ended by a size increase (overlapping add-to-position)', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionClosed(opId, btc);
+
+    // Size grew instead of shrinking: an add, not a close.
+    handlePerpsCufPositionsDelivered([{ ...btc, size: '0.02' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
   it('close span is NOT ended by a TP/SL-only change (no size change)', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsClosePositionToConfirmation,

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -17,6 +17,7 @@ import {
   watchPerpsCufOrderAbsent,
   watchPerpsCufLimitRendered,
   watchPerpsCufAnyPositions,
+  acceptPerpsCufRequest,
   handlePerpsCufPositionsDelivered,
   handlePerpsCufOrdersDelivered,
   resetPerpsCufTraceForTests,
@@ -182,10 +183,12 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsCancelOrderToConfirmation,
     });
     watchPerpsCufOrderAbsent(opA, 'o-A');
+    acceptPerpsCufRequest(opA);
     const opB = startPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,
     });
     watchPerpsCufOrderAbsent(opB, 'o-B');
+    acceptPerpsCufRequest(opB);
 
     // o-A cancelled (absent), o-B still resting.
     handlePerpsCufOrdersDelivered([{ orderId: 'o-B' }]);
@@ -447,6 +450,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsClosePositionToConfirmation,
     });
     watchPerpsCufPositionClosed(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     handlePerpsCufPositionsDelivered([{ symbol: 'ETH', size: '1' }]);
 
@@ -465,6 +469,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsClosePositionToConfirmation,
     });
     watchPerpsCufPositionClosed(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     handlePerpsCufPositionsDelivered([btc]);
     expect(mockEndTrace).not.toHaveBeenCalled();
@@ -478,6 +483,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsClosePositionToConfirmation,
     });
     watchPerpsCufPositionClosed(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     // Size grew instead of shrinking: an add, not a close.
     handlePerpsCufPositionsDelivered([{ ...btc, size: '0.02' }]);
@@ -489,6 +495,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsClosePositionToConfirmation,
     });
     watchPerpsCufPositionClosed(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     // Same size, different take-profit: not a close.
     handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '80000' }]);
@@ -500,6 +507,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsUpdateTPSLToConfirmation,
     });
     watchPerpsCufTpSlChanged(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
 
@@ -513,6 +521,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsUpdateTPSLToConfirmation,
     });
     watchPerpsCufTpSlChanged(opId, btc);
+    acceptPerpsCufRequest(opId);
 
     // Same TP/SL, different size: not a TP/SL update.
     handlePerpsCufPositionsDelivered([{ ...btc, size: '0.02' }]);
@@ -524,10 +533,12 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsClosePositionToConfirmation,
     });
     watchPerpsCufPositionClosed(closeOp, btc);
+    acceptPerpsCufRequest(closeOp);
     const tpslOp = startPerpsCufTrace({
       name: TraceName.PerpsUpdateTPSLToConfirmation,
     });
     watchPerpsCufTpSlChanged(tpslOp, btc);
+    acceptPerpsCufRequest(tpslOp);
 
     // Only TP/SL changed: ends the tpsl span, not the close span.
     handlePerpsCufPositionsDelivered([{ ...btc, takeProfitPrice: '71000' }]);
@@ -542,6 +553,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsCancelOrderToConfirmation,
     });
     watchPerpsCufOrderAbsent(opId, 'o-1');
+    acceptPerpsCufRequest(opId);
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-1' }, { orderId: 'o-2' }]);
     expect(mockEndTrace).not.toHaveBeenCalled();
@@ -549,6 +561,53 @@ describe('perpsCufTrace', () => {
     handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({ id: opId }),
+    );
+  });
+
+  it('gated confirmation defers a stream match until the request is accepted', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+
+    // Order absent before acceptance (e.g. an unrelated fill): must NOT end.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    // Controller accepts the cancel: the recorded render now completes it.
+    acceptPerpsCufRequest(opId);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: opId,
+        data: expect.objectContaining({
+          [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+        }),
+      }),
+    );
+  });
+
+  it('a failed request is not overridden by a gated stream match', () => {
+    const opId = startPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+    });
+    watchPerpsCufOrderAbsent(opId, 'o-1');
+
+    // Order vanished while the request was in flight, but the request failed.
+    handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }]);
+    endPerpsCufTrace({
+      id: opId,
+      data: { [PERPS_CUF_TAG.SUCCESS]: false },
+    });
+    // A late acceptance can no longer resurrect the span as a success.
+    acceptPerpsCufRequest(opId);
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: opId,
+        data: expect.objectContaining({ [PERPS_CUF_TAG.SUCCESS]: false }),
+      }),
     );
   });
 
@@ -614,6 +673,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsCancelOrderToConfirmation,
     });
     watchPerpsCufOrderAbsent(cancelOpId, 'o-1');
+    acceptPerpsCufRequest(cancelOpId);
     const limitOpId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
     });
@@ -649,6 +709,7 @@ describe('perpsCufTrace', () => {
       name: TraceName.PerpsCancelOrderToConfirmation,
     });
     watchPerpsCufOrderAbsent(opId, 'o-1');
+    acceptPerpsCufRequest(opId);
     const flush = jest.fn();
 
     handlePerpsCufOrdersDelivered([{ orderId: 'o-2' }], flush);

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -332,7 +332,7 @@ describe('perpsCufTrace', () => {
     );
   });
 
-  it('resolves a pending-baseline order when the first positions tick contains the symbol', async () => {
+  it('does not resolve a pending-baseline order on the first positions tick with the symbol', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
     });
@@ -342,9 +342,7 @@ describe('perpsCufTrace', () => {
 
     await expect(
       waitForPerpsPlaceOrderPositionRendered(5, opId),
-    ).resolves.toEqual(
-      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
-    );
+    ).resolves.toBeNull();
   });
 
   it('does not resolve on absence when no baseline position existed', async () => {
@@ -360,18 +358,18 @@ describe('perpsCufTrace', () => {
     ).resolves.toBeNull();
   });
 
-  it('unloaded cache: a present symbol in the first delivery confirms instead of being swallowed as baseline', async () => {
+  it('unloaded cache: captures a present first delivery as baseline, then confirms on later size change', async () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsPlaceOrderToPositionRendered,
     });
     armPerpsPlaceOrderCuf(opId, 'BTC', null, false);
+    const wait = waitForPerpsPlaceOrderPositionRendered(1000, opId);
 
     handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.01' }]);
+    handlePerpsCufPositionsDelivered([{ symbol: 'BTC', size: '0.02' }]);
 
-    await expect(
-      waitForPerpsPlaceOrderPositionRendered(5, opId),
-    ).resolves.toEqual(
-      expect.objectContaining({ position: { symbol: 'BTC', size: '0.01' } }),
+    await expect(wait).resolves.toEqual(
+      expect.objectContaining({ position: { symbol: 'BTC', size: '0.02' } }),
     );
   });
 

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -601,6 +601,37 @@ describe('perpsCufTrace', () => {
     expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
+  it('preserves the reconnect measurement span when clearing on teardown', () => {
+    const reconnectOp = startPerpsCufTrace({
+      name: TraceName.PerpsWebSocketReconnectToFreshData,
+    });
+    watchPerpsCufAnyPositions(reconnectOp);
+    const closeOp = startPerpsCufTrace({
+      name: TraceName.PerpsClosePositionToConfirmation,
+    });
+    watchPerpsCufPositionClosed(closeOp, btc);
+    acceptPerpsCufRequest(closeOp);
+
+    clearPendingPerpsCufTraces();
+
+    // The confirmation op is abandoned; the reconnect measurement survives —
+    // clearing must not end the span that is measuring the reconnection itself.
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: closeOp }),
+    );
+    expect(mockEndTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: reconnectOp }),
+    );
+
+    // Fresh positions still close the reconnect span as a success.
+    mockEndTrace.mockClear();
+    handlePerpsCufPositionsDelivered([]);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: reconnectOp }),
+    );
+  });
+
   it('cancel span ends only once the order id is absent', () => {
     const opId = startPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -28,7 +28,11 @@ const CUF_META = {
   WATCH: 'watch',
   ORDER_ID: 'orderId',
   SNAPSHOT: 'snapshot',
+  INSTANCE: 'instance',
 } as const;
+
+/** Monotonic id per span start so delayed fallbacks can't end a successor. */
+let cufInstanceCounter = 0;
 
 /** What a pending confirmation span is watching for in the stream. */
 const PERPS_CUF_WATCH = {
@@ -90,7 +94,8 @@ export function startPerpsCufTrace({
   data,
 }: StartPerpsCufTraceOptions): void {
   const startTags = buildPerpsCufStartTags(tags);
-  pendingCufMeta.set(name, {});
+  cufInstanceCounter += 1;
+  pendingCufMeta.set(name, { [CUF_META.INSTANCE]: cufInstanceCounter });
   DevLogger?.log?.(
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} started ${JSON.stringify(startTags)}`,
   );
@@ -202,15 +207,24 @@ export function waitForPerpsPlaceOrderPositionRendered(
 }
 
 /**
- * Schedule a fallback end; a no-op if another surface (e.g. the position
- * stream) closes the span first. Used when a poll misses the position so the
- * span stays open for the stream instead of closing at the poll boundary.
+ * Schedule a fallback end for the CURRENTLY pending span instance; a no-op if
+ * another surface (e.g. the position stream) closes it first, and inert if a
+ * new span with the same name has started by the time the delay fires.
  */
 export function endPerpsCufTraceAfter(
   options: EndPerpsCufTraceOptions,
   delayMs: number,
 ): void {
-  setTimeout(() => endPerpsCufTrace(options), delayMs);
+  const instance = pendingCufMeta.get(options.name)?.[CUF_META.INSTANCE];
+  if (instance === undefined) {
+    return;
+  }
+  setTimeout(() => {
+    if (pendingCufMeta.get(options.name)?.[CUF_META.INSTANCE] !== instance) {
+      return;
+    }
+    endPerpsCufTrace(options);
+  }, delayMs);
 }
 
 /**

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -38,6 +38,7 @@ let cufInstanceCounter = 0;
 const PERPS_CUF_WATCH = {
   POSITION_CHANGED: 'position_changed',
   ORDER_ABSENT: 'order_absent',
+  ORDER_PRESENT: 'order_present',
   ANY_POSITIONS: 'any_positions',
 } as const;
 
@@ -283,6 +284,17 @@ export function watchPerpsCufOrderAbsent(
   });
 }
 
+/** Watch for the given order to appear (render) in the stream before ending `name`. */
+export function watchPerpsCufOrderPresent(
+  name: TraceName,
+  orderId: string,
+): void {
+  setPerpsCufMeta(name, {
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_PRESENT,
+    [CUF_META.ORDER_ID]: orderId,
+  });
+}
+
 /** End `name` on the next positions delivery, whatever it contains. */
 export function watchPerpsCufAnyPositions(name: TraceName): void {
   setPerpsCufMeta(name, {
@@ -338,24 +350,41 @@ export function handlePerpsCufPositionsDelivered(
   }
 }
 
-/** Orders just rendered to stream subscribers: close a pending cancel span. */
+/**
+ * Orders just rendered to stream subscribers: close a pending cancel span once
+ * its order is absent, and a pending limit-order-render span once its order is
+ * present.
+ */
 export function handlePerpsCufOrdersDelivered(
   orders: readonly { orderId: string }[] | null,
 ): void {
   if (!orders) {
     return;
   }
-  const meta = pendingCufMeta.get(TraceName.PerpsCancelOrderToConfirmation);
-  if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_ABSENT) {
-    return;
-  }
-  const orderId = meta[CUF_META.ORDER_ID];
-  if (typeof orderId !== 'string') {
-    return;
-  }
-  if (orders?.every((o) => o.orderId !== orderId)) {
+  const cancelMeta = pendingCufMeta.get(
+    TraceName.PerpsCancelOrderToConfirmation,
+  );
+  if (
+    cancelMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_ABSENT &&
+    typeof cancelMeta[CUF_META.ORDER_ID] === 'string' &&
+    orders.every((o) => o.orderId !== cancelMeta[CUF_META.ORDER_ID])
+  ) {
     endPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,
+      data: { ...STREAM_END_DATA },
+    });
+  }
+
+  const placeMeta = pendingCufMeta.get(
+    TraceName.PerpsPlaceLimitOrderToOrderRendered,
+  );
+  if (
+    placeMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_PRESENT &&
+    typeof placeMeta[CUF_META.ORDER_ID] === 'string' &&
+    orders.some((o) => o.orderId === placeMeta[CUF_META.ORDER_ID])
+  ) {
+    endPerpsCufTrace({
+      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
       data: { ...STREAM_END_DATA },
     });
   }

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -2,7 +2,7 @@ import {
   PERPS_CONSTANTS,
   PERFORMANCE_CONFIG,
 } from '@metamask/perps-controller';
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import {
   trace,
   endTrace,
@@ -92,7 +92,7 @@ export function startPerpsCufTrace({
 }: StartPerpsCufTraceOptions): void {
   const startTags = buildPerpsCufStartTags(tags);
   pendingCufMeta.set(name, {});
-  DevLogger.log(
+  DevLogger?.log?.(
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} started ${JSON.stringify(startTags)}`,
   );
   trace({ name, id, op, startTime, data, tags: startTags });
@@ -122,7 +122,7 @@ export function endPerpsCufTrace({
   if (!pendingCufMeta.delete(name)) {
     return;
   }
-  DevLogger.log(
+  DevLogger?.log?.(
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} completed ${JSON.stringify(data ?? {})}`,
   );
   endTrace({ name, id, data, timestamp });

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -280,20 +280,13 @@ export function waitForPerpsPlaceOrderPositionRendered(
 }
 
 /**
- * Stream-side matcher for the place-order CUF: records when the armed position
- * first renders (new, or changed versus the pre-order baseline) and wakes the
- * waiter. `flushThrottled` is invoked before the render timestamp is stamped so
- * throttled subscribers actually receive the data at the measured instant.
- * Returns true when it matched (so the caller can flush once for the tick).
- */
-/**
  * Whether the armed position has rendered for op `opId`: a new/changed position
  * for its symbol, OR — when a position existed pre-order — that position now
  * absent (the order reduced/flipped it to zero via the order form).
  *
- * When the baseline is pending (positions cache was unloaded at submit), this
- * delivery is treated as the baseline: it is captured and NOT counted as a
- * render, so a pre-existing position can't falsely confirm the order.
+ * When the baseline is pending (positions cache was unloaded at submit), an
+ * absent first delivery is captured as the baseline. A present symbol is counted
+ * as rendered because it may be the post-fill snapshot and must not be swallowed.
  */
 function placeOrderPositionRendered(
   opId: string,
@@ -306,13 +299,11 @@ function placeOrderPositionRendered(
   }
   const current = positions.find((p) => p.symbol === symbol);
   if (meta[CUF_META.BASELINE_PENDING] === true) {
-    // First delivery after an unloaded-cache submit: this is the real
-    // pre-order state. Capture it and wait for a subsequent change.
-    setPerpsCufMeta(opId, {
-      [CUF_META.BASELINE_PENDING]: false,
-      ...(current ? { [CUF_META.SNAPSHOT]: positionSnapshot(current) } : {}),
-    });
-    return null;
+    setPerpsCufMeta(opId, { [CUF_META.BASELINE_PENDING]: false });
+    if (!current) {
+      return null;
+    }
+    return current;
   }
   const baseline = meta[CUF_META.SNAPSHOT];
   const baselineExisted = typeof baseline === 'string';

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -245,7 +245,8 @@ export function handlePerpsCufPositionsDelivered(
       continue;
     }
     const current = positions.find((p) => p.symbol === symbol);
-    if (!current || positionSnapshot(current) !== meta[CUF_META.SNAPSHOT]) {
+    const currentSnapshot = current ? positionSnapshot(current) : undefined;
+    if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
       endPerpsCufTrace({ name, data: { ...STREAM_END_DATA } });
     }
   }
@@ -275,7 +276,7 @@ export function handlePerpsCufOrdersDelivered(
   if (typeof orderId !== 'string') {
     return;
   }
-  if (!orders.some((o) => o.orderId === orderId)) {
+  if (orders?.some((o) => o.orderId === orderId) === false) {
     endPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,
       data: { ...STREAM_END_DATA },

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -1,0 +1,164 @@
+import {
+  PERPS_CONSTANTS,
+  PERFORMANCE_CONFIG,
+} from '@metamask/perps-controller';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import {
+  trace,
+  endTrace,
+  TraceName,
+  TraceOperation,
+  type TraceValue,
+} from '../../../../util/trace';
+import { PERPS_CUF_TAG, PERPS_CUF_BOUNDARY } from '../constants/perpsCufTags';
+import { getPerpsLifecycleContext } from './perpsLifecycleContext';
+
+/**
+ * Helpers for the Perps user-perceived CUF spans. These measure from the user
+ * gesture to render-complete with live data, so start and end can live in
+ * different surfaces; keying by a deterministic id (the trace name) lets the
+ * ending surface close the span the starting surface opened. A pending
+ * registry makes ends idempotent: the first surface to observe completion
+ * (e.g. the position stream) wins, later fallbacks no-op.
+ */
+
+/** Internal metadata keys shared between the starting and ending surfaces. */
+const CUF_META = {
+  SYMBOL: 'symbol',
+  TOAST_AT: 'toastAt',
+} as const;
+
+/** Open CUF spans: name -> metadata handed from starter to ender. */
+const pendingCufMeta = new Map<string, Record<string, TraceValue>>();
+
+/** Start tags shared by all CUF spans: feature + lifecycle_context, plus caller variants. */
+export function buildPerpsCufStartTags(
+  extra?: Record<string, TraceValue>,
+): Record<string, TraceValue> {
+  return {
+    [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
+    [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: getPerpsLifecycleContext(),
+    ...extra,
+  };
+}
+
+export interface StartPerpsCufTraceOptions {
+  name: TraceName;
+  id?: string;
+  op?: TraceOperation;
+  /** Flow variant tags merged onto the shared start tags. */
+  tags?: Record<string, TraceValue>;
+  startTime?: number;
+  data?: Record<string, TraceValue>;
+}
+
+export interface EndPerpsCufTraceOptions {
+  name: TraceName;
+  id?: string;
+  data?: Record<string, TraceValue>;
+  timestamp?: number;
+}
+
+/** Start a CUF span at the user gesture. */
+export function startPerpsCufTrace({
+  name,
+  id = name,
+  op = TraceOperation.PerpsOperation,
+  tags,
+  startTime,
+  data,
+}: StartPerpsCufTraceOptions): void {
+  const startTags = buildPerpsCufStartTags(tags);
+  pendingCufMeta.set(name, {});
+  DevLogger.log(
+    `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} started ${JSON.stringify(startTags)}`,
+  );
+  trace({ name, id, op, startTime, data, tags: startTags });
+}
+
+/** Attach metadata (e.g. order symbol, toast timestamp) to an open CUF span. */
+export function setPerpsCufMeta(
+  name: TraceName,
+  meta: Record<string, TraceValue>,
+): void {
+  const existing = pendingCufMeta.get(name);
+  if (existing) {
+    pendingCufMeta.set(name, { ...existing, ...meta });
+  }
+}
+
+/**
+ * End a CUF span once the flow has rendered. Idempotent: no-ops unless the
+ * span is still pending, so a fallback end after a stream end is harmless.
+ */
+export function endPerpsCufTrace({
+  name,
+  id = name,
+  data,
+  timestamp,
+}: EndPerpsCufTraceOptions): void {
+  if (!pendingCufMeta.delete(name)) {
+    return;
+  }
+  DevLogger.log(
+    `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} completed ${JSON.stringify(data ?? {})}`,
+  );
+  endTrace({ name, id, data, timestamp });
+}
+
+/** Register the order symbol the place-order CUF span is waiting on. */
+export function setPerpsPlaceOrderCufSymbol(symbol: string): void {
+  setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
+    [CUF_META.SYMBOL]: symbol,
+  });
+}
+
+/** Stamp the toast moment so the stream end can compute the toast<->position delta. */
+export function setPerpsPlaceOrderCufToastShown(): void {
+  setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
+    [CUF_META.TOAST_AT]: Date.now(),
+  });
+}
+
+/**
+ * Schedule a fallback end; a no-op if another surface (e.g. the position
+ * stream) closes the span first. Used when a poll misses the position so the
+ * span stays open for the stream instead of closing at the poll boundary.
+ */
+export function endPerpsCufTraceAfter(
+  options: EndPerpsCufTraceOptions,
+  delayMs: number,
+): void {
+  setTimeout(() => endPerpsCufTrace(options), delayMs);
+}
+
+/**
+ * Stream-side end for the place-order CUF: called by the position stream when
+ * fresh positions are delivered to subscribers (the moment the new position
+ * renders). Ends the span only if one is pending and its symbol just arrived.
+ */
+export function endPerpsPlaceOrderCufOnPositions(
+  positions: readonly { symbol: string }[] | null,
+): void {
+  const meta = pendingCufMeta.get(TraceName.PerpsPlaceOrderToPositionRendered);
+  if (!meta || !positions) {
+    return;
+  }
+  const symbol = meta[CUF_META.SYMBOL];
+  if (
+    typeof symbol !== 'string' ||
+    !positions.some((p) => p.symbol === symbol)
+  ) {
+    return;
+  }
+  const toastAt = meta[CUF_META.TOAST_AT];
+  endPerpsCufTrace({
+    name: TraceName.PerpsPlaceOrderToPositionRendered,
+    data: {
+      [PERPS_CUF_TAG.SUCCESS]: true,
+      [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+      [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]:
+        typeof toastAt === 'number' ? Date.now() - toastAt : -1,
+    },
+  });
+}

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -78,6 +78,25 @@ function tpSlSnapshot(position: PerpsCufPositionLike): string {
   return `${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
 }
 
+/**
+ * Whether `current` (the symbol's position now, or undefined if absent) is a
+ * render of an order versus `baselineSize` (the pre-order size, or undefined
+ * when there was no prior position). A render is a new position (no baseline),
+ * a changed position, OR a pre-existing position now absent because the order
+ * reduced it fully to zero. Shared by the stream matcher and the hook's
+ * synchronous fast path so the two cannot drift.
+ */
+export function isPerpsFillRendered(
+  current: PerpsCufPositionLike | undefined,
+  baselineSize: string | undefined,
+): boolean {
+  const baselineExisted = baselineSize !== undefined;
+  if (current) {
+    return !baselineExisted || positionSnapshot(current) !== baselineSize;
+  }
+  return baselineExisted;
+}
+
 /** Open CUF spans: unique op id -> metadata handed from starter to ender. */
 const pendingCufMeta = new Map<string, Record<string, TraceValue>>();
 let cufOpCounter = 0;
@@ -326,16 +345,13 @@ function placeOrderPositionRendered(
     return null;
   }
   const baseline = meta[CUF_META.SNAPSHOT];
-  const baselineExisted = typeof baseline === 'string';
-  if (current) {
-    // New (no baseline) or changed versus the pre-order baseline.
-    if (!baselineExisted || positionSnapshot(current) !== baseline) {
-      return current;
-    }
-    return null;
+  const baselineSize = typeof baseline === 'string' ? baseline : undefined;
+  if (isPerpsFillRendered(current, baselineSize)) {
+    // A present position renders itself; an absent one that existed before
+    // renders as a synthetic zero (the order closed it).
+    return current ?? { symbol, size: '0' };
   }
-  // Position absent: a render only if one existed before (order closed it).
-  return baselineExisted ? { symbol, size: '0' } : null;
+  return null;
 }
 
 /** Close confirmation: end `opId` when its position's size shrinks or vanishes. */

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -16,23 +16,21 @@ import { getPerpsLifecycleContext } from './perpsLifecycleContext';
 /**
  * Helpers for the Perps user-perceived CUF spans. These measure from the user
  * gesture to render-complete with live data, so start and end can live in
- * different surfaces; keying by a deterministic id (the trace name) lets the
- * ending surface close the span the starting surface opened. A pending
- * registry makes ends idempotent: the first surface to observe completion
- * (e.g. the position stream) wins, later fallbacks no-op.
+ * different surfaces. Each start mints a unique operation id; the pending
+ * registry is keyed by that id (not the trace name) so overlapping operations
+ * of the same flow — e.g. two cancels in flight — each get their own span and
+ * are matched/ended independently. The ending surface (usually the stream)
+ * finds the right pending op by matching its watched criteria.
  */
 
-/** Internal metadata keys shared between the starting and ending surfaces. */
+/** Internal metadata keys carried from the starting to the ending surface. */
 const CUF_META = {
+  NAME: 'name',
   SYMBOL: 'symbol',
   WATCH: 'watch',
   ORDER_ID: 'orderId',
   SNAPSHOT: 'snapshot',
-  INSTANCE: 'instance',
 } as const;
-
-/** Monotonic id per span start so delayed fallbacks can't end a successor. */
-let cufInstanceCounter = 0;
 
 /** What a pending confirmation span is watching for in the stream. */
 const PERPS_CUF_WATCH = {
@@ -54,8 +52,15 @@ function positionSnapshot(position: PerpsCufPositionLike): string {
   return `${position.size}|${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
 }
 
-/** Open CUF spans: name -> metadata handed from starter to ender. */
+/** Open CUF spans: unique op id -> metadata handed from starter to ender. */
 const pendingCufMeta = new Map<string, Record<string, TraceValue>>();
+let cufOpCounter = 0;
+
+/** Mint a unique, greppable op id for a span start. */
+function nextCufOpId(name: TraceName): string {
+  cufOpCounter += 1;
+  return `${name}#${cufOpCounter}`;
+}
 
 /** Start tags shared by all CUF spans: feature + lifecycle_context, plus caller variants. */
 export function buildPerpsCufStartTags(
@@ -70,7 +75,6 @@ export function buildPerpsCufStartTags(
 
 export interface StartPerpsCufTraceOptions {
   name: TraceName;
-  id?: string;
   op?: TraceOperation;
   /** Flow variant tags merged onto the shared start tags. */
   tags?: Record<string, TraceValue>;
@@ -78,59 +82,73 @@ export interface StartPerpsCufTraceOptions {
   data?: Record<string, TraceValue>;
 }
 
-export interface EndPerpsCufTraceOptions {
-  name: TraceName;
-  id?: string;
-  data?: Record<string, TraceValue>;
-  timestamp?: number;
-}
-
-/** Start a CUF span at the user gesture. */
+/** Start a CUF span at the user gesture. Returns the op id used to end it. */
 export function startPerpsCufTrace({
   name,
-  id = name,
   op = TraceOperation.PerpsOperation,
   tags,
   startTime,
   data,
-}: StartPerpsCufTraceOptions): void {
+}: StartPerpsCufTraceOptions): string {
+  const opId = nextCufOpId(name);
   const startTags = buildPerpsCufStartTags(tags);
-  cufInstanceCounter += 1;
-  pendingCufMeta.set(name, { [CUF_META.INSTANCE]: cufInstanceCounter });
+  pendingCufMeta.set(opId, { [CUF_META.NAME]: name });
   DevLogger?.log?.(
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} started ${JSON.stringify(startTags)}`,
   );
-  trace({ name, id, op, startTime, data, tags: startTags });
+  trace({ name, id: opId, op, startTime, data, tags: startTags });
+  return opId;
 }
 
-/** Attach metadata (e.g. order symbol, toast timestamp) to an open CUF span. */
+/** Attach metadata (e.g. order symbol, watch criteria) to an open CUF span. */
 export function setPerpsCufMeta(
-  name: TraceName,
+  opId: string,
   meta: Record<string, TraceValue>,
 ): void {
-  const existing = pendingCufMeta.get(name);
+  const existing = pendingCufMeta.get(opId);
   if (existing) {
-    pendingCufMeta.set(name, { ...existing, ...meta });
+    pendingCufMeta.set(opId, { ...existing, ...meta });
   }
+}
+
+export interface EndPerpsCufTraceOptions {
+  id: string;
+  data?: Record<string, TraceValue>;
+  timestamp?: number;
 }
 
 /**
- * End a CUF span once the flow has rendered. Idempotent: no-ops unless the
- * span is still pending, so a fallback end after a stream end is harmless.
+ * End a CUF span once the flow has rendered. Idempotent: no-ops unless the op
+ * is still pending, so a fallback end after a stream end is harmless, and a
+ * fallback for a superseded op cannot touch a newer one (distinct op ids).
  */
 export function endPerpsCufTrace({
-  name,
-  id = name,
+  id,
   data,
   timestamp,
 }: EndPerpsCufTraceOptions): void {
-  if (!pendingCufMeta.delete(name)) {
+  const meta = pendingCufMeta.get(id);
+  if (!meta) {
     return;
   }
+  pendingCufMeta.delete(id);
+  const name = meta[CUF_META.NAME] as TraceName;
   DevLogger?.log?.(
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} completed ${JSON.stringify(data ?? {})}`,
   );
   endTrace({ name, id, data, timestamp });
+}
+
+/**
+ * Schedule a fallback end for a specific op; a no-op if the stream (or the
+ * caller) closes that op first. Because ids are unique per operation, a
+ * superseded op's fallback can never close a later op of the same flow.
+ */
+export function endPerpsCufTraceAfter(
+  options: EndPerpsCufTraceOptions,
+  delayMs: number,
+): void {
+  setTimeout(() => endPerpsCufTrace(options), delayMs);
 }
 
 /** First stream render matching an armed place-order confirmation. */
@@ -141,48 +159,52 @@ export interface PerpsCufPositionRendered {
 
 let placeOrderRendered: PerpsCufPositionRendered | null = null;
 let placeOrderResolver: (() => void) | null = null;
-/** Bumped on every arm so waiters from a superseded order go inert. */
-let placeOrderGeneration = 0;
+/** Op id of the place-order span currently awaiting its position render. */
+let placeOrderOpId: string | null = null;
 
 /**
- * Arm the place-order confirmation: the stream matcher fires when a position
- * for `symbol` renders that is new or changed versus the pre-order baseline,
- * so a pre-existing position on the same market can't confirm the order early.
- * Returns a generation token; waiters from earlier generations resolve null
- * and never touch the newly armed order's span.
+ * Arm the place-order confirmation for `opId`: the stream matcher fires when a
+ * position for `symbol` renders that is new or changed versus the pre-order
+ * baseline, so a pre-existing position on the same market can't confirm early.
+ * A newer arm supersedes any earlier place-order waiter.
  */
 export function armPerpsPlaceOrderCuf(
+  opId: string,
   symbol: string,
   baseline?: PerpsCufPositionLike | null,
-): number {
-  placeOrderGeneration += 1;
+): void {
+  placeOrderOpId = opId;
   placeOrderRendered = null;
   placeOrderResolver = null;
-  setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
+  setPerpsCufMeta(opId, {
     [CUF_META.SYMBOL]: symbol,
     ...(baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {}),
   });
-  return placeOrderGeneration;
 }
 
-/** Whether `generation` still owns the place-order confirmation state. */
-export function isPerpsPlaceOrderCufCurrent(generation: number): boolean {
-  return generation === placeOrderGeneration;
+/** Whether `opId` still owns the place-order confirmation state. */
+export function isPerpsPlaceOrderCufCurrent(opId: string): boolean {
+  return opId === placeOrderOpId;
+}
+
+/** Test-only: drop all pending spans and place-order state between tests. */
+export function resetPerpsCufTraceForTests(): void {
+  pendingCufMeta.clear();
+  placeOrderRendered = null;
+  placeOrderResolver = null;
+  placeOrderOpId = null;
 }
 
 /**
  * Resolve with the armed position's first stream render, or `null` after
  * `timeoutMs`. Resolves immediately when the render already happened or when
- * `generation` has been superseded by a newer order.
+ * `opId` has been superseded by a newer order.
  */
 export function waitForPerpsPlaceOrderPositionRendered(
   timeoutMs: number,
-  generation: number,
+  opId: string,
 ): Promise<PerpsCufPositionRendered | null> {
-  if (
-    !isPerpsPlaceOrderCufCurrent(generation) ||
-    !pendingCufMeta.has(TraceName.PerpsPlaceOrderToPositionRendered)
-  ) {
+  if (!isPerpsPlaceOrderCufCurrent(opId) || !pendingCufMeta.has(opId)) {
     return Promise.resolve(null);
   }
   if (placeOrderRendered) {
@@ -197,9 +219,7 @@ export function waitForPerpsPlaceOrderPositionRendered(
       if (placeOrderResolver === wake) {
         placeOrderResolver = null;
       }
-      resolve(
-        isPerpsPlaceOrderCufCurrent(generation) ? placeOrderRendered : null,
-      );
+      resolve(isPerpsPlaceOrderCufCurrent(opId) ? placeOrderRendered : null);
     };
     const timer = setTimeout(wake, timeoutMs);
     cancelTimer = () => clearTimeout(timer);
@@ -208,39 +228,20 @@ export function waitForPerpsPlaceOrderPositionRendered(
 }
 
 /**
- * Schedule a fallback end for the CURRENTLY pending span instance; a no-op if
- * another surface (e.g. the position stream) closes it first, and inert if a
- * new span with the same name has started by the time the delay fires.
- */
-export function endPerpsCufTraceAfter(
-  options: EndPerpsCufTraceOptions,
-  delayMs: number,
-): void {
-  const instance = pendingCufMeta.get(options.name)?.[CUF_META.INSTANCE];
-  if (instance === undefined) {
-    return;
-  }
-  setTimeout(() => {
-    if (pendingCufMeta.get(options.name)?.[CUF_META.INSTANCE] !== instance) {
-      return;
-    }
-    endPerpsCufTrace(options);
-  }, delayMs);
-}
-
-/**
- * Stream-side matcher for the place-order CUF: records when the armed
- * position first renders (new, or changed versus the pre-order baseline) and
- * wakes the waiter. The hook owns ending the span so the confirmation toast
- * and the measured delta stay coupled to this render.
+ * Stream-side matcher for the place-order CUF: records when the armed position
+ * first renders (new, or changed versus the pre-order baseline) and wakes the
+ * waiter. `flushThrottled` is invoked before the render timestamp is stamped so
+ * throttled subscribers actually receive the data at the measured instant.
+ * Returns true when it matched (so the caller can flush once for the tick).
  */
 function resolvePerpsPlaceOrderCufOnPositions(
-  positions: readonly PerpsCufPositionLike[] | null,
+  positions: readonly PerpsCufPositionLike[],
+  flushThrottled?: () => void,
 ): void {
-  if (placeOrderRendered || !positions) {
+  if (placeOrderRendered || !placeOrderOpId) {
     return;
   }
-  const meta = pendingCufMeta.get(TraceName.PerpsPlaceOrderToPositionRendered);
+  const meta = pendingCufMeta.get(placeOrderOpId);
   if (!meta) {
     return;
   }
@@ -257,47 +258,42 @@ function resolvePerpsPlaceOrderCufOnPositions(
     // Pre-order position unchanged: the order's fill hasn't rendered yet.
     return;
   }
+  flushThrottled?.();
   placeOrderRendered = { position: current, renderedAt: Date.now() };
   placeOrderResolver?.();
 }
 
-/** Watch for the given position to change (or vanish) before ending `name`. */
+/** Watch for the given position to change (or vanish) before ending `opId`. */
 export function watchPerpsCufPositionChanged(
-  name: TraceName,
+  opId: string,
   position: PerpsCufPositionLike,
 ): void {
-  setPerpsCufMeta(name, {
+  setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.POSITION_CHANGED,
     [CUF_META.SYMBOL]: position.symbol,
     [CUF_META.SNAPSHOT]: positionSnapshot(position),
   });
 }
 
-/** Watch for the given order to disappear before ending `name`. */
-export function watchPerpsCufOrderAbsent(
-  name: TraceName,
-  orderId: string,
-): void {
-  setPerpsCufMeta(name, {
+/** Watch for the given order to disappear before ending `opId`. */
+export function watchPerpsCufOrderAbsent(opId: string, orderId: string): void {
+  setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_ABSENT,
     [CUF_META.ORDER_ID]: orderId,
   });
 }
 
-/** Watch for the given order to appear (render) in the stream before ending `name`. */
-export function watchPerpsCufOrderPresent(
-  name: TraceName,
-  orderId: string,
-): void {
-  setPerpsCufMeta(name, {
+/** Watch for the given order to appear (render) in the stream before ending `opId`. */
+export function watchPerpsCufOrderPresent(opId: string, orderId: string): void {
+  setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_PRESENT,
     [CUF_META.ORDER_ID]: orderId,
   });
 }
 
-/** End `name` on the next positions delivery, whatever it contains. */
-export function watchPerpsCufAnyPositions(name: TraceName): void {
-  setPerpsCufMeta(name, {
+/** End `opId` on the next positions delivery, whatever it contains. */
+export function watchPerpsCufAnyPositions(opId: string): void {
+  setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.ANY_POSITIONS,
   });
 }
@@ -307,85 +303,146 @@ const STREAM_END_DATA = {
   [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
 } as const;
 
+/** Op ids of every pending span with the given trace name. */
+function pendingOpIdsForName(name: TraceName): string[] {
+  const ids: string[] = [];
+  for (const [opId, meta] of pendingCufMeta) {
+    if (meta[CUF_META.NAME] === name) {
+      ids.push(opId);
+    }
+  }
+  return ids;
+}
+
 /**
  * Positions just rendered to stream subscribers: close every pending CUF span
  * whose watched condition is now visible (new position, changed/absent
- * position, or any fresh delivery after a reconnect).
+ * position, or any fresh delivery after a reconnect). `flushThrottled` is
+ * called once, before any span is ended, so throttled subscribers receive the
+ * update at the measured render instant instead of up to a throttle interval
+ * later.
  */
 export function handlePerpsCufPositionsDelivered(
   positions: readonly PerpsCufPositionLike[] | null,
+  flushThrottled?: () => void,
 ): void {
-  resolvePerpsPlaceOrderCufOnPositions(positions);
   if (!positions) {
     return;
   }
-  for (const name of [
+
+  // Collect matches first so a single flush covers the whole tick.
+  const positionChangedNames = [
     TraceName.PerpsClosePositionToConfirmation,
     TraceName.PerpsUpdateTPSLToConfirmation,
-  ]) {
-    const meta = pendingCufMeta.get(name);
-    if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
-      continue;
-    }
-    const symbol = meta[CUF_META.SYMBOL];
-    if (typeof symbol !== 'string') {
-      continue;
-    }
-    const current = positions.find((p) => p.symbol === symbol);
-    const currentSnapshot = current?.symbol
-      ? positionSnapshot(current)
-      : undefined;
-    if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
-      endPerpsCufTrace({ name, data: { ...STREAM_END_DATA } });
+  ];
+  const toEnd: string[] = [];
+  for (const name of positionChangedNames) {
+    for (const opId of pendingOpIdsForName(name)) {
+      const meta = pendingCufMeta.get(opId);
+      if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
+        continue;
+      }
+      const symbol = meta[CUF_META.SYMBOL];
+      if (typeof symbol !== 'string') {
+        continue;
+      }
+      const current = positions.find((p) => p.symbol === symbol);
+      const currentSnapshot = current ? positionSnapshot(current) : undefined;
+      if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
+        toEnd.push(opId);
+      }
     }
   }
-  const reconnectMeta = pendingCufMeta.get(
+  for (const opId of pendingOpIdsForName(
     TraceName.PerpsWebSocketReconnectToFreshData,
-  );
-  if (reconnectMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ANY_POSITIONS) {
-    endPerpsCufTrace({
-      name: TraceName.PerpsWebSocketReconnectToFreshData,
-      data: { ...STREAM_END_DATA },
-    });
+  )) {
+    if (
+      pendingCufMeta.get(opId)?.[CUF_META.WATCH] ===
+      PERPS_CUF_WATCH.ANY_POSITIONS
+    ) {
+      toEnd.push(opId);
+    }
+  }
+
+  const placeWillMatch =
+    !placeOrderRendered &&
+    !!placeOrderOpId &&
+    (() => {
+      const meta = pendingCufMeta.get(placeOrderOpId);
+      if (!meta) {
+        return false;
+      }
+      const symbol = meta[CUF_META.SYMBOL];
+      if (typeof symbol !== 'string') {
+        return false;
+      }
+      const current = positions.find((p) => p.symbol === symbol);
+      if (!current) {
+        return false;
+      }
+      const baseline = meta[CUF_META.SNAPSHOT];
+      return (
+        typeof baseline !== 'string' || positionSnapshot(current) !== baseline
+      );
+    })();
+
+  // Flush once if anything is about to be confirmed, so the measured render
+  // instant reflects real subscriber delivery (not the throttle enqueue).
+  if (flushThrottled && (toEnd.length > 0 || placeWillMatch)) {
+    flushThrottled();
+  }
+
+  resolvePerpsPlaceOrderCufOnPositions(positions);
+  for (const opId of toEnd) {
+    endPerpsCufTrace({ id: opId, data: { ...STREAM_END_DATA } });
   }
 }
 
 /**
- * Orders just rendered to stream subscribers: close a pending cancel span once
- * its order is absent, and a pending limit-order-render span once its order is
- * present.
+ * Orders just rendered to stream subscribers: close pending cancel spans once
+ * their order is absent, and pending limit-order-render spans once their order
+ * is present. Flushes throttled subscribers once before ending, as above.
  */
 export function handlePerpsCufOrdersDelivered(
   orders: readonly { orderId: string }[] | null,
+  flushThrottled?: () => void,
 ): void {
   if (!orders) {
     return;
   }
-  const cancelMeta = pendingCufMeta.get(
+
+  const toEnd: string[] = [];
+  for (const opId of pendingOpIdsForName(
     TraceName.PerpsCancelOrderToConfirmation,
-  );
-  if (
-    cancelMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_ABSENT &&
-    typeof cancelMeta[CUF_META.ORDER_ID] === 'string' &&
-    orders.every((o) => o.orderId !== cancelMeta[CUF_META.ORDER_ID])
-  ) {
-    endPerpsCufTrace({
-      name: TraceName.PerpsCancelOrderToConfirmation,
-      data: { ...STREAM_END_DATA },
-    });
+  )) {
+    const meta = pendingCufMeta.get(opId);
+    const orderId = meta?.[CUF_META.ORDER_ID];
+    if (
+      meta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_ABSENT &&
+      typeof orderId === 'string' &&
+      orders.every((o) => o.orderId !== orderId)
+    ) {
+      toEnd.push(opId);
+    }
+  }
+  for (const opId of pendingOpIdsForName(
+    TraceName.PerpsPlaceLimitOrderToOrderRendered,
+  )) {
+    const meta = pendingCufMeta.get(opId);
+    const orderId = meta?.[CUF_META.ORDER_ID];
+    if (
+      meta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_PRESENT &&
+      typeof orderId === 'string' &&
+      orders.some((o) => o.orderId === orderId)
+    ) {
+      toEnd.push(opId);
+    }
   }
 
-  const placeMeta = pendingCufMeta.get(
-    TraceName.PerpsPlaceLimitOrderToOrderRendered,
-  );
-  if (
-    placeMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_PRESENT &&
-    typeof placeMeta[CUF_META.ORDER_ID] === 'string' &&
-    orders.some((o) => o.orderId === placeMeta[CUF_META.ORDER_ID])
-  ) {
-    endPerpsCufTrace({
-      name: TraceName.PerpsPlaceLimitOrderToOrderRendered,
-      data: { ...STREAM_END_DATA },
-    });
+  if (flushThrottled && toEnd.length > 0) {
+    flushThrottled();
+  }
+  for (const opId of toEnd) {
+    endPerpsCufTrace({ id: opId, data: { ...STREAM_END_DATA } });
   }
 }

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -424,10 +424,10 @@ function pendingOpIdsForName(name: TraceName): string[] {
  * request is accepted. This prevents an unrelated stream change during the
  * request window from recording a failed cancel/close/TP-SL as a success.
  *
- * Returns true when the match was deferred, so the caller still flushes
- * throttled subscribers: the recorded DEFERRED_AT is the delivery instant, so
- * the flush must deliver the update to throttled subscribers at that instant
- * for the eventual span duration to be truthful.
+ * Returns true only on the FIRST deferral tick, so the caller flushes throttled
+ * subscribers exactly once: DEFERRED_AT captures that instant, so later ticks in
+ * the same await window need no further flush. The one flush ensures the
+ * throttled subscriber receives the update at DEFERRED_AT for a truthful span.
  */
 function confirmOrDefer(
   opId: string,
@@ -437,8 +437,9 @@ function confirmOrDefer(
   if (meta[CUF_META.AWAIT_ACCEPT] === true) {
     if (meta[CUF_META.DEFERRED_AT] === undefined) {
       setPerpsCufMeta(opId, { [CUF_META.DEFERRED_AT]: Date.now() });
+      return true;
     }
-    return true;
+    return false;
   }
   toEnd.push(opId);
   return false;

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -56,9 +56,9 @@ export interface PerpsCufPositionLike {
   stopLossPrice?: string;
 }
 
-/** Full render snapshot (size + TP/SL) used for the place-order fill matcher. */
+/** Position-size snapshot used for order-fill matchers; TP/SL-only updates do not fill. */
 function positionSnapshot(position: PerpsCufPositionLike): string {
-  return `${position.size}|${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
+  return position.size;
 }
 
 /** TP/SL-only snapshot: a size change must not end a TP/SL confirmation. */

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -289,7 +289,13 @@ export function isPerpsPlaceOrderCufCurrent(opId: string): boolean {
 export function clearPendingPerpsCufTraces(
   reason: string = PERPS_CUF_END_REASON.DISCONNECTED,
 ): void {
-  for (const id of Array.from(pendingCufMeta.keys())) {
+  for (const [id, meta] of Array.from(pendingCufMeta.entries())) {
+    // Preserve the reconnect-to-fresh-data span: it is armed to MEASURE a
+    // reconnection and is ended by the fresh delivery, so it must survive a
+    // teardown clear rather than be abandoned by it.
+    if (meta[CUF_META.NAME] === TraceName.PerpsWebSocketReconnectToFreshData) {
+      continue;
+    }
     endPerpsCufTrace({
       id,
       data: {

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -26,7 +26,29 @@ import { getPerpsLifecycleContext } from './perpsLifecycleContext';
 const CUF_META = {
   SYMBOL: 'symbol',
   TOAST_AT: 'toastAt',
+  WATCH: 'watch',
+  ORDER_ID: 'orderId',
+  SNAPSHOT: 'snapshot',
 } as const;
+
+/** What a pending confirmation span is watching for in the stream. */
+const PERPS_CUF_WATCH = {
+  POSITION_CHANGED: 'position_changed',
+  ORDER_ABSENT: 'order_absent',
+  ANY_POSITIONS: 'any_positions',
+} as const;
+
+/** Minimal position shape the confirmation matchers need. */
+export interface PerpsCufPositionLike {
+  symbol: string;
+  size: string;
+  takeProfitPrice?: string;
+  stopLossPrice?: string;
+}
+
+function positionSnapshot(position: PerpsCufPositionLike): string {
+  return `${position.size}|${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
+}
 
 /** Open CUF spans: name -> metadata handed from starter to ender. */
 const pendingCufMeta = new Map<string, Record<string, TraceValue>>();
@@ -161,4 +183,102 @@ export function endPerpsPlaceOrderCufOnPositions(
         typeof toastAt === 'number' ? Date.now() - toastAt : -1,
     },
   });
+}
+
+/** Watch for the given position to change (or vanish) before ending `name`. */
+export function watchPerpsCufPositionChanged(
+  name: TraceName,
+  position: PerpsCufPositionLike,
+): void {
+  setPerpsCufMeta(name, {
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.POSITION_CHANGED,
+    [CUF_META.SYMBOL]: position.symbol,
+    [CUF_META.SNAPSHOT]: positionSnapshot(position),
+  });
+}
+
+/** Watch for the given order to disappear before ending `name`. */
+export function watchPerpsCufOrderAbsent(
+  name: TraceName,
+  orderId: string,
+): void {
+  setPerpsCufMeta(name, {
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_ABSENT,
+    [CUF_META.ORDER_ID]: orderId,
+  });
+}
+
+/** End `name` on the next positions delivery, whatever it contains. */
+export function watchPerpsCufAnyPositions(name: TraceName): void {
+  setPerpsCufMeta(name, {
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.ANY_POSITIONS,
+  });
+}
+
+const STREAM_END_DATA = {
+  [PERPS_CUF_TAG.SUCCESS]: true,
+  [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
+} as const;
+
+/**
+ * Positions just rendered to stream subscribers: close every pending CUF span
+ * whose watched condition is now visible (new position, changed/absent
+ * position, or any fresh delivery after a reconnect).
+ */
+export function handlePerpsCufPositionsDelivered(
+  positions: readonly PerpsCufPositionLike[] | null,
+): void {
+  endPerpsPlaceOrderCufOnPositions(positions);
+  if (!positions) {
+    return;
+  }
+  for (const name of [
+    TraceName.PerpsClosePositionToConfirmation,
+    TraceName.PerpsUpdateTPSLToConfirmation,
+  ]) {
+    const meta = pendingCufMeta.get(name);
+    if (!meta || meta[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
+      continue;
+    }
+    const symbol = meta[CUF_META.SYMBOL];
+    if (typeof symbol !== 'string') {
+      continue;
+    }
+    const current = positions.find((p) => p.symbol === symbol);
+    if (!current || positionSnapshot(current) !== meta[CUF_META.SNAPSHOT]) {
+      endPerpsCufTrace({ name, data: { ...STREAM_END_DATA } });
+    }
+  }
+  const reconnectMeta = pendingCufMeta.get(
+    TraceName.PerpsWebSocketReconnectToFreshData,
+  );
+  if (reconnectMeta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ANY_POSITIONS) {
+    endPerpsCufTrace({
+      name: TraceName.PerpsWebSocketReconnectToFreshData,
+      data: { ...STREAM_END_DATA },
+    });
+  }
+}
+
+/** Orders just rendered to stream subscribers: close a pending cancel span. */
+export function handlePerpsCufOrdersDelivered(
+  orders: readonly { orderId: string }[] | null,
+): void {
+  if (!orders) {
+    return;
+  }
+  const meta = pendingCufMeta.get(TraceName.PerpsCancelOrderToConfirmation);
+  if (!meta || meta[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_ABSENT) {
+    return;
+  }
+  const orderId = meta[CUF_META.ORDER_ID];
+  if (typeof orderId !== 'string') {
+    return;
+  }
+  if (!orders.some((o) => o.orderId === orderId)) {
+    endPerpsCufTrace({
+      name: TraceName.PerpsCancelOrderToConfirmation,
+      data: { ...STREAM_END_DATA },
+    });
+  }
 }

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -423,19 +423,25 @@ function pendingOpIdsForName(name: TraceName): string[] {
  * defer, so acceptPerpsCufRequest can complete it as a success only once the
  * request is accepted. This prevents an unrelated stream change during the
  * request window from recording a failed cancel/close/TP-SL as a success.
+ *
+ * Returns true when the match was deferred, so the caller still flushes
+ * throttled subscribers: the recorded DEFERRED_AT is the delivery instant, so
+ * the flush must deliver the update to throttled subscribers at that instant
+ * for the eventual span duration to be truthful.
  */
 function confirmOrDefer(
   opId: string,
   meta: Record<string, TraceValue>,
   toEnd: string[],
-): void {
+): boolean {
   if (meta[CUF_META.AWAIT_ACCEPT] === true) {
     if (meta[CUF_META.DEFERRED_AT] === undefined) {
       setPerpsCufMeta(opId, { [CUF_META.DEFERRED_AT]: Date.now() });
     }
-    return;
+    return true;
   }
   toEnd.push(opId);
+  return false;
 }
 
 /**
@@ -480,6 +486,8 @@ export function handlePerpsCufPositionsDelivered(
 
   // Collect matches first so a single flush covers the whole tick.
   const toEnd: string[] = [];
+  // A gated match that is deferred still needs the flush (see confirmOrDefer).
+  let deferred = false;
   // Close: size reduced or position absent versus the pre-close size.
   for (const opId of pendingOpIdsForName(
     TraceName.PerpsClosePositionToConfirmation,
@@ -502,7 +510,7 @@ export function handlePerpsCufPositionsDelivered(
     const closed =
       !current || Math.abs(Number.parseFloat(current.size)) < baselineSize;
     if (closed) {
-      confirmOrDefer(opId, meta, toEnd);
+      deferred = confirmOrDefer(opId, meta, toEnd) || deferred;
     }
   }
   // TP/SL: the position is still present and its TP or SL value changed.
@@ -519,7 +527,7 @@ export function handlePerpsCufPositionsDelivered(
     }
     const current = positions.find((p) => p.symbol === symbol);
     if (current && tpSlSnapshot(current) !== meta[CUF_META.SNAPSHOT]) {
-      confirmOrDefer(opId, meta, toEnd);
+      deferred = confirmOrDefer(opId, meta, toEnd) || deferred;
     }
   }
   // Limit place: a marketable limit that filled renders as a new/changed
@@ -561,9 +569,10 @@ export function handlePerpsCufPositionsDelivered(
     }
   }
 
-  // Flush once if anything is about to be confirmed, so the measured render
-  // instant reflects real subscriber delivery (not the throttle enqueue).
-  if (flushThrottled && (toEnd.length > 0 || placeRenderedNow)) {
+  // Flush once if anything is about to be confirmed (or deferred), so the
+  // measured render instant reflects real subscriber delivery (not the throttle
+  // enqueue).
+  if (flushThrottled && (toEnd.length > 0 || placeRenderedNow || deferred)) {
     flushThrottled();
   }
 
@@ -593,6 +602,7 @@ export function handlePerpsCufOrdersDelivered(
   }
 
   const toEnd: string[] = [];
+  let deferred = false;
   for (const opId of pendingOpIdsForName(
     TraceName.PerpsCancelOrderToConfirmation,
   )) {
@@ -604,7 +614,7 @@ export function handlePerpsCufOrdersDelivered(
       typeof orderId === 'string' &&
       orders.every((o) => o.orderId !== orderId)
     ) {
-      confirmOrDefer(opId, meta, toEnd);
+      deferred = confirmOrDefer(opId, meta, toEnd) || deferred;
     }
   }
   for (const opId of pendingOpIdsForName(
@@ -621,7 +631,7 @@ export function handlePerpsCufOrdersDelivered(
     }
   }
 
-  if (flushThrottled && toEnd.length > 0) {
+  if (flushThrottled && (toEnd.length > 0 || deferred)) {
     flushThrottled();
   }
   for (const opId of toEnd) {

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -135,47 +135,69 @@ export interface PerpsCufPositionRendered {
 
 let placeOrderRendered: PerpsCufPositionRendered | null = null;
 let placeOrderResolver: (() => void) | null = null;
+/** Bumped on every arm so waiters from a superseded order go inert. */
+let placeOrderGeneration = 0;
 
 /**
  * Arm the place-order confirmation: the stream matcher fires when a position
  * for `symbol` renders that is new or changed versus the pre-order baseline,
  * so a pre-existing position on the same market can't confirm the order early.
+ * Returns a generation token; waiters from earlier generations resolve null
+ * and never touch the newly armed order's span.
  */
 export function armPerpsPlaceOrderCuf(
   symbol: string,
   baseline?: PerpsCufPositionLike | null,
-): void {
+): number {
+  placeOrderGeneration += 1;
   placeOrderRendered = null;
   placeOrderResolver = null;
   setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
     [CUF_META.SYMBOL]: symbol,
     ...(baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {}),
   });
+  return placeOrderGeneration;
+}
+
+/** Whether `generation` still owns the place-order confirmation state. */
+export function isPerpsPlaceOrderCufCurrent(generation: number): boolean {
+  return generation === placeOrderGeneration;
 }
 
 /**
  * Resolve with the armed position's first stream render, or `null` after
- * `timeoutMs`. Resolves immediately when the render already happened.
+ * `timeoutMs`. Resolves immediately when the render already happened or when
+ * `generation` has been superseded by a newer order.
  */
 export function waitForPerpsPlaceOrderPositionRendered(
   timeoutMs: number,
+  generation: number,
 ): Promise<PerpsCufPositionRendered | null> {
-  if (!pendingCufMeta.has(TraceName.PerpsPlaceOrderToPositionRendered)) {
+  if (
+    !isPerpsPlaceOrderCufCurrent(generation) ||
+    !pendingCufMeta.has(TraceName.PerpsPlaceOrderToPositionRendered)
+  ) {
     return Promise.resolve(null);
   }
   if (placeOrderRendered) {
     return Promise.resolve(placeOrderRendered);
   }
   return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      placeOrderResolver = null;
-      resolve(null);
-    }, timeoutMs);
-    placeOrderResolver = () => {
-      clearTimeout(timer);
-      placeOrderResolver = null;
-      resolve(placeOrderRendered);
+    let cancelTimer = () => {
+      // Replaced once the timeout is scheduled.
     };
+    const wake = () => {
+      cancelTimer();
+      if (placeOrderResolver === wake) {
+        placeOrderResolver = null;
+      }
+      resolve(
+        isPerpsPlaceOrderCufCurrent(generation) ? placeOrderRendered : null,
+      );
+    };
+    const timer = setTimeout(wake, timeoutMs);
+    cancelTimer = () => clearTimeout(timer);
+    placeOrderResolver = wake;
   });
 }
 

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -312,7 +312,7 @@ export function handlePerpsCufPositionsDelivered(
     TraceName.PerpsUpdateTPSLToConfirmation,
   ]) {
     const meta = pendingCufMeta.get(name);
-    if (!meta || meta[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
+    if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
       continue;
     }
     const symbol = meta[CUF_META.SYMBOL];
@@ -346,7 +346,7 @@ export function handlePerpsCufOrdersDelivered(
     return;
   }
   const meta = pendingCufMeta.get(TraceName.PerpsCancelOrderToConfirmation);
-  if (!meta || meta[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_ABSENT) {
+  if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_ABSENT) {
     return;
   }
   const orderId = meta[CUF_META.ORDER_ID];

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -37,6 +37,15 @@ const CUF_META = {
   // True when the positions cache was not loaded at submit, so the pre-order
   // baseline is unknown and must be captured from the first stream delivery.
   BASELINE_PENDING: 'baselinePending',
+  // Confirmation flows (cancel/close/TP-SL) arm their stream watcher at the
+  // gesture but must not record a stream success until the controller has
+  // accepted the request — otherwise an unrelated stream change during the
+  // request window would mislabel a failed request as a success. True until
+  // acceptPerpsCufRequest is called.
+  AWAIT_ACCEPT: 'awaitAccept',
+  // Instant a gated op's watched render was first seen while still awaiting
+  // acceptance; the span ends at this instant once the request is accepted.
+  DEFERRED_AT: 'deferredAt',
 } as const;
 
 /** What a pending confirmation span is watching for in the stream. */
@@ -338,6 +347,7 @@ export function watchPerpsCufPositionClosed(
     [CUF_META.WATCH]: PERPS_CUF_WATCH.POSITION_CLOSED,
     [CUF_META.SYMBOL]: position.symbol,
     [CUF_META.SNAPSHOT]: position.size,
+    [CUF_META.AWAIT_ACCEPT]: true,
   });
 }
 
@@ -350,6 +360,7 @@ export function watchPerpsCufTpSlChanged(
     [CUF_META.WATCH]: PERPS_CUF_WATCH.TPSL_CHANGED,
     [CUF_META.SYMBOL]: position.symbol,
     [CUF_META.SNAPSHOT]: tpSlSnapshot(position),
+    [CUF_META.AWAIT_ACCEPT]: true,
   });
 }
 
@@ -358,6 +369,7 @@ export function watchPerpsCufOrderAbsent(opId: string, orderId: string): void {
   setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_ABSENT,
     [CUF_META.ORDER_ID]: orderId,
+    [CUF_META.AWAIT_ACCEPT]: true,
   });
 }
 
@@ -406,6 +418,51 @@ function pendingOpIdsForName(name: TraceName): string[] {
 }
 
 /**
+ * A watched render matched for `opId`. End it now unless the op is still
+ * awaiting request acceptance — in that case record the render instant and
+ * defer, so acceptPerpsCufRequest can complete it as a success only once the
+ * request is accepted. This prevents an unrelated stream change during the
+ * request window from recording a failed cancel/close/TP-SL as a success.
+ */
+function confirmOrDefer(
+  opId: string,
+  meta: Record<string, TraceValue>,
+  toEnd: string[],
+): void {
+  if (meta[CUF_META.AWAIT_ACCEPT] === true) {
+    if (meta[CUF_META.DEFERRED_AT] === undefined) {
+      setPerpsCufMeta(opId, { [CUF_META.DEFERRED_AT]: Date.now() });
+    }
+    return;
+  }
+  toEnd.push(opId);
+}
+
+/**
+ * Mark a confirmation op's request as accepted by the controller. If its
+ * watched render was already seen while gated, end it now as a success at that
+ * recorded instant; otherwise clear the gate so the next matching delivery ends
+ * it. A no-op if the op already ended (e.g. request failed or the fallback
+ * timed out), so a later stream success can never override a failure.
+ */
+export function acceptPerpsCufRequest(opId: string): void {
+  const meta = pendingCufMeta.get(opId);
+  if (!meta) {
+    return;
+  }
+  const deferredAt = meta[CUF_META.DEFERRED_AT];
+  if (typeof deferredAt === 'number') {
+    endPerpsCufTrace({
+      id: opId,
+      data: { ...STREAM_END_DATA },
+      timestamp: deferredAt,
+    });
+    return;
+  }
+  setPerpsCufMeta(opId, { [CUF_META.AWAIT_ACCEPT]: false });
+}
+
+/**
  * Positions just rendered to stream subscribers: close every pending CUF span
  * whose watched condition is now visible (new position, changed/absent
  * position, or any fresh delivery after a reconnect). `flushThrottled` is
@@ -445,7 +502,7 @@ export function handlePerpsCufPositionsDelivered(
     const closed =
       !current || Math.abs(Number.parseFloat(current.size)) < baselineSize;
     if (closed) {
-      toEnd.push(opId);
+      confirmOrDefer(opId, meta, toEnd);
     }
   }
   // TP/SL: the position is still present and its TP or SL value changed.
@@ -462,7 +519,7 @@ export function handlePerpsCufPositionsDelivered(
     }
     const current = positions.find((p) => p.symbol === symbol);
     if (current && tpSlSnapshot(current) !== meta[CUF_META.SNAPSHOT]) {
-      toEnd.push(opId);
+      confirmOrDefer(opId, meta, toEnd);
     }
   }
   // Limit place: a marketable limit that filled renders as a new/changed
@@ -542,11 +599,12 @@ export function handlePerpsCufOrdersDelivered(
     const meta = pendingCufMeta.get(opId);
     const orderId = meta?.[CUF_META.ORDER_ID];
     if (
-      meta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_ABSENT &&
+      meta &&
+      meta[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_ABSENT &&
       typeof orderId === 'string' &&
       orders.every((o) => o.orderId !== orderId)
     ) {
-      toEnd.push(opId);
+      confirmOrDefer(opId, meta, toEnd);
     }
   }
   for (const opId of pendingOpIdsForName(

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -418,8 +418,15 @@ export function handlePerpsCufPositionsDelivered(
       continue;
     }
     const current = positions.find((p) => p.symbol === symbol);
-    const currentSize = current ? current.size : undefined;
-    if (currentSize !== meta[CUF_META.SNAPSHOT]) {
+    // A close confirms on the position vanishing or its magnitude shrinking —
+    // not on a size increase (an overlapping add must not confirm a close).
+    // Compared by absolute value so shorts (negative size) work too.
+    const baselineSize = Math.abs(
+      Number.parseFloat(String(meta[CUF_META.SNAPSHOT])),
+    );
+    const closed =
+      !current || Math.abs(Number.parseFloat(current.size)) < baselineSize;
+    if (closed) {
       toEnd.push(opId);
     }
   }

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -15,7 +15,10 @@ import {
   PERPS_CUF_BOUNDARY,
   PERPS_CUF_END_REASON,
 } from '../constants/perpsCufTags';
-import { getPerpsLifecycleContext } from './perpsLifecycleContext';
+import {
+  getPerpsLifecycleContext,
+  settlePerpsForegroundOnSpan,
+} from './perpsLifecycleContext';
 
 /**
  * Helpers for the Perps user-perceived CUF spans. These measure from the user
@@ -182,6 +185,10 @@ export function endPerpsCufTrace({
     `${PERFORMANCE_CONFIG.LoggingMarkers.SentryPerformance} PerpsCUF: ${name} completed ${JSON.stringify(data ?? {})}`,
   );
   endTrace({ name, id, data, timestamp });
+  // A completed operation/reconnect CUF also settles the foreground to `warm`
+  // (see FOREGROUND_SETTLING_SPANS): this covers a resume where a Perps screen
+  // stayed mounted, so no entry span re-completes to draw the boundary.
+  settlePerpsForegroundOnSpan(name);
 }
 
 /**

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -10,7 +10,11 @@ import {
   TraceOperation,
   type TraceValue,
 } from '../../../../util/trace';
-import { PERPS_CUF_TAG, PERPS_CUF_BOUNDARY } from '../constants/perpsCufTags';
+import {
+  PERPS_CUF_TAG,
+  PERPS_CUF_BOUNDARY,
+  PERPS_CUF_END_REASON,
+} from '../constants/perpsCufTags';
 import { getPerpsLifecycleContext } from './perpsLifecycleContext';
 
 /**
@@ -173,6 +177,19 @@ export function armPerpsPlaceOrderCuf(
   symbol: string,
   baseline?: PerpsCufPositionLike | null,
 ): void {
+  // A prior place-order op still pending is being superseded: end it now so it
+  // can't linger in the registry as an open span (the position path has no
+  // scheduled fallback — its only ends are this arm, the stream render, and the
+  // waiter timeout, all of which key off the current op id).
+  if (placeOrderOpId && pendingCufMeta.has(placeOrderOpId)) {
+    endPerpsCufTrace({
+      id: placeOrderOpId,
+      data: {
+        [PERPS_CUF_TAG.SUCCESS]: false,
+        [PERPS_CUF_TAG.REASON]: PERPS_CUF_END_REASON.SUPERSEDED,
+      },
+    });
+  }
   placeOrderOpId = opId;
   placeOrderRendered = null;
   placeOrderResolver = null;

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -278,6 +278,35 @@ export function isPerpsPlaceOrderCufCurrent(opId: string): boolean {
   return opId === placeOrderOpId;
 }
 
+/**
+ * End every pending CUF span as an abandoned failure and clear the single-flight
+ * place-order state. Called at teardown boundaries — disconnect, account or
+ * network switch — where the confirming streams are reset: without this, a
+ * pending confirmation (close/cancel/TP-SL/place) from the previous session
+ * could be falsely ended as a stream success by the next session's first
+ * delivery, since the matchers key only on symbol/orderId/baseline.
+ */
+export function clearPendingPerpsCufTraces(
+  reason: string = PERPS_CUF_END_REASON.DISCONNECTED,
+): void {
+  for (const id of Array.from(pendingCufMeta.keys())) {
+    endPerpsCufTrace({
+      id,
+      data: {
+        [PERPS_CUF_TAG.SUCCESS]: false,
+        [PERPS_CUF_TAG.REASON]: reason,
+      },
+    });
+  }
+  const resolver = placeOrderResolver;
+  placeOrderOpId = null;
+  placeOrderResolver = null;
+  placeOrderRendered = null;
+  // Wake any place-order waiter so its caller unblocks; the op id is no longer
+  // current, so it resolves null.
+  resolver?.();
+}
+
 /** Test-only: drop all pending spans and place-order state between tests. */
 export function resetPerpsCufTraceForTests(): void {
   pendingCufMeta.clear();

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -25,7 +25,6 @@ import { getPerpsLifecycleContext } from './perpsLifecycleContext';
 /** Internal metadata keys shared between the starting and ending surfaces. */
 const CUF_META = {
   SYMBOL: 'symbol',
-  TOAST_AT: 'toastAt',
   WATCH: 'watch',
   ORDER_ID: 'orderId',
   SNAPSHOT: 'snapshot',
@@ -128,17 +127,55 @@ export function endPerpsCufTrace({
   endTrace({ name, id, data, timestamp });
 }
 
-/** Register the order symbol the place-order CUF span is waiting on. */
-export function setPerpsPlaceOrderCufSymbol(symbol: string): void {
+/** First stream render matching an armed place-order confirmation. */
+export interface PerpsCufPositionRendered {
+  position: PerpsCufPositionLike;
+  renderedAt: number;
+}
+
+let placeOrderRendered: PerpsCufPositionRendered | null = null;
+let placeOrderResolver: (() => void) | null = null;
+
+/**
+ * Arm the place-order confirmation: the stream matcher fires when a position
+ * for `symbol` renders that is new or changed versus the pre-order baseline,
+ * so a pre-existing position on the same market can't confirm the order early.
+ */
+export function armPerpsPlaceOrderCuf(
+  symbol: string,
+  baseline?: PerpsCufPositionLike | null,
+): void {
+  placeOrderRendered = null;
+  placeOrderResolver = null;
   setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
     [CUF_META.SYMBOL]: symbol,
+    ...(baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {}),
   });
 }
 
-/** Stamp the toast moment so the stream end can compute the toast<->position delta. */
-export function setPerpsPlaceOrderCufToastShown(): void {
-  setPerpsCufMeta(TraceName.PerpsPlaceOrderToPositionRendered, {
-    [CUF_META.TOAST_AT]: Date.now(),
+/**
+ * Resolve with the armed position's first stream render, or `null` after
+ * `timeoutMs`. Resolves immediately when the render already happened.
+ */
+export function waitForPerpsPlaceOrderPositionRendered(
+  timeoutMs: number,
+): Promise<PerpsCufPositionRendered | null> {
+  if (!pendingCufMeta.has(TraceName.PerpsPlaceOrderToPositionRendered)) {
+    return Promise.resolve(null);
+  }
+  if (placeOrderRendered) {
+    return Promise.resolve(placeOrderRendered);
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      placeOrderResolver = null;
+      resolve(null);
+    }, timeoutMs);
+    placeOrderResolver = () => {
+      clearTimeout(timer);
+      placeOrderResolver = null;
+      resolve(placeOrderRendered);
+    };
   });
 }
 
@@ -155,34 +192,36 @@ export function endPerpsCufTraceAfter(
 }
 
 /**
- * Stream-side end for the place-order CUF: called by the position stream when
- * fresh positions are delivered to subscribers (the moment the new position
- * renders). Ends the span only if one is pending and its symbol just arrived.
+ * Stream-side matcher for the place-order CUF: records when the armed
+ * position first renders (new, or changed versus the pre-order baseline) and
+ * wakes the waiter. The hook owns ending the span so the confirmation toast
+ * and the measured delta stay coupled to this render.
  */
-export function endPerpsPlaceOrderCufOnPositions(
-  positions: readonly { symbol: string }[] | null,
+function resolvePerpsPlaceOrderCufOnPositions(
+  positions: readonly PerpsCufPositionLike[] | null,
 ): void {
+  if (placeOrderRendered || !positions) {
+    return;
+  }
   const meta = pendingCufMeta.get(TraceName.PerpsPlaceOrderToPositionRendered);
-  if (!meta || !positions) {
+  if (!meta) {
     return;
   }
   const symbol = meta[CUF_META.SYMBOL];
-  if (
-    typeof symbol !== 'string' ||
-    !positions.some((p) => p.symbol === symbol)
-  ) {
+  if (typeof symbol !== 'string') {
     return;
   }
-  const toastAt = meta[CUF_META.TOAST_AT];
-  endPerpsCufTrace({
-    name: TraceName.PerpsPlaceOrderToPositionRendered,
-    data: {
-      [PERPS_CUF_TAG.SUCCESS]: true,
-      [PERPS_CUF_TAG.BOUNDARY]: PERPS_CUF_BOUNDARY.STREAM,
-      [PERPS_CUF_TAG.TOAST_TO_POSITION_MS]:
-        typeof toastAt === 'number' ? Date.now() - toastAt : -1,
-    },
-  });
+  const current = positions.find((p) => p.symbol === symbol);
+  if (!current) {
+    return;
+  }
+  const baseline = meta[CUF_META.SNAPSHOT];
+  if (typeof baseline === 'string' && positionSnapshot(current) === baseline) {
+    // Pre-order position unchanged: the order's fill hasn't rendered yet.
+    return;
+  }
+  placeOrderRendered = { position: current, renderedAt: Date.now() };
+  placeOrderResolver?.();
 }
 
 /** Watch for the given position to change (or vanish) before ending `name`. */
@@ -228,7 +267,7 @@ const STREAM_END_DATA = {
 export function handlePerpsCufPositionsDelivered(
   positions: readonly PerpsCufPositionLike[] | null,
 ): void {
-  endPerpsPlaceOrderCufOnPositions(positions);
+  resolvePerpsPlaceOrderCufOnPositions(positions);
   if (!positions) {
     return;
   }
@@ -245,7 +284,7 @@ export function handlePerpsCufPositionsDelivered(
       continue;
     }
     const current = positions.find((p) => p.symbol === symbol);
-    const currentSnapshot = current ? positionSnapshot(current) : undefined;
+    const currentSnapshot = current && positionSnapshot(current);
     if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
       endPerpsCufTrace({ name, data: { ...STREAM_END_DATA } });
     }
@@ -276,7 +315,7 @@ export function handlePerpsCufOrdersDelivered(
   if (typeof orderId !== 'string') {
     return;
   }
-  if (orders?.some((o) => o.orderId === orderId) === false) {
+  if (!orders?.some((o) => o.orderId === orderId)) {
     endPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,
       data: { ...STREAM_END_DATA },

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -322,6 +322,10 @@ export function clearPendingPerpsCufTraces(
   reason: string = PERPS_CUF_END_REASON.DISCONNECTED,
 ): void {
   for (const [id] of Array.from(pendingCufMeta.entries())) {
+    // Clears everything, including any stale reconnect measurement span: each
+    // reconnection arms its own reconnect span AFTER this teardown clear (see
+    // performReconnection), so a fresh span is never abandoned and a stale one
+    // from a prior session cannot be falsely ended by the next delivery.
     endPerpsCufTrace({
       id,
       data: {

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -160,6 +160,11 @@ export function endPerpsCufTrace({
  * Schedule a fallback end for a specific op; a no-op if the stream (or the
  * caller) closes that op first. Because ids are unique per operation, a
  * superseded op's fallback can never close a later op of the same flow.
+ *
+ * Note: the timer is intentionally not cancelled when the op ends early — the
+ * end is idempotent, so the fallback simply no-ops. This keeps each closure
+ * alive until it fires (<= the delay, typically 30s), which is negligible for
+ * the low volume of user-driven confirmations.
  */
 export function endPerpsCufTraceAfter(
   options: EndPerpsCufTraceOptions,
@@ -183,7 +188,13 @@ let placeOrderOpId: string | null = null;
  * Arm the place-order confirmation for `opId`: the stream matcher fires when a
  * position for `symbol` renders that is new or changed versus the pre-order
  * baseline, so a pre-existing position on the same market can't confirm early.
- * A newer arm supersedes any earlier place-order waiter.
+ *
+ * The market place-order confirmation is deliberately SINGLE-FLIGHT: it uses
+ * module-level waiter/resolver state (there is one order form, guarded by
+ * `isPlacing`), so a newer arm supersedes any earlier one and ends it as
+ * `superseded`. This is the one intentional exception to the otherwise
+ * op-id-per-operation registry — the render must be measured at the toast site
+ * (the hook), which needs a single awaited handle rather than a passive watch.
  */
 export function armPerpsPlaceOrderCuf(
   opId: string,

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -38,9 +38,13 @@ const CUF_META = {
 
 /** What a pending confirmation span is watching for in the stream. */
 const PERPS_CUF_WATCH = {
-  POSITION_CHANGED: 'position_changed',
+  /** Close: position size reduced or the position vanished. */
+  POSITION_CLOSED: 'position_closed',
+  /** TP/SL update: the position's take-profit or stop-loss value changed. */
+  TPSL_CHANGED: 'tpsl_changed',
   ORDER_ABSENT: 'order_absent',
-  ORDER_PRESENT: 'order_present',
+  /** Limit place: the order rests in the orders stream OR fills into a position. */
+  ORDER_PRESENT_OR_FILLED: 'order_present_or_filled',
   ANY_POSITIONS: 'any_positions',
 } as const;
 
@@ -52,8 +56,14 @@ export interface PerpsCufPositionLike {
   stopLossPrice?: string;
 }
 
+/** Full render snapshot (size + TP/SL) used for the place-order fill matcher. */
 function positionSnapshot(position: PerpsCufPositionLike): string {
   return `${position.size}|${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
+}
+
+/** TP/SL-only snapshot: a size change must not end a TP/SL confirmation. */
+function tpSlSnapshot(position: PerpsCufPositionLike): string {
+  return `${position.takeProfitPrice ?? ''}|${position.stopLossPrice ?? ''}`;
 }
 
 /** Open CUF spans: unique op id -> metadata handed from starter to ender. */
@@ -190,9 +200,13 @@ export function armPerpsPlaceOrderCuf(
       },
     });
   }
+  // Wake any waiter from the superseded op so its caller doesn't block until
+  // the old race timer fires; it resolves null because the op id no longer owns.
+  const supersededResolver = placeOrderResolver;
   placeOrderOpId = opId;
   placeOrderRendered = null;
   placeOrderResolver = null;
+  supersededResolver?.();
   setPerpsCufMeta(opId, {
     [CUF_META.SYMBOL]: symbol,
     ...(baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {}),
@@ -251,9 +265,35 @@ export function waitForPerpsPlaceOrderPositionRendered(
  * throttled subscribers actually receive the data at the measured instant.
  * Returns true when it matched (so the caller can flush once for the tick).
  */
+/**
+ * Whether the armed position has rendered for `meta`: a new/changed position
+ * for its symbol, OR — when a position existed pre-order — that position now
+ * absent (the order reduced/flipped it to zero via the order form).
+ */
+function placeOrderPositionRendered(
+  meta: Record<string, TraceValue>,
+  positions: readonly PerpsCufPositionLike[],
+): PerpsCufPositionLike | null {
+  const symbol = meta[CUF_META.SYMBOL];
+  if (typeof symbol !== 'string') {
+    return null;
+  }
+  const current = positions.find((p) => p.symbol === symbol);
+  const baseline = meta[CUF_META.SNAPSHOT];
+  const baselineExisted = typeof baseline === 'string';
+  if (current) {
+    // New (no baseline) or changed versus the pre-order baseline.
+    if (!baselineExisted || positionSnapshot(current) !== baseline) {
+      return current;
+    }
+    return null;
+  }
+  // Position absent: a render only if one existed before (order closed it).
+  return baselineExisted ? { symbol, size: '0' } : null;
+}
+
 function resolvePerpsPlaceOrderCufOnPositions(
   positions: readonly PerpsCufPositionLike[],
-  flushThrottled?: () => void,
 ): void {
   if (placeOrderRendered || !placeOrderOpId) {
     return;
@@ -262,33 +302,35 @@ function resolvePerpsPlaceOrderCufOnPositions(
   if (!meta) {
     return;
   }
-  const symbol = meta[CUF_META.SYMBOL];
-  if (typeof symbol !== 'string') {
+  const rendered = placeOrderPositionRendered(meta, positions);
+  if (!rendered) {
     return;
   }
-  const current = positions.find((p) => p.symbol === symbol);
-  if (!current) {
-    return;
-  }
-  const baseline = meta[CUF_META.SNAPSHOT];
-  if (typeof baseline === 'string' && positionSnapshot(current) === baseline) {
-    // Pre-order position unchanged: the order's fill hasn't rendered yet.
-    return;
-  }
-  flushThrottled?.();
-  placeOrderRendered = { position: current, renderedAt: Date.now() };
+  placeOrderRendered = { position: rendered, renderedAt: Date.now() };
   placeOrderResolver?.();
 }
 
-/** Watch for the given position to change (or vanish) before ending `opId`. */
-export function watchPerpsCufPositionChanged(
+/** Close confirmation: end `opId` when its position's size shrinks or vanishes. */
+export function watchPerpsCufPositionClosed(
   opId: string,
   position: PerpsCufPositionLike,
 ): void {
   setPerpsCufMeta(opId, {
-    [CUF_META.WATCH]: PERPS_CUF_WATCH.POSITION_CHANGED,
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.POSITION_CLOSED,
     [CUF_META.SYMBOL]: position.symbol,
-    [CUF_META.SNAPSHOT]: positionSnapshot(position),
+    [CUF_META.SNAPSHOT]: position.size,
+  });
+}
+
+/** TP/SL confirmation: end `opId` when its position's TP or SL value changes. */
+export function watchPerpsCufTpSlChanged(
+  opId: string,
+  position: PerpsCufPositionLike,
+): void {
+  setPerpsCufMeta(opId, {
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.TPSL_CHANGED,
+    [CUF_META.SYMBOL]: position.symbol,
+    [CUF_META.SNAPSHOT]: tpSlSnapshot(position),
   });
 }
 
@@ -300,11 +342,25 @@ export function watchPerpsCufOrderAbsent(opId: string, orderId: string): void {
   });
 }
 
-/** Watch for the given order to appear (render) in the stream before ending `opId`. */
-export function watchPerpsCufOrderPresent(opId: string, orderId: string): void {
+/**
+ * Limit place confirmation: end `opId` when the order renders as resting in the
+ * orders stream OR fills into a position (a marketable limit never rests).
+ * `positionBaseline` is the symbol's pre-order position, so a fill is detected
+ * as a new/changed position rather than a pre-existing one.
+ */
+export function watchPerpsCufLimitRendered(
+  opId: string,
+  orderId: string,
+  symbol: string,
+  positionBaseline?: PerpsCufPositionLike | null,
+): void {
   setPerpsCufMeta(opId, {
-    [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_PRESENT,
+    [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_PRESENT_OR_FILLED,
     [CUF_META.ORDER_ID]: orderId,
+    [CUF_META.SYMBOL]: symbol,
+    ...(positionBaseline
+      ? { [CUF_META.SNAPSHOT]: positionSnapshot(positionBaseline) }
+      : {}),
   });
 }
 
@@ -348,28 +404,56 @@ export function handlePerpsCufPositionsDelivered(
   }
 
   // Collect matches first so a single flush covers the whole tick.
-  const positionChangedNames = [
-    TraceName.PerpsClosePositionToConfirmation,
-    TraceName.PerpsUpdateTPSLToConfirmation,
-  ];
   const toEnd: string[] = [];
-  for (const name of positionChangedNames) {
-    for (const opId of pendingOpIdsForName(name)) {
-      const meta = pendingCufMeta.get(opId);
-      if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CHANGED) {
-        continue;
-      }
-      const symbol = meta[CUF_META.SYMBOL];
-      if (typeof symbol !== 'string') {
-        continue;
-      }
-      const current = positions.find((p) => p.symbol === symbol);
-      const currentSnapshot = current ? positionSnapshot(current) : undefined;
-      if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
-        toEnd.push(opId);
-      }
+  // Close: size reduced or position absent versus the pre-close size.
+  for (const opId of pendingOpIdsForName(
+    TraceName.PerpsClosePositionToConfirmation,
+  )) {
+    const meta = pendingCufMeta.get(opId);
+    if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.POSITION_CLOSED) {
+      continue;
+    }
+    const symbol = meta[CUF_META.SYMBOL];
+    if (typeof symbol !== 'string') {
+      continue;
+    }
+    const current = positions.find((p) => p.symbol === symbol);
+    const currentSize = current ? current.size : undefined;
+    if (currentSize !== meta[CUF_META.SNAPSHOT]) {
+      toEnd.push(opId);
     }
   }
+  // TP/SL: the position is still present and its TP or SL value changed.
+  for (const opId of pendingOpIdsForName(
+    TraceName.PerpsUpdateTPSLToConfirmation,
+  )) {
+    const meta = pendingCufMeta.get(opId);
+    if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.TPSL_CHANGED) {
+      continue;
+    }
+    const symbol = meta[CUF_META.SYMBOL];
+    if (typeof symbol !== 'string') {
+      continue;
+    }
+    const current = positions.find((p) => p.symbol === symbol);
+    if (current && tpSlSnapshot(current) !== meta[CUF_META.SNAPSHOT]) {
+      toEnd.push(opId);
+    }
+  }
+  // Limit place: a marketable limit that filled renders as a new/changed
+  // position instead of a resting order.
+  for (const opId of pendingOpIdsForName(
+    TraceName.PerpsPlaceLimitOrderToOrderRendered,
+  )) {
+    const meta = pendingCufMeta.get(opId);
+    if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_PRESENT_OR_FILLED) {
+      continue;
+    }
+    if (placeOrderPositionRendered(meta, positions)) {
+      toEnd.push(opId);
+    }
+  }
+  // Reconnect: any fresh positions delivery.
   for (const opId of pendingOpIdsForName(
     TraceName.PerpsWebSocketReconnectToFreshData,
   )) {
@@ -381,27 +465,13 @@ export function handlePerpsCufPositionsDelivered(
     }
   }
 
-  const placeWillMatch =
-    !placeOrderRendered &&
-    !!placeOrderOpId &&
-    (() => {
-      const meta = pendingCufMeta.get(placeOrderOpId);
-      if (!meta) {
-        return false;
-      }
-      const symbol = meta[CUF_META.SYMBOL];
-      if (typeof symbol !== 'string') {
-        return false;
-      }
-      const current = positions.find((p) => p.symbol === symbol);
-      if (!current) {
-        return false;
-      }
-      const baseline = meta[CUF_META.SNAPSHOT];
-      return (
-        typeof baseline !== 'string' || positionSnapshot(current) !== baseline
-      );
-    })();
+  const placeMeta =
+    !placeOrderRendered && placeOrderOpId
+      ? pendingCufMeta.get(placeOrderOpId)
+      : undefined;
+  const placeWillMatch = placeMeta
+    ? placeOrderPositionRendered(placeMeta, positions) !== null
+    : false;
 
   // Flush once if anything is about to be confirmed, so the measured render
   // instant reflects real subscriber delivery (not the throttle enqueue).
@@ -448,7 +518,7 @@ export function handlePerpsCufOrdersDelivered(
     const meta = pendingCufMeta.get(opId);
     const orderId = meta?.[CUF_META.ORDER_ID];
     if (
-      meta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_PRESENT &&
+      meta?.[CUF_META.WATCH] === PERPS_CUF_WATCH.ORDER_PRESENT_OR_FILLED &&
       typeof orderId === 'string' &&
       orders.some((o) => o.orderId === orderId)
     ) {

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -201,6 +201,31 @@ export function endPerpsCufTraceAfter(
   setTimeout(() => endPerpsCufTrace(options), delayMs);
 }
 
+/**
+ * Fallback end for a request-then-confirm flow (cancel / close / TP-SL): the
+ * single timer must classify the two distinct failure modes. On fire it records
+ * `stream_timeout` when the controller request had settled (its render just
+ * never arrived) or `controller_timeout` when it had not (the request hung).
+ * Idempotent, so a real end (render / failure) no-ops it.
+ */
+export function endPerpsCufRequestAfter(
+  id: string,
+  hasControllerSettled: () => boolean,
+  delayMs: number,
+): void {
+  setTimeout(() => {
+    endPerpsCufTrace({
+      id,
+      data: {
+        [PERPS_CUF_TAG.SUCCESS]: false,
+        [PERPS_CUF_TAG.REASON]: hasControllerSettled()
+          ? PERPS_CUF_END_REASON.STREAM_TIMEOUT
+          : PERPS_CUF_END_REASON.CONTROLLER_TIMEOUT,
+      },
+    });
+  }, delayMs);
+}
+
 /** First stream render matching an armed place-order confirmation. */
 export interface PerpsCufPositionRendered {
   position: PerpsCufPositionLike;
@@ -282,20 +307,14 @@ export function isPerpsPlaceOrderCufCurrent(opId: string): boolean {
  * End every pending CUF span as an abandoned failure and clear the single-flight
  * place-order state. Called at teardown boundaries — disconnect, account or
  * network switch — where the confirming streams are reset: without this, a
- * pending confirmation (close/cancel/TP-SL/place) from the previous session
- * could be falsely ended as a stream success by the next session's first
- * delivery, since the matchers key only on symbol/orderId/baseline.
+ * pending confirmation or reconnect measurement from the previous session could
+ * be falsely ended as a stream success by the next session's first delivery,
+ * since the matchers key only on symbol/orderId/baseline.
  */
 export function clearPendingPerpsCufTraces(
   reason: string = PERPS_CUF_END_REASON.DISCONNECTED,
 ): void {
-  for (const [id, meta] of Array.from(pendingCufMeta.entries())) {
-    // Preserve the reconnect-to-fresh-data span: it is armed to MEASURE a
-    // reconnection and is ended by the fresh delivery, so it must survive a
-    // teardown clear rather than be abandoned by it.
-    if (meta[CUF_META.NAME] === TraceName.PerpsWebSocketReconnectToFreshData) {
-      continue;
-    }
+  for (const [id] of Array.from(pendingCufMeta.entries())) {
     endPerpsCufTrace({
       id,
       data: {

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -306,7 +306,9 @@ export function handlePerpsCufPositionsDelivered(
       continue;
     }
     const current = positions.find((p) => p.symbol === symbol);
-    const currentSnapshot = current && positionSnapshot(current);
+    const currentSnapshot = current?.symbol
+      ? positionSnapshot(current)
+      : undefined;
     if (currentSnapshot !== meta[CUF_META.SNAPSHOT]) {
       endPerpsCufTrace({ name, data: { ...STREAM_END_DATA } });
     }
@@ -337,7 +339,7 @@ export function handlePerpsCufOrdersDelivered(
   if (typeof orderId !== 'string') {
     return;
   }
-  if (!orders?.some((o) => o.orderId === orderId)) {
+  if (orders?.every((o) => o.orderId !== orderId)) {
     endPerpsCufTrace({
       name: TraceName.PerpsCancelOrderToConfirmation,
       data: { ...STREAM_END_DATA },

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -34,6 +34,9 @@ const CUF_META = {
   WATCH: 'watch',
   ORDER_ID: 'orderId',
   SNAPSHOT: 'snapshot',
+  // True when the positions cache was not loaded at submit, so the pre-order
+  // baseline is unknown and must be captured from the first stream delivery.
+  BASELINE_PENDING: 'baselinePending',
 } as const;
 
 /** What a pending confirmation span is watching for in the stream. */
@@ -186,6 +189,7 @@ export function armPerpsPlaceOrderCuf(
   opId: string,
   symbol: string,
   baseline?: PerpsCufPositionLike | null,
+  baselineLoaded: boolean = true,
 ): void {
   // A prior place-order op still pending is being superseded: end it now so it
   // can't linger in the registry as an open span (the position path has no
@@ -209,8 +213,25 @@ export function armPerpsPlaceOrderCuf(
   supersededResolver?.();
   setPerpsCufMeta(opId, {
     [CUF_META.SYMBOL]: symbol,
-    ...(baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {}),
+    ...baselineMeta(baseline, baselineLoaded),
   });
+}
+
+/**
+ * Baseline metadata for an order-render matcher. A loaded cache gives a known
+ * baseline (a position's size, or absent when none). An unloaded cache leaves
+ * the baseline pending so it's captured from the first stream delivery rather
+ * than assumed absent — otherwise a pre-existing position in that first
+ * delivery would falsely satisfy the render.
+ */
+function baselineMeta(
+  baseline: PerpsCufPositionLike | null | undefined,
+  baselineLoaded: boolean,
+): Record<string, TraceValue> {
+  if (!baselineLoaded) {
+    return { [CUF_META.BASELINE_PENDING]: true };
+  }
+  return baseline ? { [CUF_META.SNAPSHOT]: positionSnapshot(baseline) } : {};
 }
 
 /** Whether `opId` still owns the place-order confirmation state. */
@@ -266,11 +287,16 @@ export function waitForPerpsPlaceOrderPositionRendered(
  * Returns true when it matched (so the caller can flush once for the tick).
  */
 /**
- * Whether the armed position has rendered for `meta`: a new/changed position
+ * Whether the armed position has rendered for op `opId`: a new/changed position
  * for its symbol, OR — when a position existed pre-order — that position now
  * absent (the order reduced/flipped it to zero via the order form).
+ *
+ * When the baseline is pending (positions cache was unloaded at submit), this
+ * delivery is treated as the baseline: it is captured and NOT counted as a
+ * render, so a pre-existing position can't falsely confirm the order.
  */
 function placeOrderPositionRendered(
+  opId: string,
   meta: Record<string, TraceValue>,
   positions: readonly PerpsCufPositionLike[],
 ): PerpsCufPositionLike | null {
@@ -279,6 +305,15 @@ function placeOrderPositionRendered(
     return null;
   }
   const current = positions.find((p) => p.symbol === symbol);
+  if (meta[CUF_META.BASELINE_PENDING] === true) {
+    // First delivery after an unloaded-cache submit: this is the real
+    // pre-order state. Capture it and wait for a subsequent change.
+    setPerpsCufMeta(opId, {
+      [CUF_META.BASELINE_PENDING]: false,
+      ...(current ? { [CUF_META.SNAPSHOT]: positionSnapshot(current) } : {}),
+    });
+    return null;
+  }
   const baseline = meta[CUF_META.SNAPSHOT];
   const baselineExisted = typeof baseline === 'string';
   if (current) {
@@ -290,24 +325,6 @@ function placeOrderPositionRendered(
   }
   // Position absent: a render only if one existed before (order closed it).
   return baselineExisted ? { symbol, size: '0' } : null;
-}
-
-function resolvePerpsPlaceOrderCufOnPositions(
-  positions: readonly PerpsCufPositionLike[],
-): void {
-  if (placeOrderRendered || !placeOrderOpId) {
-    return;
-  }
-  const meta = pendingCufMeta.get(placeOrderOpId);
-  if (!meta) {
-    return;
-  }
-  const rendered = placeOrderPositionRendered(meta, positions);
-  if (!rendered) {
-    return;
-  }
-  placeOrderRendered = { position: rendered, renderedAt: Date.now() };
-  placeOrderResolver?.();
 }
 
 /** Close confirmation: end `opId` when its position's size shrinks or vanishes. */
@@ -353,14 +370,13 @@ export function watchPerpsCufLimitRendered(
   orderId: string,
   symbol: string,
   positionBaseline?: PerpsCufPositionLike | null,
+  baselineLoaded: boolean = true,
 ): void {
   setPerpsCufMeta(opId, {
     [CUF_META.WATCH]: PERPS_CUF_WATCH.ORDER_PRESENT_OR_FILLED,
     [CUF_META.ORDER_ID]: orderId,
     [CUF_META.SYMBOL]: symbol,
-    ...(positionBaseline
-      ? { [CUF_META.SNAPSHOT]: positionSnapshot(positionBaseline) }
-      : {}),
+    ...baselineMeta(positionBaseline, baselineLoaded),
   });
 }
 
@@ -456,7 +472,7 @@ export function handlePerpsCufPositionsDelivered(
     if (meta?.[CUF_META.WATCH] !== PERPS_CUF_WATCH.ORDER_PRESENT_OR_FILLED) {
       continue;
     }
-    if (placeOrderPositionRendered(meta, positions)) {
+    if (placeOrderPositionRendered(opId, meta, positions)) {
       toEnd.push(opId);
     }
   }
@@ -472,21 +488,33 @@ export function handlePerpsCufPositionsDelivered(
     }
   }
 
-  const placeMeta =
-    !placeOrderRendered && placeOrderOpId
-      ? pendingCufMeta.get(placeOrderOpId)
-      : undefined;
-  const placeWillMatch = placeMeta
-    ? placeOrderPositionRendered(placeMeta, positions) !== null
-    : false;
+  // Place-order render: evaluate exactly once (the matcher mutates on the
+  // baseline-capture tick, so it must not be called twice per delivery).
+  let placeRenderedNow: PerpsCufPositionLike | null = null;
+  if (!placeOrderRendered && placeOrderOpId) {
+    const meta = pendingCufMeta.get(placeOrderOpId);
+    if (meta) {
+      placeRenderedNow = placeOrderPositionRendered(
+        placeOrderOpId,
+        meta,
+        positions,
+      );
+    }
+  }
 
   // Flush once if anything is about to be confirmed, so the measured render
   // instant reflects real subscriber delivery (not the throttle enqueue).
-  if (flushThrottled && (toEnd.length > 0 || placeWillMatch)) {
+  if (flushThrottled && (toEnd.length > 0 || placeRenderedNow)) {
     flushThrottled();
   }
 
-  resolvePerpsPlaceOrderCufOnPositions(positions);
+  if (placeRenderedNow) {
+    placeOrderRendered = {
+      position: placeRenderedNow,
+      renderedAt: Date.now(),
+    };
+    placeOrderResolver?.();
+  }
   for (const opId of toEnd) {
     endPerpsCufTrace({ id: opId, data: { ...STREAM_END_DATA } });
   }

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -295,9 +295,9 @@ export function waitForPerpsPlaceOrderPositionRendered(
  * for its symbol, OR — when a position existed pre-order — that position now
  * absent (the order reduced/flipped it to zero via the order form).
  *
- * When the baseline is pending (positions cache was unloaded at submit), an
- * absent first delivery is captured as the baseline. A present symbol is counted
- * as rendered because it may be the post-fill snapshot and must not be swallowed.
+ * When the baseline is pending (positions cache was unloaded at submit), the
+ * first delivery is captured as the baseline and NOT counted as a render. This
+ * avoids falsely confirming against a pre-existing position on the first tick.
  */
 function placeOrderPositionRendered(
   opId: string,
@@ -310,11 +310,11 @@ function placeOrderPositionRendered(
   }
   const current = positions.find((p) => p.symbol === symbol);
   if (meta[CUF_META.BASELINE_PENDING] === true) {
-    setPerpsCufMeta(opId, { [CUF_META.BASELINE_PENDING]: false });
-    if (!current) {
-      return null;
-    }
-    return current;
+    setPerpsCufMeta(opId, {
+      [CUF_META.BASELINE_PENDING]: false,
+      ...(current ? { [CUF_META.SNAPSHOT]: positionSnapshot(current) } : {}),
+    });
+    return null;
   }
   const baseline = meta[CUF_META.SNAPSHOT];
   const baselineExisted = typeof baseline === 'string';

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
@@ -3,9 +3,11 @@ import {
   handlePerpsAppStateChange,
   initPerpsLifecycleTracking,
   markPerpsForegroundSettled,
+  settlePerpsForegroundOnSpan,
   resetPerpsLifecycleContextForTests,
   PERPS_LIFECYCLE_CONTEXT,
 } from './perpsLifecycleContext';
+import { TraceName } from '../../../../util/trace';
 import { AppState } from 'react-native';
 
 describe('perpsLifecycleContext', () => {
@@ -71,6 +73,32 @@ describe('perpsLifecycleContext', () => {
     );
 
     markPerpsForegroundSettled();
+
+    expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+  });
+
+  it('settles to warm when an operation CUF completes after resume (screen stayed mounted)', () => {
+    // Resume with a Perps screen already mounted: its entry span already
+    // completed and cannot re-fire, so an entry span will not settle. A
+    // completed operation CUF must settle instead, or background_resume sticks.
+    handlePerpsAppStateChange('active', 'unknown');
+    handlePerpsAppStateChange('background', 'active');
+    handlePerpsAppStateChange('active', 'background');
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME,
+    );
+
+    settlePerpsForegroundOnSpan(TraceName.PerpsClosePositionToConfirmation);
+
+    expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+  });
+
+  it('reconnect-to-fresh-data completion settles the foreground', () => {
+    handlePerpsAppStateChange('active', 'unknown');
+    handlePerpsAppStateChange('background', 'active');
+    handlePerpsAppStateChange('active', 'background');
+
+    settlePerpsForegroundOnSpan(TraceName.PerpsWebSocketReconnectToFreshData);
 
     expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
   });

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
@@ -1,10 +1,12 @@
 import {
   getPerpsLifecycleContext,
   handlePerpsAppStateChange,
+  initPerpsLifecycleTracking,
   markPerpsForegroundSettled,
   resetPerpsLifecycleContextForTests,
   PERPS_LIFECYCLE_CONTEXT,
 } from './perpsLifecycleContext';
+import { AppState } from 'react-native';
 
 describe('perpsLifecycleContext', () => {
   beforeEach(() => {
@@ -41,6 +43,23 @@ describe('perpsLifecycleContext', () => {
     expect(getPerpsLifecycleContext()).toBe(
       PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
     );
+  });
+
+  it('tags background_resume on the first resume when init happens already active', () => {
+    // Init while already foregrounded: no initial 'active' event will fire,
+    // so init must seed the flag itself.
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      value: 'active',
+    });
+    const cleanup = initPerpsLifecycleTracking();
+
+    handlePerpsAppStateChange('active', 'background');
+
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME,
+    );
+    cleanup();
   });
 
   it('returns to warm after a background_resume flow settles', () => {

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
@@ -1,0 +1,66 @@
+import {
+  getPerpsLifecycleContext,
+  handlePerpsAppStateChange,
+  markPerpsForegroundSettled,
+  resetPerpsLifecycleContextForTests,
+  PERPS_LIFECYCLE_CONTEXT,
+} from './perpsLifecycleContext';
+
+describe('perpsLifecycleContext', () => {
+  beforeEach(() => {
+    resetPerpsLifecycleContextForTests();
+  });
+
+  it('starts as cold_process on process launch', () => {
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+    );
+  });
+
+  it('becomes warm once the first foreground flow settles', () => {
+    markPerpsForegroundSettled();
+
+    expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+  });
+
+  it('tags background_resume when returning to active from background', () => {
+    handlePerpsAppStateChange('active', 'unknown');
+    markPerpsForegroundSettled();
+
+    handlePerpsAppStateChange('background', 'active');
+    handlePerpsAppStateChange('active', 'background');
+
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME,
+    );
+  });
+
+  it('does not tag background_resume on the very first foregrounding', () => {
+    handlePerpsAppStateChange('active', 'background');
+
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+    );
+  });
+
+  it('returns to warm after a background_resume flow settles', () => {
+    handlePerpsAppStateChange('active', 'unknown');
+    handlePerpsAppStateChange('background', 'active');
+    handlePerpsAppStateChange('active', 'background');
+    expect(getPerpsLifecycleContext()).toBe(
+      PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME,
+    );
+
+    markPerpsForegroundSettled();
+
+    expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+  });
+
+  it('ignores inactive/background transitions for context resolution', () => {
+    markPerpsForegroundSettled();
+
+    handlePerpsAppStateChange('inactive', 'active');
+
+    expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+  });
+});

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.ts
@@ -43,17 +43,28 @@ export function markPerpsForegroundSettled(): void {
 }
 
 /**
- * Spans whose completion means the user has seen a live Perps screen, so the
- * foreground is settled and later flows read as `warm`. This is the SINGLE
- * source of truth for the cold→warm boundary across every entry path — Home,
- * Market Details, Order, deeplinks, homepage cards. Add a new Perps entry
- * surface's render span here and every entry path stays correctly tagged; no
- * per-view opt-in is needed.
+ * Spans whose completion means the user has seen live Perps data this
+ * foreground, so it is settled and later flows read as `warm`. The SINGLE
+ * source of truth for the cold/resume→warm boundary across every path.
+ *
+ * Includes the entry-surface renders (Home, Market Details, Order — covers
+ * deeplinks and homepage cards) AND the operation/reconnect confirmations. The
+ * latter matter when the app resumes with a Perps screen already mounted: its
+ * entry span already completed and cannot settle again, so without an operation
+ * or reconnect completing the foreground, `background_resume` would stick and
+ * every later operation would be mis-tagged. The reconnect (or first operation)
+ * after a resume carries `background_resume`; everything after reads `warm`.
  */
 const FOREGROUND_SETTLING_SPANS: ReadonlySet<TraceName> = new Set([
   TraceName.PerpsEntryToLiveMarketList,
   TraceName.PerpsMarketDetailLive,
   TraceName.PerpsTradePageRender,
+  TraceName.PerpsPlaceOrderToPositionRendered,
+  TraceName.PerpsPlaceLimitOrderToOrderRendered,
+  TraceName.PerpsClosePositionToConfirmation,
+  TraceName.PerpsCancelOrderToConfirmation,
+  TraceName.PerpsUpdateTPSLToConfirmation,
+  TraceName.PerpsWebSocketReconnectToFreshData,
 ]);
 
 /** Settle the foreground when an entry-surface render span completes. */

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.ts
@@ -53,6 +53,11 @@ export function initPerpsLifecycleTracking(): () => void {
     return () => subscription?.remove();
   }
   let lastState = AppState.currentState;
+  // Already foregrounded at init: no initial 'active' event will fire, so
+  // seed the flag or the first real resume would read as the first foreground.
+  if (lastState === 'active') {
+    hasEnteredForegroundOnce = true;
+  }
   subscription = AppState.addEventListener('change', (nextState) => {
     const prevState = lastState;
     lastState = nextState;

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.ts
@@ -1,0 +1,73 @@
+import { AppState, type AppStateStatus } from 'react-native';
+
+/**
+ * Launch context for a Perps flow, used to split CUF latency by entry path.
+ * AppState cannot distinguish cold_process from warm (both are "active, never
+ * backgrounded"), so {@link markPerpsForegroundSettled} draws that boundary.
+ */
+export const PERPS_LIFECYCLE_CONTEXT = {
+  COLD_PROCESS: 'cold_process',
+  WARM: 'warm',
+  BACKGROUND_RESUME: 'background_resume',
+} as const;
+
+export type PerpsLifecycleContext =
+  (typeof PERPS_LIFECYCLE_CONTEXT)[keyof typeof PERPS_LIFECYCLE_CONTEXT];
+
+// Module load == process start.
+let currentContext: PerpsLifecycleContext =
+  PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS;
+let hasEnteredForegroundOnce = false;
+
+/** Update context from an AppState transition. Exported for tests. */
+export function handlePerpsAppStateChange(
+  nextState: AppStateStatus,
+  previousState: AppStateStatus,
+): void {
+  if (nextState !== 'active') {
+    return;
+  }
+  if (
+    hasEnteredForegroundOnce &&
+    (previousState === 'background' || previousState === 'inactive')
+  ) {
+    currentContext = PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME;
+  }
+  hasEnteredForegroundOnce = true;
+}
+
+/** Mark the current foreground's first flow done; later flows read as warm. */
+export function markPerpsForegroundSettled(): void {
+  currentContext = PERPS_LIFECYCLE_CONTEXT.WARM;
+}
+
+export function getPerpsLifecycleContext(): PerpsLifecycleContext {
+  return currentContext;
+}
+
+let subscription: { remove: () => void } | undefined;
+
+/** Subscribe to AppState so background_resume is detected. Idempotent. */
+export function initPerpsLifecycleTracking(): () => void {
+  if (subscription) {
+    return () => subscription?.remove();
+  }
+  let lastState = AppState.currentState;
+  subscription = AppState.addEventListener('change', (nextState) => {
+    const prevState = lastState;
+    lastState = nextState;
+    handlePerpsAppStateChange(nextState, prevState);
+  });
+  return () => {
+    subscription?.remove();
+    subscription = undefined;
+  };
+}
+
+/** Test-only reset. */
+export function resetPerpsLifecycleContextForTests(): void {
+  currentContext = PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS;
+  hasEnteredForegroundOnce = false;
+  subscription?.remove();
+  subscription = undefined;
+}

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.ts
@@ -1,4 +1,5 @@
 import { AppState, type AppStateStatus } from 'react-native';
+import { TraceName } from '../../../../util/trace';
 
 /**
  * Launch context for a Perps flow, used to split CUF latency by entry path.
@@ -39,6 +40,27 @@ export function handlePerpsAppStateChange(
 /** Mark the current foreground's first flow done; later flows read as warm. */
 export function markPerpsForegroundSettled(): void {
   currentContext = PERPS_LIFECYCLE_CONTEXT.WARM;
+}
+
+/**
+ * Spans whose completion means the user has seen a live Perps screen, so the
+ * foreground is settled and later flows read as `warm`. This is the SINGLE
+ * source of truth for the cold→warm boundary across every entry path — Home,
+ * Market Details, Order, deeplinks, homepage cards. Add a new Perps entry
+ * surface's render span here and every entry path stays correctly tagged; no
+ * per-view opt-in is needed.
+ */
+const FOREGROUND_SETTLING_SPANS: ReadonlySet<TraceName> = new Set([
+  TraceName.PerpsEntryToLiveMarketList,
+  TraceName.PerpsMarketDetailLive,
+  TraceName.PerpsTradePageRender,
+]);
+
+/** Settle the foreground when an entry-surface render span completes. */
+export function settlePerpsForegroundOnSpan(name: TraceName): void {
+  if (FOREGROUND_SETTLING_SPANS.has(name)) {
+    markPerpsForegroundSettled();
+  }
 }
 
 export function getPerpsLifecycleContext(): PerpsLifecycleContext {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -182,6 +182,15 @@ export enum TraceName {
   PerpsAdvancedChartInitialVisible = 'Perps Advanced Chart Initial Visible',
   /** Perps advanced chart: skeleton cleared after interval change only. */
   PerpsAdvancedChartIntervalVisible = 'Perps Advanced Chart Interval Visible',
+  // Perps user-perceived CUF spans: gesture/open -> render with live data
+  /** Tap/open -> Perps market list rendered with live prices. */
+  PerpsEntryToLiveMarketList = 'Perps Entry To Live Market List',
+  /** Market route open -> stats + chart + top-of-book live. */
+  PerpsMarketDetailLive = 'Perps Market Detail Live',
+  /** Market detail -> order form ready with current price + account state. */
+  PerpsTradePageRender = 'Perps Trade Page Render',
+  /** Order submit tap -> matching position rendered from the live stream. */
+  PerpsPlaceOrderToPositionRendered = 'Perps Place Order To Position Rendered',
   // Predict
   PredictFeedView = 'Predict Feed View',
   PredictMarketDetailsView = 'Predict Market Details View',

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -191,6 +191,8 @@ export enum TraceName {
   PerpsTradePageRender = 'Perps Trade Page Render',
   /** Order submit tap -> matching position rendered from the live stream. */
   PerpsPlaceOrderToPositionRendered = 'Perps Place Order To Position Rendered',
+  /** Limit order submit tap -> resting order rendered in the live orders stream. */
+  PerpsPlaceLimitOrderToOrderRendered = 'Perps Place Limit Order To Order Rendered',
   /** Close confirm tap -> position absent/reduced in the live stream. */
   PerpsClosePositionToConfirmation = 'Perps Close Position To Confirmation',
   /** Cancel tap -> order absent from the live stream. */

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -191,6 +191,18 @@ export enum TraceName {
   PerpsTradePageRender = 'Perps Trade Page Render',
   /** Order submit tap -> matching position rendered from the live stream. */
   PerpsPlaceOrderToPositionRendered = 'Perps Place Order To Position Rendered',
+  /** Close confirm tap -> position absent/reduced in the live stream. */
+  PerpsClosePositionToConfirmation = 'Perps Close Position To Confirmation',
+  /** Cancel tap -> order absent from the live stream. */
+  PerpsCancelOrderToConfirmation = 'Perps Cancel Order To Confirmation',
+  /** TP/SL submit -> updated values visible in the live stream. */
+  PerpsUpdateTPSLToConfirmation = 'Perps Update TPSL To Confirmation',
+  /** WebSocket price subscription -> first price delivered. */
+  PerpsWebSocketFirstPrice = 'Perps WebSocket First Price',
+  /** WebSocket top-of-book subscription -> first book delivered. */
+  PerpsWebSocketFirstOrderBook = 'Perps WebSocket First Order Book',
+  /** Reconnect start -> first fresh positions delivered. */
+  PerpsWebSocketReconnectToFreshData = 'Perps WebSocket Reconnect To Fresh Data',
   // Predict
   PredictFeedView = 'Predict Feed View',
   PredictMarketDetailsView = 'Predict Market Details View',

--- a/docs/perps/perps-sentry-reference.md
+++ b/docs/perps/perps-sentry-reference.md
@@ -10,7 +10,11 @@ This document defines all Sentry performance traces and measurements for the Per
 - API integration timing
 - Data fetch operations
 
-## Two Tracing Approaches
+## Three Tracing Approaches
+
+1. `usePerpsMeasurement` — single-component screen/render measurements.
+2. Direct `trace()` / `setMeasurement()` — controller/WebSocket/API operations.
+3. `perpsCufTrace` — cross-surface, stream-confirmed **user-perceived CUF** spans (gesture in one surface → live-data render in another). Added in TAT-3509.
 
 ### 1. `usePerpsMeasurement` Hook (UI Screens)
 
@@ -61,6 +65,13 @@ usePerpsMeasurement({
 - Completes when ALL `conditions`/`endConditions` are true
 - Auto-resets when ANY `resetConditions` become true
 - Uses unique trace IDs to prevent conflicts
+
+**Optional `tags` / `endData`:**
+
+- `tags` — filterable Sentry tags applied at span **start** (e.g. `feature`, `lifecycle_context`, flow variant). Queryable in Discover/dashboards.
+- `endData` — span attributes set at span **end**, for values only known once the flow completes (e.g. `variant: empty|position|order`, `funded|unfunded`).
+
+> ⚠️ **`conditions` vs `endConditions` — do not use the simple `conditions` API for readiness-gated spans whose duration matters.** The simple API adds a smart-default reset of `[!conditions[0]]`, meant for **visibility** toggles (bottom sheets). With a **readiness** flag as the first condition (e.g. `!isLoading`), the span resets on every render during loading (the effect re-runs each render because the arrays are fresh refs), so it restarts near readiness and **under-reports the true mount→ready latency**. Use the advanced API with only `endConditions: [...]` — it starts at mount, ends at readiness, and never resets. All three view CUF spans use `endConditions` for exactly this reason.
 
 ### 2. Direct `trace()` / `setMeasurement()` (Controllers)
 
@@ -133,7 +144,41 @@ setMeasurement(
 );
 ```
 
+### 3. `perpsCufTrace` Helper (Cross-Surface CUF Confirmations)
+
+**Use for:** User-perceived critical user flows whose start and end live in **different surfaces** — a gesture in a component (order view, home) that ends when the live WebSocket stream renders the effect in `PerpsStreamManager` (a non-React singleton). This is a different shape from `usePerpsMeasurement` (single component, boolean end-conditions), so it uses a small dedicated helper.
+
+**Location:** `app/components/UI/Perps/utils/perpsCufTrace.ts` (tags: `app/components/UI/Perps/constants/perpsCufTags.ts`)
+
+**How it works:**
+
+- `startPerpsCufTrace({ name, tags })` at the gesture mints a **unique per-operation id** and registers pending metadata (keyed by op id, not trace name — so overlapping same-flow ops each get their own span).
+- The starting surface arms a stream matcher (`watchPerpsCufOrderAbsent` / `watchPerpsCufPositionClosed` / `watchPerpsCufTpSlChanged` / `watchPerpsCufLimitRendered` / `watchPerpsCufAnyPositions`).
+- The stream dispatchers (`handlePerpsCufPositionsDelivered` / `handlePerpsCufOrdersDelivered`, called from `PerpsStreamManager`) end the matching op via `endPerpsCufTrace` when its watched condition renders; a 30s fallback (`endPerpsCufTraceAfter` / `endPerpsCufRequestAfter`) no-ops if it already ended.
+- **Request-acceptance gate:** cancel/close/TP-SL arm at the gesture but only complete as a success after the controller accepts the request (`acceptPerpsCufRequest`), so a coincidental stream change during a failed request is never recorded as success.
+- **Teardown:** `clearPendingPerpsCufTraces()` (called from the `PerpsConnectionManager` session-change handler) abandons pending confirmations as `disconnected` on an account/network/provider/HIP-3 switch, preserving the reconnect span.
+
+**Shared tags** (see `PERPS_CUF_TAG`): `feature`, `lifecycle_context` (`cold_process` | `background_resume` | `warm`, from `perpsLifecycleContext.ts`), plus flow variants — `variant` (`empty`/`position`/`order`, `funded`/`unfunded`), `direction`, `order_type`. **End data:** `success`, `boundary` (`stream`), `reason` (`request_failed`/`stream_timeout`/`controller_timeout`/`disconnected`/`superseded`/`exception`), and `toast_position_delta_ms` (signed; positive = position rendered after the toast) on market place-order.
+
 ## Event Catalog
+
+### User-Perceived CUF Spans (11 events, TAT-3509)
+
+**Purpose:** Measure the full tap/open → live-data experience (not just screen paint) at MSO boundaries, each tagged for per-context p75. Op: `perps.operation`; differentiated by `span.description` (the TraceName).
+
+| TraceName                             | Boundary (gesture → render-complete with live data)                             | Approach                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `PerpsEntryToLiveMarketList`          | Home mount → live market list (positions + markets + orders loaded)             | `usePerpsMeasurement` (`endConditions`)         |
+| `PerpsMarketDetailLive`               | Market detail mount → stats + price + account loaded                            | `usePerpsMeasurement` (`endConditions`)         |
+| `PerpsTradePageRender`                | Order view mount → price + fresh account (`!isLoadingAccount`)                  | `usePerpsMeasurement` (`endConditions`)         |
+| `PerpsPlaceOrderToPositionRendered`   | Market submit → matching position stream-rendered (+ `toast_position_delta_ms`) | `perpsCufTrace` (single-flight resolver)        |
+| `PerpsPlaceLimitOrderToOrderRendered` | Limit submit → order rests in orders stream OR fills into a position            | `perpsCufTrace` (`watchPerpsCufLimitRendered`)  |
+| `PerpsClosePositionToConfirmation`    | Close submit → position size reduced/absent (gated on acceptance)               | `perpsCufTrace` (`watchPerpsCufPositionClosed`) |
+| `PerpsCancelOrderToConfirmation`      | Cancel submit → order absent from orders stream (gated on acceptance)           | `perpsCufTrace` (`watchPerpsCufOrderAbsent`)    |
+| `PerpsUpdateTPSLToConfirmation`       | TP/SL submit → position's TP/SL value changed (gated on acceptance)             | `perpsCufTrace` (`watchPerpsCufTpSlChanged`)    |
+| `PerpsWebSocketFirstPrice`            | Price channel connect → first price delivery                                    | direct `trace()` in `PerpsStreamManager`        |
+| `PerpsWebSocketFirstOrderBook`        | Top-of-book connect → first order-book delivery                                 | direct `trace()` in `PerpsStreamManager`        |
+| `PerpsWebSocketReconnectToFreshData`  | Reconnect → first fresh positions delivery                                      | `perpsCufTrace` (`watchPerpsCufAnyPositions`)   |
 
 ### UI Screen Measurements (16 events)
 
@@ -401,6 +446,17 @@ setMeasurement(
 );
 ```
 
+### Adding a Cross-Surface CUF Span
+
+**Step 1:** Add the TraceName to `app/util/trace.ts` (op stays `perps.operation`).
+
+**Step 2:** Choose the boundary.
+
+- **Single view, mount → data-ready?** Use `usePerpsMeasurement` with **`endConditions`** (never the simple `conditions` API for readiness gates — see the reset warning above), plus `tags: buildPerpsCufStartTags(...)` and `endData` for the variant. Add the span to `FOREGROUND_SETTLING_SPANS` in `perpsLifecycleContext.ts` if it is an entry surface.
+- **Cross-surface, stream-confirmed?** Use `perpsCufTrace`: `startPerpsCufTrace({ name, tags })` at the gesture, arm a matcher, and let `PerpsStreamManager`'s dispatchers end it. For request-then-confirm flows, gate success on `acceptPerpsCufRequest` and use `endPerpsCufRequestAfter` for the fallback. Add a matcher branch to `handlePerpsCufPositionsDelivered` / `handlePerpsCufOrdersDelivered` if a new watch kind is needed.
+
+**Step 3:** Add a row to the **User-Perceived CUF Spans** catalog table above, and unit-test the matcher/gate edge cases in `perpsCufTrace.test.ts`.
+
 ## Event Naming Conventions
 
 ### TraceName Format
@@ -611,6 +667,10 @@ Fires on initial `connect()` failures and programmatic `reconnectWithNewContext(
 
 - **Trace utilities**: `app/util/trace.ts`
 - **Measurement hook**: `app/components/UI/Perps/hooks/usePerpsMeasurement.ts`
+- **CUF helper**: `app/components/UI/Perps/utils/perpsCufTrace.ts`
+- **CUF tags/reasons**: `app/components/UI/Perps/constants/perpsCufTags.ts`
+- **Lifecycle context**: `app/components/UI/Perps/utils/perpsLifecycleContext.ts`
+- **Stream manager (CUF dispatch)**: `app/components/UI/Perps/providers/PerpsStreamManager.tsx`
 - **Measurement constants**: `app/components/UI/Perps/constants/performanceMetrics.ts`
 - **Config constants**: `app/components/UI/Perps/constants/perpsConfig.ts`
 - **Controller**: `app/controllers/perps/PerpsController.ts`


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Speed is the adoption gate for Perps, but the critical user flows were not measured at user-perceived boundaries: existing spans capture screen render (e.g. market list p75 ~326ms) while the real tap→live experience runs multiple seconds, dominated by connection/preload work that was invisible in dashboards (TAT-3509, seeded by the TAT-3507 status report).

This PR instruments the CUF list as user-perceived Sentry spans, all under the existing `perps.operation` op: entry → live market list, market detail live, trade page render, order submit → stream-rendered position (with the toast↔position delta), close/cancel/TPSL confirmations (ending when the position/order stream renders the effect), websocket first-price/first-order-book, and reconnect → fresh data. Every span carries `feature`, `lifecycle_context` (`cold_process`/`background_resume`/`warm`) and flow variant tags so each MSO target row computes its own p75. A pending-span registry keyed by a unique per-operation id keeps cross-surface ends idempotent and lets overlapping same-flow operations end independently (stream render wins; a 30s timeout fallback no-ops if it already ended); cancel is instrumented at `usePerpsTrading.cancelOrder` so every cancel UI path is covered.

Boundary decisions: entry/market-detail/trade-page spans start at destination-view mount (cold connection/preload wait is captured). Market place-order ends when the matching position renders (or is reduced/flipped to zero); limit place-order gets its own order-render span that ends when the order rests OR fills into a position; close ends on a size reduction or the position vanishing; TP/SL ends on a take-profit/stop-loss change with the position still present — split so close and TP/SL never cross-confirm.

All spans were demonstrated end-to-end on device (iOS sim, testnet, executable recipes) and verified in Sentry from a local build — event IDs below. The confirmation toast is coupled to the position stream render, so `toast_position_delta_ms` (signed; positive = position rendered after the toast) measures ~0ms when coupled; when the stream ran late the same metric measured real +1494ms and +2568ms gaps vs the ≤200ms MSO target.

### Instrumentation design & edge cases

These CUFs are **cross-surface and stream-confirmed**: a span starts on a user gesture in one surface (order view, home) and ends when the live websocket stream renders the effect in another (`PerpsStreamManager`, a non-React singleton). That is a different shape from the existing `usePerpsMeasurement` hook (single component, boolean end-conditions, screen-render), which is why entry/detail/trade/ws-first render spans use `usePerpsMeasurement` while the confirmations use a small dedicated helper (`perpsCufTrace`). The helper is where the subtle correctness lives; the following edge cases are handled and unit-tested:

- **Overlapping same-flow ops** — spans are keyed by a unique per-operation id (not the trace name), so two cancels (or two orders) in flight get independent spans matched/ended by their own criteria.
- **Superseded place order** — a second market order within the 30s window ends the prior op as `superseded` (no leaked span) and wakes its waiter immediately.
- **Throttled subscribers** — before ending a stream-confirmed span the dispatcher flushes throttled subscribers' pending update, so the span ends at the real render instant, not the throttle enqueue (which under-reported warm surfaces by up to the throttle interval).
- **Paused stream** — while paused (`pauseCount>0`) `notifySubscribers` delivers nothing, so the CUF dispatch is skipped: a span must not end "rendered" when nothing rendered.
- **Close vs TP/SL** — split matchers: close ends on a size reduction (compared by magnitude so shorts work) or the position vanishing; TP/SL ends only on a take-profit/stop-loss change with the position still present. Neither cross-ends the other.
- **Marketable limit fill** — the limit order-render CUF ends when the order rests in the orders stream OR fills into a new/changed position, so an immediate fill is not a false timeout.
- **Order-form reduce-to-zero** — the market place CUF treats a pre-order position going absent (order reduced/flipped it to zero) as a valid render; the same fill predicate is shared by the synchronous fast path and the stream matcher so they can't drift.
- **Request-acceptance gating** — cancel/close/TP-SL arm their stream watcher at the gesture, but a match only completes as a success once the controller accepts the request, so a failed request whose position/order coincidentally changes in the same window is never recorded as a stream success.
- **Cold positions cache** — when the cache isn't loaded at submit, the pre-order baseline is captured from the first stream delivery rather than assumed absent, so a pre-existing position can't falsely satisfy the render.
- **Mount → ready without truncation** — the three view spans use `endConditions` (not the simple `conditions` API, whose visibility-oriented auto-reset restarts the span on every render during loading and under-reports the true latency); start at mount, end at live-data, never reset.
- **Truthful timeouts & teardown** — a hung controller request is tagged `controller_timeout` (distinct from `stream_timeout`); a stream reset on an account/network/provider/HIP-3 switch abandons pending confirmations as `disconnected` (preserving the reconnect span) so the next session can't falsely end them; spans end at the captured stream-delivery instant, not when the hook resumes.
- **Lifecycle context across entry paths** — `cold_process`/`background_resume`/`warm` is settled by the first completed live-data flow — any entry-surface render **or** operation/reconnect confirmation — from a single central set, so deeplink/homepage-card entries and a resume with a Perps screen already mounted all tag correctly (not just via Home).

**On validation:** the executable recipes prove each span really emits on-device with sensible values for a clean single flow (integration truth); all three CUF recipes were re-run green after the review hardening (span4 12/12, phaseB 31/31, limit 27/27). The concurrency and lifecycle-tagging cases above cannot be forced deterministically through a sequential on-device recipe, so they live in unit tests and were hardened through several rounds of adversarial cross-review. Note: the entry/market-detail/trade-page event IDs below prove emission from before the mount→ready fix — treat them as emission evidence, not final latency numbers, for those three spans (the place-order/`toast_position_delta_ms` samples are unaffected).

| CUF span | Sentry event (project `test-metamask-mobile`) |
| --- | --- |
| Perps Entry To Live Market List | `92445ee0f55eb1dd` |
| Perps Market Detail Live | `9a04f908e432b5cf` |
| Perps Trade Page Render | `b000f2cca435bdcc` |
| Perps Place Order To Position Rendered | `9b7b57b16f200b23` (`toast_position_delta_ms` +2568ms, stream-late sample; coupled runs measured 0/-1ms) |
| Perps Update TPSL To Confirmation | `992eec5308a542f8` |
| Perps Close Position To Confirmation | `ab3ebaf62c5d311e` |
| Perps Cancel Order To Confirmation | `93adfb9291bc9228` (1107ms; deterministic back-to-back recipe passes) |
| Perps WebSocket First Price | `9e7a10daf681d183` |
| Perps WebSocket First Order Book | `a74d6ed26ecae19a` |
| Perps WebSocket Reconnect To Fresh Data | `8343cad681ae47fb` |
| Perps Place Limit Order To Order Rendered | `see dev dashboard` (order-render CUF; two deterministic UI recipe passes, `boundary:stream`) |

Dashboards ("Perps Performance v2", one widget per CUF with p50/p75/p95 vs MSO target, lifecycle_context breakdown, volume and span-throughput health):
- Production (`metamask-mobile`, envs `production`/`main-rc` — populates once this PR ships): https://metamask.sentry.io/dashboard/8050973/
- Dev validation clone (`test-metamask-mobile`, env `development` — already showing the validation runs above): https://metamask.sentry.io/dashboard/8050972/

Both dashboards include a per-CUF widget plus the shared p75-vs-target and volume tables; the market place-order span is gated to market orders and limit orders get their own order-render widget.

Validation recipes (mm-harness, run against the iOS sim on testnet; each asserts the CUF completion marker in the run's own log window and state via `PerpsController.getPositions()/getOpenOrders()`):

<details>
<summary>Recipe 1 — place order → position rendered (span 4)</summary>

```json
{
  "schema_version": 1,
  "title": "CUF span-4 demo: order submit -> position rendered (BTC testnet)",
  "description": "Converge a clean BTC testnet baseline via the canonical perps.clean_market_testnet flow, then drive the real UI trade path (Long -> order form -> place) so the user-perceived PerpsPlaceOrderToPositionRendered span fires in usePerpsOrderExecution. Assert its DevLogger marker in metro.log (console-forwarder), then close the demo position.",
  "validate": {
    "workflow": {
      "entry": "clean-baseline",
      "nodes": {
        "clean-baseline": {
          "action": "call",
          "ref": "perps.clean_market_testnet",
          "params": {
            "market": "BTC"
          },
          "intent": "Converge a clean BTC testnet baseline (unlocked, no open BTC positions/orders)",
          "flow": "setup",
          "next": "open-market"
        },
        "open-market": {
          "action": "ui.navigate",
          "page": "perps-market",
          "market": "BTC",
          "intent": "Open the BTC market detail",
          "next": "tap-long"
        },
        "tap-long": {
          "action": "ui.press",
          "intent": "Open the trade page via the Long gesture",
          "next": "order-form-ready",
          "test_id": "perps-market-details-long-button"
        },
        "order-form-ready": {
          "action": "ui.wait_for",
          "test_id": "perps-order-view-place-order-button",
          "expected": "present",
          "intent": "Order form rendered with live price and account state",
          "next": "place-order"
        },
        "place-order": {
          "action": "ui.press",
          "intent": "Submit the market order through the UI",
          "next": "settle",
          "test_id": "perps-order-view-place-order-button"
        },
        "settle": {
          "action": "wait",
          "duration_ms": 15000,
          "intent": "Allow order fill, position confirmation, and console-forwarder flush",
          "next": "assert-span"
        },
        "assert-span": {
          "action": "watch_logs",
          "path": "temp/recipe/runtime/metro.log",
          "contains": "PerpsCUF: Perps Place Order To Position Rendered completed",
          "intent": "Assert the place-order CUF span completion marker reached metro.log",
          "next": "cleanup"
        },
        "cleanup": {
          "action": "metamask.perps.close_positions",
          "mode": "all",
          "market": "BTC",
          "network": "testnet",
          "intent": "Close the demo position",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass",
          "intent": "Span-4 CUF demonstrated end-to-end on testnet"
        }
      }
    }
  }
}
```

</details>

<details>
<summary>Recipe 2 — Phase B confirmations (TPSL, close, cancel)</summary>

```json
{
  "schema_version": 1,
  "title": "Phase B CUF demo: TPSL, close, cancel confirmations (BTC testnet)",
  "description": "Converge a clean BTC testnet baseline, create a position through the real UI, then drive TPSL update, market close, and limit-order cancel through their UI paths so each confirmation CUF span ends at its stream boundary. Markers are verified run-scoped from metro.log after the run.",
  "validate": {
    "workflow": {
      "entry": "clean-baseline",
      "nodes": {
        "clean-baseline": {
          "action": "call",
          "ref": "perps.clean_market_testnet",
          "params": {
            "market": "BTC"
          },
          "intent": "Converge a clean BTC testnet baseline",
          "flow": "setup",
          "next": "open-market"
        },
        "open-market": {
          "action": "ui.navigate",
          "page": "perps-market",
          "market": "BTC",
          "intent": "Open the BTC market detail",
          "next": "tap-long"
        },
        "tap-long": {
          "action": "ui.press",
          "test_id": "perps-market-details-long-button",
          "intent": "Open the trade page",
          "next": "order-form-ready"
        },
        "order-form-ready": {
          "action": "ui.wait_for",
          "test_id": "perps-order-view-place-order-button",
          "expected": "present",
          "intent": "Wait for the order form to render with live price and account state",
          "next": "form-settle"
        },
        "place-order": {
          "action": "ui.press",
          "test_id": "perps-order-view-place-order-button",
          "intent": "Create the demo position via the UI",
          "next": "settle-place"
        },
        "settle-place": {
          "action": "wait",
          "duration_ms": 12000,
          "intent": "Position rendered; back on market detail",
          "next": "verify-position-open"
        },
        "tpsl-sheet-ready": {
          "action": "ui.wait_for",
          "test_id": "perps-tpsl-tp-input",
          "expected": "present",
          "intent": "TPSL sheet rendered",
          "next": "set-tp"
        },
        "set-tp": {
          "action": "ui.set_input",
          "test_id": "perps-tpsl-tp-input",
          "value": "999999",
          "intent": "Set a take-profit far above entry (long)",
          "next": "confirm-tpsl"
        },
        "confirm-tpsl": {
          "action": "ui.press",
          "test_id": "perps-tpsl-set-button",
          "intent": "Submit the TPSL update",
          "next": "settle-tpsl"
        },
        "settle-tpsl": {
          "action": "wait",
          "duration_ms": 10000,
          "intent": "TPSL confirmation span ends at the stream boundary",
          "next": "tap-close"
        },
        "tap-close": {
          "action": "ui.press",
          "test_id": "perps-market-details-close-button",
          "intent": "Open the close-position flow",
          "next": "close-confirm-ready"
        },
        "close-confirm-ready": {
          "action": "ui.wait_for",
          "test_id": "close-position-confirm-button",
          "expected": "present",
          "intent": "Close confirmation rendered",
          "next": "confirm-close"
        },
        "confirm-close": {
          "action": "ui.press",
          "test_id": "close-position-confirm-button",
          "intent": "Confirm the market close",
          "next": "settle-close"
        },
        "settle-close": {
          "action": "wait",
          "duration_ms": 12000,
          "intent": "Close confirmation span ends when the position leaves the stream",
          "next": "verify-position-closed"
        },
        "place-limit": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval-async \"Engine.context.PerpsController.placeOrder({ symbol: 'BTC', isBuy: true, orderType: 'limit', price: '13000', size: '0.001', leverage: 3 }).then(function(r){ return JSON.stringify(r) })\"",
          "intent": "Rest a far-from-market limit order so cancel has a target",
          "next": "limit-settle"
        },
        "limit-settle": {
          "action": "wait",
          "duration_ms": 6000,
          "intent": "Order visible in the stream",
          "next": "expand-order-card"
        },
        "tap-cancel": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('Cancel order'))\"",
          "intent": "Cancel the order from the expanded card",
          "next": "settle-cancel"
        },
        "settle-cancel": {
          "action": "wait",
          "duration_ms": 10000,
          "intent": "Cancel confirmation span ends when the order leaves the stream",
          "next": "verify-orders-empty"
        },
        "cleanup": {
          "action": "metamask.perps.close_orders",
          "mode": "all",
          "network": "testnet",
          "intent": "Clear any leftover orders",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass",
          "intent": "Phase B confirmation CUFs demonstrated end-to-end on testnet"
        },
        "auto-close-ready": {
          "action": "ui.wait_for",
          "test_id": "position-card-auto-close-toggle",
          "expected": "present",
          "intent": "Wait for the position card auto-close entry to render",
          "next": "tap-auto-close"
        },
        "tap-auto-close": {
          "action": "ui.press",
          "test_id": "position-card-auto-close-toggle",
          "scroll_into_view": true,
          "intent": "Open the TPSL settings from the position card",
          "next": "tpsl-sheet-ready"
        },
        "expand-order-card": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('Limit long'))\"",
          "intent": "Expand the resting limit order card",
          "next": "card-settle"
        },
        "card-settle": {
          "action": "wait",
          "duration_ms": 2000,
          "intent": "Give the expanded order card time to render its actions",
          "next": "tap-cancel"
        },
        "form-settle": {
          "action": "wait",
          "duration_ms": 5000,
          "intent": "Let the order form finish loading live price and account state before submitting",
          "next": "place-order"
        },
        "verify-position-open": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; OUT=$(node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval-async \"Engine.context.PerpsController.getPositions().then(function(p){return JSON.stringify(p.length>0)})\"); echo \"state: $OUT\"; case \"$OUT\" in *true*) exit 0;; *) echo 'FAIL: order was not placed - no open position'; exit 1;; esac",
          "intent": "Verify the market order actually opened a position before continuing",
          "next": "auto-close-ready"
        },
        "verify-position-closed": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; OUT=$(node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval-async \"Engine.context.PerpsController.getPositions().then(function(p){return JSON.stringify(p.length===0)})\"); echo \"state: $OUT\"; case \"$OUT\" in *true*) exit 0;; *) echo 'FAIL: position still open after close confirm'; exit 1;; esac",
          "intent": "Verify the position is fully closed before the cancel scenario",
          "next": "place-limit"
        },
        "verify-orders-empty": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; OUT=$(node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval-async \"Engine.context.PerpsController.getOpenOrders().then(function(o){return JSON.stringify(o.length===0)})\"); echo \"state: $OUT\"; case \"$OUT\" in *true*) exit 0;; *) echo 'FAIL: order still open after cancel'; exit 1;; esac",
          "intent": "Verify the resting order is gone from the exchange after cancel",
          "next": "cleanup"
        }
      }
    }
  }
}
```

</details>

<details>
<summary>Recipe 3 — limit order submit → resting order rendered (UI keypad)</summary>

```json
{
  "schema_version": 1,
  "title": "CUF limit-order render: submit -> resting order rendered (BTC testnet)",
  "description": "Place a far-from-market BTC limit order through the real order UI (switch order type to limit, enter a resting price on the keypad, submit) so it flows through usePerpsOrderExecution and rests in the orders stream. Asserts the PerpsPlaceLimitOrderToOrderRendered CUF marker run-scoped in metro.log and that a resting order exists on the exchange. Removing the instrumentation makes the marker assertion fail.",
  "validate": {
    "workflow": {
      "entry": "clean-baseline",
      "nodes": {
        "clean-baseline": {
          "action": "call",
          "ref": "perps.clean_market_testnet",
          "params": { "market": "BTC" },
          "intent": "Converge a clean BTC testnet baseline (unlocked, no open BTC positions/orders)",
          "flow": "setup",
          "next": "open-market"
        },
        "open-market": {
          "action": "ui.navigate",
          "page": "perps-market",
          "market": "BTC",
          "intent": "Open the BTC market detail",
          "next": "tap-long"
        },
        "tap-long": {
          "action": "ui.press",
          "test_id": "perps-market-details-long-button",
          "intent": "Open the trade page via the Long gesture",
          "next": "order-form-ready"
        },
        "order-form-ready": {
          "action": "ui.wait_for",
          "test_id": "perps-order-view-place-order-button",
          "expected": "present",
          "intent": "Wait for the order form to render with live price and account state",
          "next": "open-order-type"
        },
        "open-order-type": {
          "action": "ui.press",
          "test_id": "perps-order-header-order-type-button",
          "intent": "Open the order-type bottom sheet",
          "next": "order-type-settle"
        },
        "order-type-settle": {
          "action": "wait",
          "duration_ms": 1500,
          "intent": "Let the order-type sheet finish presenting",
          "next": "select-limit"
        },
        "select-limit": {
          "action": "ui.press",
          "test_id": "perps-order-type-limit",
          "intent": "Switch to a limit order; the limit-price sheet auto-opens",
          "next": "limit-sheet-settle"
        },
        "limit-sheet-settle": {
          "action": "wait",
          "duration_ms": 2500,
          "intent": "Let the limit-price bottom sheet finish presenting",
          "next": "price-1"
        },
        "price-1": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('1'))\"",
          "intent": "Enter resting limit price digit 1",
          "next": "price-3"
        },
        "price-3": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('3'))\"",
          "intent": "Enter resting limit price digit 3",
          "next": "price-0a"
        },
        "price-0a": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('0'))\"",
          "intent": "Enter resting limit price digit 0",
          "next": "price-0b"
        },
        "price-0b": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('0'))\"",
          "intent": "Enter resting limit price digit 0",
          "next": "price-0c"
        },
        "price-0c": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval \"JSON.stringify(globalThis.__AGENTIC__.pressText('0'))\"",
          "intent": "Enter resting limit price digit 0 (price now 13000, far below market so the buy rests)",
          "next": "confirm-price"
        },
        "confirm-price": {
          "action": "ui.press",
          "test_id": "perps-limit-price-confirm-button",
          "intent": "Confirm the limit price and return to the order form",
          "next": "form-settle"
        },
        "form-settle": {
          "action": "wait",
          "duration_ms": 5000,
          "intent": "Let the order form settle with the limit price applied",
          "next": "place-order"
        },
        "place-order": {
          "action": "ui.press",
          "test_id": "perps-order-view-place-order-button",
          "intent": "Submit the limit order through the UI (flows through usePerpsOrderExecution)",
          "next": "settle"
        },
        "settle": {
          "action": "wait",
          "duration_ms": 12000,
          "intent": "Allow order acceptance, orders-stream render, and console-forwarder flush",
          "next": "verify-order-resting"
        },
        "verify-order-resting": {
          "action": "command",
          "cmd": "export WATCHER_PORT=8063 IOS_SIMULATOR=mmdev-3; OUT=$(node /Users/deeeed/dev/metamask/metamask-harness/adapters/mobile/bridge-runtime/cdp-bridge.cjs eval-async \"Engine.context.PerpsController.getOpenOrders().then(function(o){return JSON.stringify(o.length>0)})\"); echo \"state: $OUT\"; case \"$OUT\" in *true*) exit 0;; *) echo 'FAIL: no resting limit order after place'; exit 1;; esac",
          "intent": "Confirm a resting limit order exists on the exchange (order did not fill)",
          "next": "assert-span"
        },
        "assert-span": {
          "action": "watch_logs",
          "path": "temp/recipe/runtime/metro.log",
          "contains": "PerpsCUF: Perps Place Limit Order To Order Rendered completed",
          "intent": "Assert the limit-order render CUF completion marker reached metro.log",
          "next": "cleanup"
        },
        "cleanup": {
          "action": "call",
          "ref": "perps.clean_market_testnet",
          "params": { "market": "BTC" },
          "intent": "Cancel the resting order / clean the market",
          "flow": "teardown",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass",
          "intent": "Limit-order render CUF demonstrated end-to-end through the UI on testnet"
        }
      }
    }
  }
}
```

</details>

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3509

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps user-perceived CUF Sentry spans

  Scenario: user enters Perps and opens a market
    Given a dev build with MM_SENTRY_DSN set and metrics enabled
    When user opens Perps and taps a market
    Then "Perps Entry To Live Market List" and "Perps Market Detail Live" spans
      complete in Sentry tagged feature:perps and lifecycle_context

  Scenario: user places a market order (testnet)
    Given the BTC market detail with a funded testnet account
    When user taps Long and submits the order form
    Then "Perps Trade Page Render" completes on form-ready
    And "Perps Place Order To Position Rendered" completes with
      boundary:stream and a signed toast_position_delta_ms measurement

  Scenario: user updates TPSL, closes the position, cancels a resting order
    Given an open BTC position and a resting limit order
    When user sets a take profit, confirms a market close, and cancels the order
    Then the three confirmation spans complete with boundary:stream
      when the position/order stream renders each effect
```

Automated equivalents: `artifacts/cuf-span4-testnet-recipe.json` and
`artifacts/cuf-phaseb-testnet-recipe.json` (mm-harness recipes; exit 0 runs on iOS
sim `mmdev-3` with device-console markers `PERPSMARK_SENTRY PerpsCUF: …`).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — instrumentation only, no user-visible UI change. Evidence is non-visual by
design: device-console span markers and the Sentry event IDs listed in the
Description.

### **Before**

N/A

### **After**

<img width="1520" height="933" alt="image" src="https://github.com/user-attachments/assets/034ab692-e237-43af-a48c-cedf52d78030" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Android was spot-validated on a physical Pixel 6 (`Perps Market Detail Live`
marker on-device); the full Android recipe sweep is tracked as follow-up (device
connectivity, not code). Power-user impact assessed: spans are passive
start/end pairs on existing flows — no per-item work, no hot-path loops.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order placement, close/cancel/TP-SL success timing (stream vs REST) and connection teardown; behavior is mostly observability but incorrect span/matcher logic could misreport or race with overlapping trades.
> 
> **Overview**
> Adds **Sentry user-perceived CUF spans** for Perps so dashboards can measure tap/open → **live stream data**, not just screen paint. New `TraceName` values cover entry → market list, market detail, trade form, place/cancel/close/TP-SL confirmations, limit order render, WebSocket first price/order book, and reconnect → fresh positions.
> 
> **`perpsCufTrace`** starts spans at gestures and ends them when `PerpsStreamManager` deliveries match (unique op ids, acceptance gating, supersede/teardown handling). **`perpsLifecycleContext`** tags `cold_process` / `background_resume` / `warm` via AppState and settles after entry or operation spans complete.
> 
> **`usePerpsMeasurement`** gains `tags` / `endData` and settles foreground on completion; Home, Market Detail, and Order views add CUF spans using **`endConditions`** (mount → ready, no loading-time reset). **Order execution** drops post-submit `getPositions()` in favor of stream-confirmed position render, `toast_position_delta_ms`, and separate market vs limit CUF paths. Cancel/close/TP-SL/trading hooks and **`PerpsConnectionManager`** wire confirmations and **`clearPendingPerpsCufTraces`** on hard disconnect / identity change / reconnect.
> 
> Docs and broad unit tests document the three tracing approaches and matcher edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befa414d9fc4f4f1e2b66fc1e422e7f489e47001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







