### PR TITLE
fix(accounts): remove bg-default band in account group sheet (TMCU-1052)

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.tsx
@@ -117,7 +117,7 @@ const MultichainAddressRow = ({
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
-      twClassName="p-4 gap-4 bg-default"
+      twClassName="p-4 gap-4"
       testID={testID}
       {...viewProps}
     >

--- a/app/components/Views/AddressSelector/AddressSelector.tsx
+++ b/app/components/Views/AddressSelector/AddressSelector.tsx
@@ -129,7 +129,7 @@ const AddressSelector = () => {
           networkName={item.networkName}
           address={item.account.address}
           // @ts-expect-error MultichainAddressRow doesn't have twClassName in types
-          twClassName="p-0 gap-4 bg-default"
+          twClassName="p-0 gap-4"
         />
       </ListItemSelect>
     ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes elevation mismatches in the **Rewards account group** bottom sheet (`RewardOptInAccountGroupModal`) when `MM_PURE_BLACK_PREVIEW` is enabled.

**Problem:** The legacy `BottomSheet` uses `getElevatedSurfaceColor()` (`bg-alternative`), but each `MultichainAddressRow` hardcoded `bg-default`. With pure black on, `bg-default` resolves to `#000000`, producing visible horizontal banding between the elevated sheet chrome and enrolled network rows.

**Approach (minimal, mirrors TMCU-994 / #32909):**
- `MultichainAddressRow` root — remove `bg-default` so the parent surface owns the background
- `AddressSelector` — drop the explicit `bg-default` override on rows inside the elevated `BottomSheet` (same class of bug)

Full-screen list callsites (`AddressList`, `PrivateKeyList`, `MultichainAddressRowsList`) inherit `background.default` from their screen/container and are unaffected.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1052

## **Manual testing steps**

```gherkin
Feature: Rewards account group sheet pure black theming

  Scenario: user opens account group sheet with pure black enabled
    Given the app is in dark mode with MM_PURE_BLACK_PREVIEW=true
    And the user has Rewards enabled and navigates to Rewards → Settings

    When user taps an account group (e.g. "New account") to open the enroll/link bottom sheet
    Then the bottom sheet background matches the elevated pure black surface
    And enrolled network rows do not show a mismatched bg-default patch
    And section headers and list body share one uniform elevated surface

  Scenario: user opens account group sheet with pure black disabled
    Given the app is in dark mode with MM_PURE_BLACK_PREVIEW unset or false

    When user opens the account group sheet from Rewards Settings
    Then the bottom sheet and rows render as before (no visual regression)
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="accountsbefore" src="https://github.com/user-attachments/assets/3db4ae47-0782-4dc4-8e7e-2cbb522b49fa" />

### **After**

<img width="350" alt="Screenshot 2026-07-09 at 5 02 27 PM" src="https://github.com/user-attachments/assets/0277cc93-3ed6-4987-bb9f-04b9a7ea85c0" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b971c928-e806-4d58-9600-9f360b7ab12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b971c928-e806-4d58-9600-9f360b7ab12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

