### PR TITLE
fix(card): enable iOS password autofill in card signup and login

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -41,9 +41,23 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { countryCodeToFlag } from '../../util/countryCodeToFlag';
 
 const CODE_LENGTH = 6;
-const autoComplete = Platform.select<TextInputProps['autoComplete']>({
+const otpAutoComplete = Platform.select<TextInputProps['autoComplete']>({
   android: 'sms-otp',
   default: 'one-time-code',
+});
+
+const passwordTextContentType = Platform.select<
+  TextInputProps['textContentType']
+>({
+  ios: 'password',
+  default: undefined,
+});
+
+const usernameTextContentType = Platform.select<
+  TextInputProps['textContentType']
+>({
+  ios: 'username',
+  default: undefined,
 });
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -350,7 +364,7 @@ const CardAuthentication = () => {
                 numberOfLines: 1,
                 keyboardType: 'number-pad',
                 textContentType: 'oneTimeCode',
-                autoComplete,
+                autoComplete: otpAutoComplete,
                 maxLength: CODE_LENGTH,
                 accessibilityLabel: strings(
                   'card.card_otp_authentication.confirm_code_label',
@@ -461,6 +475,7 @@ const CardAuthentication = () => {
               inputProps={{
                 autoCapitalize: 'none',
                 autoComplete: 'username',
+                textContentType: usernameTextContentType,
                 numberOfLines: 1,
                 returnKeyType: 'next',
                 keyboardType: 'email-address',
@@ -493,6 +508,7 @@ const CardAuthentication = () => {
               inputProps={{
                 autoCapitalize: 'none',
                 autoComplete: 'password',
+                textContentType: passwordTextContentType,
                 numberOfLines: 1,
                 maxLength: 255,
                 returnKeyType: 'done',

--- a/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.test.tsx
@@ -292,6 +292,22 @@ describe('SignUp Component', () => {
       expect(passwordInput.props.secureTextEntry).toBe(true);
     });
 
+    it('uses password autofill props for iOS strong password suggestions', () => {
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <SignUp />
+        </Provider>,
+      );
+
+      const emailInput = getByTestId('signup-email-input');
+      const passwordInput = getByTestId('signup-password-input');
+
+      expect(emailInput.props.autoComplete).toBe('email');
+      expect(emailInput.props.textContentType).toBe('emailAddress');
+      expect(passwordInput.props.autoComplete).toBe('password-new');
+      expect(passwordInput.props.textContentType).toBe('newPassword');
+    });
+
     it('toggles password visibility when eye icon is pressed', () => {
       const { getByTestId } = render(
         <Provider store={store}>

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -34,7 +34,12 @@ import { validatePassword } from '../../util/validatePassword';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardActions, CardScreens } from '../../util/metrics';
-import { ActivityIndicator, TouchableOpacity } from 'react-native';
+import {
+  ActivityIndicator,
+  Platform,
+  TouchableOpacity,
+  TextInputProps,
+} from 'react-native';
 import {
   clearOnValueChange,
   createRegionSelectorModalNavigationDetails,
@@ -46,6 +51,20 @@ import type { Region } from '../../types';
 import { selectGeolocationLocation } from '../../../../../selectors/geolocationController';
 import { HUBSPOT_WAITLIST_URL } from '../../constants';
 import { useCardPostAuthRedirect } from '../../hooks/useCardPostAuthRedirect';
+
+const passwordAutoComplete = Platform.select<
+  TextInputProps['autoComplete']
+>({
+  android: 'password-new',
+  default: 'password-new',
+});
+
+const passwordTextContentType = Platform.select<
+  TextInputProps['textContentType']
+>({
+  ios: 'newPassword',
+  default: undefined,
+});
 
 const buildWaitlistUrl = (countryName: string, email?: string): string => {
   // country must come first per HubSpot field ordering
@@ -309,7 +328,8 @@ const SignUp = () => {
         <Label>{strings('card.card_onboarding.sign_up.email_label')}</Label>
         <TextField
           autoCapitalize={'none'}
-          autoComplete="one-time-code"
+          autoComplete="email"
+          textContentType="emailAddress"
           onChangeText={handleEmailChange}
           numberOfLines={1}
           value={email}
@@ -352,7 +372,11 @@ const SignUp = () => {
             value={password}
             maxLength={255}
             secureTextEntry={!isPasswordVisible}
-            autoComplete="one-time-code"
+            autoComplete={passwordAutoComplete}
+            textContentType={passwordTextContentType}
+            passwordRules={
+              Platform.OS === 'ios' ? 'minlength: 15;' : undefined
+            }
             accessibilityLabel={strings(
               'card.card_onboarding.sign_up.password_label',
             )}

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -52,9 +52,7 @@ import { selectGeolocationLocation } from '../../../../../selectors/geolocationC
 import { HUBSPOT_WAITLIST_URL } from '../../constants';
 import { useCardPostAuthRedirect } from '../../hooks/useCardPostAuthRedirect';
 
-const passwordAutoComplete = Platform.select<
-  TextInputProps['autoComplete']
->({
+const passwordAutoComplete = Platform.select<TextInputProps['autoComplete']>({
   android: 'password-new',
   default: 'password-new',
 });
@@ -374,9 +372,7 @@ const SignUp = () => {
             secureTextEntry={!isPasswordVisible}
             autoComplete={passwordAutoComplete}
             textContentType={passwordTextContentType}
-            passwordRules={
-              Platform.OS === 'ios' ? 'minlength: 15;' : undefined
-            }
+            passwordRules={Platform.OS === 'ios' ? 'minlength: 15;' : undefined}
             accessibilityLabel={strings(
               'card.card_onboarding.sign_up.password_label',
             )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The MetaMask Card signup password field was configured with `autoComplete="one-time-code"`, which tells iOS to treat the input as an OTP field. That suppresses Strong Password suggestions and saved-password autofill.

This PR sets the correct autofill types for the card signup form (email + new password) and adds iOS `textContentType` hints on the card login screen so saved credentials can be offered there as well.

## **Changelog**

CHANGELOG entry: Fixed MetaMask Card signup and login password fields so iOS can offer password suggestions and autofill.

## **Related issues**

Fixes: N/A (reported via screenshot / internal QA)

## **Manual testing steps**

```gherkin
Feature: Card signup iOS password autofill

  Scenario: iOS offers strong password suggestions during card signup
    Given the MetaMask app is running on an iOS device or simulator
    And the user navigates to Card onboarding signup

    When the user focuses the email field and enters an email address
    And the user focuses the "New password for MetaMask Card" field
    Then iOS shows password suggestions above the keyboard (Strong Password / saved passwords)

Feature: Card login iOS password autofill

  Scenario: iOS offers saved credentials during card login
    Given the MetaMask app is running on an iOS device or simulator
    And the user has saved card credentials in iCloud Keychain
    And the user navigates to Card authentication login

    When the user focuses the email field
    Then iOS may suggest the saved email
    When the user focuses the password field
    Then iOS may suggest the saved password
```

## **Screenshots/Recordings**

N/A — requires iOS device/simulator with Keychain configured. Verified via unit test assertions on `autoComplete` and `textContentType` props.

### **Before**

Password field used `autoComplete="one-time-code"`, blocking iOS password suggestions.

### **After**

Password field uses `autoComplete="password-new"` and `textContentType="newPassword"`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5be67b5d-83dc-4c74-8b00-0d875d88fe8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5be67b5d-83dc-4c74-8b00-0d875d88fe8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

