### PR TITLE
fix: pure black remove list background from MoneyMoreSheet

### DIFF
--- a/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.styles.tsx
@@ -1,11 +1,10 @@
 import { StyleSheet } from 'react-native';
 import type { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) =>
+const styleSheet = (_params: { theme: Theme }) =>
   StyleSheet.create({
     list: {
       paddingBottom: 16,
-      backgroundColor: params.theme.colors.background.default,
     },
     row: {
       flexDirection: 'row',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

On the Money home screen, the More bottom sheet (`MoneyMoreSheet`) uses `useElevatedSurface()` on the parent `BottomSheet`, but the list container was still painting `background.default`. With Pure Black enabled (`MM_PURE_BLACK_PREVIEW=true`), `bg-default` resolves to `#000000`, producing visible dark bands behind each menu option row.

This change removes `backgroundColor` from the `list` style so the elevated `BottomSheet` surface (`bg-alternative`) owns the background uniformly — matching the pattern already used in `MoneyAddMoneySheet.styles.tsx` and the fix from TMCU-994 / PR #32909.

## **Changelog**

CHANGELOG entry: Fixed visible dark bands behind menu rows in the Money More bottom sheet when Pure Black mode is enabled.

## **Related issues**

Fixes: TMCU-1013

## **Manual testing steps**

```gherkin
Feature: Money More sheet Pure Black background

  Scenario: user opens the More menu with Pure Black enabled
    Given MM_PURE_BLACK_PREVIEW="true" in .js.env and the app is rebuilt
    And the app is in Dark mode
    And the user is on the Money home screen

    When the user taps the ⋮ (more) menu button
    Then the More bottom sheet opens
    And menu option rows (How it works, Money account benefits, Contact support) have no visible dark rectangular bands behind them
    And the sheet background is uniformly the elevated surface color
```

## **Screenshots/Recordings**

N/A — visual fix verified via code review against the established `MoneyAddMoneySheet` pattern; QA screenshot capture recommended on device with Pure Black enabled.

### **Before**

Dark grey/black rectangular bands behind each menu row (see TMCU-1013).

<img width="427" height="321" alt="Screenshot 2026-07-08 at 5 51 54 PM" src="https://github.com/user-attachments/assets/733630fd-7e96-4f87-b8e3-ac3aa2001eca" />

### **After**

Uniform elevated surface background with no row-level patches.

<img width="419" height="315" alt="Screenshot 2026-07-08 at 6 00 38 PM" src="https://github.com/user-attachments/assets/14215c81-ad7e-4856-98f8-1d1e5b9c4de2" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf87106d-d5e3-4d25-bc96-17928ae8f054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf87106d-d5e3-4d25-bc96-17928ae8f054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

