### PR TITLE
fix: RC changelog and Slack links for Runway releases

### DIFF
--- a/scripts/build-announce/cherry-picks-section.ts
+++ b/scripts/build-announce/cherry-picks-section.ts
@@ -3,7 +3,8 @@
  *
  * Two sections are generated:
  * 1. Cherry-picks: Commits on the release branch after forking from main
- * 2. Changelog: Commits on main between the previous release and the RC cut point
+ * 2. Changelog: Commits since the previous release tag. For Runway releases,
+ * falls back to the release branch when main-line changelog is empty or only release commits.
  */
 
 import { execFileSync } from 'child_process';
@@ -57,47 +58,42 @@ function getAncestryPathCommits(
 }
 
 /**
- * Get the most recent release tag before a given commit
+ * Get the most recent release tag merged into a given commit.
+ * Uses --merged to find the highest version tag that is an ancestor of the commit.
  */
-function getPreviousReleaseTag(beforeCommit: string): string | null {
+function getPreviousReleaseTag(mergeBase: string): string | null {
   try {
-    // Get the most recent tag reachable from the commit, matching v*.*.* pattern
     const out = execFileSync(
       'git',
-      ['describe', '--tags', '--abbrev=0', '--match', 'v*.*.*', `${beforeCommit}^`],
+      ['tag', '--sort=-version:refname', '--list', 'v*.*.*', '--merged', mergeBase],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
-    return out.trim() || null;
+    const tags = out.trim().split('\n').filter(Boolean);
+    // Return first tag (highest version that's an ancestor of merge-base)
+    return tags[0] || null;
   } catch {
-    // Fallback: list tags that are ancestors of (merged into) the commit
-    try {
-      const out = execFileSync(
-        'git',
-        ['tag', '--sort=-version:refname', '--list', 'v*.*.*', '--merged', beforeCommit],
-        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-      );
-      const tags = out.trim().split('\n').filter(Boolean);
-      // Return first tag (highest version that's actually an ancestor)
-      return tags[0] || null;
-    } catch {
-      return null;
-    }
+    return null;
   }
 }
 
 /**
- * Get commits between two refs (for changelog - commits on main)
+ * Get commits between two refs.
+ * @param firstParent - If true, use --first-parent for main-line history; otherwise include all commits.
  */
 function getCommitsBetween(
   fromRef: string,
   toRef: string,
+  firstParent = true,
 ): { hash: string; subject: string }[] {
   try {
-    const out = execFileSync(
-      'git',
-      ['log', `${fromRef}..${toRef}`, '--pretty=format:%h\t%s', '--first-parent'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-    );
+    const args = ['log', `${fromRef}..${toRef}`, '--pretty=format:%h\t%s'];
+    if (firstParent) {
+      args.push('--first-parent');
+    }
+    const out = execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
 
     if (!out.trim()) return [];
 
@@ -136,6 +132,7 @@ export interface WhatsInRcResult {
   changelog: { hash: string; subject: string }[];
   mergeBase: string;
   previousTag: string | null;
+  changelogFromReleaseBranch: boolean;
 }
 
 export function extractWhatsInRc(): WhatsInRcResult {
@@ -148,18 +145,39 @@ export function extractWhatsInRc(): WhatsInRcResult {
   const cherryPicks = getAncestryPathCommits(mergeBase, headRef);
   console.log(`[cherry-picks] Found ${cherryPicks.length} commit(s)`);
 
-  // Changelog: commits on main from previous release to merge-base
+  // Changelog: commits since previous release tag
   const previousTag = getPreviousReleaseTag(mergeBase);
   let changelog: { hash: string; subject: string }[] = [];
+  let changelogFromReleaseBranch = false;
 
   if (previousTag) {
-    changelog = getCommitsBetween(previousTag, mergeBase);
-    console.log(`[changelog] Found ${changelog.length} commit(s) from ${previousTag} to merge-base`);
+    // First try: commits on main from previous release to merge-base
+    changelog = getCommitsBetween(previousTag, mergeBase, true);
+    console.log(
+      `[changelog] Found ${changelog.length} commit(s) on main from ${previousTag} to merge-base`,
+    );
+
+    // Check if changelog is empty or contains only release commits
+    // This happens for Runway releases where features are cherry-picked to release branch
+    const isOnlyReleaseCommits =
+      changelog.length > 0 && changelog.every((c) => c.subject.startsWith('release:'));
+
+    if (changelog.length === 0 || isOnlyReleaseCommits) {
+      console.log(
+        `[changelog] Main-line changelog is ${changelog.length === 0 ? 'empty' : 'only release commits'}, falling back to release branch`,
+      );
+      // Fallback: get commits from release branch since previous tag (without --first-parent)
+      changelog = getCommitsBetween(previousTag, headRef, false);
+      changelogFromReleaseBranch = true;
+      console.log(
+        `[changelog] Found ${changelog.length} commit(s) on release branch from ${previousTag}`,
+      );
+    }
   } else {
     console.log(`[changelog] Could not find previous release tag`);
   }
 
-  return { cherryPicks, changelog, mergeBase, previousTag };
+  return { cherryPicks, changelog, mergeBase, previousTag, changelogFromReleaseBranch };
 }
 
 function buildCommitTable(commits: { hash: string; subject: string }[]): string {
@@ -178,7 +196,7 @@ function buildCommitTable(commits: { hash: string; subject: string }[]): string 
 }
 
 export function buildWhatsInRcSection(result: WhatsInRcResult, buildNumber?: string): string {
-  const { cherryPicks, changelog } = result;
+  const { cherryPicks, changelog, previousTag, changelogFromReleaseBranch } = result;
 
   // If both are empty, return nothing
   if (cherryPicks.length === 0 && changelog.length === 0) {
@@ -205,9 +223,12 @@ export function buildWhatsInRcSection(result: WhatsInRcResult, buildNumber?: str
 
   // Changelog section
   if (changelog.length > 0) {
+    const changelogLabel = changelogFromReleaseBranch
+      ? `Changelog (${changelog.length} commits since ${previousTag})`
+      : `Changelog (${changelog.length} commits from main at RC cut)`;
     lines.push(`<a id="changelog${anchorSuffix}"></a>`);
     lines.push('<details>');
-    lines.push(`<summary>Changelog (${changelog.length} commits from main at RC cut)</summary>\n`);
+    lines.push(`<summary>${changelogLabel}</summary>\n`);
     lines.push(buildCommitTable(changelog));
     lines.push('\n</details>\n');
   }

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -145,12 +145,11 @@ function buildSlackMessage(options) {
       },
     );
   } else {
-    const releaseNotesMrkdwn = `<${REPO_URL}/tree/release/${version}|View release notes>`;
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `_Cherry-picks available in the release PR. ${releaseNotesMrkdwn}_`,
+        text: `_Cherry-picks available in the release PR._`,
       },
     });
   }
@@ -174,22 +173,32 @@ function buildSlackMessage(options) {
     );
   }
 
-  // Add pipeline link
-  if (pipelineUrl) {
-    blocks.push(
-      {
-        type: 'divider',
-      },
-      {
-        type: 'context',
-        elements: [
-          {
-            type: 'mrkdwn',
-            text: `<${pipelineUrl}|View Build Pipeline> | <${REPO_URL}/tree/release/${version}|View full release notes>`,
-          },
-        ],
-      },
-    );
+  // Add pipeline and RC notes links
+  if (pipelineUrl || prNumber) {
+    const links = [];
+    if (pipelineUrl) {
+      links.push(`<${pipelineUrl}|View Build Pipeline>`);
+    }
+    if (prNumber) {
+      const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
+      links.push(`<${REPO_URL}/pull/${prNumber}#user-content-whats-in-this-rc${anchorSuffix}|View full RC notes>`);
+    }
+    if (links.length > 0) {
+      blocks.push(
+        {
+          type: 'divider',
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: links.join(' | '),
+            },
+          ],
+        },
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
- Fix changelog in "What's in this RC" section to show all commits for Runway releases   
- Fix Slack "View full RC notes" link to point to PR instead of branch page 
 For 8.2.0, changelog showed only 4 release commits instead of ~224 feature commits due to
incorrect tag lookup and main-line query.  
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
- cherry-picks-section.ts: Use --merged for tag lookup, fallback to release branch when  
  main changelog is empty                                                                  
  - slack-rc-notification.mjs: Link to #whats-in-this-rc anchor, remove misleading branch  
  links                                             
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release announcement scripts (git log/tag queries and Slack copy); no mobile app runtime or security-sensitive paths.
> 
> **Overview**
> Fixes **What's in this RC** changelog generation for Runway-style releases where main-line history is empty or only `release:` commits, so RC notes list the full set of commits instead of a handful of release bumps.
> 
> **Changelog extraction** (`cherry-picks-section.ts`): Previous release tag lookup now uses `git tag --merged` on the merge-base (replacing `git describe` on the parent). Commits since that tag are taken from main with `--first-parent` first; if that range is empty or every subject starts with `release:`, the script falls back to all commits on the release branch from the tag to `HEAD`. The markdown summary label reflects whether the list came from main at RC cut or from the release branch since the prior tag.
> 
> **Slack RC notification** (`slack-rc-notification.mjs`): Removes links to the release branch tree for “release notes.” When `PR_NUMBER` is set, the footer can include **View full RC notes** pointing at the release PR anchor `#user-content-whats-in-this-rc` (with the same build-number suffix as cherry-picks), alongside the pipeline link when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6183888256f6311d6a14231b9fa50639ec2f315c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->