### PR TITLE
refactor: centralize MMDS Toaster in App component

### DIFF
--- a/.storybook/decorators/index.ts
+++ b/.storybook/decorators/index.ts
@@ -2,3 +2,4 @@ export { default as withMockStore } from './withMockStore';
 export { default as withNavigation } from './withNavigation';
 export { default as withSafeArea } from './withSafeArea';
 export { default as withTheme } from './withTheme';
+export { default as withToaster } from './withToaster';

--- a/.storybook/decorators/withToaster.tsx
+++ b/.storybook/decorators/withToaster.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Toaster } from '@metamask/design-system-react-native';
+
+const withToaster = (storyFn: () => React.ReactNode) => (
+  <>
+    {storyFn()}
+    <Toaster />
+  </>
+);
+
+export default withToaster;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,10 +3,12 @@ import {
   withTheme,
   withNavigation,
   withSafeArea,
+  withToaster,
 } from './decorators';
 
 export const decorators = [
   withTheme,
+  withToaster,
   withSafeArea,
   withNavigation,
   withMockStore,

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -41,6 +41,7 @@ import ModalConfirmation from '../../../component-library/components/Modals/Moda
 import Toast, {
   ToastContext,
 } from '../../../component-library/components/Toast';
+import { Toaster } from '@metamask/design-system-react-native';
 import AgentStepHud from '../../../dev-tools/AgenticService/AgentStepHud';
 import PerpsWebSocketHealthToast, {
   WebSocketHealthToastProvider,
@@ -873,6 +874,25 @@ const MultichainAddressList = () => {
   );
 };
 
+const MultichainPrivateKeyList = () => {
+  const route = useRoute();
+
+  return (
+    <NativeStack.Navigator
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+      }}
+    >
+      <NativeStack.Screen
+        name={Routes.MULTICHAIN_ACCOUNTS.PRIVATE_KEY_LIST}
+        component={MultichainAccountPrivateKeyList}
+        initialParams={route?.params}
+      />
+    </NativeStack.Navigator>
+  );
+};
+
 const MultichainAccountGroupDetails = () => {
   const route = useRoute();
   const { colors } = useTheme();
@@ -910,6 +930,15 @@ const MultichainAccountGroupDetails = () => {
       <NativeStack.Screen
         name={Routes.MULTICHAIN_ACCOUNTS.ADDRESS_LIST}
         component={MultichainAddressList}
+        options={{
+          ...slideFromRightNativeOptions,
+          presentation: 'card',
+          contentStyle: { backgroundColor: colors.background.default },
+        }}
+      />
+      <NativeStack.Screen
+        name={Routes.MULTICHAIN_ACCOUNTS.PRIVATE_KEY_LIST}
+        component={MultichainPrivateKeyList}
         options={{
           ...slideFromRightNativeOptions,
           presentation: 'card',
@@ -990,25 +1019,6 @@ const MultichainAccountDetailsActions = () => {
       <NativeStack.Screen
         name={Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.REVEAL_SRP_CREDENTIAL}
         component={RevealSRP}
-        initialParams={route?.params}
-      />
-    </NativeStack.Navigator>
-  );
-};
-
-const MultichainPrivateKeyList = () => {
-  const route = useRoute();
-
-  return (
-    <NativeStack.Navigator
-      screenOptions={{
-        headerShown: false,
-        animation: 'slide_from_right',
-      }}
-    >
-      <NativeStack.Screen
-        name={Routes.MULTICHAIN_ACCOUNTS.PRIVATE_KEY_LIST}
-        component={MultichainAccountPrivateKeyList}
         initialParams={route?.params}
       />
     </NativeStack.Navigator>
@@ -1374,6 +1384,16 @@ const App: React.FC = () => {
         <RampsBootstrap />
         <AppFlow />
         <Toast ref={toastRef} />
+        {/*
+          FullWindowOverlay (iOS) renders in a UIWindow above every native layer —
+          including native-stack modal screens — which a plain absolute View in the
+          JS root cannot reach (see AgentStepHud). We mount <Toaster /> as a sibling
+          after <AppFlow /> instead: MMDS toasts use absolute bottom positioning and
+          verified flows (address list, private key list, account connect) render
+          correctly without the extra window. Revisit FullWindowOverlay if a toast is
+          hidden behind a top-level AppFlow card push.
+        */}
+        <Toaster />
         <PerpsWebSocketHealthToast />
         {__DEV__ && <AgentStepHud />}
         <ControllerEventToastBridge registrations={toastRegistrations} />

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import { FullWindowOverlay } from 'react-native-screens';
 import { useRoute } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
@@ -1385,15 +1386,15 @@ const App: React.FC = () => {
         <AppFlow />
         <Toast ref={toastRef} />
         {/*
-          FullWindowOverlay (iOS) renders in a UIWindow above every native layer —
-          including native-stack modal screens — which a plain absolute View in the
-          JS root cannot reach (see AgentStepHud). We mount <Toaster /> as a sibling
-          after <AppFlow /> instead: MMDS toasts use absolute bottom positioning and
-          verified flows (address list, private key list, account connect) render
-          correctly without the extra window. Revisit FullWindowOverlay if a toast is
-          hidden behind a top-level AppFlow card push.
+          FullWindowOverlay (iOS) renders <Toaster /> in a UIWindow above every native
+          layer — including native-stack card screens — which a plain absolute View as a
+          sibling of <AppFlow /> cannot reach. On Android it is a passthrough. Legacy
+          <Toast /> stays outside the overlay; MMDS toasts require this wrapper to show
+          on pushed flows such as address list, private key list, and account connect.
         */}
-        <Toaster />
+        <FullWindowOverlay>
+          <Toaster />
+        </FullWindowOverlay>
         <PerpsWebSocketHealthToast />
         {__DEV__ && <AgentStepHud />}
         <ControllerEventToastBridge registrations={toastRegistrations} />

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1388,9 +1388,8 @@ const App: React.FC = () => {
         {/*
           FullWindowOverlay (iOS) renders <Toaster /> in a UIWindow above every native
           layer — including native-stack card screens — which a plain absolute View as a
-          sibling of <AppFlow /> cannot reach. On Android it is a passthrough. Legacy
-          <Toast /> stays outside the overlay; MMDS toasts require this wrapper to show
-          on pushed flows such as address list, private key list, and account connect.
+          sibling of <AppFlow /> cannot reach. Without this wrapper some Toasts render 
+          behind the native stack card screens and are not visible.
         */}
         <FullWindowOverlay>
           <Toaster />

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -397,7 +397,8 @@ describe('AddressList', () => {
 
       await waitFor(() => {
         expect(toast).toHaveBeenCalledWith({
-          description: strings('notifications.address_copied_to_clipboard'),
+          title: strings('notifications.address_copied_to_clipboard'),
+          severity: 'success',
           hasNoTimeout: false,
         });
       });

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -398,7 +398,6 @@ describe('AddressList', () => {
       await waitFor(() => {
         expect(toast).toHaveBeenCalledWith({
           title: strings('notifications.address_copied_to_clipboard'),
-          severity: 'success',
           hasNoTimeout: false,
         });
       });

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -98,9 +98,8 @@ export const AddressList = () => {
             callback: async () => {
               await copyAddressToClipboard();
               toast({
-                description: strings(
-                  'notifications.address_copied_to_clipboard',
-                ),
+                title: strings('notifications.address_copied_to_clipboard'),
+                severity: 'success',
                 hasNoTimeout: false,
               });
             },

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -10,7 +10,7 @@ import {
   selectInternalAccountListSpreadByScopesByGroupId,
   selectInternalAccountsByGroupId,
 } from '../../../../selectors/multichainAccounts/accounts';
-import { IconName, Toaster, toast } from '@metamask/design-system-react-native';
+import { IconName, toast } from '@metamask/design-system-react-native';
 import MultichainAddressRow, {
   MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID,
 } from '../../../../component-library/components-temp/MultichainAccounts/MultichainAddressRow';
@@ -156,7 +156,6 @@ export const AddressList = () => {
         renderItem={renderAddressItem}
         onLoad={onLoad}
       />
-      <Toaster />
     </View>
   );
 };

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -99,7 +99,6 @@ export const AddressList = () => {
               await copyAddressToClipboard();
               toast({
                 title: strings('notifications.address_copied_to_clipboard'),
-                severity: 'success',
                 hasNoTimeout: false,
               });
             },

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.stories.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { AccountGroupType, AccountGroupId } from '@metamask/account-api';
-import { Box, Toaster } from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
@@ -211,7 +211,6 @@ const MultichainAccountConnectMeta = {
         <MockNavigationWrapper>
           <Box twClassName="flex-1 bg-default">
             <Story />
-            <Toaster />
           </Box>
         </MockNavigationWrapper>
       </Provider>

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -722,7 +722,7 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
       );
 
       toast({
-        description:
+        title:
           connectedAccountLength >= 1
             ? strings('toast.permissions_updated')
             : undefined,

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -17,7 +17,6 @@ import {
   AvatarFavicon,
   AvatarFaviconSize,
   Box,
-  Toaster,
   toast,
 } from '@metamask/design-system-react-native';
 import { USER_INTENT } from '../../../../constants/permissions.ts';
@@ -1002,7 +1001,6 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
         </ScreenContainer>
       )}
       {renderPhishingModal()}
-      <Toaster />
     </Box>
   );
 };

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.test.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.test.tsx
@@ -287,7 +287,8 @@ describe('PrivateKeyList', () => {
 
     await waitFor(() => {
       expect(toast).toHaveBeenCalledWith({
-        description: strings('multichain_accounts.private_key_list.copied'),
+        title: strings('multichain_accounts.private_key_list.copied'),
+        severity: 'success',
         hasNoTimeout: false,
       });
     });

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.test.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.test.tsx
@@ -288,7 +288,6 @@ describe('PrivateKeyList', () => {
     await waitFor(() => {
       expect(toast).toHaveBeenCalledWith({
         title: strings('multichain_accounts.private_key_list.copied'),
-        severity: 'success',
         hasNoTimeout: false,
       });
     });

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -25,7 +25,6 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-  Toaster,
   toast,
 } from '@metamask/design-system-react-native';
 import Engine from '../../../../core/Engine';
@@ -326,7 +325,6 @@ export const PrivateKeyList = () => {
       />
 
       {reveal ? renderPrivateKeyList() : renderPassword()}
-      <Toaster />
     </Box>
   );
 };

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -188,7 +188,6 @@ export const PrivateKeyList = () => {
             );
             toast({
               title: strings('multichain_accounts.private_key_list.copied'),
-              severity: 'success',
               hasNoTimeout: false,
             });
           },

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -187,9 +187,8 @@ export const PrivateKeyList = () => {
               privateKeys[item.account.id],
             );
             toast({
-              description: strings(
-                'multichain_accounts.private_key_list.copied',
-              ),
+              title: strings('multichain_accounts.private_key_list.copied'),
+              severity: 'success',
               hasNoTimeout: false,
             });
           },

--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -32,6 +32,7 @@ import {
   createUIMessenger,
   UIMessenger,
 } from '../../../messengers/ui-messenger';
+import { Toaster } from '@metamask/design-system-react-native';
 
 const styles = StyleSheet.create({
   gestureRoot: {
@@ -120,6 +121,7 @@ const Root = ({ foxCode }: RootProps) => {
                                   mode={ReduceMotion.Never}
                                 />
                                 <App />
+                                <Toaster />
                               </HardwareWalletProvider>
                             </ToastContextWrapper>
                           </UIMessengerProvider>

--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -32,7 +32,6 @@ import {
   createUIMessenger,
   UIMessenger,
 } from '../../../messengers/ui-messenger';
-import { Toaster } from '@metamask/design-system-react-native';
 
 const styles = StyleSheet.create({
   gestureRoot: {
@@ -121,7 +120,6 @@ const Root = ({ foxCode }: RootProps) => {
                                   mode={ReduceMotion.Never}
                                 />
                                 <App />
-                                <Toaster />
                               </HardwareWalletProvider>
                             </ToastContextWrapper>
                           </UIMessengerProvider>


### PR DESCRIPTION
## **Description**

MMDS `toast()` requires exactly one mounted `<Toaster />` host to register its imperative API. Several multichain account screens each mounted their own `<Toaster />`, which risks duplicate hosts and toasts that never appear when `toast()` is called from a screen without a local host.

This PR centralizes MMDS toast rendering in `App.tsx` beside the legacy `<Toast />`, removes per-screen `<Toaster />` instances from AddressList, PrivateKeyList, and MultichainAccountConnect, and adds a global Storybook `withToaster` decorator so stories keep working outside the app shell.

Additional changes:
- Wrap `<Toaster />` in `FullWindowOverlay` on iOS so copy/permissions toasts render above native-stack card screens
- Register `PRIVATE_KEY_LIST` in the account group details nested stack (parity with address list navigation from Account Details)
- Migrate `toast()` calls from `description` to `title` for primary message copy; use `description` only when secondary supporting text is needed

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: Centralized MMDS Toaster

  Scenario: Copy address from account address list
    Given a wallet with a multichain account
    And the user opens Account Details then Addresses
    When the user copies an address
    Then a toast shows "Address copied to clipboard"

  Scenario: Copy private key from private key list
    Given a wallet with a multichain account
    And the user opens Account Details then Private keys
    And the user unlocks with the correct password
    When the user copies a private key
    Then a toast shows the private key copied message

  Scenario: Connect accounts permission update toast
    Given a dapp connection flow with MultichainAccountConnect
    When the user updates connected accounts
    Then a permissions updated toast appears with the site favicon
```

## **Screenshots/Recordings**

Screen recordings for the verified flows are attached in inline PR comments on the affected files (easier to review next to the code). Before/after sections below are N/A for this refactor.

### **Before**

N/A

### **After**

N/A (see inline comment recordings on `AddressList.tsx`, `PrivateKeyList.tsx`, and `MultichainAccountConnect.tsx`)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.