### PR TITLE
fix: only mount hardware wallet FullWindowOverlay when bottom sheet is visible

### DIFF
--- a/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.test.tsx
@@ -244,7 +244,16 @@ describe('HardwareWalletProvider', () => {
 
     describe('connect (internal, via bottom sheet props)', () => {
       it('connects to device', async () => {
-        renderWithActions();
+        const { result } = renderWithActions();
+
+        // The bottom sheet (and its captured props) only mounts while a flow
+        // is active, so start scanning first
+        act(() => {
+          result.current.actions.ensureDeviceReady();
+        });
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
 
         const internalConnect = capturedBottomSheetProps.connect as (
           deviceId: string,
@@ -336,6 +345,11 @@ describe('HardwareWalletProvider', () => {
           result.current.actions.setPendingOperationAddress('0xqr');
         });
 
+        // Mount the bottom sheet so its props can be captured
+        await act(async () => {
+          result.current.actions.showAwaitingConfirmation('transaction');
+        });
+
         await waitFor(() => {
           expect(capturedBottomSheetProps.walletType).toBe(
             HardwareWalletType.Qr,
@@ -359,12 +373,6 @@ describe('HardwareWalletProvider', () => {
 
         await act(async () => {
           result.current.actions.setPendingOperationAddress('0xqr');
-        });
-
-        await waitFor(() => {
-          expect(capturedBottomSheetProps.walletType).toBe(
-            HardwareWalletType.Qr,
-          );
         });
 
         expect(
@@ -458,6 +466,13 @@ describe('HardwareWalletProvider', () => {
     describe('selectDevice', () => {
       it('updates selected device in state', async () => {
         const { result } = renderWithActions();
+
+        act(() => {
+          result.current.actions.ensureDeviceReady();
+        });
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
 
         const mockDevice = { id: 'device-1', name: 'Nano X' };
 
@@ -832,6 +847,7 @@ describe('HardwareWalletProvider', () => {
       const useTestActions = () => {
         const hw = useHardwareWallet();
         return {
+          actions: hw,
           state: {
             connectionState: hw.connectionState,
           },
@@ -842,6 +858,13 @@ describe('HardwareWalletProvider', () => {
         wrapper: ({ children }: { children: React.ReactNode }) => (
           <HardwareWalletProvider>{children}</HardwareWalletProvider>
         ),
+      });
+
+      act(() => {
+        result.current.actions.ensureDeviceReady();
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
       const internalConnect = capturedBottomSheetProps.connect as (

--- a/app/core/HardwareWallet/HardwareWalletProvider.tsx
+++ b/app/core/HardwareWallet/HardwareWalletProvider.tsx
@@ -288,26 +288,39 @@ export const HardwareWalletProvider: React.FC<HardwareWalletProviderProps> = ({
     ],
   );
 
+  // Mirrors the `shouldShow` logic inside HardwareWalletBottomSheet: the sheet
+  // renders null unless a wallet type is set, the sheet is not force-hidden and
+  // the connection flow is in any non-disconnected state. The FullWindowOverlay
+  // must be fully unmounted whenever the sheet is empty because an empty
+  // overlay container is accessibilityViewIsModal=YES on iOS, which hides the
+  // entire app from VoiceOver and accessibility clients (origin: PR #32619).
+  const isBottomSheetMounted =
+    !forceHideBottomSheet &&
+    effectiveWalletType !== null &&
+    connectionState.status !== ConnectionStatus.Disconnected;
+
   return (
     <HardwareWalletContext.Provider value={contextValue}>
       {children}
-      <FullWindowOverlay>
-        <HardwareWalletBottomSheet
-          connectionState={connectionState}
-          deviceSelection={deviceSelection}
-          walletType={effectiveWalletType}
-          forceHideBottomSheet={forceHideBottomSheet}
-          retryEnsureDeviceReady={handleRetryOrClose}
-          selectDevice={selectDevice}
-          rescan={rescan}
-          connect={connect}
-          onClose={handleCloseFlow}
-          onAwaitingConfirmationCancel={handleAwaitingConfirmationCancel}
-          onConnectionSuccess={handleBottomSheetConnectionSuccess}
-          onCTAClicked={trackCTAClicked}
-          onRetryQrScan={handleRetryQrScan}
-        />
-      </FullWindowOverlay>
+      {isBottomSheetMounted && (
+        <FullWindowOverlay>
+          <HardwareWalletBottomSheet
+            connectionState={connectionState}
+            deviceSelection={deviceSelection}
+            walletType={effectiveWalletType}
+            forceHideBottomSheet={forceHideBottomSheet}
+            retryEnsureDeviceReady={handleRetryOrClose}
+            selectDevice={selectDevice}
+            rescan={rescan}
+            connect={connect}
+            onClose={handleCloseFlow}
+            onAwaitingConfirmationCancel={handleAwaitingConfirmationCancel}
+            onConnectionSuccess={handleBottomSheetConnectionSuccess}
+            onCTAClicked={trackCTAClicked}
+            onRetryQrScan={handleRetryQrScan}
+          />
+        </FullWindowOverlay>
+      )}
     </HardwareWalletContext.Provider>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

Since #32619, `HardwareWalletProvider` renders a `<FullWindowOverlay>` (from `react-native-screens`) **unconditionally** at the app root, wrapping `HardwareWalletBottomSheet`.

On iOS, `react-native-screens` attaches the overlay's native container (`RNSFullWindowOverlayContainer`) directly to the `UIWindow` with `accessibilityViewIsModal = YES` by default. When no hardware-wallet flow is active, `HardwareWalletBottomSheet` renders `null`, so the container is **empty** — but still accessibility-modal. Per UIKit semantics, a modal accessibility view makes the system ignore **every sibling view in the window**, so the entire app's accessibility tree disappears:

- **Users**: VoiceOver reads nothing — the app is unusable with assistive technology.
- **Tooling**: anything reading the iOS AX tree (XCUITest, Appium, `idb`, internal visual-testing CLI) sees zero elements/testIDs. (Detox is unaffected on iOS since it uses white-box view matching, which is why CI didn't catch this.)

Root cause was proven at runtime: an lldb view-hierarchy dump showed `RNSFullWindowOverlayContainer accessibilityViewIsModal=1 subviews=0` attached to the key window, and removing that single view instantly restored the full accessibility tree.

**Solution**: mount the `FullWindowOverlay` only when the bottom sheet actually has content. The new `isBottomSheetMounted` gate mirrors the sheet's internal `shouldShow` logic (`Disconnected` is the only `ConnectionStatus` for which the sheet renders `null`; it returns `null` synchronously, so unmounting the overlay in the same render is safe). Modal a11y behavior (focus trapping) is preserved while a hardware-wallet flow is on screen — behavior in active flows is unchanged.

Tests that read props from the mocked bottom sheet while the provider was `Disconnected` were updated to first drive the provider into an active state (`ensureDeviceReady()` → Scanning, or `showAwaitingConfirmation()` → AwaitingConfirmation), matching the pattern already used by sibling tests in the same file.

## **Changelog**

CHANGELOG entry: Fixed a bug on iOS that made the app invisible to VoiceOver and other accessibility tools while no hardware wallet flow was active

## **Related issues**

Refs: #32619

## **Manual testing steps**

```gherkin
Feature: iOS accessibility tree is exposed while hardware wallet sheet is idle

  Scenario: user relies on VoiceOver or an accessibility client with no hardware wallet flow active
    Given the app is running on an iOS device or simulator
    And no hardware wallet connection flow is active

    When an accessibility client queries the app (VoiceOver, Accessibility Inspector, or `idb ui describe-all --udid <UDID>`)
    Then the full accessibility tree is returned (screen elements, labels and testIDs are visible)
    And no empty RNSFullWindowOverlayContainer is attached to the UIWindow

  Scenario: user starts a hardware wallet connection flow
    Given the app is running on iOS

    When the user initiates a Ledger/QR hardware wallet connection
    Then the hardware wallet bottom sheet appears above all content as before
    And VoiceOver focus is contained to the sheet (modal overlay behavior unchanged)
```

Verification used during development:

```bash
# Independent AX client — should list the full element tree, not just the Application node
idb ui describe-all --udid <UDID>

# Native check — should print CLEAN while the wallet is idle
lldb -p $(pgrep -f 'CoreSimulator.*\.app/MetaMask' | head -1) \
  -o 'expr -l objc -- @import UIKit' \
  -o 'expr -l objc -O -- NSMutableString *r = [NSMutableString string]; for (UIWindow *w in [[UIApplication sharedApplication] windows]) { for (UIView *sv in [w subviews]) { if ([NSStringFromClass((Class)[sv class]) containsString:@"FullWindowOverlayContainer"]) { [r appendFormat:@"FOUND %@ modal=%d subviews=%lu\n", NSStringFromClass((Class)[sv class]), (int)[sv accessibilityViewIsModal], (unsigned long)[[sv subviews] count]]; } } } [r length] ? r : @"CLEAN — no FullWindowOverlayContainer on any window"' \
  -o detach -o quit 2>&1 | grep -E 'FOUND|CLEAN'
```

## **Screenshots/Recordings**

N/A — no visual change. The fix affects the accessibility layer only; evidence below is accessibility-tree output.

### **Before**

XCUITest raw snapshot / `idb ui describe-all` with the wallet idle — the tree is empty below the window (no testIDs, no elements):

```json
{
  "testIds": { "items": [] },
  "a11y": { "nodes": [
    { "ref": "e1", "role": "Application", "name": "MetaMask" },
    { "ref": "e2", "role": "Window", "name": "" },
    { "ref": "e3", "role": "Other", "name": "" }
  ] }
}
```

### **After**

Same query with the fix applied — full tree restored (excerpt):

```json
{
  "testIds": { "items": [
    { "testId": "import-from-seed-screen-back-button-id", "tag": "Other", "text": "Back" },
    { "testId": "import-from-seed-screen-title-id", "tag": "StaticText", "text": "Import a wallet" },
    { "testId": "import-from-seed-screen-continue-button-id", "tag": "Button", "text": "Continue" }
  ] }
}
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets root-level overlay mounting and hardware-wallet UI lifecycle on iOS accessibility; behavior during active flows is intended to stay the same, but incorrect gating could hide the sheet or break connection/signing UX.
> 
> **Overview**
> Fixes an iOS accessibility regression where an always-mounted `FullWindowOverlay` left an empty modal container on screen when no hardware wallet flow was running, hiding the whole app from VoiceOver and AX-tree tooling.
> 
> **`HardwareWalletProvider`** now gates the overlay with `isBottomSheetMounted`, aligned with the bottom sheet’s `shouldShow` rules (wallet type set, not force-hidden, connection not `Disconnected`). The sheet and overlay mount together only during an active flow; idle behavior is unchanged for users not in a HW flow.
> 
> **Tests** that read mocked bottom-sheet props were updated to start a flow first (`ensureDeviceReady()` or `showAwaitingConfirmation()`), since the sheet no longer mounts while disconnected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5764f77f2db3c71eedd1dc288ddd93e4e53af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->