### PR TITLE
fix(swaps): exclude iOS bottom safe-area on BridgeView

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -81,6 +81,7 @@ import { useSwitchTokens } from '../../hooks/useSwitchTokens';
 import {
   Pressable,
   ScrollView,
+  Platform,
   type NativeSyntheticEvent,
   type NativeScrollEvent,
 } from 'react-native';
@@ -481,7 +482,9 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   return (
     <SafeAreaView
       style={styles.screenWrapper}
-      edges={['bottom', 'left', 'right']}
+      edges={
+        Platform.OS === 'ios' ? ['left', 'right'] : ['bottom', 'left', 'right']
+      }
     >
       <HeaderStandard
         title={headerTitle}


### PR DESCRIPTION
## **Description**

Fixes a black band below the Swaps numpad on iOS when `MM_PURE_BLACK_PREVIEW` is enabled (TMCU-1006). Split from #33077 so this safe-area change can ship or roll back independently of the numpad MMDS migration.

**Problem:** `BridgeView` applies bottom safe-area padding via `SafeAreaView`, while MMDS `BottomSheetDialog` also pads for the home indicator. The gap exposes `background.default` below the elevated sheet surface.

**Approach:** On iOS only, omit the bottom safe-area edge on `BridgeView` (`edges={['left', 'right']}`), matching the Send amount screen. Android keeps `edges={['bottom', 'left', 'right']}`.

**Related:** Pairs with #33077 (numpad MMDS migration). Either PR can merge first; both are needed for the full pure-black numpad fix on iOS.

## **Changelog**

CHANGELOG entry: Fixed swaps screen safe-area gap below numpad on iOS in pure black theme

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1006

## **Manual testing steps**

```gherkin
Feature: Swaps BridgeView iOS safe-area

  Scenario: user views swaps numpad with pure black enabled on iOS
    Given the app is running on iOS in dark mode with MM_PURE_BLACK_PREVIEW=true
    And the user navigates to Swaps
    When the user taps the source amount to open the numpad
    Then no black band appears below the numpad at the home-indicator area
    And the elevated sheet surface extends to the screen bottom

  Scenario: user views swaps screen on Android
    Given the app is running on Android
    When the user navigates to Swaps
    Then bottom safe-area padding still applies as before
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-09 at 3 59 59 PM" src="https://github.com/user-attachments/assets/208e3ec3-8e78-48ba-9760-b8392d421bf4" /><img width="350" alt="Screenshot 2026-07-09 at 4 00 08 PM" src="https://github.com/user-attachments/assets/63d0a090-95e5-406d-9ed9-abfd3032e36e" />

### **After**

All swap actions and bottomsheets visible on iOS after SafeArea change

https://github.com/user-attachments/assets/2eb5d0b6-50f6-45a3-b960-b33327b39e51

<img width="350" alt="Screenshot 2026-07-09 at 4 23 06 PM" src="https://github.com/user-attachments/assets/39d2867e-3c1f-4a64-8626-29d32629f432" /><img width="350" alt="Screenshot 2026-07-09 at 4 23 13 PM" src="https://github.com/user-attachments/assets/28998a0a-ed97-4859-88dc-c3e107d31674" />

Only applied to iOS so android works as expected

https://github.com/user-attachments/assets/9ed4eef9-392f-43d3-acd0-b811ba762266

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A — layout-only safe-area edge change; existing BridgeView tests unchanged)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android (N/A — iOS-only edge change; Android behavior unchanged)
- [x] I've tested with a power user scenario (N/A)
- [x] I've instrumented key operations with Sentry traces for production performance metrics (N/A)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)