### PR TITLE
fix: keep the IDs through interval changes

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -4569,7 +4569,6 @@ function __resetPositionLineStateForTests() {
 
 
 
-
 function clearPositionLines() {
     const widget = getWidget();
     if (!widget || !isChartReady()) {
@@ -4735,10 +4734,6 @@ function registerPositionLinesOverlay() {
     registerHandler('SET_POSITION_LINES', (payload) => {
         handleSetPositionLines(payload);
     });
-    // resetData drops Drawing API shapes, so clear tracking on every OHLCV reset
-    onDataLifecycle('ohlcvReset', () => {
-        clearPositionShapeIds();
-    });
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/core/bootstrap.ts
@@ -4892,7 +4887,10 @@ function bootstrap() {
                         attachTapDismiss(widget);
                         attachMarkerHitTest(widget, chart);
                         attachVisibleRangeListeners(chart);
-                        chart.selection().onChanged().subscribe(null, () => {
+                        chart
+                            .selection()
+                            .onChanged()
+                            .subscribe(null, () => {
                             chart.selection().clear();
                         });
                         attachLegendResizeListener(widget);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/positionLines/__tests__/positionLines.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/positionLines/__tests__/positionLines.test.ts
@@ -296,8 +296,8 @@ describe('positionLines/index', () => {
       expect(getHasExplicitCurrentPriceLine()).toBe(false);
     });
 
-    it('clears shape IDs on ohlcvReset', async () => {
-      installWidget();
+    it('keeps tracked shapes on ohlcvReset so a later clear can remove persisted drawings', async () => {
+      const { createShape, removeEntity } = installWidget();
       registerPositionLinesOverlay();
 
       handleSetPositionLines({
@@ -307,6 +307,12 @@ describe('positionLines/index', () => {
       await Promise.resolve();
 
       notifyDataLifecycle('ohlcvReset');
+      expect(removeEntity).not.toHaveBeenCalled();
+      expect(createShape).toHaveBeenCalledTimes(1);
+      expect(getPositionShapeIds()).toEqual(['shape-1']);
+
+      handleSetPositionLines({ position: null });
+      expect(removeEntity).toHaveBeenCalledWith('shape-1');
       expect(getPositionShapeIds()).toEqual([]);
     });
   });

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/positionLines/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/positionLines/index.ts
@@ -5,7 +5,6 @@
 // clearPositionLines (~line 2608), and positionShapeIds state.
 
 import { reportErrorToRN } from '../../core/bridge';
-import { onDataLifecycle } from '../../core/dataLifecycle';
 import {
   getWidget,
   isChartReady,
@@ -206,10 +205,5 @@ export function handleSetPositionLines(payload: SetPositionLinesPayload): void {
 export function registerPositionLinesOverlay(): void {
   registerHandler('SET_POSITION_LINES', (payload) => {
     handleSetPositionLines(payload);
-  });
-
-  // resetData drops Drawing API shapes, so clear tracking on every OHLCV reset
-  onDataLifecycle('ohlcvReset', () => {
-    clearPositionShapeIds();
   });
 }


### PR DESCRIPTION
…_LINES close path removes them

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a Perps AdvancedChart regression where TP/SL position lines could remain visible after closing a position if the user changed chart intervals first.

The issue was introduced by the chart logic refactor: the new modular position-line overlay cleared its tracked TradingView shape IDs on OHLCV reset during interval hot-reloads. If TradingView preserved the drawings across that reset, the later close-position update no longer had the IDs needed to remove them.

The fix keeps position-line shape tracking intact across interval resets, allowing the existing SET_POSITION_LINES clear path to remove persisted TP/SL drawings when the position closes. A focused WebView overlay test was updated to cover this behavior, and the generated chart logic bundle was rebuilt.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Perps chart WebView overlay fix with a focused unit test; no auth, payments, or broad API changes.
> 
> **Overview**
> Fixes a Perps Advanced Chart bug where **TP/SL (and other position) lines could stay on the chart after a position closed** if the user had changed the chart interval first.
> 
> The position-lines overlay used to **clear its tracked TradingView shape IDs on `ohlcvReset`** (interval hot-reload). When TradingView **kept** those drawings across the reset, a later **`SET_POSITION_LINES` with `position: null`** had no IDs to call `removeEntity`, so stale lines remained.
> 
> **Change:** remove the `ohlcvReset` lifecycle hook that only wiped ID tracking (without removing shapes). IDs now survive interval resets so the existing clear path can remove persisted drawings when the position closes. The WebView overlay test was updated for this behavior; the generated `chartLogicString` bundle was rebuilt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6747d07f66b6e287697d8ca031f2198325d8c13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->