### PR TITLE
fix: swap tx fails when smart account upgrade is required cp-8.1.1

### DIFF
--- a/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch
+++ b/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch
@@ -1,0 +1,67 @@
+diff --git a/dist/strategy/batch-strategy.cjs b/dist/strategy/batch-strategy.cjs
+index b60e7724d2ea4b8a18a6f36b30d648ce1e624067..b3a9448eac2b8c4c228e94f12da66391d2a90d8c 100644
+--- a/dist/strategy/batch-strategy.cjs
++++ b/dist/strategy/batch-strategy.cjs
+@@ -1,7 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.submitBatchHandler = void 0;
+-const bridge_controller_1 = require("@metamask/bridge-controller");
+ const transaction_1 = require("../utils/transaction.cjs");
+ const types_1 = require("./types.cjs");
+ /**
+@@ -16,10 +15,6 @@ async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address &&
+-        (0, bridge_controller_1.isNativeAddress)(quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await (0, transaction_1.getAddTransactionBatchParams)({
+         tradeData,
+         requireApproval,
+@@ -29,11 +24,6 @@ async function* submitBatchHandler(args) {
+         disable7702: (0, transaction_1.shouldDisable7702)(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = (0, transaction_1.findAllTransactionsInBatch)({
+diff --git a/dist/strategy/batch-strategy.mjs b/dist/strategy/batch-strategy.mjs
+index 0db1331ffc2edba6341768cd8c30871440d0cab7..33ed12a6fe438b492e3521c72df5c8a63587f135 100644
+--- a/dist/strategy/batch-strategy.mjs
++++ b/dist/strategy/batch-strategy.mjs
+@@ -1,4 +1,3 @@
+-import { FeeType, isNativeAddress } from "@metamask/bridge-controller";
+ import { findAllTransactionsInBatch, getAddTransactionBatchParams, isApprovalTx, isTradeTx, shouldDisable7702, toQuoteAndTxMetadata } from "../utils/transaction.mjs";
+ import { SubmitStep } from "./types.mjs";
+ /**
+@@ -13,10 +12,6 @@ export async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address &&
+-        isNativeAddress(quoteResponse.quote.feeData[FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await getAddTransactionBatchParams({
+         tradeData,
+         requireApproval,
+@@ -26,11 +21,6 @@ export async function* submitBatchHandler(args) {
+         disable7702: shouldDisable7702(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = findAllTransactionsInBatch({

--- a/package.json
+++ b/package.json
@@ -212,7 +212,8 @@
     "@metamask/permission-controller": "^13.1.1",
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
     "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A66.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch",
-    "@metamask/keyring-controller": "^26.0.0"
+    "@metamask/keyring-controller": "^26.0.0",
+    "@metamask/bridge-status-controller@npm:^72.0.0": "patch:@metamask/bridge-status-controller@npm%3A72.0.2#~/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -244,7 +245,7 @@
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.12.0",
     "@metamask/bridge-controller": "^73.2.0",
-    "@metamask/bridge-status-controller": "^72.0.2",
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A72.0.2#~/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch",
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/chomp-api-service": "^3.1.0",
     "@metamask/client-controller": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8114,7 +8114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^72.0.0, @metamask/bridge-status-controller@npm:^72.0.2":
+"@metamask/bridge-status-controller@npm:72.0.2":
   version: 72.0.2
   resolution: "@metamask/bridge-status-controller@npm:72.0.2"
   dependencies:
@@ -8135,6 +8135,30 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/60f2849e351bfa39c60f18bf30056e0720ad39fce4982a70bdf85b71e85a7da71e9174ea93c3bbf69fa65618ae27ea9fc55ea0e9cfae14b79b7445509e962260
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A72.0.2#~/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch":
+  version: 72.0.2
+  resolution: "@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A72.0.2#~/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch::version=72.0.2&hash=8bb7e4"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^73.2.1"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/profile-sync-controller": "npm:^28.1.1"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/7af5a524616968c5f23c7cc3696b671fa361abe4e40db19d38a2b535bdc2a72e8db942c1d0cd42c55e722b69ccc2b6e964db5bb96f2d7104c26a93860446d0ec
   languageName: node
   linkType: hard
 
@@ -35355,7 +35379,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
     "@metamask/bridge-controller": "npm:^73.2.0"
-    "@metamask/bridge-status-controller": "npm:^72.0.2"
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A72.0.2#~/.yarn/patches/@metamask-bridge-status-controller-npm-72.0.2-da04917cf1.patch"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"
     "@metamask/build-utils": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->


Patches bridge-status-controller with swap batch-strategy fix in this [PR](https://github.com/MetaMask/core/pull/9431)

Fixes tx submission failures that happen when TX is enabled, account has not been upgraded, and the user receives a `gasIncluded=7702` quote

During the submission flow, passing `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` as addTransactionBatch params causes `checkGasFeeTokenBeforePublish` to throw the error. This PR removes the params so `checkGasFeeTokenBeforePublish` returns early

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: swap tx fails when smart account upgrade is required 


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32980v

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: swap tx submission

  Scenario: user requests a swap quote on the Base networkx
    Given STX is enabled, account is not upgraded and user has insufficient native balance

    When user submits a base:USDC to base:USDT quote
    Then their account is upgraded and the swap is submitted in the same tx

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how bridge/swap batched transactions are built and gas is estimated for smart-account (7702/delegated) flows; scoped to a vendor patch but affects money movement submission.
> 
> **Overview**
> Patches **`@metamask/bridge-status-controller` 72.0.2** so swap/bridge **batch submission** no longer derives **`gasFeeToken`** from quote TX fees or forwards **`gasFeeToken`**, **`skipInitialGasEstimate`**, and **`excludeNativeTokenForFee`** into **`getAddTransactionBatchParams`** in **`submitBatchHandler`**.
> 
> **`package.json`** and **`yarn.lock`** pin the dependency to this Yarn patch (including a **`^72.0.0`** resolution) instead of the unpatched package.
> 
> This reverts the 72.x behavior that skipped initial gas estimation for **gas-included 7702** flows when a **delegated (smart) account** needs an upgrade—addressing **failed swap transactions** in that scenario on the 7.81.0 cherry-pick line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 596694d22b4f975548ae70f58b3cbe9d1fdb9da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->