### PR TITLE
fix: remove useElevatedSurface shim from Bridge BottomSheets

### DIFF
--- a/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
@@ -36,7 +36,6 @@ import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
 import { formatTokenBalance } from '../../utils';
 import { BatchSellDestinationTokenSelectorModalSelectorsIDs } from './BatchSellDestinationTokenSelectorModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 const getTokenKey = (token: BridgeToken) => `${token.chainId}:${token.address}`;
 
@@ -87,8 +86,6 @@ export function BatchSellDestinationTokenSelectorModal() {
     chainIds:
       destinationChainIds ?? (sourceChainId ? [sourceChainId] : undefined),
   });
-  const surfaceClass = useElevatedSurface();
-
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
   }, []);
@@ -106,7 +103,6 @@ export function BatchSellDestinationTokenSelectorModal() {
       ref={sheetRef}
       goBack={navigation.goBack}
       testID={BatchSellDestinationTokenSelectorModalSelectorsIDs.SHEET}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
@@ -48,7 +48,6 @@ import { useSubmitBatchSellTx } from '../../hooks/useSubmitBatchSellTx';
 import type { BridgeToken } from '../../types';
 import { BatchSellQuoteDetails } from '../BatchSellQuoteDetailsModal';
 import { BatchSellFinalReviewModalSelectorsIDs } from './BatchSellFinalReviewModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useTrackBatchSellReviewModalSubmitted } from '../../hooks/useTrackBatchSellReviewModalSubmitted';
 
 const MAX_VISIBLE_SOURCE_TOKEN_AVATARS = 5;
@@ -305,7 +304,6 @@ export function BatchSellFinalReviewModal() {
     isGasless: batchSellQuoteData.isGasless,
     networkFee: batchSellQuoteData.networkFee,
   });
-  const surfaceClass = useElevatedSurface();
   const sheetRef = useRef<BottomSheetRef>(null);
   const [isTokenDetailsExpanded, setIsTokenDetailsExpanded] = useState(false);
   const trackBatchSellReviewModalSubmitted =
@@ -433,7 +431,6 @@ export function BatchSellFinalReviewModal() {
       ref={sheetRef}
       testID={BatchSellFinalReviewModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
@@ -15,7 +15,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { BatchSellMinimumReceivedInfoModalSelectorsIDs } from './BatchSellMinimumReceivedInfoModal.testIds';
 import { BatchSellMinimumReceivedInfoModalParams } from './BatchSellMinimumReceivedInfoModal.types';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellMinimumReceivedInfoModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
@@ -23,13 +22,10 @@ export function BatchSellMinimumReceivedInfoModal() {
   const handleBack = sourceModal
     ? () => navigation.replace(sourceModal.screen, sourceModal.params)
     : undefined;
-  const surfaceClass = useElevatedSurface();
-
   return (
     <BottomSheet
       testID={BatchSellMinimumReceivedInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
@@ -15,7 +15,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { BatchSellNetworkFeeInfoModalSelectorsIDs } from './BatchSellNetworkFeeInfoModal.testIds';
 import { BatchSellNetworkFeeInfoModalParams } from './BatchSellNetworkFeeInfoModal.types';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellNetworkFeeInfoModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
@@ -23,13 +22,10 @@ export function BatchSellNetworkFeeInfoModal() {
   const handleBack = sourceModal
     ? () => navigation.replace(sourceModal.screen, sourceModal.params)
     : undefined;
-  const surfaceClass = useElevatedSurface();
-
   return (
     <BottomSheet
       testID={BatchSellNetworkFeeInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
@@ -17,12 +17,10 @@ import {
 import { BatchSellQuoteDetails } from './BatchSellQuoteDetails';
 import { BatchSellQuoteDetailsModalSelectorsIDs } from './BatchSellQuoteDetailsModal.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellQuoteDetailsModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
   const sourceTokens = useSelector(selectBatchSellSourceTokens);
-  const surfaceClass = useElevatedSurface();
   const batchSellQuoteData = useBatchSellQuoteData({
     shouldUpdateBatchSellTrades: false,
   });
@@ -49,7 +47,6 @@ export function BatchSellQuoteDetailsModal() {
     <BottomSheet
       testID={BatchSellQuoteDetailsModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={navigation.goBack}

--- a/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
+++ b/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
@@ -19,7 +19,6 @@ import {
   useSwapBridgeNavigation,
 } from '../../hooks/useSwapBridgeNavigation';
 import { HighRateAlertModalSelectorsIDs } from './HighRateAlertModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export interface HighRateAlertModalParams {
   sourceToken: BridgeToken;
@@ -34,8 +33,6 @@ export function HighRateAlertModal() {
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'BatchSell',
   });
-  const surfaceClass = useElevatedSurface();
-
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
   }, []);
@@ -51,7 +48,6 @@ export function HighRateAlertModal() {
       ref={sheetRef}
       goBack={goBack}
       testID={HighRateAlertModalSelectorsIDs.SHEET}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -25,7 +25,6 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export interface MissingPriceModalParams {
   location: MetaMetricsSwapsEventSource;
@@ -36,7 +35,6 @@ export const MissingPriceModal = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const [loading, setLoading] = useState(false);
   const { location } = useParams<MissingPriceModalParams>();
-  const surfaceClass = useElevatedSurface();
   const sourceToken = useSelector(selectSourceToken);
   const tokenBalance = useLatestBalance({
     address: sourceToken?.address,
@@ -69,7 +67,6 @@ export const MissingPriceModal = () => {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -64,10 +64,7 @@ export const MissingPriceModal = () => {
   }, [confirmBridge]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <BottomSheetHeader
         onClose={handleClose}
         closeButtonProps={{

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -19,7 +19,6 @@ import {
   BottomSheet,
   BottomSheetRef,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const PriceImpactModal = () => {
   const { goBack } = useNavigation();
@@ -43,8 +42,6 @@ export const PriceImpactModal = () => {
   const priceImpactViewData = usePriceImpactViewData(
     activeQuote?.quote.priceData?.priceImpact,
   );
-  const surfaceClass = useElevatedSurface();
-
   const isDangerousPriceImpact = useMemo(
     () =>
       exceedsPriceImpactErrorThreshold(
@@ -68,7 +65,7 @@ export const PriceImpactModal = () => {
   }, [confirmBridge]);
 
   return (
-    <BottomSheet ref={sheetRef} goBack={goBack} twClassName={surfaceClass}>
+    <BottomSheet ref={sheetRef} goBack={goBack}>
       <PriceImpactHeader
         onClose={handleClose}
         iconName={priceImpactViewData.icon?.name}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface styling internally. This PR removes the redundant `useElevatedSurface()` shim (`twClassName={surfaceClass}`) from all Bridge-owned modals listed in TMCU-1039.

**Files updated:**
- `BatchSellDestinationTokenSelectorModal`
- `BatchSellFinalReviewModal`
- `BatchSellMinimumReceivedInfoModal`
- `BatchSellNetworkFeeInfoModal`
- `BatchSellQuoteDetailsModal`
- `HighRateAlertModal`
- `MissingPriceModal`
- `PriceImpactModal`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1039](https://consensyssoftware.atlassian.net/browse/TMCU-1039)

## **Manual testing steps**

```gherkin
Feature: Bridge BottomSheet pure-black styling

  Scenario: Batch-sell modals render with correct elevated surface
    Given the pure-black feature flag is enabled
    And the user navigates to batch-sell flow

    When the user opens any batch-sell bottom sheet (destination token selector, final review, quote details, network fee info, minimum received info)
    Then the bottom sheet background uses the correct elevated surface color

  Scenario: Bridge alert modals render with correct elevated surface
    Given the pure-black feature flag is enabled
    And the user is in a bridge flow that triggers an alert

    When the user opens High Rate Alert, Missing Price, or Price Impact modals
    Then the bottom sheet background uses the correct elevated surface color

  Scenario: No regression when pure-black flag is off
    Given the pure-black feature flag is disabled

    When the user opens any of the above Bridge bottom sheets
    Then the bottom sheet background renders as before with no visual regression
```

## **Screenshots/Recordings**

### **Before**

### **After**

BottomSheets use correct colors in both pure black true/false


https://github.com/user-attachments/assets/d16be9a4-204f-4f82-b8e4-356d281d566a


https://github.com/user-attachments/assets/e60cd820-6a21-47a4-a6d5-093ff01b1d67



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3930c63a-920a-4ecd-8622-104e3f9bd7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3930c63a-920a-4ecd-8622-104e3f9bd7d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

[TMCU-1039]: https://consensyssoftware.atlassian.net/browse/TMCU-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ