### PR TITLE
refactor(perps): migrate PerpsOrderView rows to MMDS KeyValueRow

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -40,42 +40,24 @@ const createStyles = (colors: Colors) =>
       paddingHorizontal: 16,
       flex: 1,
       flexGrow: 1,
-      gap: 1,
     },
-    detailItemWrapper: {
-      paddingVertical: 12,
-    },
-    detailItem: {
+    inputGroupContainer: {
       backgroundColor: colors.background.section,
-      overflow: 'hidden',
-    },
-    detailItemFirst: {
-      borderTopLeftRadius: 12,
-      borderTopRightRadius: 12,
-    },
-    detailItemOnly: {
       borderRadius: 12,
-    },
-    detailItemLast: {
-      borderBottomLeftRadius: 12,
-      borderBottomRightRadius: 12,
+      paddingHorizontal: 12,
+      overflow: 'hidden',
     },
     detailLeft: {
       flexDirection: 'row',
       alignItems: 'center',
       flex: 1,
     },
-    slippageValueRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 4,
-    },
     infoIcon: {
       marginLeft: 0,
-      padding: 10, // Increases touch target from 20x20 to 40x40 for better accessibility
-      marginRight: -6, // Compensate for padding to keep visual alignment
-      marginTop: -10, // Keep icon at same vertical position
-      marginBottom: -10, // Keep icon at same vertical position
+      padding: 10,
+      marginRight: -6,
+      marginTop: -10,
+      marginBottom: -10,
     },
     infoSection: {
       paddingHorizontal: 16,

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -28,6 +28,8 @@ import {
   IconName,
   IconSize,
   IconColor,
+  KeyValueRow,
+  KeyValueRowVariant,
 } from '@metamask/design-system-react-native';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
@@ -36,10 +38,6 @@ import { strings } from '../../../../../../locales/i18n';
 import ButtonSemantic, {
   ButtonSemanticSeverity,
 } from '../../../../../component-library/components-temp/Buttons/ButtonSemantic';
-import ListItem from '../../../../../component-library/components/List/ListItem';
-import ListItemColumn, {
-  WidthType,
-} from '../../../../../component-library/components/List/ListItemColumn';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import useTooltipModal from '../../../../../components/hooks/useTooltipModal';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -1350,6 +1348,17 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     setSelectedTooltip(null);
   }, []);
 
+  const handleSlippageEditPress = useCallback(() => {
+    setIsSlippageVisible(true);
+    track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+        PERPS_EVENT_VALUE.INTERACTION_TYPE.SLIPPAGE_CONFIG_OPENED,
+      [PERPS_EVENT_PROPERTY.ASSET]: orderForm.asset,
+      [PERPS_EVENT_PROPERTY.MAX_SLIPPAGE_PCT]: bpsToPercent(maxSlippageBps),
+      [PERPS_EVENT_PROPERTY.MAX_SLIPPAGE_SOURCE]: maxSlippageSource,
+    });
+  }, [track, orderForm.asset, maxSlippageBps, maxSlippageSource]);
+
   useInitPerpsPaymentToken(orderForm.asset ?? '');
 
   // Use the same calculation as handleMaxAmount in usePerpsOrderForm to avoid insufficient funds error
@@ -1472,141 +1481,67 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         {/* Order Details */}
         {!isInputFocused && (
           <View style={styles.detailsWrapper}>
-            {/* Leverage */}
-            <TouchableOpacity
-              testID={PerpsOrderViewSelectorsIDs.LEVERAGE_ROW}
-              onPress={() => setIsLeverageVisible(true)}
-              style={[
-                styles.detailItem,
-                // If there are items below (limit price, TP/SL, or Pay with), only round top corners
-                // Otherwise, round all corners
-                orderForm.type === 'limit' || !hideTPSL || isPayRowVisible
-                  ? styles.detailItemFirst
-                  : styles.detailItemOnly,
-              ]}
-            >
-              <ListItem style={styles.detailItemWrapper}>
-                <ListItemColumn widthType={WidthType.Fill}>
-                  <View style={styles.detailLeft}>
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextAlternative}
-                    >
-                      {strings('perps.order.leverage')}
-                    </Text>
-                    <TouchableOpacity
-                      onPress={() => handleTooltipPress('leverage')}
-                      style={styles.infoIcon}
-                    >
-                      <Icon
-                        name={IconName.Info}
-                        size={IconSize.Sm}
-                        color={IconColor.IconAlternative}
-                        testID={PerpsOrderViewSelectorsIDs.LEVERAGE_INFO_ICON}
-                      />
-                    </TouchableOpacity>
-                  </View>
-                </ListItemColumn>
-                <ListItemColumn widthType={WidthType.Auto}>
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    color={TextColor.TextDefault}
-                  >
-                    {isLoadingMarketData ? '...' : `${orderForm.leverage}x`}
-                  </Text>
-                </ListItemColumn>
-              </ListItem>
-            </TouchableOpacity>
-
-            {/* Limit price - only show for limit orders */}
-            {orderForm.type === 'limit' && (
+            <View style={styles.inputGroupContainer}>
               <TouchableOpacity
-                testID={PerpsOrderViewSelectorsIDs.LIMIT_PRICE_ROW}
-                onPress={() => setIsLimitPriceVisible(true)}
-                style={[
-                  styles.detailItem,
-                  // Only round bottom corners when this is the last item (no TP/SL and no Pay row below)
-                  hideTPSL && !isPayRowVisible && styles.detailItemLast,
-                ]}
+                testID={PerpsOrderViewSelectorsIDs.LEVERAGE_ROW}
+                onPress={() => setIsLeverageVisible(true)}
               >
-                <ListItem style={styles.detailItemWrapper}>
-                  <ListItemColumn widthType={WidthType.Fill}>
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextAlternative}
-                    >
-                      {strings('perps.order.limit_price')}
-                    </Text>
-                  </ListItemColumn>
-                  <ListItemColumn widthType={WidthType.Auto}>
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextDefault}
-                    >
-                      {orderForm.limitPrice !== undefined &&
+                <KeyValueRow
+                  variant={KeyValueRowVariant.Input}
+                  keyLabel={strings('perps.order.leverage')}
+                  keyEndButtonIconProps={{
+                    iconName: IconName.Info,
+                    onPress: () => handleTooltipPress('leverage'),
+                    testID: PerpsOrderViewSelectorsIDs.LEVERAGE_INFO_ICON,
+                  }}
+                  value={isLoadingMarketData ? '...' : `${orderForm.leverage}x`}
+                />
+              </TouchableOpacity>
+
+              {orderForm.type === 'limit' && (
+                <TouchableOpacity
+                  testID={PerpsOrderViewSelectorsIDs.LIMIT_PRICE_ROW}
+                  onPress={() => setIsLimitPriceVisible(true)}
+                >
+                  <KeyValueRow
+                    variant={KeyValueRowVariant.Input}
+                    keyLabel={strings('perps.order.limit_price')}
+                    value={
+                      orderForm.limitPrice !== undefined &&
                       orderForm.limitPrice !== null
                         ? formatPerpsFiat(orderForm.limitPrice, {
                             ranges: PRICE_RANGES_UNIVERSAL,
                           })
-                        : 'Set price'}
-                    </Text>
-                  </ListItemColumn>
-                </ListItem>
-              </TouchableOpacity>
-            )}
+                        : 'Set price'
+                    }
+                  />
+                </TouchableOpacity>
+              )}
 
-            {/* Combined TP/SL row - Hidden when modifying existing position */}
-            {!hideTPSL && (
-              <TouchableOpacity
-                onPress={handleTPSLPress}
-                testID={PerpsOrderViewSelectorsIDs.STOP_LOSS_BUTTON}
-                style={[
-                  styles.detailItem,
-                  !isPayRowVisible && styles.detailItemLast,
-                ]}
-              >
-                <ListItem style={styles.detailItemWrapper}>
-                  <ListItemColumn widthType={WidthType.Fill}>
-                    <View style={styles.detailLeft}>
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        color={TextColor.TextAlternative}
-                      >
-                        {strings('perps.order.tp_sl')}
-                      </Text>
-                      <TouchableOpacity
-                        onPress={() => handleTooltipPress('tp_sl')}
-                        style={styles.infoIcon}
-                      >
-                        <Icon
-                          name={IconName.Info}
-                          size={IconSize.Sm}
-                          color={IconColor.IconAlternative}
-                          testID={PerpsOrderViewSelectorsIDs.TP_SL_INFO_ICON}
-                        />
-                      </TouchableOpacity>
-                    </View>
-                  </ListItemColumn>
-                  <ListItemColumn widthType={WidthType.Auto}>
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextDefault}
-                    >
-                      {tpSlDisplayText}
-                    </Text>
-                  </ListItemColumn>
-                </ListItem>
-              </TouchableOpacity>
-            )}
-            {/* Pay with row - directly below TP/SL, same stacked box styling */}
-            {isPayRowVisible && (
-              <View style={[styles.detailItem, styles.detailItemLast]}>
+              {!hideTPSL && (
+                <TouchableOpacity
+                  onPress={handleTPSLPress}
+                  testID={PerpsOrderViewSelectorsIDs.STOP_LOSS_BUTTON}
+                >
+                  <KeyValueRow
+                    variant={KeyValueRowVariant.Input}
+                    keyLabel={strings('perps.order.tp_sl')}
+                    keyEndButtonIconProps={{
+                      iconName: IconName.Info,
+                      onPress: () => handleTooltipPress('tp_sl'),
+                      testID: PerpsOrderViewSelectorsIDs.TP_SL_INFO_ICON,
+                    }}
+                    value={tpSlDisplayText}
+                  />
+                </TouchableOpacity>
+              )}
+
+              {isPayRowVisible && (
                 <PerpsPayRow
-                  embeddedInStack
                   onPayWithInfoPress={() => handleTooltipPress('pay_with')}
                 />
-              </View>
-            )}
+              )}
+            </View>
             {hasInsufficientPayTokenBalance && (
               <View style={styles.insufficientPayTokenWarning}>
                 <Text
@@ -1682,158 +1617,98 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             { marginTop: isInputFocused ? 8 : 0 },
           ]}
         >
-          <View style={styles.infoRow}>
-            <View style={styles.detailLeft}>
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('perps.order.margin')}
-              </Text>
-              <TouchableOpacity
-                onPress={() => handleTooltipPress('margin')}
-                style={styles.infoIcon}
-              >
-                <Icon
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                  testID={PerpsOrderViewSelectorsIDs.MARGIN_INFO_ICON}
-                />
-              </TouchableOpacity>
-            </View>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-              testID={PerpsOrderViewSelectorsIDs.MARGIN_VALUE}
-            >
-              {marginRequired !== undefined && marginRequired !== null
+          <KeyValueRow
+            variant={KeyValueRowVariant.Summary}
+            keyLabel={strings('perps.order.margin')}
+            keyEndButtonIconProps={{
+              iconName: IconName.Info,
+              onPress: () => handleTooltipPress('margin'),
+              testID: PerpsOrderViewSelectorsIDs.MARGIN_INFO_ICON,
+            }}
+            value={
+              marginRequired !== undefined && marginRequired !== null
                 ? formatPerpsFiat(marginRequired, {
                     ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })
-                : PERPS_CONSTANTS.FallbackDataDisplay}
-            </Text>
-          </View>
+                : PERPS_CONSTANTS.FallbackDataDisplay
+            }
+            valueTextProps={{
+              testID: PerpsOrderViewSelectorsIDs.MARGIN_VALUE,
+            }}
+          />
 
-          <View style={styles.infoRow}>
-            <View style={styles.detailLeft}>
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('perps.order.liquidation_price')}
-              </Text>
-              <TouchableOpacity
-                onPress={() => handleTooltipPress('liquidation_price')}
-                style={styles.infoIcon}
-              >
-                <Icon
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                  testID={
-                    PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_INFO_ICON
-                  }
-                />
-              </TouchableOpacity>
-            </View>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-              testID={PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_VALUE}
-            >
-              {hasValidAmount
+          <KeyValueRow
+            variant={KeyValueRowVariant.Summary}
+            keyLabel={strings('perps.order.liquidation_price')}
+            keyEndButtonIconProps={{
+              iconName: IconName.Info,
+              onPress: () => handleTooltipPress('liquidation_price'),
+              testID: PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_INFO_ICON,
+            }}
+            value={
+              hasValidAmount
                 ? formatPerpsFiat(liquidationPrice, {
                     ranges: PRICE_RANGES_UNIVERSAL,
                   })
-                : PERPS_CONSTANTS.FallbackDataDisplay}
-            </Text>
-          </View>
+                : PERPS_CONSTANTS.FallbackDataDisplay
+            }
+            valueTextProps={{
+              testID: PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_VALUE,
+            }}
+          />
+
           {isMarketOrder && (
-            <TouchableOpacity
+            <KeyValueRow
               testID={PerpsOrderViewSelectorsIDs.SLIPPAGE_ROW}
-              onPress={() => {
-                setIsSlippageVisible(true);
-                track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-                  [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-                    PERPS_EVENT_VALUE.INTERACTION_TYPE.SLIPPAGE_CONFIG_OPENED,
-                  [PERPS_EVENT_PROPERTY.ASSET]: orderForm.asset,
-                  [PERPS_EVENT_PROPERTY.MAX_SLIPPAGE_PCT]:
-                    bpsToPercent(maxSlippageBps),
-                  [PERPS_EVENT_PROPERTY.MAX_SLIPPAGE_SOURCE]: maxSlippageSource,
-                });
+              variant={KeyValueRowVariant.Summary}
+              keyLabel={strings('perps.slippage.slippage')}
+              value={
+                estimatedSlippagePctDisplay === null
+                  ? strings('perps.slippage.row_format_pending', {
+                      value: bpsToPercent(maxSlippageBps),
+                    })
+                  : strings('perps.slippage.row_format', {
+                      est: estimatedSlippagePctDisplay,
+                      value: bpsToPercent(maxSlippageBps),
+                    })
+              }
+              valueTextProps={{
+                testID: PerpsOrderViewSelectorsIDs.SLIPPAGE_VALUE,
+                ...(exceedsMaxSlippage && {
+                  color: TextColor.ErrorDefault,
+                }),
               }}
-            >
-              <View style={styles.infoRow}>
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('perps.slippage.slippage')}
-                </Text>
-                <View style={styles.slippageValueRow}>
-                  <Text
-                    testID={PerpsOrderViewSelectorsIDs.SLIPPAGE_VALUE}
-                    variant={TextVariant.BodySm}
-                    color={
-                      exceedsMaxSlippage
-                        ? TextColor.ErrorDefault
-                        : TextColor.TextDefault
-                    }
-                  >
-                    {estimatedSlippagePctDisplay === null
-                      ? strings('perps.slippage.row_format_pending', {
-                          value: bpsToPercent(maxSlippageBps),
-                        })
-                      : strings('perps.slippage.row_format', {
-                          est: estimatedSlippagePctDisplay,
-                          value: bpsToPercent(maxSlippageBps),
-                        })}
-                  </Text>
-                  <Icon
-                    name={IconName.Edit}
-                    size={IconSize.Sm}
-                    color={IconColor.IconAlternative}
-                  />
-                </View>
-              </View>
-            </TouchableOpacity>
+              valueEndButtonIconProps={{
+                iconName: IconName.Edit,
+                onPress: handleSlippageEditPress,
+              }}
+            />
           )}
-          <View style={styles.infoRow}>
-            <View style={styles.detailLeft}>
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('perps.order.fees')}
-              </Text>
-              <TouchableOpacity
-                onPress={() => handleTooltipPress('fees')}
-                style={styles.infoIcon}
-              >
-                <Icon
-                  name={IconName.Info}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                  testID={PerpsOrderViewSelectorsIDs.FEES_INFO_ICON}
+
+          <KeyValueRow
+            variant={KeyValueRowVariant.Summary}
+            keyLabel={strings('perps.order.fees')}
+            keyEndButtonIconProps={{
+              iconName: IconName.Info,
+              onPress: () => handleTooltipPress('fees'),
+              testID: PerpsOrderViewSelectorsIDs.FEES_INFO_ICON,
+            }}
+            value={
+              isFeesLoading ? (
+                <Skeleton height={16} width={60} />
+              ) : (
+                <PerpsFeesDisplay
+                  feeDiscountPercentage={rewardsState.feeDiscountPercentage}
+                  fee={hasValidAmount ? feesToDisplay : undefined}
+                  originalFee={
+                    hasValidAmount ? undiscountedFeesToDisplay : undefined
+                  }
+                  placeholder={PERPS_CONSTANTS.FallbackDataDisplay}
+                  testID={PerpsOrderViewSelectorsIDs.FEES_VALUE}
                 />
-              </TouchableOpacity>
-            </View>
-            {isFeesLoading ? (
-              <Skeleton height={16} width={60} />
-            ) : (
-              <PerpsFeesDisplay
-                feeDiscountPercentage={rewardsState.feeDiscountPercentage}
-                fee={hasValidAmount ? feesToDisplay : undefined}
-                originalFee={
-                  hasValidAmount ? undiscountedFeesToDisplay : undefined
-                }
-                placeholder={PERPS_CONSTANTS.FallbackDataDisplay}
-                testID={PerpsOrderViewSelectorsIDs.FEES_VALUE}
-                variant={TextVariant.BodySm}
-              />
-            )}
-          </View>
+              )
+            }
+          />
 
           {/* Rewards Points Estimation */}
           {rewardsState.shouldShowRewardsRow &&

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -183,10 +183,4 @@ describe('PerpsPayRow', () => {
 
     expect(onPayWithInfoPress).toHaveBeenCalledTimes(1);
   });
-
-  it('renders with embedded style when embeddedInStack is true', () => {
-    const { getByTestId } = renderWithProvider(<PerpsPayRow embeddedInStack />);
-
-    expect(getByTestId(ConfirmationRowComponentIDs.PAY_WITH)).toBeOnTheScreen();
-  });
 });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -1,9 +1,11 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import {
-  Icon,
-  IconColor,
   IconName,
-  IconSize,
+  KeyValueRow,
+  KeyValueRowVariant,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
@@ -15,17 +17,10 @@ import Badge, {
 import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import Routes from '../../../../../constants/navigation/Routes';
 import { isHardwareAccount } from '../../../../../util/address';
 import { getNetworkImageSource } from '../../../../../util/networks';
-import { useTheme } from '../../../../../util/theme';
 import BaseTokenIcon from '../../../../Base/TokenIcon';
-import { Box } from '../../../../UI/Box/Box';
-import { AlignItems, FlexDirection } from '../../../../UI/Box/box.types';
 import {
   ConfirmationRowComponentIDs,
   TransactionPayComponentIDs,
@@ -56,50 +51,13 @@ const tokenIconStyles = StyleSheet.create({
   },
 });
 
-const createPayRowStyles = (colors: { background: { section: string } }) =>
-  StyleSheet.create({
-    payRowSection: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      backgroundColor: colors.background.section,
-      borderRadius: 8,
-      padding: 12,
-      marginBottom: 12,
-    },
-    /** When embedded below another box (e.g. TP/SL), parent provides background and radius */
-    payRowEmbedded: {
-      borderRadius: 0,
-      marginBottom: 0,
-    },
-    payRowLeft: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      flex: 1,
-    },
-    infoIcon: {
-      marginLeft: 0,
-      padding: 10,
-      marginRight: -6,
-      marginTop: -10,
-      marginBottom: -10,
-    },
-  });
-
 export interface PerpsPayRowProps {
   /** Optional callback when the info (i) icon is pressed, e.g. for tooltip */
   onPayWithInfoPress?: () => void;
-  /** When true, row is stacked below another box (e.g. TP/SL); parent provides background and border radius */
-  embeddedInStack?: boolean;
 }
 
-export const PerpsPayRow = ({
-  onPayWithInfoPress,
-  embeddedInStack = false,
-}: PerpsPayRowProps) => {
+export const PerpsPayRow = ({ onPayWithInfoPress }: PerpsPayRowProps) => {
   const navigation = useNavigation();
-  const { colors } = useTheme();
-  const styles = createPayRowStyles(colors);
   const { setConfirmationMetric } = useConfirmationMetricEvents();
   const { track } = usePerpsEventTracking();
   const { payToken } = useTransactionPayToken();
@@ -126,7 +84,6 @@ export const PerpsPayRow = ({
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET);
   }, [canEdit, navigation, setConfirmationMetric, track]);
 
-  // Display data: use local state (defaults to Perps balance) so UI always shows "Perps balance" by default
   const displayToken = matchesPerpsBalance
     ? {
         address: PERPS_BALANCE_PLACEHOLDER_ADDRESS,
@@ -154,86 +111,62 @@ export const PerpsPayRow = ({
     [displayToken.networkBadgeChainId],
   );
 
+  const valueLabel = matchesPerpsBalance
+    ? strings('perps.adjust_margin.perps_balance')
+    : displayToken.symbol;
+
+  const valueStartAccessory = matchesPerpsBalance ? (
+    <BaseTokenIcon
+      testID="perps-pay-row-token-icon"
+      icon={PERPS_BALANCE_ICON_URI}
+      symbol={strings('perps.adjust_margin.perps_balance')}
+      style={tokenIconStyles.iconSmall}
+    />
+  ) : token ? (
+    <BadgeWrapper
+      badgePosition={BadgePosition.BottomRight}
+      badgeElement={
+        <Badge
+          variant={BadgeVariant.Network}
+          imageSource={networkImageSource}
+        />
+      }
+    >
+      <BaseTokenIcon
+        testID="perps-pay-row-token-icon"
+        icon={token.image}
+        symbol={token.symbol}
+        style={tokenIconStyles.iconSmall}
+      />
+    </BadgeWrapper>
+  ) : null;
+
   return (
     <TouchableOpacity
       onPress={handleClick}
       disabled={!canEdit}
       activeOpacity={0.7}
-      style={[styles.payRowSection, embeddedInStack && styles.payRowEmbedded]}
       testID={ConfirmationRowComponentIDs.PAY_WITH}
     >
-      <Box
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        style={styles.payRowLeft}
-      >
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
-          {strings('confirm.label.pay_with')}
-        </Text>
-        <TouchableOpacity
-          onPress={() => onPayWithInfoPress?.()}
-          style={styles.infoIcon}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          testID="perps-pay-row-info"
-        >
-          <Icon
-            name={IconName.Info}
-            size={IconSize.Sm}
-            color={IconColor.IconAlternative}
-          />
-        </TouchableOpacity>
-      </Box>
-      <Box
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        gap={8}
-      >
-        {matchesPerpsBalance ? (
-          <>
-            <BaseTokenIcon
-              testID="perps-pay-row-token-icon"
-              icon={PERPS_BALANCE_ICON_URI}
-              symbol={strings('perps.adjust_margin.perps_balance')}
-              style={tokenIconStyles.iconSmall}
-            />
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Default}
-              testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
-            >
-              {strings('perps.adjust_margin.perps_balance')}
-            </Text>
-          </>
-        ) : (
-          <>
-            {token ? (
-              <BadgeWrapper
-                badgePosition={BadgePosition.BottomRight}
-                badgeElement={
-                  <Badge
-                    variant={BadgeVariant.Network}
-                    imageSource={networkImageSource}
-                  />
-                }
-              >
-                <BaseTokenIcon
-                  testID="perps-pay-row-token-icon"
-                  icon={token.image}
-                  symbol={token.symbol}
-                  style={tokenIconStyles.iconSmall}
-                />
-              </BadgeWrapper>
-            ) : null}
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Default}
-              testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
-            >
-              {displayToken.symbol}
-            </Text>
-          </>
-        )}
-      </Box>
+      <KeyValueRow
+        variant={KeyValueRowVariant.Input}
+        keyLabel={strings('confirm.label.pay_with')}
+        keyEndButtonIconProps={{
+          iconName: IconName.Info,
+          onPress: () => onPayWithInfoPress?.(),
+          testID: 'perps-pay-row-info',
+        }}
+        valueStartAccessory={valueStartAccessory}
+        value={
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
+          >
+            {valueLabel}
+          </Text>
+        }
+      />
     </TouchableOpacity>
   );
 };


### PR DESCRIPTION
## **Description**

Refactors the Perps order screen (`PerpsOrderView`) to use MMDS `KeyValueRow` instead of custom `ListItem` / manual two-column layouts.

**Why:** Align Perps trading UI with the design system and reduce bespoke row styling and layout code.

**What changed:**
- **Input group** (`KeyValueRowVariant.Input`): leverage, limit price, auto close (TP/SL), and pay with — grouped in a single `inputGroupContainer`
- **Summary group** (`KeyValueRowVariant.Summary`): margin, liquidation price, slippage, and fees
- **`PerpsPayRow`**: rewritten on `KeyValueRow` Input variant; removed `embeddedInStack` and custom section background styles
- **Tooltips**: info icons use `keyEndButtonIconProps` → existing `PerpsBottomSheetTooltip` flow
- **Slippage**: only the edit icon opens the slippage config sheet (row label/value are no longer tappable)
- **Styles**: removed obsolete `detailItem*` / `infoRow` styles used by migrated rows; rewards/points row left on the manual layout (out of scope)

Net: ~216 lines removed across 4 files. Existing testIDs preserved.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3529

## **Manual testing steps**

```gherkin
Feature: Perps order view KeyValueRow migration

  Scenario: Input rows open their respective sheets
    Given I am on the Perps order screen for a market (e.g. Short XYZ100)
    When I tap Leverage, Limit price (limit orders), Auto close (TP/SL), or Pay with
    Then the corresponding bottom sheet or selector opens
    And tapping the info icon on each row opens the tooltip without triggering the row action

  Scenario: Summary rows display quote details
    Given I have entered a valid order amount on the Perps order screen
    Then Margin, Liquidation price, and Fees show formatted values with working info tooltips
    And Slippage shows est/max values for market orders

  Scenario: Slippage edit is icon-only
    Given I am on a market order Perps order screen
    When I tap the slippage label or value text
    Then nothing happens
    When I tap the slippage edit icon
    Then the slippage configuration bottom sheet opens

  Scenario: Pay with row
    Given Trade with any token is enabled
    When I tap the Pay with row
    Then the pay-with token selector opens
    And the selected token icon and label render correctly
```

**Unit tests:** `yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx` (106 passing)

## **Screenshots/Recordings**


### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-08 at 22 32 41" src="https://github.com/user-attachments/assets/96133d18-f439-4a8e-9331-773ec958de67" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-08 at 22 49 47" src="https://github.com/user-attachments/assets/fbcef2f0-ad95-42a7-9470-9e28533836a5" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer refactor on the Perps order UI with preserved testIDs and covered unit tests; the only intentional UX change is icon-only slippage editing, not order execution logic.
> 
> **Overview**
> Replaces bespoke `ListItem` / two-column layouts on the Perps order screen with MMDS **`KeyValueRow`**, grouped into a single **Input** block (leverage, limit price, TP/SL, pay with) and **Summary** rows (margin, liquidation price, slippage, fees). Info tooltips now use `keyEndButtonIconProps`; existing testIDs are kept.
> 
> **`PerpsPayRow`** is rebuilt on the Input variant (token icon + label as value accessories) and drops `embeddedInStack` plus custom stacked-section styling now that the parent `inputGroupContainer` owns the card look.
> 
> **Slippage behavior:** opening the config sheet and `SLIPPAGE_CONFIG_OPENED` analytics move to a dedicated **edit icon** handler—the slippage label/value are no longer tappable (previously the whole row was wrapped in `TouchableOpacity`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33ddb18f967f065ce231bb9fbd1ece4a340b63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->