### PR TITLE
chore: adds metric parameter for profile-picture

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -320,6 +320,7 @@ describe('TopTradersSection', () => {
       expect.objectContaining({
         source: 'home_carousel',
         traderAddress: '0x0000000000000000000000000000000000000001',
+        traderAvatarUri: undefined,
       }),
     );
   });

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -200,6 +200,7 @@ const TopTradersSection = forwardRef<
           traderAddress: trader?.address ?? '',
           traderUsername: trader?.username,
           traderRank: trader?.rank,
+          traderAvatarUri: trader?.avatarUri,
         });
       if (!wasFollowing && openSetupIfNeeded(performFollow)) {
         return;

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -409,6 +409,7 @@ describe('TopTradersView', () => {
         traderAddress: fixtureTraders[0].address,
         traderUsername: fixtureTraders[0].username,
         traderRank: 1,
+        traderAvatarUri: fixtureTraders[0].avatarUri,
       }),
     );
   });

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -397,6 +397,7 @@ const TopTradersView = () => {
           traderAddress: trader?.address ?? '',
           traderUsername: trader?.username,
           traderRank: trader?.rank,
+          traderAvatarUri: trader?.avatarUri,
         });
       if (!wasFollowing && openSetupIfNeeded(performFollow)) {
         return;

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -959,6 +959,7 @@ describe('TraderProfileView', () => {
           source: 'trader_profile',
           traderAddress: '0xabc',
           traderUsername: 'trader1',
+          traderAvatarUri: fixtureProfile.profile.imageUrl,
         }),
       );
     });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -230,6 +230,7 @@ const TraderProfileView = () => {
         source: 'trader_profile',
         traderAddress: traderAddress || profile?.profile.address || '',
         traderUsername: profile?.profile.name,
+        traderAvatarUri: profile?.profile.imageUrl,
         // Rank only meaningful when arriving from a ranked surface; omit on
         // trader_profile to keep schema clean.
       });

--- a/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
+++ b/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
@@ -23,6 +23,7 @@ export const SocialLeaderboardEventProperties = {
   SOURCE: 'source',
   TAB: 'tab',
   TRADER_ADDRESS: 'trader_address',
+  TRADER_HAS_PROFILE_PICTURE_SET: 'trader_has_profile_picture_set',
   TRADER_RANK: 'trader_rank',
   TRADER_USERNAME: 'trader_username',
 } as const;

--- a/app/components/hooks/useFollowToggle.test.ts
+++ b/app/components/hooks/useFollowToggle.test.ts
@@ -209,13 +209,36 @@ describe('useFollowToggle', () => {
           traderAddress: '0xabc',
           traderUsername: 'alice',
           traderRank: 3,
+          traderAvatarUri: 'https://example.com/avatar.png',
         });
       });
 
       expect(mockTrack).toHaveBeenCalledTimes(1);
       expect(mockTrack).toHaveBeenCalledWith(
         expect.objectContaining({ category: expect.any(String) }),
-        expect.objectContaining({ action: 'follow', source: 'leaderboard' }),
+        expect.objectContaining({
+          action: 'follow',
+          source: 'leaderboard',
+          trader_has_profile_picture_set: true,
+        }),
+      );
+    });
+
+    it('sets trader_has_profile_picture_set to false when avatar is a known placeholder', async () => {
+      const { result } = renderHook(() => useFollowToggle('trader-1'));
+
+      await act(async () => {
+        await result.current.toggleFollow({
+          source: 'trader_profile',
+          traderAddress: '0xabc',
+          traderAvatarUri:
+            'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png',
+        });
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        expect.objectContaining({ category: expect.any(String) }),
+        expect.objectContaining({ trader_has_profile_picture_set: false }),
       );
     });
 

--- a/app/components/hooks/useFollowToggle.ts
+++ b/app/components/hooks/useFollowToggle.ts
@@ -11,6 +11,7 @@ import {
   type TraderFollowInteractionSource,
 } from '../Views/SocialLeaderboard/analytics';
 import { MetaMetricsEvents } from '../../core/Analytics';
+import { hasRealAvatar } from '../Views/Homepage/Sections/TopTraders/utils/avatarFallback';
 
 /**
  * Analytics context attached to a follow/unfollow action so the
@@ -30,6 +31,11 @@ export interface FollowToggleAnalyticsContext {
   traderUsername?: string;
   /** Leaderboard rank when triggered from leaderboard / home_carousel. */
   traderRank?: number;
+  /**
+   * Backend-provided avatar URL at tap time. Used to derive
+   * `trader_has_profile_picture_set` (real image vs Maskicon fallback).
+   */
+  traderAvatarUri?: string | null;
 }
 
 export interface UseFollowToggleManyResult {
@@ -127,6 +133,8 @@ export const useFollowToggleMany = (): UseFollowToggleManyResult => {
             [SocialLeaderboardEventProperties.SOURCE]: analyticsContext.source,
             [SocialLeaderboardEventProperties.TRADER_RANK]:
               analyticsContext.traderRank,
+            [SocialLeaderboardEventProperties.TRADER_HAS_PROFILE_PICTURE_SET]:
+              hasRealAvatar(analyticsContext.traderAvatarUri),
           });
         }
       } catch (err) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

- Add `trader_has_profile_picture_set` to `Trader Follow Interaction` analytics, derived via `hasRealAvatar()` (real image vs Maskicon/known placeholder)
- Pass `traderAvatarUri` from leaderboard, home carousel, and trader profile follow/unfollow surfaces

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-872

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only enrichment on existing follow flows; follow/unfollow behavior and API calls are unchanged.
> 
> **Overview**
> Extends **Trader Follow Interaction** analytics with `trader_has_profile_picture_set`, computed via `hasRealAvatar()` from the avatar URL at follow/unfollow time (real image vs missing/Maskicon/known placeholders like ENS fallback).
> 
> Follow surfaces now pass optional `traderAvatarUri` into `toggleFollow` analytics context from the **home carousel**, **leaderboard**, and **trader profile**. `useFollowToggle` emits the new property when analytics context is present; tests cover real avatars, placeholders, and forwarding from each UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53cdd5394a2ea70788d0f6fd1770cf76c3b91dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->