### PR TITLE
feat(confirmations): show metamask pay quote errors in alert

### DIFF
--- a/app/components/Views/confirmations/components/alerts/alert-message/alert-message.styles.ts
+++ b/app/components/Views/confirmations/components/alerts/alert-message/alert-message.styles.ts
@@ -13,10 +13,12 @@ const styleSheet = (params: { theme: Theme }) =>
       width: 4,
       backgroundColor: params.theme.colors.error.default,
     },
-    message: {
+    content: {
       flex: 1,
       paddingVertical: 12,
       paddingHorizontal: 12,
+    },
+    message: {
       color: params.theme.colors.text.default,
     },
   });

--- a/app/components/Views/confirmations/components/alerts/alert-message/alert-message.test.tsx
+++ b/app/components/Views/confirmations/components/alerts/alert-message/alert-message.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { AlertMessage } from './alert-message';
 
 const MESSAGE_MOCK = 'Test message';
+const CONTENT_MOCK = <Text testID="custom-content">Custom content</Text>;
 
 describe('AlertMessage', () => {
   it('renders message in a banner', () => {
@@ -13,8 +15,16 @@ describe('AlertMessage', () => {
     expect(getByTestId('alert-message-banner')).toBeDefined();
   });
 
-  it('renders nothing if no message is provided', () => {
+  it('renders nothing if no message or content is provided', () => {
     const { toJSON } = render(<AlertMessage alertMessage={undefined} />);
     expect(toJSON()).toBeNull();
+  });
+
+  it('renders content instead of message when content is provided', () => {
+    const { getByTestId, queryByText } = render(
+      <AlertMessage content={CONTENT_MOCK} alertMessage={MESSAGE_MOCK} />,
+    );
+    expect(getByTestId('custom-content')).toBeDefined();
+    expect(queryByText(MESSAGE_MOCK)).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/alerts/alert-message/alert-message.tsx
+++ b/app/components/Views/confirmations/components/alerts/alert-message/alert-message.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { View } from 'react-native';
 import Text, {
   TextVariant,
@@ -7,23 +7,28 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './alert-message.styles';
 
 export interface AlertMessageProps {
+  content?: ReactElement;
   alertMessage: string | undefined;
 }
 
 export const AlertMessage: React.FC<AlertMessageProps> = React.memo((props) => {
-  const { alertMessage } = props;
+  const { content, alertMessage } = props;
   const { styles } = useStyles(styleSheet, {});
 
-  if (!alertMessage) {
+  if (!content && !alertMessage) {
     return null;
   }
 
   return (
     <View style={styles.container} testID="alert-message-banner">
       <View style={styles.border} />
-      <Text variant={TextVariant.BodySM} style={styles.message}>
-        {alertMessage}
-      </Text>
+      <View style={styles.content}>
+        {content ?? (
+          <Text variant={TextVariant.BodySM} style={styles.message}>
+            {alertMessage}
+          </Text>
+        )}
+      </View>
     </View>
   );
 });

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/index.ts
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/index.ts
@@ -1,0 +1,1 @@
+export * from './no-quote-alert';

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.styles.ts
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.styles.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../../util/theme/models';
+
+const styleSheet = (params: { theme: Theme }) =>
+  StyleSheet.create({
+    message: {
+      color: params.theme.colors.text.default,
+    },
+    detailsBlock: {
+      marginTop: 6,
+      paddingVertical: 6,
+      paddingHorizontal: 8,
+      backgroundColor: params.theme.colors.background.alternative,
+      borderRadius: 4,
+    },
+    detailRow: {
+      color: params.theme.colors.text.alternative,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.test.tsx
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import type { QuoteErrorInfo } from '@metamask/transaction-pay-controller';
+import { NoQuoteAlert } from './no-quote-alert';
+import { strings } from '../../../../../../../locales/i18n';
+
+const ERROR_MESSAGE_MOCK = 'Insufficient balance for this route';
+const DETAIL_MOCK = ['reason: INSUFFICIENT_BALANCE', 'required: 100 USDC'];
+const COLLAPSED_MESSAGE = strings('alert_system.no_pay_token_quotes.message');
+
+function createError(overrides?: Partial<QuoteErrorInfo>): QuoteErrorInfo {
+  return {
+    message: ERROR_MESSAGE_MOCK,
+    detail: DETAIL_MOCK,
+    ...overrides,
+  } as QuoteErrorInfo;
+}
+
+function tap(target: Parameters<typeof fireEvent.press>[0], times: number) {
+  for (let i = 0; i < times; i++) {
+    fireEvent.press(target);
+  }
+}
+
+describe('NoQuoteAlert', () => {
+  it('renders the generic collapsed message by default', () => {
+    const { getByText, queryByText, queryByTestId } = render(
+      <NoQuoteAlert error={createError()} />,
+    );
+
+    expect(getByText(COLLAPSED_MESSAGE)).toBeDefined();
+    expect(queryByText(ERROR_MESSAGE_MOCK)).toBeNull();
+    expect(queryByTestId('no-quote-alert-details')).toBeNull();
+  });
+
+  it('does not expand after a single tap', () => {
+    const { getByText, queryByText, queryByTestId } = render(
+      <NoQuoteAlert error={createError()} />,
+    );
+
+    tap(getByText(COLLAPSED_MESSAGE), 1);
+
+    expect(getByText(COLLAPSED_MESSAGE)).toBeDefined();
+    expect(queryByText(ERROR_MESSAGE_MOCK)).toBeNull();
+    expect(queryByTestId('no-quote-alert-details')).toBeNull();
+  });
+
+  it('expands to show the error message and detail rows after two taps', () => {
+    const { getByText, queryByText, getByTestId } = render(
+      <NoQuoteAlert error={createError()} />,
+    );
+
+    tap(getByText(COLLAPSED_MESSAGE), 2);
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+    expect(queryByText(COLLAPSED_MESSAGE)).toBeNull();
+    expect(getByTestId('no-quote-alert-details')).toBeDefined();
+    DETAIL_MOCK.forEach((row) => {
+      expect(getByText(row)).toBeDefined();
+    });
+  });
+
+  it('expands the message but omits the details block when detail is empty', () => {
+    const { getByText, queryByTestId } = render(
+      <NoQuoteAlert error={createError({ detail: [] })} />,
+    );
+
+    tap(getByText(COLLAPSED_MESSAGE), 2);
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+    expect(queryByTestId('no-quote-alert-details')).toBeNull();
+  });
+
+  it('omits the details block when detail is undefined', () => {
+    const { getByText, queryByTestId } = render(
+      <NoQuoteAlert error={createError({ detail: undefined })} />,
+    );
+
+    tap(getByText(COLLAPSED_MESSAGE), 2);
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+    expect(queryByTestId('no-quote-alert-details')).toBeNull();
+  });
+});

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.test.tsx
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.test.tsx
@@ -33,6 +33,21 @@ describe('NoQuoteAlert', () => {
     expect(queryByTestId('no-quote-alert-details')).toBeNull();
   });
 
+  it('renders the insufficient balance collapsed message for that reason', () => {
+    const insufficientMessage = strings(
+      'alert_system.insufficient_pay_method_balance.message',
+    );
+
+    const { getByText, queryByText } = render(
+      <NoQuoteAlert
+        error={createError({ reason: 'insufficient-source-balance' })}
+      />,
+    );
+
+    expect(getByText(insufficientMessage)).toBeDefined();
+    expect(queryByText(COLLAPSED_MESSAGE)).toBeNull();
+  });
+
   it('does not expand after a single tap', () => {
     const { getByText, queryByText, queryByTestId } = render(
       <NoQuoteAlert error={createError()} />,
@@ -58,6 +73,23 @@ describe('NoQuoteAlert', () => {
     DETAIL_MOCK.forEach((row) => {
       expect(getByText(row)).toBeDefined();
     });
+  });
+
+  it('collapses again after another two taps', () => {
+    const { getByTestId, getByText, queryByText, queryByTestId } = render(
+      <NoQuoteAlert error={createError()} />,
+    );
+
+    const pressable = getByTestId('no-quote-alert');
+
+    tap(pressable, 2);
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+    expect(getByTestId('no-quote-alert-details')).toBeDefined();
+
+    tap(pressable, 2);
+    expect(getByText(COLLAPSED_MESSAGE)).toBeDefined();
+    expect(queryByText(ERROR_MESSAGE_MOCK)).toBeNull();
+    expect(queryByTestId('no-quote-alert-details')).toBeNull();
   });
 
   it('expands the message but omits the details block when detail is empty', () => {

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useState } from 'react';
+import { Pressable, View } from 'react-native';
+import Text, {
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { strings } from '../../../../../../../locales/i18n';
+import { useStyles } from '../../../../../hooks/useStyles';
+import type { QuoteErrorInfo } from '@metamask/transaction-pay-controller';
+import styleSheet from './no-quote-alert.styles';
+
+const TAPS_TO_EXPAND = 2;
+
+interface Props {
+  error: QuoteErrorInfo;
+}
+
+export function NoQuoteAlert({ error }: Props) {
+  const { styles } = useStyles(styleSheet, {});
+  const [tapCount, setTapCount] = useState(0);
+
+  const handlePress = useCallback(() => {
+    setTapCount((count) => Math.min(count + 1, TAPS_TO_EXPAND));
+  }, []);
+
+  const isExpanded = tapCount >= TAPS_TO_EXPAND;
+
+  return (
+    <Pressable onPress={handlePress}>
+      <Text variant={TextVariant.BodySM} style={styles.message}>
+        {isExpanded
+          ? error.message
+          : strings('alert_system.no_pay_token_quotes.message')}
+      </Text>
+      {isExpanded && error.detail && error.detail.length > 0 && (
+        <View style={styles.detailsBlock} testID="no-quote-alert-details">
+          {error.detail.map((row) => (
+            <Text
+              key={row}
+              variant={TextVariant.BodyXS}
+              style={styles.detailRow}
+            >
+              {row}
+            </Text>
+          ))}
+        </View>
+      )}
+    </Pressable>
+  );
+}

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
@@ -8,7 +8,7 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import type { QuoteErrorInfo } from '@metamask/transaction-pay-controller';
 import styleSheet from './no-quote-alert.styles';
 
-const TAPS_TO_EXPAND = 2;
+const TAPS_TO_TOGGLE = 2;
 
 interface Props {
   error: QuoteErrorInfo;
@@ -17,19 +17,30 @@ interface Props {
 export function NoQuoteAlert({ error }: Props) {
   const { styles } = useStyles(styleSheet, {});
   const [tapCount, setTapCount] = useState(0);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const handlePress = useCallback(() => {
-    setTapCount((count) => Math.min(count + 1, TAPS_TO_EXPAND));
+    setTapCount((count) => {
+      const nextCount = count + 1;
+
+      if (nextCount >= TAPS_TO_TOGGLE) {
+        setIsExpanded((expanded) => !expanded);
+        return 0;
+      }
+
+      return nextCount;
+    });
   }, []);
 
-  const isExpanded = tapCount >= TAPS_TO_EXPAND;
+  const collapsedMessage =
+    error.reason === 'insufficient-source-balance'
+      ? strings('alert_system.insufficient_pay_method_balance.message')
+      : strings('alert_system.no_pay_token_quotes.message');
 
   return (
-    <Pressable onPress={handlePress}>
+    <Pressable onPress={handlePress} testID="no-quote-alert">
       <Text variant={TextVariant.BodySM} style={styles.message}>
-        {isExpanded
-          ? error.message
-          : strings('alert_system.no_pay_token_quotes.message')}
+        {isExpanded ? error.message : collapsedMessage}
       </Text>
       {isExpanded && error.detail && error.detail.length > 0 && (
         <View style={styles.detailsBlock} testID="no-quote-alert-details">

--- a/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
+++ b/app/components/Views/confirmations/components/alerts/no-quote-alert/no-quote-alert.tsx
@@ -17,20 +17,8 @@ interface Props {
 export function NoQuoteAlert({ error }: Props) {
   const { styles } = useStyles(styleSheet, {});
   const [tapCount, setTapCount] = useState(0);
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const handlePress = useCallback(() => {
-    setTapCount((count) => {
-      const nextCount = count + 1;
-
-      if (nextCount >= TAPS_TO_TOGGLE) {
-        setIsExpanded((expanded) => !expanded);
-        return 0;
-      }
-
-      return nextCount;
-    });
-  }, []);
+  const isExpanded = Math.floor(tapCount / TAPS_TO_TOGGLE) % 2 === 1;
+  const handlePress = useCallback(() => setTapCount((c) => c + 1), []);
 
   const collapsedMessage =
     error.reason === 'insufficient-source-balance'

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -5,7 +5,6 @@ import React, {
   useContext,
   useEffect,
   useRef,
-  useState,
 } from 'react';
 import { View } from 'react-native';
 import { toCaipAssetType } from '@metamask/utils';
@@ -30,6 +29,10 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './custom-amount-info.styles';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
 import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/useTransactionCustomAmountAlerts';
+import {
+  CustomAmountStage,
+  useCustomAmountStage,
+} from '../../../hooks/custom-amount/useCustomAmountStage';
 import useMMPayNavigation from '../../../hooks/ui/useMMPayNavigation';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import {
@@ -47,11 +50,8 @@ import {
 import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
-  useTransactionPayQuotes,
-  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
@@ -76,7 +76,6 @@ import {
   ButtonVariant,
 } from '@metamask/design-system-react-native';
 import { useAlerts } from '../../../context/alert-system-context';
-import { AlertKeys } from '../../../constants/alerts';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import EngineService from '../../../../../../core/EngineService';
@@ -98,33 +97,9 @@ import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useFiatFunnelMetricsAdapter } from '../../../../../UI/Ramp/hooks/useFiatFunnelMetricsAdapter';
 import { getMoneyAccountDepositIntent } from '../../../../../UI/Money/hooks/useMoneyAccount';
 import { InfoRowSkeleton } from '../../UI/info-row/info-row';
+import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 
 const AMOUNT_UPDATE_ERROR_PREFIX = 'MetaMask Pay: Amount Update: ';
-
-type QuoteHandoff =
-  | {
-      kind: 'loading';
-      quotesLastUpdated: number | undefined;
-    }
-  | {
-      kind: 'completed';
-      quotesLastUpdated: number;
-    };
-
-function getLatestQuotesLastUpdated(
-  controllerQuotesLastUpdated: number | undefined,
-  reduxQuotesLastUpdated: number | undefined,
-) {
-  if (controllerQuotesLastUpdated === undefined) {
-    return reduxQuotesLastUpdated;
-  }
-
-  if (reduxQuotesLastUpdated === undefined) {
-    return controllerQuotesLastUpdated;
-  }
-
-  return Math.max(controllerQuotesLastUpdated, reduxQuotesLastUpdated);
-}
 
 export interface CustomAmountInfoProps {
   autoSelectFiatPayment?: boolean;
@@ -225,27 +200,23 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       (Boolean(selectedFiatPaymentMethodId) && !payToken) ||
       (!hasAvailableTokens && !payToken);
 
-    const [isKeyboardVisible, setIsKeyboardVisible] = useState(
-      !isAddMusdIntent && (!isDepositPrefillEnabled || skipDepositPrefill),
-    );
-    const isKeyboardVisibleRef = useRef(isKeyboardVisible);
-    isKeyboardVisibleRef.current = isKeyboardVisible;
-    const [isAmountUpdating, setIsAmountUpdating] = useState(false);
-    const [hasCommittedAmount, setHasCommittedAmount] = useState(false);
-    const [quoteHandoff, setQuoteHandoff] = useState<QuoteHandoff>();
+    const accountNoFundsAlert = useAccountNoFundsAlert();
+    const hasAccountNoFunds = accountNoFundsAlert.length > 0;
+
+    const { stage, setStage } = useCustomAmountStage({
+      amountFiat,
+      disablePay,
+      hasAccountNoFunds,
+      isAddMusdIntent,
+      isDepositPrefillEnabled,
+      isDepositPrefillLoading,
+      skipDepositPrefill,
+    });
+
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
-    const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
-    const wasKeyboardEverVisible = useRef(isKeyboardVisible);
-    if (isKeyboardVisible) {
-      wasKeyboardEverVisible.current = true;
-    }
-    useMMPayNavigation(
-      isKeyboardVisible,
-      setIsKeyboardVisible,
-      wasKeyboardEverVisible,
-    );
+    useMMPayNavigation(stage, setStage);
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const moneyAccountSection = usePayWithMoneyAccountSection();
     const hasPaymentOption =
@@ -255,12 +226,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       fiatEverSelectedRef.current = true;
     }
 
-    useEffect(() => {
-      if (isDepositPrefillEnabled && skipDepositPrefill && !isKeyboardVisible) {
-        setIsKeyboardVisible(true);
-      }
-    }, [isDepositPrefillEnabled, skipDepositPrefill, isKeyboardVisible]);
-
     const shouldHideAccountSelector =
       hideAccountSelector && !fiatEverSelectedRef.current;
     const transactionId = transactionMeta?.id;
@@ -269,39 +234,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const { toastRef } = useContext(ToastContext);
 
-    const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
-    const quotes = useTransactionPayQuotes();
-    const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
-    quotesLastUpdatedRef.current = quotesLastUpdated;
-    const isQuotesLoading = useIsTransactionPayLoading();
-    const hasSourceAmount = useTransactionPayHasSourceAmount();
-    const showLoadingReview =
-      isAmountUpdating || (isQuotesLoading && hasCommittedAmount);
-    const isResultReady =
-      showLoadingReview ||
-      isTransactionResultReady ||
-      (isAddMusdIntent && !isKeyboardVisible);
-    const { alerts } = useAlerts();
-    const accountNoFundsAlert = useAccountNoFundsAlert();
-    const hasAccountNoFunds = accountNoFundsAlert.length > 0;
-    const hasNoQuotesAlert = alerts.some(
-      (a) => a.key === AlertKeys.NoPayTokenQuotes,
-    );
-    const showPaymentDetails =
-      showLoadingReview ||
-      Boolean(quotes?.length) ||
-      (!isAddMusdIntent && !hasSourceAmount && !hasNoQuotesAlert);
-
-    const isAwaitingPrefillResult =
-      !hasAccountNoFunds &&
-      !skipDepositPrefill &&
-      (isDepositPrefillLoading ||
-        (isDepositPrefilled && !hasSourceAmount && !isKeyboardVisible));
-
     const { alertContent, alertMessage, alertTitle } =
       useTransactionCustomAmountAlerts({
         isInputChanged,
-        isKeyboardVisible,
+        isKeyboardVisible: stage === CustomAmountStage.AmountInput,
         pendingTokenAmount: amountHumanDebounced,
         pendingFiatAmount: amountFiatDebounced,
       });
@@ -309,19 +245,17 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const hasAutoSubmittedPrefill = useRef(false);
 
     const handleDone = useCallback(async () => {
-      const keyboardVisibleAtStart = isKeyboardVisibleRef.current;
       if (isAmountUpdateInProgressRef.current) {
         return;
       }
 
       isAmountUpdateInProgressRef.current = true;
-      setQuoteHandoff(undefined);
-      setIsAmountUpdating(true);
-      setIsKeyboardVisible(false);
+      // Enter the loading stage: keyboard hidden, totals skeletons shown.
+      setStage(CustomAmountStage.Loading);
 
       try {
         await updateTokenAmount();
-        setHasCommittedAmount(true);
+
         if (selectedFiatPaymentMethodId && transactionId) {
           Engine.context.TransactionPayController.updateFiatPayment({
             transactionId,
@@ -330,38 +264,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             },
           });
         }
+
         // Amount committed (pre-quote) funnel event; only fires once the amount
         // has been successfully applied above (no-op for non-money flows).
         trackAmountCommitted();
 
-        const transactionData = transactionId
-          ? Engine.context.TransactionPayController.state.transactionData[
-              transactionId
-            ]
-          : undefined;
-        const controllerQuotesLastUpdated = transactionData?.quotesLastUpdated;
-        const latestQuotesLastUpdated = getLatestQuotesLastUpdated(
-          controllerQuotesLastUpdated,
-          quotesLastUpdatedRef.current,
-        );
-
-        if (transactionData?.isLoading) {
-          setQuoteHandoff({
-            kind: 'loading',
-            quotesLastUpdated: latestQuotesLastUpdated,
-          });
-        } else if (
-          controllerQuotesLastUpdated !== undefined &&
-          controllerQuotesLastUpdated !== quotesLastUpdatedRef.current
-        ) {
-          setQuoteHandoff({
-            kind: 'completed',
-            quotesLastUpdated: controllerQuotesLastUpdated,
-          });
-        } else {
-          setQuoteHandoff(undefined);
-          setIsAmountUpdating(false);
-        }
+        // Stay in Loading; the stage hook leaves Loading once quotes settle.
       } catch (error) {
         const isConfirmationDismissed =
           !Engine.context.TransactionController.state.transactions.some(
@@ -376,53 +284,29 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             toastRef?.current?.closeToast(),
           ),
         );
-        setIsKeyboardVisible(true);
-        setHasCommittedAmount(false);
-        setQuoteHandoff(undefined);
-        setIsAmountUpdating(false);
-        // Keep keyboard visible so the user can retry; do not advance the flow.
+        // Reopen the keyboard so the user can retry; do not advance the flow.
+        setStage(CustomAmountStage.AmountInput);
         return;
       } finally {
         isAmountUpdateInProgressRef.current = false;
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
-      // If the keyboard was closed when handleDone started (auto-submit) but
-      // the user opened it during the await, don't dismiss it.
-      if (!keyboardVisibleAtStart && isKeyboardVisibleRef.current) {
-        return;
-      }
-      setIsKeyboardVisible(false);
+      // Notify the caller the amount was committed (e.g. to start quote-timing
+      // instrumentation). Leaving Loading is owned solely by the stage hook's
+      // exit effect, which waits for the quote fetch to settle, so we do not
+      // clear the override here.
       onAmountSubmit?.();
     }, [
       amountFiat,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
+      setStage,
       toastRef,
       trackAmountCommitted,
       transactionId,
       updateTokenAmount,
     ]);
-
-    useEffect(() => {
-      if (!quoteHandoff) {
-        return;
-      }
-
-      const hasObservedLoading =
-        quoteHandoff.kind === 'loading' && isQuotesLoading;
-      const hasObservedCompletedQuote =
-        quotesLastUpdated !== undefined &&
-        (quoteHandoff.kind === 'completed'
-          ? quotesLastUpdated >= quoteHandoff.quotesLastUpdated
-          : quoteHandoff.quotesLastUpdated === undefined ||
-            quotesLastUpdated > quoteHandoff.quotesLastUpdated);
-
-      if (hasObservedLoading || hasObservedCompletedQuote) {
-        setQuoteHandoff(undefined);
-        setIsAmountUpdating(false);
-      }
-    }, [isQuotesLoading, quoteHandoff, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {
@@ -444,7 +328,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       // The tokenKey in useDepositPrefillAmount can toggle hasPrefilled
       // (true → false → true) during background state changes, which resets
       // the guard above and would otherwise dismiss the keyboard mid-edit.
-      if (isKeyboardVisible) {
+      if (stage === CustomAmountStage.AmountInput) {
         return;
       }
 
@@ -452,7 +336,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         hasAutoSubmittedPrefill.current = true;
         handleDone();
       }
-    }, [isDepositPrefilled, amountFiat, handleDone, isKeyboardVisible]);
+    }, [isDepositPrefilled, amountFiat, handleDone, stage]);
 
     const isMaxAutoSubmitPending = useRef(false);
 
@@ -464,10 +348,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         // stranding the user on a loading screen.
         if (percentage === 100 && didApplyAmount) {
           isMaxAutoSubmitPending.current = true;
-          setIsKeyboardVisible(false);
+          // Max defers the commit to the effect below once the amount lands;
+          // show the loading skeleton through that gap rather than the derived
+          // stage, matching the direct-commit path.
+          setStage(CustomAmountStage.Loading);
         }
       },
-      [updatePendingAmountPercentage],
+      [updatePendingAmountPercentage, setStage],
     );
 
     useEffect(() => {
@@ -478,15 +365,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     }, [amountFiat, handleDone]);
 
     const handleAmountPress = useCallback(() => {
-      wasKeyboardEverVisible.current = true;
-      setIsKeyboardVisible(true);
-    }, []);
+      setStage(CustomAmountStage.AmountInput);
+    }, [setStage]);
 
     const isAccountSelectionNeeded =
       supportAccountSelection && !accountOverride;
-    const hideDetailsForNoFunds = hasAccountNoFunds && Boolean(accountOverride);
+
     const hideBuyForNoFunds =
-      Boolean(accountOverride) && (hasAccountNoFunds || isQuotesLoading);
+      Boolean(accountOverride) &&
+      (hasAccountNoFunds || stage === CustomAmountStage.Loading);
 
     const { headlessBuyError } = useConfirmationContext();
 
@@ -496,15 +383,21 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           <CustomAmount
             amountFiat={amountFiat}
             currency={currency}
-            hasAlert={Boolean(alertMessage)}
+            hasAlert={
+              stage !== CustomAmountStage.Loading && Boolean(alertMessage)
+            }
             isLoading={
               !hasAccountNoFunds &&
               !skipDepositPrefill &&
               (isPrefillPending || isDepositPrefillLoading)
             }
-            onPress={showLoadingReview ? undefined : handleAmountPress}
+            onPress={
+              stage === CustomAmountStage.Loading
+                ? undefined
+                : handleAmountPress
+            }
             disabled={!hasPaymentOption}
-            showCursor={isKeyboardVisible && !showLoadingReview}
+            showCursor={stage === CustomAmountStage.AmountInput}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -523,11 +416,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           testID={CustomAmountInfoTestIds.BOTTOM_BLOCK}
           style={styles.bottomBlock}
         >
-          <AlertMessage
-            content={alertContent}
-            alertMessage={alertMessage ?? headlessBuyError}
-          />
-          {!isResultReady && !(isKeyboardVisible && isAddMusdIntent) && (
+          {stage !== CustomAmountStage.Loading && (
+            <AlertMessage
+              content={alertContent}
+              alertMessage={alertMessage ?? headlessBuyError}
+            />
+          )}
+          {stage === CustomAmountStage.AmountInput && !isAddMusdIntent && (
             <>
               {supportAccountSelection &&
                 !selectedFiatPaymentMethodId &&
@@ -540,9 +435,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 (hasPaymentOption || hasAccountNoFunds) && <PayWithRow />}
             </>
           )}
-          {isResultReady && (
+          {stage !== CustomAmountStage.AmountInput && (
             <View
-              pointerEvents={showLoadingReview ? 'none' : 'auto'}
+              pointerEvents={
+                stage === CustomAmountStage.Loading ? 'none' : 'auto'
+              }
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
               {supportAccountSelection &&
@@ -557,10 +454,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 <Quote
                   amountFiat={amountFiat}
                   canSelectWithdrawToken={canSelectWithdrawToken}
-                  isAddMusdIntent={isAddMusdIntent}
-                  isAwaitingPrefillResult={isAwaitingPrefillResult}
-                  isLoading={showLoadingReview}
-                  showPaymentDetails={showPaymentDetails}
+                  stage={stage}
                 />
               )}
               <PercentageRow />
@@ -575,38 +469,36 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {footerText}
             </Text>
           )}
-          {isKeyboardVisible && (hasPaymentOption || hasAccountNoFunds) && (
-            <DepositKeyboard
-              hidePercentageButtons={
-                Boolean(selectedFiatPaymentMethodId) ||
-                shouldHideAccountSelector
-              }
-              alertMessage={alertTitle}
-              value={amountFiat}
-              onChange={updatePendingAmount}
-              onDonePress={handleDone}
-              onPercentagePress={handlePercentagePress}
-              hasInput={hasInput}
-              hasMax={
-                (hasMax || isMoneyDepositNoFee) &&
-                (isWithdraw || !isNativePayToken)
-              }
-            />
-          )}
+          {stage === CustomAmountStage.AmountInput &&
+            (hasPaymentOption || hasAccountNoFunds) && (
+              <DepositKeyboard
+                hidePercentageButtons={
+                  Boolean(selectedFiatPaymentMethodId) ||
+                  shouldHideAccountSelector
+                }
+                alertMessage={alertTitle}
+                value={amountFiat}
+                onChange={updatePendingAmount}
+                onDonePress={handleDone}
+                onPercentagePress={handlePercentagePress}
+                hasInput={hasInput}
+                hasMax={
+                  (hasMax || isMoneyDepositNoFee) &&
+                  (isWithdraw || !isNativePayToken)
+                }
+              />
+            )}
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {!isKeyboardVisible && (
+          {stage !== CustomAmountStage.AmountInput && (
             <ConfirmButton
               alertTitle={alertTitle}
-              disableConfirm={
-                disableConfirm ||
-                isAccountSelectionNeeded ||
-                isPrefillPending ||
-                isAwaitingPrefillResult
+              isDisabled={
+                disableConfirm || isAccountSelectionNeeded || isPrefillPending
               }
-              isAmountUpdating={isAmountUpdating}
               onContinue={trackContinue}
+              stage={stage}
             />
           )}
         </Box>
@@ -629,6 +521,48 @@ export function CustomAmountInfoSkeleton() {
         <DepositKeyboardSkeleton />
       </Box>
     </Box>
+  );
+}
+
+export function PrefillCustomAmountInfoSkeleton() {
+  const { styles } = useStyles(styleSheet, {});
+
+  return (
+    <View style={styles.container} testID="prefill-custom-amount-info-skeleton">
+      <View style={styles.inputContainer}>
+        <CustomAmountSkeleton />
+        <Skeleton height={20} width={200} />
+      </View>
+      <View>
+        <View style={styles.skeletonRow}>
+          <Skeleton height={18} width={100} />
+          <View style={styles.skeletonRowRight}>
+            <Skeleton height={28} width={28} twClassName="rounded-full" />
+            <Skeleton height={18} width={100} />
+          </View>
+        </View>
+        <View style={styles.skeletonInfoRow}>
+          <Skeleton height={18} width={100} />
+          <View style={styles.skeletonRowRight}>
+            <Skeleton height={24} width={24} twClassName="rounded-full" />
+            <Skeleton height={18} width={100} />
+          </View>
+        </View>
+        <View style={styles.skeletonInfoRow}>
+          <Skeleton height={16} width={100} />
+          <Skeleton height={16} width={100} />
+        </View>
+        <View style={styles.skeletonInfoRow}>
+          <Skeleton height={16} width={100} />
+          <Skeleton height={16} width={100} />
+        </View>
+        <View style={styles.skeletonInfoRow}>
+          <Skeleton height={16} width={100} />
+          <Skeleton height={16} width={100} />
+        </View>
+        <Skeleton height={48} style={styles.buttonSkeleton} />
+      </View>
+    </View>
   );
 }
 
@@ -722,41 +656,31 @@ function BuySection() {
 function Quote({
   amountFiat,
   canSelectWithdrawToken,
-  isAddMusdIntent,
-  isAwaitingPrefillResult,
-  isLoading,
-  showPaymentDetails,
+  stage,
 }: Readonly<{
   amountFiat: string;
   canSelectWithdrawToken: boolean;
-  isAddMusdIntent: boolean;
-  isAwaitingPrefillResult: boolean;
-  isLoading: boolean;
-  showPaymentDetails: boolean;
+  stage: CustomAmountStage;
 }>) {
-  if (isLoading) {
+  if (stage === CustomAmountStage.Loading) {
     return <PaymentDetailsSkeleton />;
   }
 
-  if (showPaymentDetails && !isAwaitingPrefillResult) {
-    return (
-      <>
-        <BridgeFeeRow />
-        <BridgeTimeRow />
-        {canSelectWithdrawToken ? (
-          <ReceiveRow inputAmountUsd={amountFiat} />
-        ) : (
-          <TotalRow />
-        )}
-      </>
-    );
+  if (stage === CustomAmountStage.NoQuote) {
+    return null;
   }
 
-  if (isAddMusdIntent || isAwaitingPrefillResult) {
-    return <PaymentDetailsSkeleton />;
-  }
-
-  return null;
+  return (
+    <>
+      <BridgeFeeRow />
+      <BridgeTimeRow />
+      {canSelectWithdrawToken ? (
+        <ReceiveRow inputAmountUsd={amountFiat} />
+      ) : (
+        <TotalRow />
+      )}
+    </>
+  );
 }
 
 function PaymentDetailsSkeleton() {
@@ -771,33 +695,25 @@ function PaymentDetailsSkeleton() {
 
 function ConfirmButton({
   alertTitle,
-  disableConfirm,
-  isAmountUpdating,
+  isDisabled,
   onContinue,
+  stage,
 }: Readonly<{
   alertTitle: string | undefined;
-  disableConfirm?: boolean;
-  isAmountUpdating?: boolean;
+  isDisabled: boolean;
   onContinue?: () => void;
+  stage: CustomAmountStage;
 }>) {
   const { styles } = useStyles(styleSheet, {});
   const { hasBlockingAlerts } = useAlerts();
   const { isHeadlessBuyInProgress, setIsConfirmationSubmitting } =
     useConfirmationContext();
-  const isLoading = useIsTransactionPayLoading();
   const { onConfirm } = useConfirmActions();
-  const disabled =
-    hasBlockingAlerts ||
-    isLoading ||
-    Boolean(disableConfirm) ||
-    isAmountUpdating ||
-    isHeadlessBuyInProgress;
-  const buttonLabel = useButtonLabel();
 
   const handleConfirm = useCallback(async () => {
     setIsConfirmationSubmitting(true);
-    // Continue / Add Funds CTA funnel event; no-op for non-money flows.
     onContinue?.();
+
     try {
       await onConfirm();
     } catch (error) {
@@ -805,6 +721,19 @@ function ConfirmButton({
       throw error;
     }
   }, [onConfirm, onContinue, setIsConfirmationSubmitting]);
+
+  const disabled =
+    isDisabled ||
+    stage !== CustomAmountStage.ShowTotals ||
+    hasBlockingAlerts ||
+    isHeadlessBuyInProgress;
+
+  const enabledButtonLabel = useButtonLabel();
+
+  const buttonLabel =
+    stage === CustomAmountStage.Loading
+      ? enabledButtonLabel
+      : (alertTitle ?? enabledButtonLabel);
 
   return (
     <Button
@@ -818,23 +747,8 @@ function ConfirmButton({
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     >
-      {isAmountUpdating ? buttonLabel : (alertTitle ?? buttonLabel)}
+      {buttonLabel}
     </Button>
-  );
-}
-
-function useIsResultReady({
-  isKeyboardVisible,
-}: {
-  isKeyboardVisible: boolean;
-}) {
-  const quotes = useTransactionPayQuotes();
-  const isQuotesLoading = useIsTransactionPayLoading();
-  const hasSourceAmount = useTransactionPayHasSourceAmount();
-
-  return (
-    !isKeyboardVisible &&
-    (isQuotesLoading || Boolean(quotes?.length) || !hasSourceAmount)
   );
 }
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 import { View } from 'react-native';
 import { toCaipAssetType } from '@metamask/utils';
@@ -29,10 +30,6 @@ import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './custom-amount-info.styles';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
 import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/useTransactionCustomAmountAlerts';
-import {
-  CustomAmountStage,
-  useCustomAmountStage,
-} from '../../../hooks/custom-amount/useCustomAmountStage';
 import useMMPayNavigation from '../../../hooks/ui/useMMPayNavigation';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import {
@@ -50,8 +47,11 @@ import {
 import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
+  useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
@@ -76,6 +76,7 @@ import {
   ButtonVariant,
 } from '@metamask/design-system-react-native';
 import { useAlerts } from '../../../context/alert-system-context';
+import { AlertKeys } from '../../../constants/alerts';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import EngineService from '../../../../../../core/EngineService';
@@ -97,9 +98,33 @@ import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useFiatFunnelMetricsAdapter } from '../../../../../UI/Ramp/hooks/useFiatFunnelMetricsAdapter';
 import { getMoneyAccountDepositIntent } from '../../../../../UI/Money/hooks/useMoneyAccount';
 import { InfoRowSkeleton } from '../../UI/info-row/info-row';
-import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 
 const AMOUNT_UPDATE_ERROR_PREFIX = 'MetaMask Pay: Amount Update: ';
+
+type QuoteHandoff =
+  | {
+      kind: 'loading';
+      quotesLastUpdated: number | undefined;
+    }
+  | {
+      kind: 'completed';
+      quotesLastUpdated: number;
+    };
+
+function getLatestQuotesLastUpdated(
+  controllerQuotesLastUpdated: number | undefined,
+  reduxQuotesLastUpdated: number | undefined,
+) {
+  if (controllerQuotesLastUpdated === undefined) {
+    return reduxQuotesLastUpdated;
+  }
+
+  if (reduxQuotesLastUpdated === undefined) {
+    return controllerQuotesLastUpdated;
+  }
+
+  return Math.max(controllerQuotesLastUpdated, reduxQuotesLastUpdated);
+}
 
 export interface CustomAmountInfoProps {
   autoSelectFiatPayment?: boolean;
@@ -200,23 +225,27 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       (Boolean(selectedFiatPaymentMethodId) && !payToken) ||
       (!hasAvailableTokens && !payToken);
 
-    const accountNoFundsAlert = useAccountNoFundsAlert();
-    const hasAccountNoFunds = accountNoFundsAlert.length > 0;
-
-    const { stage, setStage } = useCustomAmountStage({
-      amountFiat,
-      disablePay,
-      hasAccountNoFunds,
-      isAddMusdIntent,
-      isDepositPrefillEnabled,
-      isDepositPrefillLoading,
-      skipDepositPrefill,
-    });
-
+    const [isKeyboardVisible, setIsKeyboardVisible] = useState(
+      !isAddMusdIntent && (!isDepositPrefillEnabled || skipDepositPrefill),
+    );
+    const isKeyboardVisibleRef = useRef(isKeyboardVisible);
+    isKeyboardVisibleRef.current = isKeyboardVisible;
+    const [isAmountUpdating, setIsAmountUpdating] = useState(false);
+    const [hasCommittedAmount, setHasCommittedAmount] = useState(false);
+    const [quoteHandoff, setQuoteHandoff] = useState<QuoteHandoff>();
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
-    useMMPayNavigation(stage, setStage);
+    const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
+    const wasKeyboardEverVisible = useRef(isKeyboardVisible);
+    if (isKeyboardVisible) {
+      wasKeyboardEverVisible.current = true;
+    }
+    useMMPayNavigation(
+      isKeyboardVisible,
+      setIsKeyboardVisible,
+      wasKeyboardEverVisible,
+    );
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const moneyAccountSection = usePayWithMoneyAccountSection();
     const hasPaymentOption =
@@ -226,6 +255,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       fiatEverSelectedRef.current = true;
     }
 
+    useEffect(() => {
+      if (isDepositPrefillEnabled && skipDepositPrefill && !isKeyboardVisible) {
+        setIsKeyboardVisible(true);
+      }
+    }, [isDepositPrefillEnabled, skipDepositPrefill, isKeyboardVisible]);
+
     const shouldHideAccountSelector =
       hideAccountSelector && !fiatEverSelectedRef.current;
     const transactionId = transactionMeta?.id;
@@ -234,27 +269,59 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const { toastRef } = useContext(ToastContext);
 
-    const { alertMessage, alertTitle } = useTransactionCustomAmountAlerts({
-      isInputChanged,
-      isKeyboardVisible: stage === CustomAmountStage.AmountInput,
-      pendingTokenAmount: amountHumanDebounced,
-      pendingFiatAmount: amountFiatDebounced,
-    });
+    const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
+    const quotes = useTransactionPayQuotes();
+    const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
+    quotesLastUpdatedRef.current = quotesLastUpdated;
+    const isQuotesLoading = useIsTransactionPayLoading();
+    const hasSourceAmount = useTransactionPayHasSourceAmount();
+    const showLoadingReview =
+      isAmountUpdating || (isQuotesLoading && hasCommittedAmount);
+    const isResultReady =
+      showLoadingReview ||
+      isTransactionResultReady ||
+      (isAddMusdIntent && !isKeyboardVisible);
+    const { alerts } = useAlerts();
+    const accountNoFundsAlert = useAccountNoFundsAlert();
+    const hasAccountNoFunds = accountNoFundsAlert.length > 0;
+    const hasNoQuotesAlert = alerts.some(
+      (a) => a.key === AlertKeys.NoPayTokenQuotes,
+    );
+    const showPaymentDetails =
+      showLoadingReview ||
+      Boolean(quotes?.length) ||
+      (!isAddMusdIntent && !hasSourceAmount && !hasNoQuotesAlert);
+
+    const isAwaitingPrefillResult =
+      !hasAccountNoFunds &&
+      !skipDepositPrefill &&
+      (isDepositPrefillLoading ||
+        (isDepositPrefilled && !hasSourceAmount && !isKeyboardVisible));
+
+    const { alertContent, alertMessage, alertTitle } =
+      useTransactionCustomAmountAlerts({
+        isInputChanged,
+        isKeyboardVisible,
+        pendingTokenAmount: amountHumanDebounced,
+        pendingFiatAmount: amountFiatDebounced,
+      });
 
     const hasAutoSubmittedPrefill = useRef(false);
 
     const handleDone = useCallback(async () => {
+      const keyboardVisibleAtStart = isKeyboardVisibleRef.current;
       if (isAmountUpdateInProgressRef.current) {
         return;
       }
 
       isAmountUpdateInProgressRef.current = true;
-      // Enter the loading stage: keyboard hidden, totals skeletons shown.
-      setStage(CustomAmountStage.Loading);
+      setQuoteHandoff(undefined);
+      setIsAmountUpdating(true);
+      setIsKeyboardVisible(false);
 
       try {
         await updateTokenAmount();
-
+        setHasCommittedAmount(true);
         if (selectedFiatPaymentMethodId && transactionId) {
           Engine.context.TransactionPayController.updateFiatPayment({
             transactionId,
@@ -263,12 +330,38 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             },
           });
         }
-
         // Amount committed (pre-quote) funnel event; only fires once the amount
         // has been successfully applied above (no-op for non-money flows).
         trackAmountCommitted();
 
-        // Stay in Loading; the stage hook leaves Loading once quotes settle.
+        const transactionData = transactionId
+          ? Engine.context.TransactionPayController.state.transactionData[
+              transactionId
+            ]
+          : undefined;
+        const controllerQuotesLastUpdated = transactionData?.quotesLastUpdated;
+        const latestQuotesLastUpdated = getLatestQuotesLastUpdated(
+          controllerQuotesLastUpdated,
+          quotesLastUpdatedRef.current,
+        );
+
+        if (transactionData?.isLoading) {
+          setQuoteHandoff({
+            kind: 'loading',
+            quotesLastUpdated: latestQuotesLastUpdated,
+          });
+        } else if (
+          controllerQuotesLastUpdated !== undefined &&
+          controllerQuotesLastUpdated !== quotesLastUpdatedRef.current
+        ) {
+          setQuoteHandoff({
+            kind: 'completed',
+            quotesLastUpdated: controllerQuotesLastUpdated,
+          });
+        } else {
+          setQuoteHandoff(undefined);
+          setIsAmountUpdating(false);
+        }
       } catch (error) {
         const isConfirmationDismissed =
           !Engine.context.TransactionController.state.transactions.some(
@@ -283,29 +376,53 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             toastRef?.current?.closeToast(),
           ),
         );
-        // Reopen the keyboard so the user can retry; do not advance the flow.
-        setStage(CustomAmountStage.AmountInput);
+        setIsKeyboardVisible(true);
+        setHasCommittedAmount(false);
+        setQuoteHandoff(undefined);
+        setIsAmountUpdating(false);
+        // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
       } finally {
         isAmountUpdateInProgressRef.current = false;
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
-      // Notify the caller the amount was committed (e.g. to start quote-timing
-      // instrumentation). Leaving Loading is owned solely by the stage hook's
-      // exit effect, which waits for the quote fetch to settle, so we do not
-      // clear the override here.
+      // If the keyboard was closed when handleDone started (auto-submit) but
+      // the user opened it during the await, don't dismiss it.
+      if (!keyboardVisibleAtStart && isKeyboardVisibleRef.current) {
+        return;
+      }
+      setIsKeyboardVisible(false);
       onAmountSubmit?.();
     }, [
       amountFiat,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
-      setStage,
       toastRef,
       trackAmountCommitted,
       transactionId,
       updateTokenAmount,
     ]);
+
+    useEffect(() => {
+      if (!quoteHandoff) {
+        return;
+      }
+
+      const hasObservedLoading =
+        quoteHandoff.kind === 'loading' && isQuotesLoading;
+      const hasObservedCompletedQuote =
+        quotesLastUpdated !== undefined &&
+        (quoteHandoff.kind === 'completed'
+          ? quotesLastUpdated >= quoteHandoff.quotesLastUpdated
+          : quoteHandoff.quotesLastUpdated === undefined ||
+            quotesLastUpdated > quoteHandoff.quotesLastUpdated);
+
+      if (hasObservedLoading || hasObservedCompletedQuote) {
+        setQuoteHandoff(undefined);
+        setIsAmountUpdating(false);
+      }
+    }, [isQuotesLoading, quoteHandoff, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {
@@ -327,7 +444,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       // The tokenKey in useDepositPrefillAmount can toggle hasPrefilled
       // (true → false → true) during background state changes, which resets
       // the guard above and would otherwise dismiss the keyboard mid-edit.
-      if (stage === CustomAmountStage.AmountInput) {
+      if (isKeyboardVisible) {
         return;
       }
 
@@ -335,7 +452,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         hasAutoSubmittedPrefill.current = true;
         handleDone();
       }
-    }, [isDepositPrefilled, amountFiat, handleDone, stage]);
+    }, [isDepositPrefilled, amountFiat, handleDone, isKeyboardVisible]);
 
     const isMaxAutoSubmitPending = useRef(false);
 
@@ -347,13 +464,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         // stranding the user on a loading screen.
         if (percentage === 100 && didApplyAmount) {
           isMaxAutoSubmitPending.current = true;
-          // Max defers the commit to the effect below once the amount lands;
-          // show the loading skeleton through that gap rather than the derived
-          // stage, matching the direct-commit path.
-          setStage(CustomAmountStage.Loading);
+          setIsKeyboardVisible(false);
         }
       },
-      [updatePendingAmountPercentage, setStage],
+      [updatePendingAmountPercentage],
     );
 
     useEffect(() => {
@@ -364,15 +478,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     }, [amountFiat, handleDone]);
 
     const handleAmountPress = useCallback(() => {
-      setStage(CustomAmountStage.AmountInput);
-    }, [setStage]);
+      wasKeyboardEverVisible.current = true;
+      setIsKeyboardVisible(true);
+    }, []);
 
     const isAccountSelectionNeeded =
       supportAccountSelection && !accountOverride;
-
+    const hideDetailsForNoFunds = hasAccountNoFunds && Boolean(accountOverride);
     const hideBuyForNoFunds =
-      Boolean(accountOverride) &&
-      (hasAccountNoFunds || stage === CustomAmountStage.Loading);
+      Boolean(accountOverride) && (hasAccountNoFunds || isQuotesLoading);
 
     const { headlessBuyError } = useConfirmationContext();
 
@@ -382,21 +496,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           <CustomAmount
             amountFiat={amountFiat}
             currency={currency}
-            hasAlert={
-              stage !== CustomAmountStage.Loading && Boolean(alertMessage)
-            }
+            hasAlert={Boolean(alertMessage)}
             isLoading={
               !hasAccountNoFunds &&
               !skipDepositPrefill &&
               (isPrefillPending || isDepositPrefillLoading)
             }
-            onPress={
-              stage === CustomAmountStage.Loading
-                ? undefined
-                : handleAmountPress
-            }
+            onPress={showLoadingReview ? undefined : handleAmountPress}
             disabled={!hasPaymentOption}
-            showCursor={stage === CustomAmountStage.AmountInput}
+            showCursor={isKeyboardVisible && !showLoadingReview}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -415,10 +523,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           testID={CustomAmountInfoTestIds.BOTTOM_BLOCK}
           style={styles.bottomBlock}
         >
-          {stage !== CustomAmountStage.Loading && (
-            <AlertMessage alertMessage={alertMessage ?? headlessBuyError} />
-          )}
-          {stage === CustomAmountStage.AmountInput && !isAddMusdIntent && (
+          <AlertMessage
+            content={alertContent}
+            alertMessage={alertMessage ?? headlessBuyError}
+          />
+          {!isResultReady && !(isKeyboardVisible && isAddMusdIntent) && (
             <>
               {supportAccountSelection &&
                 !selectedFiatPaymentMethodId &&
@@ -431,11 +540,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 (hasPaymentOption || hasAccountNoFunds) && <PayWithRow />}
             </>
           )}
-          {stage !== CustomAmountStage.AmountInput && (
+          {isResultReady && (
             <View
-              pointerEvents={
-                stage === CustomAmountStage.Loading ? 'none' : 'auto'
-              }
+              pointerEvents={showLoadingReview ? 'none' : 'auto'}
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
               {supportAccountSelection &&
@@ -450,7 +557,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 <Quote
                   amountFiat={amountFiat}
                   canSelectWithdrawToken={canSelectWithdrawToken}
-                  stage={stage}
+                  isAddMusdIntent={isAddMusdIntent}
+                  isAwaitingPrefillResult={isAwaitingPrefillResult}
+                  isLoading={showLoadingReview}
+                  showPaymentDetails={showPaymentDetails}
                 />
               )}
               <PercentageRow />
@@ -465,36 +575,38 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {footerText}
             </Text>
           )}
-          {stage === CustomAmountStage.AmountInput &&
-            (hasPaymentOption || hasAccountNoFunds) && (
-              <DepositKeyboard
-                hidePercentageButtons={
-                  Boolean(selectedFiatPaymentMethodId) ||
-                  shouldHideAccountSelector
-                }
-                alertMessage={alertTitle}
-                value={amountFiat}
-                onChange={updatePendingAmount}
-                onDonePress={handleDone}
-                onPercentagePress={handlePercentagePress}
-                hasInput={hasInput}
-                hasMax={
-                  (hasMax || isMoneyDepositNoFee) &&
-                  (isWithdraw || !isNativePayToken)
-                }
-              />
-            )}
+          {isKeyboardVisible && (hasPaymentOption || hasAccountNoFunds) && (
+            <DepositKeyboard
+              hidePercentageButtons={
+                Boolean(selectedFiatPaymentMethodId) ||
+                shouldHideAccountSelector
+              }
+              alertMessage={alertTitle}
+              value={amountFiat}
+              onChange={updatePendingAmount}
+              onDonePress={handleDone}
+              onPercentagePress={handlePercentagePress}
+              hasInput={hasInput}
+              hasMax={
+                (hasMax || isMoneyDepositNoFee) &&
+                (isWithdraw || !isNativePayToken)
+              }
+            />
+          )}
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {stage !== CustomAmountStage.AmountInput && (
+          {!isKeyboardVisible && (
             <ConfirmButton
               alertTitle={alertTitle}
-              isDisabled={
-                disableConfirm || isAccountSelectionNeeded || isPrefillPending
+              disableConfirm={
+                disableConfirm ||
+                isAccountSelectionNeeded ||
+                isPrefillPending ||
+                isAwaitingPrefillResult
               }
+              isAmountUpdating={isAmountUpdating}
               onContinue={trackContinue}
-              stage={stage}
             />
           )}
         </Box>
@@ -517,48 +629,6 @@ export function CustomAmountInfoSkeleton() {
         <DepositKeyboardSkeleton />
       </Box>
     </Box>
-  );
-}
-
-export function PrefillCustomAmountInfoSkeleton() {
-  const { styles } = useStyles(styleSheet, {});
-
-  return (
-    <View style={styles.container} testID="prefill-custom-amount-info-skeleton">
-      <View style={styles.inputContainer}>
-        <CustomAmountSkeleton />
-        <Skeleton height={20} width={200} />
-      </View>
-      <View>
-        <View style={styles.skeletonRow}>
-          <Skeleton height={18} width={100} />
-          <View style={styles.skeletonRowRight}>
-            <Skeleton height={28} width={28} twClassName="rounded-full" />
-            <Skeleton height={18} width={100} />
-          </View>
-        </View>
-        <View style={styles.skeletonInfoRow}>
-          <Skeleton height={18} width={100} />
-          <View style={styles.skeletonRowRight}>
-            <Skeleton height={24} width={24} twClassName="rounded-full" />
-            <Skeleton height={18} width={100} />
-          </View>
-        </View>
-        <View style={styles.skeletonInfoRow}>
-          <Skeleton height={16} width={100} />
-          <Skeleton height={16} width={100} />
-        </View>
-        <View style={styles.skeletonInfoRow}>
-          <Skeleton height={16} width={100} />
-          <Skeleton height={16} width={100} />
-        </View>
-        <View style={styles.skeletonInfoRow}>
-          <Skeleton height={16} width={100} />
-          <Skeleton height={16} width={100} />
-        </View>
-        <Skeleton height={48} style={styles.buttonSkeleton} />
-      </View>
-    </View>
   );
 }
 
@@ -652,31 +722,41 @@ function BuySection() {
 function Quote({
   amountFiat,
   canSelectWithdrawToken,
-  stage,
+  isAddMusdIntent,
+  isAwaitingPrefillResult,
+  isLoading,
+  showPaymentDetails,
 }: Readonly<{
   amountFiat: string;
   canSelectWithdrawToken: boolean;
-  stage: CustomAmountStage;
+  isAddMusdIntent: boolean;
+  isAwaitingPrefillResult: boolean;
+  isLoading: boolean;
+  showPaymentDetails: boolean;
 }>) {
-  if (stage === CustomAmountStage.Loading) {
+  if (isLoading) {
     return <PaymentDetailsSkeleton />;
   }
 
-  if (stage === CustomAmountStage.NoQuote) {
-    return null;
+  if (showPaymentDetails && !isAwaitingPrefillResult) {
+    return (
+      <>
+        <BridgeFeeRow />
+        <BridgeTimeRow />
+        {canSelectWithdrawToken ? (
+          <ReceiveRow inputAmountUsd={amountFiat} />
+        ) : (
+          <TotalRow />
+        )}
+      </>
+    );
   }
 
-  return (
-    <>
-      <BridgeFeeRow />
-      <BridgeTimeRow />
-      {canSelectWithdrawToken ? (
-        <ReceiveRow inputAmountUsd={amountFiat} />
-      ) : (
-        <TotalRow />
-      )}
-    </>
-  );
+  if (isAddMusdIntent || isAwaitingPrefillResult) {
+    return <PaymentDetailsSkeleton />;
+  }
+
+  return null;
 }
 
 function PaymentDetailsSkeleton() {
@@ -691,25 +771,33 @@ function PaymentDetailsSkeleton() {
 
 function ConfirmButton({
   alertTitle,
-  isDisabled,
+  disableConfirm,
+  isAmountUpdating,
   onContinue,
-  stage,
 }: Readonly<{
   alertTitle: string | undefined;
-  isDisabled: boolean;
+  disableConfirm?: boolean;
+  isAmountUpdating?: boolean;
   onContinue?: () => void;
-  stage: CustomAmountStage;
 }>) {
   const { styles } = useStyles(styleSheet, {});
   const { hasBlockingAlerts } = useAlerts();
   const { isHeadlessBuyInProgress, setIsConfirmationSubmitting } =
     useConfirmationContext();
+  const isLoading = useIsTransactionPayLoading();
   const { onConfirm } = useConfirmActions();
+  const disabled =
+    hasBlockingAlerts ||
+    isLoading ||
+    Boolean(disableConfirm) ||
+    isAmountUpdating ||
+    isHeadlessBuyInProgress;
+  const buttonLabel = useButtonLabel();
 
   const handleConfirm = useCallback(async () => {
     setIsConfirmationSubmitting(true);
+    // Continue / Add Funds CTA funnel event; no-op for non-money flows.
     onContinue?.();
-
     try {
       await onConfirm();
     } catch (error) {
@@ -717,19 +805,6 @@ function ConfirmButton({
       throw error;
     }
   }, [onConfirm, onContinue, setIsConfirmationSubmitting]);
-
-  const disabled =
-    isDisabled ||
-    stage !== CustomAmountStage.ShowTotals ||
-    hasBlockingAlerts ||
-    isHeadlessBuyInProgress;
-
-  const enabledButtonLabel = useButtonLabel();
-
-  const buttonLabel =
-    stage === CustomAmountStage.Loading
-      ? enabledButtonLabel
-      : (alertTitle ?? enabledButtonLabel);
 
   return (
     <Button
@@ -743,8 +818,23 @@ function ConfirmButton({
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     >
-      {buttonLabel}
+      {isAmountUpdating ? buttonLabel : (alertTitle ?? buttonLabel)}
     </Button>
+  );
+}
+
+function useIsResultReady({
+  isKeyboardVisible,
+}: {
+  isKeyboardVisible: boolean;
+}) {
+  const quotes = useTransactionPayQuotes();
+  const isQuotesLoading = useIsTransactionPayLoading();
+  const hasSourceAmount = useTransactionPayHasSourceAmount();
+
+  return (
+    !isKeyboardVisible &&
+    (isQuotesLoading || Boolean(quotes?.length) || !hasSourceAmount)
   );
 }
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -16,14 +16,12 @@ import {
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
   useTransactionPayQuoteError,
-  useTransactionPayQuotes,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
-  useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
 import {
   TransactionPayQuote,
   TransactionPayRequiredToken,
-  TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
@@ -53,9 +51,8 @@ function runHook() {
 
 describe('useNoPayTokenQuotesAlert', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
-  const useTransactionPaySourceAmountsMock = jest.mocked(
-    useTransactionPaySourceAmounts,
+  const useTransactionPayQuotesRawMock = jest.mocked(
+    useTransactionPayQuotesRaw,
   );
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
@@ -79,10 +76,7 @@ describe('useNoPayTokenQuotesAlert', () => {
     } as ReturnType<typeof useTransactionPayToken>);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
-    useTransactionPayQuotesMock.mockReturnValue(undefined);
-    useTransactionPaySourceAmountsMock.mockReturnValue([
-      {} as TransactionPaySourceAmount,
-    ]);
+    useTransactionPayQuotesRawMock.mockReturnValue(undefined);
     useTransactionPayIsPostQuoteMock.mockReturnValue(false);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useTransactionPayWithdrawMock.mockReturnValue({
@@ -102,7 +96,6 @@ describe('useNoPayTokenQuotesAlert', () => {
         key: AlertKeys.NoPayTokenQuotes,
         field: RowAlertKey.PayWith,
         message: strings('alert_system.no_pay_token_quotes.message'),
-        alertDetails: undefined,
         title: strings('alert_system.no_pay_token_quotes.title'),
         severity: Severity.Danger,
         isBlocking: true,
@@ -134,7 +127,7 @@ describe('useNoPayTokenQuotesAlert', () => {
   });
 
   it('returns no alerts if quotes available', () => {
-    useTransactionPayQuotesMock.mockReturnValue([
+    useTransactionPayQuotesRawMock.mockReturnValue([
       {} as TransactionPayQuote<Json>,
     ]);
 
@@ -160,8 +153,7 @@ describe('useNoPayTokenQuotesAlert', () => {
       amountFiat: '50.00',
     });
 
-    useTransactionPaySourceAmountsMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
 
     const { result } = runHook();
 
@@ -185,121 +177,32 @@ describe('useNoPayTokenQuotesAlert', () => {
       rampsQuote: { id: 'quote-1' },
     } as never);
 
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
 
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns alert for fiat when sourceAmounts is non-empty but no rampsQuote', () => {
+  it('returns no alerts for fiat when amount is not entered', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
     } as ReturnType<typeof useTransactionPayToken>);
 
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
       selectedPaymentMethodId: 'pm-card',
-      amountFiat: '50.00',
     });
 
-    useTransactionPaySourceAmountsMock.mockReturnValue([
-      {} as TransactionPaySourceAmount,
-    ]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
-
-    const { result } = runHook();
-
-    expect(result.current).toEqual([
-      expect.objectContaining({
-        key: AlertKeys.NoPayTokenQuotes,
-        severity: Severity.Danger,
-        isBlocking: true,
-      }),
-    ]);
-  });
-
-  it('returns no alerts for fiat when amount is not entered', () => {
-    jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
-      selectedPaymentMethodId: 'pm-card',
-    });
-
-    useTransactionPaySourceAmountsMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
 
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
   });
 
-  // Non-post-quote: `sourceAmount.targetTokenAddress` is a required-token
-  // address, so matching it against a `skipIfBalance` required token means the
-  // only required token is optional (gas) and no quote is needed.
-  it('returns no alerts when all source amounts target skipIfBalance required tokens (non-post-quote)', () => {
-    const optionalTokenAddress =
-      '0x0000000000000000000000000000000000000000' as Hex;
-
-    useTransactionPaySourceAmountsMock.mockReturnValue([
-      {
-        targetTokenAddress: optionalTokenAddress,
-      } as TransactionPaySourceAmount,
-    ]);
-
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: optionalTokenAddress,
-        skipIfBalance: true,
-      } as TransactionPayRequiredToken,
-    ]);
-
-    const { result } = runHook();
-
-    expect(result.current).toStrictEqual([]);
-  });
-
-  // Regression for #29297: perps withdraw $0.1 → ETH on Ethereum. The
-  // destination native token address (`0x0…0`) was false-matching the
-  // Arbitrum native gas required token (also `0x0…0`, `skipIfBalance: true`),
-  // making `isOptionalOnly` true and suppressing the "No quotes" alert, which
-  // let the UI render a huge bogus `targetNetwork` fee.
-  it('returns alert for post-quote even when sourceAmount target address false-matches a skipIfBalance required token', () => {
-    const nativeTokenAddress =
-      '0x0000000000000000000000000000000000000000' as Hex;
-
+  it('returns alert for post-quote when a required token has a positive amount and no quotes', () => {
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-
-    useTransactionPaySourceAmountsMock.mockReturnValue([
-      {
-        targetTokenAddress: nativeTokenAddress,
-      } as TransactionPaySourceAmount,
-    ]);
-
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: nativeTokenAddress,
-        chainId: '0xa4b1' as Hex,
-        skipIfBalance: true,
-      } as TransactionPayRequiredToken,
-    ]);
-
-    const { result } = runHook();
-
-    expect(result.current).toEqual([
-      expect.objectContaining({
-        key: AlertKeys.NoPayTokenQuotes,
-        severity: Severity.Danger,
-        isBlocking: true,
-      }),
-    ]);
-  });
-
-  // Money account withdraw MUSD -> MUSD: `calculatePostQuoteSourceAmounts`
-  // filters out same-token/same-chain entries, so `sourceAmounts` is empty
-  // even when the user has entered a positive amount. The alert must still
-  // fire so the Withdraw button stays disabled.
-  it('returns alert for post-quote when sourceAmounts is empty but a required token has a positive amount', () => {
-    useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPaySourceAmountsMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
       {
@@ -321,16 +224,20 @@ describe('useNoPayTokenQuotesAlert', () => {
     ]);
   });
 
-  it('returns no alerts for post-quote with empty sourceAmounts when the required token amount is zero', () => {
+  it('returns no alerts for post-quote when a no-op raw quote is present', () => {
+    // A direct, same-token route returns a no-op quote rather than an empty
+    // list. Raw quotes are non-empty, so the alert is suppressed even though
+    // the filtered quote list would be empty.
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPaySourceAmountsMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([
+      {} as TransactionPayQuote<Json>,
+    ]);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
       {
         address: ADDRESS_MOCK,
         chainId: CHAIN_ID_MOCK,
-        amountRaw: '0',
+        amountRaw: '10000',
         skipIfBalance: false,
       } as TransactionPayRequiredToken,
     ]);
@@ -340,10 +247,9 @@ describe('useNoPayTokenQuotesAlert', () => {
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns alert for post-quote with empty sourceAmounts when isMaxAmount is true', () => {
+  it('returns alert for post-quote when isMaxAmount is true', () => {
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPaySourceAmountsMock.mockReturnValue([]);
-    useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
     jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(true);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
@@ -373,8 +279,7 @@ describe('useNoPayTokenQuotesAlert', () => {
         payToken: undefined,
       } as ReturnType<typeof useTransactionPayToken>);
       useIsTransactionPayLoadingMock.mockReturnValue(false);
-      useTransactionPayQuotesMock.mockReturnValue([]);
-      useTransactionPaySourceAmountsMock.mockReturnValue([]);
+      useTransactionPayQuotesRawMock.mockReturnValue([]);
       useTransactionPayIsPostQuoteMock.mockReturnValue(false);
       useTransactionPayRequiredTokensMock.mockReturnValue([
         {
@@ -429,7 +334,7 @@ describe('useNoPayTokenQuotesAlert', () => {
       jest.mocked(useTransactionMetadataRequest).mockReturnValue({
         type: TransactionType.moneyAccountDeposit,
       } as never);
-      useTransactionPayQuotesMock.mockReturnValue([
+      useTransactionPayQuotesRawMock.mockReturnValue([
         {} as TransactionPayQuote<Json>,
       ]);
 
@@ -458,8 +363,7 @@ describe('useNoPayTokenQuotesAlert', () => {
     });
 
     beforeEach(() => {
-      useTransactionPayQuotesMock.mockReturnValue([]);
-      useTransactionPaySourceAmountsMock.mockReturnValue([]);
+      useTransactionPayQuotesRawMock.mockReturnValue([]);
       useTransactionPayWithdrawMock.mockReturnValue({
         isWithdraw: true,
         canSelectWithdrawToken: true,
@@ -496,7 +400,12 @@ describe('useNoPayTokenQuotesAlert', () => {
     });
 
     it('returns no alerts when the destination token and pay config are set', () => {
+      // A configured same-token withdraw resolves to a direct no-op route,
+      // which is returned as a non-empty raw quote list.
       useTransactionPayIsPostQuoteMock.mockReturnValue(true);
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        {} as TransactionPayQuote<Json>,
+      ]);
 
       const { result } = runHook();
 
@@ -540,8 +449,7 @@ describe('useNoPayTokenQuotesAlert', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: undefined,
       } as ReturnType<typeof useTransactionPayToken>);
-      useTransactionPayQuotesMock.mockReturnValue([]);
-      useTransactionPaySourceAmountsMock.mockReturnValue([]);
+      useTransactionPayQuotesRawMock.mockReturnValue([]);
       useTransactionPayRequiredTokensMock.mockReturnValue([
         {
           address: ADDRESS_MOCK,
@@ -571,13 +479,16 @@ describe('useNoPayTokenQuotesAlert', () => {
       expect(result.current).toStrictEqual([]);
     });
 
-    it('returns no alerts when a payment token is set', () => {
+    it('returns no alerts when a payment token is set and quotes are available', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: ADDRESS_MOCK,
           chainId: CHAIN_ID_MOCK,
         },
       } as ReturnType<typeof useTransactionPayToken>);
+      useTransactionPayQuotesRawMock.mockReturnValue([
+        {} as TransactionPayQuote<Json>,
+      ]);
 
       const { result } = runHook();
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -2,7 +2,7 @@ import { cloneDeep, merge } from 'lodash';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
-import { Severity } from '../../types/alerts';
+import { Alert, Severity } from '../../types/alerts';
 import { useNoPayTokenQuotesAlert } from './useNoPayTokenQuotesAlert';
 import { RootState } from '../../../../../reducers';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
@@ -15,12 +15,15 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
-  useTransactionPayQuotesRaw,
+  useTransactionPayQuoteError,
+  useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
+  useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
 import {
   TransactionPayQuote,
   TransactionPayRequiredToken,
+  TransactionPaySourceAmount,
 } from '@metamask/transaction-pay-controller';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
@@ -50,8 +53,9 @@ function runHook() {
 
 describe('useNoPayTokenQuotesAlert', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useTransactionPayQuotesRawMock = jest.mocked(
-    useTransactionPayQuotesRaw,
+  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useTransactionPaySourceAmountsMock = jest.mocked(
+    useTransactionPaySourceAmounts,
   );
   const useIsTransactionPayLoadingMock = jest.mocked(
     useIsTransactionPayLoading,
@@ -75,7 +79,10 @@ describe('useNoPayTokenQuotesAlert', () => {
     } as ReturnType<typeof useTransactionPayToken>);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);
-    useTransactionPayQuotesRawMock.mockReturnValue(undefined);
+    useTransactionPayQuotesMock.mockReturnValue(undefined);
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {} as TransactionPaySourceAmount,
+    ]);
     useTransactionPayIsPostQuoteMock.mockReturnValue(false);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useTransactionPayWithdrawMock.mockReturnValue({
@@ -84,6 +91,7 @@ describe('useNoPayTokenQuotesAlert', () => {
     });
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
     jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(false);
+    jest.mocked(useTransactionPayQuoteError).mockReturnValue(undefined);
   });
 
   it('returns alert if pay token selected and no quotes available', () => {
@@ -94,6 +102,7 @@ describe('useNoPayTokenQuotesAlert', () => {
         key: AlertKeys.NoPayTokenQuotes,
         field: RowAlertKey.PayWith,
         message: strings('alert_system.no_pay_token_quotes.message'),
+        alertDetails: undefined,
         title: strings('alert_system.no_pay_token_quotes.title'),
         severity: Severity.Danger,
         isBlocking: true,
@@ -101,8 +110,31 @@ describe('useNoPayTokenQuotesAlert', () => {
     ]);
   });
 
+  it('uses quoteError message and detail when present', () => {
+    const quoteError = {
+      message: 'Insufficient balance',
+      reason: 'insufficient-source-balance' as const,
+      detail: ['Required: 1.5 USDC', 'Current: 1 USDC', 'Missing: 0.5 USDC'],
+    };
+    jest.mocked(useTransactionPayQuoteError).mockReturnValue(quoteError);
+
+    const { result } = runHook();
+
+    expect(result.current).toHaveLength(1);
+    const resultAlert = result.current[0] as Alert;
+    expect(resultAlert.key).toBe(AlertKeys.NoPayTokenQuotes);
+    expect(resultAlert.field).toBe(RowAlertKey.PayWith);
+    expect(resultAlert.content).toBeDefined();
+    expect(resultAlert.message).toBe('Insufficient balance');
+    expect(resultAlert.title).toBe(
+      strings('alert_system.no_pay_token_quotes.title'),
+    );
+    expect(resultAlert.severity).toBe(Severity.Danger);
+    expect(resultAlert.isBlocking).toBe(true);
+  });
+
   it('returns no alerts if quotes available', () => {
-    useTransactionPayQuotesRawMock.mockReturnValue([
+    useTransactionPayQuotesMock.mockReturnValue([
       {} as TransactionPayQuote<Json>,
     ]);
 
@@ -128,7 +160,8 @@ describe('useNoPayTokenQuotesAlert', () => {
       amountFiat: '50.00',
     });
 
-    useTransactionPayQuotesRawMock.mockReturnValue([]);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
 
     const { result } = runHook();
 
@@ -152,32 +185,121 @@ describe('useNoPayTokenQuotesAlert', () => {
       rampsQuote: { id: 'quote-1' },
     } as never);
 
-    useTransactionPayQuotesRawMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
 
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns no alerts for fiat when amount is not entered', () => {
+  it('returns alert for fiat when sourceAmounts is non-empty but no rampsQuote', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
     } as ReturnType<typeof useTransactionPayToken>);
 
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
       selectedPaymentMethodId: 'pm-card',
+      amountFiat: '50.00',
     });
 
-    useTransactionPayQuotesRawMock.mockReturnValue([]);
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {} as TransactionPaySourceAmount,
+    ]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        key: AlertKeys.NoPayTokenQuotes,
+        severity: Severity.Danger,
+        isBlocking: true,
+      }),
+    ]);
+  });
+
+  it('returns no alerts for fiat when amount is not entered', () => {
+    jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+    });
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
 
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns alert for post-quote when a required token has a positive amount and no quotes', () => {
+  // Non-post-quote: `sourceAmount.targetTokenAddress` is a required-token
+  // address, so matching it against a `skipIfBalance` required token means the
+  // only required token is optional (gas) and no quote is needed.
+  it('returns no alerts when all source amounts target skipIfBalance required tokens (non-post-quote)', () => {
+    const optionalTokenAddress =
+      '0x0000000000000000000000000000000000000000' as Hex;
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {
+        targetTokenAddress: optionalTokenAddress,
+      } as TransactionPaySourceAmount,
+    ]);
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: optionalTokenAddress,
+        skipIfBalance: true,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  // Regression for #29297: perps withdraw $0.1 → ETH on Ethereum. The
+  // destination native token address (`0x0…0`) was false-matching the
+  // Arbitrum native gas required token (also `0x0…0`, `skipIfBalance: true`),
+  // making `isOptionalOnly` true and suppressing the "No quotes" alert, which
+  // let the UI render a huge bogus `targetNetwork` fee.
+  it('returns alert for post-quote even when sourceAmount target address false-matches a skipIfBalance required token', () => {
+    const nativeTokenAddress =
+      '0x0000000000000000000000000000000000000000' as Hex;
+
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPayQuotesRawMock.mockReturnValue([]);
+
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      {
+        targetTokenAddress: nativeTokenAddress,
+      } as TransactionPaySourceAmount,
+    ]);
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: nativeTokenAddress,
+        chainId: '0xa4b1' as Hex,
+        skipIfBalance: true,
+      } as TransactionPayRequiredToken,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        key: AlertKeys.NoPayTokenQuotes,
+        severity: Severity.Danger,
+        isBlocking: true,
+      }),
+    ]);
+  });
+
+  // Money account withdraw MUSD -> MUSD: `calculatePostQuoteSourceAmounts`
+  // filters out same-token/same-chain entries, so `sourceAmounts` is empty
+  // even when the user has entered a positive amount. The alert must still
+  // fire so the Withdraw button stays disabled.
+  it('returns alert for post-quote when sourceAmounts is empty but a required token has a positive amount', () => {
+    useTransactionPayIsPostQuoteMock.mockReturnValue(true);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
       {
@@ -199,20 +321,16 @@ describe('useNoPayTokenQuotesAlert', () => {
     ]);
   });
 
-  it('returns no alerts for post-quote when a no-op raw quote is present', () => {
-    // A direct, same-token route returns a no-op quote rather than an empty
-    // list. Raw quotes are non-empty, so the alert is suppressed even though
-    // the filtered quote list would be empty.
+  it('returns no alerts for post-quote with empty sourceAmounts when the required token amount is zero', () => {
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPayQuotesRawMock.mockReturnValue([
-      {} as TransactionPayQuote<Json>,
-    ]);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
       {
         address: ADDRESS_MOCK,
         chainId: CHAIN_ID_MOCK,
-        amountRaw: '10000',
+        amountRaw: '0',
         skipIfBalance: false,
       } as TransactionPayRequiredToken,
     ]);
@@ -222,9 +340,10 @@ describe('useNoPayTokenQuotesAlert', () => {
     expect(result.current).toStrictEqual([]);
   });
 
-  it('returns alert for post-quote when isMaxAmount is true', () => {
+  it('returns alert for post-quote with empty sourceAmounts when isMaxAmount is true', () => {
     useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-    useTransactionPayQuotesRawMock.mockReturnValue([]);
+    useTransactionPaySourceAmountsMock.mockReturnValue([]);
+    useTransactionPayQuotesMock.mockReturnValue([]);
     jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(true);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([
@@ -254,7 +373,8 @@ describe('useNoPayTokenQuotesAlert', () => {
         payToken: undefined,
       } as ReturnType<typeof useTransactionPayToken>);
       useIsTransactionPayLoadingMock.mockReturnValue(false);
-      useTransactionPayQuotesRawMock.mockReturnValue([]);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPaySourceAmountsMock.mockReturnValue([]);
       useTransactionPayIsPostQuoteMock.mockReturnValue(false);
       useTransactionPayRequiredTokensMock.mockReturnValue([
         {
@@ -309,7 +429,7 @@ describe('useNoPayTokenQuotesAlert', () => {
       jest.mocked(useTransactionMetadataRequest).mockReturnValue({
         type: TransactionType.moneyAccountDeposit,
       } as never);
-      useTransactionPayQuotesRawMock.mockReturnValue([
+      useTransactionPayQuotesMock.mockReturnValue([
         {} as TransactionPayQuote<Json>,
       ]);
 
@@ -338,7 +458,8 @@ describe('useNoPayTokenQuotesAlert', () => {
     });
 
     beforeEach(() => {
-      useTransactionPayQuotesRawMock.mockReturnValue([]);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPaySourceAmountsMock.mockReturnValue([]);
       useTransactionPayWithdrawMock.mockReturnValue({
         isWithdraw: true,
         canSelectWithdrawToken: true,
@@ -375,12 +496,7 @@ describe('useNoPayTokenQuotesAlert', () => {
     });
 
     it('returns no alerts when the destination token and pay config are set', () => {
-      // A configured same-token withdraw resolves to a direct no-op route,
-      // which is returned as a non-empty raw quote list.
       useTransactionPayIsPostQuoteMock.mockReturnValue(true);
-      useTransactionPayQuotesRawMock.mockReturnValue([
-        {} as TransactionPayQuote<Json>,
-      ]);
 
       const { result } = runHook();
 
@@ -424,7 +540,8 @@ describe('useNoPayTokenQuotesAlert', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: undefined,
       } as ReturnType<typeof useTransactionPayToken>);
-      useTransactionPayQuotesRawMock.mockReturnValue([]);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPaySourceAmountsMock.mockReturnValue([]);
       useTransactionPayRequiredTokensMock.mockReturnValue([
         {
           address: ADDRESS_MOCK,
@@ -454,16 +571,13 @@ describe('useNoPayTokenQuotesAlert', () => {
       expect(result.current).toStrictEqual([]);
     });
 
-    it('returns no alerts when a payment token is set and quotes are available', () => {
+    it('returns no alerts when a payment token is set', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: ADDRESS_MOCK,
           chainId: CHAIN_ID_MOCK,
         },
       } as ReturnType<typeof useTransactionPayToken>);
-      useTransactionPayQuotesRawMock.mockReturnValue([
-        {} as TransactionPayQuote<Json>,
-      ]);
 
       const { result } = runHook();
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
@@ -51,12 +51,10 @@ export function useNoPayTokenQuotesAlert() {
     !fiatPayment?.rampsQuote &&
     quotes?.length === 0;
 
-  // Post-quote flows (e.g. money account withdraw) where no quote was
-  // returned. Excludes withdraw flows where the user can select a different
-  // withdraw token (`canSelectWithdrawToken`), which are handled by the
-  // shouldShowWithdrawNotInitialisedAlert branch. Does not require non-empty
-  // `sourceAmounts`, so same-token withdraw cases (e.g. MUSD→MUSD with an
-  // empty amounts list) correctly surface the alert.
+  // Post-quote flows (e.g. money account withdraw) where `sourceAmounts` is
+  // non-empty but no quote was returned. The non-fiat branch above may not
+  // fire, so we also emit the alert when the user has entered a positive
+  // input amount but no quote is available.
   const hasPositiveRequiredAmount = (requiredTokens ?? []).some(
     (t) =>
       !t.skipIfBalance &&
@@ -67,7 +65,6 @@ export function useNoPayTokenQuotesAlert() {
     isPostQuote &&
     Boolean(payToken) &&
     !isQuotesLoading &&
-    !canSelectWithdrawToken &&
     !quotes?.length &&
     hasPositiveRequiredAmount;
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
@@ -1,7 +1,8 @@
+import React, { useMemo } from 'react';
 import { hasTransactionType } from '@metamask/transaction-controller';
 
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
-import { useMemo } from 'react';
+import { NoQuoteAlert } from '../../components/alerts/no-quote-alert';
 import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
@@ -11,8 +12,10 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
-  useTransactionPayQuotesRaw,
+  useTransactionPayQuoteError,
+  useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
+  useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import {
@@ -24,13 +27,15 @@ import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
 export function useNoPayTokenQuotesAlert() {
   const { payToken } = useTransactionPayToken();
   const fiatPayment = useTransactionPayFiatPayment();
-  const quotes = useTransactionPayQuotesRaw();
+  const quotes = useTransactionPayQuotes();
   const isQuotesLoading = useIsTransactionPayLoading();
+  const sourceAmounts = useTransactionPaySourceAmounts();
   const requiredTokens = useTransactionPayRequiredTokens();
   const isPostQuote = useTransactionPayIsPostQuote();
   const isMaxAmount = useTransactionPayIsMaxAmount();
   const transactionMeta = useTransactionMetadataRequest();
   const { canSelectWithdrawToken } = useTransactionPayWithdraw();
+  const quoteError = useTransactionPayQuoteError();
 
   const fiatAmount = Number(fiatPayment?.amountFiat);
   const hasValidFiatAmount = Number.isFinite(fiatAmount) && fiatAmount > 0;
@@ -38,8 +43,27 @@ export function useNoPayTokenQuotesAlert() {
     fiatPayment?.selectedPaymentMethodId,
   );
 
+  // For non-post-quote flows, sourceAmount.targetTokenAddress refers to a
+  // required token address, so matching against `requiredTokens` is valid.
+  // For post-quote flows (perps/predict/moneyAccount withdraw, musdConversion),
+  // sourceAmount.targetTokenAddress is the destination token address, so this
+  // lookup is meaningless and can false-match a skipped gas token across
+  // chains (e.g. destination native ETH `0x0…0` vs. Arbitrum native gas
+  // `0x0…0`). See issue #29297.
+  const isOptionalOnly =
+    !isPostQuote &&
+    (sourceAmounts ?? []).every(
+      (t) =>
+        requiredTokens?.find((rt) => rt.address === t.targetTokenAddress)
+          ?.skipIfBalance,
+    );
+
   const shouldShowNonFiatNoQuotesAlert =
-    payToken && !isQuotesLoading && !quotes?.length;
+    payToken &&
+    !isQuotesLoading &&
+    sourceAmounts?.length &&
+    !quotes?.length &&
+    !isOptionalOnly;
 
   const shouldShowFiatNoQuotesAlert =
     hasSelectedFiatPaymentMethod &&
@@ -48,10 +72,12 @@ export function useNoPayTokenQuotesAlert() {
     !fiatPayment?.rampsQuote &&
     quotes?.length === 0;
 
-  // Post-quote flows (e.g. money account withdraw) where `sourceAmounts` is
-  // non-empty but no quote was returned. The non-fiat branch above may not
-  // fire, so we also emit the alert when the user has entered a positive
-  // input amount but no quote is available.
+  // Post-quote flows (e.g. money account withdraw) where no quote was
+  // returned. Excludes withdraw flows where the user can select a different
+  // withdraw token (`canSelectWithdrawToken`), which are handled by the
+  // shouldShowWithdrawNotInitialisedAlert branch. Does not require non-empty
+  // `sourceAmounts`, so same-token withdraw cases (e.g. MUSD→MUSD with an
+  // empty amounts list) correctly surface the alert.
   const hasPositiveRequiredAmount = (requiredTokens ?? []).some(
     (t) =>
       !t.skipIfBalance &&
@@ -62,6 +88,7 @@ export function useNoPayTokenQuotesAlert() {
     isPostQuote &&
     Boolean(payToken) &&
     !isQuotesLoading &&
+    !canSelectWithdrawToken &&
     !quotes?.length &&
     hasPositiveRequiredAmount;
 
@@ -97,13 +124,19 @@ export function useNoPayTokenQuotesAlert() {
     !payToken &&
     !hasSelectedFiatPaymentMethod;
 
+  // A quote may be returned but fail validation (e.g. insufficient balance).
+  // The quote still renders prices/fees, but the alert blocks confirmation and
+  // surfaces the structured reason and detail rows provided by core.
+  const shouldShowQuoteErrorAlert = Boolean(quoteError);
+
   const showAlert =
     shouldShowNonFiatNoQuotesAlert ||
     shouldShowFiatNoQuotesAlert ||
     shouldShowPostQuoteNoQuotesAlert ||
     shouldShowQuoteRequiredNoQuotesAlert ||
     shouldShowWithdrawNotInitialisedAlert ||
-    shouldShowPayTokenNotSelectedAlert;
+    shouldShowPayTokenNotSelectedAlert ||
+    shouldShowQuoteErrorAlert;
 
   return useMemo(() => {
     if (!showAlert) {
@@ -114,11 +147,16 @@ export function useNoPayTokenQuotesAlert() {
       {
         key: AlertKeys.NoPayTokenQuotes,
         field: RowAlertKey.PayWith,
-        message: strings('alert_system.no_pay_token_quotes.message'),
+        ...(quoteError
+          ? {
+              content: <NoQuoteAlert error={quoteError} />,
+              message: quoteError.message,
+            }
+          : { message: strings('alert_system.no_pay_token_quotes.message') }),
         title: strings('alert_system.no_pay_token_quotes.title'),
         severity: Severity.Danger,
         isBlocking: true,
       },
     ];
-  }, [showAlert]);
+  }, [showAlert, quoteError]);
 }

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
@@ -13,9 +13,8 @@ import {
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
   useTransactionPayQuoteError,
-  useTransactionPayQuotes,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
-  useTransactionPaySourceAmounts,
 } from '../pay/useTransactionPayData';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import {
@@ -27,9 +26,8 @@ import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
 export function useNoPayTokenQuotesAlert() {
   const { payToken } = useTransactionPayToken();
   const fiatPayment = useTransactionPayFiatPayment();
-  const quotes = useTransactionPayQuotes();
+  const quotes = useTransactionPayQuotesRaw();
   const isQuotesLoading = useIsTransactionPayLoading();
-  const sourceAmounts = useTransactionPaySourceAmounts();
   const requiredTokens = useTransactionPayRequiredTokens();
   const isPostQuote = useTransactionPayIsPostQuote();
   const isMaxAmount = useTransactionPayIsMaxAmount();
@@ -43,27 +41,8 @@ export function useNoPayTokenQuotesAlert() {
     fiatPayment?.selectedPaymentMethodId,
   );
 
-  // For non-post-quote flows, sourceAmount.targetTokenAddress refers to a
-  // required token address, so matching against `requiredTokens` is valid.
-  // For post-quote flows (perps/predict/moneyAccount withdraw, musdConversion),
-  // sourceAmount.targetTokenAddress is the destination token address, so this
-  // lookup is meaningless and can false-match a skipped gas token across
-  // chains (e.g. destination native ETH `0x0…0` vs. Arbitrum native gas
-  // `0x0…0`). See issue #29297.
-  const isOptionalOnly =
-    !isPostQuote &&
-    (sourceAmounts ?? []).every(
-      (t) =>
-        requiredTokens?.find((rt) => rt.address === t.targetTokenAddress)
-          ?.skipIfBalance,
-    );
-
   const shouldShowNonFiatNoQuotesAlert =
-    payToken &&
-    !isQuotesLoading &&
-    sourceAmounts?.length &&
-    !quotes?.length &&
-    !isOptionalOnly;
+    payToken && !isQuotesLoading && !quotes?.length;
 
   const shouldShowFiatNoQuotesAlert =
     hasSelectedFiatPaymentMethod &&

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -5,6 +5,7 @@ import {
   selectTransactionPayFiatPaymentByTransactionId,
   selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayIsPostQuoteByTransactionId,
+  selectTransactionPayQuoteErrorByTransactionId,
   selectTransactionPayQuotesByTransactionId,
   selectTransactionPayQuotesLastUpdatedByTransactionId,
   selectTransactionPayRawQuotesByTransactionId,
@@ -68,6 +69,10 @@ export function useTransactionPayIsPostQuote() {
 
 export function useTransactionPayFiatPayment() {
   return useTransactionPayData(selectTransactionPayFiatPaymentByTransactionId);
+}
+
+export function useTransactionPayQuoteError() {
+  return useTransactionPayData(selectTransactionPayQuoteErrorByTransactionId);
 }
 
 function useTransactionPayData<T>(

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.test.ts
@@ -101,6 +101,20 @@ describe('useTransactionCustomAmountAlerts', () => {
     expect(result.current.alertMessage).toBe(MESSAGE_MOCK);
   });
 
+  it('returns content from the first alert', () => {
+    const content = {
+      type: 'View',
+      props: {},
+    } as unknown as import('react').ReactElement;
+    useAlertsMock.mockReturnValue({
+      alerts: [{ ...ALERT_MOCK, content }],
+    } as AlertsContextParams);
+
+    const { result } = runHook();
+
+    expect(result.current.alertContent).toBe(content);
+  });
+
   it('returns no alert message if no title', () => {
     useAlertsMock.mockReturnValue({
       alerts: [

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { AlertKeys } from '../../constants/alerts';
 import { useAlerts } from '../../context/alert-system-context';
 import { usePendingAmountAlerts } from '../alerts/usePendingAmountAlerts';
@@ -43,6 +43,7 @@ export function useTransactionCustomAmountAlerts({
   pendingTokenAmount: string;
   pendingFiatAmount?: string;
 }): {
+  alertContent?: ReactElement;
   alertMessage?: string;
   alertTitle?: string;
 } {
@@ -97,7 +98,10 @@ export function useTransactionCustomAmountAlerts({
     ? (firstAlert.message as string | undefined)
     : undefined;
 
+  const alertContent = firstAlert.content as ReactElement | undefined;
+
   return {
+    alertContent,
     alertMessage,
     alertTitle,
   };

--- a/app/selectors/transactionPayController.ts
+++ b/app/selectors/transactionPayController.ts
@@ -100,3 +100,8 @@ export const selectPaymentOverrideByTransactionId = createSelector(
     (transactionData as Record<string, unknown> | undefined)
       ?.paymentOverride as string | undefined,
 );
+
+export const selectTransactionPayQuoteErrorByTransactionId = createSelector(
+  selectTransactionDataByTransactionId,
+  (transactionData) => transactionData?.quoteError,
+);


### PR DESCRIPTION
## **Description**

When a MetaMask Pay quote fails (e.g. insufficient balance), the confirmation screen previously showed a generic "No quotes available" message with no explanation. Core now returns a structured error on each quote; this PR surfaces it.

- Adds a `NoQuoteAlert` component that shows a reason-appropriate collapsed message (`insufficient-source-balance` → "Insufficient balance"; anything else → the generic string), with a double-tap to toggle a full error view showing core's `message` and `detail` rows.
- Wires the alert into the existing "Pay with" row alert system via a new selector, hook, and `content` prop on `AlertMessage` — the alert blocks confirm while prices/fees continue to render.
- Fixes the post-quote "no quotes" check so same-token withdraw flows (e.g. MUSD → MUSD) correctly surface an alert when their amounts list is empty.

Depends on MetaMask/core#9143, which adds the structured `quoteError` (`message`, `detail`, `reason`) to each pay quote.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/core/pull/9143

## **Manual testing steps**

```gherkin
Feature: Pay quote error surfaced in confirmation alert

  Scenario: a pay quote can't be used
    Given a transaction that requires a MetaMask Pay quote
    And the selected pay token produces a quote that can't be used

    When the confirmation screen loads
    Then a blocking alert is shown on the "Pay with" row
    And the confirm button is disabled

  Scenario: tapping the alert reveals the full error
    When the user double-taps the alert
    Then the full error message and detail rows are shown
    And double-tapping again collapses it
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation blocking behavior and pay quote error UX on the critical confirm path, but scope is UI wiring and read-only controller state with tests.
> 
> **Overview**
> When MetaMask Pay returns a quote that fails validation (e.g. insufficient balance), confirmations now show a **blocking “Pay with” alert** with a reason-specific collapsed message instead of only the generic “no quotes” copy. Core’s structured `quoteError` is read per transaction via a new selector and `useTransactionPayQuoteError`, and `useNoPayTokenQuotesAlert` treats a present `quoteError` as a separate show condition while still blocking confirm.
> 
> A new **`NoQuoteAlert`** component renders that error: double-tap toggles between the collapsed string (`insufficient-source-balance` uses the insufficient-balance i18n key) and the full `message` plus optional `detail` rows. **`AlertMessage`** gains an optional `content` slot (with layout split into `content` vs `message` styles), and the custom-amount flow passes **`alertContent`** from the alert system so rich UI can replace plain banner text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c3eb4e95176b588b40689e6e28838cec60f8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->