### PR TITLE
fix(card): value Money account balance via vmUSD share price and USD peg

### DIFF
--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -2219,6 +2219,28 @@ describe('useAssetBalances', () => {
       expect(balanceInfo?.balanceFiat).toBe('$100.00');
     });
 
+    it('falls back to the raw share balance (1:1 USD) when the vault exchange rate is a raw zero', () => {
+      // A non-empty "0" rate is truthy but must not zero out the balance — it is
+      // treated as unavailable, so shares are shown 1:1 as USD.
+      setExchangeRate('0');
+      setupSelectorMock({});
+      mockFormatWithThreshold.mockImplementation((value: number | null) =>
+        value !== null && value !== undefined
+          ? `$${value.toFixed(2)}`
+          : '$0.00',
+      );
+
+      const { result } = renderHook(() =>
+        useAssetBalances([mockMoneyAccountToken]),
+      );
+
+      const key = `${mockMoneyAccountToken.address?.toLowerCase()}-${mockMoneyAccountToken.caipChainId}-${mockMoneyAccountToken.walletAddress?.toLowerCase()}`;
+      const balanceInfo = result.current.get(key);
+
+      expect(balanceInfo?.rawFiatNumber).toBe(100);
+      expect(balanceInfo?.balanceFiat).toBe('$100.00');
+    });
+
     it('applies the vmUSD vault exchange rate to convert shares into their mUSD (USD) value', () => {
       // 100 vmUSD shares × 1.05 share price = 105 mUSD = $105.00. No market rate
       // is applied — mUSD is valued at its USD peg.
@@ -2259,6 +2281,29 @@ describe('useAssetBalances', () => {
 
       expect(balanceInfo?.rawFiatNumber).toBe(100);
       expect(balanceInfo?.balanceFiat).toBe('$100.00');
+    });
+
+    it('polls the vault exchange rate on an interval so it does not drift from the Money balance', () => {
+      // The Money tab refreshes the balance (with an embedded vmUSD→mUSD value)
+      // on a 30s interval, so the Card must poll the vault rate on the same
+      // cadence rather than caching a stale rate.
+      setExchangeRate('1000000');
+      setupSelectorMock({});
+
+      renderHook(() => useAssetBalances([mockMoneyAccountToken]));
+
+      const exchangeRateCall = mockUseQuery.mock.calls.find(
+        ([options]: [{ queryKey?: unknown[] }]) =>
+          options?.queryKey?.[0] ===
+          'MoneyAccountBalanceService:getExchangeRate',
+      );
+
+      expect(exchangeRateCall?.[0]).toEqual(
+        expect.objectContaining({
+          enabled: true,
+          refetchInterval: 30 * 1000,
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -11,8 +11,17 @@ import { selectAsset } from '../../../../selectors/assets/assets-list';
 import { useTokensWithBalance } from '../../Bridge/hooks/useTokensWithBalance';
 import Engine from '../../../../core/Engine';
 import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
+import { useQuery } from '@metamask/react-data-query';
 
 jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: jest.fn(() => ({ data: undefined })),
+}));
+jest.mock('../../Money/queryKeys', () => ({
+  MoneyAccountBalanceServiceQueryKeys: {
+    GET_EXCHANGE_RATE: 'MoneyAccountBalanceService:getExchangeRate',
+  },
+}));
 jest.mock('../../Tokens/util', () => ({
   deriveBalanceFromAssetMarketDetails: jest.fn(),
 }));
@@ -92,6 +101,7 @@ const mockBuildTokenIconUrl = buildTokenIconUrl as jest.MockedFunction<
 const mockUseTokensWithBalance = useTokensWithBalance as jest.MockedFunction<
   typeof useTokensWithBalance
 >;
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
 
 describe('useAssetBalances', () => {
   const mockEvmToken: CardFundingToken = {
@@ -2122,6 +2132,18 @@ describe('useAssetBalances', () => {
       isMoneyAccountEntry: true,
     } as CardFundingToken;
 
+    beforeEach(() => {
+      // Default: no vault exchange rate available → 1:1 share↔mUSD fallback.
+      mockUseQuery.mockReturnValue({ data: undefined } as any);
+    });
+
+    // Sets the vmUSD→mUSD vault exchange rate (raw uint256, mUSD-scaled: 1e6 = 1.0).
+    const setExchangeRate = (rate: string | undefined) => {
+      mockUseQuery.mockReturnValue({
+        data: rate === undefined ? undefined : { rate },
+      } as any);
+    };
+
     const setupSelectorMock = (marketData: Record<string, unknown>) => {
       mockUseSelector.mockImplementation((selector: any) => {
         if (typeof selector === 'function') {
@@ -2148,9 +2170,11 @@ describe('useAssetBalances', () => {
       });
     };
 
-    it('converts the USD-denominated balance into the display currency using the mUSD fiat rate', () => {
-      // mUSD price-in-native-currency (0.00046 ETH) × ETH→currency rate (2000)
-      // → mUSD fiat rate of 0.92, so 100 mUSD spend power = 92 in display currency.
+    it('values the balance 1:1 in USD (mUSD is USD-pegged), ignoring live mUSD market data', () => {
+      // Even with mUSD market data present (which would imply a 0.92 rate), the
+      // money account is valued at its USD peg to stay identical to the Money
+      // tab: 100 mUSD → $100.00, not $92.
+      setExchangeRate('1000000');
       setupSelectorMock({
         '0x1': {
           [MUSD_TOKEN_ADDRESS.toLowerCase()]: { price: 0.00046 },
@@ -2169,12 +2193,56 @@ describe('useAssetBalances', () => {
       const key = `${mockMoneyAccountToken.address?.toLowerCase()}-${mockMoneyAccountToken.caipChainId}-${mockMoneyAccountToken.walletAddress?.toLowerCase()}`;
       const balanceInfo = result.current.get(key);
 
-      expect(balanceInfo?.rawFiatNumber).toBeCloseTo(92, 5);
-      expect(balanceInfo?.balanceFiat).toBe('$92.00');
+      expect(balanceInfo?.rawFiatNumber).toBe(100);
+      expect(balanceInfo?.balanceFiat).toBe('$100.00');
     });
 
-    it('falls back to a 1:1 label when the mUSD fiat rate is unavailable', () => {
-      // No mUSD market data → no rate → balance is shown 1:1 (correct for USD).
+    it('falls back to the raw share balance (1:1 USD) when the vault exchange rate is unavailable', () => {
+      // No exchange rate → vmUSD shares are shown 1:1 as USD (no worse than
+      // today, and correct once the rate loads).
+      setExchangeRate(undefined);
+      setupSelectorMock({});
+      mockFormatWithThreshold.mockImplementation((value: number | null) =>
+        value !== null && value !== undefined
+          ? `$${value.toFixed(2)}`
+          : '$0.00',
+      );
+
+      const { result } = renderHook(() =>
+        useAssetBalances([mockMoneyAccountToken]),
+      );
+
+      const key = `${mockMoneyAccountToken.address?.toLowerCase()}-${mockMoneyAccountToken.caipChainId}-${mockMoneyAccountToken.walletAddress?.toLowerCase()}`;
+      const balanceInfo = result.current.get(key);
+
+      expect(balanceInfo?.rawFiatNumber).toBe(100);
+      expect(balanceInfo?.balanceFiat).toBe('$100.00');
+    });
+
+    it('applies the vmUSD vault exchange rate to convert shares into their mUSD (USD) value', () => {
+      // 100 vmUSD shares × 1.05 share price = 105 mUSD = $105.00. No market rate
+      // is applied — mUSD is valued at its USD peg.
+      setExchangeRate('1050000');
+      setupSelectorMock({});
+      mockFormatWithThreshold.mockImplementation((value: number | null) =>
+        value !== null && value !== undefined
+          ? `$${value.toFixed(2)}`
+          : '$0.00',
+      );
+
+      const { result } = renderHook(() =>
+        useAssetBalances([mockMoneyAccountToken]),
+      );
+
+      const key = `${mockMoneyAccountToken.address?.toLowerCase()}-${mockMoneyAccountToken.caipChainId}-${mockMoneyAccountToken.walletAddress?.toLowerCase()}`;
+      const balanceInfo = result.current.get(key);
+
+      expect(balanceInfo?.rawFiatNumber).toBeCloseTo(105, 5);
+      expect(balanceInfo?.balanceFiat).toBe('$105.00');
+    });
+
+    it('treats a share price of exactly 1.0 as unchanged mUSD value', () => {
+      setExchangeRate('1000000');
       setupSelectorMock({});
       mockFormatWithThreshold.mockImplementation((value: number | null) =>
         value !== null && value !== undefined

--- a/app/components/UI/Card/hooks/useAssetBalances.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalances.tsx
@@ -2,6 +2,11 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../reducers';
 import { useMemo, useCallback } from 'react';
 import { Hex } from '@metamask/utils';
+import BigNumber from 'bignumber.js';
+import { type ExchangeRateResponse } from '@metamask/money-account-balance-service';
+import { useQuery } from '@metamask/react-data-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { MoneyAccountBalanceServiceQueryKeys } from '../../Money/queryKeys';
 import { FundingStatus, CardFundingToken } from '../types';
 import { getAssetBalanceKey } from '../util/getAssetBalanceKey';
 import { useTokensWithBalance } from '../../Bridge/hooks/useTokensWithBalance';
@@ -22,9 +27,7 @@ import {
 } from '../../../../selectors/assets/assets-migration';
 import { CARD_CHAIN_IDS } from '../constants';
 import { balanceToFiatNumber } from '../../../../util/number/bigint';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../../Earn/constants/musd';
-import { toChecksumAddress } from '../../../../util/address';
+import { MUSD_DECIMALS } from '../../Earn/constants/musd';
 
 const extractTrailingCurrencyCode = (value: string): string | undefined => {
   const match = value.trim().match(/([A-Za-z]{3})$/);
@@ -187,28 +190,31 @@ export const useAssetBalances = (
 
   const currentCurrency = useSelector(selectCurrentCurrency);
 
-  const musdFiatRate = useMemo<number | undefined>(() => {
-    const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
-    if (!musdAddress) {
+  // The Money account funding token is vmUSD — a yield-bearing Veda vault share
+  // whose on-chain balance is denominated in shares, not mUSD. Its mUSD value is
+  // `shares × exchangeRate`, so we fetch the vault exchange rate to convert it,
+  // matching how the Money account balance is derived. Only fetched when a Money
+  // account entry is present to avoid an unnecessary RPC read.
+  const hasMoneyAccountEntry = useMemo(
+    () => tokens.some((token) => token?.isMoneyAccountEntry),
+    [tokens],
+  );
+
+  const exchangeRateQuery = useQuery({
+    queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_EXCHANGE_RATE],
+    enabled: hasMoneyAccountEntry,
+  }) as UseQueryResult<ExchangeRateResponse>;
+
+  // Human-readable mUSD-per-vmUSD-share rate (e.g. 1.0002). The raw rate is a
+  // uint256 scaled to mUSD decimals, so a value of 1_000_000 means 1.0.
+  const vmusdToMusdRate = useMemo<number | undefined>(() => {
+    const rawRate = exchangeRateQuery.data?.rate;
+    if (!rawRate) {
       return undefined;
     }
-
-    const checksumAddress = toChecksumAddress(musdAddress) as Hex;
-    const nativeCurrency = networkConfigs?.[CHAIN_IDS.MAINNET]?.nativeCurrency;
-    const conversionRate = nativeCurrency
-      ? currencyRates?.[nativeCurrency]?.conversionRate
-      : undefined;
-
-    const priceInNativeCurrency =
-      marketData?.[CHAIN_IDS.MAINNET]?.[checksumAddress]?.price ??
-      marketData?.[CHAIN_IDS.MAINNET]?.[musdAddress]?.price;
-
-    if (!conversionRate || priceInNativeCurrency === undefined) {
-      return undefined;
-    }
-
-    return priceInNativeCurrency * conversionRate;
-  }, [marketData, currencyRates, networkConfigs]);
+    const parsed = new BigNumber(rawRate).shiftedBy(-MUSD_DECIMALS);
+    return parsed.isFinite() ? parsed.toNumber() : undefined;
+  }, [exchangeRateQuery.data]);
 
   // Helper: Determine which balance to use based on token state
   const determineBalanceToUse = useCallback(
@@ -714,13 +720,22 @@ export const useAssetBalances = (
 
       if (token.isMoneyAccountEntry) {
         const safeBalance = Number.isNaN(rawTokenBalance) ? 0 : rawTokenBalance;
-        const convertedFiat =
-          musdFiatRate !== undefined ? safeBalance * musdFiatRate : safeBalance;
-        balanceFiat = formatWithThreshold(convertedFiat, 0.01, I18n.locale, {
+        // vmUSD is a Veda vault share, so convert it to its mUSD value via the
+        // vault exchange rate (falling back to 1:1 when the rate is unavailable).
+        // mUSD is a USD-pegged stablecoin, so the mUSD amount IS the dollar
+        // value — we render it as USD 1:1 rather than through live market data,
+        // exactly as the Money account balance does (`moneyFormatUsd`). This
+        // keeps the Card "Avail. balance" identical to the Money balance for the
+        // same vmUSD position.
+        const musdBalance =
+          vmusdToMusdRate !== undefined
+            ? safeBalance * vmusdToMusdRate
+            : safeBalance;
+        balanceFiat = formatWithThreshold(musdBalance, 0.01, I18n.locale, {
           style: 'currency',
-          currency: currentCurrency?.toUpperCase() || 'USD',
+          currency: 'USD',
         });
-        rawFiatNumber = convertedFiat;
+        rawFiatNumber = musdBalance;
       }
 
       // Build asset object
@@ -750,8 +765,7 @@ export const useAssetBalances = (
     calculateSolanaFiat,
     calculateEvmFiat,
     buildAssetObject,
-    currentCurrency,
-    musdFiatRate,
+    vmusdToMusdRate,
   ]);
 
   return balancesMap;

--- a/app/components/UI/Card/hooks/useAssetBalances.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalances.tsx
@@ -29,6 +29,11 @@ import { CARD_CHAIN_IDS } from '../constants';
 import { balanceToFiatNumber } from '../../../../util/number/bigint';
 import { MUSD_DECIMALS } from '../../Earn/constants/musd';
 
+// Poll the vault exchange rate on the same cadence the Money tab refreshes the
+// account balance (which embeds a fresh vmUSD→mUSD value), so the Card's
+// "Avail. balance" tracks the Money balance instead of holding a stale rate.
+const EXCHANGE_RATE_REFETCH_INTERVAL_MS = 30 * 1000; // 30 seconds
+
 const extractTrailingCurrencyCode = (value: string): string | undefined => {
   const match = value.trim().match(/([A-Za-z]{3})$/);
   return match ? match[1].toUpperCase() : undefined;
@@ -203,6 +208,7 @@ export const useAssetBalances = (
   const exchangeRateQuery = useQuery({
     queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_EXCHANGE_RATE],
     enabled: hasMoneyAccountEntry,
+    refetchInterval: EXCHANGE_RATE_REFETCH_INTERVAL_MS,
   }) as UseQueryResult<ExchangeRateResponse>;
 
   // Human-readable mUSD-per-vmUSD-share rate (e.g. 1.0002). The raw rate is a
@@ -213,7 +219,12 @@ export const useAssetBalances = (
       return undefined;
     }
     const parsed = new BigNumber(rawRate).shiftedBy(-MUSD_DECIMALS);
-    return parsed.isFinite() ? parsed.toNumber() : undefined;
+    // A non-positive or non-finite rate (e.g. a raw "0") is treated as
+    // unavailable so we fall back to the 1:1 share↔mUSD conversion rather than
+    // zeroing out the balance.
+    return parsed.isFinite() && parsed.isGreaterThan(0)
+      ? parsed.toNumber()
+      : undefined;
   }, [exchangeRateQuery.data]);
 
   // Helper: Determine which balance to use based on token state


### PR DESCRIPTION
The Card "Avail. balance" for the Money account read the raw vmUSD token amount and re-priced it through mUSD's live market rate, so it drifted below the Money tab balance — the gap being the yield-bearing vmUSD share price (which grows over time) plus the market-vs-peg difference on mUSD.

Convert the vmUSD share balance to mUSD using the vault exchange rate (MoneyAccountBalanceService:getExchangeRate) and value mUSD at its 1:1 USD peg, mirroring how the Money account balance is derived. The Card now matches the Money balance for the same vmUSD position, while still respecting the delegation allowance clamp (min(balance, allowance)).

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Card was displaying the vmUSD amount when the Money Account was used. It needs to use the vault conversion rate. This PR fixes it.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes the Money Account amount used by Card

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="1080" height="2404" alt="Screenshot_20260709-095849" src="https://github.com/user-attachments/assets/22829888-dacb-48d0-b4f6-994436b65b3f" />

### **After**

<!-- [screenshots/recordings] -->
<img width="1080" height="2404" alt="Screenshot_20260709-112719" src="https://github.com/user-attachments/assets/de8f4d86-eec7-4b02-8324-222dac254870" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible Card spendable balance logic changes for Money account funding and adds a conditional service query; scope is limited to `isMoneyAccountEntry` tokens with solid test coverage.
> 
> **Overview**
> Fixes Card **Avail. balance** for the Money account so it matches the Money tab instead of showing a lower number from raw vmUSD shares priced through live mUSD market data.
> 
> **`useAssetBalances`** now loads **`MoneyAccountBalanceService:getExchangeRate`** (only when a Money account funding token is present), refetches every **30s**, converts vmUSD shares to mUSD with that rate (invalid/missing/zero raw rate → **1:1** fallback), and formats the result as **USD at the mUSD peg**—not via `musdFiatRate` / mainnet market prices or the user’s display currency.
> 
> Tests mock **`useQuery`**, assert peg behavior, vault multiplier (e.g. 1.05), zero-rate handling, and the refetch interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a78bc69bbb7532e1b0cbab91b70c893c8cfc751d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->