### PR TITLE
fix(ramps): restore RAMPS_TRANSACTION_CONFIRMED for UB2 callback buys

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -33,6 +33,13 @@ jest.mock('../../hooks/useRampsOrders', () => ({
   useRampsOrders: jest.fn(),
 }));
 
+const mockTrackRampEvent = jest.fn();
+jest.mock('../../hooks/useAnalytics', () => ({
+  __esModule: true,
+  default: () => mockTrackRampEvent,
+  trackEvent: mockTrackRampEvent,
+}));
+
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
 }));
@@ -748,16 +755,14 @@ describe('Checkout', () => {
       });
 
       await waitFor(() => {
-        expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-          MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED,
+        expect(mockTrackRampEvent).toHaveBeenCalledWith(
+          'RAMPS_TRANSACTION_CONFIRMED',
+          expect.objectContaining({
+            ramp_type: 'HEADLESS',
+            ramp_surface: 'money_account',
+          }),
         );
       });
-      expect(mockAddProperties).toHaveBeenCalledWith(
-        expect.objectContaining({
-          ramp_type: 'HEADLESS',
-          ramp_surface: 'money_account',
-        }),
-      );
     });
 
     it('still adds the order to Redux and dispatches protect-wallet when headless', async () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -728,6 +728,38 @@ describe('Checkout', () => {
       expect(mockNavigation.reset).not.toHaveBeenCalled();
     });
 
+    it('fires RAMPS_TRANSACTION_CONFIRMED for a successful headless callback', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        params: { rampSurface: 'money_account' },
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
+
+      await act(async () => {
+        fireEvent.press(getByTestId('trigger-callback-navigation'));
+      });
+
+      await waitFor(() => {
+        expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+          MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED,
+        );
+      });
+      expect(mockAddProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+        }),
+      );
+    });
+
     it('still adds the order to Redux and dispatches protect-wallet when headless', async () => {
       mockGetSession.mockReturnValue({
         id: 'hs-1',

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -13,7 +13,10 @@ import { useNavigation } from '@react-navigation/native';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { callbackBaseUrl } from '../../Aggregator/sdk';
-import { normalizeProviderCode, RampsOrderStatus } from '@metamask/ramps-controller';
+import {
+  normalizeProviderCode,
+  RampsOrderStatus,
+} from '@metamask/ramps-controller';
 import { FIAT_ORDER_PROVIDERS } from '../../../../../constants/on-ramp';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -32,6 +35,7 @@ import {
   buildRampsTransactionConfirmedPayload,
   shouldEmitRampsTransactionConfirmed,
 } from '../../utils/buildRampsTransactionConfirmedPayload';
+import useRampAnalytics from '../../hooks/useAnalytics';
 import {
   BottomSheet,
   HeaderStandard,
@@ -108,6 +112,7 @@ const Checkout = () => {
   const { addOrder, addPrecreatedOrder, getOrderFromCallback } =
     useRampsOrders();
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const trackRampEvent = useRampAnalytics();
   const { userRegion } = useRampsUserRegion();
   const {
     url: uri,
@@ -442,16 +447,13 @@ const Checkout = () => {
           ) {
             emitTerminalOrderAnalyticsFromCallback(rampsOrder);
           } else if (shouldEmitRampsTransactionConfirmed(rampsOrder.status)) {
-            trackEvent(
-              createEventBuilder(MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED)
-                .addProperties(
-                  buildRampsTransactionConfirmedPayload(rampsOrder, {
-                    rampType: 'HEADLESS',
-                    region: regionCode ?? '',
-                    rampSurface: headlessRampSurface,
-                  }),
-                )
-                .build(),
+            trackRampEvent(
+              'RAMPS_TRANSACTION_CONFIRMED',
+              buildRampsTransactionConfirmedPayload(rampsOrder, {
+                rampType: 'HEADLESS',
+                region: regionCode ?? '',
+                rampSurface: headlessRampSurface,
+              }),
             );
             emitTerminalOrderAnalyticsFromCallback(rampsOrder);
           }
@@ -525,6 +527,7 @@ const Checkout = () => {
       headlessBaseOverrides,
       headlessRampSurface,
       regionCode,
+      trackRampEvent,
     ],
   );
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -13,7 +13,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { callbackBaseUrl } from '../../Aggregator/sdk';
-import { normalizeProviderCode } from '@metamask/ramps-controller';
+import { normalizeProviderCode, RampsOrderStatus } from '@metamask/ramps-controller';
 import { FIAT_ORDER_PROVIDERS } from '../../../../../constants/on-ramp';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -28,6 +28,10 @@ import { protectWalletModalVisible } from '../../../../../actions/user';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
 import { emitTerminalOrderAnalyticsFromCallback } from '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
 import { setHeadlessOrderContext } from '../../../../../core/Engine/controllers/ramps-controller/headlessOrderContextRegistry';
+import {
+  buildRampsTransactionConfirmedPayload,
+  shouldEmitRampsTransactionConfirmed,
+} from '../../utils/buildRampsTransactionConfirmedPayload';
 import {
   BottomSheet,
   HeaderStandard,
@@ -432,7 +436,25 @@ const Checkout = () => {
           // already-terminal order here is never polled and its terminal
           // metrics event would be lost. Emit it directly (no-ops for
           // non-terminal orders and dedups against the polling path).
-          emitTerminalOrderAnalyticsFromCallback(rampsOrder);
+          if (
+            rampsOrder.status === RampsOrderStatus.Failed ||
+            rampsOrder.status === RampsOrderStatus.IdExpired
+          ) {
+            emitTerminalOrderAnalyticsFromCallback(rampsOrder);
+          } else if (shouldEmitRampsTransactionConfirmed(rampsOrder.status)) {
+            trackEvent(
+              createEventBuilder(MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED)
+                .addProperties(
+                  buildRampsTransactionConfirmedPayload(rampsOrder, {
+                    rampType: 'HEADLESS',
+                    region: regionCode ?? '',
+                    rampSurface: headlessRampSurface,
+                  }),
+                )
+                .build(),
+            );
+            emitTerminalOrderAnalyticsFromCallback(rampsOrder);
+          }
 
           dispatch(protectWalletModalVisible());
           try {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -225,6 +225,71 @@ describe('OrderDetails', () => {
     expect(mockTrackEvent).toHaveBeenCalled();
   });
 
+  it('tracks RAMPS_TRANSACTION_CONFIRMED when callback fetch succeeds', async () => {
+    const pendingOrder = {
+      providerOrderId: 'ord-cb-confirmed',
+      status: RampsOrderStatus.Pending,
+      fiatAmount: 50,
+      cryptoAmount: 0.01,
+      exchangeRate: 5000,
+      totalFeesFiat: 2,
+      paymentMethod: { id: 'card' },
+      network: { chainId: 'eip155:1', name: 'Ethereum' },
+      cryptoCurrency: { assetId: 'eth', symbol: 'ETH' },
+      fiatCurrency: { symbol: 'USD' },
+      region: 'US',
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    };
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue(pendingOrder);
+
+    render();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ramp_type: 'UNIFIED_BUY_2',
+          amount_source: 50,
+          country: 'US',
+        }),
+      );
+    });
+  });
+
+  it('does not track RAMPS_TRANSACTION_CONFIRMED when callback order failed', async () => {
+    mockUseParams.mockReturnValue({
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    });
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue({
+      providerOrderId: 'ord-failed',
+      status: RampsOrderStatus.Failed,
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    });
+
+    render();
+
+    await waitFor(() => {
+      expect(mockAddOrder).toHaveBeenCalled();
+    });
+
+    const confirmedCalls = mockTrackEvent.mock.calls.filter(
+      (call) =>
+        call[0]?.ramp_type === 'UNIFIED_BUY_2' &&
+        call[0]?.amount_source !== undefined,
+    );
+    expect(confirmedCalls).toHaveLength(0);
+  });
+
   it('shows V2 order toast when callback fetch succeeds', async () => {
     const { showV2OrderToast } = jest.requireMock(
       '../../utils/v2OrderToast',

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -48,6 +48,12 @@ jest.mock('../../utils/v2OrderToast', () => ({
 }));
 
 const mockTrackEvent = jest.fn();
+const mockTrackRampEvent = jest.fn();
+jest.mock('../../hooks/useAnalytics', () => ({
+  __esModule: true,
+  default: () => mockTrackRampEvent,
+  trackEvent: mockTrackRampEvent,
+}));
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
     trackEvent: mockTrackEvent,
@@ -252,7 +258,8 @@ describe('OrderDetails', () => {
     render();
 
     await waitFor(() => {
-      expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect(mockTrackRampEvent).toHaveBeenCalledWith(
+        'RAMPS_TRANSACTION_CONFIRMED',
         expect.objectContaining({
           ramp_type: 'UNIFIED_BUY_2',
           amount_source: 50,
@@ -282,10 +289,8 @@ describe('OrderDetails', () => {
       expect(mockAddOrder).toHaveBeenCalled();
     });
 
-    const confirmedCalls = mockTrackEvent.mock.calls.filter(
-      (call) =>
-        call[0]?.ramp_type === 'UNIFIED_BUY_2' &&
-        call[0]?.amount_source !== undefined,
+    const confirmedCalls = mockTrackRampEvent.mock.calls.filter(
+      (call) => call[0] === 'RAMPS_TRANSACTION_CONFIRMED',
     );
     expect(confirmedCalls).toHaveLength(0);
   });

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -38,6 +38,10 @@ import OrderContent from './OrderContent';
 import { emitTerminalOrderAnalyticsFromCallback } from '../../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
+import {
+  buildRampsTransactionConfirmedPayload,
+  shouldEmitRampsTransactionConfirmed,
+} from '../../utils/buildRampsTransactionConfirmedPayload';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
@@ -114,6 +118,19 @@ const OrderDetails = () => {
         }
         addOrder(fetchedOrder);
 
+        if (shouldEmitRampsTransactionConfirmed(fetchedOrder.status)) {
+          trackEvent(
+            createEventBuilder(MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED)
+              .addProperties(
+                buildRampsTransactionConfirmedPayload(fetchedOrder, {
+                  rampType: 'UNIFIED_BUY_2',
+                  region: fetchedOrder.region ?? '',
+                }),
+              )
+              .build(),
+          );
+        }
+
         // TRAM-3691: a callback-fetched order that is already terminal is never
         // polled, so `orderStatusChanged` never fires and the terminal metrics
         // event would be lost. Emit it directly (no-ops for non-terminal orders
@@ -151,7 +168,7 @@ const OrderDetails = () => {
         setIsLoading(false);
       }
     },
-    [getOrderFromCallback, addOrder, navigation, params.cryptocurrency],
+    [getOrderFromCallback, addOrder, navigation, params.cryptocurrency, trackEvent, createEventBuilder],
   );
 
   const handleHeaderBack = useCallback(() => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -42,6 +42,7 @@ import {
   buildRampsTransactionConfirmedPayload,
   shouldEmitRampsTransactionConfirmed,
 } from '../../utils/buildRampsTransactionConfirmedPayload';
+import useRampAnalytics from '../../hooks/useAnalytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
@@ -89,6 +90,7 @@ const OrderDetails = () => {
   const { colors } = theme;
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const trackRampEvent = useRampAnalytics();
 
   const [isRefreshing, setIsRefreshing] = useState(false);
   const hasFetchedFromCallback = useRef(false);
@@ -119,15 +121,12 @@ const OrderDetails = () => {
         addOrder(fetchedOrder);
 
         if (shouldEmitRampsTransactionConfirmed(fetchedOrder.status)) {
-          trackEvent(
-            createEventBuilder(MetaMetricsEvents.RAMPS_TRANSACTION_CONFIRMED)
-              .addProperties(
-                buildRampsTransactionConfirmedPayload(fetchedOrder, {
-                  rampType: 'UNIFIED_BUY_2',
-                  region: fetchedOrder.region ?? '',
-                }),
-              )
-              .build(),
+          trackRampEvent(
+            'RAMPS_TRANSACTION_CONFIRMED',
+            buildRampsTransactionConfirmedPayload(fetchedOrder, {
+              rampType: 'UNIFIED_BUY_2',
+              region: fetchedOrder.region ?? '',
+            }),
           );
         }
 
@@ -168,7 +167,13 @@ const OrderDetails = () => {
         setIsLoading(false);
       }
     },
-    [getOrderFromCallback, addOrder, navigation, params.cryptocurrency, trackEvent, createEventBuilder],
+    [
+      getOrderFromCallback,
+      addOrder,
+      navigation,
+      params.cryptocurrency,
+      trackRampEvent,
+    ],
   );
 
   const handleHeaderBack = useCallback(() => {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -40,6 +40,10 @@ import { dismissHeadlessFlow } from '../headless/headlessEntryNavigation';
 import { getChainIdFromAssetId } from '../headless';
 import { setHeadlessOrderContext } from '../../../../core/Engine/controllers/ramps-controller/headlessOrderContextRegistry';
 import { emitTerminalOrderAnalyticsFromCallback } from '../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
+import {
+  buildRampsTransactionConfirmedPayload,
+  shouldEmitRampsTransactionConfirmed,
+} from '../utils/buildRampsTransactionConfirmedPayload';
 
 interface RampStackParamList {
   /** `baseRouteParams` (e.g. `headlessSessionId`) are merged onto this route in resets — see `navigateToVerifyIdentityCallback`. */
@@ -547,30 +551,15 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
             rampsOrder.status === RampsOrderStatus.IdExpired
           ) {
             emitTerminalOrderAnalyticsFromCallback(rampsOrder);
-          } else {
-            trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-              ramp_type: wasHeadless ? 'HEADLESS' : 'DEPOSIT',
-              ramp_surface: rampSurface,
-              amount_source: Number(rampsOrder.fiatAmount),
-              amount_destination: Number(rampsOrder.cryptoAmount),
-              exchange_rate: Number(rampsOrder.exchangeRate),
-              gas_fee: rampsOrder.networkFees
-                ? Number(rampsOrder.networkFees)
-                : 0,
-              processing_fee: rampsOrder.partnerFees
-                ? Number(rampsOrder.partnerFees)
-                : 0,
-              total_fee: Number(rampsOrder.totalFeesFiat),
-              payment_method_id: rampsOrder.paymentMethod?.id || '',
-              country: regionIsoCode,
-              region: regionIsoCode,
-              chain_id: rampsOrder.network?.chainId || '',
-              currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
-              currency_destination_symbol:
-                rampsOrder.cryptoCurrency?.symbol || '',
-              currency_destination_network: rampsOrder.network?.name || '',
-              currency_source: rampsOrder.fiatCurrency?.symbol || '',
-            });
+          } else if (shouldEmitRampsTransactionConfirmed(rampsOrder.status)) {
+            trackEvent(
+              'RAMPS_TRANSACTION_CONFIRMED',
+              buildRampsTransactionConfirmedPayload(rampsOrder, {
+                rampType: wasHeadless ? 'HEADLESS' : 'DEPOSIT',
+                region: regionIsoCode,
+                rampSurface,
+              }),
+            );
           }
         } catch (error) {
           processingOrderIdRef.current = null;
@@ -784,31 +773,16 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
                   navigateToOrderProcessingCallback({
                     orderId: rampsOrder.providerOrderId,
                   });
-                  trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-                    ramp_type: 'HEADLESS',
-                    ramp_surface: rampSurface,
-                    amount_source: Number(rampsOrder.fiatAmount),
-                    amount_destination: Number(rampsOrder.cryptoAmount),
-                    exchange_rate: Number(rampsOrder.exchangeRate),
-                    gas_fee: rampsOrder.networkFees
-                      ? Number(rampsOrder.networkFees)
-                      : 0,
-                    processing_fee: rampsOrder.partnerFees
-                      ? Number(rampsOrder.partnerFees)
-                      : 0,
-                    total_fee: Number(rampsOrder.totalFeesFiat),
-                    payment_method_id: rampsOrder.paymentMethod?.id || '',
-                    country: regionIsoCode,
-                    region: regionIsoCode,
-                    chain_id: rampsOrder.network?.chainId || '',
-                    currency_destination:
-                      rampsOrder.cryptoCurrency?.assetId || '',
-                    currency_destination_symbol:
-                      rampsOrder.cryptoCurrency?.symbol || '',
-                    currency_destination_network:
-                      rampsOrder.network?.name || '',
-                    currency_source: rampsOrder.fiatCurrency?.symbol || '',
-                  });
+                  if (shouldEmitRampsTransactionConfirmed(rampsOrder.status)) {
+                    trackEvent(
+                      'RAMPS_TRANSACTION_CONFIRMED',
+                      buildRampsTransactionConfirmedPayload(rampsOrder, {
+                        rampType: 'HEADLESS',
+                        region: regionIsoCode,
+                        rampSurface,
+                      }),
+                    );
+                  }
                   return true;
                 }
 

--- a/app/components/UI/Ramp/types/depositAnalytics.ts
+++ b/app/components/UI/Ramp/types/depositAnalytics.ts
@@ -182,7 +182,7 @@ interface RampsAddressEntered {
 
 interface RampsTransactionConfirmed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'DEPOSIT' | 'HEADLESS' | 'UNIFIED_BUY_2';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;

--- a/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
+++ b/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
@@ -1,0 +1,81 @@
+import { RampsOrderStatus } from '@metamask/ramps-controller';
+import {
+  buildRampsTransactionConfirmedPayload,
+  shouldEmitRampsTransactionConfirmed,
+} from './buildRampsTransactionConfirmedPayload';
+
+const baseOrder = {
+  providerOrderId: 'ord-1',
+  status: RampsOrderStatus.Pending,
+  fiatAmount: 100,
+  cryptoAmount: 0.05,
+  exchangeRate: 2000,
+  networkFees: 1,
+  partnerFees: 2,
+  totalFeesFiat: 3,
+  paymentMethod: { id: 'card' },
+  network: { chainId: 'eip155:1', name: 'Ethereum' },
+  cryptoCurrency: { assetId: 'eth', symbol: 'ETH' },
+  fiatCurrency: { symbol: 'USD' },
+  region: 'US',
+};
+
+describe('shouldEmitRampsTransactionConfirmed', () => {
+  it('returns true for non-terminal failure statuses', () => {
+    expect(
+      shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Pending),
+    ).toBe(true);
+    expect(
+      shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Completed),
+    ).toBe(true);
+  });
+
+  it('returns false for terminal failure statuses', () => {
+    expect(shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Failed)).toBe(
+      false,
+    );
+    expect(
+      shouldEmitRampsTransactionConfirmed(RampsOrderStatus.IdExpired),
+    ).toBe(false);
+  });
+});
+
+describe('buildRampsTransactionConfirmedPayload', () => {
+  it('builds the unified buy payload with ramp_type UNIFIED_BUY_2', () => {
+    const payload = buildRampsTransactionConfirmedPayload(baseOrder, {
+      rampType: 'UNIFIED_BUY_2',
+      region: 'US',
+    });
+
+    expect(payload).toEqual({
+      ramp_type: 'UNIFIED_BUY_2',
+      ramp_surface: undefined,
+      amount_source: 100,
+      amount_destination: 0.05,
+      exchange_rate: 2000,
+      gas_fee: 1,
+      processing_fee: 2,
+      total_fee: 3,
+      payment_method_id: 'card',
+      country: 'US',
+      region: 'US',
+      chain_id: 'eip155:1',
+      currency_destination: 'eth',
+      currency_destination_symbol: 'ETH',
+      currency_destination_network: 'Ethereum',
+      currency_source: 'USD',
+    });
+  });
+
+  it('includes ramp_surface for headless flows', () => {
+    const payload = buildRampsTransactionConfirmedPayload(baseOrder, {
+      rampType: 'HEADLESS',
+      region: 'GB',
+      rampSurface: 'MONEY_ACCOUNT',
+    });
+
+    expect(payload.ramp_type).toBe('HEADLESS');
+    expect(payload.ramp_surface).toBe('MONEY_ACCOUNT');
+    expect(payload.country).toBe('GB');
+  });
+});

--- a/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
+++ b/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
@@ -77,7 +77,7 @@ describe('buildRampsTransactionConfirmedPayload', () => {
     });
 
     expect(payload.ramp_type).toBe('HEADLESS');
-    expect(payload.ramp_surface).toBe('MONEY_ACCOUNT');
+    expect(payload.ramp_surface).toBe('money_account');
     expect(payload.country).toBe('GB');
   });
 });

--- a/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
+++ b/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
@@ -1,30 +1,32 @@
-import { RampsOrderStatus } from '@metamask/ramps-controller';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
 import {
   buildRampsTransactionConfirmedPayload,
   shouldEmitRampsTransactionConfirmed,
 } from './buildRampsTransactionConfirmedPayload';
 
-const baseOrder = {
-  providerOrderId: 'ord-1',
-  status: RampsOrderStatus.Pending,
-  fiatAmount: 100,
-  cryptoAmount: 0.05,
-  exchangeRate: 2000,
-  networkFees: 1,
-  partnerFees: 2,
-  totalFeesFiat: 3,
-  paymentMethod: { id: 'card' },
-  network: { chainId: 'eip155:1', name: 'Ethereum' },
-  cryptoCurrency: { assetId: 'eth', symbol: 'ETH' },
-  fiatCurrency: { symbol: 'USD' },
-  region: 'US',
-};
+const makeRampsOrder = (overrides: Partial<RampsOrder> = {}): RampsOrder =>
+  ({
+    providerOrderId: 'ord-1',
+    status: RampsOrderStatus.Pending,
+    fiatAmount: 100,
+    cryptoAmount: 0.05,
+    exchangeRate: 2000,
+    networkFees: 1,
+    partnerFees: 2,
+    totalFeesFiat: 3,
+    paymentMethod: { id: 'card' },
+    network: { chainId: 'eip155:1', name: 'Ethereum' },
+    cryptoCurrency: { assetId: 'eth', symbol: 'ETH' },
+    fiatCurrency: { symbol: 'USD' },
+    region: 'US',
+    ...overrides,
+  }) as RampsOrder;
 
 describe('shouldEmitRampsTransactionConfirmed', () => {
   it('returns true for non-terminal failure statuses', () => {
-    expect(
-      shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Pending),
-    ).toBe(true);
+    expect(shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Pending)).toBe(
+      true,
+    );
     expect(
       shouldEmitRampsTransactionConfirmed(RampsOrderStatus.Completed),
     ).toBe(true);
@@ -42,7 +44,7 @@ describe('shouldEmitRampsTransactionConfirmed', () => {
 
 describe('buildRampsTransactionConfirmedPayload', () => {
   it('builds the unified buy payload with ramp_type UNIFIED_BUY_2', () => {
-    const payload = buildRampsTransactionConfirmedPayload(baseOrder, {
+    const payload = buildRampsTransactionConfirmedPayload(makeRampsOrder(), {
       rampType: 'UNIFIED_BUY_2',
       region: 'US',
     });
@@ -68,10 +70,10 @@ describe('buildRampsTransactionConfirmedPayload', () => {
   });
 
   it('includes ramp_surface for headless flows', () => {
-    const payload = buildRampsTransactionConfirmedPayload(baseOrder, {
+    const payload = buildRampsTransactionConfirmedPayload(makeRampsOrder(), {
       rampType: 'HEADLESS',
       region: 'GB',
-      rampSurface: 'MONEY_ACCOUNT',
+      rampSurface: 'money_account',
     });
 
     expect(payload.ramp_type).toBe('HEADLESS');

--- a/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.ts
+++ b/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.ts
@@ -1,0 +1,58 @@
+import {
+  type RampsOrder,
+  RampsOrderStatus,
+} from '@metamask/ramps-controller';
+import type {
+  AnalyticsEvents,
+  RampSurface,
+} from '../types/depositAnalytics';
+
+type RampsTransactionConfirmedRampType =
+  AnalyticsEvents['RAMPS_TRANSACTION_CONFIRMED']['ramp_type'];
+
+/**
+ * Returns whether an order should emit `RAMPS_TRANSACTION_CONFIRMED`.
+ * Terminal failures must not report as confirmed/placed (TRAM-3691).
+ */
+export function shouldEmitRampsTransactionConfirmed(
+  status: RampsOrder['status'],
+): boolean {
+  return (
+    status !== RampsOrderStatus.Failed &&
+    status !== RampsOrderStatus.IdExpired
+  );
+}
+
+/**
+ * Builds the `RAMPS_TRANSACTION_CONFIRMED` payload from a `RampsOrder`.
+ * Shared across UB2 callback paths (OrderDetails, Checkout, Transak routing).
+ */
+export function buildRampsTransactionConfirmedPayload(
+  order: RampsOrder,
+  options: {
+    rampType: RampsTransactionConfirmedRampType;
+    region: string;
+    rampSurface?: RampSurface;
+  },
+): AnalyticsEvents['RAMPS_TRANSACTION_CONFIRMED'] {
+  const { rampType, region, rampSurface } = options;
+
+  return {
+    ramp_type: rampType,
+    ramp_surface: rampSurface,
+    amount_source: Number(order.fiatAmount),
+    amount_destination: Number(order.cryptoAmount),
+    exchange_rate: Number(order.exchangeRate),
+    gas_fee: order.networkFees ? Number(order.networkFees) : 0,
+    processing_fee: order.partnerFees ? Number(order.partnerFees) : 0,
+    total_fee: Number(order.totalFeesFiat),
+    payment_method_id: order.paymentMethod?.id || '',
+    country: region,
+    region,
+    chain_id: order.network?.chainId || '',
+    currency_destination: order.cryptoCurrency?.assetId || '',
+    currency_destination_symbol: order.cryptoCurrency?.symbol || '',
+    currency_destination_network: order.network?.name || '',
+    currency_source: order.fiatCurrency?.symbol || '',
+  };
+}

--- a/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.ts
+++ b/app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.ts
@@ -1,11 +1,5 @@
-import {
-  type RampsOrder,
-  RampsOrderStatus,
-} from '@metamask/ramps-controller';
-import type {
-  AnalyticsEvents,
-  RampSurface,
-} from '../types/depositAnalytics';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
+import type { AnalyticsEvents, RampSurface } from '../types/depositAnalytics';
 
 type RampsTransactionConfirmedRampType =
   AnalyticsEvents['RAMPS_TRANSACTION_CONFIRMED']['ramp_type'];
@@ -18,8 +12,7 @@ export function shouldEmitRampsTransactionConfirmed(
   status: RampsOrder['status'],
 ): boolean {
   return (
-    status !== RampsOrderStatus.Failed &&
-    status !== RampsOrderStatus.IdExpired
+    status !== RampsOrderStatus.Failed && status !== RampsOrderStatus.IdExpired
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Mixpanel showed a sharp drop in **Ramps Transaction Confirmed** starting ~July 3, coinciding with **v8.1.0** adoption. Investigation found this was expected: #31768 removed the legacy deposit routing (`useDepositRouting`) that emitted `RAMPS_TRANSACTION_CONFIRMED` on every native card checkout, but the UB2 replacement path (Checkout → OrderDetails) never emitted the event.

`Ramps Transaction Completed` continued to fire via controller polling; the ratio flipped because Confirmed volume collapsed, not because Completed spiked.

## Solution

Restore `RAMPS_TRANSACTION_CONFIRMED` for the standard UB2 webview buy path:

- **OrderDetails** — emit on successful callback resolution with `ramp_type: UNIFIED_BUY_2`
- **Checkout (headless)** — emit on successful headless callback with `ramp_type: HEADLESS` (this path skips OrderDetails)
- **Shared payload builder** — `buildRampsTransactionConfirmedPayload` used by OrderDetails, Checkout, and `useTransakRouting` to keep schema consistent
- **Schema** — extend `RampsTransactionConfirmed.ramp_type` to include `UNIFIED_BUY_2`

Terminal failures (`Failed` / `IdExpired`) still do **not** emit Confirmed (TRAM-3691 behavior preserved).

## Risk

Low — analytics-only change on existing callback paths. No user-facing behavior change.

## Verification

```bash
yarn jest app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.test.ts
yarn jest app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx -t "RAMPS_TRANSACTION_CONFIRMED"
yarn jest app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx -t "RAMPS_TRANSACTION_CONFIRMED"
yarn lint:tsc
yarn format:check app/components/UI/Ramp/utils/buildRampsTransactionConfirmedPayload.ts app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx app/components/UI/Ramp/Views/Checkout/Checkout.tsx
```

## Post-merge

Once shipped, expect `Ramps Transaction Confirmed` uniques to recover for v8.1.0+ users on the webview buy path. Filter by `ramp_type = UNIFIED_BUY_2` to isolate UB2 volume from legacy `DEPOSIT` / `HEADLESS` flows.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C04G8UGLL4R/p1783530918727979?thread_ts=1783530918.727979&cid=C04G8UGLL4R)

<div><a href="https://cursor.com/agents/bc-794af259-ce05-50a4-b160-ff2463342f05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-794af259-ce05-50a4-b160-ff2463342f05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

