### PR TITLE
fix: Remove redundant useElevatedSurface from Money BottomSheets

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -35,7 +35,6 @@ import {
 } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
 import { useRegionHasNativeFiatProvider } from '../../hooks/useRegionHasNativeFiatProvider';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { selectTransactions } from '../../../../../selectors/transactionController';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
 import MoneySheetOptionsList, {
@@ -59,7 +58,6 @@ const MoneyAddMoneySheet: React.FC = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const {
     fiatBalanceAggregated,
@@ -256,7 +254,6 @@ const MoneyAddMoneySheet: React.FC = () => {
       goBack={handleGoBack}
       testID={MoneyAddMoneySheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         <Text variant={TextVariant.HeadingSm}>

--- a/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.tsx
+++ b/app/components/UI/Money/components/MoneyApyInfoSheet/MoneyApyInfoSheet.tsx
@@ -13,7 +13,6 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import styleSheet from './MoneyApyInfoSheet.styles';
 import { MoneyApyInfoSheetTestIds } from './MoneyApyInfoSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
 import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
@@ -30,7 +29,6 @@ const MoneyApyInfoSheet = () => {
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
   const { apy, variant = 'default' } = useParams<MoneyApyInfoSheetParams>();
-  const surfaceClass = useElevatedSurface();
 
   const { trackBottomSheetViewed } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_APY_INFO_SHEET,
@@ -74,7 +72,6 @@ const MoneyApyInfoSheet = () => {
       goBack={handleGoBack}
       testID={MoneyApyInfoSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSm}>

--- a/app/components/UI/Money/components/MoneyBalanceInfoSheet/MoneyBalanceInfoSheet.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceInfoSheet/MoneyBalanceInfoSheet.tsx
@@ -12,7 +12,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './MoneyBalanceInfoSheet.styles';
 import { MoneyBalanceInfoSheetTestIds } from './MoneyBalanceInfoSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import useMountEffect from '../../hooks/useMountEffect';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
@@ -21,7 +20,6 @@ const MoneyBalanceInfoSheet = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const { trackBottomSheetViewed } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_BALANCE_INFO_SHEET,
@@ -43,7 +41,6 @@ const MoneyBalanceInfoSheet = () => {
       goBack={handleGoBack}
       testID={MoneyBalanceInfoSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text

--- a/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.test.tsx
+++ b/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.test.tsx
@@ -20,10 +20,6 @@ jest.mock('../../hooks/useMoneyAnalytics', () => ({
   useMoneyAnalytics: jest.fn(),
 }));
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 const mockUseRoute = jest.fn();
 
 jest.mock('@react-navigation/native', () => {

--- a/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.tsx
+++ b/app/components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal.tsx
@@ -11,7 +11,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { MoneyDeeplinkModalTestIds } from './MoneyDeeplinkModal.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
@@ -34,8 +33,6 @@ const MoneyDeeplinkModal = () => {
 
   const title = route.params?.title;
   const description = route.params?.description;
-
-  const surfaceClass = useElevatedSurface();
 
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
@@ -65,7 +62,6 @@ const MoneyDeeplinkModal = () => {
     <BottomSheet
       ref={bottomSheetRef}
       testID={MoneyDeeplinkModalTestIds.SHEET}
-      twClassName={surfaceClass}
       onClose={handleClose}
     >
       <BottomSheetHeader

--- a/app/components/UI/Money/components/MoneyEarnCryptoInfoSheet/MoneyEarnCryptoInfoSheet.tsx
+++ b/app/components/UI/Money/components/MoneyEarnCryptoInfoSheet/MoneyEarnCryptoInfoSheet.tsx
@@ -16,7 +16,6 @@ import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import styleSheet from './MoneyEarnCryptoInfoSheet.styles';
 import { MoneyEarnCryptoInfoSheetTestIds } from './MoneyEarnCryptoInfoSheet.testIds';
 
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
 import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
@@ -33,7 +32,6 @@ const MoneyEarnCryptoInfoSheet = () => {
   const { styles } = useStyles(styleSheet, {});
   const { variant = 'default' } = useParams<MoneyEarnCryptoInfoSheetParams>();
   const { apyPercent } = useMoneyAccountBalance();
-  const surfaceClass = useElevatedSurface();
 
   const { trackBottomSheetViewed } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_EARN_CRYPTO_INFO_SHEET,
@@ -60,7 +58,6 @@ const MoneyEarnCryptoInfoSheet = () => {
       goBack={handleGoBack}
       testID={MoneyEarnCryptoInfoSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text

--- a/app/components/UI/Money/components/MoneyEarningsInfoSheet/MoneyEarningsInfoSheet.tsx
+++ b/app/components/UI/Money/components/MoneyEarningsInfoSheet/MoneyEarningsInfoSheet.tsx
@@ -12,7 +12,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './MoneyEarningsInfoSheet.styles';
 import { MoneyEarningsInfoSheetTestIds } from './MoneyEarningsInfoSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
 import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
@@ -21,7 +20,6 @@ const MoneyEarningsInfoSheet = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const { trackBottomSheetViewed } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_EARNINGS_INFO_SHEET,
@@ -43,7 +41,6 @@ const MoneyEarningsInfoSheet = () => {
       goBack={handleGoBack}
       testID={MoneyEarningsInfoSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSm}>

--- a/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.tsx
+++ b/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.tsx
@@ -11,7 +11,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { MoneyGeoBlockSheetTestIds } from './MoneyGeoBlockSheet.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
@@ -22,8 +21,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 
 const MoneyGeoBlockSheet = () => {
   const navigation = useNavigation();
-
-  const surfaceClass = useElevatedSurface();
 
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
@@ -53,7 +50,6 @@ const MoneyGeoBlockSheet = () => {
     <BottomSheet
       ref={bottomSheetRef}
       testID={MoneyGeoBlockSheetTestIds.SHEET}
-      twClassName={surfaceClass}
       onClose={handleClose}
     >
       <BottomSheetHeader

--- a/app/components/UI/Money/components/MoneyLinkCardSheet/MoneyLinkCardSheet.tsx
+++ b/app/components/UI/Money/components/MoneyLinkCardSheet/MoneyLinkCardSheet.tsx
@@ -29,7 +29,6 @@ import mmCardRegular from '../../../../../images/mm_card_regular.png';
 import mmCardMetal from '../../../../../images/mm_card_metal.png';
 import styleSheet from './MoneyLinkCardSheet.styles';
 import { MoneyLinkCardSheetTestIds } from './MoneyLinkCardSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
@@ -62,7 +61,6 @@ const MoneyLinkCardSheet = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const cardHomeData = useSelector(selectCardHomeData);
   const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
-  const surfaceClass = useElevatedSurface();
   const isMetalCard = cardHomeData?.card?.type === CardType.METAL;
   const routeParams = route.params as MoneyLinkCardSheetRouteParams | undefined;
   const originEntryPoint =
@@ -163,7 +161,6 @@ const MoneyLinkCardSheet = () => {
       goBack={handleGoBack}
       testID={MoneyLinkCardSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx
+++ b/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx
@@ -21,7 +21,6 @@ import { METAMASK_SUPPORT_URL } from '../../../../../constants/urls';
 import styleSheet from './MoneyMoreSheet.styles';
 import { openInAppBrowser } from '../../utils/openInAppBrowser';
 import { MoneyMoreSheetTestIds } from './MoneyMoreSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
 import {
@@ -42,7 +41,6 @@ const MoneyMoreSheet = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
-  const surfaceClass = useElevatedSurface();
 
   const { trackBottomSheetViewed, trackSurfaceClicked } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_MORE_SHEET,
@@ -118,7 +116,6 @@ const MoneyMoreSheet = () => {
       goBack={handleGoBack}
       testID={MoneyMoreSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         <Text variant={TextVariant.HeadingSm}>

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
@@ -32,7 +32,6 @@ import MoneySheetOptionsList, {
 } from '../MoneySheetOptionsList';
 import styleSheet from './MoneyTransferSheet.styles';
 import { MoneyTransferSheetTestIds } from './MoneyTransferSheet.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import {
   BOTTOM_SHEET_NAMES,
   COMPONENT_NAMES,
@@ -48,7 +47,6 @@ const MoneyTransferSheet = () => {
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
   const { initiateWithdrawal } = useMoneyAccountWithdrawal();
-  const surfaceClass = useElevatedSurface();
   const { isEnabled: isPerpsEnabled, initiatePerpsDeposit } =
     useMoneyPerpsDeposit();
   const { isEnabled: isPredictEnabled, initiatePredictDeposit } =
@@ -211,7 +209,6 @@ const MoneyTransferSheet = () => {
       goBack={handleGoBack}
       testID={MoneyTransferSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         <Text variant={TextVariant.HeadingSm}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles elevated surface styling internally via `usePureBlack`. The stopgap `useElevatedSurface()` shim from `app/util/theme/themeUtils.ts` is redundant on Money MMDS BottomSheet callsites.

This PR removes the `useElevatedSurface` import, `surfaceClass` variable, and `twClassName={surfaceClass}` prop from all 10 Money MMDS BottomSheet components, and removes the obsolete mock from `MoneyDeeplinkModal.test.tsx`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1038

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

BottomSheets colors work as expected

https://github.com/user-attachments/assets/0d1fa1fc-818b-4cfa-be8c-70226d070558

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc3f2811-fafe-4ff1-a7a0-a9ba924d3adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc3f2811-fafe-4ff1-a7a0-a9ba924d3adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

