### PR TITLE
fix(money): use funding-method copy for Add funds toast (MUSD-1126)

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -302,7 +302,7 @@ describe('MoneyAddMoneySheet', () => {
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockInitiateDeposit).toHaveBeenCalledWith(undefined);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({ intent: 'convert' });
   });
 
   it('hides the Deposit funds option when moneyAccountDeposit is not in enabledTransactionTypes', () => {
@@ -384,7 +384,7 @@ describe('MoneyAddMoneySheet', () => {
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockInitiateDeposit).toHaveBeenCalledWith(undefined);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({ intent: 'convert' });
   });
 
   it('shows the Deposit funds option when fiat deposit is enabled', () => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -149,7 +149,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
     });
 
-    startDeposit();
+    startDeposit({ intent: 'convert' });
   }, [startDeposit, trackSurfaceClicked]);
 
   const handleDepositFunds = useCallback(() => {

--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -273,7 +273,7 @@ describe('useMoneyAccountDeposit', () => {
     clearMoneyAccountDepositIntent(observedBatchId);
   });
 
-  it('defaults intent to "convert" when omitted', async () => {
+  it('registers no intent when omitted, leaving it to be derived from the transaction', async () => {
     let observedBatchId: string | undefined;
     mockAddTransactionBatch.mockImplementationOnce(async (args) => {
       observedBatchId = (args as { batchId: string }).batchId;
@@ -286,7 +286,7 @@ describe('useMoneyAccountDeposit', () => {
       await result.current.initiateDeposit();
     });
 
-    expect(getMoneyAccountDepositIntent(observedBatchId)).toBe('convert');
+    expect(getMoneyAccountDepositIntent(observedBatchId)).toBeUndefined();
     clearMoneyAccountDepositIntent(observedBatchId);
   });
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -67,7 +67,6 @@ export function useMoneyAccountDeposit() {
   const initiateDeposit = useCallback(
     async (options?: InitiateDepositOptions) => {
       const preferredPaymentToken = options?.preferredPaymentToken;
-      const intent: MoneyAccountDepositIntent = options?.intent ?? 'convert';
       if (!vaultConfig) {
         throw new Error(`${LOG_TAG} Missing vault config`);
       }
@@ -95,7 +94,12 @@ export function useMoneyAccountDeposit() {
       const isGasFeeSponsored = isMonadMainnetChainId(chainIdHex);
 
       const batchId = bytesToHex(new Uint8Array(uuidParse(uuidv4())));
-      depositIntentByBatchId.set(batchId.toLowerCase(), intent);
+      // Only record an explicit funding intent (card / addMusd). Generic deposits
+      // (e.g. the home "Add" button) are left unset so the toast derives the
+      // intent from the transaction's actual payment method instead of a guess.
+      if (options?.intent) {
+        depositIntentByBatchId.set(batchId.toLowerCase(), options.intent);
+      }
 
       const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
         amount: BigInt(0),

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -434,6 +434,55 @@ describe('useMoneyTransactionStatus', () => {
       expect(depositFailedFn).toHaveBeenCalledWith({ intent: 'addMusd' });
     });
 
+    describe('intent falls back to the transaction funding method when no batch intent is stored', () => {
+      it('derives "card" from a fiat on-ramp deposit', () => {
+        const { statusUpdatedHandler } = renderAndGetHandlers();
+
+        statusUpdatedHandler({
+          transactionMeta: buildTxMeta({
+            id: 'tx-fiat-deposit',
+            type: TransactionType.moneyAccountDeposit,
+            status: TransactionStatus.approved,
+            metamaskPay: { fiat: true },
+          } as unknown as Partial<TransactionMeta>),
+        });
+        jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+        expect(depositInProgressFn).toHaveBeenCalledWith({ intent: 'card' });
+      });
+
+      it('derives "addMusd" from a deposit paid with mUSD', () => {
+        const { statusUpdatedHandler } = renderAndGetHandlers();
+
+        statusUpdatedHandler({
+          transactionMeta: buildTxMeta({
+            id: 'tx-musd-deposit',
+            type: TransactionType.moneyAccountDeposit,
+            status: TransactionStatus.approved,
+            metamaskPay: { tokenAddress: MUSD_ADDRESS },
+          } as unknown as Partial<TransactionMeta>),
+        });
+        jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+        expect(depositInProgressFn).toHaveBeenCalledWith({ intent: 'addMusd' });
+      });
+
+      it('derives "convert" from a crypto deposit with no fiat/mUSD payment', () => {
+        const { statusUpdatedHandler } = renderAndGetHandlers();
+
+        statusUpdatedHandler({
+          transactionMeta: buildTxMeta({
+            id: 'tx-crypto-deposit',
+            type: TransactionType.moneyAccountDeposit,
+            status: TransactionStatus.approved,
+          }),
+        });
+        jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+        expect(depositInProgressFn).toHaveBeenCalledWith({ intent: 'convert' });
+      });
+    });
+
     it('confirmed → success toast with decoded fiat amount', () => {
       const { confirmedHandler } = renderAndGetHandlers();
 
@@ -1119,7 +1168,10 @@ describe('useMoneyTransactionStatus', () => {
         }),
       );
 
-      expect(depositSuccessFn).toHaveBeenCalledWith({ amountFiat: undefined });
+      expect(depositSuccessFn).toHaveBeenCalledWith({
+        amountFiat: undefined,
+        intent: 'convert',
+      });
     });
   });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -106,6 +106,18 @@ Object.defineProperty(Engine, 'controllerMessenger', {
   configurable: true,
 });
 
+const mockControllerTransactions: TransactionMeta[] = [];
+
+Object.defineProperty(Engine, 'context', {
+  value: {
+    TransactionController: {
+      state: { transactions: mockControllerTransactions },
+    },
+  },
+  writable: true,
+  configurable: true,
+});
+
 const mockUseMoneyToasts = jest.mocked(useMoneyToasts);
 
 const TELLER_INTERFACE = new ethers.utils.Interface([
@@ -238,6 +250,7 @@ describe('useMoneyTransactionStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockControllerTransactions.length = 0;
 
     mockUseMoneyToasts.mockReturnValue({
       showToast: mockShowToast,
@@ -480,6 +493,29 @@ describe('useMoneyTransactionStatus', () => {
         jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
 
         expect(depositInProgressFn).toHaveBeenCalledWith({ intent: 'convert' });
+      });
+
+      it('re-reads metamaskPay populated after approval instead of the stale snapshot', () => {
+        const { statusUpdatedHandler } = renderAndGetHandlers();
+
+        // `approved` fires with no payment data yet.
+        const approvedMeta = buildTxMeta({
+          id: 'tx-late-metamaskpay',
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.approved,
+        });
+        statusUpdatedHandler({ transactionMeta: approvedMeta });
+
+        // Controller fills in `metamaskPay` before the deferred toast fires,
+        // without another status event re-delivering the meta.
+        mockControllerTransactions.push({
+          ...approvedMeta,
+          metamaskPay: { fiat: true },
+        } as unknown as TransactionMeta);
+
+        jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+        expect(depositInProgressFn).toHaveBeenCalledWith({ intent: 'card' });
       });
     });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -163,6 +163,19 @@ const FAILED_KEY = 'failed';
 const CONFIRMED_KEY = 'confirmed';
 export const IN_PROGRESS_DELAY_MS = 1500;
 
+// Reads the freshest copy of a transaction from controller state. The deferred
+// in-progress toast derives deposit intent from `metamaskPay`, which can be
+// populated after the `approved` event that scheduled the toast without another
+// status change re-delivering the meta — so the captured snapshot is unsafe for
+// derivation.
+function latestTransactionMeta(
+  transactionId: string,
+): TransactionMeta | undefined {
+  return Engine.context.TransactionController.state.transactions.find(
+    (tx) => tx.id === transactionId,
+  );
+}
+
 export const useMoneyTransactionStatus = () => {
   const { showToast, MoneyToastOptions } = useMoneyToasts();
   const shownToastsRef = useRef<Set<string>>(new Set());
@@ -217,7 +230,9 @@ export const useMoneyTransactionStatus = () => {
         if (isSend) {
           showToast(MoneyToastOptions.send.inProgress());
         } else if (isMoneyDepositTx(transactionMeta)) {
-          const intent = resolveDepositIntent(transactionMeta);
+          const freshMeta =
+            latestTransactionMeta(transactionMeta.id) ?? transactionMeta;
+          const intent = resolveDepositIntent(freshMeta);
           showToast(MoneyToastOptions.deposit.inProgress({ intent }));
         } else {
           showToast(MoneyToastOptions.withdraw.inProgress());

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -38,6 +38,7 @@ import {
   isPerpsPredictMoneyWithdraw,
   nestedTxWithType,
   perpsPredictServiceFamily,
+  resolveMoneyDepositIntent,
 } from '../utils/moneyTransactionGuards';
 import useMoneyToasts from './useMoneyToasts';
 import {
@@ -200,6 +201,12 @@ export const useMoneyTransactionStatus = () => {
       return toastKey;
     };
 
+    // Prefer the intent captured when the deposit was initiated; fall back to
+    // deriving it from the transaction's own payment data when it's missing.
+    const resolveDepositIntent = (transactionMeta: TransactionMeta) =>
+      getMoneyAccountDepositIntent(transactionMeta.batchId) ??
+      resolveMoneyDepositIntent(transactionMeta);
+
     const showInProgressFor = (transactionMeta: TransactionMeta) => {
       const isSend = isPerpsPredictMoneyDeposit(transactionMeta);
       if (!isMoneyAccountTx(transactionMeta) && !isSend) return;
@@ -210,7 +217,7 @@ export const useMoneyTransactionStatus = () => {
         if (isSend) {
           showToast(MoneyToastOptions.send.inProgress());
         } else if (isMoneyDepositTx(transactionMeta)) {
-          const intent = getMoneyAccountDepositIntent(transactionMeta.batchId);
+          const intent = resolveDepositIntent(transactionMeta);
           showToast(MoneyToastOptions.deposit.inProgress({ intent }));
         } else {
           showToast(MoneyToastOptions.withdraw.inProgress());
@@ -227,7 +234,7 @@ export const useMoneyTransactionStatus = () => {
       if (isSend) {
         showToast(MoneyToastOptions.send.failed());
       } else if (isMoneyDepositTx(transactionMeta)) {
-        const intent = getMoneyAccountDepositIntent(transactionMeta.batchId);
+        const intent = resolveDepositIntent(transactionMeta);
         showToast(MoneyToastOptions.deposit.failed({ intent }));
         clearMoneyAccountDepositIntent(transactionMeta.batchId);
       } else {
@@ -291,7 +298,7 @@ export const useMoneyTransactionStatus = () => {
           : undefined;
 
       if (isMoneyDepositTx(transactionMeta)) {
-        const intent = getMoneyAccountDepositIntent(transactionMeta.batchId);
+        const intent = resolveDepositIntent(transactionMeta);
         showToast(MoneyToastOptions.deposit.success({ amountFiat, intent }));
         clearMoneyAccountDepositIntent(transactionMeta.batchId);
       } else {

--- a/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
@@ -17,6 +17,7 @@ import {
   nestedTxWithType,
   perpsPredictServiceFamily,
   getMMPayChainIds,
+  resolveMoneyDepositIntent,
 } from './moneyTransactionGuards';
 
 const baseTx = {
@@ -86,6 +87,42 @@ describe('isMoneyDepositTx', () => {
     expect(isMoneyDepositTx(makeTx(TransactionType.contractInteraction))).toBe(
       false,
     );
+  });
+});
+
+describe('resolveMoneyDepositIntent', () => {
+  const makeDepositTx = (
+    metamaskPay?: Record<string, unknown>,
+  ): TransactionMeta =>
+    ({
+      ...baseTx,
+      type: TransactionType.moneyAccountDeposit,
+      metamaskPay,
+    }) as unknown as TransactionMeta;
+
+  it('returns "card" for a fiat on-ramp deposit', () => {
+    expect(resolveMoneyDepositIntent(makeDepositTx({ fiat: true }))).toBe(
+      'card',
+    );
+  });
+
+  it('returns "addMusd" for a deposit paid with mUSD', () => {
+    expect(
+      resolveMoneyDepositIntent(
+        makeDepositTx({ tokenAddress: MUSD_TOKEN_ADDRESS }),
+      ),
+    ).toBe('addMusd');
+  });
+
+  it('returns "convert" for a crypto deposit with no fiat/mUSD payment', () => {
+    expect(resolveMoneyDepositIntent(makeDepositTx())).toBe('convert');
+    expect(
+      resolveMoneyDepositIntent(
+        makeDepositTx({
+          tokenAddress: '0x1234567890123456789012345678901234567890',
+        }),
+      ),
+    ).toBe('convert');
   });
 });
 

--- a/app/components/UI/Money/utils/moneyTransactionGuards.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.ts
@@ -7,6 +7,7 @@ import {
   isMusdOnMoneyAccountChain,
   isMusdToken,
 } from '../../Earn/constants/musd';
+import type { MoneyAccountDepositIntent } from '../hooks/useMoneyAccount';
 
 /**
  * Returns the first nested transaction matching a given TransactionType,
@@ -25,6 +26,25 @@ export const isMoneyDepositTx = (transactionMeta: TransactionMeta) =>
   Boolean(
     nestedTxWithType(transactionMeta, TransactionType.moneyAccountDeposit),
   );
+
+/**
+ * Derives the funding method of a Money account deposit from the transaction's
+ * own payment data, so toast copy matches the flow the user actually took:
+ * - fiat on-ramp (Apple Pay / debit / credit) → `card`
+ * - paid with mUSD from holdings → `addMusd`
+ * - any other crypto → `convert`
+ */
+export const resolveMoneyDepositIntent = (
+  transactionMeta: TransactionMeta,
+): MoneyAccountDepositIntent => {
+  if (transactionMeta.metamaskPay?.fiat) {
+    return 'card';
+  }
+  if (isMusdToken(transactionMeta.metamaskPay?.tokenAddress)) {
+    return 'addMusd';
+  }
+  return 'convert';
+};
 
 export const isMoneyWithdrawTx = (transactionMeta: TransactionMeta) =>
   transactionMeta.type === TransactionType.moneyAccountWithdraw ||


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money **Add funds** toast showed "Converting crypto" regardless of the funding method — most notably for mUSD deposits and the generic home **Add** button, which should read "Adding funds" and "Depositing" respectively.

**Root cause:** the toast pipeline resolved the funding method from an out-of-band `batchId → intent` map that defaulted to `'convert'` whenever no explicit intent was stored (e.g. the home Add button). That default leaked into the toast as "Converting crypto".

**Fix:** derive the intent from the transaction's own payment data instead of the map guess. `resolveMoneyDepositIntent(tx)` reads `metamaskPay`:

- `metamaskPay.fiat` (Apple Pay / debit / credit) → `card` → **Depositing**
- mUSD pay token → `addMusd` → **Adding funds**
- any other crypto → `convert` → **Converting crypto**

`initiateDeposit` now only records an *explicit* intent (the "Deposit funds" / "Move mUSD" sheet buttons); generic deposits are left unset so the toast falls through to derivation. The toast resolves `getMoneyAccountDepositIntent(batchId) ?? resolveMoneyDepositIntent(tx)`, so the copy always follows the funding method the user actually used.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money Add funds toast so its copy matches the funding method — "Depositing" for card/Apple Pay, "Adding funds" for mUSD, and "Converting crypto" for crypto conversions — instead of always showing "Converting crypto".

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1126

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Add funds toast copy

  Scenario: Deposit with a card / Apple Pay
    Given I am on the Money account
    When I add funds and pay with Apple Pay, debit, or credit
    Then the toast reads "Depositing"

  Scenario: Deposit with mUSD from holdings
    Given I am on the Money account
    When I add funds paying with mUSD
    Then the toast reads "Adding funds"

  Scenario: Convert crypto
    Given I am on the Money account
    When I add funds paying with another crypto token
    Then the toast reads "Converting crypto"

  Scenario: Generic "Add" from the Money balance card
    Given I am on the wallet home
    When I tap "Add" on the Money balance card and complete the deposit
    Then the toast copy follows the payment method I chose (not always "Converting")
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — copy-only change. Before this fix the toast always showed "Converting crypto" for the Add flow regardless of funding method.

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/ee495b17-43b2-4c58-8eec-d8031b35b8f9

https://github.com/user-attachments/assets/2c5fe3bb-ba0b-4c32-a3ed-42398ca1369c


Copy now matches the Figma spec per funding method:
- Converting crypto: https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=6412-27527&m=dev
- Depositing (Apple Pay / debit / credit): https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=10382-54194
- Adding funds (mUSD): https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=10382-46931

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing toast copy and intent resolution only; behavior is covered by expanded unit tests with no auth, payments, or persistence changes.
> 
> **Overview**
> Fixes Money **Add funds** toasts that always showed “Converting crypto” by resolving copy from how the deposit was actually funded instead of defaulting missing batch intents to `convert`.
> 
> **Deposit intent:** `initiateDeposit` only writes the batch-id map when `options.intent` is set (sheet actions like Deposit funds / Move mUSD). Generic entry points no longer get a guessed intent. **Convert crypto** in the add-money sheet now passes `{ intent: 'convert' }` explicitly.
> 
> **Derivation:** New `resolveMoneyDepositIntent` maps `metamaskPay` to `card` (fiat), `addMusd` (mUSD), or `convert` (other crypto). Toasts use `getMoneyAccountDepositIntent(batchId) ?? resolveMoneyDepositIntent(tx)` for in-progress, failed, and success deposit toasts.
> 
> **Deferred in-progress:** The delayed in-progress toast re-reads the transaction from `TransactionController` state so `metamaskPay` filled in after `approved` is used, not a stale event snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6059cef6e667cd4496c554e904a17641616b3380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->