### PR TITLE
test: improve UT coverage on explore now tab

### DIFF
--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -14,9 +14,8 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-// Feed hooks — return empty/not-loading so NowTab renders without network calls.
 jest.mock('../feeds/tokens/useTokensFeed', () => ({
-  useTokensFeed: jest.fn(() => ({ data: [], isLoading: false })),
+  useTokensFeed: jest.fn(),
 }));
 
 jest.mock('../feeds/tokens/CryptoMoversPillItem', () => {
@@ -77,31 +76,12 @@ jest.mock('../feeds/perps/perpsNavigation', () => ({
   ) => mockNavigateToPerpsMarketList(nav, filter, sortOptionId, options),
 }));
 
-interface MockPredictionMarket {
-  id: string;
-}
-
-const mockUsePredictionsFeed = jest.fn<
-  { data: MockPredictionMarket[]; isLoading: boolean },
-  []
->(() => ({
-  data: [],
-  isLoading: false,
-}));
 jest.mock('../feeds/predictions/usePredictionsFeed', () => ({
-  usePredictionsFeed: () => mockUsePredictionsFeed(),
+  usePredictionsFeed: jest.fn(),
 }));
 
-const mockUseWorldCupPredictionsFeed = jest.fn<
-  { data: MockPredictionMarket[]; isLoading: boolean; isEnabled: boolean },
-  []
->(() => ({
-  data: [],
-  isLoading: false,
-  isEnabled: false,
-}));
 jest.mock('../feeds/predictions/useWorldCupPredictionsFeed', () => ({
-  useWorldCupPredictionsFeed: () => mockUseWorldCupPredictionsFeed(),
+  useWorldCupPredictionsFeed: jest.fn(),
 }));
 
 jest.mock('../feeds/predictions/PredictionRowItem', () => {
@@ -128,10 +108,9 @@ jest.mock('../components/HorizontalCarousel', () => {
 });
 
 jest.mock('../feeds/stocks/useStocksFeed', () => ({
-  useStocksFeed: jest.fn(() => ({ data: [], isLoading: false })),
+  useStocksFeed: jest.fn(),
 }));
 
-// Mock PerpsSectionProvider as a transparent passthrough.
 jest.mock('../feeds/perps/PerpsSectionProvider', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { createElement } = require('react');
@@ -140,12 +119,6 @@ jest.mock('../feeds/perps/PerpsSectionProvider', () => {
   return ({ children }: { children: unknown }) =>
     createElement(View, null, children);
 });
-
-// Mock WhatsHappeningSection to keep its transitive deps (Engine, analytics)
-// out of this unit test. We control rendering via mockWhatsHappeningImpl.
-const mockWhatsHappeningImpl = jest.fn<React.ReactElement | null, [unknown]>(
-  () => null,
-);
 
 const mockWhatsHappeningRefresh = jest.fn();
 const mockUseWhatsHappening = jest.fn(() => ({
@@ -206,26 +179,29 @@ jest.mock('../feeds/predictions/PredictionsCarouselSection', () => ({
   }) => mockPredictionsCarouselSection(props),
 }));
 
-jest.mock('../../../UI/WhatsHappening', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { forwardRef } = require('react');
-  return {
-    __esModule: true,
-    default: forwardRef((props: unknown, ref: unknown) =>
-      mockWhatsHappeningImpl({ ...(props as object), ref }),
-    ),
-  };
-});
+jest.mock('../../../UI/WhatsHappening', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
 
 import { useSelector } from 'react-redux';
 import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../../UI/Predict';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import WhatsHappeningSection from '../../../UI/WhatsHappening';
 import NowTab from './NowTab';
 import type { RefreshConfig } from '../hooks/useExploreRefresh';
 import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
+import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
+import { useWorldCupPredictionsFeed } from '../feeds/predictions/useWorldCupPredictionsFeed';
+import { useStocksFeed } from '../feeds/stocks/useStocksFeed';
 import Routes from '../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../../UI/Predict/constants/eventNames';
+
+const mockUsePredictionsFeed = jest.mocked(usePredictionsFeed);
+const mockUseWorldCupPredictionsFeed = jest.mocked(useWorldCupPredictionsFeed);
+const mockUseStocksFeed = jest.mocked(useStocksFeed);
+const mockWhatsHappeningImpl = jest.mocked(WhatsHappeningSection);
 
 const defaultRefresh: RefreshConfig = { trigger: 0, silentRefresh: true };
 const defaultTabProps = {
@@ -235,7 +211,106 @@ const defaultTabProps = {
 };
 
 const predictSectionTestId = 'section-header-view-all-predictions';
+const cryptoMoversSectionTestId = 'section-header-view-all-crypto_movers';
+const perpsSectionTestId = 'section-header-view-all-perps';
 const whatsHappeningSectionTestId = 'whats-happening-carousel';
+const stocksSectionTestId = 'section-header-view-all-stocks';
+
+const NOW_TAB_SECTION_ORDER_TEST_IDS = [
+  predictSectionTestId,
+  cryptoMoversSectionTestId,
+  perpsSectionTestId,
+  whatsHappeningSectionTestId,
+  stocksSectionTestId,
+] as const;
+
+const createWhatsHappeningCarousel = () =>
+  React.createElement('View', { testID: whatsHappeningSectionTestId });
+
+const createMockSelectorImpl =
+  ({
+    perpsEnabled = false,
+    predictEnabled = false,
+    whatsHappeningEnabled = false,
+  }: {
+    perpsEnabled?: boolean;
+    predictEnabled?: boolean;
+    whatsHappeningEnabled?: boolean;
+  }) =>
+  (selector: unknown) => {
+    if (selector === selectPerpsEnabledFlag) return perpsEnabled;
+    if (selector === selectPredictEnabledFlag) return predictEnabled;
+    if (selector === selectWhatsHappeningEnabled) return whatsHappeningEnabled;
+    return undefined;
+  };
+
+const arrangeMocks = () => {
+  jest.clearAllMocks();
+
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+  const mockUseTokensFeed = useTokensFeed as jest.MockedFunction<
+    typeof useTokensFeed
+  >;
+
+  mockUseSelector.mockImplementation(
+    createMockSelectorImpl({
+      perpsEnabled: false,
+      predictEnabled: false,
+      whatsHappeningEnabled: false,
+    }),
+  );
+
+  mockUsePredictionsFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+  });
+  mockUseWorldCupPredictionsFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isEnabled: false,
+    refetch: jest.fn(),
+  });
+  mockUsePerpsFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+    defaultSortOptionId: 'priceChange',
+  });
+  mockUseTokensFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+  });
+  mockUseStocksFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+  });
+  mockUseWhatsHappening.mockReturnValue({
+    items: [],
+    isLoading: false,
+    error: null,
+    refresh: mockWhatsHappeningRefresh,
+  });
+  mockWhatsHappeningImpl.mockReturnValue(null);
+
+  return {
+    useSelector: mockUseSelector,
+    useTokensFeed: mockUseTokensFeed,
+    usePerpsFeed: mockUsePerpsFeed,
+    usePredictionsFeed: mockUsePredictionsFeed,
+    useWorldCupPredictionsFeed: mockUseWorldCupPredictionsFeed,
+    useStocksFeed: mockUseStocksFeed,
+    useWhatsHappening: mockUseWhatsHappening,
+    whatsHappeningImpl: mockWhatsHappeningImpl,
+    whatsHappeningRefresh: mockWhatsHappeningRefresh,
+    navigateToPerpsMarketList: mockNavigateToPerpsMarketList,
+    navigate: mockNavigate,
+  };
+};
 
 const renderNowTab = (props = defaultTabProps) =>
   render(
@@ -270,72 +345,52 @@ const collectTestIds = (node: unknown): string[] => {
   return [...ownTestIds, ...childTestIds];
 };
 
-const getIntroSectionOrder = (tree: unknown) =>
+const getNowTabSectionOrder = (tree: unknown) =>
   collectTestIds(tree).filter((testId) =>
-    [predictSectionTestId, whatsHappeningSectionTestId].includes(testId),
+    NOW_TAB_SECTION_ORDER_TEST_IDS.includes(
+      testId as (typeof NOW_TAB_SECTION_ORDER_TEST_IDS)[number],
+    ),
   );
 
-const mockUseTokensFeed = useTokensFeed as jest.MockedFunction<
-  typeof useTokensFeed
->;
-
-beforeEach(() => {
-  jest.clearAllMocks();
-  mockUsePerpsFeed.mockReturnValue({
-    data: [],
-    isLoading: false,
-    refetch: jest.fn(),
-    defaultSortOptionId: 'priceChange' as const,
-  });
-  mockUsePredictionsFeed.mockReturnValue({ data: [], isLoading: false });
-  mockUseWorldCupPredictionsFeed.mockReturnValue({
-    data: [],
-    isLoading: false,
-    isEnabled: false,
-  });
-  mockUseWhatsHappening.mockReturnValue({
-    items: [],
-    isLoading: false,
-    error: null,
-    refresh: mockWhatsHappeningRefresh,
-  });
-  mockWhatsHappeningImpl.mockReturnValue(null);
-});
+const defaultCryptoMoversTokens = [
+  {
+    assetId: 'eip155:1/erc20:0x1',
+    symbol: 'ONE',
+    priceChangePct: { h1: '1.23' },
+  },
+  {
+    assetId: 'eip155:1/erc20:0x2',
+    symbol: 'TWO',
+    priceChangePct: { h1: '2.34' },
+  },
+  {
+    assetId: 'eip155:1/erc20:0x3',
+    symbol: 'THREE',
+    priceChangePct: { h1: '3.45' },
+  },
+];
 
 describe('NowTab — WhatsHappeningSection integration', () => {
-  const mockUseSelector = useSelector as jest.MockedFunction<
-    typeof useSelector
-  >;
-
-  const mockSelectorBase = (selector: unknown) => {
-    if (selector === selectPerpsEnabledFlag) return false;
-    if (selector === selectPredictEnabledFlag) return false;
-    return undefined;
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseSelector.mockImplementation(mockSelectorBase);
-    // Default: section mock renders nothing; individual tests override as needed.
-    mockWhatsHappeningImpl.mockReturnValue(null);
-  });
-
-  it('mounts WhatsHappeningSection and renders it when the feature flag is enabled', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return true;
-      return mockSelectorBase(selector);
-    });
-    mockUseWhatsHappening.mockReturnValue({
+  const arrangeWhatsHappeningMocks = () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        whatsHappeningEnabled: true,
+      }),
+    );
+    mocks.useWhatsHappening.mockReturnValue({
       items: [{ id: 'trend-0' }],
       isLoading: false,
       error: null,
       refresh: mockWhatsHappeningRefresh,
     });
-    (mockWhatsHappeningImpl as jest.Mock).mockReturnValue(
-      React.createElement('View', {
-        testID: 'whats-happening-carousel',
-      }),
-    );
+    mocks.whatsHappeningImpl.mockReturnValue(createWhatsHappeningCarousel());
+
+    return mocks;
+  };
+
+  it('mounts WhatsHappeningSection and renders it when the feature flag is enabled', () => {
+    arrangeWhatsHappeningMocks();
 
     renderNowTab();
 
@@ -343,27 +398,24 @@ describe('NowTab — WhatsHappeningSection integration', () => {
   });
 
   it('does not mount WhatsHappeningSection when the feature flag is disabled', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return false;
-      return mockSelectorBase(selector);
-    });
-
+    const mocks = arrangeWhatsHappeningMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        whatsHappeningEnabled: false,
+      }),
+    );
     renderNowTab();
 
-    // Section is not even mounted, so the mock should never have been called.
-    expect(mockWhatsHappeningImpl).not.toHaveBeenCalled();
+    expect(mocks.whatsHappeningImpl).not.toHaveBeenCalled();
     expect(screen.queryByTestId('whats-happening-carousel')).toBeNull();
   });
 
   it('calls whatsHappening.refresh when pull-to-refresh is triggered', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return true;
-      return mockSelectorBase(selector);
-    });
+    const mocks = arrangeWhatsHappeningMocks();
 
     const { rerender } = renderNowTab();
 
-    expect(mockWhatsHappeningRefresh).not.toHaveBeenCalled();
+    expect(mocks.whatsHappeningRefresh).not.toHaveBeenCalled();
 
     rerender(
       <NavigationContainer>
@@ -374,123 +426,45 @@ describe('NowTab — WhatsHappeningSection integration', () => {
       </NavigationContainer>,
     );
 
-    expect(mockWhatsHappeningRefresh).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders Predict before Whats Happening', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return true;
-      if (selector === selectPredictEnabledFlag) return true;
-      return mockSelectorBase(selector);
-    });
-    mockUsePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }],
-      isLoading: false,
-    });
-    mockUseWhatsHappening.mockReturnValue({
-      items: [{ id: 'trend-0' }],
-      isLoading: false,
-      error: null,
-      refresh: mockWhatsHappeningRefresh,
-    });
-    mockWhatsHappeningImpl.mockReturnValue(
-      React.createElement('View', {
-        testID: whatsHappeningSectionTestId,
-      }),
-    );
-
-    const { toJSON } = renderNowTab();
-
-    expect(getIntroSectionOrder(toJSON())).toEqual([
-      predictSectionTestId,
-      whatsHappeningSectionTestId,
-    ]);
-  });
-
-  it('does not add a divider when Whats Happening feed is empty', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return true;
-      if (selector === selectPredictEnabledFlag) return true;
-      return mockSelectorBase(selector);
-    });
-    mockUsePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }],
-      isLoading: false,
-    });
-    mockUseWhatsHappening.mockReturnValue({
-      items: [],
-      isLoading: false,
-      error: null,
-      refresh: mockWhatsHappeningRefresh,
-    });
-
-    renderNowTab();
-
-    expect(screen.queryByTestId('explore-section-divider')).toBeNull();
-  });
-
-  it('adds a divider between Predict and Whats Happening when Whats Happening has content', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectWhatsHappeningEnabled) return true;
-      if (selector === selectPredictEnabledFlag) return true;
-      return mockSelectorBase(selector);
-    });
-    mockUsePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }],
-      isLoading: false,
-    });
-    mockUseWhatsHappening.mockReturnValue({
-      items: [{ id: 'trend-0' }],
-      isLoading: false,
-      error: null,
-      refresh: mockWhatsHappeningRefresh,
-    });
-    mockWhatsHappeningImpl.mockReturnValue(
-      React.createElement('View', {
-        testID: whatsHappeningSectionTestId,
-      }),
-    );
-
-    renderNowTab();
-
-    expect(screen.getByTestId('explore-section-divider')).toBeOnTheScreen();
+    expect(mocks.whatsHappeningRefresh).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('NowTab — Perps Movers "View All" navigation', () => {
-  const mockUseSelector = useSelector as jest.MockedFunction<
-    typeof useSelector
-  >;
+  const arrangePerpsMoversMocks = (
+    marketData?: { market: { symbol: string; change24hPercent: string } }[],
+  ) => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        perpsEnabled: true,
+      }),
+    );
 
-  // Selector base: perps enabled, everything else off.
-  const mockSelectorBase = (selector: unknown) => {
-    if (selector === selectPerpsEnabledFlag) return true;
-    if (selector === selectPredictEnabledFlag) return false;
-    return undefined;
-  };
+    const mockMarketData = marketData ?? [
+      { market: { symbol: 'BTC', change24hPercent: '5' } },
+    ];
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseSelector.mockImplementation(mockSelectorBase);
-    mockWhatsHappeningImpl.mockReturnValue(null);
-  });
-
-  it('calls navigateToPerpsMarketList with "all" filter, price change sort, and gainers direction by default', () => {
-    // Return one market so PerpsBlock does not bail out with an early null return.
-    mockUsePerpsFeed.mockReturnValue({
-      data: [{ market: { symbol: 'BTC', change24hPercent: '5' } }] as never,
+    mocks.usePerpsFeed.mockReturnValue({
+      data: mockMarketData as never,
       isLoading: false,
       refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
+      defaultSortOptionId: 'priceChange',
     });
+
+    return mocks;
+  };
+
+  it('calls navigateToPerpsMarketList with "all" filter, price change sort, and gainers direction by default', () => {
+    const mocks = arrangePerpsMoversMocks();
 
     renderNowTab();
 
     fireEvent.press(screen.getByTestId('section-header-view-all-perps'));
 
-    expect(mockNavigateToPerpsMarketList).toHaveBeenCalledTimes(1);
-    expect(mockNavigateToPerpsMarketList).toHaveBeenCalledWith(
-      expect.anything(), // navigation object
+    expect(mocks.navigateToPerpsMarketList).toHaveBeenCalledTimes(1);
+    expect(mocks.navigateToPerpsMarketList).toHaveBeenCalledWith(
+      expect.anything(),
       'all',
       'priceChange',
       { sortDirection: 'desc' },
@@ -498,15 +472,10 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('renders Gainers by default and filters out negative price changes', () => {
-    mockUsePerpsFeed.mockReturnValue({
-      data: [
-        { market: { symbol: 'BTC', change24hPercent: '5' } },
-        { market: { symbol: 'ETH', change24hPercent: '-3' } },
-      ] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
-    });
+    arrangePerpsMoversMocks([
+      { market: { symbol: 'BTC', change24hPercent: '5' } },
+      { market: { symbol: 'ETH', change24hPercent: '-3' } },
+    ]);
 
     renderNowTab();
 
@@ -516,11 +485,12 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('renders pill skeletons while Perps Movers are loading', () => {
-    mockUsePerpsFeed.mockReturnValue({
+    const mocks = arrangePerpsMoversMocks();
+    mocks.usePerpsFeed.mockReturnValue({
       data: [],
       isLoading: true,
       refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
+      defaultSortOptionId: 'priceChange',
     });
 
     renderNowTab();
@@ -531,15 +501,15 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('renders placeholder perps when price change data is unavailable after loading', () => {
-    mockUsePerpsFeed.mockReturnValue({
-      data: [
-        { market: { symbol: 'BTC', change24hPercent: '' } },
-        { market: { symbol: 'ETH', change24hPercent: undefined } },
-      ] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
-    });
+    arrangePerpsMoversMocks([
+      { market: { symbol: 'BTC', change24hPercent: '' } },
+      {
+        market: {
+          symbol: 'ETH',
+          change24hPercent: undefined as unknown as string,
+        },
+      },
+    ]);
 
     renderNowTab();
 
@@ -549,15 +519,10 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('does not render pill skeletons when price change data is valid but filtered out', () => {
-    mockUsePerpsFeed.mockReturnValue({
-      data: [
-        { market: { symbol: 'BTC', change24hPercent: '0%' } },
-        { market: { symbol: 'ETH', change24hPercent: '0.00%' } },
-      ] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
-    });
+    arrangePerpsMoversMocks([
+      { market: { symbol: 'BTC', change24hPercent: '0%' } },
+      { market: { symbol: 'ETH', change24hPercent: '0.00%' } },
+    ]);
 
     renderNowTab();
 
@@ -565,16 +530,11 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('renders Losers sorted by biggest negative move and passes ascending sort direction to the market list', () => {
-    mockUsePerpsFeed.mockReturnValue({
-      data: [
-        { market: { symbol: 'BTC', change24hPercent: '5' } },
-        { market: { symbol: 'ETH', change24hPercent: '-3' } },
-        { market: { symbol: 'SOL', change24hPercent: '-8' } },
-      ] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange' as const,
-    });
+    const mocks = arrangePerpsMoversMocks([
+      { market: { symbol: 'BTC', change24hPercent: '5' } },
+      { market: { symbol: 'ETH', change24hPercent: '-3' } },
+      { market: { symbol: 'SOL', change24hPercent: '-8' } },
+    ]);
 
     renderNowTab();
 
@@ -586,7 +546,7 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
 
     fireEvent.press(screen.getByTestId('section-header-view-all-perps'));
 
-    expect(mockNavigateToPerpsMarketList).toHaveBeenCalledWith(
+    expect(mocks.navigateToPerpsMarketList).toHaveBeenCalledWith(
       expect.anything(),
       'all',
       'priceChange',
@@ -595,12 +555,12 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
   });
 
   it('does not render the Perps Movers section when the perps flag is disabled', () => {
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectPerpsEnabledFlag) return false;
-      if (selector === selectPredictEnabledFlag) return false;
-      return undefined;
-    });
-
+    const mocks = arrangePerpsMoversMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        perpsEnabled: false,
+      }),
+    );
     renderNowTab();
 
     expect(screen.queryByTestId('section-header-view-all-perps')).toBeNull();
@@ -608,30 +568,28 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
 });
 
 describe('NowTab — Predictions navigation', () => {
-  const mockUseSelector = useSelector as jest.MockedFunction<
-    typeof useSelector
-  >;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectPerpsEnabledFlag) return false;
-      if (selector === selectPredictEnabledFlag) return true;
-      if (selector === selectWhatsHappeningEnabled) return false;
-      return undefined;
-    });
-    mockUsePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }],
+  const arrangePredictSelectionMocks = () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        predictEnabled: true,
+      }),
+    );
+    mocks.usePredictionsFeed.mockReturnValue({
+      data: [{ id: 'market-1' }] as never,
       isLoading: false,
+      refetch: jest.fn(),
     });
-  });
+    return mocks;
+  };
 
   it('opens the Predict trending tab from the Predictions section title', () => {
+    const mocks = arrangePredictSelectionMocks();
     renderNowTab();
 
     fireEvent.press(screen.getByTestId(predictSectionTestId));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+    expect(mocks.navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
       params: {
         entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
@@ -641,10 +599,13 @@ describe('NowTab — Predictions navigation', () => {
   });
 
   it('opens the World Cup screen from the Predictions section title when World Cup predictions are enabled', () => {
-    mockUseWorldCupPredictionsFeed.mockReturnValue({
-      data: [{ id: 'world-cup-market-1' }],
+    const mocks = arrangePredictSelectionMocks();
+
+    mocks.useWorldCupPredictionsFeed.mockReturnValue({
+      data: [{ id: 'world-cup-market-1' }] as never,
       isLoading: false,
       isEnabled: true,
+      refetch: jest.fn(),
     });
 
     renderNowTab();
@@ -653,7 +614,7 @@ describe('NowTab — Predictions navigation', () => {
 
     fireEvent.press(screen.getByTestId(predictSectionTestId));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+    expect(mocks.navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.WORLD_CUP,
       params: {
         entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
@@ -664,45 +625,22 @@ describe('NowTab — Predictions navigation', () => {
 });
 
 describe('NowTab — Crypto Movers', () => {
-  const mockUseSelector = useSelector as jest.MockedFunction<
-    typeof useSelector
-  >;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectPerpsEnabledFlag) return false;
-      if (selector === selectPredictEnabledFlag) return false;
-      if (selector === selectWhatsHappeningEnabled) return false;
-      return undefined;
-    });
-    mockUseTokensFeed.mockReturnValue({
-      data: [
-        {
-          assetId: 'eip155:1/erc20:0x1',
-          symbol: 'ONE',
-          priceChangePct: { h1: '1.23' },
-        },
-        {
-          assetId: 'eip155:1/erc20:0x2',
-          symbol: 'TWO',
-          priceChangePct: { h1: '2.34' },
-        },
-        {
-          assetId: 'eip155:1/erc20:0x3',
-          symbol: 'THREE',
-          priceChangePct: { h1: '3.45' },
-        },
-      ] as never,
+  const arrangeCryptoMoversMocks = () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(createMockSelectorImpl({}));
+    mocks.useTokensFeed.mockReturnValue({
+      data: defaultCryptoMoversTokens as never,
       isLoading: false,
       refetch: jest.fn(),
     });
-  });
+    return mocks;
+  };
 
   it('requests and opens Crypto Movers with the 1h filter', () => {
+    const mocks = arrangeCryptoMoversMocks();
     renderNowTab();
 
-    expect(mockUseTokensFeed).toHaveBeenCalledWith({
+    expect(mocks.useTokensFeed).toHaveBeenCalledWith({
       refresh: defaultRefresh,
       hideRiskyTokens: true,
       timeOption: '1h',
@@ -712,7 +650,7 @@ describe('NowTab — Crypto Movers', () => {
       screen.getByTestId('section-header-view-all-crypto_movers'),
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith(
+    expect(mocks.navigate).toHaveBeenCalledWith(
       Routes.WALLET.TRENDING_TOKENS_FULL_VIEW,
       {
         initialTimeOption: '1h',
@@ -723,6 +661,7 @@ describe('NowTab — Crypto Movers', () => {
   });
 
   it('renders Crypto Movers across three rows', () => {
+    arrangeCryptoMoversMocks();
     renderNowTab();
 
     expect(
@@ -737,7 +676,8 @@ describe('NowTab — Crypto Movers', () => {
   });
 
   it('renders up to 18 Crypto Movers pills', () => {
-    mockUseTokensFeed.mockReturnValue({
+    const mocks = arrangeCryptoMoversMocks();
+    mocks.useTokensFeed.mockReturnValue({
       data: Array.from({ length: 19 }, (_, index) => ({
         assetId: `eip155:1/erc20:0x${index}`,
         symbol: `T${index}`,
@@ -751,5 +691,76 @@ describe('NowTab — Crypto Movers', () => {
 
     expect(screen.getByTestId('section-pill-eip155:1/erc20:0x17')).toBeTruthy();
     expect(screen.queryByTestId('section-pill-eip155:1/erc20:0x18')).toBeNull();
+  });
+});
+
+describe('NowTab — section ordering', () => {
+  const arrangeAllSectionsVisibleMocks = () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        perpsEnabled: true,
+        predictEnabled: true,
+        whatsHappeningEnabled: true,
+      }),
+    );
+    mocks.usePerpsFeed.mockReturnValue({
+      data: [{ market: { symbol: 'BTC', change24hPercent: '5' } }] as never,
+      isLoading: false,
+      refetch: jest.fn(),
+      defaultSortOptionId: 'priceChange',
+    });
+    mocks.usePredictionsFeed.mockReturnValue({
+      data: [{ id: 'market-1' }] as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.useTokensFeed.mockReturnValue({
+      data: defaultCryptoMoversTokens as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.useWhatsHappening.mockReturnValue({
+      items: [{ id: 'trend-0' }],
+      isLoading: false,
+      error: null,
+      refresh: mockWhatsHappeningRefresh,
+    });
+    mocks.whatsHappeningImpl.mockReturnValue(createWhatsHappeningCarousel());
+    mocks.useStocksFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+    });
+
+    return mocks;
+  };
+
+  it('renders all sections in fixed order when every section is visible', () => {
+    arrangeAllSectionsVisibleMocks();
+    const { toJSON } = renderNowTab();
+
+    expect(getNowTabSectionOrder(toJSON())).toEqual([
+      ...NOW_TAB_SECTION_ORDER_TEST_IDS,
+    ]);
+  });
+
+  it('keeps relative order when middle sections are hidden', () => {
+    const mocks = arrangeAllSectionsVisibleMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({
+        perpsEnabled: false,
+        predictEnabled: true,
+        whatsHappeningEnabled: false,
+      }),
+    );
+
+    const { toJSON } = renderNowTab();
+
+    expect(getNowTabSectionOrder(toJSON())).toEqual([
+      predictSectionTestId,
+      cryptoMoversSectionTestId,
+      stocksSectionTestId,
+    ]);
   });
 });

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -216,14 +216,6 @@ const perpsSectionTestId = 'section-header-view-all-perps';
 const whatsHappeningSectionTestId = 'whats-happening-carousel';
 const stocksSectionTestId = 'section-header-view-all-stocks';
 
-const NOW_TAB_SECTION_ORDER_TEST_IDS = [
-  predictSectionTestId,
-  cryptoMoversSectionTestId,
-  perpsSectionTestId,
-  whatsHappeningSectionTestId,
-  stocksSectionTestId,
-] as const;
-
 const createWhatsHappeningCarousel = () =>
   React.createElement('View', { testID: whatsHappeningSectionTestId });
 
@@ -263,7 +255,7 @@ const arrangeMocks = () => {
   );
 
   mockUsePredictionsFeed.mockReturnValue({
-    data: [],
+    data: [{ id: 'market-1' }] as never,
     isLoading: false,
     refetch: jest.fn(),
   });
@@ -274,28 +266,44 @@ const arrangeMocks = () => {
     refetch: jest.fn(),
   });
   mockUsePerpsFeed.mockReturnValue({
-    data: [],
+    data: [{ market: { symbol: 'BTC', change24hPercent: '5' } }] as never,
     isLoading: false,
     refetch: jest.fn(),
     defaultSortOptionId: 'priceChange',
   });
   mockUseTokensFeed.mockReturnValue({
-    data: [],
+    data: [
+      {
+        assetId: 'eip155:1/erc20:0x1',
+        symbol: 'ONE',
+        priceChangePct: { h1: '1.23' },
+      },
+      {
+        assetId: 'eip155:1/erc20:0x2',
+        symbol: 'TWO',
+        priceChangePct: { h1: '2.34' },
+      },
+      {
+        assetId: 'eip155:1/erc20:0x3',
+        symbol: 'THREE',
+        priceChangePct: { h1: '3.45' },
+      },
+    ] as never,
     isLoading: false,
     refetch: jest.fn(),
   });
   mockUseStocksFeed.mockReturnValue({
     data: [],
-    isLoading: false,
+    isLoading: true,
     refetch: jest.fn(),
   });
   mockUseWhatsHappening.mockReturnValue({
-    items: [],
+    items: [{ id: 'trend-0' }],
     isLoading: false,
     error: null,
     refresh: mockWhatsHappeningRefresh,
   });
-  mockWhatsHappeningImpl.mockReturnValue(null);
+  mockWhatsHappeningImpl.mockReturnValue(createWhatsHappeningCarousel());
 
   return {
     useSelector: mockUseSelector,
@@ -319,57 +327,6 @@ const renderNowTab = (props = defaultTabProps) =>
     </NavigationContainer>,
   );
 
-interface RenderNode {
-  props?: {
-    testID?: string;
-  };
-  children?: unknown[] | null;
-}
-
-const isRenderNode = (node: unknown): node is RenderNode =>
-  Boolean(node) && typeof node === 'object';
-
-const collectTestIds = (node: unknown): string[] => {
-  if (Array.isArray(node)) {
-    return node.flatMap(collectTestIds);
-  }
-
-  if (!isRenderNode(node)) {
-    return [];
-  }
-
-  const ownTestIds =
-    typeof node.props?.testID === 'string' ? [node.props.testID] : [];
-  const childTestIds = node.children?.flatMap(collectTestIds) ?? [];
-
-  return [...ownTestIds, ...childTestIds];
-};
-
-const getNowTabSectionOrder = (tree: unknown) =>
-  collectTestIds(tree).filter((testId) =>
-    NOW_TAB_SECTION_ORDER_TEST_IDS.includes(
-      testId as (typeof NOW_TAB_SECTION_ORDER_TEST_IDS)[number],
-    ),
-  );
-
-const defaultCryptoMoversTokens = [
-  {
-    assetId: 'eip155:1/erc20:0x1',
-    symbol: 'ONE',
-    priceChangePct: { h1: '1.23' },
-  },
-  {
-    assetId: 'eip155:1/erc20:0x2',
-    symbol: 'TWO',
-    priceChangePct: { h1: '2.34' },
-  },
-  {
-    assetId: 'eip155:1/erc20:0x3',
-    symbol: 'THREE',
-    priceChangePct: { h1: '3.45' },
-  },
-];
-
 describe('NowTab — WhatsHappeningSection integration', () => {
   const arrangeWhatsHappeningMocks = () => {
     const mocks = arrangeMocks();
@@ -378,13 +335,6 @@ describe('NowTab — WhatsHappeningSection integration', () => {
         whatsHappeningEnabled: true,
       }),
     );
-    mocks.useWhatsHappening.mockReturnValue({
-      items: [{ id: 'trend-0' }],
-      isLoading: false,
-      error: null,
-      refresh: mockWhatsHappeningRefresh,
-    });
-    mocks.whatsHappeningImpl.mockReturnValue(createWhatsHappeningCarousel());
 
     return mocks;
   };
@@ -432,7 +382,9 @@ describe('NowTab — WhatsHappeningSection integration', () => {
 
 describe('NowTab — Perps Movers "View All" navigation', () => {
   const arrangePerpsMoversMocks = (
-    marketData?: { market: { symbol: string; change24hPercent: string } }[],
+    marketDataOverride?: {
+      market: { symbol: string; change24hPercent: string };
+    }[],
   ) => {
     const mocks = arrangeMocks();
     mocks.useSelector.mockImplementation(
@@ -441,16 +393,14 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
       }),
     );
 
-    const mockMarketData = marketData ?? [
-      { market: { symbol: 'BTC', change24hPercent: '5' } },
-    ];
-
-    mocks.usePerpsFeed.mockReturnValue({
-      data: mockMarketData as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange',
-    });
+    if (marketDataOverride) {
+      mocks.usePerpsFeed.mockReturnValue({
+        data: marketDataOverride as never,
+        isLoading: false,
+        refetch: jest.fn(),
+        defaultSortOptionId: 'priceChange',
+      });
+    }
 
     return mocks;
   };
@@ -575,11 +525,7 @@ describe('NowTab — Predictions navigation', () => {
         predictEnabled: true,
       }),
     );
-    mocks.usePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-    });
+
     return mocks;
   };
 
@@ -628,11 +574,6 @@ describe('NowTab — Crypto Movers', () => {
   const arrangeCryptoMoversMocks = () => {
     const mocks = arrangeMocks();
     mocks.useSelector.mockImplementation(createMockSelectorImpl({}));
-    mocks.useTokensFeed.mockReturnValue({
-      data: defaultCryptoMoversTokens as never,
-      isLoading: false,
-      refetch: jest.fn(),
-    });
     return mocks;
   };
 
@@ -704,45 +645,57 @@ describe('NowTab — section ordering', () => {
         whatsHappeningEnabled: true,
       }),
     );
-    mocks.usePerpsFeed.mockReturnValue({
-      data: [{ market: { symbol: 'BTC', change24hPercent: '5' } }] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-      defaultSortOptionId: 'priceChange',
-    });
-    mocks.usePredictionsFeed.mockReturnValue({
-      data: [{ id: 'market-1' }] as never,
-      isLoading: false,
-      refetch: jest.fn(),
-    });
-    mocks.useTokensFeed.mockReturnValue({
-      data: defaultCryptoMoversTokens as never,
-      isLoading: false,
-      refetch: jest.fn(),
-    });
-    mocks.useWhatsHappening.mockReturnValue({
-      items: [{ id: 'trend-0' }],
-      isLoading: false,
-      error: null,
-      refresh: mockWhatsHappeningRefresh,
-    });
-    mocks.whatsHappeningImpl.mockReturnValue(createWhatsHappeningCarousel());
-    mocks.useStocksFeed.mockReturnValue({
-      data: [],
-      isLoading: true,
-      refetch: jest.fn(),
-    });
 
     return mocks;
   };
 
+  const NOW_TAB_SECTION_ORDER_TEST_IDS = [
+    'explore-section-predict',
+    'explore-section-crypto_movers',
+    'explore-section-perps',
+    'explore-section-wh',
+    'explore-section-stocks',
+  ] as const;
+
+  type RootType = ReturnType<typeof render>['root'];
+
+  const NOW_TAB_SECTION_ORDER_TEST_IDS_SET = new Set<string>(
+    NOW_TAB_SECTION_ORDER_TEST_IDS,
+  );
+
+  const getNowTabSectionOrder = (tree: RootType): string[] => {
+    if (!tree) {
+      return [];
+    }
+
+    const processSections = (sectionTree: RootType): string[] => {
+      if (Array.isArray(sectionTree)) {
+        return sectionTree.flatMap(processSections);
+      }
+
+      const testID = sectionTree.props?.testID;
+      const ownTestIds =
+        typeof testID === 'string' &&
+        NOW_TAB_SECTION_ORDER_TEST_IDS_SET.has(testID)
+          ? [testID]
+          : [];
+
+      const childTestIds = (sectionTree.children ?? []).flatMap((child) =>
+        typeof child === 'string' ? [] : processSections(child),
+      );
+
+      return [...ownTestIds, ...childTestIds];
+    };
+
+    const results = processSections(tree);
+    return [...new Set(results)];
+  };
+
   it('renders all sections in fixed order when every section is visible', () => {
     arrangeAllSectionsVisibleMocks();
-    const { toJSON } = renderNowTab();
+    const { root } = renderNowTab();
 
-    expect(getNowTabSectionOrder(toJSON())).toEqual([
-      ...NOW_TAB_SECTION_ORDER_TEST_IDS,
-    ]);
+    expect(getNowTabSectionOrder(root)).toEqual(NOW_TAB_SECTION_ORDER_TEST_IDS);
   });
 
   it('keeps relative order when middle sections are hidden', () => {
@@ -755,12 +708,12 @@ describe('NowTab — section ordering', () => {
       }),
     );
 
-    const { toJSON } = renderNowTab();
+    const { root } = renderNowTab();
 
-    expect(getNowTabSectionOrder(toJSON())).toEqual([
-      predictSectionTestId,
-      cryptoMoversSectionTestId,
-      stocksSectionTestId,
+    expect(getNowTabSectionOrder(root)).toEqual([
+      'explore-section-predict',
+      'explore-section-crypto_movers',
+      'explore-section-stocks',
     ]);
   });
 });


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

UTs now have cleaner/dry specs, and also tests section ordering

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: test: improve UT coverage on explore now tab

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to NowTab.test.tsx with no production code touched.
> 
> **Overview**
> Refactors **`NowTab.test.tsx`** around shared **`arrangeMocks`**, **`createMockSelectorImpl`**, and per-suite arrange helpers so feed hooks, feature flags, and navigation mocks are set up in one place instead of repeated **`beforeEach`** blocks.
> 
> Feed and **`WhatsHappening`** mocks are simplified (plain **`jest.fn()`** / **`jest.mocked`**), and assertions use the objects returned from arrange helpers rather than module-level mock references.
> 
> **Section ordering** is covered by a new describe block that walks the render tree for **`explore-section-*`** test IDs and asserts the full order (predict → crypto movers → perps → what's happening → stocks) and that relative order is preserved when perps and what's happening are hidden.
> 
> Tests that only checked predict vs what's happening order and **`explore-section-divider`** visibility are **removed** in favor of the broader section-order specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6e8931b41202342c41e70af6396e9044b8248a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->