### PR TITLE
feat: enrichment client side

### DIFF
--- a/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch
@@ -1,8 +1,24 @@
 diff --git a/dist/AssetsController.cjs b/dist/AssetsController.cjs
-index 480338e18fc5d1b9a1dc247318ebac15c90f3015..d0336478a03cf52d1a5cdc21c377bd4d78097ee9 100644
+index 480338e18fc5d1b9a1dc247318ebac15c90f3015..89728499841ddfdf82e3e79306d99d9e9e45d5e9 100644
 --- a/dist/AssetsController.cjs
 +++ b/dist/AssetsController.cjs
-@@ -1237,17 +1237,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+@@ -210,7 +210,14 @@ function normalizeResponse(response) {
+  */
+ function mergeAccountBalances(previousBalances, accountBalances, customAssetIds, replaceCoveredChains) {
+     if (!replaceCoveredChains) {
+-        return { ...previousBalances, ...accountBalances };
++        const next = { ...previousBalances };
++        for (const [assetId, balance] of Object.entries(accountBalances)) {
++            next[assetId] = {
++                ...(previousBalances[assetId] ?? { amount: '0' }),
++                ...balance,
++            };
++        }
++        return next;
+     }
+     const coveredChains = new Set(Object.keys(accountBalances).map((assetId) => assetId.split('/')[0]));
+     const next = {};
+@@ -1237,17 +1244,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
              previousCount: __classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").size,
              currentCount: currentIds.size,
          });
@@ -23,7 +39,7 @@ index 480338e18fc5d1b9a1dc247318ebac15c90f3015..d0336478a03cf52d1a5cdc21c377bd4d
      const releaseLock = await __classPrivateFieldGet(this, _AssetsController_accountRefreshMutex, "f").acquire();
      try {
          await this.getAssets(accounts, {
-@@ -1255,6 +1256,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+@@ -1255,6 +1263,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
              forceUpdate: true,
          });
          __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
@@ -36,7 +52,7 @@ index 480338e18fc5d1b9a1dc247318ebac15c90f3015..d0336478a03cf52d1a5cdc21c377bd4d
      }
      catch (error) {
          log('Failed to fetch assets after tree change', error);
-@@ -2141,8 +2148,9 @@ async function _AssetsController_handleAccountGroupChanged() {
+@@ -2141,8 +2155,9 @@ async function _AssetsController_handleAccountGroupChanged() {
      // Refresh subscriptions for new chain set
      __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
      // Do one-time fetch for newly enabled chains; merge so we keep existing chain balances
@@ -49,10 +65,26 @@ index 480338e18fc5d1b9a1dc247318ebac15c90f3015..d0336478a03cf52d1a5cdc21c377bd4d
              forceUpdate: true,
              updateMode: 'merge',
 diff --git a/dist/AssetsController.mjs b/dist/AssetsController.mjs
-index b2bec5f3ac0e3ee5aa2e4b4438c18899cce6f1d5..7dea54b53eff656dc70de340e1c50c4ea6e36260 100644
+index b2bec5f3ac0e3ee5aa2e4b4438c18899cce6f1d5..3a5bca79e9e501008d178e42c54925bb023e3ee9 100644
 --- a/dist/AssetsController.mjs
 +++ b/dist/AssetsController.mjs
-@@ -1230,17 +1230,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+@@ -204,7 +204,14 @@ function normalizeResponse(response) {
+  */
+ function mergeAccountBalances(previousBalances, accountBalances, customAssetIds, replaceCoveredChains) {
+     if (!replaceCoveredChains) {
+-        return { ...previousBalances, ...accountBalances };
++        const next = { ...previousBalances };
++        for (const [assetId, balance] of Object.entries(accountBalances)) {
++            next[assetId] = {
++                ...(previousBalances[assetId] ?? { amount: '0' }),
++                ...balance,
++            };
++        }
++        return next;
+     }
+     const coveredChains = new Set(Object.keys(accountBalances).map((assetId) => assetId.split('/')[0]));
+     const next = {};
+@@ -1230,17 +1237,18 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
              previousCount: __classPrivateFieldGet(this, _AssetsController_lastKnownAccountIds, "f").size,
              currentCount: currentIds.size,
          });
@@ -73,7 +105,7 @@ index b2bec5f3ac0e3ee5aa2e4b4438c18899cce6f1d5..7dea54b53eff656dc70de340e1c50c4e
      const releaseLock = await __classPrivateFieldGet(this, _AssetsController_accountRefreshMutex, "f").acquire();
      try {
          await this.getAssets(accounts, {
-@@ -1248,6 +1249,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+@@ -1248,6 +1256,12 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
              forceUpdate: true,
          });
          __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
@@ -86,7 +118,7 @@ index b2bec5f3ac0e3ee5aa2e4b4438c18899cce6f1d5..7dea54b53eff656dc70de340e1c50c4e
      }
      catch (error) {
          log('Failed to fetch assets after tree change', error);
-@@ -2134,8 +2141,9 @@ async function _AssetsController_handleAccountGroupChanged() {
+@@ -2134,8 +2148,9 @@ async function _AssetsController_handleAccountGroupChanged() {
      // Refresh subscriptions for new chain set
      __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_subscribeAssets).call(this);
      // Do one-time fetch for newly enabled chains; merge so we keep existing chain balances

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -264,11 +264,11 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
   ///: BEGIN:ONLY_INCLUDE_IF(stellar)
   const isAssetInactive = isAssetRequireActivate({
     assetId: token.address,
-    assetMetadata: token.accountAssetInfo,
+    assetMetadata: token.metadata,
   });
   const baseReserve = computeBaseReserve({
     assetId: token.address,
-    assetMetadata: token.accountAssetInfo,
+    assetMetadata: token.metadata,
   });
   ///: END:ONLY_INCLUDE_IF
 

--- a/app/components/UI/TokenDetails/hooks/useAssetActivation.ts
+++ b/app/components/UI/TokenDetails/hooks/useAssetActivation.ts
@@ -52,7 +52,7 @@ export function useAssetActivation({ asset }: { asset: TokenI | undefined }) {
     return selectAsset(state, {
       address: asset.address,
       chainId: asset.chainId,
-    })?.accountAssetInfo;
+    })?.metadata;
   });
 
   const [isDeactivating, setIsDeactivating] = useState(false);

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -191,7 +191,7 @@ export const TokenListItem = React.memo(
     ///: BEGIN:ONLY_INCLUDE_IF(stellar)
     const isAssetInactive = isAssetRequireActivate({
       assetId: asset?.address,
-      assetMetadata: asset?.accountAssetInfo,
+      assetMetadata: asset?.metadata,
     });
     ///: END:ONLY_INCLUDE_IF
 

--- a/app/components/UI/Tokens/types.ts
+++ b/app/components/UI/Tokens/types.ts
@@ -27,7 +27,7 @@ export interface TokenI {
   pricePercentChange1d?: number;
   rwaData?: TokenRwaData;
   securityData?: TokenSecurityData;
-  accountAssetInfo?: {
+  metadata?: {
     limit?: string;
     baseReserve?: string;
   };

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -276,10 +276,6 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
       }
 
       const { MultichainAssetsController } = Engine.context;
-      await MultichainAssetsController.addAssets(
-        addresses as CaipAssetType[],
-        selectedNonEvmAccount.id,
-      );
 
       if (isAssetsUnifyStateEnabled) {
         try {
@@ -307,6 +303,11 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
         }
       }
     } else {
+      await MultichainAssetsController.addAssets(
+        addresses as CaipAssetType[],
+        selectedNonEvmAccount.id,
+      );
+
       const caipChainId = formatChainIdToCaip(
         selectedChainId as SupportedCaipChainId,
       );

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -96,6 +96,10 @@ import { multichainAccountServiceInit } from './controllers/multichain-account-s
 import { snapAccountServiceInit } from './controllers/snap-account-service/snap-account-service-init';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
 ///: END:ONLY_INCLUDE_IF
+///: BEGIN:ONLY_INCLUDE_IF(stellar)
+import { startStellarAccountAssetInfoEnrichmentBridge } from './utils/stellar-account-asset-info-enrichment-bridge';
+import { selectIsStellarAccountsEnabled } from '../../selectors/featureFlagController/stellarAccountsEnabled';
+///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   cronjobControllerInit,
@@ -673,6 +677,16 @@ export class Engine {
         delete childControllers[name];
       }
     });
+
+    ///: BEGIN:ONLY_INCLUDE_IF(stellar)
+    startStellarAccountAssetInfoEnrichmentBridge({
+      messenger: this.controllerMessenger,
+      accountsController,
+      isEnabled: () =>
+        selectIsAssetsUnifyStateEnabled(store.getState()) &&
+        selectIsStellarAccountsEnabled(store.getState()),
+    });
+    ///: END:ONLY_INCLUDE_IF
 
     this.controllerMessenger.subscribe(
       AppConstants.NETWORK_STATE_CHANGE_EVENT,

--- a/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.test.ts
+++ b/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.test.ts
@@ -1,0 +1,152 @@
+///: BEGIN:ONLY_INCLUDE_IF(stellar)
+import { startStellarAccountAssetInfoEnrichmentBridge } from './stellar-account-asset-info-enrichment-bridge';
+import {
+  enrichAllStellarClassicAccountAssetInfo,
+  enrichStellarAccountAssetInfo,
+  findAccountsNeedingStellarEnrichment,
+} from '../../../util/stellar/enrich-stellar-account-asset-info';
+
+jest.mock('../../../util/stellar/enrich-stellar-account-asset-info', () => ({
+  enrichAllStellarClassicAccountAssetInfo: jest
+    .fn()
+    .mockResolvedValue(undefined),
+  enrichStellarAccountAssetInfo: jest.fn().mockResolvedValue(undefined),
+  findAccountsNeedingStellarEnrichment: jest.fn().mockReturnValue(new Map()),
+  isStellarClassicAssetId: jest.requireActual(
+    '../../../util/stellar/enrich-stellar-account-asset-info',
+  ).isStellarClassicAssetId,
+}));
+
+const STELLAR_USDC =
+  'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const SOLANA_SOL = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+
+describe('startStellarAccountAssetInfoEnrichmentBridge', () => {
+  function setup({ enabled = true }: { enabled?: boolean } = {}) {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const messenger = {
+      subscribe: jest.fn(
+        (event: string, callback: (...args: unknown[]) => unknown) => {
+          handlers.set(event, callback);
+        },
+      ),
+      unsubscribe: jest.fn(),
+    };
+    const account = { id: 'account-1' };
+    const accountsController = {
+      getAccount: jest.fn().mockReturnValue(account),
+    };
+
+    const cleanup = startStellarAccountAssetInfoEnrichmentBridge({
+      messenger: messenger as never,
+      accountsController: accountsController as never,
+      isEnabled: () => enabled,
+    });
+
+    return {
+      handlers,
+      messenger,
+      accountsController,
+      account,
+      cleanup,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('enriches Stellar assets after asset list updates', async () => {
+    const { handlers, accountsController, account } = setup();
+    const listHandler = handlers.get(
+      'AccountsController:accountAssetListUpdated',
+    ) as (payload: {
+      assets: Record<string, { added: string[]; removed: string[] }>;
+    }) => Promise<void>;
+
+    await listHandler({
+      assets: {
+        'account-1': {
+          added: [STELLAR_USDC, SOLANA_SOL],
+          removed: [],
+        },
+      },
+    });
+
+    expect(accountsController.getAccount).toHaveBeenCalledWith('account-1');
+    expect(enrichAllStellarClassicAccountAssetInfo).toHaveBeenCalledWith(
+      account,
+      'stellar:pubnet',
+      { force: true },
+    );
+  });
+
+  it('does nothing for asset list updates when disabled', async () => {
+    const { handlers } = setup({ enabled: false });
+    const listHandler = handlers.get(
+      'AccountsController:accountAssetListUpdated',
+    ) as (payload: {
+      assets: Record<string, { added: string[]; removed: string[] }>;
+    }) => Promise<void>;
+
+    await listHandler({
+      assets: {
+        'account-1': {
+          added: [STELLAR_USDC],
+          removed: [],
+        },
+      },
+    });
+
+    expect(enrichAllStellarClassicAccountAssetInfo).not.toHaveBeenCalled();
+  });
+
+  it('enriches missing accountAssetInfo after AssetsController state changes', async () => {
+    const needing = new Map([
+      ['account-1', new Map([['stellar:pubnet' as const, [STELLAR_USDC]]])],
+    ]);
+    jest.mocked(findAccountsNeedingStellarEnrichment).mockReturnValue(needing);
+
+    const { handlers, account } = setup();
+    const stateHandler = handlers.get('AssetsController:stateChange') as (
+      state: unknown,
+    ) => void;
+
+    stateHandler({
+      assetsBalance: {
+        'account-1': {
+          [STELLAR_USDC]: { amount: '10' },
+        },
+      },
+    });
+
+    await jest.runAllTimersAsync();
+
+    expect(enrichStellarAccountAssetInfo).toHaveBeenCalledWith({
+      account,
+      chainId: 'stellar:pubnet',
+      assetIds: [STELLAR_USDC],
+    });
+  });
+
+  it('unsubscribes both handlers on cleanup', () => {
+    const { cleanup, messenger } = setup();
+
+    cleanup();
+
+    expect(messenger.unsubscribe).toHaveBeenCalledWith(
+      'AccountsController:accountAssetListUpdated',
+      expect.any(Function),
+    );
+    expect(messenger.unsubscribe).toHaveBeenCalledWith(
+      'AssetsController:stateChange',
+      expect.any(Function),
+    );
+  });
+});
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.test.ts
+++ b/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.test.ts
@@ -106,7 +106,7 @@ describe('startStellarAccountAssetInfoEnrichmentBridge', () => {
     expect(enrichAllStellarClassicAccountAssetInfo).not.toHaveBeenCalled();
   });
 
-  it('enriches missing accountAssetInfo after AssetsController state changes', async () => {
+  it('enriches missing metadata after AssetsController state changes', async () => {
     const needing = new Map([
       ['account-1', new Map([['stellar:pubnet' as const, [STELLAR_USDC]]])],
     ]);

--- a/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.ts
+++ b/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.ts
@@ -1,0 +1,195 @@
+///: BEGIN:ONLY_INCLUDE_IF(stellar)
+import type { AccountsControllerAccountAssetListUpdatedEvent } from '@metamask/accounts-controller';
+import type { AssetsController } from '@metamask/assets-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { KnownCaipNamespace, parseCaipAssetType } from '@metamask/utils';
+
+import Logger from '../../../util/Logger';
+import {
+  enrichAllStellarClassicAccountAssetInfo,
+  enrichStellarAccountAssetInfo,
+  findAccountsNeedingStellarEnrichment,
+  isStellarClassicAssetId,
+} from '../../../util/stellar/enrich-stellar-account-asset-info';
+import type { RootExtendedMessenger } from '../types';
+
+type AccountAssetListUpdatedPayload =
+  AccountsControllerAccountAssetListUpdatedEvent['payload'][0];
+
+type AssetsControllerState = AssetsController['state'];
+
+type StellarAccountAssetInfoEnrichmentBridgeOptions = {
+  messenger: RootExtendedMessenger;
+  accountsController: {
+    getAccount: (accountId: string) => InternalAccount | undefined;
+  };
+  isEnabled: () => boolean;
+};
+
+const STATE_CHANGE_DEBOUNCE_MS = 250;
+
+function getStellarChainIds(assetIds: CaipAssetType[]): CaipChainId[] {
+  const chainIds = new Set<CaipChainId>();
+
+  for (const assetId of assetIds) {
+    try {
+      const { chain } = parseCaipAssetType(assetId);
+      if (chain.namespace === KnownCaipNamespace.Stellar) {
+        chainIds.add(`${chain.namespace}:${chain.reference}` as CaipChainId);
+      }
+    } catch {
+      // Ignore malformed snap payload entries.
+    }
+  }
+
+  return [...chainIds];
+}
+
+/**
+ * Bridges Stellar Snap asset-list updates and AssetsController balance state
+ * into client-side `getAccountAssetInfo` enrichment.
+ *
+ * - `AccountsController:accountAssetListUpdated`: refresh trustline fields for
+ *   affected Stellar assets.
+ * - `AssetsController:stateChange`: fill missing `accountAssetInfo` after
+ *   balances land (cold start / account switch / poll).
+ *
+ * @param options - Bridge dependencies.
+ * @returns A cleanup function that unsubscribes the bridge.
+ */
+export function startStellarAccountAssetInfoEnrichmentBridge({
+  messenger,
+  accountsController,
+  isEnabled,
+}: StellarAccountAssetInfoEnrichmentBridgeOptions): () => void {
+  let stateChangeTimer: ReturnType<typeof setTimeout> | undefined;
+  let enrichingFromStateChange = false;
+
+  const handleAccountAssetListUpdated = async ({
+    assets,
+  }: AccountAssetListUpdatedPayload) => {
+    if (!isEnabled()) {
+      return;
+    }
+
+    for (const [accountId, { added, removed }] of Object.entries(assets)) {
+      const stellarTouched = [...added, ...removed].filter((assetId) =>
+        isStellarClassicAssetId(assetId),
+      ) as CaipAssetType[];
+      const affectedChainIds = getStellarChainIds(stellarTouched);
+
+      if (affectedChainIds.length === 0) {
+        continue;
+      }
+
+      try {
+        const account = accountsController.getAccount(accountId);
+        if (!account) {
+          continue;
+        }
+
+        for (const chainId of affectedChainIds) {
+          await enrichAllStellarClassicAccountAssetInfo(account, chainId, {
+            force: true,
+          });
+        }
+      } catch (error) {
+        Logger.log(
+          error,
+          'StellarAccountAssetInfoEnrichmentBridge: failed to refresh after asset list update',
+        );
+      }
+    }
+  };
+
+  const enrichMissingFromState = async (state: AssetsControllerState) => {
+    if (!isEnabled() || enrichingFromStateChange) {
+      return;
+    }
+
+    const needingEnrichment = findAccountsNeedingStellarEnrichment(
+      state.assetsBalance as Record<
+        string,
+        Record<
+          string,
+          { amount?: string; accountAssetInfo?: Record<string, unknown> }
+        >
+      >,
+    );
+    if (needingEnrichment.size === 0) {
+      return;
+    }
+
+    enrichingFromStateChange = true;
+    try {
+      for (const [accountId, byChain] of needingEnrichment) {
+        const account = accountsController.getAccount(accountId);
+        if (!account) {
+          continue;
+        }
+
+        for (const [chainId, assetIds] of byChain) {
+          try {
+            await enrichStellarAccountAssetInfo({
+              account,
+              chainId,
+              assetIds,
+            });
+          } catch (error) {
+            Logger.log(
+              error,
+              'StellarAccountAssetInfoEnrichmentBridge: failed to enrich missing accountAssetInfo',
+            );
+          }
+        }
+      }
+    } finally {
+      enrichingFromStateChange = false;
+    }
+  };
+
+  const handleAssetsControllerStateChange = (state: AssetsControllerState) => {
+    if (!isEnabled()) {
+      return;
+    }
+
+    if (stateChangeTimer) {
+      clearTimeout(stateChangeTimer);
+    }
+
+    stateChangeTimer = setTimeout(() => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      enrichMissingFromState(state).catch((error) => {
+        Logger.log(
+          error,
+          'StellarAccountAssetInfoEnrichmentBridge: stateChange enrichment failed',
+        );
+      });
+    }, STATE_CHANGE_DEBOUNCE_MS);
+  };
+
+  messenger.subscribe(
+    'AccountsController:accountAssetListUpdated',
+    handleAccountAssetListUpdated,
+  );
+  messenger.subscribe(
+    'AssetsController:stateChange',
+    handleAssetsControllerStateChange,
+  );
+
+  return () => {
+    if (stateChangeTimer) {
+      clearTimeout(stateChangeTimer);
+    }
+    messenger.unsubscribe(
+      'AccountsController:accountAssetListUpdated',
+      handleAccountAssetListUpdated,
+    );
+    messenger.unsubscribe(
+      'AssetsController:stateChange',
+      handleAssetsControllerStateChange,
+    );
+  };
+}
+///: END:ONLY_INCLUDE_IF

--- a/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.ts
+++ b/app/core/Engine/utils/stellar-account-asset-info-enrichment-bridge.ts
@@ -52,7 +52,7 @@ function getStellarChainIds(assetIds: CaipAssetType[]): CaipChainId[] {
  *
  * - `AccountsController:accountAssetListUpdated`: refresh trustline fields for
  *   affected Stellar assets.
- * - `AssetsController:stateChange`: fill missing `accountAssetInfo` after
+ * - `AssetsController:stateChange`: fill missing balance `metadata` after
  *   balances land (cold start / account switch / poll).
  *
  * @param options - Bridge dependencies.
@@ -111,10 +111,7 @@ export function startStellarAccountAssetInfoEnrichmentBridge({
     const needingEnrichment = findAccountsNeedingStellarEnrichment(
       state.assetsBalance as Record<
         string,
-        Record<
-          string,
-          { amount?: string; accountAssetInfo?: Record<string, unknown> }
-        >
+        Record<string, { amount?: string; metadata?: Record<string, unknown> }>
       >,
     );
     if (needingEnrichment.size === 0) {
@@ -139,7 +136,7 @@ export function startStellarAccountAssetInfoEnrichmentBridge({
           } catch (error) {
             Logger.log(
               error,
-              'StellarAccountAssetInfoEnrichmentBridge: failed to enrich missing accountAssetInfo',
+              'StellarAccountAssetInfoEnrichmentBridge: failed to enrich missing metadata',
             );
           }
         }

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -1836,11 +1836,11 @@ describe('selectAsset', () => {
     expect(result?.isStaked).not.toBeUndefined();
   });
 
-  it('propagates accountAssetInfo from multichain asset into TokenI', () => {
+  it('propagates metadata from multichain asset into TokenI', () => {
     const innerSelector = jest.mocked(innerSelectAssetsBySelectedAccountGroup);
     const stellarAssetId =
       'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
-    const accountAssetInfo = { limit: '1000', authorized: true };
+    const metadata = { limit: '1000', authorized: true };
 
     innerSelector.mockReturnValue({
       'stellar:pubnet': [
@@ -1857,7 +1857,7 @@ describe('selectAsset', () => {
           symbol: 'USDC',
           isNative: false,
           fiat: undefined,
-          accountAssetInfo,
+          metadata,
         },
       ],
     } as AccountGroupAssets);
@@ -1872,7 +1872,7 @@ describe('selectAsset', () => {
       isStaked: false,
     });
 
-    expect(result?.accountAssetInfo).toStrictEqual(accountAssetInfo);
+    expect(result?.metadata).toStrictEqual(metadata);
 
     innerSelector.mockImplementation(
       jest.requireActual('@metamask/assets-controllers')

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -163,13 +163,13 @@ function filterArcUsdcErc20Token(
   };
 }
 
-type BalanceRowWithAccountAssetInfo = {
+type BalanceRowWithMetadata = {
   amount?: string;
-  accountAssetInfo?: TokenI['accountAssetInfo'];
+  metadata?: TokenI['metadata'];
 };
 
 /**
- * Re-attaches Snap `accountAssetInfo` from migrated balances onto Asset rows.
+ * Re-attaches Snap balance `metadata` from migrated balances onto Asset rows.
  *
  * `@metamask/assets-controllers` `selectAllMultichainAssets` only copies
  * `balance.amount` into Asset, so trustline metadata would otherwise be lost
@@ -183,16 +183,16 @@ function attachAccountAssetInfoFromBalances(
   for (const [chainId, chainAssets] of Object.entries(assets)) {
     next[chainId] = chainAssets.map((asset) => {
       const balanceRow = balances[asset.accountId]?.[asset.assetId] as
-        | BalanceRowWithAccountAssetInfo
+        | BalanceRowWithMetadata
         | undefined;
-      const accountAssetInfo = balanceRow?.accountAssetInfo;
-      if (accountAssetInfo === undefined) {
+      const metadata = balanceRow?.metadata;
+      if (metadata === undefined) {
         return asset;
       }
       return {
         ...asset,
-        accountAssetInfo,
-      } as Asset & { accountAssetInfo?: TokenI['accountAssetInfo'] };
+        metadata,
+      } as Asset & { metadata?: TokenI['metadata'] };
     });
   }
 
@@ -650,7 +650,7 @@ const oneHundredths = 0.01;
 function assetToToken(
   asset: Asset & {
     isStaked?: boolean;
-    accountAssetInfo?: TokenI['accountAssetInfo'];
+    metadata?: TokenI['metadata'];
   },
   aggregators?: string[],
   rwaData?: TokenI['rwaData'],
@@ -697,9 +697,7 @@ function assetToToken(
     ticker: asset.symbol,
     accountType: asset.accountType,
     rwaData,
-    ...(asset.accountAssetInfo !== undefined
-      ? { accountAssetInfo: asset.accountAssetInfo }
-      : {}),
+    ...(asset.metadata !== undefined ? { metadata: asset.metadata } : {}),
   };
 }
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -163,6 +163,42 @@ function filterArcUsdcErc20Token(
   };
 }
 
+type BalanceRowWithAccountAssetInfo = {
+  amount?: string;
+  accountAssetInfo?: TokenI['accountAssetInfo'];
+};
+
+/**
+ * Re-attaches Snap `accountAssetInfo` from migrated balances onto Asset rows.
+ *
+ * `@metamask/assets-controllers` `selectAllMultichainAssets` only copies
+ * `balance.amount` into Asset, so trustline metadata would otherwise be lost
+ * before TokenList / TokenDetails read it.
+ */
+function attachAccountAssetInfoFromBalances(
+  assets: AccountGroupAssets,
+  balances: ReturnType<typeof getMultiChainBalancesControllerBalances>,
+): AccountGroupAssets {
+  const next: AccountGroupAssets = {};
+  for (const [chainId, chainAssets] of Object.entries(assets)) {
+    next[chainId] = chainAssets.map((asset) => {
+      const balanceRow = balances[asset.accountId]?.[asset.assetId] as
+        | BalanceRowWithAccountAssetInfo
+        | undefined;
+      const accountAssetInfo = balanceRow?.accountAssetInfo;
+      if (accountAssetInfo === undefined) {
+        return asset;
+      }
+      return {
+        ...asset,
+        accountAssetInfo,
+      } as Asset & { accountAssetInfo?: TokenI['accountAssetInfo'] };
+    });
+  }
+
+  return next;
+}
+
 /**
  * Invokes the assets-controllers selector; on failure returns {} so the wallet UI
  * does not red-screen during brief AccountTree / internalAccounts mismatch (e.g. after unlock).
@@ -183,8 +219,11 @@ function callSelectAssetsBySelectedAccountGroup(
 export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
   getStateForAssetSelector,
   (assetsState) =>
-    filterArcUsdcErc20Token(
-      callSelectAssetsBySelectedAccountGroup(assetsState),
+    attachAccountAssetInfoFromBalances(
+      filterArcUsdcErc20Token(
+        callSelectAssetsBySelectedAccountGroup(assetsState),
+      ),
+      assetsState.balances,
     ),
 );
 

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -626,13 +626,13 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
 
         const rawBalanceRow = balance as {
           amount: string;
-          accountAssetInfo?: Record<string, unknown>;
+          metadata?: Record<string, unknown>;
         };
         const selectorBalanceRow = {
           amount: balance.amount,
           unit: metadata.symbol,
-          ...(rawBalanceRow.accountAssetInfo !== undefined
-            ? { accountAssetInfo: rawBalanceRow.accountAssetInfo }
+          ...(rawBalanceRow.metadata !== undefined
+            ? { metadata: rawBalanceRow.metadata }
             : {}),
         };
 

--- a/app/util/stellar/enrich-stellar-account-asset-info.test.ts
+++ b/app/util/stellar/enrich-stellar-account-asset-info.test.ts
@@ -37,7 +37,7 @@ describe('enrich-stellar-account-asset-info', () => {
     state: {
       assetsBalance: Record<
         string,
-        Record<string, { amount?: string; accountAssetInfo?: unknown }>
+        Record<string, { amount?: string; metadata?: unknown }>
       >;
     };
     getCustomAssets: jest.Mock;
@@ -88,7 +88,7 @@ describe('enrich-stellar-account-asset-info', () => {
   });
 
   describe('findAccountsNeedingStellarEnrichment', () => {
-    it('returns classic assets missing accountAssetInfo', () => {
+    it('returns classic assets missing metadata', () => {
       const result = findAccountsNeedingStellarEnrichment({
         'account-1': {
           [STELLAR_USDC]: { amount: '10' },
@@ -102,12 +102,12 @@ describe('enrich-stellar-account-asset-info', () => {
       ]);
     });
 
-    it('skips assets that already have accountAssetInfo', () => {
+    it('skips assets that already have metadata', () => {
       const result = findAccountsNeedingStellarEnrichment({
         'account-1': {
           [STELLAR_USDC]: {
             amount: '10',
-            accountAssetInfo: { limit: '1000' },
+            metadata: { limit: '1000' },
           },
         },
       });
@@ -140,7 +140,7 @@ describe('enrich-stellar-account-asset-info', () => {
             'account-1': {
               [STELLAR_USDC]: {
                 amount: '10',
-                accountAssetInfo: { limit: '1000', authorized: true },
+                metadata: { limit: '1000', authorized: true },
               },
             },
           },

--- a/app/util/stellar/enrich-stellar-account-asset-info.test.ts
+++ b/app/util/stellar/enrich-stellar-account-asset-info.test.ts
@@ -1,0 +1,183 @@
+///: BEGIN:ONLY_INCLUDE_IF(stellar)
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import Engine from '../../core/Engine';
+import { requestStellarGetAccountAssetInfo } from './stellar-snap-client-requests';
+import {
+  enrichStellarAccountAssetInfo,
+  findAccountsNeedingStellarEnrichment,
+  isStellarClassicAssetId,
+  listStellarClassicAssetIdsForAccount,
+  resetStellarAccountAssetInfoEnrichmentInFlight,
+} from './enrich-stellar-account-asset-info';
+
+jest.mock('../../core/Engine', () => ({
+  context: {
+    AssetsController: {
+      state: {
+        assetsBalance: {},
+      },
+      getCustomAssets: jest.fn().mockReturnValue([]),
+      handleAssetsUpdate: jest.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+jest.mock('./stellar-snap-client-requests', () => ({
+  requestStellarGetAccountAssetInfo: jest.fn(),
+}));
+
+const STELLAR_USDC =
+  'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const STELLAR_XLM = 'stellar:pubnet/slip44:148';
+const SOLANA_SOL = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+
+describe('enrich-stellar-account-asset-info', () => {
+  const account = { id: 'account-1' } as InternalAccount;
+  const assetsController = Engine.context.AssetsController as {
+    state: {
+      assetsBalance: Record<
+        string,
+        Record<string, { amount?: string; accountAssetInfo?: unknown }>
+      >;
+    };
+    getCustomAssets: jest.Mock;
+    handleAssetsUpdate: jest.Mock;
+  };
+  const requestMock = requestStellarGetAccountAssetInfo as jest.MockedFunction<
+    typeof requestStellarGetAccountAssetInfo
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStellarAccountAssetInfoEnrichmentInFlight();
+    assetsController.state.assetsBalance = {
+      'account-1': {
+        [STELLAR_USDC]: { amount: '10' },
+        [STELLAR_XLM]: { amount: '1' },
+      },
+    };
+    assetsController.getCustomAssets.mockReturnValue([]);
+  });
+
+  describe('isStellarClassicAssetId', () => {
+    it('returns true for Stellar classic assets', () => {
+      expect(isStellarClassicAssetId(STELLAR_USDC)).toBe(true);
+    });
+
+    it('returns false for native XLM and non-Stellar assets', () => {
+      expect(isStellarClassicAssetId(STELLAR_XLM)).toBe(false);
+      expect(isStellarClassicAssetId(SOLANA_SOL)).toBe(false);
+    });
+  });
+
+  describe('listStellarClassicAssetIdsForAccount', () => {
+    it('lists classic assets from balances and optional custom assets', () => {
+      assetsController.getCustomAssets.mockReturnValue([
+        'stellar:pubnet/asset:EURC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      ]);
+
+      expect(
+        listStellarClassicAssetIdsForAccount('account-1', 'stellar:pubnet', {
+          includeCustomAssets: true,
+        }),
+      ).toStrictEqual([
+        STELLAR_USDC,
+        'stellar:pubnet/asset:EURC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      ]);
+    });
+  });
+
+  describe('findAccountsNeedingStellarEnrichment', () => {
+    it('returns classic assets missing accountAssetInfo', () => {
+      const result = findAccountsNeedingStellarEnrichment({
+        'account-1': {
+          [STELLAR_USDC]: { amount: '10' },
+          [STELLAR_XLM]: { amount: '1' },
+          [SOLANA_SOL]: { amount: '2' },
+        },
+      });
+
+      expect(result.get('account-1')?.get('stellar:pubnet')).toStrictEqual([
+        STELLAR_USDC,
+      ]);
+    });
+
+    it('skips assets that already have accountAssetInfo', () => {
+      const result = findAccountsNeedingStellarEnrichment({
+        'account-1': {
+          [STELLAR_USDC]: {
+            amount: '10',
+            accountAssetInfo: { limit: '1000' },
+          },
+        },
+      });
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('enrichStellarAccountAssetInfo', () => {
+    it('merges Snap enrichment into AssetsController balances', async () => {
+      requestMock.mockResolvedValueOnce({
+        [STELLAR_USDC]: { limit: '1000', authorized: true },
+      });
+
+      await enrichStellarAccountAssetInfo({
+        account,
+        chainId: 'stellar:pubnet',
+        assetIds: [STELLAR_USDC],
+      });
+
+      expect(requestMock).toHaveBeenCalledWith({
+        accountId: 'account-1',
+        scope: 'stellar:pubnet',
+        assets: [STELLAR_USDC],
+      });
+      expect(assetsController.handleAssetsUpdate).toHaveBeenCalledWith(
+        {
+          updateMode: 'merge',
+          assetsBalance: {
+            'account-1': {
+              [STELLAR_USDC]: {
+                amount: '10',
+                accountAssetInfo: { limit: '1000', authorized: true },
+              },
+            },
+          },
+        },
+        'StellarAccountAssetInfoEnrichment',
+      );
+    });
+
+    it('dedupes concurrent enrich calls for the same account and chain', async () => {
+      let resolveRequest:
+        | ((value: Record<string, Record<string, unknown>>) => void)
+        | undefined;
+      requestMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRequest = resolve;
+          }),
+      );
+
+      const first = enrichStellarAccountAssetInfo({
+        account,
+        chainId: 'stellar:pubnet',
+        assetIds: [STELLAR_USDC],
+      });
+      const second = enrichStellarAccountAssetInfo({
+        account,
+        chainId: 'stellar:pubnet',
+        assetIds: [STELLAR_USDC],
+      });
+
+      resolveRequest?.({
+        [STELLAR_USDC]: { limit: '1000', authorized: true },
+      });
+      await Promise.all([first, second]);
+
+      expect(requestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+///: END:ONLY_INCLUDE_IF

--- a/app/util/stellar/enrich-stellar-account-asset-info.ts
+++ b/app/util/stellar/enrich-stellar-account-asset-info.ts
@@ -17,7 +17,7 @@ const inFlightByKey = new Map<string, Promise<void>>();
 
 type BalanceRow = {
   amount?: string;
-  accountAssetInfo?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 };
 
 /**
@@ -52,10 +52,7 @@ export function listStellarClassicAssetIdsForAccount(
   for (const assetId of Object.keys(balances)) {
     try {
       const parsed = parseCaipAssetType(assetId as CaipAssetType);
-      if (
-        parsed.chainId === chainId &&
-        parsed.assetNamespace === 'asset'
-      ) {
+      if (parsed.chainId === chainId && parsed.assetNamespace === 'asset') {
         assetIds.add(assetId as CaipAssetType);
       }
     } catch {
@@ -67,10 +64,7 @@ export function listStellarClassicAssetIdsForAccount(
     for (const assetId of AssetsController.getCustomAssets(accountId)) {
       try {
         const parsed = parseCaipAssetType(assetId as CaipAssetType);
-        if (
-          parsed.chainId === chainId &&
-          parsed.assetNamespace === 'asset'
-        ) {
+        if (parsed.chainId === chainId && parsed.assetNamespace === 'asset') {
           assetIds.add(assetId as CaipAssetType);
         }
       } catch {
@@ -84,7 +78,7 @@ export function listStellarClassicAssetIdsForAccount(
 
 /**
  * Collects Stellar classic assets that are present in balances but missing
- * `accountAssetInfo`, grouped by account and chain.
+ * `metadata`, grouped by account and chain.
  */
 export function findAccountsNeedingStellarEnrichment(
   assetsBalance: Record<string, Record<string, BalanceRow>>,
@@ -93,7 +87,7 @@ export function findAccountsNeedingStellarEnrichment(
 
   for (const [accountId, accountBalances] of Object.entries(assetsBalance)) {
     for (const [assetId, row] of Object.entries(accountBalances)) {
-      if (row?.accountAssetInfo !== undefined) {
+      if (row?.metadata !== undefined) {
         continue;
       }
       if (!isStellarClassicAssetId(assetId)) {
@@ -223,24 +217,21 @@ export async function enrichStellarAccountAssetInfo({
 
     const assetsBalance: Record<
       string,
-      Record<
-        string,
-        { amount: string; accountAssetInfo?: Record<string, unknown> }
-      >
+      Record<string, { amount: string; metadata?: Record<string, unknown> }>
     > = {
       [account.id]: {},
     };
 
     for (const assetId of assetIds) {
-      const accountAssetInfo = enrichment[assetId];
-      if (accountAssetInfo === undefined) {
+      const metadata = enrichment[assetId];
+      if (metadata === undefined) {
         continue;
       }
 
       const existingRow = existingBalances[assetId] as BalanceRow | undefined;
       assetsBalance[account.id][assetId] = {
         amount: existingRow?.amount ?? '0',
-        accountAssetInfo,
+        metadata,
       };
     }
 

--- a/app/util/stellar/enrich-stellar-account-asset-info.ts
+++ b/app/util/stellar/enrich-stellar-account-asset-info.ts
@@ -1,0 +1,296 @@
+///: BEGIN:ONLY_INCLUDE_IF(stellar)
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import {
+  type CaipAssetType,
+  type CaipChainId,
+  KnownCaipNamespace,
+  parseCaipAssetType,
+} from '@metamask/utils';
+import Engine from '../../core/Engine';
+import Logger from '../Logger';
+import { requestStellarGetAccountAssetInfo } from './stellar-snap-client-requests';
+
+const ACCOUNT_ASSET_INFO_SNAP_TIMEOUT_MS = 15_000;
+const ENRICHMENT_TIMEOUT = Symbol('enrichmentTimeout');
+
+const inFlightByKey = new Map<string, Promise<void>>();
+
+type BalanceRow = {
+  amount?: string;
+  accountAssetInfo?: Record<string, unknown>;
+};
+
+/**
+ * Returns true when the CAIP-19 asset id is a Stellar classic (`asset:`) asset.
+ */
+export function isStellarClassicAssetId(assetId: string): boolean {
+  try {
+    const parsed = parseCaipAssetType(assetId as CaipAssetType);
+    return (
+      parsed.chain.namespace === KnownCaipNamespace.Stellar &&
+      parsed.assetNamespace === 'asset'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lists Stellar classic asset ids for an account on a chain from AssetsController
+ * balances, optionally including custom assets that may have dropped off the
+ * Snap asset list (e.g. limit-0 trustline tombstones).
+ */
+export function listStellarClassicAssetIdsForAccount(
+  accountId: string,
+  chainId: CaipChainId,
+  options?: { includeCustomAssets?: boolean },
+): CaipAssetType[] {
+  const { AssetsController } = Engine.context;
+  const balances = AssetsController.state.assetsBalance[accountId] ?? {};
+  const assetIds = new Set<CaipAssetType>();
+
+  for (const assetId of Object.keys(balances)) {
+    try {
+      const parsed = parseCaipAssetType(assetId as CaipAssetType);
+      if (
+        parsed.chainId === chainId &&
+        parsed.assetNamespace === 'asset'
+      ) {
+        assetIds.add(assetId as CaipAssetType);
+      }
+    } catch {
+      // Ignore malformed asset ids.
+    }
+  }
+
+  if (options?.includeCustomAssets) {
+    for (const assetId of AssetsController.getCustomAssets(accountId)) {
+      try {
+        const parsed = parseCaipAssetType(assetId as CaipAssetType);
+        if (
+          parsed.chainId === chainId &&
+          parsed.assetNamespace === 'asset'
+        ) {
+          assetIds.add(assetId as CaipAssetType);
+        }
+      } catch {
+        // Ignore malformed custom asset ids.
+      }
+    }
+  }
+
+  return [...assetIds];
+}
+
+/**
+ * Collects Stellar classic assets that are present in balances but missing
+ * `accountAssetInfo`, grouped by account and chain.
+ */
+export function findAccountsNeedingStellarEnrichment(
+  assetsBalance: Record<string, Record<string, BalanceRow>>,
+): Map<string, Map<CaipChainId, CaipAssetType[]>> {
+  const byAccount = new Map<string, Map<CaipChainId, CaipAssetType[]>>();
+
+  for (const [accountId, accountBalances] of Object.entries(assetsBalance)) {
+    for (const [assetId, row] of Object.entries(accountBalances)) {
+      if (row?.accountAssetInfo !== undefined) {
+        continue;
+      }
+      if (!isStellarClassicAssetId(assetId)) {
+        continue;
+      }
+
+      let chainId: CaipChainId;
+      try {
+        chainId = parseCaipAssetType(assetId as CaipAssetType)
+          .chainId as CaipChainId;
+      } catch {
+        continue;
+      }
+
+      let byChain = byAccount.get(accountId);
+      if (!byChain) {
+        byChain = new Map();
+        byAccount.set(accountId, byChain);
+      }
+      const assets = byChain.get(chainId) ?? [];
+      assets.push(assetId as CaipAssetType);
+      byChain.set(chainId, assets);
+    }
+  }
+
+  return byAccount;
+}
+
+async function fetchAccountAssetInfoWithTimeout(params: {
+  accountId: string;
+  chainId: CaipChainId;
+  assetIds: CaipAssetType[];
+}): Promise<Record<string, Record<string, unknown>> | undefined> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const snapRequest = requestStellarGetAccountAssetInfo({
+    accountId: params.accountId,
+    scope: params.chainId,
+    assets: params.assetIds,
+  });
+
+  try {
+    const result = await Promise.race([
+      snapRequest,
+      new Promise<typeof ENRICHMENT_TIMEOUT>((resolve) => {
+        timeoutId = setTimeout(
+          () => resolve(ENRICHMENT_TIMEOUT),
+          ACCOUNT_ASSET_INFO_SNAP_TIMEOUT_MS,
+        );
+      }),
+    ]);
+
+    if (result === ENRICHMENT_TIMEOUT) {
+      snapRequest.catch((error) => {
+        Logger.error(
+          error as Error,
+          'enrichStellarAccountAssetInfo: getAccountAssetInfo failed after timeout',
+        );
+      });
+      return undefined;
+    }
+
+    return result;
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+/**
+ * Fetches Snap `getAccountAssetInfo` for the given assets and merges the result
+ * into `AssetsController` balance rows.
+ *
+ * Concurrent calls for the same account/chain share one in-flight request.
+ * Pass `force: true` after trustline changes so existing enrichment is refreshed.
+ */
+export async function enrichStellarAccountAssetInfo({
+  account,
+  chainId,
+  assetIds,
+  force = false,
+}: {
+  account: InternalAccount;
+  chainId: CaipChainId;
+  assetIds: CaipAssetType[];
+  force?: boolean;
+}): Promise<void> {
+  if (assetIds.length === 0) {
+    return;
+  }
+
+  const key = `${account.id}:${chainId}`;
+  const existing = inFlightByKey.get(key);
+  if (existing) {
+    await existing;
+    // Concurrent callers share the in-flight request. A later forced refresh
+    // (e.g. after trustline change) starts a new request once the shared one
+    // has settled.
+    if (!force) {
+      return;
+    }
+  }
+
+  const run = (async () => {
+    const { AssetsController } = Engine.context;
+    const existingBalances =
+      AssetsController.state.assetsBalance[account.id] ?? {};
+
+    let enrichment: Record<string, Record<string, unknown>> | undefined;
+    try {
+      enrichment = await fetchAccountAssetInfoWithTimeout({
+        accountId: account.id,
+        chainId,
+        assetIds,
+      });
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'enrichStellarAccountAssetInfo: getAccountAssetInfo failed',
+      );
+      return;
+    }
+
+    if (!enrichment || typeof enrichment !== 'object') {
+      return;
+    }
+
+    const assetsBalance: Record<
+      string,
+      Record<
+        string,
+        { amount: string; accountAssetInfo?: Record<string, unknown> }
+      >
+    > = {
+      [account.id]: {},
+    };
+
+    for (const assetId of assetIds) {
+      const accountAssetInfo = enrichment[assetId];
+      if (accountAssetInfo === undefined) {
+        continue;
+      }
+
+      const existingRow = existingBalances[assetId] as BalanceRow | undefined;
+      assetsBalance[account.id][assetId] = {
+        amount: existingRow?.amount ?? '0',
+        accountAssetInfo,
+      };
+    }
+
+    if (Object.keys(assetsBalance[account.id]).length === 0) {
+      return;
+    }
+
+    try {
+      await AssetsController.handleAssetsUpdate(
+        { updateMode: 'merge', assetsBalance },
+        'StellarAccountAssetInfoEnrichment',
+      );
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'enrichStellarAccountAssetInfo: handleAssetsUpdate failed',
+      );
+    }
+  })().finally(() => {
+    inFlightByKey.delete(key);
+  });
+
+  inFlightByKey.set(key, run);
+  await run;
+}
+
+/**
+ * Enriches every Stellar classic asset currently held for the account/chain,
+ * including custom assets that may no longer appear in the Snap asset list.
+ */
+export async function enrichAllStellarClassicAccountAssetInfo(
+  account: InternalAccount,
+  chainId: CaipChainId,
+  options?: { force?: boolean },
+): Promise<void> {
+  const assetIds = listStellarClassicAssetIdsForAccount(account.id, chainId, {
+    includeCustomAssets: true,
+  });
+  await enrichStellarAccountAssetInfo({
+    account,
+    chainId,
+    assetIds,
+    force: options?.force,
+  });
+}
+
+/**
+ * Test helper to clear in-flight dedupe state between unit tests.
+ */
+export function resetStellarAccountAssetInfoEnrichmentInFlight(): void {
+  inFlightByKey.clear();
+}
+///: END:ONLY_INCLUDE_IF

--- a/app/util/stellar/stellar-snap-client-requests.test.ts
+++ b/app/util/stellar/stellar-snap-client-requests.test.ts
@@ -6,6 +6,7 @@ import { STELLAR_WALLET_SNAP_ID } from '../../core/SnapKeyring/StellarWalletSnap
 import {
   requestStellarChangeTrustOptAdd,
   requestStellarChangeTrustOptDelete,
+  requestStellarGetAccountAssetInfo,
 } from './stellar-snap-client-requests';
 
 jest.mock('../../core/Engine', () => ({
@@ -78,6 +79,41 @@ describe('stellar-snap-client-requests', () => {
           params: expect.objectContaining({ action: 'delete' }),
         }),
       }),
+    );
+  });
+
+  it('calls getAccountAssetInfo via handleSnapRequest', async () => {
+    handleSnapRequestMock.mockResolvedValueOnce({
+      'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN':
+        { limit: '1000', authorized: true },
+    });
+
+    await requestStellarGetAccountAssetInfo({
+      accountId: 'account-id',
+      scope: 'stellar:pubnet',
+      assets: [
+        'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      ],
+    });
+
+    expect(handleSnapRequestMock).toHaveBeenCalledWith(
+      Engine.controllerMessenger,
+      {
+        snapId: STELLAR_WALLET_SNAP_ID,
+        origin: 'metamask',
+        handler: HandlerType.OnClientRequest,
+        request: {
+          jsonrpc: '2.0',
+          method: 'getAccountAssetInfo',
+          params: {
+            accountId: 'account-id',
+            scope: 'stellar:pubnet',
+            assets: [
+              'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            ],
+          },
+        },
+      },
     );
   });
 });

--- a/app/util/stellar/stellar-snap-client-requests.ts
+++ b/app/util/stellar/stellar-snap-client-requests.ts
@@ -48,4 +48,24 @@ export async function requestStellarChangeTrustOptDelete(params: {
     },
   });
 }
+
+/**
+ * Fetches Snap account-asset enrichment (e.g. Stellar trustline fields).
+ */
+export async function requestStellarGetAccountAssetInfo(params: {
+  accountId: string;
+  scope: CaipChainId;
+  assets: CaipAssetType[];
+}): Promise<Record<string, Record<string, unknown>> | undefined> {
+  return (await handleSnapRequest(Engine.controllerMessenger, {
+    snapId: STELLAR_WALLET_SNAP_ID,
+    origin: 'metamask',
+    handler: HandlerType.OnClientRequest,
+    request: {
+      jsonrpc: '2.0',
+      method: 'getAccountAssetInfo',
+      params,
+    },
+  })) as Record<string, Record<string, unknown>> | undefined;
+}
 ///: END:ONLY_INCLUDE_IF

--- a/package.json
+++ b/package.json
@@ -220,7 +220,9 @@
     "expo-web-browser@npm:~55.0.16": "55.0.16",
     "@expo/cli@npm:55.0.32": "patch:@expo/cli@npm%3A55.0.32#~/.yarn/patches/@expo-cli-npm-55.0.32-5fb47bae24.patch",
     "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch",
-    "@metamask/stellar-wallet-snap": "patch:@metamask-previews/stellar-wallet-snap@npm%3A0.0.1-preview-a3c0091#~/.yarn/patches/@metamask-previews-stellar-wallet-snap-npm-0.0.1-preview-a3c0091-052886e43f.patch"
+    "@metamask/stellar-wallet-snap": "patch:@metamask-previews/stellar-wallet-snap@npm%3A0.0.1-preview-a3c0091#~/.yarn/patches/@metamask-previews-stellar-wallet-snap-npm-0.0.1-preview-a3c0091-052886e43f.patch",
+    "@metamask/assets-controllers": "109.2.1",
+    "@metamask/assets-controller@npm:^10.0.1": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -245,7 +247,7 @@
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^10.1.0",
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch",
     "@metamask/assets-controllers": "^109.2.1",
     "@metamask/authenticated-user-storage": "^3.0.0",
     "@metamask/base-controller": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7900,16 +7900,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^7.2.0, @metamask/account-tree-controller@npm:^7.5.0, @metamask/account-tree-controller@npm:^7.5.3":
-  version: 7.5.3
-  resolution: "@metamask/account-tree-controller@npm:7.5.3"
+"@metamask/account-tree-controller@npm:^7.2.0, @metamask/account-tree-controller@npm:^7.5.0, @metamask/account-tree-controller@npm:^7.5.2, @metamask/account-tree-controller@npm:^7.5.3, @metamask/account-tree-controller@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "@metamask/account-tree-controller@npm:7.5.4"
   dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.3"
+    "@metamask/accounts-controller": "npm:^39.0.4"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/multichain-account-service": "npm:^11.0.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/multichain-account-service": "npm:^12.0.0"
     "@metamask/profile-sync-controller": "npm:^28.2.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
@@ -7921,7 +7921,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/c792ffbb36e460bd9ad5a02d6d43dbd1c6a03993605bf9727555ac1c1e0599331dda42d5b96c4f7af1fcb1d1a6c8311d1f85854f0a2f56a0d693beeabc30ef09
+  checksum: 10/da47eacc508c2810b4f0d152d0eac98c912c3887f7375542191dc9c70135666d8421a3c9c1b585644c6fe6ff991ba44fbab2061f12f2aecc766390657bc84b87
   languageName: node
   linkType: hard
 
@@ -8020,9 +8020,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^10.0.1, @metamask/assets-controller@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "@metamask/assets-controller@npm:10.1.0"
+"@metamask/assets-controller@npm:10.0.1":
+  version: 10.0.1
+  resolution: "@metamask/assets-controller@npm:10.0.1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -8038,7 +8038,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
     "@metamask/keyring-snap-client": "npm:^9.0.2"
-    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
     "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/network-enablement-controller": "npm:^5.4.1"
     "@metamask/permission-controller": "npm:^13.1.1"
@@ -8053,13 +8053,50 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/5b87620a3f62120ed8f76b0a2263b997ad41b2821e713dbf86b0208f07321c7a0a6fd0074a1b38d2e44315886d2d50b85f7b64a6fa451656f836353efbd641b9
+  checksum: 10/884f7e9df63629ca4b5bfacd4a65cb01ac76e873e70e1f6186addde3cc8ad5ae8e6ef8a145929797c68bb94c8da8bc56fd27a48555a8db918729d21196e0a6fb
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^109.2.1, @metamask/assets-controllers@npm:^109.3.0":
-  version: 109.3.0
-  resolution: "@metamask/assets-controllers@npm:109.3.0"
+"@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch":
+  version: 10.0.1
+  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch::version=10.0.1&hash=c4b6b7"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/account-tree-controller": "npm:^7.5.3"
+    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/assets-controllers": "npm:^109.3.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/client-controller": "npm:^1.0.1"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/core-backend": "npm:^6.5.0"
+    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.0.2"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.4.1"
+    "@metamask/permission-controller": "npm:^13.1.1"
+    "@metamask/phishing-controller": "npm:^17.2.0"
+    "@metamask/polling-controller": "npm:^16.0.8"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/transaction-controller": "npm:^68.2.2"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/a15cf763b02c066d84a7aa7b9611a2b733ba0729a2e13ab0a2eb6e75de289b4ae065449e92035a3db429b5450b19177e680a1be57a56509875b5fffad9e13566
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controllers@npm:109.2.1":
+  version: 109.2.1
+  resolution: "@metamask/assets-controllers@npm:109.2.1"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -8068,24 +8105,24 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^7.5.3"
-    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/account-tree-controller": "npm:^7.5.2"
+    "@metamask/accounts-controller": "npm:^39.0.2"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^6.5.0"
+    "@metamask/core-backend": "npm:^6.3.3"
     "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^11.1.0"
-    "@metamask/network-controller": "npm:^34.0.0"
-    "@metamask/network-enablement-controller": "npm:^5.4.1"
+    "@metamask/multichain-account-service": "npm:^10.0.3"
+    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.4.0"
     "@metamask/permission-controller": "npm:^13.1.1"
     "@metamask/phishing-controller": "npm:^17.2.0"
-    "@metamask/polling-controller": "npm:^16.0.8"
+    "@metamask/polling-controller": "npm:^16.0.7"
     "@metamask/preferences-controller": "npm:^23.1.0"
     "@metamask/profile-sync-controller": "npm:^28.2.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
@@ -8093,7 +8130,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
     "@metamask/storage-service": "npm:^1.0.2"
-    "@metamask/transaction-controller": "npm:^68.2.2"
+    "@metamask/transaction-controller": "npm:^68.1.1"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@types/bn.js": "npm:^5.1.5"
@@ -8110,7 +8147,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/496f8a91b52c89d0b3ea3dc9c7bf7e9a0933b0b02dcf783e83a7654d52f02c4e9e35090b73b25064d86983dca226779878a3e3d6e5248170bda752ac32736dcd
+  checksum: 10/dcbd5372deba46a0bd2f867400876231c20554f50b81d78ff448f882440345b6ff55ec2e0d6f4cab4237879ab43e3ab7a6fd77c0efbd3244d53523616352ab42
   languageName: node
   linkType: hard
 
@@ -8853,21 +8890,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-snap-keyring@npm:^22.3.0":
-  version: 22.3.0
-  resolution: "@metamask/eth-snap-keyring@npm:22.3.0"
+"@metamask/eth-snap-keyring@npm:^22.0.1, @metamask/eth-snap-keyring@npm:^22.3.0":
+  version: 22.4.0
+  resolution: "@metamask/eth-snap-keyring@npm:22.4.0"
   dependencies:
     "@ethereumjs/tx": "npm:^5.4.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-internal-snap-client": "npm:^10.0.3"
+    "@metamask/keyring-internal-snap-client": "npm:^10.0.4"
     "@metamask/keyring-sdk": "npm:^2.2.0"
-    "@metamask/keyring-snap-sdk": "npm:^9.0.2"
+    "@metamask/keyring-snap-sdk": "npm:^9.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.3"
+    "@metamask/snaps-utils": "npm:^12.2.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@types/uuid": "npm:^9.0.8"
@@ -8875,7 +8912,33 @@ __metadata:
     uuid: "npm:^9.0.1"
   peerDependencies:
     "@metamask/keyring-api": ^23.0.0
-  checksum: 10/d110a2cd97e0cd22eae7d5e87ea14ae09530d3d47204b4bc565ffd70f8af75133a2c3c15b0f51e49478b379ee40ea9980d3591c85a8e24c21e3768b8f1d8c1b8
+  checksum: 10/16cdf47083d5feed3346ae19a507ff491e4d9c53e15c943670b25441bdcfc71ff8d99f25c6bdb56035942e65fec77087582ee1fdf786cc2380de3144a5fa41b0
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-snap-keyring@npm:^23.0.0":
+  version: 23.0.1
+  resolution: "@metamask/eth-snap-keyring@npm:23.0.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-internal-snap-client": "npm:^10.0.5"
+    "@metamask/keyring-sdk": "npm:^2.2.0"
+    "@metamask/keyring-snap-sdk": "npm:^9.2.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/messenger": "npm:^1.1.1"
+    "@metamask/snaps-controllers": "npm:^19.0.1"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.2.1"
+    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@types/uuid": "npm:^9.0.8"
+    async-mutex: "npm:^0.5.0"
+    uuid: "npm:^9.0.1"
+  peerDependencies:
+    "@metamask/keyring-api": ^23.0.0
+  checksum: 10/9e5ce3f5e6d5747f82f2229d4da77fc680c4533061a733a66810246ab6810c6b9429731883cbebb525bf2d5c341eef93a5a4e1b4773bc02e49f0fd1630697b7a
   languageName: node
   linkType: hard
 
@@ -9102,15 +9165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^23.1.0, @metamask/keyring-api@npm:^23.2.0, @metamask/keyring-api@npm:^23.3.0":
-  version: 23.3.0
-  resolution: "@metamask/keyring-api@npm:23.3.0"
+"@metamask/keyring-api@npm:^23.1.0, @metamask/keyring-api@npm:^23.2.0, @metamask/keyring-api@npm:^23.3.0, @metamask/keyring-api@npm:^23.5.0":
+  version: 23.5.0
+  resolution: "@metamask/keyring-api@npm:23.5.0"
   dependencies:
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.3.0"
     "@metamask/utils": "npm:^11.11.0"
     bitcoin-address-validation: "npm:^2.2.3"
-  checksum: 10/c6ad3bf4294b09730d752d548b1cd0c1c622f357a12c7287af2b5889a01e99a4d20316cc9e96840d5c5619eee0f9305d4dfc03febd0bd136e72de95ce3fd0a1e
+  checksum: 10/2d8a4b378f5bad77284feb58bc7f3b64d541751527c693e43f7e4d860333bc55593e27fc5264fc908d719912b374f77dabec3f5e491bb49f72501fd2f5c43e68
   languageName: node
   linkType: hard
 
@@ -9148,16 +9211,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-internal-snap-client@npm:^10.0.3":
-  version: 10.0.3
-  resolution: "@metamask/keyring-internal-snap-client@npm:10.0.3"
+"@metamask/keyring-internal-snap-client@npm:^10.0.4, @metamask/keyring-internal-snap-client@npm:^10.0.5":
+  version: 10.0.5
+  resolution: "@metamask/keyring-internal-snap-client@npm:10.0.5"
   dependencies:
-    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-snap-client": "npm:^9.0.2"
-    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/keyring-snap-client": "npm:^9.2.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/messenger": "npm:^1.1.1"
-  checksum: 10/30c00a2f39125e7f99bd6513096f23fa243f30cd7ce4e77aa96f52c66fa99c077dfba0544d2693e16c283a2a5610f6b844eaa39130d1f760390d6ca1f53f0507
+  checksum: 10/ae81aee3ed4ed75785d22fd57a7b169b7e540e208afb917640bd47eadbc30c52e64df2f05e3a429447951ac40da1c0a568e9d5c29a5d10b844c28ae919bf1d50
   languageName: node
   linkType: hard
 
@@ -9179,35 +9242,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-snap-client@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "@metamask/keyring-snap-client@npm:9.0.2"
+"@metamask/keyring-snap-client@npm:^9.0.2, @metamask/keyring-snap-client@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@metamask/keyring-snap-client@npm:9.2.0"
   dependencies:
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-utils": "npm:^3.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/superstruct": "npm:^3.3.0"
     "@types/uuid": "npm:^9.0.8"
     uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^19.0.0
-  checksum: 10/f4de52be334d941fffafb6458260875706a09315d68856577a66dd36b069de00260632cfcd0fe9b56528382512dee2c226f61430aafb619869f1b1711d3ffffd
+  checksum: 10/2ccf7a36386f26f248f58527a1757d7a793488e27ad2d978cc15ffa98277f57941eed377360b7cf258cdc935de9311380fb46eb83242b3ff8959ad6e155b78b4
   languageName: node
   linkType: hard
 
-"@metamask/keyring-snap-sdk@npm:^9.0.1, @metamask/keyring-snap-sdk@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "@metamask/keyring-snap-sdk@npm:9.0.2"
+"@metamask/keyring-snap-sdk@npm:^9.0.1, @metamask/keyring-snap-sdk@npm:^9.1.0, @metamask/keyring-snap-sdk@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@metamask/keyring-snap-sdk@npm:9.2.0"
   dependencies:
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.3.0"
     "@metamask/utils": "npm:^11.11.0"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-api": ^23.0.0
     "@metamask/providers": ^19.0.0
-  checksum: 10/a3fa4c306b058f484042e4460f8d19d509c4725cb49c40328dd905555bae33e07e29262891500acbcb845891af3721a562a36914286fc876f37668ce63f1bee1
+  checksum: 10/2fcce104e314f9dcea3125741d50875c26b4b9d0241f66568e513e221abd121af88f6842c2a459f7984d9147158936c58ae9936561d703429fbc4d2eccd9611c
   languageName: node
   linkType: hard
 
@@ -9378,7 +9441,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^11.0.0, @metamask/multichain-account-service@npm:^11.1.0":
+"@metamask/multichain-account-service@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "@metamask/multichain-account-service@npm:10.0.3"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/accounts-controller": "npm:^39.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/eth-snap-keyring": "npm:^22.0.1"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.0.2"
+    "@metamask/keyring-utils": "npm:^3.2.1"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/snap-account-service": "npm:^0.3.1"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/account-api": ^1.0.4
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/ed945f17e571b96baab959c29e5bdc68573de6e613d79834fbd9eb55025e7c85d3e92ae4cf8454ccefdb45e6331ecfe9f859feb4217cbe1b3083086166128057
+  languageName: node
+  linkType: hard
+
+"@metamask/multichain-account-service@npm:^11.0.0":
   version: 11.1.0
   resolution: "@metamask/multichain-account-service@npm:11.1.0"
   dependencies:
@@ -9406,6 +9500,37 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/d2f3332944ecddf6c312b14312dafa9a4696b60673ed185cbfd68f547f6ca4ca1bd1dd640742a763a62f8f3a3c4cbd19067d3904aba3c47e1cbd69db80b7ce59
+  languageName: node
+  linkType: hard
+
+"@metamask/multichain-account-service@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "@metamask/multichain-account-service@npm:12.0.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/eth-snap-keyring": "npm:^23.0.0"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.2.0"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/snap-account-service": "npm:^2.0.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/account-api": ^1.0.4
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/2ef522ddeeef3c41096d628299fb84f05ebb3891a400e2e150c36b4ddd247ec170a81f18396be3e3da01b16bcf2c542f1915dc0e5c5bac9768311247adb42210
   languageName: node
   linkType: hard
 
@@ -9517,7 +9642,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-enablement-controller@npm:^5.3.0, @metamask/network-enablement-controller@npm:^5.4.1":
+"@metamask/network-enablement-controller@npm:^5.3.0, @metamask/network-enablement-controller@npm:^5.4.0, @metamask/network-enablement-controller@npm:^5.4.1":
   version: 5.4.1
   resolution: "@metamask/network-enablement-controller@npm:5.4.1"
   dependencies:
@@ -10110,6 +10235,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/snap-account-service@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@metamask/snap-account-service@npm:0.3.1"
+  dependencies:
+    "@metamask/account-api": "npm:^1.0.4"
+    "@metamask/account-tree-controller": "npm:^7.5.2"
+    "@metamask/eth-snap-keyring": "npm:^22.0.1"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
+    "@metamask/keyring-snap-sdk": "npm:^9.0.1"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/de442502dd59910e991dd57b0c107bdc8fd5b027a2190350f2d6a1a68913f0e65d0e46a3f3cc47aee8a824c5e6dc8062a9f5ecadb4f8b62b92efe71cb4404094
+  languageName: node
+  linkType: hard
+
 "@metamask/snap-account-service@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/snap-account-service@npm:1.0.0"
@@ -10126,6 +10270,26 @@ __metadata:
     "@metamask/utils": "npm:^11.11.0"
     lodash: "npm:^4.17.21"
   checksum: 10/58e664b23d57c1fc2cae55a3c61fab4a89a077a45482f50ea8083ec6f93316de678e730caa5dd735f61021f9964727aafb8c4dfac903060abcde9799abf33246
+  languageName: node
+  linkType: hard
+
+"@metamask/snap-account-service@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/snap-account-service@npm:2.0.0"
+  dependencies:
+    "@metamask/account-api": "npm:^1.0.4"
+    "@metamask/account-tree-controller": "npm:^7.5.4"
+    "@metamask/eth-snap-keyring": "npm:^23.0.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/keyring-internal-snap-client": "npm:^10.0.5"
+    "@metamask/keyring-snap-sdk": "npm:^9.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/a0e860bc34933775c5271ef560efbf8b84eb60e460c7a7586a8169d54750cb9a59500c3c73e97cf0baebb8951830d136f8bb9a7322186ee46b0d6687d7203997
   languageName: node
   linkType: hard
 
@@ -10370,8 +10534,8 @@ __metadata:
 
 "@metamask/stellar-wallet-snap@patch:@metamask-previews/stellar-wallet-snap@npm%3A0.0.1-preview-a3c0091#~/.yarn/patches/@metamask-previews-stellar-wallet-snap-npm-0.0.1-preview-a3c0091-052886e43f.patch":
   version: 0.0.1-preview-a3c0091
-  resolution: "@metamask/stellar-wallet-snap@patch:@metamask-previews/stellar-wallet-snap@npm%3A0.0.1-preview-a3c0091#~/.yarn/patches/@metamask-previews-stellar-wallet-snap-npm-0.0.1-preview-a3c0091-052886e43f.patch::version=0.0.1-preview-a3c0091&hash=6b4657"
-  checksum: 10/8dda652118efdc46a05c4fedc5b7ed58755eee0772e4a1d80eb93d66ba8e6885cbc4385c83fba416c74c9404190a78d31a4efbe7ddb9c5e5df03285c1b7e5082
+  resolution: "@metamask/stellar-wallet-snap@patch:@metamask-previews/stellar-wallet-snap@npm%3A0.0.1-preview-a3c0091#~/.yarn/patches/@metamask-previews-stellar-wallet-snap-npm-0.0.1-preview-a3c0091-052886e43f.patch::version=0.0.1-preview-a3c0091&hash=f73bac"
+  checksum: 10/266b8803344c50908bec5188d5226c7a3cd858ae85b3fd94ea125430e2fd073698cc2322e4184ee5a258139db690c0b0162eea540b4cf3e5462d2d7e7ca9f5d2
   languageName: node
   linkType: hard
 
@@ -35672,7 +35836,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^10.1.0"
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch"
     "@metamask/assets-controllers": "npm:^109.2.1"
     "@metamask/authenticated-user-storage": "npm:^3.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `AssetsController` balance merge and account-tree refresh paths used by unified assets state; incorrect merging could affect displayed balances or metadata across chains, though the change is narrowly scoped to merge semantics and new-account fetching.
> 
> **Overview**
> Extends the vendored **`@metamask/assets-controller`** Yarn patch so balance updates behave correctly with **client-side Stellar trustline/metadata enrichment**.
> 
> **`mergeAccountBalances`** no longer shallow-merges per account; for each asset id it **merges into the existing balance object** (defaulting `amount` to `'0'` when missing) so partial updates—e.g. enrichment writing **`metadata`** via `handleAssetsUpdate` with `updateMode: 'merge'`—are not wiped when a later fetch only supplies `amount`.
> 
> On **account tree changes**, the controller now tracks **newly added accounts** and, after the usual refresh, runs an extra **`getAssets`** for those accounts across **all enabled chains**, so multichain/Stellar balances populate when accounts are added without a full restart.
> 
> A small refactor in **`_AssetsController_handleAccountGroupChanged`** reuses a cached `accounts` variable when fetching balances for newly enabled chains (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21fb2ca072b28d346804a6a74f8d19133ea8c70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->