### PR TITLE
perf(predict): only fetch market data for the active feed tab

### DIFF
--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -97,7 +97,10 @@ jest.mock('../../hooks/usePredictSearchMarketData', () => ({
   usePredictSearchMarketData: jest.fn(),
 }));
 
-import { usePredictMarketData } from '../../hooks/usePredictMarketData';
+import {
+  usePredictMarketData,
+  type UsePredictMarketDataOptions,
+} from '../../hooks/usePredictMarketData';
 import { usePredictSearchMarketData } from '../../hooks/usePredictSearchMarketData';
 
 const mockUsePredictMarketData = usePredictMarketData as jest.Mock;
@@ -1373,10 +1376,9 @@ describe('PredictFeed', () => {
     // user has already visited) should pass `enabled: true` so that just the
     // visible tab fires a getMarkets request on mount.
     const getEnabledForCategory = (category: string): boolean | undefined => {
-      const calls = mockUsePredictMarketData.mock.calls.filter(
-        (call: [{ category?: string; enabled?: boolean }]) =>
-          call[0]?.category === category,
-      );
+      const calls = (
+        mockUsePredictMarketData.mock.calls as [UsePredictMarketDataOptions][]
+      ).filter((call) => call[0]?.category === category);
       return calls[calls.length - 1]?.[0]?.enabled;
     };
 
@@ -1448,6 +1450,38 @@ describe('PredictFeed', () => {
       // "new" stays warm (enabled never flips back to false) so it never refetches.
       expect(getEnabledForCategory('new')).toBe(true);
       expect(getEnabledForCategory('trending')).toBe(true);
+    });
+
+    it('resets the fetch gate on remount for tabs inactive at that point', () => {
+      wireTabSwitchToActiveIndex();
+
+      const { getByTestId, unmount } = render(<PredictFeed />);
+
+      // Warm up "new" so it has fetched at least once.
+      fireEvent.press(getByTestId(getPredictFeedMockSelector.tabKey('new')));
+      expect(getEnabledForCategory('new')).toBe(true);
+
+      unmount();
+      mockUsePredictMarketData.mock.calls.length = 0;
+
+      // On remount "new" is inactive again, so useState(isActive) re-initializes
+      // hasEverBeenActive to false and the tab does not fetch until re-visited.
+      render(<PredictFeed />);
+
+      expect(getEnabledForCategory('trending')).toBe(true);
+      expect(getEnabledForCategory('new')).toBe(false);
+    });
+
+    it('enables only the active optional feature-flag tab on mount', () => {
+      // Hot tab is rendered first, making it the initial active tab.
+      mockHotTabFlag.enabled = true;
+      mockHotTabFlag.queryParams = 'tag_id=149';
+
+      render(<PredictFeed />);
+
+      expect(getEnabledForCategory('hot')).toBe(true);
+      expect(getEnabledForCategory('trending')).toBe(false);
+      expect(getEnabledForCategory('new')).toBe(false);
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -1366,4 +1366,88 @@ describe('PredictFeed', () => {
       );
     });
   });
+
+  describe('lazy tab data fetching (enabled gate)', () => {
+    // PagerView mounts every PredictTabContent at once, so usePredictMarketData
+    // is called for every tab on every render. Only the active tab (and tabs the
+    // user has already visited) should pass `enabled: true` so that just the
+    // visible tab fires a getMarkets request on mount.
+    const getEnabledForCategory = (category: string): boolean | undefined => {
+      const calls = mockUsePredictMarketData.mock.calls.filter(
+        (call: [{ category?: string; enabled?: boolean }]) =>
+          call[0]?.category === category,
+      );
+      return calls[calls.length - 1]?.[0]?.enabled;
+    };
+
+    const wireTabSwitchToActiveIndex = () => {
+      mockUseFeedScrollManager.mockImplementation(
+        ({ setActiveIndex }: { setActiveIndex: (index: number) => void }) => ({
+          headerTranslateY: { value: 0 },
+          headerHidden: false,
+          headerHeight: 100,
+          tabBarHeight: 48,
+          layoutReady: true,
+          onTabSwitch: setActiveIndex,
+          scrollHandler: jest.fn(),
+          onHeaderLayout: jest.fn(),
+          onTabBarLayout: jest.fn(),
+        }),
+      );
+    };
+
+    it('enables only the active tab and disables the rest on mount', () => {
+      render(<PredictFeed />);
+
+      // Default active tab is the first base tab ("trending").
+      expect(getEnabledForCategory('trending')).toBe(true);
+      expect(getEnabledForCategory('ending-soon')).toBe(false);
+      expect(getEnabledForCategory('new')).toBe(false);
+      expect(getEnabledForCategory('sports')).toBe(false);
+      expect(getEnabledForCategory('crypto')).toBe(false);
+      expect(getEnabledForCategory('politics')).toBe(false);
+    });
+
+    it('enables the deep-linked tab and disables the others on mount', () => {
+      mockUseRoute.mockReturnValue({
+        params: { entryPoint: 'deeplink', tab: 'new' },
+      });
+
+      render(<PredictFeed />);
+
+      expect(getEnabledForCategory('new')).toBe(true);
+      expect(getEnabledForCategory('trending')).toBe(false);
+      expect(getEnabledForCategory('sports')).toBe(false);
+    });
+
+    it('enables a tab once the user switches to it', () => {
+      wireTabSwitchToActiveIndex();
+
+      const { getByTestId } = render(<PredictFeed />);
+
+      expect(getEnabledForCategory('new')).toBe(false);
+
+      fireEvent.press(getByTestId(getPredictFeedMockSelector.tabKey('new')));
+
+      expect(getEnabledForCategory('new')).toBe(true);
+    });
+
+    it('keeps a previously-visited tab enabled when switching back (warm cache)', () => {
+      wireTabSwitchToActiveIndex();
+
+      const { getByTestId } = render(<PredictFeed />);
+
+      // Visit "new", then return to "trending".
+      fireEvent.press(getByTestId(getPredictFeedMockSelector.tabKey('new')));
+      expect(getEnabledForCategory('new')).toBe(true);
+
+      fireEvent.press(
+        getByTestId(getPredictFeedMockSelector.tabKey('trending')),
+      );
+
+      // "new" stays warm (enabled never flips back to false) so it never refetches.
+      expect(getEnabledForCategory('new')).toBe(true);
+      expect(getEnabledForCategory('trending')).toBe(true);
+    });
+  });
 });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -286,13 +286,20 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
 
   const [hasEverBeenActive, setHasEverBeenActive] = useState(isActive);
   useEffect(() => {
-    if (isActive && !hasEverBeenActive) {
+    if (isActive) {
       setHasEverBeenActive(true);
     }
-  }, [isActive, hasEverBeenActive]);
+  }, [isActive]);
 
   const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
   const refine = upDownEnabled ? deduplicateSeriesMarkets : undefined;
+
+  // Skip getMarkets for tabs that have never been visible. PagerView mounts
+  // every PredictTabContent at once, so without this gate each tab fetches on
+  // mount. The `isActive` term covers the first render a tab activates, before
+  // the effect above flips `hasEverBeenActive`; `hasEverBeenActive` then keeps
+  // already-visited tabs warm when swiping back.
+  const fetchEnabled = isActive || hasEverBeenActive;
 
   const {
     marketData,
@@ -307,13 +314,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     pageSize: 20,
     customQueryParams,
     refine,
-    // Only fetch for the active tab or tabs the user has already visited.
-    // PagerView mounts every PredictTabContent at once; without this gate each
-    // tab would fire its own getMarkets on mount. Using `isActive ||
-    // hasEverBeenActive` enables the fetch in the same render the tab becomes
-    // active (so the hook's useLayoutEffect empty-frame guard runs before
-    // paint) while keeping already-visited tabs warm when swiping back.
-    enabled: isActive || hasEverBeenActive,
+    enabled: fetchEnabled,
   });
 
   const [isRefreshing, setIsRefreshing] = useState(false);

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -307,6 +307,13 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     pageSize: 20,
     customQueryParams,
     refine,
+    // Only fetch for the active tab or tabs the user has already visited.
+    // PagerView mounts every PredictTabContent at once; without this gate each
+    // tab would fire its own getMarkets on mount. Using `isActive ||
+    // hasEverBeenActive` enables the fetch in the same render the tab becomes
+    // active (so the hook's useLayoutEffect empty-frame guard runs before
+    // paint) while keeping already-visited tabs warm when swiping back.
+    enabled: isActive || hasEverBeenActive,
   });
 
   const [isRefreshing, setIsRefreshing] = useState(false);


### PR DESCRIPTION
## **Description**

`PredictFeedTabs` renders a `PagerView` that mounts a `PredictTabContent` for every tab at once. Each `PredictTabContent` calls `usePredictMarketData(...)` but did not pass the `enabled` flag the hook supports, so with `enabled` defaulting to `true` every tab (Trending, New, plus optional Hot / World Cup / Wimbledon tabs) fired its own `PredictController.getMarkets` request on mount — even though only one tab is visible.

This is a request-waterfall / eager-work-on-mount pattern: N parallel fetches contend with the visible tab's request (slowing its time-to-interactive), waste bandwidth, and do work for tabs the user may never open.

**Solution:** gate the fetch with `enabled: isActive || hasEverBeenActive` so only the active tab (and tabs the user has already visited) fetch. `hasEverBeenActive` is already tracked in the component. Using the `isActive || hasEverBeenActive` form (rather than `hasEverBeenActive` alone) enables the fetch in the same render a tab becomes active, so the hook's `useLayoutEffect` empty-frame guard runs before paint, while keeping already-loaded tabs warm when swiping back.

## **Changelog**

CHANGELOG entry: perf(predict): only fetch market data for the active feed tab

## **Related issues**

Fixes: PRED-968
Refs: https://github.com/MetaMask/metamask-mobile/issues/31326

## **Manual testing steps**

```gherkin
Feature: Predict feed lazy tab fetching

  Scenario: Only the active tab fetches on first open
    Given I have the Predict feed with multiple tabs (Trending, New, and others)
    When I open the Predict feed for the first time
    Then only the active tab's category logs "Fetching market data for category:" on first paint
    And no other tab fires a getMarkets request

  Scenario: Switching to a new tab fetches once
    Given I am on the Predict feed
    When I switch to a tab I have not visited yet
    Then exactly one new getMarkets request fires for that tab's category

  Scenario: Returning to a visited tab does not refetch
    Given I have already visited a tab
    When I switch back to it
    Then no new getMarkets request fires (warm cache preserved)
```

## **Screenshots/Recordings**

_To be added._

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Before (left), After (right)

https://github.com/user-attachments/assets/7edf6c50-866f-4f42-8cd5-d9ff4fdf0aa5



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only gating of existing fetch behavior with targeted unit tests; no auth or data-model changes.
> 
> **Overview**
> **Predict feed tabs no longer all call `getMarkets` on mount.** `PredictTabContent` now passes `enabled: isActive || hasEverBeenActive` into `usePredictMarketData`, so only the visible tab fetches initially and tabs stay warm after the user visits them (PagerView still mounts every tab).
> 
> The `hasEverBeenActive` effect is simplified so any active tab sets the flag (not only the first activation), which pairs with `isActive` for the first render when a tab becomes visible.
> 
> **Tests** add a `lazy tab data fetching (enabled gate)` suite covering default tab, deeplink tab, tab switch, warm cache, remount reset, and feature-flag tabs (e.g. Hot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83540f007491f2267bed461167dcb6a732b2c344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->