### PR TITLE
docs: expand Toast Storybook gallery

### DIFF
--- a/.storybook/index.js
+++ b/.storybook/index.js
@@ -1,9 +1,21 @@
+import { useEffect } from 'react';
 import { getStorybookUI } from '@storybook/react-native';
+import { hideAsync } from 'expo-splash-screen';
 
 import './storybook.requires';
 
-const StorybookUIRoot = getStorybookUI({
+const StorybookUI = getStorybookUI({
   asyncStorage: null,
 });
+
+const StorybookUIRoot = () => {
+  useEffect(() => {
+    hideAsync().catch(() => {
+      // Non-fatal when splash is unavailable in dev.
+    });
+  }, []);
+
+  return <StorybookUI />;
+};
 
 export { StorybookUIRoot as default };

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.stories.tsx
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.stories.tsx
@@ -1,0 +1,181 @@
+/* eslint-disable no-console */
+import React, { useCallback, useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+import Button, { ButtonVariants } from '../../components/Buttons/Button';
+import BaseNotification from './index';
+import type {
+  BaseNotificationData,
+  BaseNotificationProps,
+  BaseNotificationStatus,
+} from './BaseNotification.types';
+
+interface NotificationTrigger {
+  label: string;
+  status: BaseNotificationStatus;
+  data?: BaseNotificationData;
+  autoDismiss?: boolean;
+  onHide?: () => void;
+}
+
+interface ActiveNotification extends NotificationTrigger {
+  key: number;
+}
+
+interface NotificationTriggerSection {
+  title: string;
+  triggers: NotificationTrigger[];
+}
+
+const STORYBOOK_PROPS: Pick<
+  BaseNotificationProps,
+  'persistUntilDismiss' | 'isVisible'
+> = {
+  isVisible: true,
+  persistUntilDismiss: true,
+};
+
+const LOADING_TRIGGERS: NotificationTrigger[] = [
+  { label: 'Pending', status: 'pending' },
+  { label: 'Pending deposit', status: 'pending_deposit' },
+  { label: 'Pending withdrawal', status: 'pending_withdrawal' },
+  {
+    label: 'Speedup',
+    status: 'speedup',
+    data: { nonce: '12' },
+  },
+];
+
+const SUCCESS_TRIGGERS: NotificationTrigger[] = [
+  {
+    label: 'Success',
+    status: 'success',
+    data: { nonce: '42' },
+  },
+  { label: 'Success deposit', status: 'success_deposit' },
+  { label: 'Success withdrawal', status: 'success_withdrawal' },
+  {
+    label: 'Received',
+    status: 'received',
+    data: { amount: '0.5', assetType: 'ETH' },
+  },
+  { label: 'Received payment', status: 'received_payment' },
+  { label: 'ETH received', status: 'eth_received' },
+  { label: 'Import success', status: 'import_success' },
+  { label: 'Simple notification', status: 'simple_notification' },
+];
+
+const FAILURE_TRIGGERS: NotificationTrigger[] = [
+  { label: 'Error', status: 'error' },
+  { label: 'Cancelled', status: 'cancelled' },
+  {
+    label: 'Simple notification rejected',
+    status: 'simple_notification_rejected',
+  },
+];
+
+const INTERACTION_TRIGGERS: NotificationTrigger[] = [
+  {
+    label: 'Custom copy',
+    status: 'simple_notification',
+    data: {
+      title: 'Transaction submitted',
+      description: 'Your swap is being processed on Ethereum Mainnet.',
+    },
+  },
+  {
+    label: 'With close button',
+    status: 'success',
+    autoDismiss: true,
+    data: {
+      title: 'Wallet ready',
+      description: 'Your wallet was imported successfully.',
+    },
+    onHide: () => {
+      console.log('BaseNotification dismissed');
+    },
+  },
+];
+
+const STORY_SECTIONS: NotificationTriggerSection[] = [
+  { title: 'Loading', triggers: LOADING_TRIGGERS },
+  { title: 'Success', triggers: SUCCESS_TRIGGERS },
+  { title: 'Failure', triggers: FAILURE_TRIGGERS },
+  { title: 'Interaction', triggers: INTERACTION_TRIGGERS },
+];
+
+const StoryContainer = ({ children }: { children: React.ReactNode }) => {
+  const tw = useTailwind();
+
+  return (
+    <View style={tw.style('relative min-h-[320px] w-full bg-default')}>
+      {children}
+    </View>
+  );
+};
+
+const NotificationTriggerStory = ({
+  sections,
+}: {
+  sections: NotificationTriggerSection[];
+}) => {
+  const tw = useTailwind();
+  const [active, setActive] = useState<ActiveNotification | null>(null);
+
+  const showNotification = useCallback((trigger: NotificationTrigger) => {
+    setActive(null);
+    setTimeout(() => {
+      setActive({
+        key: Date.now(),
+        ...trigger,
+      });
+    }, 50);
+  }, []);
+
+  return (
+    <StoryContainer>
+      <ScrollView
+        contentContainerStyle={tw.style('gap-6 p-4 pb-32')}
+        keyboardShouldPersistTaps="handled"
+      >
+        {sections.map((section) => (
+          <View key={section.title} style={tw.style('gap-2')}>
+            <Text variant={TextVariant.HeadingSm}>{section.title}</Text>
+            {section.triggers.map((trigger) => (
+              <Button
+                key={trigger.label}
+                variant={ButtonVariants.Secondary}
+                label={trigger.label}
+                onPress={() => showNotification(trigger)}
+              />
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+      {active && (
+        <BaseNotification
+          key={active.key}
+          {...STORYBOOK_PROPS}
+          status={active.status}
+          data={active.data}
+          autoDismiss={active.autoDismiss}
+          onHide={active.onHide}
+          onDismissComplete={() => setActive(null)}
+        />
+      )}
+    </StoryContainer>
+  );
+};
+
+const BaseNotificationMeta = {
+  title: 'Components Temp / BaseNotification',
+  component: BaseNotification,
+};
+
+export default BaseNotificationMeta;
+
+export const Default = {
+  render: () => <NotificationTriggerStory sections={STORY_SECTIONS} />,
+};

--- a/app/component-library/components/Toast/Toast.stories.tsx
+++ b/app/component-library/components/Toast/Toast.stories.tsx
@@ -1,120 +1,353 @@
-// Third party dependencies.
-import React, { useContext } from 'react';
-import { Alert, View } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
-import type { Meta } from '@storybook/react-native';
-
-// External dependencies.
-import Button, { ButtonVariants } from '../Buttons/Button';
+import React, { useCallback, useContext, useMemo, type RefObject } from 'react';
+import { Alert, ScrollView, View } from 'react-native';
+import {
+  IconColor as ReactNativeDsIconColor,
+  IconSize as ReactNativeDsIconSize,
+  Spinner,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
-// Internal dependencies.
-import { default as ToastComponent } from './Toast';
+import { useAppThemeFromContext } from '../../../util/theme';
+import type { Theme } from '../../../util/theme/models';
+import Button, { ButtonVariants } from '../Buttons/Button';
+import { IconColor, IconName } from '../Icons/Icon';
+import Toast from './Toast';
 import { ToastContext, ToastContextWrapper } from './Toast.context';
-import { ToastOptions, ToastVariants } from './Toast.types';
 import {
-  TEST_ACCOUNT_ADDRESS,
-  TEST_AVATAR_TYPE,
-  TEST_NETWORK_IMAGE_URL,
-} from './Toast.constants';
+  ButtonIconVariant,
+  ToastOptions,
+  ToastRef,
+  ToastVariants,
+} from './Toast.types';
+import { visibilityDuration } from './Toast.constants';
 
-interface ToastStoryArgs {
-  variant: ToastVariants;
+const STORYBOOK_TOAST_OPTIONS: Pick<ToastOptions, 'hasNoTimeout'> = {
+  hasNoTimeout: true,
+};
+
+const presentStoryToast = (
+  toastRef: RefObject<ToastRef | null> | undefined,
+  options: ToastOptions,
+) => {
+  toastRef?.current?.showToast({
+    ...STORYBOOK_TOAST_OPTIONS,
+    ...options,
+  });
+};
+
+const StoryContainer = ({ children }: { children: React.ReactNode }) => {
+  const tw = useTailwind();
+
+  return (
+    <View style={tw.style('relative min-h-full w-full flex-1 bg-default')}>
+      {children}
+    </View>
+  );
+};
+
+const StoryToastHost = ({
+  toastRef,
+}: {
+  toastRef: RefObject<ToastRef | null> | undefined;
+}) => {
+  const tw = useTailwind();
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={tw.style('absolute inset-x-0 top-0 z-50')}
+    >
+      <Toast ref={toastRef} />
+    </View>
+  );
+};
+
+interface ToastTrigger {
+  label: string;
+  getOptions: (theme: Theme) => ToastOptions;
 }
 
-export default {
-  title: 'Component Library / Toast',
-  component: ToastComponent,
-  decorators: [
-    (StoryComponent) => (
-      <SafeAreaProvider>
-        <ToastContextWrapper>
-          <StoryComponent />
-        </ToastContextWrapper>
-      </SafeAreaProvider>
-    ),
-  ],
-  argTypes: {
-    variant: {
-      options: ToastVariants,
-      control: {
-        type: 'select',
-      },
-      defaultValue: ToastVariants.Plain,
-    },
+interface ToastTriggerSection {
+  title: string;
+  triggers: ToastTrigger[];
+}
+
+const autoDismissToastOptions = (): ToastOptions => ({
+  variant: ToastVariants.Plain,
+  hasNoTimeout: false,
+  labelOptions: [{ label: 'This toast dismisses automatically.' }],
+  descriptionOptions: {
+    description: `Visible for ${visibilityDuration / 1000}s, then animates away.`,
   },
-} as Meta;
+});
+
+const getPlainTriggers = (): ToastTrigger[] => [
+  {
+    label: 'Plain',
+    getOptions: () => ({
+      variant: ToastVariants.Plain,
+      hasNoTimeout: true,
+      labelOptions: [{ label: 'This is a plain toast message.' }],
+    }),
+  },
+  {
+    label: 'Plain with description',
+    getOptions: () => ({
+      variant: ToastVariants.Plain,
+      hasNoTimeout: true,
+      labelOptions: [{ label: 'Transaction submitted', isBold: true }],
+      descriptionOptions: {
+        description: 'Your swap is being processed on Ethereum Mainnet.',
+      },
+    }),
+  },
+  {
+    label: 'Plain with bold labels',
+    getOptions: () => ({
+      variant: ToastVariants.Plain,
+      hasNoTimeout: true,
+      labelOptions: [
+        { label: 'Switching to' },
+        { label: ' Account 2', isBold: true },
+        { label: '.' },
+      ],
+    }),
+  },
+];
+
+const getAutodismissTriggers = (): ToastTrigger[] => [
+  {
+    label: 'Auto dismiss',
+    getOptions: () => autoDismissToastOptions(),
+  },
+];
+
+const getIconTriggers = (): ToastTrigger[] => [
+  {
+    label: 'Icon success',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Confirmation,
+      iconColor: IconColor.Success,
+      labelOptions: [
+        { label: 'Order placed', isBold: true },
+        { label: '\n', isBold: false },
+        { label: 'Your market order was submitted.', isBold: false },
+      ],
+    }),
+  },
+  {
+    label: 'Icon loading',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Loading,
+      iconColor: IconColor.Primary,
+      labelOptions: [
+        { label: 'Deposit in progress', isBold: true },
+        { label: '\n', isBold: false },
+        { label: 'This may take a few minutes.', isBold: false },
+      ],
+      startAccessory: (
+        <Spinner
+          color={ReactNativeDsIconColor.IconDefault}
+          spinnerIconProps={{ size: ReactNativeDsIconSize.Lg }}
+        />
+      ),
+    }),
+  },
+  {
+    label: 'Icon error',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Warning,
+      iconColor: IconColor.Error,
+      labelOptions: [
+        { label: 'Transaction failed', isBold: true },
+        { label: '\n', isBold: false },
+        { label: 'Please try again.', isBold: false },
+      ],
+    }),
+  },
+  {
+    label: 'Icon warning',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Warning,
+      iconColor: IconColor.Warning,
+      labelOptions: [
+        { label: 'Taking longer than expected', isBold: true },
+        { label: '\n', isBold: false },
+        { label: 'Your transaction is still pending.', isBold: false },
+      ],
+    }),
+  },
+  {
+    label: 'Icon info',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Info,
+      iconColor: IconColor.Default,
+      labelOptions: [
+        { label: 'Network switched', isBold: true },
+        { label: '\n', isBold: false },
+        { label: 'You are now connected to Linea.', isBold: false },
+      ],
+    }),
+  },
+];
+
+const getSpacingTriggers = (): ToastTrigger[] => [
+  {
+    label: '2-line description',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Confirmation,
+      iconColor: IconColor.Success,
+      labelOptions: [{ label: 'Order placed', isBold: true }],
+      descriptionOptions: {
+        description:
+          'Your market order was submitted and is being processed on Ethereum Mainnet.',
+      },
+    }),
+  },
+  {
+    label: '1-line description + link',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Confirmation,
+      iconColor: IconColor.Success,
+      labelOptions: [{ label: 'Order placed', isBold: true }],
+      descriptionOptions: {
+        description: 'Your market order was submitted.',
+      },
+      linkButtonOptions: {
+        label: 'View activity',
+        onPress: () => Alert.alert('View activity pressed'),
+      },
+    }),
+  },
+  {
+    label: '1-line description + trailing button',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Confirmation,
+      iconColor: IconColor.Success,
+      labelOptions: [{ label: 'Deposit complete', isBold: true }],
+      descriptionOptions: {
+        description: '100 USDC added',
+      },
+      closeButtonOptions: {
+        label: 'Track',
+        variant: ButtonVariants.Secondary,
+        onPress: () => Alert.alert('Track pressed'),
+      },
+    }),
+  },
+  {
+    label: 'Wrapped title + description',
+    getOptions: () => ({
+      variant: ToastVariants.Icon,
+      hasNoTimeout: true,
+      iconName: IconName.Warning,
+      iconColor: IconColor.Warning,
+      labelOptions: [
+        {
+          label: 'Taking longer than expected for this transaction to complete',
+          isBold: true,
+        },
+      ],
+      descriptionOptions: {
+        description: 'Your transaction is still pending.',
+      },
+    }),
+  },
+];
+
+const getCloseActionTriggers = (): ToastTrigger[] => [
+  {
+    label: 'With close icon button',
+    getOptions: () => ({
+      variant: ToastVariants.Plain,
+      hasNoTimeout: true,
+      labelOptions: [{ label: 'Notification with dismiss icon.' }],
+      closeButtonOptions: {
+        variant: ButtonIconVariant.Icon,
+        iconName: IconName.Close,
+        onPress: () => Alert.alert('Close pressed'),
+      },
+    }),
+  },
+];
+
+const getStorySections = (theme: Theme): ToastTriggerSection[] => [
+  { title: 'Animation', triggers: getAutodismissTriggers() },
+  { title: 'Plain', triggers: getPlainTriggers() },
+  { title: 'Icon', triggers: getIconTriggers() },
+  { title: 'Close / action', triggers: getCloseActionTriggers() },
+  { title: 'Spacing', triggers: getSpacingTriggers() },
+];
+
+const ToastTriggerStoryContent = () => {
+  const tw = useTailwind();
+  const theme = useAppThemeFromContext();
+  const { toastRef } = useContext(ToastContext);
+  const sections = useMemo(() => getStorySections(theme), [theme]);
+
+  const showToast = useCallback(
+    (trigger: ToastTrigger) => {
+      presentStoryToast(toastRef, trigger.getOptions(theme));
+    },
+    [theme, toastRef],
+  );
+
+  return (
+    <StoryContainer>
+      <ScrollView
+        contentContainerStyle={tw.style('gap-6 p-4 pb-32')}
+        keyboardShouldPersistTaps="handled"
+      >
+        {sections.map((section) => (
+          <View key={section.title} style={tw.style('gap-2')}>
+            <Text variant={TextVariant.HeadingSm}>{section.title}</Text>
+            {section.triggers.map((trigger) => (
+              <Button
+                key={trigger.label}
+                variant={ButtonVariants.Secondary}
+                label={trigger.label}
+                onPress={() => showToast(trigger)}
+              />
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+      <StoryToastHost toastRef={toastRef} />
+    </StoryContainer>
+  );
+};
+
+const ToastTriggerStory = () => (
+  <ToastContextWrapper>
+    <ToastTriggerStoryContent />
+  </ToastContextWrapper>
+);
+
+const ToastMeta = {
+  title: 'Component Library / Toast',
+  component: Toast,
+};
+
+export default ToastMeta;
 
 export const Default = {
-  args: {
-    variant: ToastVariants.Plain,
-  },
-  render: function Render(args: ToastStoryArgs) {
-    const { toastRef } = useContext(ToastContext);
-    const tw = useTailwind();
-
-    let toastOptions: ToastOptions;
-
-    switch (args.variant) {
-      case ToastVariants.Plain:
-        toastOptions = {
-          variant: ToastVariants.Plain,
-          hasNoTimeout: false,
-          labelOptions: [{ label: 'This is a Toast message.' }],
-        };
-        break;
-      case ToastVariants.Account:
-        toastOptions = {
-          variant: ToastVariants.Account,
-          hasNoTimeout: false,
-          labelOptions: [
-            { label: 'Switching to' },
-            { label: ' Account 2.', isBold: true },
-          ],
-          accountAddress: TEST_ACCOUNT_ADDRESS,
-          accountAvatarType: TEST_AVATAR_TYPE,
-        };
-        break;
-      case ToastVariants.Network:
-        toastOptions = {
-          variant: ToastVariants.Network,
-          hasNoTimeout: false,
-          labelOptions: [
-            { label: 'Added' },
-            { label: ' Mainnet', isBold: true },
-            { label: ' network.' },
-          ],
-          networkImageSource: { uri: TEST_NETWORK_IMAGE_URL },
-          descriptionOptions: {
-            description: 'This is a description text for the network toast.',
-          },
-          linkButtonOptions: {
-            label: 'Click here!',
-            onPress: () => {
-              Alert.alert('Clicked toast link!');
-            },
-          },
-        };
-        break;
-      default:
-        toastOptions = {
-          variant: ToastVariants.Plain,
-          hasNoTimeout: false,
-          labelOptions: [{ label: 'This is a Toast message.' }],
-        };
-    }
-
-    return (
-      <View style={tw.style('min-h-[300px] relative')}>
-        <Button
-          variant={ButtonVariants.Secondary}
-          label={`Show ${args.variant} Toast`}
-          onPress={() => {
-            toastRef?.current?.showToast(toastOptions);
-          }}
-        />
-        <ToastComponent ref={toastRef} />
-      </View>
-    );
-  },
+  render: () => <ToastTriggerStory />,
 };

--- a/index.js
+++ b/index.js
@@ -115,16 +115,16 @@ if (IGNORE_BOXLOGS_DEVELOPMENT === 'true') {
 }
 
 /* Uncomment and comment regular registration below */
-// import Storybook from './.storybook';
-// AppRegistry.registerComponent(name, () => Storybook);
+import Storybook from './.storybook';
+AppRegistry.registerComponent(name, () => Storybook);
 
 /**
  * Application entry point responsible for registering root component
  */
-AppRegistry.registerComponent(name, () =>
-  // Disable Sentry for E2E tests
-  hasTestOverrides ? Root : Sentry.wrap(Root),
-);
+// AppRegistry.registerComponent(name, () =>
+//   // Disable Sentry for E2E tests
+//   hasTestOverrides ? Root : Sentry.wrap(Root),
+// );
 
 function setupGlobalErrorHandler() {
   const reactNativeDefaultHandler = global.ErrorUtils.getGlobalHandler();


### PR DESCRIPTION
## **Description**

### 1. What is the reason for this change?

The existing Toast Storybook story only exposed a single variant dropdown (`Plain`, `Account`, `Network`), which made it difficult to review spacing, icon states, close actions, and dismiss animation in one place.

### 2. What is the improvement/solution?

This PR replaces that story with a scrollable trigger gallery grouped by use case (animation, plain, icon, close/action, spacing). The toast host is pinned to the top of the screen to better match in-app positioning. This is a Storybook-only change with no production code updates.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Storybook-only draft for internal Toast design review; no linked ticket

## **Manual testing steps**

```gherkin
Feature: Toast Storybook gallery

  Scenario: Preview toast variants in Storybook
    Given Storybook is running for this branch
    And the user navigates to Component Library / Toast
    When the user taps triggers in each section (Animation, Plain, Icon, Close / action, Spacing)
    Then the corresponding toast appears at the top of the screen
    And auto-dismiss behavior works for the Animation example
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.