### PR TITLE
feat(money): shimmer the 4% APY label (MUSD-1048)

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
@@ -1,15 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withDelay,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from 'react-native-reanimated';
-import LinearGradient from 'react-native-linear-gradient';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { ShimmerBand, useShimmerSweep } from '../../../../Shimmer';
 
 export interface ShimmerOverlayProps {
   children: React.ReactNode;
@@ -39,9 +31,6 @@ const DEFAULT_COLORS = [
   'rgba(255,255,255,0)',
 ] as const;
 
-const GRADIENT_START = { x: 0, y: 0.5 } as const;
-const GRADIENT_END = { x: 1, y: 0.5 } as const;
-
 const styles = StyleSheet.create({
   wrapper: {
     position: 'relative',
@@ -50,14 +39,6 @@ const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
     overflow: 'hidden',
-  },
-  band: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-  },
-  gradient: {
-    flex: 1,
   },
 });
 
@@ -77,37 +58,9 @@ const ShimmerOverlay: React.FC<ShimmerOverlayProps> = ({
   colors = DEFAULT_COLORS,
   testID,
 }) => {
-  const [width, setWidth] = useState(0);
-  const translateX = useSharedValue(0);
-  const bandWidth = width * widthFraction;
-
-  useEffect(() => {
-    if (width === 0) return;
-
-    translateX.value = -bandWidth;
-    translateX.value = withRepeat(
-      withSequence(
-        withTiming(width, {
-          duration: sweepDurationMs,
-          easing: Easing.inOut(Easing.ease),
-        }),
-        withDelay(pauseDurationMs, withTiming(-bandWidth, { duration: 0 })),
-      ),
-      -1,
-      false,
-    );
-  }, [width, bandWidth, sweepDurationMs, pauseDurationMs, translateX]);
-
-  const animatedBandStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
-
-  const handleLayout = (event: LayoutChangeEvent) => {
-    const next = event.nativeEvent.layout.width;
-    if (next !== width) {
-      setWidth(next);
-    }
-  };
+  const { width, bandWidth, animatedBandStyle, handleLayout } = useShimmerSweep(
+    { widthFraction, sweepDurationMs, pauseDurationMs },
+  );
 
   return (
     <View
@@ -121,16 +74,11 @@ const ShimmerOverlay: React.FC<ShimmerOverlayProps> = ({
           style={styles.overlay}
           testID={testID}
         >
-          <Animated.View
-            style={[styles.band, { width: bandWidth }, animatedBandStyle]}
-          >
-            <LinearGradient
-              colors={colors as unknown as string[]}
-              start={GRADIENT_START}
-              end={GRADIENT_END}
-              style={styles.gradient}
-            />
-          </Animated.View>
+          <ShimmerBand
+            bandWidth={bandWidth}
+            animatedStyle={animatedBandStyle}
+            colors={colors}
+          />
         </Animated.View>
       )}
     </View>

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
@@ -14,6 +14,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
+import TextShimmer from '../TextShimmer';
 import { MoneyBalanceSummaryTestIds } from './MoneyBalanceSummary.testIds';
 import { isPositiveNumberOrZero } from '../../utils/number';
 import { MoneyBalanceDisplayState } from '../../types';
@@ -46,13 +47,20 @@ const MoneyBalanceSummary = ({
     }
     return (
       <>
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.SuccessDefault}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
           testID={MoneyBalanceSummaryTestIds.APY}
         >
-          {strings('money.apy_label', { percentage: apy })}
+          <TextShimmer>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.SuccessDefault}
+            >
+              {strings('money.apy_label', { percentage: apy })}
+            </Text>
+          </TextShimmer>
           <Text
             variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
@@ -60,7 +68,7 @@ const MoneyBalanceSummary = ({
           >
             {strings('money.apy_currency_suffix')}
           </Text>
-        </Text>
+        </Box>
         {onApyInfoPress && (
           <ButtonIcon
             iconName={IconName.Info}

--- a/app/components/UI/Money/components/TextShimmer/TextShimmer.test.tsx
+++ b/app/components/UI/Money/components/TextShimmer/TextShimmer.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Text, type LayoutChangeEvent } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import TextShimmer from './TextShimmer';
+
+jest.mock('@react-native-masked-view/masked-view', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return function MockMaskedView({
+    children,
+    maskElement,
+    testID,
+  }: {
+    children?: React.ReactNode;
+    maskElement?: React.ReactNode;
+    testID?: string;
+  }) {
+    return ReactActual.createElement(View, { testID }, maskElement, children);
+  };
+});
+
+jest.mock('react-native-linear-gradient', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return function MockLinearGradient({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }) {
+    return ReactActual.createElement(View, null, children);
+  };
+});
+
+const OVERLAY_TEST_ID = 'apy-shimmer';
+
+const layoutEvent = (width: number) =>
+  ({
+    nativeEvent: { layout: { width, height: 20, x: 0, y: 0 } },
+  }) as LayoutChangeEvent;
+
+type TestInstance = Parameters<typeof fireEvent>[0];
+
+// Fires a `layout` event on the shimmer wrapper (the parent of the text node),
+// narrowing away the nullable `parent` without naming a deprecated type.
+const fireLayout = (node: TestInstance, width: number) => {
+  const wrapper = node.parent;
+  if (!wrapper) {
+    throw new Error('TextShimmer wrapper not found');
+  }
+  fireEvent(wrapper, 'layout', layoutEvent(width));
+};
+
+describe('TextShimmer', () => {
+  it('renders its children', () => {
+    const { getByText } = render(
+      <TextShimmer>
+        <Text>4% APY</Text>
+      </TextShimmer>,
+    );
+
+    expect(getByText('4% APY')).toBeOnTheScreen();
+  });
+
+  it('does not render the shimmer overlay before layout is measured', () => {
+    const { queryByTestId } = render(
+      <TextShimmer testID={OVERLAY_TEST_ID}>
+        <Text testID="label">4% APY</Text>
+      </TextShimmer>,
+    );
+
+    expect(queryByTestId(OVERLAY_TEST_ID)).toBeNull();
+  });
+
+  it('renders the masked shimmer overlay once a non-zero width is measured', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TextShimmer testID={OVERLAY_TEST_ID}>
+        <Text testID="label">4% APY</Text>
+      </TextShimmer>,
+    );
+
+    fireLayout(getByTestId('label'), 200);
+
+    expect(queryByTestId(OVERLAY_TEST_ID)).toBeOnTheScreen();
+  });
+
+  it('keeps the overlay hidden when the measured width is zero', () => {
+    const { getByText, queryByTestId } = render(
+      <TextShimmer testID={OVERLAY_TEST_ID}>
+        <Text>4% APY</Text>
+      </TextShimmer>,
+    );
+
+    fireLayout(getByText('4% APY'), 0);
+
+    expect(queryByTestId(OVERLAY_TEST_ID)).toBeNull();
+  });
+
+  it('accepts custom timing and appearance props without error', () => {
+    const { getByTestId, queryByTestId } = render(
+      <TextShimmer
+        testID={OVERLAY_TEST_ID}
+        sweepDurationMs={800}
+        pauseDurationMs={6000}
+        widthFraction={0.3}
+        colors={['rgba(0,0,0,0)', 'rgba(0,0,0,0.5)', 'rgba(0,0,0,0)']}
+      >
+        <Text testID="label">4% APY</Text>
+      </TextShimmer>,
+    );
+
+    fireLayout(getByTestId('label'), 120);
+
+    expect(queryByTestId(OVERLAY_TEST_ID)).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Money/components/TextShimmer/TextShimmer.tsx
+++ b/app/components/UI/Money/components/TextShimmer/TextShimmer.tsx
@@ -1,0 +1,136 @@
+import MaskedView from '@react-native-masked-view/masked-view';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import LinearGradient from 'react-native-linear-gradient';
+
+export interface TextShimmerProps {
+  /**
+   * The text element to shimmer. It is rendered as-is for its colour and
+   * reused as the mask, so the highlight is clipped to the glyph shapes
+   * rather than a rectangle.
+   */
+  children: React.ReactElement;
+  /**
+   * Width of the highlight band as a fraction of the measured text width.
+   */
+  widthFraction?: number;
+  sweepDurationMs?: number;
+  pauseDurationMs?: number;
+  /**
+   * Gradient stops for the highlight band. Defaults to a bright white sweep
+   * that reads as a reflective glint over coloured text.
+   */
+  colors?: readonly string[];
+  testID?: string;
+}
+
+const DEFAULT_COLORS = [
+  'rgba(255,255,255,0)',
+  'rgba(255,255,255,0.7)',
+  'rgba(255,255,255,0)',
+] as const;
+
+const GRADIENT_START = { x: 0, y: 0.5 } as const;
+const GRADIENT_END = { x: 1, y: 0.5 } as const;
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  band: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+  },
+  gradient: {
+    flex: 1,
+  },
+});
+
+/**
+ * Renders `children` (a text element) and sweeps a bright highlight across it,
+ * masked to the glyph shapes. The overlay is non-interactive.
+ */
+const TextShimmer: React.FC<TextShimmerProps> = ({
+  children,
+  widthFraction = 0.5,
+  sweepDurationMs = 1000,
+  pauseDurationMs = 4000,
+  colors = DEFAULT_COLORS,
+  testID,
+}) => {
+  const [width, setWidth] = useState(0);
+  const translateX = useSharedValue(0);
+  const bandWidth = width * widthFraction;
+
+  useEffect(() => {
+    if (width === 0) return;
+
+    translateX.value = -bandWidth;
+    translateX.value = withRepeat(
+      withSequence(
+        withTiming(width, {
+          duration: sweepDurationMs,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        withDelay(pauseDurationMs, withTiming(-bandWidth, { duration: 0 })),
+      ),
+      -1,
+      false,
+    );
+  }, [width, bandWidth, sweepDurationMs, pauseDurationMs, translateX]);
+
+  const animatedBandStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const handleLayout = (event: LayoutChangeEvent) => {
+    const next = event.nativeEvent.layout.width;
+    if (next !== width) {
+      setWidth(next);
+    }
+  };
+
+  return (
+    <View onLayout={handleLayout} style={styles.wrapper}>
+      {children}
+      {width > 0 && (
+        <MaskedView
+          pointerEvents="none"
+          style={styles.overlay}
+          maskElement={children}
+          testID={testID}
+        >
+          <Animated.View
+            style={[styles.band, { width: bandWidth }, animatedBandStyle]}
+          >
+            <LinearGradient
+              colors={colors as unknown as string[]}
+              start={GRADIENT_START}
+              end={GRADIENT_END}
+              style={styles.gradient}
+            />
+          </Animated.View>
+        </MaskedView>
+      )}
+    </View>
+  );
+};
+
+export default TextShimmer;

--- a/app/components/UI/Money/components/TextShimmer/TextShimmer.tsx
+++ b/app/components/UI/Money/components/TextShimmer/TextShimmer.tsx
@@ -1,16 +1,7 @@
 import MaskedView from '@react-native-masked-view/masked-view';
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withDelay,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from 'react-native-reanimated';
-import LinearGradient from 'react-native-linear-gradient';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ShimmerBand, useShimmerSweep } from '../../../Shimmer';
 
 export interface TextShimmerProps {
   /**
@@ -39,9 +30,6 @@ const DEFAULT_COLORS = [
   'rgba(255,255,255,0)',
 ] as const;
 
-const GRADIENT_START = { x: 0, y: 0.5 } as const;
-const GRADIENT_END = { x: 1, y: 0.5 } as const;
-
 const styles = StyleSheet.create({
   wrapper: {
     position: 'relative',
@@ -52,14 +40,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-  },
-  band: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-  },
-  gradient: {
-    flex: 1,
   },
 });
 
@@ -75,37 +55,9 @@ const TextShimmer: React.FC<TextShimmerProps> = ({
   colors = DEFAULT_COLORS,
   testID,
 }) => {
-  const [width, setWidth] = useState(0);
-  const translateX = useSharedValue(0);
-  const bandWidth = width * widthFraction;
-
-  useEffect(() => {
-    if (width === 0) return;
-
-    translateX.value = -bandWidth;
-    translateX.value = withRepeat(
-      withSequence(
-        withTiming(width, {
-          duration: sweepDurationMs,
-          easing: Easing.inOut(Easing.ease),
-        }),
-        withDelay(pauseDurationMs, withTiming(-bandWidth, { duration: 0 })),
-      ),
-      -1,
-      false,
-    );
-  }, [width, bandWidth, sweepDurationMs, pauseDurationMs, translateX]);
-
-  const animatedBandStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }));
-
-  const handleLayout = (event: LayoutChangeEvent) => {
-    const next = event.nativeEvent.layout.width;
-    if (next !== width) {
-      setWidth(next);
-    }
-  };
+  const { width, bandWidth, animatedBandStyle, handleLayout } = useShimmerSweep(
+    { widthFraction, sweepDurationMs, pauseDurationMs },
+  );
 
   return (
     <View onLayout={handleLayout} style={styles.wrapper}>
@@ -117,16 +69,11 @@ const TextShimmer: React.FC<TextShimmerProps> = ({
           maskElement={children}
           testID={testID}
         >
-          <Animated.View
-            style={[styles.band, { width: bandWidth }, animatedBandStyle]}
-          >
-            <LinearGradient
-              colors={colors as unknown as string[]}
-              start={GRADIENT_START}
-              end={GRADIENT_END}
-              style={styles.gradient}
-            />
-          </Animated.View>
+          <ShimmerBand
+            bandWidth={bandWidth}
+            animatedStyle={animatedBandStyle}
+            colors={colors}
+          />
         </MaskedView>
       )}
     </View>

--- a/app/components/UI/Money/components/TextShimmer/index.ts
+++ b/app/components/UI/Money/components/TextShimmer/index.ts
@@ -1,0 +1,2 @@
+export { default } from './TextShimmer';
+export type { TextShimmerProps } from './TextShimmer';

--- a/app/components/UI/Shimmer/ShimmerBand.tsx
+++ b/app/components/UI/Shimmer/ShimmerBand.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import Animated from 'react-native-reanimated';
+import LinearGradient from 'react-native-linear-gradient';
+
+const GRADIENT_START = { x: 0, y: 0.5 } as const;
+const GRADIENT_END = { x: 1, y: 0.5 } as const;
+
+const styles = StyleSheet.create({
+  band: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+  },
+  gradient: {
+    flex: 1,
+  },
+});
+
+export interface ShimmerBandProps {
+  bandWidth: number;
+  /**
+   * The animated transform from `useShimmerSweep` that slides the band across
+   * its container.
+   */
+  animatedStyle: StyleProp<ViewStyle>;
+  /**
+   * Gradient stops for the band. Callers own the palette because it depends on
+   * the surface (a subtle white sweep on dark surfaces, a bright glint over
+   * coloured text, ...).
+   */
+  colors: readonly string[];
+}
+
+/**
+ * The moving highlight band shared by every shimmer: an absolutely-positioned
+ * animated view filled with a horizontal gradient. Callers clip it to their own
+ * shape — a rounded rectangle, a glyph mask, and so on.
+ */
+const ShimmerBand: React.FC<ShimmerBandProps> = ({
+  bandWidth,
+  animatedStyle,
+  colors,
+}) => (
+  <Animated.View style={[styles.band, { width: bandWidth }, animatedStyle]}>
+    <LinearGradient
+      colors={colors as unknown as string[]}
+      start={GRADIENT_START}
+      end={GRADIENT_END}
+      style={styles.gradient}
+    />
+  </Animated.View>
+);
+
+export default ShimmerBand;

--- a/app/components/UI/Shimmer/index.ts
+++ b/app/components/UI/Shimmer/index.ts
@@ -1,0 +1,4 @@
+export { default as ShimmerBand } from './ShimmerBand';
+export type { ShimmerBandProps } from './ShimmerBand';
+export { useShimmerSweep } from './useShimmerSweep';
+export type { ShimmerSweepOptions } from './useShimmerSweep';

--- a/app/components/UI/Shimmer/useShimmerSweep.ts
+++ b/app/components/UI/Shimmer/useShimmerSweep.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { type LayoutChangeEvent } from 'react-native';
+import {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+export interface ShimmerSweepOptions {
+  /**
+   * Width of the highlight band as a fraction of the measured element width.
+   */
+  widthFraction: number;
+  sweepDurationMs: number;
+  pauseDurationMs: number;
+}
+
+/**
+ * Drives a horizontal highlight band across a measured element: it sweeps once,
+ * pauses, then repeats. Returns the measured width (so callers can defer
+ * rendering until the element has a size), the band width, the animated
+ * transform to apply to the band, and an `onLayout` handler to feed the
+ * measurement back in.
+ */
+export const useShimmerSweep = ({
+  widthFraction,
+  sweepDurationMs,
+  pauseDurationMs,
+}: ShimmerSweepOptions) => {
+  const [width, setWidth] = useState(0);
+  const translateX = useSharedValue(0);
+  const bandWidth = width * widthFraction;
+
+  useEffect(() => {
+    if (width === 0) return;
+
+    translateX.value = -bandWidth;
+    translateX.value = withRepeat(
+      withSequence(
+        withTiming(width, {
+          duration: sweepDurationMs,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        withDelay(pauseDurationMs, withTiming(-bandWidth, { duration: 0 })),
+      ),
+      -1,
+      false,
+    );
+  }, [width, bandWidth, sweepDurationMs, pauseDurationMs, translateX]);
+
+  const animatedBandStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const handleLayout = (event: LayoutChangeEvent) => {
+    const next = event.nativeEvent.layout.width;
+    if (next !== width) {
+      setWidth(next);
+    }
+  };
+
+  return { width, bandWidth, animatedBandStyle, handleLayout };
+};


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Implements the **4% APY Shimmer** animation from the Money Motion Design spec (MUSD-1048, animation #2).

Adds a small reusable `TextShimmer` component that renders a text element and sweeps a bright highlight band across it. The highlight is drawn with a `MaskedView` masked to the text's own glyph shapes, so the glint is clipped to the letters rather than a rectangle. The sweep is driven by `react-native-reanimated` (a timed translate with a configurable pause between passes), and the overlay is non-interactive.

`TextShimmer` is wired into `MoneyBalanceSummary` to animate the `4% APY` label. The component is intentionally generic (configurable band width, sweep/pause duration, and gradient colours) so it can be reused for future shimmer effects.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a shimmer animation to the APY label on the Money account screen.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/MUSD-1048

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: APY label shimmer

  Scenario: user views the Money account balance summary
    Given the user is on a Money account with an APY

    When the balance summary renders
    Then the "4% APY" label shows a highlight that sweeps across the text
    And the sweep repeats after a short pause
    And the highlight is clipped to the shape of the glyphs, not a rectangle
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/72e48ffb-19d4-4054-869d-b24eb7c92742


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation and component reuse; Spending Limit shimmer behavior should stay equivalent aside from shared implementation.
> 
> **Overview**
> Adds a **glyph-masked shimmer** on the Money balance summary APY percentage via new **`TextShimmer`**, which reuses shared **`useShimmerSweep`** / **`ShimmerBand`** under `app/components/UI/Shimmer`.
> 
> **`ShimmerOverlay`** (Spending Limit) is refactored to use the same primitives instead of inlined Reanimated + gradient logic, so rectangle-clipped and text-clipped effects share one animation path.
> 
> **`MoneyBalanceSummary`** wraps only the APY percentage text in `TextShimmer`; the currency suffix and info button layout stay unchanged in a row `Box`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae4a931a14b5d7a1a94f98ac3216f8c87afd8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->