### PR TITLE
feat: recently added feature flag cp-8.3.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1404,4 +1404,37 @@ describe('PerpsHomeView', () => {
       expect(properties?.sections_displayed).toContain('recently_added');
     });
   });
+
+  describe('Recently Added header navigation', () => {
+    it('navigates to the market list filtered to new markets when the header is pressed', () => {
+      mockUseSelector.mockImplementation(
+        (selector: unknown) => selector === selectPerpsRecentlyAddedEnabledFlag,
+      );
+      mockUsePerpsHomeData.mockReturnValue({
+        ...mockDefaultData,
+        recentlyAddedMarkets: [
+          {
+            symbol: 'BTC',
+            name: 'Bitcoin',
+            price: '$50000',
+            change24h: '+$1250',
+            change24hPercent: '+2.5%',
+            volume: '$1.2B',
+            listedAt: Date.now() - 3 * 60 * 60 * 1000,
+          },
+        ],
+      });
+
+      const { getByTestId } = render(<PerpsHomeView />);
+
+      fireEvent.press(
+        getByTestId(PerpsHomeViewSelectorsIDs.RECENTLY_ADDED_HEADER),
+      );
+
+      expect(mockNavigateToMarketList).toHaveBeenCalledWith({
+        defaultMarketTypeFilter: 'new',
+        source: PERPS_EVENT_VALUE.SOURCE.PERPS_HOME,
+      });
+    });
+  });
 });

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -6,6 +6,7 @@ import {
   selectPerpsFeedbackEnabledFlag,
   selectPerpsProductsEnabledFlag,
   selectPerpsTopMoversEnabledFlag,
+  selectPerpsRecentlyAddedEnabledFlag,
   selectPerpsWatchlistEnabledFlag,
 } from '../../selectors/featureFlags';
 import { usePerpsCategories } from '../../hooks/usePerpsCategories';
@@ -1359,6 +1360,48 @@ describe('PerpsHomeView', () => {
         mockUsePerpsEventTracking.mock.calls,
       );
       expect(properties?.sections_displayed).not.toContain('top_movers');
+    });
+
+    it('excludes recently_added when the feature flag is off even though data is present', () => {
+      mockUseSelector.mockReturnValue(false);
+      mockUsePerpsHomeData.mockReturnValue({
+        ...mockDefaultData,
+        recentlyAddedMarkets: [{ symbol: 'BTC' }],
+      });
+
+      render(<PerpsHomeView />);
+
+      const properties = getBaseEventProperties(
+        mockUsePerpsEventTracking.mock.calls,
+      );
+      expect(properties?.sections_displayed).not.toContain('recently_added');
+    });
+
+    it('includes recently_added when the feature flag is on and data is present', () => {
+      mockUseSelector.mockImplementation(
+        (selector: unknown) => selector === selectPerpsRecentlyAddedEnabledFlag,
+      );
+      mockUsePerpsHomeData.mockReturnValue({
+        ...mockDefaultData,
+        recentlyAddedMarkets: [
+          {
+            symbol: 'BTC',
+            name: 'Bitcoin',
+            price: '$50000',
+            change24h: '+$1250',
+            change24hPercent: '+2.5%',
+            volume: '$1.2B',
+            listedAt: Date.now() - 3 * 60 * 60 * 1000,
+          },
+        ],
+      });
+
+      render(<PerpsHomeView />);
+
+      const properties = getBaseEventProperties(
+        mockUsePerpsEventTracking.mock.calls,
+      );
+      expect(properties?.sections_displayed).toContain('recently_added');
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -62,6 +62,7 @@ import {
   selectPerpsServiceInterruptionBannerEnabledFlag,
   selectPerpsProductsEnabledFlag,
   selectPerpsTopMoversEnabledFlag,
+  selectPerpsRecentlyAddedEnabledFlag,
   selectPerpsWatchlistEnabledFlag,
 } from '../../selectors/featureFlags';
 import { usePerpsCategories } from '../../hooks/usePerpsCategories';
@@ -164,6 +165,9 @@ const PerpsHomeView = ({
   const isWhatsHappeningEnabled = useSelector(selectWhatsHappeningEnabled);
   const isProductsEnabled = useSelector(selectPerpsProductsEnabledFlag);
   const isTopMoversEnabled = useSelector(selectPerpsTopMoversEnabledFlag);
+  const isRecentlyAddedEnabled = useSelector(
+    selectPerpsRecentlyAddedEnabledFlag,
+  );
   const isWatchlistEnabled = useSelector(selectPerpsWatchlistEnabledFlag);
   // Mirrors PerpsProducts' own visibility check (enabled + has categories).
   const productCategories = usePerpsCategories();
@@ -299,6 +303,11 @@ const PerpsHomeView = ({
     isLoading,
   } = usePerpsHomeData({});
 
+  // Independently gates the section from the Terminal backend flag that
+  // supplies `listedAt` data, so it can be hidden even when that data flows.
+  const isRecentlyAddedVisible =
+    isRecentlyAddedEnabled && recentlyAddedMarkets.length > 0;
+
   // Mirrors PerpsWatchlistMarkets V1/V2 gating: suggestions only count toward
   // section visibility when the redesigned watchlist flag is on.
   const isWatchlistVisible =
@@ -397,8 +406,8 @@ const PerpsHomeView = ({
     if (isTopMoversVisible)
       sections.push(PERPS_EVENT_VALUE.SECTION_NAME.TOP_MOVERS);
     // Recently Added self-hides when there are no markets listed in the last
-    // 30 days; no loading skeleton, so gate purely on data length.
-    if (recentlyAddedMarkets.length > 0) sections.push('recently_added');
+    // 30 days, or when the feature flag is off.
+    if (isRecentlyAddedVisible) sections.push('recently_added');
     // Explore category lists render a skeleton while markets load, then self-hide
     // when their own market array is empty.
     if (isLoading.markets || perpsMarkets.length > 0)
@@ -422,7 +431,7 @@ const PerpsHomeView = ({
     isProductsEnabled,
     productCategories,
     isTopMoversVisible,
-    recentlyAddedMarkets,
+    isRecentlyAddedVisible,
     perpsMarkets,
     commoditiesMarkets,
     stocksMarkets,
@@ -752,9 +761,9 @@ const PerpsHomeView = ({
       {
         key: 'recently-added',
         // Mirrors PerpsRecentlyAddedSection's own render gate (markets.length
-        // === 0 -> null) so PerpsHomeSectionList does not render an orphan
-        // divider for an empty rail.
-        visible: recentlyAddedMarkets.length > 0,
+        // === 0 -> null) plus the feature flag, so PerpsHomeSectionList does
+        // not render an orphan divider for an empty/disabled rail.
+        visible: isRecentlyAddedVisible,
         onLayout: handleSectionLayout('recently_added'),
         content: (
           <PerpsRecentlyAddedSection
@@ -874,6 +883,7 @@ const PerpsHomeView = ({
       isProductsEnabled,
       productCategories.length,
       isTopMoversVisible,
+      isRecentlyAddedVisible,
       recentlyAddedMarkets,
       handleRecentlyAddedMarketPress,
       perpsMarkets,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -405,9 +405,6 @@ const PerpsHomeView = ({
     // PerpsHomeSectionList does not render an orphan divider.
     if (isTopMoversVisible)
       sections.push(PERPS_EVENT_VALUE.SECTION_NAME.TOP_MOVERS);
-    // Recently Added self-hides when there are no markets listed in the last
-    // 30 days, or when the feature flag is off.
-    if (isRecentlyAddedVisible) sections.push('recently_added');
     // Explore category lists render a skeleton while markets load, then self-hide
     // when their own market array is empty.
     if (isLoading.markets || perpsMarkets.length > 0)
@@ -421,6 +418,9 @@ const PerpsHomeView = ({
     // Recent activity shows a skeleton while loading, then self-hides when empty.
     if (isLoading.activity || recentActivity.length > 0)
       sections.push(PERPS_EVENT_VALUE.SECTION_NAME.RECENT_ACTIVITY);
+    // Recently Added self-hides when there are no markets listed in the last
+    // 30 days, or when the feature flag is off.
+    if (isRecentlyAddedVisible) sections.push('recently_added');
     return sections;
   }, [
     isLoading,
@@ -759,20 +759,6 @@ const PerpsHomeView = ({
         ),
       },
       {
-        key: 'recently-added',
-        // Mirrors PerpsRecentlyAddedSection's own render gate (markets.length
-        // === 0 -> null) plus the feature flag, so PerpsHomeSectionList does
-        // not render an orphan divider for an empty/disabled rail.
-        visible: isRecentlyAddedVisible,
-        onLayout: handleSectionLayout('recently_added'),
-        content: (
-          <PerpsRecentlyAddedSection
-            markets={recentlyAddedMarkets}
-            onMarketPress={handleRecentlyAddedMarketPress}
-          />
-        ),
-      },
-      {
         key: 'crypto',
         visible: isLoading.markets || perpsMarkets.length > 0,
         onLayout: handleSectionLayout(
@@ -857,6 +843,20 @@ const PerpsHomeView = ({
           <PerpsRecentActivityList
             transactions={recentActivity}
             isLoading={isLoading.activity}
+          />
+        ),
+      },
+      {
+        key: 'recently-added',
+        // Mirrors PerpsRecentlyAddedSection's own render gate (markets.length
+        // === 0 -> null) plus the feature flag, so PerpsHomeSectionList does
+        // not render an orphan divider for an empty/disabled rail.
+        visible: isRecentlyAddedVisible,
+        onLayout: handleSectionLayout('recently_added'),
+        content: (
+          <PerpsRecentlyAddedSection
+            markets={recentlyAddedMarkets}
+            onMarketPress={handleRecentlyAddedMarketPress}
           />
         ),
       },

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -513,6 +513,14 @@ const PerpsHomeView = ({
     [perpsNavigation],
   );
 
+  const handleRecentlyAddedHeaderPress = useCallback(() => {
+    perpsNavigation.navigateToMarketList({
+      defaultMarketTypeFilter: 'new',
+      source: PERPS_EVENT_VALUE.SOURCE.PERPS_HOME,
+      ...(transactionActiveAbTests?.length ? { transactionActiveAbTests } : {}),
+    });
+  }, [perpsNavigation, transactionActiveAbTests]);
+
   const navigtateToTutorial = useCallback(() => {
     // Track tutorial button click
     trackEvent(
@@ -844,6 +852,7 @@ const PerpsHomeView = ({
           <PerpsRecentlyAddedSection
             markets={recentlyAddedMarkets}
             onMarketPress={handleRecentlyAddedMarketPress}
+            onViewAllPress={handleRecentlyAddedHeaderPress}
           />
         ),
       },
@@ -886,6 +895,7 @@ const PerpsHomeView = ({
       isRecentlyAddedVisible,
       recentlyAddedMarkets,
       handleRecentlyAddedMarketPress,
+      handleRecentlyAddedHeaderPress,
       perpsMarkets,
       commoditiesMarkets,
       stocksMarkets,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -415,12 +415,12 @@ const PerpsHomeView = ({
       sections.push(PERPS_EVENT_VALUE.SECTION_NAME.EXPLORE_STOCKS);
     if (isLoading.markets || forexMarkets.length > 0)
       sections.push(PERPS_EVENT_VALUE.SECTION_NAME.EXPLORE_FOREX);
-    // Recent activity shows a skeleton while loading, then self-hides when empty.
-    if (isLoading.activity || recentActivity.length > 0)
-      sections.push(PERPS_EVENT_VALUE.SECTION_NAME.RECENT_ACTIVITY);
     // Recently Added self-hides when there are no markets listed in the last
     // 30 days, or when the feature flag is off.
     if (isRecentlyAddedVisible) sections.push('recently_added');
+    // Recent activity shows a skeleton while loading, then self-hides when empty.
+    if (isLoading.activity || recentActivity.length > 0)
+      sections.push(PERPS_EVENT_VALUE.SECTION_NAME.RECENT_ACTIVITY);
     return sections;
   }, [
     isLoading,
@@ -834,19 +834,6 @@ const PerpsHomeView = ({
         ),
       },
       {
-        key: 'recent-activity',
-        visible: isLoading.activity || recentActivity.length > 0,
-        onLayout: handleSectionLayout(
-          PERPS_EVENT_VALUE.SECTION_NAME.RECENT_ACTIVITY,
-        ),
-        content: (
-          <PerpsRecentActivityList
-            transactions={recentActivity}
-            isLoading={isLoading.activity}
-          />
-        ),
-      },
-      {
         key: 'recently-added',
         // Mirrors PerpsRecentlyAddedSection's own render gate (markets.length
         // === 0 -> null) plus the feature flag, so PerpsHomeSectionList does
@@ -857,6 +844,19 @@ const PerpsHomeView = ({
           <PerpsRecentlyAddedSection
             markets={recentlyAddedMarkets}
             onMarketPress={handleRecentlyAddedMarketPress}
+          />
+        ),
+      },
+      {
+        key: 'recent-activity',
+        visible: isLoading.activity || recentActivity.length > 0,
+        onLayout: handleSectionLayout(
+          PERPS_EVENT_VALUE.SECTION_NAME.RECENT_ACTIVITY,
+        ),
+        content: (
+          <PerpsRecentActivityList
+            transactions={recentActivity}
+            isLoading={isLoading.activity}
           />
         ),
       },

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
@@ -16,18 +16,21 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 12,
       backgroundColor: colors.background.muted,
       padding: 12,
-      gap: 8,
     },
     logoRow: {
+      marginBottom: 12,
+    },
+    name: {
+      marginBottom: 4,
+    },
+    priceRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      justifyContent: 'space-between',
+      gap: 6,
     },
     timeLabel: {
       flexShrink: 1,
-    },
-    priceRow: {
-      gap: 2,
+      marginTop: 10,
     },
   });
 };

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
@@ -14,7 +14,7 @@ const styleSheet = (params: { theme: Theme }) => {
     tile: {
       width: 128,
       borderRadius: 12,
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.background.muted,
       padding: 12,
       gap: 8,
     },

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.styles.ts
@@ -9,6 +9,7 @@ const styleSheet = (params: { theme: Theme }) => {
     scrollContent: {
       paddingHorizontal: 16,
       paddingBottom: 4,
+      paddingTop: 8,
       gap: 12,
     },
     tile: {

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
@@ -128,14 +128,36 @@ describe('PerpsRecentlyAddedSection', () => {
   });
 
   describe('tile content', () => {
-    it('displays the market symbol', () => {
+    it('displays the market name when available', () => {
       render(
         <PerpsRecentlyAddedSection
-          markets={[createMarket({ symbol: 'BTC' })]}
+          markets={[createMarket({ symbol: 'BTC', name: 'Bitcoin' })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+      expect(screen.getByText('Bitcoin')).toBeOnTheScreen();
+      expect(screen.queryByText('BTC')).toBeNull();
+    });
+
+    it('falls back to the display symbol when no name is available', () => {
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'BTC', name: undefined })]}
           onMarketPress={jest.fn()}
         />,
       );
       expect(screen.getByText('BTC')).toBeOnTheScreen();
+    });
+
+    it('strips the HIP-3 dex prefix from the fallback symbol (e.g. "xyz:SKHY" -> "SKHY")', () => {
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'xyz:SKHY', name: undefined })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+      expect(screen.getByText('SKHY')).toBeOnTheScreen();
+      expect(screen.queryByText('xyz:SKHY')).toBeNull();
     });
 
     it('displays the market price', () => {

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
@@ -4,6 +4,31 @@ import type { PerpsMarketData } from '@metamask/perps-controller';
 import PerpsRecentlyAddedSection from './PerpsRecentlyAddedSection';
 import { PerpsHomeViewSelectorsIDs } from '../../Perps.testIds';
 
+jest.mock('../../selectors/featureFlags', () => ({
+  selectPerpsShowFullAssetNamesFlag: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const { selectPerpsShowFullAssetNamesFlag } = jest.requireMock(
+  '../../selectors/featureFlags',
+);
+const { useSelector } = jest.requireMock('react-redux');
+const mockUseSelector = useSelector as jest.MockedFunction<
+  (selector: unknown) => unknown
+>;
+
+// Helper to stub useSelector so only selectPerpsShowFullAssetNamesFlag
+// resolves to the given value, and every other selector returns false.
+const mockSelectors = (showFullAssetNames: boolean) => {
+  mockUseSelector.mockImplementation((selector) =>
+    selector === selectPerpsShowFullAssetNamesFlag ? showFullAssetNames : false,
+  );
+};
+
 // Stub design-system components that pull in native modules
 jest.mock('@metamask/design-system-react-native', () => {
   const { View, Text } = jest.requireActual('react-native');
@@ -41,6 +66,10 @@ jest.mock('../../../../../../locales/i18n', () => ({
 const NOW = 1_750_000_000_000;
 beforeEach(() => {
   jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  // Default to the flag being on so existing tests (written before the flag
+  // gated this label) keep exercising the "show name" behavior; the
+  // "Full Asset Name Feature Flag" block below covers both states explicitly.
+  mockSelectors(true);
 });
 afterEach(() => {
   jest.restoreAllMocks();
@@ -269,6 +298,63 @@ describe('PerpsRecentlyAddedSection', () => {
         screen.getByTestId('perps-recently-added-tile-BTC'),
       ).toBeOnTheScreen();
       expect(screen.queryByText(/ago/)).toBeNull();
+    });
+  });
+
+  describe('Full Asset Name Feature Flag', () => {
+    it('shows the ticker symbol instead of the name when the flag is disabled', () => {
+      mockSelectors(false);
+
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'BTC', name: 'Bitcoin' })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('BTC')).toBeOnTheScreen();
+      expect(screen.queryByText('Bitcoin')).toBeNull();
+    });
+
+    it('shows the full name when the flag is enabled', () => {
+      mockSelectors(true);
+
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'BTC', name: 'Bitcoin' })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Bitcoin')).toBeOnTheScreen();
+      expect(screen.queryByText('BTC')).toBeNull();
+    });
+
+    it('falls back to the ticker when the flag is enabled but name is missing', () => {
+      mockSelectors(true);
+
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'BTC', name: undefined })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('BTC')).toBeOnTheScreen();
+    });
+
+    it('strips the HIP-3 dex prefix from the ticker when the flag is disabled', () => {
+      mockSelectors(false);
+
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket({ symbol: 'xyz:SKHY', name: 'Some Asset' })]}
+          onMarketPress={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('SKHY')).toBeOnTheScreen();
+      expect(screen.queryByText('xyz:SKHY')).toBeNull();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.test.tsx
@@ -9,8 +9,19 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { View, Text } = jest.requireActual('react-native');
   return {
     SectionDivider: () => <View testID="section-divider" />,
-    SectionHeader: ({ title, testID }: { title: string; testID?: string }) => (
-      <Text testID={testID}>{title}</Text>
+    SectionHeader: ({
+      title,
+      testID,
+      onPress,
+    }: {
+      title: string;
+      testID?: string;
+      isInteractive?: boolean;
+      onPress?: () => void;
+    }) => (
+      <Text testID={testID} onPress={onPress}>
+        {title}
+      </Text>
     ),
   };
 });
@@ -107,6 +118,24 @@ describe('PerpsRecentlyAddedSection', () => {
       expect(
         screen.getByTestId('perps-recently-added-tile-SOL'),
       ).toBeOnTheScreen();
+    });
+
+    it('calls onViewAllPress when the header is pressed', () => {
+      const onViewAllPress = jest.fn();
+
+      render(
+        <PerpsRecentlyAddedSection
+          markets={[createMarket()]}
+          onMarketPress={jest.fn()}
+          onViewAllPress={onViewAllPress}
+        />,
+      );
+
+      fireEvent.press(
+        screen.getByTestId(PerpsHomeViewSelectorsIDs.RECENTLY_ADDED_HEADER),
+      );
+
+      expect(onViewAllPress).toHaveBeenCalledTimes(1);
     });
 
     it('renders each market logo', () => {

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
@@ -50,26 +50,18 @@ const PerpsRecentlyAddedTile: React.FC<{
     >
       <View style={styles.logoRow}>
         <PerpsTokenLogo symbol={market.symbol} size={32} />
-        {market.listedAt !== undefined && (
-          <Text
-            variant={TextVariant.BodyXS}
-            color={TextColor.Alternative}
-            style={styles.timeLabel}
-            numberOfLines={1}
-          >
-            {formatTimeSinceListing(market.listedAt)}
-          </Text>
-        )}
       </View>
 
+      <Text
+        variant={TextVariant.BodySMMedium}
+        color={TextColor.Default}
+        style={styles.name}
+        numberOfLines={1}
+      >
+        {assetLabel}
+      </Text>
+
       <View style={styles.priceRow}>
-        <Text
-          variant={TextVariant.BodySMMedium}
-          color={TextColor.Default}
-          numberOfLines={1}
-        >
-          {assetLabel}
-        </Text>
         <Text
           variant={TextVariant.BodyXS}
           color={TextColor.Default}
@@ -85,6 +77,17 @@ const PerpsRecentlyAddedTile: React.FC<{
           {market.change24hPercent}
         </Text>
       </View>
+
+      {market.listedAt !== undefined && (
+        <Text
+          variant={TextVariant.BodyXS}
+          color={TextColor.Alternative}
+          style={styles.timeLabel}
+          numberOfLines={1}
+        >
+          {formatTimeSinceListing(market.listedAt)}
+        </Text>
+      )}
     </TouchableOpacity>
   );
 };
@@ -103,6 +106,7 @@ const PerpsRecentlyAddedTile: React.FC<{
 const PerpsRecentlyAddedSection: React.FC<PerpsRecentlyAddedSectionProps> = ({
   markets,
   onMarketPress,
+  onViewAllPress,
 }) => {
   const { styles } = useStyles(styleSheet, {});
 
@@ -114,6 +118,8 @@ const PerpsRecentlyAddedSection: React.FC<PerpsRecentlyAddedSectionProps> = ({
     <View testID={PerpsHomeViewSelectorsIDs.RECENTLY_ADDED_SECTION}>
       <SectionHeader
         title={strings('perps.home.recently_added')}
+        isInteractive={Boolean(onViewAllPress)}
+        onPress={onViewAllPress}
         testID={PerpsHomeViewSelectorsIDs.RECENTLY_ADDED_HEADER}
       />
       <ScrollView

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
@@ -1,7 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { ScrollView, TouchableOpacity, View } from 'react-native';
 import { SectionHeader } from '@metamask/design-system-react-native';
-import type { PerpsMarketData } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  type PerpsMarketData,
+} from '@metamask/perps-controller';
 import Text, {
   TextVariant,
   TextColor,
@@ -26,6 +29,15 @@ const PerpsRecentlyAddedTile: React.FC<{
 
   const isPositiveChange = !market.change24h.startsWith('-');
   const changeColor = isPositiveChange ? TextColor.Success : TextColor.Error;
+
+  // Prefer the display name (e.g. "Bitcoin"); fall back to the display symbol
+  // when no name is available. Both branches go through getPerpsDisplaySymbol
+  // so a HIP-3 `dex:SYMBOL` value (e.g. "xyz:SKHY") never renders with its raw
+  // dex prefix, whether it comes from `name` or `symbol`.
+  const assetLabel = useMemo(
+    () => getPerpsDisplaySymbol(market.name || market.symbol),
+    [market.name, market.symbol],
+  );
 
   return (
     <TouchableOpacity
@@ -56,7 +68,7 @@ const PerpsRecentlyAddedTile: React.FC<{
           color={TextColor.Default}
           numberOfLines={1}
         >
-          {market.symbol}
+          {assetLabel}
         </Text>
         <Text
           variant={TextVariant.BodyXS}

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { ScrollView, TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { SectionHeader } from '@metamask/design-system-react-native';
 import {
   getPerpsDisplaySymbol,
@@ -14,6 +15,7 @@ import { strings } from '../../../../../../locales/i18n';
 import PerpsTokenLogo from '../PerpsTokenLogo/PerpsTokenLogo';
 import { formatTimeSinceListing } from '../../utils/time';
 import { PerpsHomeViewSelectorsIDs } from '../../Perps.testIds';
+import { selectPerpsShowFullAssetNamesFlag } from '../../selectors/featureFlags';
 import styleSheet from './PerpsRecentlyAddedSection.styles';
 import type { PerpsRecentlyAddedSectionProps } from './PerpsRecentlyAddedSection.types';
 
@@ -22,6 +24,7 @@ const PerpsRecentlyAddedTile: React.FC<{
   onPress: (market: PerpsMarketData) => void;
 }> = ({ market, onPress }) => {
   const { styles } = useStyles(styleSheet, {});
+  const showFullAssetNames = useSelector(selectPerpsShowFullAssetNamesFlag);
 
   const handlePress = useCallback(() => {
     onPress(market);
@@ -30,14 +33,15 @@ const PerpsRecentlyAddedTile: React.FC<{
   const isPositiveChange = !market.change24h.startsWith('-');
   const changeColor = isPositiveChange ? TextColor.Success : TextColor.Error;
 
-  // Prefer the display name (e.g. "Bitcoin"); fall back to the display symbol
-  // when no name is available. Both branches go through getPerpsDisplaySymbol
-  // so a HIP-3 `dex:SYMBOL` value (e.g. "xyz:SKHY") never renders with its raw
-  // dex prefix, whether it comes from `name` or `symbol`.
-  const assetLabel = useMemo(
-    () => getPerpsDisplaySymbol(market.name || market.symbol),
-    [market.name, market.symbol],
-  );
+  // Mirrors PerpsMarketRowItem: prefer the display name (e.g. "Bitcoin") only
+  // when the flag is on, otherwise fall back to the display symbol. Both
+  // branches go through getPerpsDisplaySymbol so a HIP-3 `dex:SYMBOL` value
+  // (e.g. "xyz:SKHY") never renders with its raw dex prefix.
+  const assetLabel = useMemo(() => {
+    const label =
+      showFullAssetNames && market.name ? market.name : market.symbol;
+    return getPerpsDisplaySymbol(label);
+  }, [showFullAssetNames, market.name, market.symbol]);
 
   return (
     <TouchableOpacity

--- a/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.types.ts
+++ b/app/components/UI/Perps/components/PerpsRecentlyAddedSection/PerpsRecentlyAddedSection.types.ts
@@ -3,4 +3,6 @@ import type { PerpsMarketData } from '@metamask/perps-controller';
 export interface PerpsRecentlyAddedSectionProps {
   markets: PerpsMarketData[];
   onMarketPress: (market: PerpsMarketData) => void;
+  /** Called when the section header is pressed. Omit to render a non-interactive header. */
+  onViewAllPress?: () => void;
 }

--- a/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Perps/mocks/remoteFeatureFlagMocks.ts
@@ -19,5 +19,6 @@ export const mockedPerpsFeatureFlagsEnabledState: Record<
   perpsAdvancedChartEnabledV2: mockEnabledPerpsLDFlag,
   perpsWatchlistV2Enabled: mockEnabledPerpsLDFlag,
   perpsTerminalBackendEnabled: mockEnabledPerpsLDFlag,
+  perpsRecentlyAddedEnabled: mockEnabledPerpsLDFlag,
   perpsShowFullAssetNames: mockEnabledPerpsLDFlag,
 };

--- a/app/components/UI/Perps/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.test.ts
@@ -16,6 +16,7 @@ import {
   selectPerpsRewardsReferralCodeEnabledFlag,
   selectPerpsMYXProviderEnabledFlag,
   selectPerpsWatchlistEnabledFlag,
+  selectPerpsRecentlyAddedEnabledFlag,
   selectPerpsShowFullAssetNamesFlag,
   PERPS_SHOW_FULL_ASSET_NAMES_FLAG_KEY,
 } from '.';
@@ -1707,6 +1708,144 @@ describe('Perps Feature Flag Selectors', () => {
       };
 
       const result = selectPerpsWatchlistEnabledFlag(stateWithNullRemoteFlag);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectPerpsRecentlyAddedEnabledFlag', () => {
+    const createEmptyFlagsState = () => ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {},
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    });
+
+    it('returns false when remote flag is not set', () => {
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        createEmptyFlagsState(),
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true when remote flag is valid and enabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+
+      const stateWithEnabledRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsRecentlyAddedEnabled: {
+                  enabled: true,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        stateWithEnabledRemoteFlag,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+
+      const stateWithDisabledRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsRecentlyAddedEnabled: {
+                  enabled: false,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        stateWithDisabledRemoteFlag,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns false when enabled but version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+
+      const stateWithVersionCheckFailure = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsRecentlyAddedEnabled: {
+                  enabled: true,
+                  minimumVersion: '99.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        stateWithVersionCheckFailure,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const stateWithInvalidRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsRecentlyAddedEnabled: {
+                  enabled: 'invalid',
+                  minimumVersion: 123,
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        stateWithInvalidRemoteFlag,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is null', () => {
+      const stateWithNullRemoteFlag = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsRecentlyAddedEnabled: null,
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsRecentlyAddedEnabledFlag(
+        stateWithNullRemoteFlag,
+      );
       expect(result).toBe(false);
     });
   });

--- a/app/components/UI/Perps/selectors/featureFlags/index.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.ts
@@ -396,6 +396,23 @@ export const selectPerpsTopMoversEnabledFlag = createSelector(
 );
 
 /**
+ * Selector for Perps Recently Added feature flag.
+ * Controls visibility of the Recently Added section on the Perps home screen,
+ * independently of the Terminal backend flag that supplies `listedAt` data.
+ *
+ * @returns boolean - true if the Recently Added section should be shown, false otherwise
+ */
+export const selectPerpsRecentlyAddedEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.perpsRecentlyAddedEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);
+
+/**
  * Selector for Perps Watchlist redesign feature flag
  * Controls whether the redesigned Watchlist UI (empty state, suggested markets,
  * show-more/less, tappable header, animations, 10-asset limit) and the

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5809,6 +5809,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  perpsRecentlyAddedEnabled: {
+    name: 'perpsRecentlyAddedEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '8.3.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   predictWimbledon: {
     name: 'predictWimbledon',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds an explicit perpsRecentlyAddedEnabled remote feature flag (with minimum-version gating) to control the "Recently Added" section on the Perps home screen, independent of perpsTerminalBackendEnabled. Previously the section's visibility was only transitively gated by the Terminal API flag that supplies listedAt data, so there was no way to hide the UI while still allowing that data to flow.

Also fixes the section's position: it was rendering right after Top Movers instead of after Forex/Recent Activity as originally specced, so it's now the last content section before the navigation card.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: gates recently added section behind feature flag

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<img width="430" height="931" alt="Screenshot 2026-07-09 at 12 20 14 PM" src="https://github.com/user-attachments/assets/ce4f96aa-ad5d-41c7-82d8-746288792036" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Perps home UI and remote feature-flag gating only; behavior is covered by new tests with no auth or payment changes.
> 
> **Overview**
> Introduces **`perpsRecentlyAddedEnabled`** as a version-gated remote flag so the Perps home **Recently Added** rail can be turned off without relying on Terminal/`listedAt` data alone. **`PerpsHomeView`** now shows the section only when the flag is on **and** there are markets (`isRecentlyAddedVisible`), and analytics **`sections_displayed`** follow the same rule.
> 
> **Layout:** the Recently Added block is moved from immediately after Top Movers to **after the explore Forex section** and **before Recent Activity**, matching the intended home order.
> 
> **Recently Added UI:** tiles are restyled (muted background, name above price/change, time label below). Labels respect **`perpsShowFullAssetNames`** and **`getPerpsDisplaySymbol`** (including HIP-3 `dex:SYMBOL` stripping). The section header is tappable and opens the market list with **`defaultMarketTypeFilter: 'new'`**.
> 
> Registry entry, mocks, and unit/integration tests cover the new selector, visibility, navigation, and tile labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efe8d395bb0ae0ba39f221dbb9b104c4c235263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->