### PR TITLE
fix: Add BaseNotification iOS spring animation and dismiss lifecycle (1/3)

### DIFF
--- a/app/component-library/components-temp/BaseNotification/BaseNotification.constants.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.constants.ts
@@ -1,0 +1,9 @@
+import type { WithSpringConfig } from 'react-native-reanimated';
+
+export const NOTIFICATION_VISIBILITY_DURATION = 2750;
+export const NOTIFICATION_TOP_PADDING = 8;
+export const NOTIFICATION_MODAL_OVERLAY_ELEVATION = 200;
+export const NOTIFICATION_SPRING_CONFIG: WithSpringConfig = {
+  dampingRatio: 0.85,
+  duration: 500,
+};

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
@@ -1,39 +1,55 @@
-import { StyleSheet } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
+
+const marginWidth = 16;
+const notificationWidth = Dimensions.get('window').width - marginWidth * 2;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
   const { colors } = theme;
 
   return StyleSheet.create({
-    floatingBackground: {
+    base: {
+      position: 'absolute',
+      top: 0,
+      left: marginWidth,
+      width: notificationWidth,
       backgroundColor: colors.background.section,
-      marginHorizontal: 16,
       borderRadius: 8,
       borderWidth: 1,
       borderColor: colors.border.muted,
-    },
-    defaultFlashFloating: {
-      padding: 16,
+      paddingTop: 12,
+      paddingBottom: 12,
+      paddingLeft: 16,
+      paddingRight: 16,
       flexDirection: 'row',
+      alignItems: 'center',
+    },
+    baseWithCloseIconButton: {
+      paddingRight: 8,
+    },
+    pressableContent: {
       flex: 1,
-      borderRadius: 8,
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    flashIcon: {
+      marginRight: 15,
     },
     flashLabel: {
       flex: 1,
       flexDirection: 'column',
+      justifyContent: 'center',
+    },
+    flashTitle: {
+      color: colors.text.default,
+      marginBottom: 2,
+      lineHeight: 18,
     },
     flashText: {
       flex: 1,
       lineHeight: 18,
-    },
-    flashTitle: {
-      flex: 1,
-      marginBottom: 2,
-      lineHeight: 18,
-    },
-    flashIcon: {
-      marginRight: 15,
+      color: colors.text.default,
     },
   });
 };

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.types.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.types.ts
@@ -30,4 +30,12 @@ export interface BaseNotificationProps {
   onPress?: () => void;
   onHide?: () => void;
   autoDismiss?: boolean;
+  /** When false the notification is not rendered. Defaults to true. */
+  isVisible?: boolean;
+  /** Called after the exit spring animation completes. */
+  onDismissComplete?: () => void;
+  /** Auto-dismiss delay in ms. Defaults to NOTIFICATION_VISIBILITY_DURATION (2750ms). */
+  dismissDuration?: number;
+  /** When true, the notification stays visible until manually dismissed. */
+  persistUntilDismiss?: boolean;
 }

--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
 import BaseNotification, { getDescription } from './';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { strings } from '../../../../locales/i18n';
 import { BaseNotificationStatus } from './BaseNotification.types';
+
+const mockUseSafeAreaInsets = jest.fn(() => ({
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockUseSafeAreaInsets(),
+}));
 
 const defaultData = {
   description: 'Testing description',
@@ -30,7 +41,30 @@ const allStatuses: BaseNotificationStatus[] = [
   'simple_notification_rejected',
 ];
 
+const mockLayoutEvent = {
+  nativeEvent: { layout: { height: 100, width: 300, x: 0, y: 0 } },
+};
+
+const triggerEnterLayout = (
+  getByTestId: ReturnType<typeof renderWithProvider>['getByTestId'],
+) => {
+  fireEvent(
+    getByTestId('base-notification-container'),
+    'layout',
+    mockLayoutEvent,
+  );
+};
+
 describe('BaseNotification', () => {
+  beforeEach(() => {
+    mockUseSafeAreaInsets.mockReturnValue({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+  });
+
   it.each(allStatuses)('renders for status %s', (status) => {
     const { getByTestId } = renderWithProvider(
       <BaseNotification status={status} data={defaultData} />,
@@ -85,18 +119,230 @@ describe('BaseNotification', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the close affordance when autoDismiss is true', () => {
+  it('invokes onHide when the close affordance is pressed', async () => {
+    jest.useFakeTimers();
     const onHide = jest.fn();
     const { getByTestId } = renderWithProvider(
       <BaseNotification
         status="success"
         data={defaultData}
         autoDismiss
+        persistUntilDismiss
         onHide={onHide}
       />,
     );
-    fireEvent.press(getByTestId('base-notification-close'));
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('base-notification-close'));
+      jest.runAllTimers();
+    });
+
     expect(onHide).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('renders nothing when isVisible is false', () => {
+    const { queryByTestId } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        isVisible={false}
+      />,
+    );
+
+    expect(queryByTestId('base-notification-container')).not.toBeOnTheScreen();
+  });
+
+  it('invokes onDismissComplete after the auto dismiss animation completes', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('handles unmount and ignores duplicate layout after enter', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, unmount } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={5000}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+    triggerEnterLayout(getByTestId);
+    unmount();
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('restarts auto dismiss when visible status changes without layout', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, rerender } = renderWithProvider(
+      <BaseNotification
+        status="pending"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.advanceTimersByTime(50);
+    });
+
+    rerender(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('does not restart auto dismiss when only the title changes', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, rerender } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    rerender(
+      <BaseNotification
+        status="success"
+        data={{ ...defaultData, title: 'Updated Title' }}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('repositions when the safe area top inset changes after enter', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, rerender } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={5000}
+        persistUntilDismiss
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    mockUseSafeAreaInsets.mockReturnValue({
+      top: 48,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+
+    rerender(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={5000}
+        persistUntilDismiss
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('completes auto dismiss when the safe area top inset changes after enter', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, rerender } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.advanceTimersByTime(50);
+    });
+
+    mockUseSafeAreaInsets.mockReturnValue({
+      top: 48,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+
+    rerender(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
   describe('EIP-7702 transactions (without nonce)', () => {

--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -155,6 +155,50 @@ describe('BaseNotification', () => {
     expect(queryByTestId('base-notification-container')).not.toBeOnTheScreen();
   });
 
+  it('invokes onDismissComplete when isVisible becomes false after enter', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={5000}
+        isVisible
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    rerender(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={5000}
+        isVisible={false}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    expect(queryByTestId('base-notification-container')).not.toBeOnTheScreen();
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('does not invoke onDismissComplete when isVisible starts false', () => {
+    const onDismissComplete = jest.fn();
+    renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        isVisible={false}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    expect(onDismissComplete).not.toHaveBeenCalled();
+  });
+
   it('invokes onDismissComplete after the auto dismiss animation completes', async () => {
     jest.useFakeTimers();
     const onDismissComplete = jest.fn();

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -259,6 +259,7 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   useEffect(() => {
     const statusChanged = prevStatusRef.current !== status;
     const visibilityChanged = prevIsVisibleRef.current !== isVisible;
+    const wasVisible = prevIsVisibleRef.current;
     prevStatusRef.current = status;
     prevIsVisibleRef.current = isVisible;
 
@@ -269,16 +270,35 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
       return;
     }
 
+    const hadEntered = hasEnteredRef.current;
+
+    if (!isVisible) {
+      cancelAnimation(translateYProgress);
+      hasEnteredRef.current = false;
+
+      if (visibilityChanged && wasVisible && hadEntered) {
+        handleDismissComplete();
+      }
+
+      return;
+    }
+
     hasEnteredRef.current = false;
     dismissCompleteCalledRef.current = false;
     cancelAnimation(translateYProgress);
 
-    if (!isVisible || measuredHeightRef.current === null) {
+    if (measuredHeightRef.current === null) {
       return;
     }
 
     startEnterAnimation(measuredHeightRef.current);
-  }, [isVisible, startEnterAnimation, status, translateYProgress]);
+  }, [
+    handleDismissComplete,
+    isVisible,
+    startEnterAnimation,
+    status,
+    translateYProgress,
+  ]);
 
   const runExitAnimation = useCallback(
     (onComplete?: () => void) => {

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -1,5 +1,21 @@
-import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  Dimensions,
+  LayoutChangeEvent,
+  StyleProp,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  cancelAnimation,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Text,
   TextVariant,
@@ -15,10 +31,14 @@ import {
   ButtonIconSize,
 } from '@metamask/design-system-react-native';
 
-import { baseStyles } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
 import { useStyles } from '../../hooks';
 import { ToastSelectorsIDs } from '../../components/Toast/ToastModal.testIds';
+import {
+  NOTIFICATION_SPRING_CONFIG,
+  NOTIFICATION_TOP_PADDING,
+  NOTIFICATION_VISIBILITY_DURATION,
+} from './BaseNotification.constants';
 
 import styleSheet from './BaseNotification.styles';
 import {
@@ -26,6 +46,11 @@ import {
   BaseNotificationProps,
   BaseNotificationStatus,
 } from './BaseNotification.types';
+
+const screenHeight = Dimensions.get('window').height;
+
+const getHiddenTranslateY = (height: number, topInset: number) =>
+  -(height + topInset);
 
 export const getIcon = (status: BaseNotificationStatus | undefined) => {
   switch (status) {
@@ -73,7 +98,8 @@ const getTitle = (
     case 'pending_withdrawal':
       return strings('notifications.pending_withdrawal_title');
     case 'success': {
-      const parsed = nonce != null ? parseInt(String(nonce)) : NaN;
+      const parsed =
+        nonce != null ? Number.parseInt(String(nonce), 10) : Number.NaN;
       if (!Number.isNaN(parsed)) {
         return strings('notifications.success_title', { nonce: parsed });
       }
@@ -88,7 +114,8 @@ const getTitle = (
     case 'received':
       return strings('notifications.received_title', { amount, assetType });
     case 'speedup': {
-      const parsed = nonce != null ? parseInt(String(nonce)) : NaN;
+      const parsed =
+        nonce != null ? Number.parseInt(String(nonce), 10) : Number.NaN;
       if (!Number.isNaN(parsed)) {
         return strings('notifications.speedup_title', { nonce: parsed });
       }
@@ -123,49 +150,238 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   onPress,
   onHide,
   autoDismiss = false,
+  isVisible = true,
+  onDismissComplete,
+  dismissDuration,
+  persistUntilDismiss = false,
 }) => {
   const { styles } = useStyles(styleSheet, {});
+  const { top: topInset } = useSafeAreaInsets();
   const safeData: BaseNotificationData = data ?? {};
   const { description = null, title = null } = safeData;
 
+  const notificationHeight = useSharedValue(screenHeight);
+  const translateYProgress = useSharedValue(
+    getHiddenTranslateY(screenHeight, topInset),
+  );
+  const topInsetOffset = useSharedValue(topInset);
+  const hasEnteredRef = useRef(false);
+  const dismissCompleteCalledRef = useRef(false);
+  const measuredHeightRef = useRef<number | null>(null);
+  const prevStatusRef = useRef(status);
+  const prevIsVisibleRef = useRef(isVisible);
+  const dismissDurationMs = dismissDuration ?? NOTIFICATION_VISIBILITY_DURATION;
+
+  const hasCloseIconButton = autoDismiss;
+  const resolvedDescription = !description
+    ? getDescription(status, safeData)
+    : description;
+  const animatedStyle = useAnimatedStyle(() => ({
+    top: topInsetOffset.value,
+    transform: [{ translateY: translateYProgress.value }],
+  }));
+  const baseStyle: StyleProp<ViewStyle> = useMemo(
+    () => [
+      styles.base,
+      hasCloseIconButton && styles.baseWithCloseIconButton,
+      animatedStyle,
+    ],
+    [
+      styles.base,
+      styles.baseWithCloseIconButton,
+      animatedStyle,
+      hasCloseIconButton,
+    ],
+  );
+
+  const handleDismissComplete = useCallback(() => {
+    if (dismissCompleteCalledRef.current) {
+      return;
+    }
+
+    dismissCompleteCalledRef.current = true;
+    onDismissComplete?.();
+  }, [onDismissComplete]);
+
+  const startEnterAnimation = useCallback(
+    (height: number) => {
+      if (!isVisible) {
+        return;
+      }
+
+      cancelAnimation(translateYProgress);
+      hasEnteredRef.current = true;
+      const hiddenTranslateY = getHiddenTranslateY(
+        height,
+        topInsetOffset.value,
+      );
+      const visibleTranslateY = NOTIFICATION_TOP_PADDING;
+
+      notificationHeight.value = height;
+      translateYProgress.value = hiddenTranslateY;
+
+      if (persistUntilDismiss) {
+        translateYProgress.value = withSpring(
+          visibleTranslateY,
+          NOTIFICATION_SPRING_CONFIG,
+        );
+        return;
+      }
+
+      translateYProgress.value = withSpring(
+        visibleTranslateY,
+        NOTIFICATION_SPRING_CONFIG,
+        () => {
+          translateYProgress.value = withDelay(
+            dismissDurationMs,
+            withSpring(hiddenTranslateY, NOTIFICATION_SPRING_CONFIG, () => {
+              runOnJS(handleDismissComplete)();
+            }),
+          );
+        },
+      );
+    },
+    [
+      dismissDurationMs,
+      handleDismissComplete,
+      isVisible,
+      notificationHeight,
+      persistUntilDismiss,
+      topInsetOffset,
+      translateYProgress,
+    ],
+  );
+
+  useEffect(() => {
+    topInsetOffset.value = withSpring(topInset, NOTIFICATION_SPRING_CONFIG);
+  }, [topInset, topInsetOffset]);
+
+  useEffect(() => {
+    const statusChanged = prevStatusRef.current !== status;
+    const visibilityChanged = prevIsVisibleRef.current !== isVisible;
+    prevStatusRef.current = status;
+    prevIsVisibleRef.current = isVisible;
+
+    const shouldRestartDismiss =
+      statusChanged || visibilityChanged || !hasEnteredRef.current;
+
+    if (!shouldRestartDismiss) {
+      return;
+    }
+
+    hasEnteredRef.current = false;
+    dismissCompleteCalledRef.current = false;
+    cancelAnimation(translateYProgress);
+
+    if (!isVisible || measuredHeightRef.current === null) {
+      return;
+    }
+
+    startEnterAnimation(measuredHeightRef.current);
+  }, [isVisible, startEnterAnimation, status, translateYProgress]);
+
+  const runExitAnimation = useCallback(
+    (onComplete?: () => void) => {
+      const hiddenTranslateY = getHiddenTranslateY(
+        notificationHeight.value,
+        topInsetOffset.value,
+      );
+
+      translateYProgress.value = withSpring(
+        hiddenTranslateY,
+        NOTIFICATION_SPRING_CONFIG,
+        () => {
+          if (onComplete) {
+            runOnJS(onComplete)();
+          }
+        },
+      );
+    },
+    [notificationHeight, topInsetOffset, translateYProgress],
+  );
+
+  useEffect(
+    () => () => {
+      if (hasEnteredRef.current && !dismissCompleteCalledRef.current) {
+        dismissCompleteCalledRef.current = true;
+        onDismissComplete?.();
+      }
+    },
+    [onDismissComplete],
+  );
+
+  const handleManualDismiss = useCallback(() => {
+    cancelAnimation(translateYProgress);
+    runExitAnimation(() => {
+      onHide?.();
+      handleDismissComplete();
+    });
+  }, [handleDismissComplete, onHide, runExitAnimation, translateYProgress]);
+
+  const onAnimatedViewLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (!isVisible) {
+        return;
+      }
+
+      const { height } = event.nativeEvent.layout;
+      const heightChanged = measuredHeightRef.current !== height;
+      measuredHeightRef.current = height;
+
+      if (hasEnteredRef.current && !heightChanged) {
+        return;
+      }
+
+      startEnterAnimation(height);
+    },
+    [isVisible, startEnterAnimation],
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+
   return (
-    <View style={baseStyles.flexGrow}>
-      <View style={styles.floatingBackground}>
-        <TouchableOpacity
-          style={styles.defaultFlashFloating}
-          onPress={onPress}
-          activeOpacity={0.8}
-        >
-          <View style={styles.flashIcon}>{getIcon(status)}</View>
-          <View style={styles.flashLabel}>
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Bold}
-              color={TextColor.TextDefault}
-              style={styles.flashTitle}
-              testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
-            >
-              {!title ? getTitle(status, safeData) : title}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextDefault}
-              style={styles.flashText}
-            >
-              {!description ? getDescription(status, safeData) : description}
-            </Text>
-          </View>
-          {autoDismiss && (
-            <ButtonIcon
-              iconName={IconName.Close}
-              size={ButtonIconSize.Md}
-              onPress={onHide}
-              testID="base-notification-close"
-            />
-          )}
-        </TouchableOpacity>
-      </View>
-    </View>
+    <Animated.View
+      onLayout={onAnimatedViewLayout}
+      style={baseStyle}
+      testID="base-notification-container"
+    >
+      <TouchableOpacity
+        style={styles.pressableContent}
+        onPress={onPress}
+        activeOpacity={0.8}
+        disabled={!onPress}
+      >
+        <View style={styles.flashIcon}>{getIcon(status)}</View>
+        <View style={styles.flashLabel}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Bold}
+            color={TextColor.TextDefault}
+            style={styles.flashTitle}
+            testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
+          >
+            {!title ? getTitle(status, safeData) : title}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextDefault}
+            style={styles.flashText}
+          >
+            {resolvedDescription}
+          </Text>
+        </View>
+      </TouchableOpacity>
+      {autoDismiss && (
+        <ButtonIcon
+          iconName={IconName.Close}
+          size={ButtonIconSize.Md}
+          onPress={handleManualDismiss}
+          testID="base-notification-close"
+        />
+      )}
+    </Animated.View>
   );
 };
 


### PR DESCRIPTION
## **Description**

### 1. What is the reason for this change?

The legacy `BaseNotification` appeared at the bottom of the screen, often covering key CTAs in flows such as Quick Buy.

This PR moves the shared legacy component to the **top of the screen** and replaces the existing slide animation with **spring-based motion** that more closely matches iOS notification banners. It also adds internal dismiss lifecycle props so consumers can advance the notification queue reliably.

This is **PR 1 of 3** in a stacked series:
- **#33096** (this PR) — `BaseNotification` core animation & lifecycle
- **#33101** — consumer wiring + onboarding integration
- **#33097** — visual polish (spacing, colors, multi-line alignment)

This provides a behavioral UX improvement without migrating all call sites to `@metamask/design-system-react-native`. In the long term, `BaseNotification` should be deprecated in favor of the MMDS Toast component.

### 2. What are the key improvements?

**Position & animation**
- Notifications now appear from the top of the screen (below the safe area).
- Replaced the existing animation with `withSpring` using `NOTIFICATION_SPRING_CONFIG`.
- Notification height is measured on layout for accurate positioning.
- Auto-dismiss uses a delayed spring exit animation.

**API & lifecycle**
- Added `isVisible`, `onDismissComplete`, `dismissDuration`, and `persistUntilDismiss`.
- Moved dismiss animation and timing into `BaseNotification`.

**Tests**
- Added coverage for spring dismiss lifecycle, safe-area repositioning, content-change restart, and close-button behavior.

### 3. Which features are impacted?

`BaseNotification` component only in this PR. End-user flows are wired in #33101.

**Note:** Visual styling is unchanged from current production in this PR (border radius, shadows, typography polish land in #33097).

## **Changelog**

CHANGELOG entry: null

## **Related issues**



## **Manual testing steps**

N/A — component-only change in this PR. End-to-end manual testing steps are in #33101 and #33097.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Animation and dismiss timing logic is non-trivial and affects how transaction toasts show and clear; consumer wiring lands in a follow-up PR, but regressions in queue/dismiss callbacks are possible.
> 
> **Overview**
> **`BaseNotification`** is reworked to behave like a top-of-screen iOS-style banner instead of a static in-flow card.
> 
> The banner is **absolutely positioned** below the safe area, with **Reanimated spring** enter/exit motion driven by layout-measured height and shared constants (`NOTIFICATION_VISIBILITY_DURATION`, spring config). **Auto-dismiss** chains a delayed spring exit; manual close runs exit animation then calls **`onHide`** and **`onDismissComplete`**.
> 
> New props **`isVisible`**, **`onDismissComplete`**, **`dismissDuration`**, and **`persistUntilDismiss`** let parents control visibility and advance a notification queue when dismiss finishes (including on unmount or when **`isVisible`** flips false). Status changes restart the dismiss timer; title-only data updates do not. Safe-area inset changes animate **`top`** without spurious dismiss when **`persistUntilDismiss`** is set.
> 
> Styles shift to a fixed-width top **`base`** container with separate pressable content and close button layout. Tests add safe-area mocks, layout triggers, and broad lifecycle coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ccc05dd7c06d04f6a90d34a3f91d067a06057b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->