### PR TITLE
fix(predict): widen dead outcome filter thresholds to 1%/99% cp-8.2.0

### DIFF
--- a/app/components/UI/Predict/utils/marketStaleness.test.ts
+++ b/app/components/UI/Predict/utils/marketStaleness.test.ts
@@ -112,19 +112,19 @@ describe('marketStaleness', () => {
   describe('isPredictOutcomeDead', () => {
     it('treats probabilities at or beyond the dead thresholds as dead', () => {
       expect(
-        isPredictOutcomeDead(createOutcome({ id: 'high', price: 0.95 })),
+        isPredictOutcomeDead(createOutcome({ id: 'high', price: 0.99 })),
       ).toBe(true);
       expect(
-        isPredictOutcomeDead(createOutcome({ id: 'low', price: 0.05 })),
+        isPredictOutcomeDead(createOutcome({ id: 'low', price: 0.01 })),
       ).toBe(true);
     });
 
     it('keeps probabilities inside the dead thresholds live', () => {
       expect(
-        isPredictOutcomeDead(createOutcome({ id: 'high-live', price: 0.949 })),
+        isPredictOutcomeDead(createOutcome({ id: 'high-live', price: 0.989 })),
       ).toBe(false);
       expect(
-        isPredictOutcomeDead(createOutcome({ id: 'low-live', price: 0.051 })),
+        isPredictOutcomeDead(createOutcome({ id: 'low-live', price: 0.011 })),
       ).toBe(false);
     });
 
@@ -138,8 +138,8 @@ describe('marketStaleness', () => {
       const market = createMarket({
         id: 'all-dead',
         outcomes: [
-          createOutcome({ id: 'dead-high', price: 0.97 }),
-          createOutcome({ id: 'dead-low', price: 0.03 }),
+          createOutcome({ id: 'dead-high', price: 0.995 }),
+          createOutcome({ id: 'dead-low', price: 0.005 }),
         ],
       });
 
@@ -152,9 +152,9 @@ describe('marketStaleness', () => {
       const market = createMarket({
         id: 'partial',
         outcomes: [
-          createOutcome({ id: 'dead-high', price: 0.97 }),
+          createOutcome({ id: 'dead-high', price: 0.995 }),
           liveOne,
-          createOutcome({ id: 'dead-low', price: 0.03 }),
+          createOutcome({ id: 'dead-low', price: 0.005 }),
           liveTwo,
         ],
       });
@@ -339,12 +339,12 @@ describe('marketStaleness', () => {
       const market = createMarket({
         id: 'stale-top-outcome',
         outcomes: [
-          createOutcome({ id: 'dead-high', price: 0.97 }),
+          createOutcome({ id: 'dead-high', price: 0.995 }),
           createOutcome({ id: 'live', price: 0.5 }),
         ],
       });
 
-      expect(getPredictMarketProbabilityPenalty(market)).toBeCloseTo(0.8);
+      expect(getPredictMarketProbabilityPenalty(market)).toBeCloseTo(0.75);
     });
 
     it('applies last-hour time penalty to daily markets', () => {
@@ -388,7 +388,7 @@ describe('marketStaleness', () => {
         recurrence: Recurrence.DAILY,
         endDate: '2026-03-18T12:30:00.000Z',
         outcomes: [
-          createOutcome({ id: 'stale-dead', price: 0.99 }),
+          createOutcome({ id: 'stale-dead', price: 0.999 }),
           createOutcome({ id: 'stale-live', price: 0.5 }),
         ],
       });

--- a/app/components/UI/Predict/utils/marketStaleness.ts
+++ b/app/components/UI/Predict/utils/marketStaleness.ts
@@ -7,8 +7,8 @@ import {
 } from '../types';
 import { isGameEnded } from './scoreboard';
 
-export const PREDICT_DEAD_OUTCOME_HIGH_THRESHOLD = 0.95;
-export const PREDICT_DEAD_OUTCOME_LOW_THRESHOLD = 0.05;
+export const PREDICT_DEAD_OUTCOME_HIGH_THRESHOLD = 0.99;
+export const PREDICT_DEAD_OUTCOME_LOW_THRESHOLD = 0.01;
 export const PREDICT_MIN_STALENESS_PENALTY = 0.1;
 export const PREDICT_LAST_HOUR_TIME_PENALTY = 0.5;
 
@@ -196,9 +196,13 @@ export const getPredictMarketProbabilityPenalty = (
     return 1;
   }
 
+  // Scale the penalty so a probability at the high threshold keeps a full score
+  // of 1 and a probability of 1 lands at 0.5, regardless of the threshold width.
+  const penaltySlope = 0.5 / (1 - PREDICT_DEAD_OUTCOME_HIGH_THRESHOLD);
+
   return Math.max(
     PREDICT_MIN_STALENESS_PENALTY,
-    1 - (maxProbability - PREDICT_DEAD_OUTCOME_HIGH_THRESHOLD) * 10,
+    1 - (maxProbability - PREDICT_DEAD_OUTCOME_HIGH_THRESHOLD) * penaltySlope,
   );
 };
 


### PR DESCRIPTION
## **Description**

The "dead outcomes" filter introduced in PR #30405 removes market outcomes whose win probability sits at or beyond the extreme thresholds. It was calibrated at **5%/95%**, which is appropriate for binary markets (where an extreme probability signals a settled outcome) but is too aggressive for multi-participant markets like the World Cup **Winner** market, where most teams legitimately carry low win probabilities. As a result the Winner market only surfaced ~5 teams instead of all remaining tournament participants.

This PR widens the filter thresholds from **5%/95%** to **1%/99%** so low-probability participants remain visible, while still filtering genuinely settled binary-market outcomes.

The staleness-ranking probability penalty previously used a hardcoded slope (`* 10`) that was tied to the old 5% window. It is now derived from the high threshold (`0.5 / (1 - HIGH_THRESHOLD)`) so the penalty curve endpoint stays identical (full score at the threshold, 0.5 at probability 1) regardless of the window width.

## **Changelog**

CHANGELOG entry: Fixed the World Cup Winner market on the Props tab hiding most teams by widening the dead-outcome probability filter from 5%/95% to 1%/99%.

## **Related issues**

Fixes: [PRED-1080](https://consensyssoftware.atlassian.net/browse/PRED-1080)

## **Manual testing steps**

```gherkin
Feature: World Cup Winner market visibility

  Scenario: user views the Winner market on the Props tab
    Given the World Cup Hub is enabled via LaunchDarkly
    And the Winner market component is enabled

    When user opens the Props tab and selects the Winner market
    Then all active/remaining teams are displayed regardless of their win probability
    And only teams with win probability <= 1% or >= 99% are hidden as dead outcomes

  Scenario: dead-outcome filter still applies to binary markets
    Given a standard binary market has a settled outcome (probability >= 99% or <= 1%)

    When user views that market
    Then the settled/dead outcome is filtered out as before
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — logic-only change; behavior verified via unit tests -->

### **After**

<!-- N/A — logic-only change; behavior verified via unit tests -->


https://github.com/user-attachments/assets/3b099c61-c63b-409a-8f8b-fa7aa98d8cf1



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1080]: https://consensyssoftware.atlassian.net/browse/PRED-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Predict visibility/ranking logic with matching unit test updates; no auth, payments, or data-layer changes.
> 
> **Overview**
> Widens Predict **dead-outcome** probability cutoffs from **5%/95%** to **1%/99%** so multi-outcome markets (e.g. World Cup Winner) keep legitimately low-probability teams visible while still hiding near-settled extremes.
> 
> **Staleness ranking** no longer uses a fixed `* 10` penalty slope tied to the old window; it derives `penaltySlope` from the high threshold so scoring stays **1.0 at the threshold** and **0.5 at probability 1** when the window changes. Unit tests in `marketStaleness.test.ts` are updated for the new thresholds and penalty values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b9991f0b65aaa8c1cf81fadc302f78b896a854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->