### PR TITLE
perf(e2e): reduce Appium login bootstrap time (MMQA-2019)

### DIFF
--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -15,7 +15,7 @@ import { PlatformDetector } from '../framework/PlatformLocator';
 import { resolveE2EWaitTimeoutMs } from '../framework/Constants';
 import {
   isLoginScreenDisplayed,
-  isWalletHomeReadyOnAndroid,
+  isWalletHomeReadyOnAndroidStable,
   isWalletHomeReadyOnIOS,
 } from './wallet-home-readiness';
 // eslint-disable-next-line import-x/no-nodejs-modules
@@ -265,8 +265,11 @@ export const waitForAppReady = async (
           logger.debug(`App ready on login after ${Date.now() - startTime}ms`);
           return 'login';
         }
+        // Login flickered during rehydration — skip wallet probe this iteration.
+        await sleep(pollIntervalMs);
+        continue;
       }
-      if (await isWalletHomeReadyOnAndroid()) {
+      if (await isWalletHomeReadyOnAndroidStable()) {
         logger.debug(
           `App on wallet home after ${Date.now() - startTime}ms — skipping login wait`,
         );

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -13,7 +13,11 @@ import LoginView from '../page-objects/wallet/LoginView';
 import WalletView from '../page-objects/wallet/WalletView';
 import { PlatformDetector } from '../framework/PlatformLocator';
 import { resolveE2EWaitTimeoutMs } from '../framework/Constants';
-import { isWalletHomeReadyOnIOS } from './wallet-home-readiness';
+import {
+  isLoginScreenDisplayed,
+  isWalletHomeReadyOnAndroid,
+  isWalletHomeReadyOnIOS,
+} from './wallet-home-readiness';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import { execSync } from 'node:child_process';
 
@@ -221,6 +225,8 @@ export const dismissAndroidSystemOverlaysPlaywright =
     }
   };
 
+export type AppReadyScreen = 'login' | 'wallet';
+
 /**
  * Waits for app initialization and rehydration to complete.
  * This ensures the app is in a stable state before proceeding with tests.
@@ -230,14 +236,15 @@ export const dismissAndroidSystemOverlaysPlaywright =
  * @async
  * @function waitForAppReady
  * @param {number} timeout - Maximum time to wait in milliseconds (default: 20000)
- * @returns {Promise<void>} Resolves when app is ready
+ * @returns {Promise<AppReadyScreen>} Which screen the app stabilized on
  * @throws {Error} Throws an error if app fails to stabilize within timeout
  */
 export const waitForAppReady = async (
   timeout: number = resolveE2EWaitTimeoutMs(60_000),
-): Promise<void> => {
+): Promise<AppReadyScreen> => {
   const startTime = Date.now();
   const deadline = startTime + timeout;
+  const pollIntervalMs = FrameworkDetector.isAppium() ? 500 : 2000;
 
   logger.debug('Waiting for app to reach login or wallet home...');
 
@@ -247,7 +254,23 @@ export const waitForAppReady = async (
         logger.debug(
           `App on wallet home after ${Date.now() - startTime}ms (iOS readiness) — skipping login wait`,
         );
-        return;
+        return 'wallet';
+      }
+    } else if (FrameworkDetector.isAppium() && PlatformDetector.isAndroid()) {
+      // Android Appium: probe login before wallet-screen. The wallet container
+      // may exist in the native tree while the lock screen is showing.
+      if (await isLoginScreenDisplayed()) {
+        await sleep(500);
+        if (await isLoginScreenDisplayed()) {
+          logger.debug(`App ready on login after ${Date.now() - startTime}ms`);
+          return 'login';
+        }
+      }
+      if (await isWalletHomeReadyOnAndroid()) {
+        logger.debug(
+          `App on wallet home after ${Date.now() - startTime}ms — skipping login wait`,
+        );
+        return 'wallet';
       }
     } else {
       try {
@@ -258,29 +281,31 @@ export const waitForAppReady = async (
         logger.debug(
           `App on wallet home after ${Date.now() - startTime}ms — skipping login wait`,
         );
-        return;
+        return 'wallet';
       } catch {
         // Not on wallet yet.
       }
     }
 
-    try {
-      await Assertions.expectElementToBeVisible(LoginView.container, {
-        description: 'Login view should be stable',
-        timeout: 3000,
-      });
-      await sleep(500);
-      await Assertions.expectElementToBeVisible(LoginView.container, {
-        description: 'Login view should remain visible',
-        timeout: 1500,
-      });
-      logger.debug(`App ready on login after ${Date.now() - startTime}ms`);
-      return;
-    } catch {
-      // Still booting — keep polling.
+    if (!(FrameworkDetector.isAppium() && PlatformDetector.isAndroid())) {
+      try {
+        await Assertions.expectElementToBeVisible(LoginView.container, {
+          description: 'Login view should be stable',
+          timeout: 3000,
+        });
+        await sleep(500);
+        await Assertions.expectElementToBeVisible(LoginView.container, {
+          description: 'Login view should remain visible',
+          timeout: 1500,
+        });
+        logger.debug(`App ready on login after ${Date.now() - startTime}ms`);
+        return 'login';
+      } catch {
+        // Still booting — keep polling.
+      }
     }
 
-    await sleep(2000);
+    await sleep(pollIntervalMs);
   }
 
   throw new Error(

--- a/tests/flows/wallet-home-readiness.ts
+++ b/tests/flows/wallet-home-readiness.ts
@@ -1,8 +1,11 @@
 import PlaywrightMatchers from '../framework/PlaywrightMatchers';
 import { withImplicitWait } from '../framework/PlaywrightUtilities';
 import { PlatformDetector } from '../framework/PlatformLocator';
+import { sleep } from '../framework/Utilities';
 import { WalletViewSelectorsIDs } from '../../app/components/Views/Wallet/WalletView.testIds';
 import { LoginViewSelectors } from '../../app/components/Views/Login/LoginView.testIds';
+
+const READINESS_STABILITY_MS = 500;
 
 const IOS_WALLET_HOME_INDICATOR_IDS = [
   WalletViewSelectorsIDs.WALLET_HEADER_ROOT,
@@ -37,6 +40,14 @@ export const isWalletHomeReadyOnAndroid = async (): Promise<boolean> => {
     return false;
   }
   return !(await isLoginScreenDisplayed());
+};
+
+export const isWalletHomeReadyOnAndroidStable = async (): Promise<boolean> => {
+  if (!(await isWalletHomeReadyOnAndroid())) {
+    return false;
+  }
+  await sleep(READINESS_STABILITY_MS);
+  return isWalletHomeReadyOnAndroid();
 };
 
 const isElementDisplayedById = isTestIdDisplayed;

--- a/tests/flows/wallet-home-readiness.ts
+++ b/tests/flows/wallet-home-readiness.ts
@@ -1,5 +1,6 @@
 import PlaywrightMatchers from '../framework/PlaywrightMatchers';
 import { withImplicitWait } from '../framework/PlaywrightUtilities';
+import { PlatformDetector } from '../framework/PlatformLocator';
 import { WalletViewSelectorsIDs } from '../../app/components/Views/Wallet/WalletView.testIds';
 import { LoginViewSelectors } from '../../app/components/Views/Login/LoginView.testIds';
 
@@ -11,7 +12,8 @@ const IOS_WALLET_HOME_INDICATOR_IDS = [
   WalletViewSelectorsIDs.ACTION_BUTTONS_CONTAINER,
 ] as const;
 
-const isElementDisplayedById = async (testId: string): Promise<boolean> => {
+/** Fast Appium probe — avoids full assertion polling on every bootstrap loop. */
+export const isTestIdDisplayed = async (testId: string): Promise<boolean> => {
   try {
     return await withImplicitWait(500, async () => {
       const el = await PlaywrightMatchers.getElementById(testId, {
@@ -23,6 +25,21 @@ const isElementDisplayedById = async (testId: string): Promise<boolean> => {
     return false;
   }
 };
+
+export const isLoginScreenDisplayed = (): Promise<boolean> =>
+  isTestIdDisplayed(LoginViewSelectors.CONTAINER);
+
+export const isWalletContainerDisplayed = (): Promise<boolean> =>
+  isTestIdDisplayed(WalletViewSelectorsIDs.WALLET_CONTAINER);
+
+export const isWalletHomeReadyOnAndroid = async (): Promise<boolean> => {
+  if (!(await isWalletContainerDisplayed())) {
+    return false;
+  }
+  return !(await isLoginScreenDisplayed());
+};
+
+const isElementDisplayedById = isTestIdDisplayed;
 
 const isAnyWalletHomeIndicatorDisplayedOnIOS = async (): Promise<boolean> => {
   for (const testId of IOS_WALLET_HOME_INDICATOR_IDS) {
@@ -63,4 +80,14 @@ export const isWalletHomeReadyOnIOS = async (): Promise<boolean> => {
     return true;
   }
   return isWalletScreenExistsWithLoginHiddenOnIOS();
+};
+
+export const isWalletHomeReadyOnAppium = async (): Promise<boolean> => {
+  if (PlatformDetector.isIOS()) {
+    return isWalletHomeReadyOnIOS();
+  }
+  if (PlatformDetector.isAndroid()) {
+    return isWalletHomeReadyOnAndroid();
+  }
+  return false;
 };

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -3,6 +3,7 @@ import NetworkView from '../page-objects/Settings/NetworksView';
 import {
   createLogger,
   encapsulated,
+  FrameworkDetector,
   Matchers,
   PlatformDetector,
   PlaywrightAssertions,
@@ -55,6 +56,8 @@ import ExperienceEnhancerBottomSheet from '../page-objects/Onboarding/Experience
 import { fetchProductionFeatureFlags } from '../performance/feature-flag-helper';
 import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.testIds';
 import {
+  isLoginScreenDisplayed,
+  isWalletHomeReadyOnAndroidStable,
   isWalletHomeReadyOnAppium,
   isWalletHomeReadyOnIOS,
 } from './wallet-home-readiness';
@@ -96,6 +99,23 @@ export const waitForWalletHomePlaywright = async (
   throw new Error(
     `Wallet home not ready within ${timeout}ms (iOS wallet readiness indicators not satisfied)`,
   );
+};
+
+const isUnlockedWalletHomeReady = async (): Promise<boolean> => {
+  if (FrameworkDetector.isAppium() && PlatformDetector.isAndroid()) {
+    return isWalletHomeReadyOnAndroidStable();
+  }
+  if (!(await isWalletHomeReadyOnAppium())) {
+    return false;
+  }
+  return !(await isLoginScreenDisplayed());
+};
+
+const completeUnlockedWalletHome = async (
+  dismissPostLoginModals: () => Promise<void>,
+): Promise<void> => {
+  await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(30_000));
+  await dismissPostLoginModals();
 };
 
 /**
@@ -717,15 +737,15 @@ export const loginToAppPlaywright = async (
 
   await dismissAndroidSystemOverlaysPlaywright();
 
-  if (await isWalletHomeReadyOnAppium()) {
-    await dismissPostLoginModals();
+  if (await isUnlockedWalletHomeReady()) {
+    await completeUnlockedWalletHome(dismissPostLoginModals);
     return;
   }
 
   const readyScreen = await waitForAppReady(resolveE2EWaitTimeoutMs(60_000));
 
   if (readyScreen === 'wallet') {
-    await dismissPostLoginModals();
+    await completeUnlockedWalletHome(dismissPostLoginModals);
     return;
   }
 

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -54,7 +54,10 @@ import OnboardingInterestQuestionnaireView from '../page-objects/Onboarding/Onbo
 import ExperienceEnhancerBottomSheet from '../page-objects/Onboarding/ExperienceEnhancerBottomSheet';
 import { fetchProductionFeatureFlags } from '../performance/feature-flag-helper';
 import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.testIds';
-import { isWalletHomeReadyOnIOS } from './wallet-home-readiness';
+import {
+  isWalletHomeReadyOnAppium,
+  isWalletHomeReadyOnIOS,
+} from './wallet-home-readiness';
 
 const logger = createLogger({
   name: 'WalletFlow',
@@ -713,42 +716,39 @@ export const loginToAppPlaywright = async (
   };
 
   await dismissAndroidSystemOverlaysPlaywright();
-  await waitForAppReady(resolveE2EWaitTimeoutMs(60_000));
 
-  // Fast path: already on wallet home (e.g. session persisted across tests).
-  try {
-    await waitForWalletHomePlaywright(2_000);
+  if (await isWalletHomeReadyOnAppium()) {
     await dismissPostLoginModals();
     return;
-  } catch {
-    // Login screen expected — continue below.
   }
 
-  // Dev menu overlays wallet/explore, not the login screen. Probing it while
-  // login is visible wastes ~20s on absent Continue/xmark/Close elements.
-  const onLoginScreen = await Utilities.isElementVisible(
-    LoginView.container,
-    1500,
-  );
-  if (!onLoginScreen) {
+  const readyScreen = await waitForAppReady(resolveE2EWaitTimeoutMs(60_000));
+
+  if (readyScreen === 'wallet') {
+    await dismissPostLoginModals();
+    return;
+  }
+
+  try {
+    await PlaywrightAssertions.expectElementToBeVisible(
+      asPlaywrightElement(LoginView.passwordInput),
+      {
+        description: 'Login password input',
+        timeout: 3_000,
+      },
+    );
+  } catch {
+    // Dev menu can overlay login on local builds — dismiss and retry once.
     await dismissDeveloperMenuPlaywright();
     await dismissAndroidSystemOverlaysPlaywright();
+    await PlaywrightAssertions.expectElementToBeVisible(
+      asPlaywrightElement(LoginView.passwordInput),
+      {
+        description: 'Login password input',
+        timeout: 5_000,
+      },
+    );
   }
-
-  await PlaywrightAssertions.expectElementToBeVisible(
-    asPlaywrightElement(LoginView.container),
-    {
-      description: 'Login view container',
-      timeout: 5_000,
-    },
-  );
-  await PlaywrightAssertions.expectElementToBeVisible(
-    asPlaywrightElement(LoginView.passwordInput),
-    {
-      description: 'Login password input',
-      timeout: 3_000,
-    },
-  );
 
   const password = getPasswordForScenario(scenarioType);
   // Type password and unlock


### PR DESCRIPTION
## **Description**

Appium smoke tests share `loginToAppPlaywright` / `waitForAppReady` for startup. On Android, the previous bootstrap loop probed `wallet-screen` before login, burned several seconds per poll when the wallet container existed in the native tree behind the lock screen, and re-ran wallet/dev-menu checks after login was already detected.

This PR speeds up the shared login path for all Appium specs by:

1. **`waitForAppReady`** — On Android Appium, probe login before wallet, use fast `withImplicitWait` readiness helpers, poll every 500ms, return `'login' | 'wallet'`, and keep a two-probe login stability check (500ms apart) to avoid rehydration flicker false positives.
2. **`loginToAppPlaywright`** — Short-circuit when wallet home is already visible, branch on `waitForAppReady` result to skip redundant wallet probes and dev-menu work on the login happy path, and assert only the password input before typing.
3. **`wallet-home-readiness`** — Export lightweight `isLoginScreenDisplayed`, `isWalletHomeReadyOnAndroid`, and `isWalletHomeReadyOnAppium` probes reused by both flows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MMQA-2019

## **Manual testing steps**

```gherkin
Feature: Appium login bootstrap performance

  Scenario: cold start reaches password input faster on Android
    Given an Android emulator is running with MetaMask installed
    And the app is on the lock/login screen after restart

    When I run an Appium smoke spec that calls loginToAppPlaywright
      | command |
      | CI=true ANDROID_DEVICE_UDID=emulator-5554 SKIP_DEVICE_BOOT=true yarn appium-smoke:android -- tests/smoke-appium/accounts/import-srp.spec.ts |

    Then login completes and the wallet home is visible
    And time from login screen detection to password entry is reduced versus main

  Scenario: persisted session skips full bootstrap
    Given the wallet home is already visible from a prior test session

    When loginToAppPlaywright runs again in the same worker

    Then it returns without re-entering the password
```

Local verification commands:

```bash
CI=true ANDROID_DEVICE_UDID=emulator-5554 SKIP_DEVICE_BOOT=true yarn appium-smoke:android -- tests/smoke-appium/accounts/import-srp.spec.ts
```

## **Screenshots/Recordings**

N/A — E2E infrastructure timing improvement; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)