### PR TITLE
fix: stellar send flow

### DIFF
--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.constants.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.constants.ts
@@ -25,6 +25,7 @@ export const NETWORK_MULTI_SELECTOR_TEST_IDS = {
 
 export enum NetworkToCaipChainId {
   SOLANA = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  STELLAR = 'stellar:pubnet',
   ETHEREUM = 'eip155:1',
   LINEA = 'eip155:59144',
   AVALANCHE = 'eip155:43114',

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -88,6 +88,11 @@ export const TRENDING_NETWORK_THRESHOLDS: Record<
     minLiquidity: 100000, // Minimum filter
     minVolume24h: 25000, // Minimum filter
   },
+
+  [NetworkToCaipChainId.STELLAR]: {
+    minLiquidity: 100000, // Minimum filter
+    minVolume24h: 25000, // Minimum filter
+  },
 };
 
 /**

--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -123,6 +123,15 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.ZKSYNC_ERA,
     }),
   },
+  // TODO: re-enable when Trending API is resolved to have sep41 to trustline asset ID
+  // Otherwise the icon and name is missing
+  //   {
+  //     id: NetworkToCaipChainId.STELLAR,
+  //     name: 'Stellar',
+  //     caipChainId: NetworkToCaipChainId.STELLAR,
+  //     isSelected: false,
+  //     imageSource: getNetworkImageSource({ chainId: NetworkToCaipChainId.STELLAR }),
+  //   },
 ];
 
 /**

--- a/app/components/Views/confirmations/hooks/send/useAccounts.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.ts
@@ -65,6 +65,7 @@ export const useAccounts = (): RecipientType[] => {
       if (isTronSendType) {
         return isTronAccount(account);
       }
+      /// END:ONLY_INCLUDE_IF
       /// BEGIN:ONLY_INCLUDE_IF(stellar)
       if (isStellarSendType) {
         return isStellarAccount(account);

--- a/app/components/Views/confirmations/hooks/send/useAccounts.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.ts
@@ -14,6 +14,9 @@ import {
   /// BEGIN:ONLY_INCLUDE_IF(tron)
   isTronAccount,
   /// END:ONLY_INCLUDE_IF
+  /// BEGIN:ONLY_INCLUDE_IF(stellar)
+  isStellarAccount,
+  /// END:ONLY_INCLUDE_IF
 } from '../../../../../core/Multichain/utils';
 import { type RecipientType } from '../../components/UI/recipient';
 import { useSendContext } from '../../context/send-context';
@@ -31,6 +34,9 @@ export const useAccounts = (): RecipientType[] => {
     /// END:ONLY_INCLUDE_IF
     /// BEGIN:ONLY_INCLUDE_IF(tron)
     isTronSendType,
+    /// END:ONLY_INCLUDE_IF
+    /// BEGIN:ONLY_INCLUDE_IF(stellar)
+    isStellarSendType,
     /// END:ONLY_INCLUDE_IF
   } = useSendType();
 
@@ -59,6 +65,10 @@ export const useAccounts = (): RecipientType[] => {
       if (isTronSendType) {
         return isTronAccount(account);
       }
+      /// BEGIN:ONLY_INCLUDE_IF(stellar)
+      if (isStellarSendType) {
+        return isStellarAccount(account);
+      }
       /// END:ONLY_INCLUDE_IF
       return false;
     },
@@ -71,6 +81,9 @@ export const useAccounts = (): RecipientType[] => {
       /// END:ONLY_INCLUDE_IF
       /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
+      /// END:ONLY_INCLUDE_IF
+      /// BEGIN:ONLY_INCLUDE_IF(stellar)
+      isStellarSendType,
       /// END:ONLY_INCLUDE_IF
       from,
     ],

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.ts
@@ -17,6 +17,7 @@ export function useSendTokens({
     isPredefinedBitcoin,
     isPredefinedSolana,
     isPredefinedEvm,
+    isPredefinedStellar,
   } = useSendType();
   const allTokens = useAccountTokens({
     includeNoBalance,
@@ -30,6 +31,7 @@ export function useSendTokens({
       solana: !!isPredefinedSolana,
       tron: !!isPredefinedTron,
       bip122: !!isPredefinedBitcoin,
+      stellar: !!isPredefinedStellar,
     };
 
     const matchedAccountType = Object.entries(accountTypeMap).find(
@@ -49,5 +51,6 @@ export function useSendTokens({
     isPredefinedSolana,
     isPredefinedTron,
     isPredefinedBitcoin,
+    isPredefinedStellar,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -54,10 +54,12 @@ describe('useSendType', () => {
         isSolanaSendType: undefined,
         isBitcoinSendType: undefined,
         isTronSendType: undefined,
+        isStellarSendType: undefined,
         isPredefinedEvm: false,
         isPredefinedSolana: false,
         isPredefinedBitcoin: false,
         isPredefinedTron: false,
+        isPredefinedStellar: false,
       });
     });
   });

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -4,6 +4,9 @@ import {
   isBitcoinChainId,
   /// END:ONLY_INCLUDE_IF
   isSolanaChainId,
+  /// BEGIN:ONLY_INCLUDE_IF(stellar)
+  isStellarChainId,
+  /// END:ONLY_INCLUDE_IF
 } from '@metamask/bridge-controller';
 import { useCallback, useMemo } from 'react';
 
@@ -28,6 +31,7 @@ export const useSendType = () => {
   const isPredefinedBitcoin = predefinedRecipient?.chainType === 'bitcoin';
   const isPredefinedSolana = predefinedRecipient?.chainType === 'solana';
   const isPredefinedTron = predefinedRecipient?.chainType === 'tron';
+  const isPredefinedStellar = predefinedRecipient?.chainType === 'stellar';
 
   const isPredefinedNonEvm =
     predefinedRecipient?.chainType && predefinedRecipient.chainType !== 'evm';
@@ -75,6 +79,13 @@ export const useSendType = () => {
   );
   /// END:ONLY_INCLUDE_IF
 
+  /// BEGIN:ONLY_INCLUDE_IF(stellar)
+  const isStellarSendType = useMemo(
+    () => createChainTypeCheck(isPredefinedStellar, isStellarChainId),
+    [createChainTypeCheck, isPredefinedStellar],
+  );
+  /// END:ONLY_INCLUDE_IF
+
   const assetIsNative =
     asset && 'isNative' in asset ? Boolean(asset.isNative) : undefined;
 
@@ -95,6 +106,10 @@ export const useSendType = () => {
       isTronSendType,
       isPredefinedTron,
       /// END:ONLY_INCLUDE_IF
+      /// BEGIN:ONLY_INCLUDE_IF(stellar)
+      isStellarSendType,
+      isPredefinedStellar,
+      /// END:ONLY_INCLUDE_IF
     }),
     [
       isEvmSendType,
@@ -110,6 +125,10 @@ export const useSendType = () => {
       /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
       isPredefinedTron,
+      /// END:ONLY_INCLUDE_IF
+      /// BEGIN:ONLY_INCLUDE_IF(stellar)
+      isStellarSendType,
+      isPredefinedStellar,
       /// END:ONLY_INCLUDE_IF
     ],
   );

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
@@ -117,6 +117,34 @@ describe('useToAddressValidation', () => {
     });
   });
 
+  it('validate stellar address correctly', async () => {
+    mockUseSendContext.mockReturnValue({
+      asset: {
+        name: 'Stellar',
+        address: 'stellar:pubnet/slip44:148',
+        isNative: true,
+        chainId: 'stellar:pubnet',
+        symbol: 'XLM',
+        decimals: 7,
+      },
+      to: 'dummy',
+      chainId: 'stellar:pubnet',
+    } as unknown as ReturnType<typeof useSendContext>);
+    const { result } = renderHookWithProvider(
+      () => useToAddressValidation(),
+      mockState,
+    );
+    await waitFor(() => {
+      expect(result.current).toStrictEqual({
+        loading: false,
+        resolvedAddress: undefined,
+        toAddressError: 'Invalid address',
+        toAddressValidated: 'dummy',
+        toAddressWarning: undefined,
+      });
+    });
+  });
+
   it('validate tron address correctly', async () => {
     mockUseSendContext.mockReturnValue({
       asset: {

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
@@ -10,6 +10,7 @@ import {
   validateSolanaAddress,
   validateBitcoinAddress,
   validateTronAddress,
+  validateStellarAddress,
 } from '../../utils/send-address-validations';
 import { useSendContext } from '../../context/send-context';
 import { useSendType } from './useSendType';
@@ -24,8 +25,13 @@ interface ValidationResult {
 
 export const useToAddressValidation = () => {
   const { asset, chainId, to } = useSendContext();
-  const { isEvmSendType, isSolanaSendType, isBitcoinSendType, isTronSendType } =
-    useSendType();
+  const {
+    isEvmSendType,
+    isSolanaSendType,
+    isBitcoinSendType,
+    isTronSendType,
+    isStellarSendType,
+  } = useSendType();
   const { validateName } = useNameValidation();
   const [result, setResult] = useState<ValidationResult>({});
   const [loading, setLoading] = useState(false);
@@ -67,6 +73,10 @@ export const useToAddressValidation = () => {
         return validateTronAddress(toAddress);
       }
 
+      if (isStellarSendType) {
+        return validateStellarAddress(toAddress);
+      }
+
       if (isENS(toAddress)) {
         return await validateName(chainId, toAddress);
       }
@@ -82,6 +92,7 @@ export const useToAddressValidation = () => {
       isSolanaSendType,
       isBitcoinSendType,
       isTronSendType,
+      isStellarSendType,
       validateName,
     ],
   );

--- a/app/components/Views/confirmations/utils/send-address-validations.test.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.test.ts
@@ -5,6 +5,7 @@ import {
   validateBitcoinAddress,
   validateHexAddress,
   validateSolanaAddress,
+  validateStellarAddress,
   validateTronAddress,
 } from './send-address-validations';
 jest.mock('./token', () => ({
@@ -97,6 +98,24 @@ describe('validateSolanaAddress', () => {
   it('does not returns error if address is solana address', () => {
     expect(
       validateSolanaAddress('14grJpemFaf88c8tiVb77W7TYg2W3ir6pfkKz3YjhhZ5'),
+    ).toStrictEqual({});
+  });
+});
+
+describe('validateStellarAddress', () => {
+  it('returns error if address is not stellar address', () => {
+    expect(
+      validateStellarAddress('0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477'),
+    ).toStrictEqual({
+      error: 'Invalid address',
+    });
+  });
+
+  it('does not return error if address is stellar address', () => {
+    expect(
+      validateStellarAddress(
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI',
+      ),
     ).toStrictEqual({});
   });
 });

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -10,6 +10,7 @@ import {
 import {
   isBtcMainnetAddress,
   isTronAddress,
+  isStellarAddress,
 } from '../../../../core/Multichain/utils';
 import { LOWER_CASED_BURN_ADDRESSES } from '../../../../constants/address';
 
@@ -109,6 +110,20 @@ export const validateTronAddress = (
   warning?: string;
 } => {
   if (!isTronAddress(toAddress)) {
+    return {
+      error: strings('send.invalid_address'),
+    };
+  }
+  return {};
+};
+
+export const validateStellarAddress = (
+  toAddress: string,
+): {
+  error?: string;
+  warning?: string;
+} => {
+  if (!isStellarAddress(toAddress)) {
     return {
       error: strings('send.invalid_address'),
     };

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -37,6 +37,7 @@ export enum ChainType {
   SOLANA = 'solana',
   BITCOIN = 'bitcoin',
   TRON = 'tron',
+  STELLAR = 'stellar',
 }
 
 export interface PredefinedRecipient {
@@ -84,7 +85,7 @@ export function isValidPositiveNumericString(str: string) {
  * @param params.asset - Optional preselected asset (token or NFT) to send. When provided, skips the asset selection screen.
  * @param params.predefinedRecipient - Optional recipient with chain information. Should be an object containing:
  * - `address`: The recipient's address string
- * - `chainType`: One of 'evm', 'solana', 'bitcoin', or 'tron'
+ * - `chainType`: One of 'evm', 'solana', 'bitcoin', or 'tron' or 'stellar'
  *
  * @remarks
  * The predefinedRecipient is passed through navigation params and can be used by downstream screens

--- a/app/constants/bridge.ts
+++ b/app/constants/bridge.ts
@@ -1,4 +1,4 @@
-import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
+import { SolScope, BtcScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   BRIDGE_DEV_API_BASE_URL,
@@ -36,6 +36,7 @@ export const NETWORK_TO_SHORT_NETWORK_NAME_MAP: Record<
   [SolScope.Mainnet]: 'Solana',
   [BtcScope.Mainnet]: 'BTC',
   [TrxScope.Mainnet]: 'Tron',
+  [XlmScope.Mainnet]: 'Stellar',
 };
 
 export const BRIDGE_API_BASE_URL =

--- a/app/constants/snaps.ts
+++ b/app/constants/snaps.ts
@@ -66,6 +66,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     name: 'Tron',
   },
   {
+    path: ['m', `44'`, `148'`],
+    curve: 'ed25519',
+    name: 'Stellar',
+  },
+  {
     path: ['m', `44'`, `2'`],
     curve: 'secp256k1',
     name: 'Litecoin',

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -5,6 +5,7 @@ import {
   BtcAccountType,
   TrxAccountType,
   TrxScope,
+  XlmAccountType,
 } from '@metamask/keyring-api';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 import Engine from '../Engine';
@@ -199,6 +200,27 @@ export function isTronAddress(address: string): boolean {
     Logger.error(new Error('Error decoding Tron address'), { error });
     return false;
   }
+}
+
+/**
+ * Returns whether an account is a Stellar account.
+ *
+ * @param account - The internal account to check.
+ * @returns `true` if the account is of type Eoa, false otherwise.
+ */
+export function isStellarAccount(account: InternalAccount): boolean {
+  const { Account } = XlmAccountType;
+  return Boolean(account && account.type === Account);
+}
+
+/**
+ * Stellar account address (StrKey, starts with G).
+ *
+ * @param address - The address to check.
+ * @returns `true` if the string matches the Stellar account key format.
+ */
+export function isStellarAddress(address: string): boolean {
+  return /^G[A-Z2-7]{55}$/u.test(address);
 }
 
 /**

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -339,6 +339,25 @@ describe('isValidAddressInputViaQRCode', () => {
     });
   });
 
+  describe('Stellar addresses', () => {
+    it('should be valid for Stellar mainnet address', () => {
+      const mockInput =
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(true);
+    });
+
+    it('should be invalid for invalid Stellar address (wrong length)', () => {
+      const mockInput = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQ';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(false);
+    });
+
+    it('should be invalid for invalid Stellar address (does not start with G)', () => {
+      const mockInput =
+        'HBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(false);
+    });
+  });
+
   describe('Tron addresses', () => {
     it('should be valid for Tron mainnet address', () => {
       const mockInput = 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7';

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -8,6 +8,7 @@ import { isAddress as isSolanaAddress } from '@solana/addresses';
 import {
   isBtcMainnetAddress,
   isTronAddress,
+  isStellarAddress,
 } from '../../core/Multichain/utils';
 import {
   getChecksumAddress,
@@ -807,7 +808,7 @@ export async function validateAddressOrENS(
     confusableCollection,
   };
 }
-/** Method to evaluate if an input is a valid ethereum, solana, bitcoin, or tron address
+/** Method to evaluate if an input is a valid ethereum, solana, bitcoin, stellar or tron address
  * via QR code scanning.
  *
  * @param {string} input - a random string.
@@ -823,6 +824,10 @@ export function isValidAddressInputViaQRCode(input: string) {
   }
 
   if (isTronAddress(input)) {
+    return true;
+  }
+
+  if (isStellarAddress(input)) {
     return true;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches send recipient validation and account/token filtering for a new chain; mistakes could block sends or show wrong accounts, but changes are gated by feature flags and mirror existing non-EVM chains.
> 
> **Overview**
> Adds **Stellar (XLM)** support to the confirmations send path using the same multichain pattern as Tron/Solana/Bitcoin.
> 
> **Send flow:** `useSendType` exposes `isStellarSendType` / `isPredefinedStellar` (via `isStellarChainId` and `chainType: 'stellar'`). Recipient account picking (`useAccounts`), token filtering (`useSendTokens`), and `to` validation (`validateStellarAddress` → `isStellarAddress`) are hooked up behind `ONLY_INCLUDE_IF(stellar)`.
> 
> **Shared utilities:** `isStellarAccount`, `isStellarAddress` (G… StrKey), QR scan acceptance in `isValidAddressInputViaQRCode`, bridge label for `XlmScope.Mainnet`, and Stellar BIP44 path in snap constants.
> 
> **Trending:** Registers `stellar:pubnet` CAIP ID and liquidity/volume thresholds; the **Stellar network row stays commented out** until the Trending API maps sep41/trustline asset IDs (icons/names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86351a8886817b24fe844d9f8a7c68055354825c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->