### PR TITLE
fix(swaps): tune swap discovery feed section layout

### DIFF
--- a/app/components/UI/Bridge/components/SwapDiscoveryFeed/SwapDiscoveryFeed.tsx
+++ b/app/components/UI/Bridge/components/SwapDiscoveryFeed/SwapDiscoveryFeed.tsx
@@ -33,7 +33,7 @@ import {
 import { SwapDiscoveryFeedTestIds } from './SwapDiscoveryFeed.testIds';
 
 const HOT_TOKENS_TIME_OPTION = TimeOption.OneHour;
-const HOT_TOKENS_ROW_COUNT = 3;
+const HOT_TOKENS_ROW_COUNT = 2;
 const HOT_TOKENS_MAX_PILLS = 18;
 
 interface FeedSlice {
@@ -225,7 +225,7 @@ const SwapDiscoveryFeedContent: React.FC = () => {
 
   return (
     <Box twClassName="px-1" testID={SwapDiscoveryFeedTestIds.ROOT}>
-      <ExploreSectionList sections={sections} />
+      <ExploreSectionList sections={sections} includeDividers={false} />
     </Box>
   );
 };

--- a/app/components/Views/TrendingView/components/ExploreSectionList.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSectionList.tsx
@@ -10,6 +10,7 @@ export interface ExploreSectionItem {
 
 interface ExploreSectionListProps {
   sections: ExploreSectionItem[];
+  includeDividers?: boolean;
 }
 
 /**
@@ -18,11 +19,12 @@ interface ExploreSectionListProps {
  */
 const ExploreSectionList: React.FC<ExploreSectionListProps> = ({
   sections,
+  includeDividers = true,
 }) => (
   <>
     {sections.map((section, index) => (
       <Fragment key={section.key}>
-        {index > 0 ? (
+        {includeDividers && index > 0 ? (
           <Box testID="explore-section-divider">
             <SectionDivider />
           </Box>


### PR DESCRIPTION
## **Description**

The swap discovery feed reuses `ExploreSectionList`, which inserts dividers between sections for the Explore tab. On the swap zero state those dividers add unwanted spacing between hot tokens, trending, and stocks blocks.

This PR adds an optional `includeDividers` prop (default `true`) to `ExploreSectionList` and disables dividers for `SwapDiscoveryFeed`. It also sets hot-token pill rows to two so the preview matches the intended compact layout.

## **Changelog**

CHANGELOG entry: Improved spacing and hot-token layout on the swap discovery feed zero state.

## **Related issues**

Fixes:

Refs: SWAPS-4666

## **Manual testing steps**

```gherkin
Feature: Swap discovery feed layout

  Scenario: User opens swap with discovery feed variant
    Given the swapsSWAPS4666AbtestDiscoveryFeedRevamp flag assigns discovery_feed
    And the user navigates to the Swap / Bridge zero state

    When the discovery feed loads hot tokens, trending, and stocks sections
    Then sections render without inter-section dividers
    And the hot tokens pill preview shows two rows
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only spacing and pill row count on the swap discovery feed; Explore tab keeps default dividers.
> 
> **Overview**
> Tightens the swap zero-state discovery feed layout by reusing `ExploreSectionList` without inter-section dividers and showing a shorter hot-tokens pill preview.
> 
> `ExploreSectionList` gains an optional **`includeDividers`** prop (defaults to **`true`** so Explore tab behavior is unchanged). **`SwapDiscoveryFeed`** passes **`includeDividers={false}`** so hot tokens, trending, and stocks blocks sit closer together without **`SectionDivider`** spacing.
> 
> Hot tokens preview **`rowCount`** is reduced from **3** to **2** via **`HOT_TOKENS_ROW_COUNT`** for a more compact pill grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62879d0d54e5e68bfde66698731bad603b064709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->