### PR TITLE
fix: pure black remove APY info sheet content background

### DIFF
--- a/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.styles.ts
+++ b/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.styles.ts
@@ -1,13 +1,11 @@
 import { StyleSheet } from 'react-native';
-import type { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) =>
+const styleSheet = () =>
   StyleSheet.create({
     content: {
       paddingHorizontal: 16,
       paddingBottom: 8,
       gap: 16,
-      backgroundColor: params.theme.colors.background.default,
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

On the Money home screen, the APY info bottom sheet (`MoneyApyInfoSheet`, default variant) uses `useElevatedSurface()` on the parent `BottomSheet`, but the content wrapper was still painting `background.default`. With Pure Black enabled (`MM_PURE_BLACK_PREVIEW=true`), `bg-default` resolves to `#000000`, producing visible dark bands behind the multi-paragraph APY disclaimer content.

This change removes `backgroundColor` from the `content` style so the elevated `BottomSheet` surface (`bg-alternative`) owns the background uniformly — matching the fix applied for the deposit variant in TMCU-1011 and the pattern from TMCU-994 / PR #32909.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1015

## **Manual testing steps**

```gherkin
Feature: Money APY info sheet pure black background

  Scenario: APY info sheet shows uniform elevated surface in pure black dark mode
    Given MM_PURE_BLACK_PREVIEW="true" is set in .js.env
    And the app is in Dark mode
    And the user is on the Money home screen with a visible balance and APY label

    When the user taps the info icon next to the APY label
    Then the Annual Percentage Yield (APY) bottom sheet opens
    And the paragraph content area has no visible dark bands behind the text
    And the sheet background is uniformly the elevated surface color
```

## **Screenshots/Recordings**

N/A — Pure Black preview soak testing environment not available in cloud agent. Visual fix is a one-line style removal consistent with TMCU-1011 / TMCU-994.

### **Before**

<img width="423" height="451" alt="Screenshot 2026-07-08 at 5 50 53 PM" src="https://github.com/user-attachments/assets/0f35c004-ca6b-4888-9ec5-58b35f18558c" />

### **After**

<img width="428" height="470" alt="Screenshot 2026-07-08 at 6 06 12 PM" src="https://github.com/user-attachments/assets/d165d10f-8965-433f-9950-f37da6859cbd" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07c2f7dc-5df4-41ec-93be-954b8a7f047e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07c2f7dc-5df4-41ec-93be-954b8a7f047e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

