### PR TITLE
chore: remove 'hasMusdBonus' on mUSD popular token list item to get rid of obsolete references to merkl campaign cp-8.2.0

### DIFF
--- a/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.test.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.test.ts
@@ -99,27 +99,6 @@ describe('usePopularTokens', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('includes localized description for mUSD token', async () => {
-    mockHandleFetch.mockResolvedValue({});
-
-    const { result } = renderHook(() => usePopularTokens());
-
-    await waitFor(() => {
-      expect(result.current.isInitialLoading).toBe(false);
-    });
-
-    const musdToken = result.current.tokens.find(
-      (token) => token.symbol === 'mUSD',
-    );
-    expect(musdToken?.description).toBe('Get 3% mUSD bonus');
-
-    // Other tokens should not have a description
-    const ethToken = result.current.tokens.find(
-      (token) => token.symbol === 'ETH',
-    );
-    expect(ethToken?.description).toBeUndefined();
-  });
-
   it('sets error state when fetch fails', async () => {
     mockHandleFetch.mockRejectedValue(new Error('Network error'));
 

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
@@ -35,7 +35,6 @@ const POPULAR_TOKENS = [
     name: 'MetaMask USD',
     symbol: 'mUSD',
     // Description will be added dynamically with localized string
-    hasMusdBonus: true,
     iconUrl: buildIconUrl('eip155', '1', 'erc20', MUSD_TOKEN_ADDRESS),
   },
   {


### PR DESCRIPTION

## **Description**

Remove `hasMusdBonus` from mUSD on the popular tokens list. Other references to the bonus were removed by disabling flags, however this one renders unconditionally

## **Changelog**


CHANGELOG entry: Remove `hasMusdBonus` from mUSD on the popular tokens list



Fixes: [#33046 
](https://github.com/MetaMask/metamask-mobile/issues/33046)
## **Manual testing steps**


```gherkin
Feature: no musd bonus

  Scenario: user looks at popular token list
    Given I have no balance so I see the popular token list

    When user looks at the musd entry
    Then they will not see "Get 3% mUSD bonus"
```

## **Screenshots/Recordings**


### **Before**

<img width="1170" height="2532" alt="simulator_screenshot_420974EC-9A09-4B87-A1D0-8E0B994E4B96" src="https://github.com/user-attachments/assets/28dd5189-ac13-4f18-8a1b-5e0affbe1172" />


### **After**
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-07-09 at 14 43 55" src="https://github.com/user-attachments/assets/5293b691-3f33-4fb8-85e6-64fa5ff3177b" />


## **Pre-merge author checklist**


- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage copy-only change for the popular tokens list; no auth, payments, or data-handling impact.
> 
> **Overview**
> Stops showing the **"Get 3% mUSD bonus"** promo on the homepage **popular tokens** mUSD row by removing **`hasMusdBonus`** from the mUSD entry in **`usePopularTokens`** (other Merkl/bonus UI was already gated off; this path was still unconditional).
> 
> The hook test that asserted the localized mUSD **description** is removed. mUSD should now follow the same **price / 1d change** subtitle as the other popular tokens when it appears in the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73175b0c95e1dbd2edc798fc0d62350c96d6590a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->