### PR TITLE
fix(rewards): remove useElevatedSurface from MMDS BottomSheets (TMCU-1042)

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx
@@ -25,7 +25,6 @@ import ContentfulRichText, {
 } from '../ContentfulRichText/ContentfulRichText';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 interface CampaignOptInSheetProps {
   campaign: CampaignDto;
@@ -44,7 +43,6 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { optInToCampaign, isOptingIn, optInError } = useOptInToCampaign();
   const { showToast, RewardsToastOptions } = useRewardsToast();
-  const surfaceClass = useElevatedSurface();
 
   const handleOptIn = useCallback(async () => {
     try {
@@ -78,7 +76,7 @@ const CampaignOptInSheet: React.FC<CampaignOptInSheetProps> = ({
   ]);
 
   return (
-    <BottomSheet onClose={onClose} twClassName={surfaceClass}>
+    <BottomSheet onClose={onClose}>
       <Box twClassName="px-4 pb-4">
         {/* Header: centered title + close button */}
         <Box

--- a/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAccountPickerSheet.tsx
@@ -31,7 +31,6 @@ import {
   type AccountPickerConfig,
 } from './OndoPortfolio';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 interface OndoAccountPickerSheetProps {
   pendingPicker: AccountPickerConfig;
@@ -48,14 +47,13 @@ const OndoAccountPickerSheet: React.FC<OndoAccountPickerSheetProps> = ({
 }) => {
   const selectedGroup = useSelector(selectResolvedSelectedAccountGroup);
   const { height: screenHeight } = useWindowDimensions();
-  const surfaceClass = useElevatedSurface();
   const listStyle = useMemo(
     () => ({ maxHeight: screenHeight * 0.4 }),
     [screenHeight],
   );
 
   return (
-    <BottomSheet onClose={onClose} ref={sheetRef} twClassName={surfaceClass}>
+    <BottomSheet onClose={onClose} ref={sheetRef}>
       <BottomSheetHeader
         onClose={() => sheetRef.current?.onCloseBottomSheet(onClose)}
       >

--- a/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoAfterHoursSheet.tsx
@@ -21,7 +21,6 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { formatTimeRemaining } from '../../utils/formatUtils';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 interface OndoAfterHoursSheetProps {
   onClose: () => void;
@@ -36,10 +35,8 @@ const OndoAfterHoursSheet: React.FC<OndoAfterHoursSheetProps> = ({
 }) => {
   const countdownText = nextOpenAt ? formatTimeRemaining(nextOpenAt) : null;
 
-  const surfaceClass = useElevatedSurface();
-
   return (
-    <BottomSheet onClose={onClose} twClassName={surfaceClass}>
+    <BottomSheet onClose={onClose}>
       <Box twClassName="px-4 pb-4">
         {/* Header row: spacer + close button */}
         <Box

--- a/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
@@ -19,7 +19,6 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { ONDO_GM_REQUIRED_QUALIFIED_DAYS } from '../../utils/ondoCampaignConstants';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS = {
   CONTAINER: 'ondo-not-eligible-sheet-container',
@@ -38,13 +37,10 @@ const OndoNotEligibleSheet: React.FC<OndoNotEligibleSheetProps> = ({
   onClose,
   onConfirm,
 }) => {
-  const surfaceClass = useElevatedSurface();
-
   return (
     <BottomSheet
       onClose={onClose}
       testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER}
-      twClassName={surfaceClass}
     >
       <Box twClassName="px-4 pb-4">
         {/* Close button */}

--- a/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
@@ -38,81 +38,81 @@ const OndoNotEligibleSheet: React.FC<OndoNotEligibleSheetProps> = ({
   onConfirm,
 }) => (
   <BottomSheet
-      onClose={onClose}
-      testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER}
-    >
-      <Box twClassName="px-4 pb-4">
-        {/* Close button */}
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="justify-end mb-4"
-        >
-          <ButtonIcon
-            iconName={IconName.Close}
-            iconProps={{ color: IconColor.IconDefault }}
-            onPress={onClose}
-            testID="ondo-not-eligible-sheet-close"
-          />
-        </Box>
-
-        {/* Warning icon */}
-        <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
-          <Icon
-            name={IconName.Danger}
-            size={IconSize.Xl}
-            color={IconColor.WarningDefault}
-          />
-        </Box>
-
-        {/* Title */}
-        <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
-          <Text
-            variant={TextVariant.HeadingMd}
-            fontWeight={FontWeight.Bold}
-            testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.TITLE}
-          >
-            {strings('rewards.ondo_campaign_not_eligible.title')}
-          </Text>
-        </Box>
-
-        {/* Body */}
-        <Box twClassName="mb-6">
-          <Text
-            variant={TextVariant.BodyMd}
-            color={TextColor.TextAlternative}
-            twClassName="text-center"
-            testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.BODY}
-          >
-            {strings('rewards.ondo_campaign_not_eligible.body', {
-              days: ONDO_GM_REQUIRED_QUALIFIED_DAYS,
-            })}
-          </Text>
-        </Box>
-
-        {/* Buttons */}
-        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
-          <Button
-            variant={ButtonVariant.Secondary}
-            size={ButtonSize.Lg}
-            onPress={onClose}
-            twClassName="flex-1"
-            testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CANCEL}
-          >
-            {strings('rewards.ondo_campaign_not_eligible.cancel')}
-          </Button>
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            onPress={onConfirm}
-            twClassName="flex-1"
-            testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONFIRM}
-          >
-            {strings('rewards.ondo_campaign_not_eligible.confirm')}
-          </Button>
-        </Box>
+    onClose={onClose}
+    testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER}
+  >
+    <Box twClassName="px-4 pb-4">
+      {/* Close button */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="justify-end mb-4"
+      >
+        <ButtonIcon
+          iconName={IconName.Close}
+          iconProps={{ color: IconColor.IconDefault }}
+          onPress={onClose}
+          testID="ondo-not-eligible-sheet-close"
+        />
       </Box>
-    </BottomSheet>
+
+      {/* Warning icon */}
+      <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+        <Icon
+          name={IconName.Danger}
+          size={IconSize.Xl}
+          color={IconColor.WarningDefault}
+        />
+      </Box>
+
+      {/* Title */}
+      <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.TITLE}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.title')}
+        </Text>
+      </Box>
+
+      {/* Body */}
+      <Box twClassName="mb-6">
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.BODY}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.body', {
+            days: ONDO_GM_REQUIRED_QUALIFIED_DAYS,
+          })}
+        </Text>
+      </Box>
+
+      {/* Buttons */}
+      <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          onPress={onClose}
+          twClassName="flex-1"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CANCEL}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.cancel')}
+        </Button>
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onPress={onConfirm}
+          twClassName="flex-1"
+          testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONFIRM}
+        >
+          {strings('rewards.ondo_campaign_not_eligible.confirm')}
+        </Button>
+      </Box>
+    </Box>
+  </BottomSheet>
 );
 
 export default OndoNotEligibleSheet;

--- a/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoNotEligibleSheet.tsx
@@ -36,9 +36,8 @@ interface OndoNotEligibleSheetProps {
 const OndoNotEligibleSheet: React.FC<OndoNotEligibleSheetProps> = ({
   onClose,
   onConfirm,
-}) => {
-  return (
-    <BottomSheet
+}) => (
+  <BottomSheet
       onClose={onClose}
       testID={ONDO_NOT_ELIGIBLE_SHEET_TEST_IDS.CONTAINER}
     >
@@ -114,7 +113,6 @@ const OndoNotEligibleSheet: React.FC<OndoNotEligibleSheetProps> = ({
         </Box>
       </Box>
     </BottomSheet>
-  );
-};
+);
 
 export default OndoNotEligibleSheet;

--- a/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.test.tsx
@@ -47,10 +47,6 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 describe('VipSwapsVolumeInfoSheet', () => {
   it('renders the daily-refresh title and description', () => {
     const { getByTestId } = render(

--- a/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
@@ -28,9 +28,8 @@ interface VipSwapsVolumeInfoSheetProps {
 
 const VipSwapsVolumeInfoSheet: React.FC<VipSwapsVolumeInfoSheetProps> = ({
   onClose,
-}) => {
-  return (
-    <BottomSheet
+}) => (
+  <BottomSheet
       onClose={onClose}
       testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.SHEET}
     >
@@ -77,7 +76,6 @@ const VipSwapsVolumeInfoSheet: React.FC<VipSwapsVolumeInfoSheetProps> = ({
         </Box>
       </Box>
     </BottomSheet>
-  );
-};
+);
 
 export default VipSwapsVolumeInfoSheet;

--- a/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
@@ -16,7 +16,6 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS = {
   SHEET: 'vip-swaps-volume-info-sheet',
@@ -30,12 +29,9 @@ interface VipSwapsVolumeInfoSheetProps {
 const VipSwapsVolumeInfoSheet: React.FC<VipSwapsVolumeInfoSheetProps> = ({
   onClose,
 }) => {
-  const surfaceClass = useElevatedSurface();
-
   return (
     <BottomSheet
       onClose={onClose}
-      twClassName={surfaceClass}
       testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.SHEET}
     >
       <Box twClassName="px-4 pb-4">

--- a/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapsVolumeInfoSheet.tsx
@@ -30,52 +30,52 @@ const VipSwapsVolumeInfoSheet: React.FC<VipSwapsVolumeInfoSheetProps> = ({
   onClose,
 }) => (
   <BottomSheet
-      onClose={onClose}
-      testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.SHEET}
-    >
-      <Box twClassName="px-4 pb-4">
-        {/* Header row: spacer + close button */}
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          justifyContent={BoxJustifyContent.End}
-          twClassName="mb-4"
-        >
-          <ButtonIcon
-            iconName={IconName.Close}
-            iconProps={{ color: IconColor.IconDefault }}
-            onPress={onClose}
-            testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.CLOSE}
-          />
-        </Box>
-
-        {/* Info icon */}
-        <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
-          <Icon
-            name={IconName.Info}
-            size={IconSize.Xl}
-            color={IconColor.IconAlternative}
-          />
-        </Box>
-
-        <Box twClassName="gap-2">
-          <Text
-            variant={TextVariant.HeadingMd}
-            fontWeight={FontWeight.Bold}
-            twClassName="text-center"
-          >
-            {strings('rewards.vip.swaps_volume_info_title')}
-          </Text>
-          <Text
-            variant={TextVariant.BodyMd}
-            color={TextColor.TextAlternative}
-            twClassName="text-center"
-          >
-            {strings('rewards.vip.swaps_volume_info_description')}
-          </Text>
-        </Box>
+    onClose={onClose}
+    testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.SHEET}
+  >
+    <Box twClassName="px-4 pb-4">
+      {/* Header row: spacer + close button */}
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.End}
+        twClassName="mb-4"
+      >
+        <ButtonIcon
+          iconName={IconName.Close}
+          iconProps={{ color: IconColor.IconDefault }}
+          onPress={onClose}
+          testID={VIP_SWAPS_VOLUME_INFO_SHEET_TEST_IDS.CLOSE}
+        />
       </Box>
-    </BottomSheet>
+
+      {/* Info icon */}
+      <Box alignItems={BoxAlignItems.Center} twClassName="mb-4">
+        <Icon
+          name={IconName.Info}
+          size={IconSize.Xl}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+
+      <Box twClassName="gap-2">
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Bold}
+          twClassName="text-center"
+        >
+          {strings('rewards.vip.swaps_volume_info_title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+        >
+          {strings('rewards.vip.swaps_volume_info_description')}
+        </Text>
+      </Box>
+    </Box>
+  </BottomSheet>
 );
 
 export default VipSwapsVolumeInfoSheet;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface styling internally. This PR removes the redundant `useElevatedSurface()` shim from Rewards campaign and VIP bottom sheets so they rely on the design-system component instead of duplicating surface logic.

**Updated files:**
- `CampaignOptInSheet.tsx`
- `OndoAccountPickerSheet.tsx`
- `OndoAfterHoursSheet.tsx`
- `OndoNotEligibleSheet.tsx`
- `VipSwapsVolumeInfoSheet.tsx`
- `VipSwapsVolumeInfoSheet.test.tsx` (removed obsolete theme mock)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1042

## **Manual testing steps**

```gherkin
Feature: Pure black Rewards bottom sheets

  Scenario: Rewards bottom sheets render with correct elevated surface in pure black mode
    Given the app is running with MM_PURE_BLACK_PREVIEW enabled in dark mode
    And the user navigates to Rewards

    When the user opens any of the campaign opt-in, Ondo account picker, Ondo after-hours, Ondo not eligible, or VIP swaps volume info bottom sheets
    Then each sheet should display with the correct elevated surface background (not collapsing into the pure-black screen background)
```

N/A for automated-only cleanup; visual QA recommended on device with pure black preview enabled.

## **Screenshots/Recordings**

N/A — internal styling cleanup with no user-facing copy or layout changes. Pure black visual QA should be done on device.

### **Before**

N/A

### **After**

BottomSheets still display with the correct colors in pure black

<img width="426" height="869" alt="Screenshot 2026-07-09 at 2 59 40 PM" src="https://github.com/user-attachments/assets/bf292ea8-02df-44d5-950d-43985eb8bc4a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — removal-only change, no new APIs)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable (N/A — styling-only change; iOS simulator visual QA sufficient)
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens (N/A — no performance-sensitive paths touched)
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example (N/A — no new traced operations)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d383551c-f3d3-4ba9-a8d8-f559468f62e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d383551c-f3d3-4ba9-a8d8-f559468f62e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>