### PR TITLE
feat: MUSD-1140 add sentry tracing for money account balance service network requests cp-8.3.0

### DIFF
--- a/app/core/Engine/controllers/money-account-balance-service-init.test.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.test.ts
@@ -1,3 +1,4 @@
+import { AppState } from 'react-native';
 import { buildMessengerClientInitRequestMock } from '../utils/test-utils';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getMoneyAccountBalanceServiceMessenger } from '../messengers/money-account-balance-service-messenger';
@@ -8,12 +9,18 @@ import {
   MoneyAccountBalanceServiceMessenger,
 } from '@metamask/money-account-balance-service';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { trace } from '../../../util/trace';
 
 jest.mock('@metamask/money-account-balance-service', () => ({
   ...jest.requireActual('@metamask/money-account-balance-service'),
   MoneyAccountBalanceService: jest.fn().mockImplementation(() => ({
     init: jest.fn(),
   })),
+}));
+
+jest.mock('../../../util/trace', () => ({
+  ...jest.requireActual('../../../util/trace'),
+  trace: jest.fn(),
 }));
 
 function getInitRequestMock(): jest.Mocked<
@@ -53,5 +60,101 @@ describe('moneyAccountBalanceServiceInit', () => {
 
     const serviceMock = jest.mocked(MoneyAccountBalanceService);
     expect(serviceMock.mock.results[0].value.init).toHaveBeenCalled();
+  });
+});
+
+describe('trace tagging', () => {
+  type TracedFn = (
+    request: { name: string; data?: Record<string, unknown> },
+    fn?: (...args: unknown[]) => unknown,
+  ) => unknown;
+
+  const getTracedFn = (): TracedFn => {
+    const serviceMock = jest.mocked(MoneyAccountBalanceService);
+    const passedOptions = serviceMock.mock.calls[0][0];
+    return passedOptions.trace as unknown as TracedFn;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'active',
+      configurable: true,
+    });
+  });
+
+  it('tags trace requests with the current app state', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'background',
+      configurable: true,
+    });
+    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const tracedFn = getTracedFn();
+
+    tracedFn({ name: 'test-op' });
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ app_state: 'background' }),
+      }),
+      undefined,
+    );
+  });
+
+  it('tags trace requests with unknown app state when currentState is unset', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: undefined,
+      configurable: true,
+    });
+    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const tracedFn = getTracedFn();
+
+    tracedFn({ name: 'test-op' });
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ app_state: 'unknown' }),
+      }),
+      undefined,
+    );
+  });
+
+  it('preserves data already provided by the caller', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'active',
+      configurable: true,
+    });
+    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const tracedFn = getTracedFn();
+
+    tracedFn({ name: 'test-op', data: { address: '0x123' } });
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'test-op',
+        data: expect.objectContaining({
+          address: '0x123',
+          app_state: 'active',
+        }),
+      }),
+      undefined,
+    );
+  });
+
+  it('forwards the callback function to trace', () => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: 'active',
+      configurable: true,
+    });
+    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const tracedFn = getTracedFn();
+    const callback = jest.fn();
+
+    tracedFn({ name: 'test-op' }, callback);
+
+    expect(trace).toHaveBeenCalledWith(expect.anything(), callback);
   });
 });

--- a/app/core/Engine/controllers/money-account-balance-service-init.test.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.test.ts
@@ -46,6 +46,10 @@ const getServiceConstructorOptions = (): MoneyAccountBalanceServiceOptions => {
 };
 
 describe('moneyAccountBalanceServiceInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns a MoneyAccountBalanceService instance', () => {
     const initRequest = getInitRequestMock();
 
@@ -127,6 +131,7 @@ describe('trace tagging', () => {
         tags: { source: 'unit-test' },
         data: expect.objectContaining({ app_state: 'background' }),
       }),
+      expect.any(Function),
     );
   });
 
@@ -141,6 +146,7 @@ describe('trace tagging', () => {
       expect.objectContaining({
         data: expect.objectContaining({ app_state: 'unknown' }),
       }),
+      expect.any(Function),
     );
   });
 
@@ -159,6 +165,7 @@ describe('trace tagging', () => {
           app_state: 'active',
         }),
       }),
+      expect.any(Function),
     );
   });
 

--- a/app/core/Engine/controllers/money-account-balance-service-init.test.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.test.ts
@@ -6,10 +6,13 @@ import { MessengerClientInitRequest } from '../types';
 import { moneyAccountBalanceServiceInit } from './money-account-balance-service-init';
 import {
   MoneyAccountBalanceService,
+  MoneyAccountBalanceServiceOptions,
   MoneyAccountBalanceServiceMessenger,
+  MoneyAccountBalanceServiceTraceCallback,
+  MoneyAccountBalanceServiceTraceRequest,
 } from '@metamask/money-account-balance-service';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
-import { trace } from '../../../util/trace';
+import { trace, TraceOperation } from '../../../util/trace';
 
 jest.mock('@metamask/money-account-balance-service', () => ({
   ...jest.requireActual('@metamask/money-account-balance-service'),
@@ -37,26 +40,36 @@ function getInitRequestMock(): jest.Mocked<
   };
 }
 
+const getServiceConstructorOptions = (): MoneyAccountBalanceServiceOptions => {
+  const serviceMock = jest.mocked(MoneyAccountBalanceService);
+  return serviceMock.mock.calls[0][0];
+};
+
 describe('moneyAccountBalanceServiceInit', () => {
   it('returns a MoneyAccountBalanceService instance', () => {
-    const { controller } = moneyAccountBalanceServiceInit(getInitRequestMock());
+    const initRequest = getInitRequestMock();
 
-    expect(controller).toBeDefined();
+    const { controller } = moneyAccountBalanceServiceInit(initRequest);
+
+    expect(controller).toBe(
+      jest.mocked(MoneyAccountBalanceService).mock.results[0].value,
+    );
   });
 
   it('passes messenger to the service', () => {
-    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const initRequest = getInitRequestMock();
 
-    const serviceMock = jest.mocked(MoneyAccountBalanceService);
-    expect(serviceMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        messenger: expect.any(Object),
-      }),
+    moneyAccountBalanceServiceInit(initRequest);
+
+    expect(getServiceConstructorOptions().messenger).toStrictEqual(
+      initRequest.controllerMessenger,
     );
   });
 
   it('calls init on the service', () => {
-    moneyAccountBalanceServiceInit(getInitRequestMock());
+    const initRequest = getInitRequestMock();
+
+    moneyAccountBalanceServiceInit(initRequest);
 
     const serviceMock = jest.mocked(MoneyAccountBalanceService);
     expect(serviceMock.mock.results[0].value.init).toHaveBeenCalled();
@@ -64,15 +77,30 @@ describe('moneyAccountBalanceServiceInit', () => {
 });
 
 describe('trace tagging', () => {
-  type TracedFn = (
-    request: { name: string; data?: Record<string, unknown> },
-    fn?: (...args: unknown[]) => unknown,
-  ) => unknown;
+  const createTraceRequest = (
+    overrides: Partial<MoneyAccountBalanceServiceTraceRequest> = {},
+  ): MoneyAccountBalanceServiceTraceRequest => ({
+    id: 'test-trace-id',
+    name: 'Get Money Account Balance RPC',
+    startTime: 1000,
+    tags: { source: 'unit-test' },
+    data: {},
+    ...overrides,
+  });
 
-  const getTracedFn = (): TracedFn => {
-    const serviceMock = jest.mocked(MoneyAccountBalanceService);
-    const passedOptions = serviceMock.mock.calls[0][0];
-    return passedOptions.trace as unknown as TracedFn;
+  const getTraceCallback = (): MoneyAccountBalanceServiceTraceCallback => {
+    const traceCallback = getServiceConstructorOptions().trace;
+    if (!traceCallback) {
+      throw new Error('MoneyAccountBalanceService trace callback was not set');
+    }
+    return traceCallback;
+  };
+
+  const setAppStateCurrentState = (currentState: string | undefined) => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: currentState,
+      configurable: true,
+    });
   };
 
   beforeEach(() => {
@@ -80,80 +108,67 @@ describe('trace tagging', () => {
   });
 
   afterEach(() => {
-    Object.defineProperty(AppState, 'currentState', {
-      value: 'active',
-      configurable: true,
-    });
+    setAppStateCurrentState('active');
   });
 
-  it('tags trace requests with the current app state', () => {
-    Object.defineProperty(AppState, 'currentState', {
-      value: 'background',
-      configurable: true,
-    });
+  it('passes trace callback that tags requests with the current app state', async () => {
+    setAppStateCurrentState('background');
     moneyAccountBalanceServiceInit(getInitRequestMock());
-    const tracedFn = getTracedFn();
+    const traceCallback = getTraceCallback();
 
-    tracedFn({ name: 'test-op' });
+    await traceCallback(createTraceRequest());
 
     expect(trace).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: 'test-trace-id',
+        name: 'Get Money Account Balance RPC',
+        startTime: 1000,
+        op: TraceOperation.MoneyAccountDataFetch,
+        tags: { source: 'unit-test' },
         data: expect.objectContaining({ app_state: 'background' }),
       }),
-      undefined,
     );
   });
 
-  it('tags trace requests with unknown app state when currentState is unset', () => {
-    Object.defineProperty(AppState, 'currentState', {
-      value: undefined,
-      configurable: true,
-    });
+  it('tags trace requests with unknown app state when currentState is unset', async () => {
+    setAppStateCurrentState(undefined);
     moneyAccountBalanceServiceInit(getInitRequestMock());
-    const tracedFn = getTracedFn();
+    const traceCallback = getTraceCallback();
 
-    tracedFn({ name: 'test-op' });
+    await traceCallback(createTraceRequest());
 
     expect(trace).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ app_state: 'unknown' }),
       }),
-      undefined,
     );
   });
 
-  it('preserves data already provided by the caller', () => {
-    Object.defineProperty(AppState, 'currentState', {
-      value: 'active',
-      configurable: true,
-    });
+  it('preserves data already provided by the caller', async () => {
+    setAppStateCurrentState('active');
     moneyAccountBalanceServiceInit(getInitRequestMock());
-    const tracedFn = getTracedFn();
+    const traceCallback = getTraceCallback();
 
-    tracedFn({ name: 'test-op', data: { address: '0x123' } });
+    await traceCallback(createTraceRequest({ data: { address: '0x123' } }));
 
     expect(trace).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: 'test-op',
+        name: 'Get Money Account Balance RPC',
         data: expect.objectContaining({
           address: '0x123',
           app_state: 'active',
         }),
       }),
-      undefined,
     );
   });
 
-  it('forwards the callback function to trace', () => {
-    Object.defineProperty(AppState, 'currentState', {
-      value: 'active',
-      configurable: true,
-    });
+  it('forwards the callback function to trace', async () => {
+    setAppStateCurrentState('active');
     moneyAccountBalanceServiceInit(getInitRequestMock());
-    const tracedFn = getTracedFn();
+    const traceCallback = getTraceCallback();
     const callback = jest.fn();
 
-    tracedFn({ name: 'test-op' }, callback);
+    await traceCallback(createTraceRequest(), callback);
 
     expect(trace).toHaveBeenCalledWith(expect.anything(), callback);
   });

--- a/app/core/Engine/controllers/money-account-balance-service-init.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.ts
@@ -3,27 +3,34 @@ import { MessengerClientInitFunction } from '../types';
 import {
   MoneyAccountBalanceService,
   MoneyAccountBalanceServiceMessenger,
+  MoneyAccountBalanceServiceTraceCallback,
+  MoneyAccountBalanceServiceTraceRequest,
 } from '@metamask/money-account-balance-service';
-import { trace, TraceOperation } from '../../../util/trace';
+import type { TraceContext } from '@metamask/controller-utils';
+import { trace, TraceOperation, TraceRequest } from '../../../util/trace';
 
-// TODO: Clean up typing in file after testing
-const traceMoneyAccountDataFetch = (
-  request: Record<string, unknown>,
-  fn?: (...args: unknown[]) => unknown,
-) => {
-  const taggedRequest = {
-    ...request,
-    op: TraceOperation.MoneyAccountDataFetch,
-    data: {
-      ...(request.data as Record<string, unknown> | undefined),
-      app_state: AppState.currentState ?? 'unknown',
-    },
+const traceMoneyAccountDataFetch: MoneyAccountBalanceServiceTraceCallback =
+  async <ReturnType>(
+    request: MoneyAccountBalanceServiceTraceRequest,
+    fn?: (context?: TraceContext) => ReturnType,
+  ): Promise<ReturnType> => {
+    const taggedRequest: TraceRequest = {
+      id: request.id,
+      name: request.name as TraceRequest['name'],
+      startTime: request.startTime,
+      op: TraceOperation.MoneyAccountDataFetch,
+      tags: request.tags,
+      data: {
+        ...request.data,
+        app_state: AppState.currentState ?? 'unknown',
+      },
+    };
+    if (!fn) {
+      trace(taggedRequest);
+      return undefined as ReturnType;
+    }
+    return await Promise.resolve(trace(taggedRequest, fn));
   };
-
-  // Remove disabled rule after testing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (trace as any)(taggedRequest, fn);
-};
 
 /**
  * Initialize the money account balance service.
@@ -38,9 +45,7 @@ export const moneyAccountBalanceServiceInit: MessengerClientInitFunction<
 > = ({ controllerMessenger }) => {
   const controller = new MoneyAccountBalanceService({
     messenger: controllerMessenger,
-    // Remove disabled rule after testing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    trace: traceMoneyAccountDataFetch as any,
+    trace: traceMoneyAccountDataFetch,
   });
 
   controller.init();

--- a/app/core/Engine/controllers/money-account-balance-service-init.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.ts
@@ -12,7 +12,7 @@ import { trace, TraceOperation, TraceRequest } from '../../../util/trace';
 const traceMoneyAccountDataFetch: MoneyAccountBalanceServiceTraceCallback =
   async <ReturnType>(
     request: MoneyAccountBalanceServiceTraceRequest,
-    fn?: (context?: TraceContext) => ReturnType,
+    fn: (context?: TraceContext) => ReturnType = () => undefined as ReturnType,
   ): Promise<ReturnType> => {
     const taggedRequest: TraceRequest = {
       id: request.id,
@@ -25,10 +25,6 @@ const traceMoneyAccountDataFetch: MoneyAccountBalanceServiceTraceCallback =
         app_state: AppState.currentState ?? 'unknown',
       },
     };
-    if (!fn) {
-      trace(taggedRequest);
-      return undefined as ReturnType;
-    }
     return await Promise.resolve(trace(taggedRequest, fn));
   };
 

--- a/app/core/Engine/controllers/money-account-balance-service-init.ts
+++ b/app/core/Engine/controllers/money-account-balance-service-init.ts
@@ -1,8 +1,29 @@
+import { AppState } from 'react-native';
 import { MessengerClientInitFunction } from '../types';
 import {
   MoneyAccountBalanceService,
   MoneyAccountBalanceServiceMessenger,
 } from '@metamask/money-account-balance-service';
+import { trace, TraceOperation } from '../../../util/trace';
+
+// TODO: Clean up typing in file after testing
+const traceMoneyAccountDataFetch = (
+  request: Record<string, unknown>,
+  fn?: (...args: unknown[]) => unknown,
+) => {
+  const taggedRequest = {
+    ...request,
+    op: TraceOperation.MoneyAccountDataFetch,
+    data: {
+      ...(request.data as Record<string, unknown> | undefined),
+      app_state: AppState.currentState ?? 'unknown',
+    },
+  };
+
+  // Remove disabled rule after testing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (trace as any)(taggedRequest, fn);
+};
 
 /**
  * Initialize the money account balance service.
@@ -17,6 +38,9 @@ export const moneyAccountBalanceServiceInit: MessengerClientInitFunction<
 > = ({ controllerMessenger }) => {
   const controller = new MoneyAccountBalanceService({
     messenger: controllerMessenger,
+    // Remove disabled rule after testing
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    trace: traceMoneyAccountDataFetch as any,
   });
 
   controller.init();

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -314,6 +314,7 @@ export enum TraceOperation {
   HomepageSectionPerformance = 'homepage.section.performance',
   // Money Home Performance
   MoneyHomePerformance = 'money.home.performance',
+  MoneyAccountDataFetch = 'money.account.data_fetch',
   /** Token overview OHLCV WebView: initial load or asset/currency change */
   TokenOverviewAdvancedChart = 'token_overview.advanced_chart',
   /** Token overview OHLCV WebView: time range change only */

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-balance-service": "^2.1.0",
+    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.2.0",
     "@metamask/multichain-account-service": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service",
+    "@metamask/money-account-balance-service": "^2.2.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.2.0",
     "@metamask/multichain-account-service": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9344,9 +9344,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service::locator=metamask%40workspace%3A.":
-  version: 2.1.2
-  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=5cdae2&locator=metamask%40workspace%3A."
+"@metamask/money-account-balance-service@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@metamask/money-account-balance-service@npm:2.2.0"
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
@@ -9358,7 +9358,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/ed332bb141f951f0fdf900d67e3908e27f14fa47fdb52266e2b238a418d7ebee58275d0771f19ebb069e73f293fb4b3035246b40472e24162de6e13e5153faa6
+  checksum: 10/d9f64c561b6ec4338e73b6a4e7315d102ef63f627f7fed53b9a3a36479b47651cab99b66a71e5b9178d1a447b864d30b087c8a597275a90462857b8ad87bd277
   languageName: node
   linkType: hard
 
@@ -35806,7 +35806,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service"
+    "@metamask/money-account-balance-service": "npm:^2.2.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.2.0"
     "@metamask/multichain-account-service": "npm:^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9344,21 +9344,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-balance-service@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/money-account-balance-service@npm:2.1.0"
+"@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service::locator=metamask%40workspace%3A.":
+  version: 2.1.2
+  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=e66321&locator=metamask%40workspace%3A."
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/base-data-service": "npm:^0.1.3"
-    "@metamask/controller-utils": "npm:^12.2.0"
-    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/3bc2947f2b93c0d3ceaa5637c728998153d3dc1a2bf4b6e6d503b9cf4e8cbf8288f76189b378e190c67d324652985cd6fc48c55506511f972f94e6e837b3df89
+  checksum: 10/cddd04a1c1978cf321f95c830f0caf7856d7070eba7ccf69c3a35ed2277746c1ec11a8023ce38c5bb2c3863dbe79acf345980b52ae47bfc645688a1a9c58d43d
   languageName: node
   linkType: hard
 
@@ -35806,7 +35806,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-balance-service": "npm:^2.1.0"
+    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.2.0"
     "@metamask/multichain-account-service": "npm:^11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9346,7 +9346,7 @@ __metadata:
 
 "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service::locator=metamask%40workspace%3A.":
   version: 2.1.2
-  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=e66321&locator=metamask%40workspace%3A."
+  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=5cdae2&locator=metamask%40workspace%3A."
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
@@ -9358,7 +9358,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/cddd04a1c1978cf321f95c830f0caf7856d7070eba7ccf69c3a35ed2277746c1ec11a8023ce38c5bb2c3863dbe79acf345980b52ae47bfc645688a1a9c58d43d
+  checksum: 10/ed332bb141f951f0fdf900d67e3908e27f14fa47fdb52266e2b238a418d7ebee58275d0771f19ebb069e73f293fb4b3035246b40472e24162de6e13e5153faa6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Wires Sentry tracing into `MoneyAccountBalanceService` so its network requests show up as spans instead of being invisible to us in production. We had no way to tell how long balance fetches take or spot regressions, so this bumps the service package to `2.2.0` (which adds the trace callback hook) and passes in a callback that tags each span with app foreground/background state and forwards it to our existing `trace()` util under a new `MoneyAccountDataFetch` operation.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1140: Add Sentry tracing for money-account-balance-service network requests](https://consensyssoftware.atlassian.net/browse/MUSD-1140)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account balance service tracing

  Scenario: user opens the Money home screen
    Given the user has a Money account
    When the app fetches the account balance
    Then a "money.account.data_fetch" span is recorded in Sentry with the current app state
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — instrumentation-only change, verified via Sentry span output rather than UI.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
