### PR TITLE
refactor: use MMDS tertiary Button for MetaMask Card sign-up

### DIFF
--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -8,7 +8,6 @@ import React, {
 import { useNavigation } from '@react-navigation/native';
 import {
   Box,
-  FontWeight,
   Text,
   TextVariant,
   Icon,
@@ -406,16 +405,15 @@ const SignUp = () => {
           ? strings('card.card_onboarding.sign_up.join_waitlist')
           : strings('card.card_onboarding.continue_button')}
       </Button>
-      <TouchableOpacity onPress={handleAlreadyHaveAccountPress}>
-        <Text
-          testID="signup-i-already-have-an-account-text"
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-          twClassName="text-default text-center p-4"
-        >
-          {strings('card.card_onboarding.sign_up.i_already_have_an_account')}
-        </Text>
-      </TouchableOpacity>
+      <Button
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.Lg}
+        onPress={handleAlreadyHaveAccountPress}
+        isFullWidth
+        testID="signup-i-already-have-an-account-text"
+      >
+        {strings('card.card_onboarding.sign_up.i_already_have_an_account')}
+      </Button>
     </>
   );
 

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -411,6 +411,7 @@ const SignUp = () => {
         onPress={handleAlreadyHaveAccountPress}
         isFullWidth
         testID="signup-i-already-have-an-account-text"
+        twClassName="mt-2"
       >
         {strings('card.card_onboarding.sign_up.i_already_have_an_account')}
       </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Replaces the custom `TouchableOpacity` + `Text` implementation for the "I already have a MetaMask Card" action on the card sign-up screen with the MMDS `Button` component using the `tertiary` variant. This aligns the secondary CTA with the design system and matches how similar link-style actions are implemented elsewhere in the app.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: MetaMask Card sign-up secondary CTA

  Scenario: user taps "I already have a MetaMask Card"
    Given the user is on the MetaMask Card sign-up screen ("Let's get started")
    When the user taps "I already have a MetaMask Card"
    Then the app navigates to the card authentication screen
    And the button renders using the MMDS tertiary Button styling
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/285f9817-a96f-45a9-b4dd-d0fced80a3d7

### **After**

https://github.com/user-attachments/assets/27d9e55e-2632-438e-a0ec-9121048c6567

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cebe746f-c012-47fa-a6e8-c5f72cee3ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cebe746f-c012-47fa-a6e8-c5f72cee3ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

