### PR TITLE
fix: iOS onboarding sheet terms/privacy webview dismiss

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -717,6 +717,14 @@ const RootModalFlow = (props: RootModalFlowProps) => (
       name={Routes.SHEET.IMPORT_WALLET_TIP}
       component={ImportWalletTipBottomSheet}
     />
+    <NativeStack.Screen
+      name={Routes.WEBVIEW.SIMPLE}
+      component={SimpleWebview}
+      options={{
+        presentation: 'modal',
+        animation: 'slide_from_bottom',
+      }}
+    />
   </NativeStack.Navigator>
 );
 

--- a/app/components/Views/OnboardingSheet/index.test.tsx
+++ b/app/components/Views/OnboardingSheet/index.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import OnboardingSheet from '.';
 import { strings } from '../../../../locales/i18n';
 import AppConstants from '../../../core/AppConstants';
+import Routes from '../../../constants/navigation/Routes';
 
 // Mock callback functions
 const mockOnPressCreate = jest.fn();
@@ -12,6 +13,28 @@ const mockOnPressContinueWithApple = jest.fn();
 
 const mockNavigate = jest.fn();
 const mockUseRoute = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const MockBottomSheet = forwardRef(
+    (
+      { children }: { children: React.ReactNode },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: jest.fn(),
+        onOpenBottomSheet: jest.fn(),
+      }));
+      return <View>{children}</View>;
+    },
+  );
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+  };
+});
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -155,12 +178,9 @@ describe('OnboardingSheet', () => {
         const termsLink = getByTestId('terms-of-use-link');
         fireEvent.press(termsLink);
 
-        expect(mockNavigate).toHaveBeenCalledWith('Webview', {
-          screen: 'SimpleWebview',
-          params: {
-            url: AppConstants.URLS.TERMS_OF_USE_URL,
-            title: strings('onboarding.terms_of_use'),
-          },
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.SIMPLE, {
+          url: AppConstants.URLS.TERMS_OF_USE_URL,
+          title: strings('onboarding.terms_of_use'),
         });
       });
 
@@ -170,12 +190,9 @@ describe('OnboardingSheet', () => {
         const privacyLink = getByTestId('privacy-notice-link');
         fireEvent.press(privacyLink);
 
-        expect(mockNavigate).toHaveBeenCalledWith('Webview', {
-          screen: 'SimpleWebview',
-          params: {
-            url: AppConstants.URLS.PRIVACY_NOTICE,
-            title: strings('onboarding.privacy_notice'),
-          },
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.SIMPLE, {
+          url: AppConstants.URLS.PRIVACY_NOTICE,
+          title: strings('onboarding.privacy_notice'),
         });
       });
     });

--- a/app/components/Views/OnboardingSheet/index.tsx
+++ b/app/components/Views/OnboardingSheet/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 import { AppThemeKey } from '../../../util/theme/models';
@@ -10,6 +10,7 @@ import AppleWhiteIcon from 'images/apple-white.svg';
 import { OnboardingSheetSelectorIDs } from './OnboardingSheet.testIds';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import AppConstants from '../../../core/AppConstants';
+import Routes from '../../../constants/navigation/Routes';
 import { colors as commonColors } from '../../../styles/common';
 import {
   Box,
@@ -89,15 +90,15 @@ const OnboardingSheet = () => {
     }
   };
 
-  const goTo = (url: string, title: string) => {
-    navigation.navigate('Webview', {
-      screen: 'SimpleWebview',
-      params: {
+  const goTo = useCallback(
+    (url: string, title: string) => {
+      navigation.navigate(Routes.WEBVIEW.SIMPLE, {
         url,
         title,
-      },
-    });
-  };
+      });
+    },
+    [navigation],
+  );
 
   const onPressTermsOfUse = () => {
     const url = AppConstants.URLS.TERMS_OF_USE_URL;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
On iOS, tapping Terms of use or Privacy policy on the seedless onboarding sheet caused the legal webview to open and close immediately.

Terms/Privacy links navigated from RootModalFlow to OnboardingRootNav, which raced with the sheet’s goBack and immediately dismissed the webview. The fix registers SimpleWebview in RootModalFlow and opens it from the same stack without closing the sheet first.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue on iOS where Terms of Use and Privacy Policy links on the onboarding sheet would open and immediately close.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-888

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Onboarding sheet legal links on iOS

  Scenario: Terms of Use opens and stays open
    Given the user is on the onboarding screen with the seedless onboarding sheet open
    When the user taps "Terms of use"
    Then the legal webview opens as a modal bottom sheet
    And the webview remains open until the user taps back

  Scenario: Privacy Policy opens and stays open
    Given the user is on the onboarding screen with the seedless onboarding sheet open
    When the user taps "Privacy policy"
    Then the privacy webview opens as a modal bottom sheet
    And the webview remains open until the user taps back

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/a4946f04-ccb3-42eb-a164-f0a973044a7c


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/15c3fc21-b387-4621-8d43-25195dbe945b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small onboarding navigation change limited to legal link webview presentation; no auth, wallet, or data-handling changes.
> 
> **Overview**
> Fixes **iOS dismissal** when users open Terms of Use or Privacy Notice from the onboarding sheet by changing how the legal webview is presented.
> 
> **OnboardingSheet** no longer navigates through a nested `Webview` → `SimpleWebview` route. It now pushes **`Routes.WEBVIEW.SIMPLE`** with `url` and `title` at the top level, and `goTo` is wrapped in `useCallback`.
> 
> **RootModalFlow** registers **`SimpleWebview`** on the same native stack as the onboarding sheet, with **modal** presentation and **slide_from_bottom** animation, so the legal pages open as a sibling screen users can dismiss correctly on iOS.
> 
> Tests expect the new `navigate` shape and add a **BottomSheet** mock so the sheet renders under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325ba9b07d3058e8664e680ac1768cc086d2d84c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->