### PR TITLE
fix: restore Metro hot reload by routing dev websockets by scheme

### DIFF
--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -86,6 +86,7 @@ describe('NitroWebSocketSetup', () => {
         expect(sentinel).toHaveBeenCalledWith(
           'ws://localhost:8081/hot',
           undefined,
+          undefined,
         );
       } finally {
         devGlobal.__DEV__ = originalDev;
@@ -121,6 +122,24 @@ describe('NitroWebSocketSetup', () => {
       expect(MockOriginalWebSocket).toHaveBeenCalledWith(
         'ws://localhost:8081/hot',
         undefined,
+        undefined,
+      );
+      expect(MockNitroWebSocket).not.toHaveBeenCalled();
+    });
+
+    it('forwards the third RN options argument ({ headers }) to the built-in WebSocket', () => {
+      const options = { headers: { Authorization: 'Bearer token' } };
+
+      new (global.WebSocket as unknown as new (
+        url: string,
+        protocols?: string | string[],
+        options?: unknown,
+      ) => WebSocket)('ws://localhost:8099', undefined, options);
+
+      expect(MockOriginalWebSocket).toHaveBeenCalledWith(
+        'ws://localhost:8099',
+        undefined,
+        options,
       );
       expect(MockNitroWebSocket).not.toHaveBeenCalled();
     });

--- a/app/core/NitroWebSocketSetup.test.ts
+++ b/app/core/NitroWebSocketSetup.test.ts
@@ -47,14 +47,121 @@ jest.mock('react-native-nitro-websockets', () => ({
   }),
 }));
 
-import './NitroWebSocketSetup';
+import {
+  installDevNitroWebSocket,
+  installProductionNitroWebSocket,
+  NitroWebSocketAdapter,
+} from './NitroWebSocketSetup';
 
 const MockNitroWebSocket = jest.mocked(NitroWebSocket);
 
+const originalGlobalWebSocket = global.WebSocket;
+
 describe('NitroWebSocketSetup', () => {
+  beforeAll(() => {
+    installProductionNitroWebSocket();
+  });
+
+  afterAll(() => {
+    global.WebSocket = originalGlobalWebSocket;
+  });
+
   describe('module-level side effects', () => {
-    it('installs NitroWebSocketAdapter as global.WebSocket', () => {
+    it('keeps ws:// sockets (Metro hot reload) on the built-in WebSocket when imported in dev (__DEV__)', () => {
+      // __DEV__ is a bare global injected by RN/Jest — not typed on globalThis.
+      const devGlobal = global as unknown as { __DEV__: boolean };
+      const originalDev = devGlobal.__DEV__;
+      const sentinel = jest.fn();
+
+      devGlobal.__DEV__ = true;
+      global.WebSocket = sentinel as unknown as typeof WebSocket;
+      try {
+        jest.isolateModules(() => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          require('./NitroWebSocketSetup');
+        });
+
+        new global.WebSocket('ws://localhost:8081/hot');
+
+        expect(sentinel).toHaveBeenCalledWith(
+          'ws://localhost:8081/hot',
+          undefined,
+        );
+      } finally {
+        devGlobal.__DEV__ = originalDev;
+        global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
+      }
+    });
+
+    it('installs NitroWebSocketAdapter as global.WebSocket when installed explicitly', () => {
       new global.WebSocket('wss://example.com');
+
+      expect(MockNitroWebSocket).toHaveBeenCalled();
+    });
+  });
+
+  describe('installDevNitroWebSocket — scheme routing', () => {
+    let MockOriginalWebSocket: jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      MockOriginalWebSocket = jest.fn();
+      global.WebSocket = MockOriginalWebSocket as unknown as typeof WebSocket;
+      installDevNitroWebSocket();
+    });
+
+    afterEach(() => {
+      // Restore the adapter installed by the outer beforeAll for later suites.
+      installProductionNitroWebSocket();
+    });
+
+    it('routes ws:// sockets (Metro HMR /hot) to the built-in WebSocket', () => {
+      new global.WebSocket('ws://localhost:8081/hot');
+
+      expect(MockOriginalWebSocket).toHaveBeenCalledWith(
+        'ws://localhost:8081/hot',
+        undefined,
+      );
+      expect(MockNitroWebSocket).not.toHaveBeenCalled();
+    });
+
+    it('routes ws:// sockets to the built-in WebSocket regardless of host (LAN device, emulator)', () => {
+      new global.WebSocket('ws://10.0.2.2:8081/hot');
+
+      expect(MockOriginalWebSocket).toHaveBeenCalled();
+      expect(MockNitroWebSocket).not.toHaveBeenCalled();
+    });
+
+    it('routes wss:// application sockets through NitroWebSocket', () => {
+      new global.WebSocket('wss://example.com', 'proto1');
+
+      expect(MockNitroWebSocket).toHaveBeenCalledWith(
+        'wss://example.com',
+        'proto1',
+        undefined,
+      );
+      expect(MockOriginalWebSocket).not.toHaveBeenCalled();
+    });
+
+    it('matches the wss scheme case-insensitively', () => {
+      new global.WebSocket('WSS://example.com');
+
+      expect(MockNitroWebSocket).toHaveBeenCalled();
+      expect(MockOriginalWebSocket).not.toHaveBeenCalled();
+    });
+
+    it('exposes W3C ready state constants on the routing constructor', () => {
+      expect(global.WebSocket.CONNECTING).toBe(0);
+      expect(global.WebSocket.OPEN).toBe(1);
+      expect(global.WebSocket.CLOSING).toBe(2);
+      expect(global.WebSocket.CLOSED).toBe(3);
+    });
+
+    it('falls back to the Nitro adapter when no built-in WebSocket exists', () => {
+      global.WebSocket = undefined as unknown as typeof WebSocket;
+
+      installDevNitroWebSocket();
+      new global.WebSocket('ws://localhost:8081/hot');
 
       expect(MockNitroWebSocket).toHaveBeenCalled();
     });

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -274,8 +274,43 @@ export function installProductionNitroWebSocket(): void {
   global.WebSocket = NitroWebSocketAdapter as unknown as typeof WebSocket;
 }
 
+// Dev builds route by scheme: ws:// → RN built-in (Metro HMR, LogBox), wss:// → Nitro.
+// Metro's HMRClient uses global.WebSocket after startup, so a blanket replacement breaks hot reload.
+export function installDevNitroWebSocket(): void {
+  const OriginalWebSocket = global.WebSocket;
+
+  if (!OriginalWebSocket) {
+    installProductionNitroWebSocket();
+    return;
+  }
+
+  function SchemeRoutingWebSocket(
+    url: string,
+    protocols?: string | string[],
+    headers?: Record<string, string>,
+  ) {
+    if (typeof url === 'string' && /^wss:/i.test(url)) {
+      return new NitroWebSocketAdapter(url, protocols, headers);
+    }
+    // ws:// (Metro HMR, LogBox) keeps RN's built-in WebSocket.
+    return new OriginalWebSocket(url, protocols);
+  }
+  Object.assign(SchemeRoutingWebSocket, {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  });
+
+  global.WebSocket = SchemeRoutingWebSocket as unknown as typeof WebSocket;
+}
+
 if (!hasTestOverrides) {
-  installProductionNitroWebSocket();
+  if (__DEV__) {
+    installDevNitroWebSocket();
+  } else {
+    installProductionNitroWebSocket();
+  }
 }
 
 export { NitroWebSocketAdapter };

--- a/app/core/NitroWebSocketSetup.ts
+++ b/app/core/NitroWebSocketSetup.ts
@@ -284,16 +284,30 @@ export function installDevNitroWebSocket(): void {
     return;
   }
 
+  type RNWebSocketConstructor = new (
+    url: string,
+    protocols?: string | string[],
+    options?: unknown,
+  ) => WebSocket;
+
   function SchemeRoutingWebSocket(
     url: string,
     protocols?: string | string[],
-    headers?: Record<string, string>,
+    optionsOrHeaders?: unknown,
   ) {
     if (typeof url === 'string' && /^wss:/i.test(url)) {
-      return new NitroWebSocketAdapter(url, protocols, headers);
+      return new NitroWebSocketAdapter(
+        url,
+        protocols,
+        optionsOrHeaders as Record<string, string> | undefined,
+      );
     }
     // ws:// (Metro HMR, LogBox) keeps RN's built-in WebSocket.
-    return new OriginalWebSocket(url, protocols);
+    return new (OriginalWebSocket as unknown as RNWebSocketConstructor)(
+      url,
+      protocols,
+      optionsOrHeaders,
+    );
   }
   Object.assign(SchemeRoutingWebSocket, {
     CONNECTING: 0,


### PR DESCRIPTION
PR #32472 replaced global.WebSocket with NitroWebSocketAdapter for all connections. That broke Fast Refresh in dev: Metro's HMR client (metro-runtime HMRClient) connects via new global.WebSocket(...) after the bundle executes, so the ws://…:8081/hot socket was routed through Nitro instead of RN's built-in WebSocket.

This PR adds a dev-only scheme router in NitroWebSocketSetup.ts:

wss:// → NitroWebSocketAdapter (Perps, Predict, gateway, etc.)
ws:// → RN's built-in WebSocket (Metro HMR, LogBox, local debug bridges)
Production builds are unchanged (all traffic still goes through Nitro). Scheme routing avoids dev-server host detection, so it works on LAN devices and emulators.

Added unit tests for scheme routing (installDevNitroWebSocket) alongside the existing adapter tests from #32472.


<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Refs: #32472

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Dev WebSocket scheme routing

  Scenario: Fast Refresh works after nitro-websockets integration
    Given a dev build on iOS or Android with Metro running
    And the app is unlocked and a screen is visible (e.g. Login or Onboarding)

    When I edit a visible UI string in that screen and save the file
    Then the app reflects the change without a full reload
    And Metro logs a successful HMR update (no "Disconnected from Metro" error)

  Scenario: Application wss:// sockets still use Nitro in dev
    Given a dev build with an unlocked wallet

    When I open a feature that uses live WebSocket data (e.g. Perps or Predict)
    Then prices/positions update in real time over wss://
    And no WebSocket connection errors appear in the console

  Scenario: Production WebSocket behaviour is unchanged
    Given a release/production build

    When the app opens WebSocket connections
    Then all sockets route through NitroWebSocketAdapter (no scheme router)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global `WebSocket` initialization in dev, which affects every socket in the app; production path is unchanged and behavior is covered by new routing tests.
> 
> **Overview**
> Fixes **Fast Refresh** after the global `WebSocket` swap to Nitro by no longer sending every dev connection through `NitroWebSocketAdapter`.
> 
> In **`__DEV__`**, module startup now calls **`installDevNitroWebSocket`**, which wraps `global.WebSocket` in a **scheme router**: **`wss://`** (case-insensitive) still uses **`NitroWebSocketAdapter`**; **`ws://`** uses React Native’s **original** `WebSocket` so Metro HMR (`…/hot`), LogBox, and local bridges keep working on any host. **Production** still uses **`installProductionNitroWebSocket`** (all traffic via Nitro). If no built-in `WebSocket` exists, dev install **falls back** to the Nitro adapter.
> 
> Tests were expanded for **`installDevNitroWebSocket`** (routing, RN third-arg options, W3C constants, fallback) and for **`__DEV__`** import behavior vs explicit production install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77792c5746715b2950f735b4b8371e68260e20ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->