### PR TITLE
fix: port missing color-sync logic from chartLogic.js to modular WebView

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -708,6 +708,82 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
 
     // ---- Declarative prop syncing ----
 
+    // Hot-swap chart colors via postMessage whenever overrides change.
+    // IMPORTANT: this effect MUST be declared BEFORE the OHLCV-sync effect
+    // below. React fires effects in declaration order, so colours reach the
+    // WebView before SET_OHLCV_DATA. The WebView updates its theme state
+    // first; when onChartReady fires (after the data triggers widget
+    // creation), flushPendingTheme() reads the already-correct colour.
+    // This mirrors main's pendingMessages queue, which drained
+    // SET_THEME_COLORS inside onChartReady before applySeriesColors().
+    useEffect(() => {
+      if (!webViewLoaded) return;
+      if (!themeColorsSentRef.current) {
+        const effectiveCurrentPriceColor = resolveCurrentPriceColor({
+          lastValuePillColor: labelStyleOverrides?.lastValuePillColor,
+          currentPriceLineColorOverride,
+          lineColorOverride,
+          successColorOverride,
+          themeSuccessDefault: theme.colors.success.default,
+        });
+        const colorsMatch =
+          lineColorOverride === initialLineColorRef.current &&
+          successColorOverride === initialSuccessColorRef.current &&
+          errorColorOverride === initialErrorColorRef.current &&
+          effectiveCurrentPriceColor === initialCurrentPriceColorRef.current &&
+          volumeSuccessColorOverride === initialVolumeSuccessColorRef.current &&
+          volumeErrorColorOverride === initialVolumeErrorColorRef.current;
+        themeColorsSentRef.current = true;
+        if (
+          colorsMatch &&
+          currentPriceLineColorOverride === undefined &&
+          volumeSuccessColorOverride === undefined &&
+          volumeErrorColorOverride === undefined
+        )
+          return;
+      }
+      const effectiveSuccessColor =
+        successColorOverride ?? theme.colors.success.default;
+      const effectiveLineColor = lineColorOverride ?? effectiveSuccessColor;
+      const effectiveErrorColor =
+        errorColorOverride ?? theme.colors.error.default;
+      const effectiveCurrentPriceColor = resolveCurrentPriceColor({
+        lastValuePillColor: labelStyleOverrides?.lastValuePillColor,
+        currentPriceLineColorOverride,
+        lineColorOverride,
+        successColorOverride,
+        themeSuccessDefault: theme.colors.success.default,
+      });
+      const effectiveVolumeSuccessColor =
+        volumeSuccessColorOverride ?? effectiveSuccessColor;
+      const effectiveVolumeErrorColor =
+        volumeErrorColorOverride ?? effectiveErrorColor;
+      postMessage({
+        type: 'SET_THEME_COLORS',
+        payload: {
+          lineColor: effectiveLineColor,
+          successColor: effectiveSuccessColor,
+          errorColor: effectiveErrorColor,
+          currentPriceColor: effectiveCurrentPriceColor,
+          volumeSuccessColor: effectiveVolumeSuccessColor,
+          volumeErrorColor: effectiveVolumeErrorColor,
+        },
+      });
+    }, [
+      lineColorOverride,
+      successColorOverride,
+      errorColorOverride,
+      currentPriceLineColorOverride,
+      labelStyleOverrides?.lastValuePillColor,
+      volumeSuccessColorOverride,
+      volumeErrorColorOverride,
+      webViewLoaded,
+      chartReadyCount,
+      postMessage,
+      theme.colors.success.default,
+      theme.colors.error.default,
+    ]);
+
     useEffect(() => {
       // `webViewLoaded` (state) is in deps so this re-runs once the new WebView
       // loads; `webViewLoadedRef` is the synchronously-correct value that prevents
@@ -921,79 +997,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         payload: { heightRatio: subPaneHeightRatio ?? null },
       });
     }, [subPaneHeightRatio, chartReadyCount, postMessage]);
-
-    // Hot-swap chart colors via postMessage whenever overrides change.
-    // Gates on webViewLoaded (not chartReady) so messages sent during chart
-    // init get queued in pendingMessages and drained inside onChartReady —
-    // before the first overlay paint — eliminating stale-color flashes.
-    // Skips only the very first invocation (mount) when all color overrides
-    // still match the HTML template; all subsequent changes always send.
-    useEffect(() => {
-      if (!webViewLoaded) return;
-      if (!themeColorsSentRef.current) {
-        const effectiveCurrentPriceColor = resolveCurrentPriceColor({
-          lastValuePillColor: labelStyleOverrides?.lastValuePillColor,
-          currentPriceLineColorOverride,
-          lineColorOverride,
-          successColorOverride,
-          themeSuccessDefault: theme.colors.success.default,
-        });
-        const colorsMatch =
-          lineColorOverride === initialLineColorRef.current &&
-          successColorOverride === initialSuccessColorRef.current &&
-          errorColorOverride === initialErrorColorRef.current &&
-          effectiveCurrentPriceColor === initialCurrentPriceColorRef.current &&
-          volumeSuccessColorOverride === initialVolumeSuccessColorRef.current &&
-          volumeErrorColorOverride === initialVolumeErrorColorRef.current;
-        themeColorsSentRef.current = true;
-        if (
-          colorsMatch &&
-          currentPriceLineColorOverride === undefined &&
-          volumeSuccessColorOverride === undefined &&
-          volumeErrorColorOverride === undefined
-        )
-          return;
-      }
-      const effectiveSuccessColor =
-        successColorOverride ?? theme.colors.success.default;
-      const effectiveLineColor = lineColorOverride ?? effectiveSuccessColor;
-      const effectiveErrorColor =
-        errorColorOverride ?? theme.colors.error.default;
-      const effectiveCurrentPriceColor = resolveCurrentPriceColor({
-        lastValuePillColor: labelStyleOverrides?.lastValuePillColor,
-        currentPriceLineColorOverride,
-        lineColorOverride,
-        successColorOverride,
-        themeSuccessDefault: theme.colors.success.default,
-      });
-      const effectiveVolumeSuccessColor =
-        volumeSuccessColorOverride ?? effectiveSuccessColor;
-      const effectiveVolumeErrorColor =
-        volumeErrorColorOverride ?? effectiveErrorColor;
-      postMessage({
-        type: 'SET_THEME_COLORS',
-        payload: {
-          lineColor: effectiveLineColor,
-          successColor: effectiveSuccessColor,
-          errorColor: effectiveErrorColor,
-          currentPriceColor: effectiveCurrentPriceColor,
-          volumeSuccessColor: effectiveVolumeSuccessColor,
-          volumeErrorColor: effectiveVolumeErrorColor,
-        },
-      });
-    }, [
-      lineColorOverride,
-      successColorOverride,
-      errorColorOverride,
-      currentPriceLineColorOverride,
-      labelStyleOverrides?.lastValuePillColor,
-      volumeSuccessColorOverride,
-      volumeErrorColorOverride,
-      webViewLoaded,
-      postMessage,
-      theme.colors.success.default,
-      theme.colors.error.default,
-    ]);
 
     // On first paint, wait for indicators/legend before hiding skeleton. After the chart
     // has been revealed once, keep it visible while users toggle indicators live.

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -655,22 +655,71 @@ function applyThemeColors(payload) {
     setTheme(updated);
     const widget = getWidget();
     if (!widget || !isChartReady()) {
-        // Theme is now updated in state; the next listener / chart-ready cycle
-        // will pick it up. Mid-init theme changes are rare in practice.
         notifyListeners(updated);
         return;
     }
+    const lineColor = getThemeLineColor(updated);
     try {
         widget.applyOverrides({
             ...getCandleStyleOverrides(updated),
-            ...getSeriesColorOverrides(getThemeLineColor(updated), getThemeLastPriceLineColor(updated)),
+            ...getSeriesColorOverrides(lineColor, getThemeLastPriceLineColor(updated)),
             ...getBuiltInScaleLabelOverrides(updated),
         });
     }
     catch (error) {
         reportErrorToRN(error);
     }
+    applySeriesStyleProperties(widget, lineColor);
     notifyListeners(updated);
+}
+/**
+ * Re-apply the current theme from state to the widget. Called on chart ready
+ * to flush any SET_THEME_COLORS that arrived before the chart was initialized.
+ * Ensures the first visible frame shows the correct color, not stale CONFIG.
+ */
+function flushPendingTheme() {
+    const theme = getTheme();
+    if (!theme)
+        return;
+    const widget = getWidget();
+    if (!widget || !isChartReady())
+        return;
+    const lineColor = getThemeLineColor(theme);
+    try {
+        widget.applyOverrides({
+            ...getCandleStyleOverrides(theme),
+            ...getSeriesColorOverrides(lineColor, getThemeLastPriceLineColor(theme)),
+            ...getBuiltInScaleLabelOverrides(theme),
+        });
+    }
+    catch (error) {
+        reportErrorToRN(error);
+    }
+    applySeriesStyleProperties(widget, lineColor);
+}
+/**
+ * Directly update the live series stroke color for line (2) and baseline (10)
+ * chart styles. \`applyOverrides\` only sets widget-level defaults; this call
+ * ensures the already-rendered series picks up the new color immediately.
+ */
+function applySeriesStyleProperties(widget, lineColor) {
+    try {
+        const series = widget.activeChart().getSeries();
+        series.setChartStyleProperties(2, {
+            color: lineColor,
+            colorType: 'solid',
+            linewidth: 2,
+        });
+        series.setChartStyleProperties(10, {
+            topLineColor: lineColor,
+            bottomLineColor: lineColor,
+            topLineWidth: 2,
+            bottomLineWidth: 2,
+        });
+    }
+    catch (error) {
+        reportErrorToRN(error);
+    }
 }
 function notifyListeners(theme) {
     for (const listener of listeners) {
@@ -4873,6 +4922,7 @@ function bootstrap() {
                 timeframe: buildInitialTimeframe(),
                 onReady: (widget) => {
                     try {
+                        flushPendingTheme();
                         applyScaleLayout();
                         applyVisualOverrides(config.visualOverrides);
                         setupLegendOverlay(config.legendOverlay, config.indicatorColors);
@@ -4892,7 +4942,10 @@ function bootstrap() {
                         attachTapDismiss(widget);
                         attachMarkerHitTest(widget, chart);
                         attachVisibleRangeListeners(chart);
-                        chart.selection().onChanged().subscribe(null, () => {
+                        chart
+                            .selection()
+                            .onChanged()
+                            .subscribe(null, () => {
                             chart.selection().clear();
                         });
                         attachLegendResizeListener(widget);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/bootstrap.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/bootstrap.ts
@@ -17,7 +17,11 @@
 import { onFromRN, postToRN, reportErrorToRN } from './bridge';
 import { loadTradingViewLibrary } from './loadLibrary';
 import { dispatchInboundMessage, registerHandler } from '../messages/handler';
-import { applyThemeColors, initThemeFromConfig } from '../widget/theme';
+import {
+  applyThemeColors,
+  flushPendingTheme,
+  initThemeFromConfig,
+} from '../widget/theme';
 import { customDatafeed } from '../widget/datafeed';
 import { advancedChartPriceFormatterFactory } from '../widget/priceFormatter';
 import { getApproxBarDurationSec } from './timeUtils';
@@ -168,6 +172,7 @@ export function bootstrap(): ChartConfig {
           timeframe: buildInitialTimeframe(),
           onReady: (widget) => {
             try {
+              flushPendingTheme();
               applyScaleLayout();
               applyVisualOverrides(config.visualOverrides);
               setupLegendOverlay(config.legendOverlay, config.indicatorColors);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
@@ -150,6 +150,11 @@ export interface TVCrosshairParams {
 export interface TVMainSeries {
   /** Re-attaches the main series to the right price scale. */
   detachToRight(): void;
+  /** Directly update style properties for a specific chart type (2=line, 10=baseline, etc.). */
+  setChartStyleProperties(
+    chartStyle: number,
+    properties: Record<string, unknown>,
+  ): void;
 }
 
 /** Entity id returned by TradingView's `createShape`. */

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/theme.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/theme.test.ts
@@ -4,6 +4,7 @@
 import {
   __resetThemeForTests,
   applyThemeColors,
+  flushPendingTheme,
   getCandleStyleOverrides,
   getCurrentPriceVisualColor,
   getSeriesColorOverrides,
@@ -39,6 +40,29 @@ const baseTheme: ChartTheme = {
   primaryColor: 'rgb(0,51,255)',
   currentPriceColor: 'rgb(34,34,0)',
 };
+
+/**
+ * Creates a mock TVChartingLibraryWidget with a full activeChart → getSeries
+ * chain so applySeriesStyleProperties can be exercised.
+ */
+function createMockWidget(overrides?: {
+  applyOverrides?: jest.Mock;
+  setChartStyleProperties?: jest.Mock;
+}) {
+  const setChartStyleProperties =
+    overrides?.setChartStyleProperties ?? jest.fn();
+  const applyOverridesFn = overrides?.applyOverrides ?? jest.fn();
+  return {
+    widget: {
+      applyOverrides: applyOverridesFn,
+      activeChart: () => ({
+        getSeries: () => ({ setChartStyleProperties }),
+      }),
+    } as unknown as TVChartingLibraryWidget,
+    applyOverrides: applyOverridesFn,
+    setChartStyleProperties,
+  };
+}
 
 describe('widget/theme color helpers', () => {
   it('getThemeLineColor returns lineColor when set, else successColor', () => {
@@ -231,6 +255,243 @@ describe('initThemeFromConfig + applyThemeColors', () => {
 
     expect(bridge.postMessage).toHaveBeenCalledWith(
       expect.stringContaining('"message":"override fail"'),
+    );
+  });
+
+  it('calls setChartStyleProperties for line (2) and baseline (10) styles', () => {
+    initThemeFromConfig(baseTheme);
+    const { widget, setChartStyleProperties } = createMockWidget();
+    setWidget(widget);
+    setChartReady(true);
+
+    applyThemeColors({ lineColor: 'rgb(99,88,77)' });
+
+    expect(setChartStyleProperties).toHaveBeenCalledTimes(2);
+    expect(setChartStyleProperties).toHaveBeenCalledWith(2, {
+      color: 'rgb(99,88,77)',
+      colorType: 'solid',
+      linewidth: 2,
+    });
+    expect(setChartStyleProperties).toHaveBeenCalledWith(10, {
+      topLineColor: 'rgb(99,88,77)',
+      bottomLineColor: 'rgb(99,88,77)',
+      topLineWidth: 2,
+      bottomLineWidth: 2,
+    });
+  });
+
+  it('reports setChartStyleProperties errors to RN without throwing', () => {
+    initThemeFromConfig(baseTheme);
+    const bridge = { postMessage: jest.fn() };
+    (
+      window as unknown as { ReactNativeWebView: typeof bridge }
+    ).ReactNativeWebView = bridge;
+
+    const { widget } = createMockWidget({
+      setChartStyleProperties: jest.fn(() => {
+        throw new Error('series style fail');
+      }),
+    });
+    setWidget(widget);
+    setChartReady(true);
+
+    expect(() => applyThemeColors({ lineColor: 'rgb(1,2,3)' })).not.toThrow();
+    expect(bridge.postMessage).toHaveBeenCalledWith(
+      expect.stringContaining('"message":"series style fail"'),
+    );
+  });
+
+  it('uses successColor as lineColor fallback for series style properties', () => {
+    initThemeFromConfig({ ...baseTheme, lineColor: '' });
+    const { widget, setChartStyleProperties } = createMockWidget();
+    setWidget(widget);
+    setChartReady(true);
+
+    applyThemeColors({ successColor: 'rgb(0,200,100)' });
+
+    expect(setChartStyleProperties).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ color: 'rgb(0,200,100)' }),
+    );
+  });
+});
+
+describe('flushPendingTheme', () => {
+  beforeEach(() => {
+    __resetStateForTests();
+    __resetThemeForTests();
+    delete (window as unknown as { ReactNativeWebView?: unknown })
+      .ReactNativeWebView;
+  });
+
+  it('is a no-op when state.theme is null', () => {
+    expect(() => flushPendingTheme()).not.toThrow();
+  });
+
+  it('is a no-op when widget is null', () => {
+    initThemeFromConfig(baseTheme);
+    expect(() => flushPendingTheme()).not.toThrow();
+  });
+
+  it('is a no-op when chart is not ready', () => {
+    initThemeFromConfig(baseTheme);
+    const { widget, applyOverrides } = createMockWidget();
+    setWidget(widget);
+
+    flushPendingTheme();
+
+    expect(applyOverrides).not.toHaveBeenCalled();
+  });
+
+  it('applies full overrides and series style properties when chart is ready', () => {
+    initThemeFromConfig(baseTheme);
+    const { widget, applyOverrides, setChartStyleProperties } =
+      createMockWidget();
+    setWidget(widget);
+    setChartReady(true);
+
+    flushPendingTheme();
+
+    expect(applyOverrides).toHaveBeenCalledTimes(1);
+    const overrides = applyOverrides.mock.calls[0][0];
+    expect(overrides['mainSeriesProperties.lineStyle.color']).toBe(
+      'rgb(171,205,239)',
+    );
+    expect(overrides['mainSeriesProperties.candleStyle.upColor']).toBe(
+      'rgb(0,255,0)',
+    );
+    expect(overrides['scalesProperties.textColor']).toBe('rgb(255,255,255)');
+
+    expect(setChartStyleProperties).toHaveBeenCalledTimes(2);
+    expect(setChartStyleProperties).toHaveBeenCalledWith(2, {
+      color: 'rgb(171,205,239)',
+      colorType: 'solid',
+      linewidth: 2,
+    });
+    expect(setChartStyleProperties).toHaveBeenCalledWith(10, {
+      topLineColor: 'rgb(171,205,239)',
+      bottomLineColor: 'rgb(171,205,239)',
+      topLineWidth: 2,
+      bottomLineWidth: 2,
+    });
+  });
+
+  it('uses successColor when lineColor is empty', () => {
+    initThemeFromConfig({ ...baseTheme, lineColor: '' });
+    const { widget, applyOverrides, setChartStyleProperties } =
+      createMockWidget();
+    setWidget(widget);
+    setChartReady(true);
+
+    flushPendingTheme();
+
+    const overrides = applyOverrides.mock.calls[0][0];
+    expect(overrides['mainSeriesProperties.lineStyle.color']).toBe(
+      'rgb(0,255,0)',
+    );
+    expect(setChartStyleProperties).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ color: 'rgb(0,255,0)' }),
+    );
+  });
+
+  it('flushes the latest theme after applyThemeColors updated it', () => {
+    initThemeFromConfig(baseTheme);
+    applyThemeColors({ lineColor: 'rgb(222,111,0)' });
+
+    const { widget, applyOverrides, setChartStyleProperties } =
+      createMockWidget();
+    setWidget(widget);
+    setChartReady(true);
+
+    flushPendingTheme();
+
+    const overrides = applyOverrides.mock.calls[0][0];
+    expect(overrides['mainSeriesProperties.lineStyle.color']).toBe(
+      'rgb(222,111,0)',
+    );
+    expect(setChartStyleProperties).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ color: 'rgb(222,111,0)' }),
+    );
+  });
+
+  it('reports applyOverrides errors to RN without throwing', () => {
+    initThemeFromConfig(baseTheme);
+    const bridge = { postMessage: jest.fn() };
+    (
+      window as unknown as { ReactNativeWebView: typeof bridge }
+    ).ReactNativeWebView = bridge;
+
+    const { widget } = createMockWidget({
+      applyOverrides: jest.fn(() => {
+        throw new Error('flush override fail');
+      }),
+    });
+    setWidget(widget);
+    setChartReady(true);
+
+    expect(() => flushPendingTheme()).not.toThrow();
+    expect(bridge.postMessage).toHaveBeenCalledWith(
+      expect.stringContaining('"message":"flush override fail"'),
+    );
+  });
+
+  it('reports setChartStyleProperties errors to RN without throwing', () => {
+    initThemeFromConfig(baseTheme);
+    const bridge = { postMessage: jest.fn() };
+    (
+      window as unknown as { ReactNativeWebView: typeof bridge }
+    ).ReactNativeWebView = bridge;
+
+    const { widget } = createMockWidget({
+      setChartStyleProperties: jest.fn(() => {
+        throw new Error('flush series fail');
+      }),
+    });
+    setWidget(widget);
+    setChartReady(true);
+
+    expect(() => flushPendingTheme()).not.toThrow();
+    expect(bridge.postMessage).toHaveBeenCalledWith(
+      expect.stringContaining('"message":"flush series fail"'),
+    );
+  });
+});
+
+describe('getBuiltInScaleLabelOverrides fallback chain', () => {
+  it('falls back to sectionBackgroundColor when crosshairBackgroundColor is empty', () => {
+    const theme = { ...baseTheme, crosshairBackgroundColor: '' };
+    const overrides = getBuiltInScaleLabelOverrides(theme);
+    expect(overrides['scalesProperties.crosshairLabelBgColorDark']).toBe(
+      'rgb(34,34,34)',
+    );
+  });
+
+  it('falls back to backgroundColor when both crosshair and section are empty', () => {
+    const theme = {
+      ...baseTheme,
+      crosshairBackgroundColor: '',
+      sectionBackgroundColor: '',
+    };
+    const overrides = getBuiltInScaleLabelOverrides(theme);
+    expect(overrides['scalesProperties.crosshairLabelBgColorDark']).toBe(
+      'rgb(0,0,0)',
+    );
+  });
+
+  it('sets priceLineColor from currentPriceColor when available', () => {
+    const overrides = getBuiltInScaleLabelOverrides(baseTheme);
+    expect(overrides['mainSeriesProperties.priceLineColor']).toBe(
+      'rgb(34,34,0)',
+    );
+  });
+
+  it('falls back priceLineColor through lineColor when no currentPriceColor', () => {
+    const theme = { ...baseTheme, currentPriceColor: '' };
+    const overrides = getBuiltInScaleLabelOverrides(theme);
+    expect(overrides['mainSeriesProperties.priceLineColor']).toBe(
+      'rgb(171,205,239)',
     );
   });
 });

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/theme.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/theme.ts
@@ -15,7 +15,7 @@
 
 import { reportErrorToRN } from '../core/bridge';
 import { getWidget, isChartReady, getTheme, setTheme } from '../core/state';
-import type { ChartTheme } from '../core/types';
+import type { ChartTheme, TVChartingLibraryWidget } from '../core/types';
 import type { SetThemeColorsPayload } from '../messages/contract';
 
 type ThemeListener = (theme: ChartTheme) => void;
@@ -173,17 +173,17 @@ export function applyThemeColors(payload: SetThemeColorsPayload): void {
 
   const widget = getWidget();
   if (!widget || !isChartReady()) {
-    // Theme is now updated in state; the next listener / chart-ready cycle
-    // will pick it up. Mid-init theme changes are rare in practice.
     notifyListeners(updated);
     return;
   }
+
+  const lineColor = getThemeLineColor(updated);
 
   try {
     widget.applyOverrides({
       ...getCandleStyleOverrides(updated),
       ...getSeriesColorOverrides(
-        getThemeLineColor(updated),
+        lineColor,
         getThemeLastPriceLineColor(updated),
       ),
       ...getBuiltInScaleLabelOverrides(updated),
@@ -192,7 +192,60 @@ export function applyThemeColors(payload: SetThemeColorsPayload): void {
     reportErrorToRN(error);
   }
 
+  applySeriesStyleProperties(widget, lineColor);
+
   notifyListeners(updated);
+}
+
+/**
+ * Re-apply the current theme from state to the widget. Called on chart ready
+ * to flush any SET_THEME_COLORS that arrived before the chart was initialized.
+ * Ensures the first visible frame shows the correct color, not stale CONFIG.
+ */
+export function flushPendingTheme(): void {
+  const theme = getTheme();
+  if (!theme) return;
+  const widget = getWidget();
+  if (!widget || !isChartReady()) return;
+
+  const lineColor = getThemeLineColor(theme);
+  try {
+    widget.applyOverrides({
+      ...getCandleStyleOverrides(theme),
+      ...getSeriesColorOverrides(lineColor, getThemeLastPriceLineColor(theme)),
+      ...getBuiltInScaleLabelOverrides(theme),
+    });
+  } catch (error) {
+    reportErrorToRN(error);
+  }
+  applySeriesStyleProperties(widget, lineColor);
+}
+
+/**
+ * Directly update the live series stroke color for line (2) and baseline (10)
+ * chart styles. `applyOverrides` only sets widget-level defaults; this call
+ * ensures the already-rendered series picks up the new color immediately.
+ */
+function applySeriesStyleProperties(
+  widget: TVChartingLibraryWidget,
+  lineColor: string,
+): void {
+  try {
+    const series = widget.activeChart().getSeries();
+    series.setChartStyleProperties(2, {
+      color: lineColor,
+      colorType: 'solid',
+      linewidth: 2,
+    });
+    series.setChartStyleProperties(10, {
+      topLineColor: lineColor,
+      bottomLineColor: lineColor,
+      topLineWidth: 2,
+      bottomLineWidth: 2,
+    });
+  } catch (error) {
+    reportErrorToRN(error);
+  }
 }
 
 function notifyListeners(theme: ChartTheme): void {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

- Ports three functions from main's `chartLogic.js` that were dropped during the modular WebView refactor, causing the chart line color to desync from the header on timeframe switches
- Adds `applySeriesStyleProperties()` to directly update the live series color via `setChartStyleProperties()` (the existing `applyOverrides()` only sets widget-level defaults)
- Adds `flushPendingTheme()` (equivalent to main's `applySeriesColors()`) called inside `onChartReady` to apply any theme updates that arrived before the chart was ready
- Moves `SET_THEME_COLORS` effect above the OHLCV sync effect so colors reach the WebView before data, matching main's pending-queue drain order

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/98158985-b13e-4c96-a8d9-917a9a8f9a80



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a1675ad3-398d-4345-9045-96b4b18ccfb5



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chart init ordering and TradingView widget APIs; wrong timing could still cause brief color flashes, but scope is limited to Advanced Chart theming with solid test coverage.
> 
> **Overview**
> Fixes **chart line color drifting from the header** (e.g. on timeframe switches) by restoring color-sync behavior that was lost in the modular WebView refactor.
> 
> On the **React Native** side, the `SET_THEME_COLORS` effect is **moved above** the OHLCV sync effect so theme messages reach the WebView **before** `SET_OHLCV_DATA`, matching the old pending-queue order. The effect also depends on `chartReadyCount` so colors re-sync when the chart becomes ready again.
> 
> In the **WebView**, `applyThemeColors` now calls **`applySeriesStyleProperties`**, which uses TradingView’s `setChartStyleProperties` for line (2) and baseline (10) styles—because `applyOverrides` alone only updates defaults, not the live series. **`flushPendingTheme`** applies the current theme from state when the widget becomes ready (first thing in `onReady`), so early `SET_THEME_COLORS` messages aren’t lost and the first frame isn’t stale CONFIG colors.
> 
> Types add `setChartStyleProperties` on the main series interface; **`theme.test.ts`** gains coverage for series styling, `flushPendingTheme`, and scale-label fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f7a6b0c32457296654ed9ba0167d22e5938463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->