### PR TITLE
fix: remove useElevatedSurface shim from Ramp BottomSheets

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -54,7 +54,6 @@ import {
   extractHostname,
   type CloseSource,
 } from '../../utils/webviewFunnelAnalytics';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 interface CheckoutParams {
   url: string;
@@ -599,7 +598,6 @@ const Checkout = () => {
     /* no-op until initialized */
   });
   const closeHeadlessOnUnmountRef = useRef<() => void>(() => undefined);
-  const surfaceClass = useElevatedSurface();
   closeHeadlessOnUnmountRef.current = () => {
     if (!headlessSessionId || hasTerminatedHeadlessSessionRef.current) {
       return;
@@ -664,7 +662,6 @@ const Checkout = () => {
         goBack={navigation.goBack}
         isFullscreen
         keyboardAvoidingViewEnabled={false}
-        twClassName={surfaceClass}
       >
         {sharedHeader}
         <ScreenLayout>
@@ -699,7 +696,6 @@ const Checkout = () => {
         isFullscreen
         isInteractable={!Device.isAndroid()}
         keyboardAvoidingViewEnabled={false}
-        twClassName={surfaceClass}
       >
         {sharedHeader}
         <WebView
@@ -776,7 +772,6 @@ const Checkout = () => {
       goBack={navigation.goBack}
       isFullscreen
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       {sharedHeader}
       <ScreenLayout>

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
@@ -27,7 +27,6 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../../locales/i18n';
 import Logger from '../../../../../../util/Logger';
 import styleSheet from './ErrorDetailsModal.styles';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface ErrorDetailsModalParams {
   errorMessage: string;
@@ -58,7 +57,6 @@ function ErrorDetailsModal() {
     showChangeProvider,
     amount,
   } = useParams<ErrorDetailsModalParams>();
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -96,7 +94,6 @@ function ErrorDetailsModal() {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         onClose={handleClose}

--- a/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ErrorDetailsModal/ErrorDetailsModal.tsx
@@ -91,10 +91,7 @@ function ErrorDetailsModal() {
   }, [navigation, amount]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderStandard
         onClose={handleClose}
         closeButtonProps={{ testID: 'error-details-close-button' }}

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -37,7 +37,6 @@ import { getRampCallbackBaseUrl } from '../../../utils/getRampCallbackBaseUrl';
 import { isCustomAction } from '../../../types';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface PaymentSelectionModalParams {
   amount?: number;
@@ -113,7 +112,6 @@ function PaymentSelectionModal() {
 
   const { data: quotes, loading: quotesLoading } =
     useRampsQuotes(quoteFetchParams);
-  const surfaceClass = useElevatedSurface();
 
   const handleChangeProviderPress = useCallback(() => {
     trackEvent(
@@ -273,7 +271,6 @@ function PaymentSelectionModal() {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <View style={styles.containerOuter}>
         <View style={styles.paymentPanelContent}>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -268,10 +268,7 @@ function PaymentSelectionModal() {
   };
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <View style={styles.containerOuter}>
         <View style={styles.paymentPanelContent}>
           <HeaderStandard

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
@@ -23,7 +23,6 @@ import { useNavigation } from '@react-navigation/native';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { PROCESSING_INFO_MODAL_TEST_IDS } from './ProcessingInfoModal.testIds';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface ProcessingInfoModalParams {
   providerName: string;
@@ -48,7 +47,6 @@ function ProcessingInfoModal() {
   const navigation = useNavigation();
   const { providerName, providerSupportUrl, statusDescription } =
     useParams<ProcessingInfoModalParams>();
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -101,7 +99,6 @@ function ProcessingInfoModal() {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         onClose={handleClose}

--- a/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal.tsx
@@ -96,10 +96,7 @@ function ProcessingInfoModal() {
   ]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderStandard
         onClose={handleClose}
         closeButtonProps={{

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelectionModal.tsx
@@ -28,7 +28,6 @@ import styleSheet from './ProviderSelectionModal.styles';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { strings } from '../../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface ProviderSelectionModalParams {
   amount?: number;
@@ -136,7 +135,6 @@ function ProviderSelectionModal() {
     loading: quotesLoading,
     error: quotesError,
   } = useRampsQuotes(quoteFetchParams);
-  const surfaceClass = useElevatedSurface();
 
   const handleDismiss = useCallback(
     (hasPendingAction?: boolean) => {
@@ -182,7 +180,6 @@ function ProviderSelectionModal() {
       ref={sheetRef}
       goBack={navigation.goBack}
       onClose={handleDismiss}
-      twClassName={surfaceClass}
     >
       <View style={styles.container}>
         <ProviderSelection

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -196,10 +196,7 @@ function SettingsModal() {
   }, []);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderStandard
         title={strings('fiat_on_ramp.build_quote_settings_modal.title')}
         onClose={handleClosePress}

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -34,7 +34,6 @@ import {
   resetProviderToken,
 } from '../../../utils/ProviderTokenVault';
 import { PROVIDER_LINKS } from '../../../Aggregator/types';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 /**
  * Transak native provider path prefix - matches both production
@@ -56,7 +55,6 @@ function SettingsModal() {
   const navigation = useNavigation();
   const { toastRef } = useContext(ToastContext);
   const { selectedProvider, setSelectedProvider } = useRampsProviders();
-  const surfaceClass = useElevatedSurface();
   const [isAuthenticatedWithProvider, setIsAuthenticatedWithProvider] =
     useState<boolean>(false);
 
@@ -201,7 +199,6 @@ function SettingsModal() {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         title={strings('fiat_on_ramp.build_quote_settings_modal.title')}

--- a/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/TokenNotAvailableModal/TokenNotAvailableModal.tsx
@@ -27,7 +27,6 @@ import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS } from './TokenNotAvailableModal.testIds';
 import type { BuyFlowOrigin } from '../../BuildQuote/BuildQuote';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface TokenNotAvailableModalParams {
   assetId: string;
@@ -50,7 +49,6 @@ function TokenNotAvailableModal() {
 
   const { selectedProvider } = useRampsProviders();
   const { selectedToken } = useRampsTokens();
-  const surfaceClass = useElevatedSurface();
 
   const tokenName = selectedToken?.name ?? '';
   const providerName = selectedProvider?.name ?? '';
@@ -162,7 +160,6 @@ function TokenNotAvailableModal() {
       goBack={navigation.goBack}
       onClose={handleDismiss}
       testID={TOKEN_NOT_AVAILABLE_MODAL_TEST_IDS.MODAL}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         title={strings('fiat_on_ramp.token_unavailable_modal.title')}

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedStateModal/UnsupportedStateModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedStateModal/UnsupportedStateModal.tsx
@@ -23,7 +23,6 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../../locales/i18n';
 import { createStateSelectorModalNavigationDetails } from '../StateSelectorModal';
 import { useRampsUserRegion } from '../../../hooks/useRampsUserRegion';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export interface UnsupportedStateModalParams {
   stateCode?: string;
@@ -45,7 +44,6 @@ function UnsupportedStateModal() {
     useParams<UnsupportedStateModalParams>();
 
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const closeBottomSheetAndNavigate = useCallback(
     (navigateFunc: () => void) => {
@@ -81,7 +79,6 @@ function UnsupportedStateModal() {
       ref={sheetRef}
       goBack={navigation.goBack}
       isInteractable={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingMd}>

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
@@ -27,10 +27,7 @@ function UnsupportedTokenModal() {
   const { styles } = useStyles(styleSheet, {});
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderStandard
         title={strings('deposit.token_modal.unsupported_token_title')}
         onClose={() => sheetRef.current?.onCloseBottomSheet()}

--- a/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/UnsupportedTokenModal/UnsupportedTokenModal.tsx
@@ -14,7 +14,6 @@ import styleSheet from './UnsupportedTokenModal.styles';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { createNavigationDetails } from '../../../../../../util/navigation/navUtils';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export const createUnsupportedTokenModalNavigationDetails =
   createNavigationDetails(
@@ -26,13 +25,11 @@ function UnsupportedTokenModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   return (
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         title={strings('deposit.token_modal.unsupported_token_title')}

--- a/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.tsx
+++ b/app/components/UI/Ramp/components/EligibilityFailedModal/EligibilityFailedModal.tsx
@@ -19,7 +19,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { ELIGIBILITY_FAILED_MODAL_TEST_IDS } from './EligibilityFailedModal.testIds';
 import { METAMASK_SUPPORT_URL } from '../../../../../constants/urls';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 const SUPPORT_URL = METAMASK_SUPPORT_URL;
 
@@ -33,7 +32,6 @@ function EligibilityFailedModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const navigateToContactSupport = useCallback(() => {
     Linking.openURL(SUPPORT_URL).catch((error: unknown) => {
@@ -51,7 +49,6 @@ function EligibilityFailedModal() {
       goBack={navigation.goBack}
       isInteractable={false}
       testID={ELIGIBILITY_FAILED_MODAL_TEST_IDS.MODAL}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.tsx
+++ b/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.tsx
@@ -12,7 +12,6 @@ import {
   TextVariant,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export interface RampInfoBottomSheetAction {
   /** Button label */
@@ -55,7 +54,6 @@ function RampInfoBottomSheet({
 }: RampInfoBottomSheetProps) {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -67,7 +65,6 @@ function RampInfoBottomSheet({
       goBack={navigation.goBack}
       isInteractable={false}
       testID={testIDs.MODAL}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Ramp/components/SearchableSelectorBottomSheet/SearchableSelectorBottomSheet.tsx
+++ b/app/components/UI/Ramp/components/SearchableSelectorBottomSheet/SearchableSelectorBottomSheet.tsx
@@ -95,10 +95,7 @@ function SearchableSelectorBottomSheet<T>({
   );
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <HeaderStandard
         title={title}
         onClose={() => sheetRef.current?.onCloseBottomSheet()}

--- a/app/components/UI/Ramp/components/SearchableSelectorBottomSheet/SearchableSelectorBottomSheet.tsx
+++ b/app/components/UI/Ramp/components/SearchableSelectorBottomSheet/SearchableSelectorBottomSheet.tsx
@@ -19,7 +19,6 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks/useStyles';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import styleSheet from './SearchableSelectorBottomSheet.styles';
 
 export interface SearchableSelectorBottomSheetProps<T> {
@@ -61,7 +60,6 @@ function SearchableSelectorBottomSheet<T>({
   const [searchString, setSearchString] = useState('');
   const { height: screenHeight } = useWindowDimensions();
   const { styles } = useStyles(styleSheet, { screenHeight });
-  const surfaceClass = useElevatedSurface();
 
   const data = useMemo(
     () => getResults(searchString),
@@ -100,7 +98,6 @@ function SearchableSelectorBottomSheet<T>({
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
     >
       <HeaderStandard
         title={title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface internally. This PR removes the redundant `useElevatedSurface()` shim and `twClassName` props from all Ramp/Buy MMDS bottom sheet callsites as part of the Pure Black Background Schema cleanup (TMCU-622).

**Files updated (12):**
- `EligibilityFailedModal`, `RampInfoBottomSheet`, `SearchableSelectorBottomSheet`
- `Checkout`
- `ErrorDetailsModal`, `PaymentSelectionModal`, `ProcessingInfoModal`, `ProviderSelectionModal`, `SettingsModal`, `TokenNotAvailableModal`, `UnsupportedStateModal`, `UnsupportedTokenModal`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1037](https://consensyssoftware.atlassian.net/browse/TMCU-1037)

## **Manual testing steps**

N/A — mechanical removal of a deprecated theme shim. MMDS `BottomSheet` now owns elevated surface styling. No behavioral change expected with the pure-black flag off; with the flag on, bottom sheets should continue to render with elevated surfaces via MMDS internals.

Recommended QA (from ticket acceptance criteria):
- Verify buy/checkout/provider/payment modals render correctly with pure-black flag on
- Verify no regression with pure-black flag off

## **Screenshots/Recordings**

N/A — no visual change expected; styling responsibility moved from callsite shim to MMDS `BottomSheet`.

### **Before**

### **After**

Both pure black true/false render all BottomSheets with correct color

https://github.com/user-attachments/assets/e0402da9-bff8-40c9-8e1b-57cc5ef650e1


https://github.com/user-attachments/assets/a567e926-67bf-4e19-a547-4d55668f912a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15d05b67-d8bb-412d-8079-9d9a38eca570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15d05b67-d8bb-412d-8079-9d9a38eca570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1037]: https://consensyssoftware.atlassian.net/browse/TMCU-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ