### PR TITLE
fix: MUSD-1146 change pooled-staking Earn CTA to Stake

### DIFF
--- a/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
+++ b/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
@@ -4,6 +4,7 @@ import { WalletViewSelectorsIDs } from '../../../../Views/Wallet/WalletView.test
 import StakeButton from './index';
 import Routes from '../../../../../constants/navigation/Routes';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../locales/i18n';
 import {
   MOCK_ETH_MAINNET_ASSET,
   MOCK_USDC_MAINNET_ASSET,
@@ -248,6 +249,12 @@ describe('StakeButton', () => {
   });
 
   describe('Pooled-Staking', () => {
+    it('renders "Stake" as CTA label for pooled-staking', () => {
+      const { getByText } = renderComponent();
+
+      expect(getByText(strings('stake.stake'))).toBeOnTheScreen();
+    });
+
     it('navigates to Stake Input screen when stake button is pressed and user is eligible', async () => {
       const { getByTestId } = renderComponent();
 
@@ -324,6 +331,17 @@ describe('StakeButton', () => {
   });
 
   describe('Stablecoin Lending', () => {
+    it('renders "Earn" as CTA label for stablecoin lending', () => {
+      const { getByText } = renderWithProvider(
+        <StakeButton asset={MOCK_USDC_MAINNET_ASSET_WITH_MINIMUM_BALANCE} />,
+        {
+          state: STATE_MOCK,
+        },
+      );
+
+      expect(getByText(strings('stake.earn'))).toBeOnTheScreen();
+    });
+
     it('navigates to Lending Input View when earn button is pressed', async () => {
       const { getByTestId } = renderWithProvider(
         <StakeButton asset={MOCK_USDC_MAINNET_ASSET_WITH_MINIMUM_BALANCE} />,

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -88,7 +88,7 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
             chain_id: getDecimalChainId(earnToken.chainId as Hex),
             location: EVENT_LOCATIONS.HOME_SCREEN,
             action_type: 'deposit',
-            text: 'Earn',
+            text: 'Stake',
             token: earnToken.symbol,
             network: network?.name,
             experience: EARN_EXPERIENCES.POOLED_STAKING,
@@ -118,7 +118,7 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
           chain_id: getDecimalChainId(chainId),
           location: EVENT_LOCATIONS.HOME_SCREEN,
           action_type: 'deposit',
-          text: 'Earn',
+          text: 'Stake',
           token: earnToken.symbol,
           network: network?.name,
           url: AppConstants.STAKE.URL,
@@ -160,9 +160,14 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
     return <></>;
 
   const renderEarnButtonText = () => {
+    const ctaLabel =
+      primaryExperienceType === EARN_EXPERIENCES.POOLED_STAKING
+        ? strings('stake.stake')
+        : strings('stake.earn');
+
     ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (isTronNative && isTrxStakingEnabled && tronApyPercent) {
-      return `${strings('stake.earn')} ${tronApyPercent}`;
+      return `${ctaLabel} ${tronApyPercent}`;
     }
     ///: END:ONLY_INCLUDE_IF
 
@@ -171,7 +176,7 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
       Number.isFinite(aprNumber) && aprNumber > 0
         ? ` ${aprNumber.toFixed(1)}%`
         : '';
-    return `${strings('stake.earn')}${aprText}`;
+    return `${ctaLabel}${aprText}`;
   };
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates the pooled-staking CTA copy on the main token list from **“Earn”** to **“Stake”** to better distinguish pooled-staking from lending.
- Keeps stablecoin lending CTA as **“Earn”**.
- Click behavior is unchanged.

## Changes
- `StakeButton` now renders `strings('stake.stake')` when the primary earn experience is pooled-staking, otherwise `strings('stake.earn')`.
- Updates stake CTA analytics `text` property to `Stake` for pooled-staking.
- Adds unit coverage to assert pooled-staking shows **Stake** and stablecoin lending shows **Earn**.

## Test Plan
- `yarn jest app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx --runInBand --coverage=false`

## Jira
- MUSD-1146
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D09K7S6L316/p1783624500665669?thread_ts=1783624500.665669&cid=D09K7S6L316)

<div><a href="https://cursor.com/agents/bc-7fcd013a-07f7-5b83-bc7b-6a55ba7b7e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fcd013a-07f7-5b83-bc7b-6a55ba7b7e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

