### PR TITLE
chore: memoize useBridgeQuoteData

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -364,24 +364,43 @@ export const useBridgeQuoteData = ({
     }
   }, [manuallySelectedQuote, dispatch]);
 
-  const returnValue = {
-    bestQuote,
-    quoteFetchError,
-    activeQuote,
-    quotesLoadingStatus,
-    destTokenAmount,
-    isLoading,
-    formattedQuoteData,
-    isNoQuotesAvailable,
-    willRefresh,
-    isExpired,
-    blockaidError,
-    shouldShowPriceImpactWarning,
-    validQuotes,
-    needsNewQuote,
-    isActiveQuoteForCurrentTokenPair:
-      isQuoteSourceTokenMatch && isQuoteDestTokenMatch,
-  };
+  const isActiveQuoteForCurrentTokenPair =
+    isQuoteSourceTokenMatch && isQuoteDestTokenMatch;
 
-  return returnValue;
+  return useMemo(
+    () => ({
+      bestQuote,
+      quoteFetchError,
+      activeQuote,
+      quotesLoadingStatus,
+      destTokenAmount,
+      isLoading,
+      formattedQuoteData,
+      isNoQuotesAvailable,
+      willRefresh,
+      isExpired,
+      blockaidError,
+      shouldShowPriceImpactWarning,
+      validQuotes,
+      needsNewQuote,
+      isActiveQuoteForCurrentTokenPair,
+    }),
+    [
+      bestQuote,
+      quoteFetchError,
+      activeQuote,
+      quotesLoadingStatus,
+      destTokenAmount,
+      isLoading,
+      formattedQuoteData,
+      isNoQuotesAvailable,
+      willRefresh,
+      isExpired,
+      blockaidError,
+      shouldShowPriceImpactWarning,
+      validQuotes,
+      needsNewQuote,
+      isActiveQuoteForCurrentTokenPair,
+    ],
+  );
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -1849,4 +1849,31 @@ describe('useBridgeQuoteData', () => {
       expect(result.current.willRefresh).toBe(true);
     });
   });
+
+  describe('memoization', () => {
+    it('keeps the same return object reference when inputs do not change', () => {
+      const bridgeQuotes = {
+        recommendedQuote: mockQuoteWithMetadata,
+        alternativeQuotes: [],
+      };
+      (selectBridgeQuotes as unknown as jest.Mock).mockReturnValue(
+        bridgeQuotes,
+      );
+
+      const testState = createBridgeTestState({});
+
+      const { result, rerender } = renderHookWithProvider(
+        () => useBridgeQuoteData(),
+        {
+          state: testState,
+        },
+      );
+
+      const firstResult = result.current;
+
+      rerender({ state: testState });
+
+      expect(result.current).toBe(firstResult);
+    });
+  });
 });


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


This PR fixes unnecessary Bridge quote context value churn reported in [#31370](https://github.com/MetaMask/metamask-mobile/issues/31370). `useBridgeQuoteData` previously returned a fresh object on every render, which meant `BridgeQuoteDataProvider` passed a new context value reference to consumers even when the returned quote data fields were unchanged.

The hook now memoizes its final return object with dependencies for every returned field. This keeps the context value reference stable when quote data has not changed, while still producing a new value when quote, loading, validation, or token-pair state changes.

Validation evidence from a temporary in-app provider identity probe:

| Metric | Before Fix | After Fix | Result |
| --- | ---: | ---: | --- |
| Provider renders | 36 | 37 | 🟡 About same |
| Initial value references | 1 | 1 | 🟡 About same |
| Same value references | 0 | 14 | 🟢 Improved |
| Changed value references | 35 | 22 | 🟢 Improved |
| Post-initial unchanged reference rate | 0 / 35 (0.0%) | 14 / 36 (38.9%) | 🟢 Improved |
| Post-initial changed reference rate | 35 / 35 (100.0%) | 22 / 36 (61.1%) | 🟢 Improved |

Raw probe logs:

```text
Before:
[MMM-31370] BridgeQuoteDataProvider value identity probe complete: 36 provider renders, 1 initial value, 0 same value, 35 changed value in 60s

After:
[MMM-31370] BridgeQuoteDataProvider value identity probe complete: 37 provider renders, 1 initial value, 14 same value, 22 changed value in 60s
```

Probe code in `app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.tsx`

```
  const identityProbeStartedAtRef = useRef(Date.now());
  const previousValueRef = useRef<BridgeQuoteDataContextValue | undefined>(
    undefined,
  );
  const providerRenderCountRef = useRef(0);
  const initialValueCountRef = useRef(0);
  const sameValueCountRef = useRef(0);
  const changedValueCountRef = useRef(0);
  const hasCompletedIdentityProbeRef = useRef(false);

  useEffect(() => {
    const probeStartedAt = identityProbeStartedAtRef.current;
    const timeoutId = setTimeout(() => {
      hasCompletedIdentityProbeRef.current = true;
      logBridgeQuoteDataIdentityProbe(
        `BridgeQuoteDataProvider value identity probe complete: ${providerRenderCountRef.current} provider renders, ${initialValueCountRef.current} initial value, ${sameValueCountRef.current} same value, ${changedValueCountRef.current} changed value in 60s`,
      );
    }, BRIDGE_QUOTE_DATA_IDENTITY_PROBE_DURATION_MS);

    return () => {
      clearTimeout(timeoutId);

      if (!hasCompletedIdentityProbeRef.current) {
        logBridgeQuoteDataIdentityProbe(
          `BridgeQuoteDataProvider value identity probe stopped early: ${providerRenderCountRef.current} provider renders, ${initialValueCountRef.current} initial value, ${sameValueCountRef.current} same value, ${changedValueCountRef.current} changed value in ${
            Date.now() - probeStartedAt
          }ms`,
        );
      }
    };
  }, []);

  if (!hasCompletedIdentityProbeRef.current) {
    providerRenderCountRef.current += 1;

    if (previousValueRef.current === undefined) {
      initialValueCountRef.current += 1;
    } else if (Object.is(previousValueRef.current, value)) {
      sameValueCountRef.current += 1;
    } else {
      changedValueCountRef.current += 1;
    }

    previousValueRef.current = value;
  }
```

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31370

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge quote data context value stability

  Scenario: Quote data provider keeps the same value reference when quote data is unchanged
    Given the app is on the Unified Swaps / Bridge flow
    And the provider identity probe is temporarily enabled

    When the user requests a quote for 1 ETH to mUSD
    And the quote flow runs for 60 seconds

    Then the before-fix probe reports 0 same value references after the initial render
    And the after-fix probe reports same value references for provider renders where quote data fields are unchanged
```

Automated validation:

```shell
yarn jest app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts -t "keeps the same return object reference when inputs do not change"
yarn jest app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
yarn jest app/components/UI/Bridge/hooks/useBridgeQuoteData/BridgeQuoteDataContext.test.tsx
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no UI changes. Provider identity probe result is included in the Description section.

### **After**

N/A — no UI changes. Provider identity probe result is included in the Description section.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1854a7d0a639e7c652fb642b0b3206698532f291. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->