### PR TITLE
fix(confirmations): remove footer background and align skeleton buttons in Pure Black

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.styles.ts
+++ b/app/components/Views/confirmations/components/footer/footer.styles.ts
@@ -65,7 +65,8 @@ const styleSheet = (params: {
       justifyContent: 'center',
     },
     footerSkeletonContainer: {
-      ...baseFooterStyle,
+      paddingHorizontal: 16,
+      paddingTop: 16,
       flexDirection: 'row',
       paddingBottom: 32,
       gap: 16,

--- a/app/components/Views/confirmations/components/footer/footer.styles.ts
+++ b/app/components/Views/confirmations/components/footer/footer.styles.ts
@@ -73,7 +73,7 @@ const styleSheet = (params: {
     },
     footerButtonSkeleton: {
       flex: 1,
-      borderRadius: 99,
+      borderRadius: 12,
     },
   });
 };

--- a/app/components/Views/confirmations/components/footer/footer.styles.ts
+++ b/app/components/Views/confirmations/components/footer/footer.styles.ts
@@ -30,7 +30,6 @@ const styleSheet = (params: {
   };
 }) => {
   const {
-    theme: { colors },
     vars: { isStakingConfirmationBool, isFullScreenConfirmation },
   } = params;
 
@@ -42,7 +41,6 @@ const styleSheet = (params: {
       );
 
   const baseFooterStyle = {
-    backgroundColor: colors.background.default,
     paddingHorizontal: 16,
     paddingTop: 16,
   };
@@ -65,8 +63,7 @@ const styleSheet = (params: {
       justifyContent: 'center',
     },
     footerSkeletonContainer: {
-      paddingHorizontal: 16,
-      paddingTop: 16,
+      ...baseFooterStyle,
       flexDirection: 'row',
       paddingBottom: 32,
       gap: 16,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

During the redesigned send/transfer confirmation loading state, the confirmation footer painted its own `background.default` surface via `baseFooterStyle`. In Pure Black mode (`MM_PURE_BLACK_PREVIEW=true`) that produced a visible footer band behind `FooterSkeleton` pill loaders, and the skeleton pills used `borderRadius: 99` instead of matching the real Cancel/Confirm buttons.

This change removes `backgroundColor` from `baseFooterStyle` so both the loaded `Footer` (`styles.base` on `BottomSheetFooter`) and `FooterSkeleton` inherit the parent confirmation surface from `confirm-component.styles.ts` (`flatContainer` / `bottomSheetDialogSheet`). Skeleton button placeholders now use `borderRadius: 12` to match the MMDS button border radius. Padding and layout are unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1018

## **Manual testing steps**

```gherkin
Feature: Transfer confirmation footer in Pure Black mode

  Scenario: Footer skeleton has no visible background band and matches button shape
    Given MM_PURE_BLACK_PREVIEW="true" in .js.env
    And the app is in Dark mode
    When the user initiates a send/transfer (e.g. 0.001 SepoliaETH)
    And the confirmation screen is loading (TransferInfoSkeleton + FooterSkeleton)
    Then the footer skeleton area should not show a distinct background band behind the skeleton buttons
    And the skeleton buttons should use the same MMDS button border radius as the loaded Cancel/Confirm buttons
```

## **Screenshots/Recordings**

Pure Black preview visual fix; QA screenshots and recording below.

### **Before**

Footer skeleton showed a distinct `background.default` band behind fully rounded pill loaders in Pure Black mode.

<img width="417" height="872" alt="confirmations-footer" src="https://github.com/user-attachments/assets/461deb4a-cc34-4804-b247-5aac5ff7c066" />

### **After**

Footer inherits the parent confirmation surface; skeleton buttons match the MMDS button border radius of the loaded footer.

<img width="350" alt="Screenshot 2026-07-09 at 3 30 51 PM" src="https://github.com/user-attachments/assets/49a8b861-7e2a-4c89-b453-69c83c0301ed" /><img width="350" alt="Screenshot 2026-07-09 at 3 30 55 PM" src="https://github.com/user-attachments/assets/fa455e6d-97db-43db-9ac5-02378e4035ee" />

https://github.com/user-attachments/assets/217e44ec-461b-4093-839b-d008226286e5

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (no new tests needed — style-only change; existing footer unit tests pass)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — no new functions or APIs)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable (N/A — style-only change; iOS simulator visual QA sufficient)
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens (N/A — no performance-sensitive paths touched)
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example (N/A — no new traced operations)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6c6f536-3462-4ec0-a255-8267a02780c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6c6f536-3462-4ec0-a255-8267a02780c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
