### PR TITLE
fix: pure black remove bg-default band in APY info sheet

### DIFF
--- a/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.styles.ts
+++ b/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.styles.ts
@@ -1,13 +1,11 @@
 import { StyleSheet } from 'react-native';
-import type { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) =>
+const styleSheet = () =>
   StyleSheet.create({
     content: {
       paddingHorizontal: 16,
       paddingBottom: 8,
       gap: 16,
-      backgroundColor: params.theme.colors.background.default,
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes a Pure Black elevation mismatch in the **Add funds** APY info bottom sheet (`MoneyApyInfoSheet`, `variant: deposit`).

**Problem:** The parent `BottomSheet` uses `useElevatedSurface()` (`bg-alternative`), but the content wrapper still painted `background.default`. With `MM_PURE_BLACK_PREVIEW=true`, `bg-default` resolves to `#000000`, producing a visible dark band behind the APY disclaimer paragraph.

**Fix:** Remove `backgroundColor` from the `content` style so the elevated `BottomSheet` surface owns the background uniformly. Follows the same pattern as [PR #32909](https://github.com/MetaMask/metamask-mobile/pull/32909) / TMCU-994.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1011

## **Manual testing steps**

```gherkin
Feature: Add funds APY info sheet pure black theming

  Scenario: user opens APY info sheet with pure black enabled
    Given the app is in dark mode with MM_PURE_BLACK_PREVIEW=true
    And the user is on Money → Add funds (deposit confirmation with numpad)

    When user taps the info (i) icon next to Earn APY
    Then the Annual Percentage Yield (APY) bottom sheet background is uniform
    And no dark band appears behind the disclaimer paragraph

  Scenario: user opens APY info sheet with pure black disabled
    Given the app is in dark mode with MM_PURE_BLACK_PREVIEW unset or false

    When user opens the APY info sheet from Add funds
    Then the bottom sheet renders as before (no visual regression)
```

## **Screenshots/Recordings**

### **Before**

Visible `bg-default` (#000000) rectangle behind the APY disclaimer text inside the elevated sheet.

<img width="405" height="204" alt="Screenshot 2026-07-08 at 5 42 17 PM" src="https://github.com/user-attachments/assets/9e790994-59db-4abe-9a8f-ecc1ca27f0ba" />

### **After**

Content area is transparent; elevated `BottomSheet` surface (`bg-alternative`) is uniform.

<img width="397" height="249" alt="Screenshot 2026-07-08 at 5 38 36 PM" src="https://github.com/user-attachments/assets/771370cf-e990-40cf-91ed-1ebf1dbf2926" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63342667-6392-4fe7-9101-17b841af77e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63342667-6392-4fe7-9101-17b841af77e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

