### PR TITLE
fix(perps): disable autocorrect on market search

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -775,6 +775,18 @@ describe('PerpsMarketListView', () => {
       ).toBeOnTheScreen();
     });
 
+    it('disables autocorrect and autocapitalize on the search input', () => {
+      renderWithProvider(<PerpsMarketListView />, { state: mockState });
+
+      const searchInput = screen.getByTestId(
+        PerpsMarketListViewSelectorsIDs.SEARCH_BAR,
+      );
+
+      expect(searchInput.props.autoCorrect).toBe(false);
+      expect(searchInput.props.autoCapitalize).toBe('none');
+      expect(searchInput.props.autoComplete).toBe('off');
+    });
+
     it('shows all markets when search query is empty', async () => {
       renderWithProvider(<PerpsMarketListView />, { state: mockState });
 

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -480,6 +480,9 @@ const PerpsMarketListView = ({
             onPressClearButton={() => setSearchQuery('')}
             placeholder={strings('perps.search_by_token_symbol')}
             testID={PerpsMarketListViewSelectorsIDs.SEARCH_BAR}
+            autoComplete="off"
+            autoCorrect={false}
+            autoCapitalize="none"
             clearButtonProps={{
               testID: PerpsMarketListViewSelectorsIDs.SEARCH_CLEAR_BUTTON,
             }}


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The keyboard was auto-correcting and auto-capitalizing text typed into the Perps market search bar, changing the token symbol the user was trying to search for (e.g. "sol" could get auto-corrected to something else, or auto-capitalized to "Sol").

This PR sets `autoComplete="off"`, `autoCorrect={false}`, and `autoCapitalize="none"` on the `TextFieldSearch` input in `PerpsMarketListView`, matching the existing pattern already used for the Bridge token search input (`BridgeTokenSelector`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the keyboard auto-correcting and auto-capitalizing text typed into the Perps market search bar

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TAT-3354](https://consensyssoftware.atlassian.net/browse/TAT-3354)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market search keyboard behavior

  Scenario: user types a lowercase token symbol in market search
    Given I am on the Perps Markets list screen
    And I tap the search input

    When I type "sol"
    Then no autocorrect suggestion strip should appear above the keyboard
    And the typed text should remain exactly "sol", not auto-capitalized or altered
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - behavior-only change to keyboard configuration; not visually distinguishable in a static screenshot. See manual testing steps above to verify.

### **After**

N/A - behavior-only change to keyboard configuration; not visually distinguishable in a static screenshot. See manual testing steps above to verify.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TAT-3354]: https://consensyssoftware.atlassian.net/browse/TAT-3354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only TextInput prop changes on a single screen with a matching unit test; no auth, data, or trading logic touched.
> 
> **Overview**
> Fixes the Perps **Markets** search bar so the OS keyboard no longer autocorrects, auto-capitalizes, or suggests completions while users type token symbols (e.g. `sol` staying lowercase).
> 
> The `TextFieldSearch` in `PerpsMarketListView` now passes `autoComplete="off"`, `autoCorrect={false}`, and `autoCapitalize="none"`, aligned with other symbol-style search inputs in the app. A unit test asserts those props on the search field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec0138ea18bded4d338b8b8f6be65b0df5ae050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->