### PR TITLE
chore: improve token details chart hotreload path

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -166,9 +166,9 @@ const state = {
     rnBackedPagination: { enabled: false },
     hasExplicitCurrentPriceLine: false,
     hotReloadSeq: 0,
-    inHotReloadPreResetPhase: false,
     slbMode: false,
     slbCenteringPending: false,
+    legendOwnsLayoutSettle: false,
 };
 // ----- Widget lifecycle ---------------------------------------------------
 function getWidget() {
@@ -350,12 +350,6 @@ function bumpHotReloadSeq() {
 function getHotReloadSeq() {
     return state.hotReloadSeq;
 }
-function isInHotReloadPreResetPhase() {
-    return state.inHotReloadPreResetPhase;
-}
-function setInHotReloadPreResetPhase(phase) {
-    state.inHotReloadPreResetPhase = phase;
-}
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 function getSlbMode() {
     return state.slbMode;
@@ -368,6 +362,13 @@ function isSlbCenteringPending() {
 }
 function setSlbCenteringPending(pending) {
     state.slbCenteringPending = pending;
+}
+// ----- Legend owns layout settle ---------------------------------------------
+function setLegendOwnsLayoutSettle(owns) {
+    state.legendOwnsLayoutSettle = owns;
+}
+function doesLegendOwnLayoutSettle() {
+    return state.legendOwnsLayoutSettle;
 }
 // ----- Explicit current price line -------------------------------------------
 function getHasExplicitCurrentPriceLine() {
@@ -405,9 +406,9 @@ function __resetStateForTests() {
     state.rnBackedPagination = { enabled: false };
     state.hasExplicitCurrentPriceLine = false;
     state.hotReloadSeq = 0;
-    state.inHotReloadPreResetPhase = false;
     state.slbMode = false;
     state.slbCenteringPending = false;
+    state.legendOwnsLayoutSettle = false;
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/core/loadLibrary.ts
@@ -1333,10 +1334,6 @@ const customDatafeed = {
             const fromMs = periodParams.from * 1000;
             const toMs = periodParams.to * 1000;
             const { countBack, firstDataRequest } = periodParams;
-            if (firstDataRequest && isInHotReloadPreResetPhase()) {
-                onResult([], { noData: true });
-                return;
-            }
             const bars = filterBarsForRange(fromMs, toMs, countBack);
             if (bars.length > 0) {
                 onResult(bars, { noData: false });
@@ -1582,6 +1579,16 @@ function detectResolution(data) {
 let firstDataCallback = null;
 let firstDataDelivered = false;
 /**
+ * When active indicators exist, defers the CHART_LAYOUT_SETTLED signal to the
+ * legend module so it fires after the first successful legend render — not on
+ * the premature 2-rAF timer in emitLayoutSettled.
+ */
+function claimLegendSettleOwnership() {
+    if (getActiveStudies().size > 0 || getMaStudies().size > 0) {
+        setLegendOwnsLayoutSettle(true);
+    }
+}
+/**
  * Registers the callback invoked the first time SET_OHLCV_DATA arrives.
  * Bootstrap wires this to widget creation (loads the TV library if needed,
  * then calls createChartWidget).
@@ -1625,7 +1632,8 @@ function handleSetOHLCVData(payload) {
         try {
             const chart = widget.activeChart();
             if (previousResolution === newResolution) {
-                setInHotReloadPreResetPhase(false);
+                // Same resolution — TV won't re-fetch via getBars, so we must
+                // resetData to force it to pick up the new bars from the datafeed.
                 resetDatafeedCacheBeforeHotReload(widget);
                 chart.resetData();
                 resetMainPriceScaleAutoScale(chart);
@@ -1634,30 +1642,23 @@ function handleSetOHLCVData(payload) {
                 emitLayoutSettled();
             }
             else {
-                setInHotReloadPreResetPhase(true);
+                // Different resolution — let setResolution handle the transition
+                // naturally. TV calls getBars internally, the datafeed returns the
+                // new bars (already stored via setOhlcvData above), and TV renders
+                // them smoothly without a blank frame. No resetData needed.
+                claimLegendSettleOwnership();
                 const seq = bumpHotReloadSeq();
                 chart.setResolution(newResolution, () => {
                     if (getHotReloadSeq() !== seq) {
                         return;
                     }
-                    setInHotReloadPreResetPhase(false);
-                    try {
-                        resetDatafeedCacheBeforeHotReload(widget);
-                        chart.resetData();
-                        resetMainPriceScaleAutoScale(chart);
-                        notifyDataLifecycle('ohlcvReset');
-                        applyVisibleRange(chart);
-                        emitLayoutSettled();
-                    }
-                    catch (error) {
-                        setInHotReloadPreResetPhase(false);
-                        reportErrorToRN(error);
-                    }
+                    resetMainPriceScaleAutoScale(chart);
+                    applyVisibleRange(chart);
+                    emitLayoutSettled();
                 });
             }
         }
         catch (error) {
-            setInHotReloadPreResetPhase(false);
             reportErrorToRN(error);
         }
         return;
@@ -1731,6 +1732,9 @@ function applyVisibleRange(chart) {
     subscription.subscribe(null, onLoaded);
 }
 function emitLayoutSettled() {
+    if (doesLegendOwnLayoutSettle()) {
+        return;
+    }
     const send = () => {
         if (getWidget() && isChartReady()) {
             postToRN('CHART_LAYOUT_SETTLED', {});
@@ -2997,7 +3001,13 @@ function hasAnyEmpty(entries) {
 }
 function notifyLegendRendered() {
     requestAnimationFrame(() => {
-        requestAnimationFrame(() => postToRN('LEGEND_RENDERED', {}));
+        requestAnimationFrame(() => {
+            postToRN('LEGEND_RENDERED', {});
+            if (doesLegendOwnLayoutSettle()) {
+                setLegendOwnsLayoutSettle(false);
+                postToRN('CHART_LAYOUT_SETTLED', {});
+            }
+        });
     });
 }
 function clearTimer() {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -3148,7 +3148,9 @@ function subscribeStudyDataLoaded(chart, studyId) {
     try {
         const study = chart.getStudyById(studyId);
         if (study?.onDataLoaded) {
-            study.onDataLoaded().subscribe(null, () => scheduleLegendRefresh());
+            study.onDataLoaded().subscribe(null, () => {
+                scheduleLegendRefresh();
+            });
             return;
         }
     }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -1134,8 +1134,12 @@ function holdCenteredVisibleRange(chart, fromSec, toSec) {
  *
  * The centering flag is cleared after success so subsequent REALTIME_UPDATE
  * messages don't re-trigger the slide. Only a fresh SET_OHLCV_DATA resets it.
+ *
+ * When \`options.immediate\` is true, applies centering synchronously instead of
+ * waiting for \`onDataLoaded\`. Used after \`setResolution\` where TradingView has
+ * already completed its data cycle by the time the callback fires.
  */
-function slbCenterViewport(chart) {
+function slbCenterViewport(chart, options) {
     if (!getSlbMode() || !isSlbCenteringPending())
         return;
     const fromMs = getVisibleFromMs();
@@ -1143,9 +1147,7 @@ function slbCenterViewport(chart) {
     if (fromMs == null || toMs == null)
         return;
     const capturedGeneration = getOhlcvGeneration();
-    const subscription = chart.onDataLoaded();
-    const onLoaded = () => {
-        subscription.unsubscribe(null, onLoaded);
+    const applyCenter = () => {
         if (capturedGeneration !== getOhlcvGeneration())
             return;
         if (!isSlbCenteringPending())
@@ -1177,6 +1179,15 @@ function slbCenterViewport(chart) {
         catch (error) {
             reportErrorToRN(error);
         }
+    };
+    if (options?.immediate) {
+        applyCenter();
+        return;
+    }
+    const subscription = chart.onDataLoaded();
+    const onLoaded = () => {
+        subscription.unsubscribe(null, onLoaded);
+        applyCenter();
     };
     subscription.subscribe(null, onLoaded);
 }
@@ -1653,7 +1664,7 @@ function handleSetOHLCVData(payload) {
                         return;
                     }
                     resetMainPriceScaleAutoScale(chart);
-                    applyVisibleRange(chart);
+                    applyVisibleRange(chart, { dataAlreadyLoaded: true });
                     emitLayoutSettled();
                 });
             }
@@ -1688,12 +1699,12 @@ function handleRealtimeUpdate(payload) {
         volume: bar.volume,
     });
 }
-function applyVisibleRange(chart) {
+function applyVisibleRange(chart, options) {
     // Strategy C (SLB): center the viewport on the trade window using both
     // visibleFromMs and visibleToMs. Handled by the socialLeaderboard overlay
     // which subscribes to onDataLoaded and frames the exact trade window.
     if (getSlbMode()) {
-        slbCenterViewport(chart);
+        slbCenterViewport(chart, { immediate: options?.dataAlreadyLoaded });
         return;
     }
     const fromMs = getVisibleFromMs();

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
@@ -52,8 +52,6 @@ interface CoreState {
   hasExplicitCurrentPriceLine: boolean;
   /** Sequence counter for setResolution callbacks; stale callbacks bail when mismatched. */
   hotReloadSeq: number;
-  /** True between setResolution call and its callback; getBars returns noData during this window. */
-  inHotReloadPreResetPhase: boolean;
   /** SLB scoping flag — activates Strategy C (bulk back-fill) pagination. */
   slbMode: boolean;
   /**
@@ -62,6 +60,12 @@ interface CoreState {
    * so re-centering only happens on a fresh SET_OHLCV_DATA.
    */
   slbCenteringPending: boolean;
+  /**
+   * When true, the legend module owns the CHART_LAYOUT_SETTLED signal.
+   * ohlcvIngestion skips its early 2-rAF-tick emit and lets the legend
+   * fire it after the first successful render post-reset.
+   */
+  legendOwnsLayoutSettle: boolean;
 }
 
 const emptyPagination = (): OHLCVPaginationConfig => ({
@@ -95,9 +99,9 @@ const state: CoreState = {
   rnBackedPagination: { enabled: false },
   hasExplicitCurrentPriceLine: false,
   hotReloadSeq: 0,
-  inHotReloadPreResetPhase: false,
   slbMode: false,
   slbCenteringPending: false,
+  legendOwnsLayoutSettle: false,
 };
 
 // ----- Widget lifecycle ---------------------------------------------------
@@ -344,14 +348,6 @@ export function getHotReloadSeq(): number {
   return state.hotReloadSeq;
 }
 
-export function isInHotReloadPreResetPhase(): boolean {
-  return state.inHotReloadPreResetPhase;
-}
-
-export function setInHotReloadPreResetPhase(phase: boolean): void {
-  state.inHotReloadPreResetPhase = phase;
-}
-
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 
 export function getSlbMode(): boolean {
@@ -368,6 +364,16 @@ export function isSlbCenteringPending(): boolean {
 
 export function setSlbCenteringPending(pending: boolean): void {
   state.slbCenteringPending = pending;
+}
+
+// ----- Legend owns layout settle ---------------------------------------------
+
+export function setLegendOwnsLayoutSettle(owns: boolean): void {
+  state.legendOwnsLayoutSettle = owns;
+}
+
+export function doesLegendOwnLayoutSettle(): boolean {
+  return state.legendOwnsLayoutSettle;
 }
 
 // ----- Explicit current price line -------------------------------------------
@@ -409,7 +415,7 @@ export function __resetStateForTests(): void {
   state.rnBackedPagination = { enabled: false };
   state.hasExplicitCurrentPriceLine = false;
   state.hotReloadSeq = 0;
-  state.inHotReloadPreResetPhase = false;
   state.slbMode = false;
   state.slbCenteringPending = false;
+  state.legendOwnsLayoutSettle = false;
 }

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -12,8 +12,10 @@ import {
 } from '../legend';
 import {
   __resetStateForTests,
+  doesLegendOwnLayoutSettle,
   registerStudy,
   setChartReady,
+  setLegendOwnsLayoutSettle,
   setTheme,
   setVolumeStudyId,
   setWidget,
@@ -877,6 +879,204 @@ describe('legend', () => {
       expect(overlay.querySelectorAll('.legend-pill').length).toBe(4);
       const html = overlay.innerHTML;
       expect(html.indexOf('RSI(14)')).toBeLessThan(html.indexOf('MACD(12,26)'));
+    });
+  });
+
+  describe('notifyLegendRendered — legendOwnsLayoutSettle integration', () => {
+    it('posts CHART_LAYOUT_SETTLED and clears the flag when legendOwnsLayoutSettle is true', async () => {
+      const data = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 50.0]],
+      );
+      const { chart } = makeChart(data);
+      enableOverlayWithStudies(chart);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      setLegendOwnsLayoutSettle(true);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      expect(postToRN).toHaveBeenCalledWith('LEGEND_RENDERED', {});
+      expect(postToRN).toHaveBeenCalledWith('CHART_LAYOUT_SETTLED', {});
+      expect(doesLegendOwnLayoutSettle()).toBe(false);
+    });
+
+    it('does not post CHART_LAYOUT_SETTLED when legendOwnsLayoutSettle is false', async () => {
+      const data = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 50.0]],
+      );
+      const { chart } = makeChart(data);
+      enableOverlayWithStudies(chart);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      expect(postToRN).toHaveBeenCalledWith('LEGEND_RENDERED', {});
+      expect(postToRN).not.toHaveBeenCalledWith(
+        'CHART_LAYOUT_SETTLED',
+        expect.anything(),
+      );
+    });
+
+    it('posts CHART_LAYOUT_SETTLED via timeout fallback when legendOwnsLayoutSettle is true', () => {
+      const { chart } = makeChart(new Error('fail'));
+      enableOverlayWithStudies(chart);
+      registerStudy('active', 'MACD', 'sid-macd' as StudyId);
+      setLegendOwnsLayoutSettle(true);
+
+      refreshStudyLegendFromExport();
+      jest.advanceTimersByTime(3000);
+
+      expect(postToRN).toHaveBeenCalledWith('CHART_LAYOUT_SETTLED', {});
+      expect(doesLegendOwnLayoutSettle()).toBe(false);
+    });
+  });
+
+  describe('handleExportData edge cases', () => {
+    it('retries when data has valid schema but empty data array last row', async () => {
+      const data = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [],
+      );
+      (data as { data: unknown[] }).data = [undefined as unknown as number[]];
+      const { chart, exportData } = makeChart(data);
+      enableOverlayWithStudies(chart);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+      jest.advanceTimersByTime(100);
+      expect(exportData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('updateLegendOverlayLayout with price-axis', () => {
+    it('computes pixel max-width from price-axis left boundary', () => {
+      const container = installContainer();
+      setupLegendOverlay({ enabled: true }, undefined);
+      const axisNode = document.createElement('div');
+      axisNode.classList.add('price-axis-container');
+      container.appendChild(axisNode);
+
+      Object.defineProperty(container, 'clientWidth', {
+        value: 400,
+        configurable: true,
+      });
+      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+        left: 0,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 400,
+        height: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      });
+      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
+        left: 350,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 50,
+        height: 600,
+        x: 350,
+        y: 0,
+        toJSON: () => ({}),
+      });
+
+      updateLegendOverlayLayout();
+      const overlay = document.getElementById(OVERLAY_ID);
+      // boundaryLeft = 350 - 0 = 350; maxWidth = 350 - 8 - 4 = 338px
+      expect(overlay?.style.maxWidth).toBe('338px');
+    });
+
+    it('uses fallback max-width when container clientWidth is 0', () => {
+      const container = installContainer();
+      setupLegendOverlay({ enabled: true }, undefined);
+      const axisNode = document.createElement('div');
+      axisNode.classList.add('price-axis-container');
+      container.appendChild(axisNode);
+
+      Object.defineProperty(container, 'clientWidth', {
+        value: 0,
+        configurable: true,
+      });
+      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      });
+      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
+        left: 350,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 50,
+        height: 600,
+        x: 350,
+        y: 0,
+        toJSON: () => ({}),
+      });
+
+      updateLegendOverlayLayout();
+      const overlay = document.getElementById(OVERLAY_ID);
+      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+    });
+
+    it('uses fallback when price-axis is too small (width < 2)', () => {
+      const container = installContainer();
+      setupLegendOverlay({ enabled: true }, undefined);
+      const axisNode = document.createElement('div');
+      axisNode.classList.add('price-axis-container');
+      container.appendChild(axisNode);
+
+      Object.defineProperty(container, 'clientWidth', {
+        value: 400,
+        configurable: true,
+      });
+      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+        left: 0,
+        top: 0,
+        right: 400,
+        bottom: 600,
+        width: 400,
+        height: 600,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      });
+      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
+        left: 350,
+        top: 0,
+        right: 351,
+        bottom: 600,
+        width: 1,
+        height: 600,
+        x: 350,
+        y: 0,
+        toJSON: () => ({}),
+      });
+
+      updateLegendOverlayLayout();
+      const overlay = document.getElementById(OVERLAY_ID);
+      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
     });
   });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -15,6 +15,7 @@
 
 import { postToRN } from '../../core/bridge';
 import {
+  doesLegendOwnLayoutSettle,
   getActiveStudies,
   getLegendStudyOrder,
   getMaStudies,
@@ -22,6 +23,7 @@ import {
   getVolumeStudyId,
   getWidget,
   isChartReady,
+  setLegendOwnsLayoutSettle,
 } from '../../core/state';
 import { eachChartDocument } from '../../widget/tvDomHelpers';
 import type {
@@ -343,7 +345,13 @@ function hasAnyEmpty(entries: StudyDataEntry[]): boolean {
 
 function notifyLegendRendered(): void {
   requestAnimationFrame(() => {
-    requestAnimationFrame(() => postToRN('LEGEND_RENDERED', {}));
+    requestAnimationFrame(() => {
+      postToRN('LEGEND_RENDERED', {});
+      if (doesLegendOwnLayoutSettle()) {
+        setLegendOwnsLayoutSettle(false);
+        postToRN('CHART_LAYOUT_SETTLED', {});
+      }
+    });
   });
 }
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -507,7 +507,9 @@ export function subscribeStudyDataLoaded(
   try {
     const study = chart.getStudyById(studyId);
     if (study?.onDataLoaded) {
-      study.onDataLoaded().subscribe(null, () => scheduleLegendRefresh());
+      study.onDataLoaded().subscribe(null, () => {
+        scheduleLegendRefresh();
+      });
       return;
     }
   } catch {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/__tests__/socialLeaderboard.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/__tests__/socialLeaderboard.test.ts
@@ -223,6 +223,35 @@ describe('slbCenterViewport', () => {
     expect(stub.setRangeCalls).toHaveLength(0);
   });
 
+  it('immediate mode: applies the visible range synchronously without onDataLoaded', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(8 * HOUR_MS);
+    setVisibleToMs(LAST_BAR_MS);
+
+    slbCenterViewport(stub.chart, { immediate: true });
+    // Should fire immediately — no need to call fireDataLoaded.
+    expect(stub.setRangeCalls).toHaveLength(1);
+    expect(stub.setRangeCalls[0].options).toEqual({ percentRightMargin: 0 });
+  });
+
+  it('immediate mode: historical frame applies hold loop synchronously', () => {
+    const stub = makeStubChart();
+    installWidget(stub.chart);
+    setVisibleFromMs(1 * HOUR_MS);
+    setVisibleToMs(3 * HOUR_MS);
+
+    slbCenterViewport(stub.chart, { immediate: true });
+    // First assertion fires synchronously from the hold loop.
+    expect(stub.setRangeCalls.length).toBeGreaterThanOrEqual(1);
+    jest.advanceTimersByTime(1000);
+    expect(stub.setRangeCalls.length).toBeGreaterThan(1);
+
+    const first = stub.setRangeCalls[0].range;
+    expect(first.from).toBeLessThan(1 * 60 * 60);
+    expect(first.to).toBeGreaterThanOrEqual(3 * 60 * 60);
+  });
+
   it('clears the centering-pending flag after framing', () => {
     const stub = makeStubChart();
     installWidget(stub.chart);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/socialLeaderboard/index.ts
@@ -118,8 +118,15 @@ function holdCenteredVisibleRange(
  *
  * The centering flag is cleared after success so subsequent REALTIME_UPDATE
  * messages don't re-trigger the slide. Only a fresh SET_OHLCV_DATA resets it.
+ *
+ * When `options.immediate` is true, applies centering synchronously instead of
+ * waiting for `onDataLoaded`. Used after `setResolution` where TradingView has
+ * already completed its data cycle by the time the callback fires.
  */
-export function slbCenterViewport(chart: TVActiveChart): void {
+export function slbCenterViewport(
+  chart: TVActiveChart,
+  options?: { immediate?: boolean },
+): void {
   if (!getSlbMode() || !isSlbCenteringPending()) return;
 
   const fromMs = getVisibleFromMs();
@@ -127,11 +134,8 @@ export function slbCenterViewport(chart: TVActiveChart): void {
   if (fromMs == null || toMs == null) return;
 
   const capturedGeneration = getOhlcvGeneration();
-  const subscription = chart.onDataLoaded();
 
-  const onLoaded = (): void => {
-    subscription.unsubscribe(null, onLoaded);
-
+  const applyCenter = (): void => {
     if (capturedGeneration !== getOhlcvGeneration()) return;
     if (!isSlbCenteringPending()) return;
 
@@ -168,6 +172,16 @@ export function slbCenterViewport(chart: TVActiveChart): void {
     }
   };
 
+  if (options?.immediate) {
+    applyCenter();
+    return;
+  }
+
+  const subscription = chart.onDataLoaded();
+  const onLoaded = (): void => {
+    subscription.unsubscribe(null, onLoaded);
+    applyCenter();
+  };
   subscription.subscribe(null, onLoaded);
 }
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/datafeed.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/datafeed.test.ts
@@ -9,7 +9,6 @@ import {
 import {
   __resetStateForTests,
   getRealtimeCallbacks,
-  setInHotReloadPreResetPhase,
   setOhlcvData,
   setOhlcvPagination,
   setRnBackedPagination,
@@ -173,22 +172,6 @@ describe('customDatafeed', () => {
     expect(requestOlderBarsFromRN).toHaveBeenCalledWith(
       expect.objectContaining({ resolution: '5' }),
     );
-  });
-
-  it('getBars returns noData during hot-reload pre-reset phase on firstDataRequest', () => {
-    setOhlcvData([
-      { time: 100_000, open: 1, high: 1, low: 1, close: 1, volume: 0 },
-    ]);
-    setInHotReloadPreResetPhase(true);
-    const onResult = jest.fn();
-    customDatafeed.getBars(
-      stubSymbolInfo,
-      '5' as TVResolution,
-      periodParams({ from: 90, to: 200, firstDataRequest: true }),
-      onResult,
-      jest.fn(),
-    );
-    expect(onResult).toHaveBeenCalledWith([], { noData: true });
   });
 
   it('getBars returns noData when neither pagination source is available', () => {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/ohlcvIngestion.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/__tests__/ohlcvIngestion.test.ts
@@ -15,7 +15,6 @@ import {
   getOhlcvPagination,
   getRnBackedPagination,
   getVisibleFromMs,
-  isInHotReloadPreResetPhase,
   setChartReady,
   setWidget,
 } from '../../core/state';
@@ -150,9 +149,13 @@ describe('handleSetOHLCVData', () => {
       data: Array.from({ length: 3 }, (_, i) => bar(i * 300_000)),
     });
     expect(setResolution).toHaveBeenCalledWith('5', expect.any(Function));
+    // resetData is NOT called on the resolution-change path; TV handles it
+    // naturally via setResolution + getBars.
     expect(resetData).not.toHaveBeenCalled();
     setResCb();
-    expect(resetData).toHaveBeenCalled();
+    expect(resetData).not.toHaveBeenCalled();
+    // Callback runs applyVisibleRange → setRightOffset
+    expect(getTimeScale).toHaveBeenCalled();
   });
 
   it('ignores stale setResolution callback when a newer interval arrives', () => {
@@ -193,83 +196,13 @@ describe('handleSetOHLCVData', () => {
 
     expect(setResCbs).toHaveLength(2);
 
-    // Fire the stale 5m callback — should be ignored
+    // Fire the stale 5m callback — should be ignored (no side-effects)
     setResCbs[0]();
-    expect(resetData).not.toHaveBeenCalled();
+    expect(getTimeScale).not.toHaveBeenCalled();
 
     // Fire the current 15m callback — should proceed
     setResCbs[1]();
-    expect(resetData).toHaveBeenCalledTimes(1);
-  });
-
-  it('sets inHotReloadPreResetPhase during setResolution window', () => {
-    let setResCb: () => void = () => undefined;
-    const setResolution = jest
-      .fn()
-      .mockImplementation((_res: string, cb: () => void) => {
-        setResCb = cb;
-      });
-    const chart = {
-      resetData: jest.fn(),
-      setResolution,
-      onDataLoaded: jest
-        .fn()
-        .mockReturnValue({ subscribe: jest.fn(), unsubscribe: jest.fn() }),
-      getTimeScale: jest.fn().mockReturnValue({ setRightOffset: jest.fn() }),
-    } as unknown as TVActiveChart;
-
-    handleSetOHLCVData({ data: oneMinuteApart(2) });
-    setWidget({
-      activeChart: () => chart,
-    } as unknown as TVChartingLibraryWidget);
-    setChartReady(true);
-
-    handleSetOHLCVData({
-      data: Array.from({ length: 3 }, (_, i) => bar(i * 300_000)),
-    });
-
-    expect(isInHotReloadPreResetPhase()).toBe(true);
-    setResCb();
-    expect(isInHotReloadPreResetPhase()).toBe(false);
-  });
-
-  it('clears inHotReloadPreResetPhase when same-resolution data arrives during pending setResolution', () => {
-    let setResCb: () => void = () => undefined;
-    const setResolution = jest
-      .fn()
-      .mockImplementation((_res: string, cb: () => void) => {
-        setResCb = cb;
-      });
-    const chart = {
-      resetData: jest.fn(),
-      setResolution,
-      onDataLoaded: jest
-        .fn()
-        .mockReturnValue({ subscribe: jest.fn(), unsubscribe: jest.fn() }),
-      getTimeScale: jest.fn().mockReturnValue({ setRightOffset: jest.fn() }),
-    } as unknown as TVActiveChart;
-
-    handleSetOHLCVData({ data: oneMinuteApart(2) });
-    setWidget({
-      activeChart: () => chart,
-    } as unknown as TVChartingLibraryWidget);
-    setChartReady(true);
-
-    // Switch 1m → 5m: sets inHotReloadPreResetPhase = true
-    handleSetOHLCVData({
-      data: Array.from({ length: 3 }, (_, i) => bar(i * 300_000)),
-    });
-    expect(isInHotReloadPreResetPhase()).toBe(true);
-
-    // Same 5m data arrives again before the callback fires
-    handleSetOHLCVData({
-      data: Array.from({ length: 3 }, (_, i) => bar(i * 300_000)),
-    });
-    expect(isInHotReloadPreResetPhase()).toBe(false);
-
-    // Stale callback should be ignored
-    setResCb();
-    expect(isInHotReloadPreResetPhase()).toBe(false);
+    expect(getTimeScale).toHaveBeenCalled();
   });
 
   it('calls widget.resetCache before resetData on same-resolution reload', () => {
@@ -944,16 +877,13 @@ describe('error paths', () => {
     expect(failingCb).toHaveBeenCalledTimes(2);
   });
 
-  it('reports error when resetData throws inside setResolution callback', () => {
+  it('reports error when setRightOffset throws inside setResolution callback', () => {
     (
       window as unknown as { ReactNativeWebView: { postMessage: jest.Mock } }
     ).ReactNativeWebView = { postMessage: jest.fn() };
 
     let setResCb: () => void = () => undefined;
     const chart = {
-      resetData: jest.fn().mockImplementation(() => {
-        throw new Error('resetData inside setResolution');
-      }),
       setResolution: jest
         .fn()
         .mockImplementation((_res: string, cb: () => void) => {
@@ -962,7 +892,11 @@ describe('error paths', () => {
       onDataLoaded: jest
         .fn()
         .mockReturnValue({ subscribe: jest.fn(), unsubscribe: jest.fn() }),
-      getTimeScale: jest.fn().mockReturnValue({ setRightOffset: jest.fn() }),
+      getTimeScale: jest.fn().mockReturnValue({
+        setRightOffset: jest.fn().mockImplementation(() => {
+          throw new Error('setRightOffset inside setResolution');
+        }),
+      }),
       getPanes: jest.fn().mockReturnValue([]),
     } as unknown as TVActiveChart;
 
@@ -978,7 +912,7 @@ describe('error paths', () => {
       data: Array.from({ length: 3 }, (_, i) => bar(i * 300_000)),
     });
 
-    // Fire the setResolution callback — resetData throws inside.
+    // Fire the setResolution callback — setRightOffset throws inside applyVisibleRange.
     expect(() => setResCb()).not.toThrow();
 
     const bridge = (
@@ -989,7 +923,7 @@ describe('error paths', () => {
         const parsed = JSON.parse(call[0]);
         return (
           parsed.type === 'ERROR' &&
-          parsed.payload.message.includes('resetData inside setResolution')
+          parsed.payload.message.includes('setRightOffset inside setResolution')
         );
       },
     );

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/datafeed.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/datafeed.ts
@@ -11,7 +11,6 @@ import {
   getOhlcvPagination,
   getRealtimeCallbacks,
   getRnBackedPagination,
-  isInHotReloadPreResetPhase,
   registerRealtimeCallback,
   unregisterRealtimeCallback,
 } from '../core/state';
@@ -149,11 +148,6 @@ export const customDatafeed: TVDatafeed = {
       const fromMs = periodParams.from * 1000;
       const toMs = periodParams.to * 1000;
       const { countBack, firstDataRequest } = periodParams;
-
-      if (firstDataRequest && isInHotReloadPreResetPhase()) {
-        onResult([], { noData: true });
-        return;
-      }
 
       const bars = filterBarsForRange(fromMs, toMs, countBack);
       if (bars.length > 0) {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/ohlcvIngestion.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/ohlcvIngestion.ts
@@ -22,8 +22,11 @@ import {
   bumpHotReloadSeq,
   bumpOhlcvGeneration,
   clearOhlcvPagination,
+  doesLegendOwnLayoutSettle,
+  getActiveStudies,
   getCurrentResolution,
   getHotReloadSeq,
+  getMaStudies,
   getOhlcvData,
   getOhlcvGeneration,
   getSlbMode,
@@ -31,7 +34,7 @@ import {
   getWidget,
   isChartReady,
   setCurrentResolution,
-  setInHotReloadPreResetPhase,
+  setLegendOwnsLayoutSettle,
   setOhlcvData,
   setOhlcvPagination,
   setRnBackedPagination,
@@ -53,6 +56,17 @@ type FirstDataCallback = () => void;
 
 let firstDataCallback: FirstDataCallback | null = null;
 let firstDataDelivered = false;
+
+/**
+ * When active indicators exist, defers the CHART_LAYOUT_SETTLED signal to the
+ * legend module so it fires after the first successful legend render — not on
+ * the premature 2-rAF timer in emitLayoutSettled.
+ */
+function claimLegendSettleOwnership(): void {
+  if (getActiveStudies().size > 0 || getMaStudies().size > 0) {
+    setLegendOwnsLayoutSettle(true);
+  }
+}
 
 /**
  * Registers the callback invoked the first time SET_OHLCV_DATA arrives.
@@ -106,7 +120,8 @@ export function handleSetOHLCVData(payload: SetOHLCVDataPayload): void {
     try {
       const chart = widget.activeChart();
       if (previousResolution === newResolution) {
-        setInHotReloadPreResetPhase(false);
+        // Same resolution — TV won't re-fetch via getBars, so we must
+        // resetData to force it to pick up the new bars from the datafeed.
         resetDatafeedCacheBeforeHotReload(widget);
         chart.resetData();
         resetMainPriceScaleAutoScale(chart);
@@ -114,28 +129,22 @@ export function handleSetOHLCVData(payload: SetOHLCVDataPayload): void {
         applyVisibleRange(chart);
         emitLayoutSettled();
       } else {
-        setInHotReloadPreResetPhase(true);
+        // Different resolution — let setResolution handle the transition
+        // naturally. TV calls getBars internally, the datafeed returns the
+        // new bars (already stored via setOhlcvData above), and TV renders
+        // them smoothly without a blank frame. No resetData needed.
+        claimLegendSettleOwnership();
         const seq = bumpHotReloadSeq();
         chart.setResolution(newResolution, () => {
           if (getHotReloadSeq() !== seq) {
             return;
           }
-          setInHotReloadPreResetPhase(false);
-          try {
-            resetDatafeedCacheBeforeHotReload(widget);
-            chart.resetData();
-            resetMainPriceScaleAutoScale(chart);
-            notifyDataLifecycle('ohlcvReset');
-            applyVisibleRange(chart);
-            emitLayoutSettled();
-          } catch (error) {
-            setInHotReloadPreResetPhase(false);
-            reportErrorToRN(error);
-          }
+          resetMainPriceScaleAutoScale(chart);
+          applyVisibleRange(chart);
+          emitLayoutSettled();
         });
       }
     } catch (error) {
-      setInHotReloadPreResetPhase(false);
       reportErrorToRN(error);
     }
     return;
@@ -218,6 +227,9 @@ function applyVisibleRange(chart: TVActiveChart): void {
 }
 
 function emitLayoutSettled(): void {
+  if (doesLegendOwnLayoutSettle()) {
+    return;
+  }
   const send = (): void => {
     if (getWidget() && isChartReady()) {
       postToRN('CHART_LAYOUT_SETTLED', {});

--- a/app/components/UI/Charts/AdvancedChart/webview/src/widget/ohlcvIngestion.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/widget/ohlcvIngestion.ts
@@ -140,7 +140,7 @@ export function handleSetOHLCVData(payload: SetOHLCVDataPayload): void {
             return;
           }
           resetMainPriceScaleAutoScale(chart);
-          applyVisibleRange(chart);
+          applyVisibleRange(chart, { dataAlreadyLoaded: true });
           emitLayoutSettled();
         });
       }
@@ -179,12 +179,15 @@ export function handleRealtimeUpdate(
   });
 }
 
-function applyVisibleRange(chart: TVActiveChart): void {
+function applyVisibleRange(
+  chart: TVActiveChart,
+  options?: { dataAlreadyLoaded?: boolean },
+): void {
   // Strategy C (SLB): center the viewport on the trade window using both
   // visibleFromMs and visibleToMs. Handled by the socialLeaderboard overlay
   // which subscribes to onDataLoaded and frames the exact trade window.
   if (getSlbMode()) {
-    slbCenterViewport(chart);
+    slbCenterViewport(chart, { immediate: options?.dataAlreadyLoaded });
     return;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When technical indicators (MACD, MA, RSI, etc.) are enabled on the Token Details chart, switching timeframes caused a brief blank flash. The chart would go completely empty (showing only the sub-pane separator and TV logo) before redrawing with new data.

**Root cause:** The custom datafeed's `getBars` method had an `isInHotReloadPreResetPhase` guard that returned `{ noData: true }` during `setResolution()` — forcing TradingView to render an empty chart. After the callback, `resetData()` was called to force a second data fetch, which finally rendered the candles. This created an unnecessary blank frame between the two fetches.

**Fix:** Let TradingView's `setResolution()` handle the resolution change naturally, the way the charting library was designed. Since the new OHLCV bars are already stored in the datafeed (via `setOhlcvData`) before `setResolution()` is called, the datafeed can serve them immediately when TV internally calls `getBars`. This eliminates the blank frame entirely — no `resetData()` needed on the different-resolution path.
Additionally, when indicators are active, `CHART_LAYOUT_SETTLED` is now deferred to fire after the legend has rendered with real values (instead of on a premature 2-rAF-tick timer), ensuring the signal accurately reflects visual readiness.

# SLB viewport framing fix after hot-reload optimization

### Before (main)

The `setResolution` callback called `chart.resetData()` after TV completed its resolution switch, which triggered a **second** `getBars` → `onDataLoaded` cycle:

```
setResolution(newRes, callback)
  └─ callback fires:
       ├─ chart.resetData()          ← triggers NEW getBars → onDataLoaded cycle
       ├─ notifyDataLifecycle('ohlcvReset')
       ├─ applyVisibleRange()        ← subscribes to onDataLoaded (catches it ✓)
       └─ emitLayoutSettled()
```

**Problem:** `resetData()` tears down and rebuilds the chart, causing a visible **blank-frame flash** on every timeframe switch.

### After (this branch)

The hot-reload optimization removes `resetData()` from the `setResolution` callback so TV handles the transition smoothly — no teardown, no flash:

```
setResolution(newRes, callback)
  └─ TV internally calls getBars → renders new bars → fires onDataLoaded
       └─ THEN callback fires:
            ├─ applyVisibleRange({ dataAlreadyLoaded: true })
            │    └─ slbCenterViewport({ immediate: true })
            │         └─ setVisibleRange applied synchronously ✓
            └─ emitLayoutSettled()
```

Without `resetData()`, the `onDataLoaded` event fires **before** the callback runs. SLB's `slbCenterViewport` was subscribing to `onDataLoaded` inside that callback — missing the already-fired event, so the trade-framing viewport was never applied.

**Fix:** When `applyVisibleRange` is called from the `setResolution` callback, it passes `{ dataAlreadyLoaded: true }`, which flows into `slbCenterViewport` as `{ immediate: true }`. This applies the trade-window centering synchronously instead of waiting for an event that already happened.

### Why Token Details is unaffected

Token Details doesn't use `slbMode` and its `visibleFromMs` is `null`, so `applyVisibleRange` takes the synchronous `setRightOffset(2)` path — no `onDataLoaded` subscription needed in either the old or new code.


## **Changelog**
CHANGELOG entry: Fixed blank flash on Token Details chart when switching timeframes with technical indicators enabled


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3605

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token Details chart timeframe switching
  Scenario: user switches timeframes with technical indicators enabled
    Given user is on a token details page with technical indicators (e.g. MACD, MA) enabled
    When user taps different timeframe buttons (1m, 5m, 15m, 1h, 1d, 1w)
    Then chart transitions smoothly without a blank flash between intervals
    And indicator legend values update to reflect the new timeframe data
    And no stale legend values from the previous interval are visible
  Scenario: user switches timeframes without technical indicators
    Given user is on a token details page with no technical indicators enabled
    When user taps different timeframe buttons
    Then chart transitions as before with no regression
  Scenario: initial chart load still shows skeleton
    Given user navigates to a token details page for the first time
    When the chart is loading
    Then a skeleton loader is visible until chart, indicators, and legend are fully ready
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

**_You might not always be able to see this flash but it happens sometimes_**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/cbbe6783-1d1e-4790-84b9-93b065f55563



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a156f040-0274-4435-be99-be05738dc67a



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core OHLCV hot-reload, RN bridge timing (`CHART_LAYOUT_SETTLED`), and SLB viewport logic in the Advanced Chart WebView—high user visibility but well-covered by tests.
> 
> **Overview**
> **Token Details chart** timeframe switches with technical indicators no longer flash a blank chart during hot reload.
> 
> The WebView **drops the hot-reload “pre-reset” phase** that made `getBars` return `noData` on the first request and then **`resetData()` inside the `setResolution` callback**. On a **resolution change**, new bars are already in the datafeed, so TradingView’s normal `setResolution` → `getBars` path redraws without an empty frame; **same-resolution** updates still use **`resetData()`** and cache reset.
> 
> When **indicators or MAs are active**, **`CHART_LAYOUT_SETTLED`** can be **owned by the legend**: ingestion skips the early 2-rAF emit and the legend posts settle after a successful render (including timeout fallback).
> 
> **Social Leaderboard** viewport centering gains **`immediate`** mode so trade-window framing runs synchronously after `setResolution` when data is already loaded (fixing missed `onDataLoaded`).
> 
> Tests are updated for the new paths plus legend/settle and SLB immediate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed596c5854e8e730672d9296e6409c84b3d3379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->