### PR TITLE
fix(money): vertically center Earn-on-your-crypto tooltip icon (MUSD-1139)

### DIFF
--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -102,6 +102,21 @@ const MoneyPotentialEarnings = ({
     return null;
   }
 
+  const infoIcon = onInfoPress ? (
+    <>
+      {' '}
+      <Text twClassName="align-middle">
+        <Icon
+          testID={MoneyPotentialEarningsTestIds.INFO_BUTTON}
+          name={IconName.Info}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+          onPress={onInfoPress}
+        />
+      </Text>
+    </>
+  ) : null;
+
   return (
     <Box testID={MoneyPotentialEarningsTestIds.CONTAINER}>
       <Box twClassName="px-4 py-3 gap-3">
@@ -137,19 +152,7 @@ const MoneyPotentialEarnings = ({
             {` ${strings(
               'money.potential_earnings.description_with_amounts_suffix',
             )}`}
-            {onInfoPress && (
-              <>
-                {' '}
-                <Icon
-                  testID={MoneyPotentialEarningsTestIds.INFO_BUTTON}
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                  style={{ transform: [{ translateY: 3 }] }}
-                  onPress={onInfoPress}
-                />
-              </>
-            )}
+            {infoIcon}
           </Text>
         ) : (
           <Text
@@ -158,19 +161,7 @@ const MoneyPotentialEarnings = ({
             color={TextColor.TextAlternative}
           >
             {strings('money.potential_earnings.description')}
-            {onInfoPress && (
-              <>
-                {' '}
-                <Icon
-                  testID={MoneyPotentialEarningsTestIds.INFO_BUTTON}
-                  onPress={onInfoPress}
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                  style={{ transform: [{ translateY: 3 }] }}
-                />
-              </>
-            )}
+            {infoIcon}
           </Text>
         )}
       </Box>


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The tooltip info icon (ⓘ) in the **"Earn on your crypto"** section was not vertically centered with the section description text — it sat too high relative to the line it trails.

The icon is rendered inline inside the description `<Text>` and was positioned with a hardcoded `transform: [{ translateY: 3 }]`. That magic-number nudge is both insufficient and inherently platform-inconsistent, because inline views align to different baselines on iOS vs Android.

This replaces the transform with `align-middle` (`verticalAlign: 'middle'`), the design-system-idiomatic, cross-platform way to center an inline element on the text line. The duplicated icon (copy-pasted across the amounts and fallback description branches) is also extracted into a single shared element.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the tooltip icon in the "Earn on your crypto" section so it is vertically centered with the description text.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1139

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn on your crypto tooltip alignment

  Scenario: user views the Earn on your crypto section
    Given the user is on the Money account home screen
    And the user has eligible crypto to convert

    When the "Earn on your crypto" section is displayed
    Then the tooltip info icon is vertically centered with the section description text
    And the alignment is consistent on both iOS and Android
    And other tooltip icons in the Money account are unaffected
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/297cedca-4ec7-456f-9050-2d58508e7f66" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only alignment and small refactor in one Money component; no logic or data changes.
> 
> **Overview**
> Fixes vertical alignment of the inline info (ⓘ) icon in **Earn on your crypto** (`MoneyPotentialEarnings`) so it sits on the description line instead of sitting high.
> 
> The duplicated icon markup in the “with amounts” and fallback description branches is consolidated into a shared **`infoIcon`**. Alignment no longer uses **`transform: [{ translateY: 3 }]`**; the icon is wrapped in **`Text`** with **`twClassName="align-middle"`** for cross-platform inline centering. **`onInfoPress`** behavior and test IDs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edfa626e6204ce7d847ed8463d0730021eb58d43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->