### PR TITLE
fix: Polish BaseNotification styles and multi-line layout spacing (3/3)

### DIFF
--- a/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
@@ -1,6 +1,6 @@
 import { Dimensions, StyleSheet } from 'react-native';
 import { AppThemeKey, Theme } from '../../../util/theme/models';
-import { NOTIFICATION_OVERLAY_ELEVATION } from './BaseNotification.constants';
+import { NOTIFICATION_MODAL_OVERLAY_ELEVATION } from './BaseNotification.constants';
 const marginWidth = 16;
 const notificationWidth = Dimensions.get('window').width - marginWidth * 2;
 
@@ -14,8 +14,8 @@ const styleSheet = (params: { theme: Theme }) => {
       top: 0,
       left: marginWidth,
       width: notificationWidth,
-      zIndex: NOTIFICATION_OVERLAY_ELEVATION,
-      elevation: NOTIFICATION_OVERLAY_ELEVATION,
+      zIndex: NOTIFICATION_MODAL_OVERLAY_ELEVATION,
+      elevation: NOTIFICATION_MODAL_OVERLAY_ELEVATION,
       backgroundColor:
         theme.themeAppearance === AppThemeKey.light
           ? colors.background.default

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.styles.ts
@@ -1,12 +1,12 @@
 import { Dimensions, StyleSheet } from 'react-native';
-import { Theme } from '../../../util/theme/models';
-
+import { AppThemeKey, Theme } from '../../../util/theme/models';
+import { NOTIFICATION_OVERLAY_ELEVATION } from './BaseNotification.constants';
 const marginWidth = 16;
 const notificationWidth = Dimensions.get('window').width - marginWidth * 2;
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
-  const { colors } = theme;
+  const { colors, shadows } = theme;
 
   return StyleSheet.create({
     base: {
@@ -14,8 +14,14 @@ const styleSheet = (params: { theme: Theme }) => {
       top: 0,
       left: marginWidth,
       width: notificationWidth,
-      backgroundColor: colors.background.section,
-      borderRadius: 8,
+      zIndex: NOTIFICATION_OVERLAY_ELEVATION,
+      elevation: NOTIFICATION_OVERLAY_ELEVATION,
+      backgroundColor:
+        theme.themeAppearance === AppThemeKey.light
+          ? colors.background.default
+          : colors.background.section,
+      ...(theme.themeAppearance === AppThemeKey.light ? shadows.size.md : {}),
+      borderRadius: 16,
       borderWidth: 1,
       borderColor: colors.border.muted,
       paddingTop: 12,
@@ -24,6 +30,10 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingRight: 16,
       flexDirection: 'row',
       alignItems: 'center',
+      gap: 16,
+    },
+    baseTopAligned: {
+      alignItems: 'flex-start',
     },
     baseWithCloseIconButton: {
       paddingRight: 8,
@@ -32,24 +42,26 @@ const styleSheet = (params: { theme: Theme }) => {
       flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
+      gap: 16,
     },
-    flashIcon: {
-      marginRight: 15,
+    pressableContentTopAligned: {
+      alignItems: 'flex-start',
     },
     flashLabel: {
       flex: 1,
-      flexDirection: 'column',
       justifyContent: 'center',
+    },
+    flashLabelTopAligned: {
+      justifyContent: 'flex-start',
     },
     flashTitle: {
       color: colors.text.default,
-      marginBottom: 2,
-      lineHeight: 18,
     },
     flashText: {
-      flex: 1,
-      lineHeight: 18,
-      color: colors.text.default,
+      marginTop: 2,
+    },
+    closeButton: {
+      marginTop: -4,
     },
   });
 };

--- a/app/component-library/components-temp/BaseNotification/BaseNotification.testIds.ts
+++ b/app/component-library/components-temp/BaseNotification/BaseNotification.testIds.ts
@@ -1,0 +1,4 @@
+export const BaseNotificationTestIds = {
+  CONTAINER: 'toast',
+  NOTIFICATION_TITLE: 'notification-title',
+};

--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
 import { act, fireEvent } from '@testing-library/react-native';
-import BaseNotification, { getDescription } from './';
+import { StyleSheet } from 'react-native';
+import BaseNotification, { getDescription, getIcon } from './';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { strings } from '../../../../locales/i18n';
 import { BaseNotificationStatus } from './BaseNotification.types';
-
-const mockUseSafeAreaInsets = jest.fn(() => ({
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-}));
-
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => mockUseSafeAreaInsets(),
-}));
+import { BaseNotificationTestIds } from './BaseNotification.testIds';
+import { AppThemeKey, Theme } from '../../../util/theme/models';
+import { resolveDarkTheme, brandColor } from '@metamask/design-tokens';
+import { isPureBlackEnabled } from '../../../util/theme/pureBlackPreview';
+import { mockTheme } from '../../../util/theme';
+import styleSheet from './BaseNotification.styles';
 
 const defaultData = {
   description: 'Testing description',
@@ -55,14 +51,130 @@ const triggerEnterLayout = (
   );
 };
 
+const resolvedDarkTheme = resolveDarkTheme(isPureBlackEnabled);
+
+const darkTheme: Theme = {
+  colors: resolvedDarkTheme.colors,
+  themeAppearance: AppThemeKey.dark,
+  typography: resolvedDarkTheme.typography,
+  shadows: resolvedDarkTheme.shadows,
+  brandColors: brandColor,
+};
+
+describe('BaseNotification styles', () => {
+  it('uses section background in dark theme', () => {
+    const styles = styleSheet({ theme: darkTheme });
+
+    expect(styles.base.backgroundColor).toBe(
+      resolvedDarkTheme.colors.background.section,
+    );
+  });
+
+  it('uses default background and shadow in light theme', () => {
+    const styles = styleSheet({ theme: mockTheme });
+
+    expect(styles.base.backgroundColor).toBe(
+      mockTheme.colors.background.default,
+    );
+    expect(styles.base.shadowOpacity).toBeDefined();
+  });
+});
+
 describe('BaseNotification', () => {
-  beforeEach(() => {
-    mockUseSafeAreaInsets.mockReturnValue({
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
+  it('returns null icon for unknown status', () => {
+    expect(getIcon(undefined)).toBeNull();
+  });
+
+  it('returns typed description when amount and type are provided', () => {
+    const amount = '1 ETH';
+
+    expect(getDescription('received', { amount, type: 'erc20' })).toBe(
+      strings('notifications.erc20_received_message', { amount }),
+    );
+  });
+
+  it('top-aligns content after multi-line title and description layout events', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <BaseNotification status="success" data={defaultData} autoDismiss />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    fireEvent(
+      getByTestId(BaseNotificationTestIds.NOTIFICATION_TITLE),
+      'onTextLayout',
+      {
+        nativeEvent: { lines: [{ text: 'line 1' }, { text: 'line 2' }] },
+      },
+    );
+    fireEvent(getByText(defaultData.description), 'onTextLayout', {
+      nativeEvent: { lines: [{ text: 'description line' }] },
     });
+
+    const labelsContainer = getByTestId(BaseNotificationTestIds.CONTAINER);
+    const labelsStyle = StyleSheet.flatten(labelsContainer.props.style);
+
+    expect(labelsStyle.justifyContent).toBe('flex-start');
+
+    const closeButton = getByTestId('base-notification-close');
+    const closeButtonStyle = StyleSheet.flatten(closeButton.props.style);
+
+    expect(closeButtonStyle.marginTop).toBeDefined();
+  });
+
+  it('top-aligns content when description spans multiple lines', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={{ title: 'Title', description: 'Description' }}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    fireEvent(getByText('Description'), 'onTextLayout', {
+      nativeEvent: {
+        lines: [{ text: 'description line 1' }, { text: 'description line 2' }],
+      },
+    });
+
+    const labelsContainer = getByTestId(BaseNotificationTestIds.CONTAINER);
+    const labelsStyle = StyleSheet.flatten(labelsContainer.props.style);
+
+    expect(labelsStyle.justifyContent).toBe('flex-start');
+  });
+
+  it('renders without generated title for statuses outside getTitle', () => {
+    const { getByTestId } = renderWithProvider(
+      <BaseNotification status="eth_received" data={{}} />,
+    );
+
+    expect(
+      getByTestId(BaseNotificationTestIds.NOTIFICATION_TITLE),
+    ).toBeOnTheScreen();
+  });
+
+  it('invokes onDismissComplete only once when auto dismiss timers run twice', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.runAllTimers();
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
   it.each(allStatuses)('renders for status %s', (status) => {
@@ -155,50 +267,6 @@ describe('BaseNotification', () => {
     expect(queryByTestId('base-notification-container')).not.toBeOnTheScreen();
   });
 
-  it('invokes onDismissComplete when isVisible becomes false after enter', async () => {
-    jest.useFakeTimers();
-    const onDismissComplete = jest.fn();
-    const { getByTestId, queryByTestId, rerender } = renderWithProvider(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={5000}
-        isVisible
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    triggerEnterLayout(getByTestId);
-
-    rerender(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={5000}
-        isVisible={false}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    expect(queryByTestId('base-notification-container')).not.toBeOnTheScreen();
-    expect(onDismissComplete).toHaveBeenCalledTimes(1);
-    jest.useRealTimers();
-  });
-
-  it('does not invoke onDismissComplete when isVisible starts false', () => {
-    const onDismissComplete = jest.fn();
-    renderWithProvider(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        isVisible={false}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    expect(onDismissComplete).not.toHaveBeenCalled();
-  });
-
   it('invokes onDismissComplete after the auto dismiss animation completes', async () => {
     jest.useFakeTimers();
     const onDismissComplete = jest.fn();
@@ -241,12 +309,12 @@ describe('BaseNotification', () => {
     jest.useRealTimers();
   });
 
-  it('restarts auto dismiss when visible status changes without layout', async () => {
+  it('restarts auto dismiss when visible content changes without layout', async () => {
     jest.useFakeTimers();
     const onDismissComplete = jest.fn();
     const { getByTestId, rerender } = renderWithProvider(
       <BaseNotification
-        status="pending"
+        status="success"
         data={defaultData}
         dismissDuration={100}
         onDismissComplete={onDismissComplete}
@@ -258,124 +326,11 @@ describe('BaseNotification', () => {
     await act(async () => {
       jest.advanceTimersByTime(50);
     });
-
-    rerender(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={100}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    await act(async () => {
-      jest.runAllTimers();
-    });
-
-    expect(onDismissComplete).toHaveBeenCalledTimes(1);
-    jest.useRealTimers();
-  });
-
-  it('does not restart auto dismiss when only the title changes', async () => {
-    jest.useFakeTimers();
-    const onDismissComplete = jest.fn();
-    const { getByTestId, rerender } = renderWithProvider(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={100}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    triggerEnterLayout(getByTestId);
 
     rerender(
       <BaseNotification
         status="success"
         data={{ ...defaultData, title: 'Updated Title' }}
-        dismissDuration={100}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    await act(async () => {
-      jest.runAllTimers();
-    });
-
-    expect(onDismissComplete).toHaveBeenCalledTimes(1);
-    jest.useRealTimers();
-  });
-
-  it('repositions when the safe area top inset changes after enter', async () => {
-    jest.useFakeTimers();
-    const onDismissComplete = jest.fn();
-    const { getByTestId, rerender } = renderWithProvider(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={5000}
-        persistUntilDismiss
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    triggerEnterLayout(getByTestId);
-
-    mockUseSafeAreaInsets.mockReturnValue({
-      top: 48,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    });
-
-    rerender(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={5000}
-        persistUntilDismiss
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    await act(async () => {
-      jest.runAllTimers();
-    });
-
-    expect(onDismissComplete).not.toHaveBeenCalled();
-    jest.useRealTimers();
-  });
-
-  it('completes auto dismiss when the safe area top inset changes after enter', async () => {
-    jest.useFakeTimers();
-    const onDismissComplete = jest.fn();
-    const { getByTestId, rerender } = renderWithProvider(
-      <BaseNotification
-        status="success"
-        data={defaultData}
-        dismissDuration={100}
-        onDismissComplete={onDismissComplete}
-      />,
-    );
-
-    triggerEnterLayout(getByTestId);
-
-    await act(async () => {
-      jest.advanceTimersByTime(50);
-    });
-
-    mockUseSafeAreaInsets.mockReturnValue({
-      top: 48,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    });
-
-    rerender(
-      <BaseNotification
-        status="success"
-        data={defaultData}
         dismissDuration={100}
         onDismissComplete={onDismissComplete}
       />,

--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -122,6 +122,30 @@ describe('BaseNotification', () => {
     expect(closeButtonStyle.marginTop).toBeDefined();
   });
 
+  it('top-aligns content when title spans multiple lines without description', () => {
+    const { getByTestId } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={{ title: 'Title', description: '' }}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    fireEvent(
+      getByTestId(BaseNotificationTestIds.NOTIFICATION_TITLE),
+      'onTextLayout',
+      {
+        nativeEvent: { lines: [{ text: 'line 1' }, { text: 'line 2' }] },
+      },
+    );
+
+    const labelsContainer = getByTestId(BaseNotificationTestIds.CONTAINER);
+    const labelsStyle = StyleSheet.flatten(labelsContainer.props.style);
+
+    expect(labelsStyle.justifyContent).toBe('flex-start');
+  });
+
   it('top-aligns content when description spans multiple lines', () => {
     const { getByTestId, getByText } = renderWithProvider(
       <BaseNotification
@@ -280,6 +304,36 @@ describe('BaseNotification', () => {
     );
 
     triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('does not restart auto dismiss when layout height changes after enter', async () => {
+    jest.useFakeTimers();
+    const onDismissComplete = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={defaultData}
+        dismissDuration={100}
+        onDismissComplete={onDismissComplete}
+      />,
+    );
+
+    triggerEnterLayout(getByTestId);
+
+    await act(async () => {
+      jest.advanceTimersByTime(50);
+    });
+
+    fireEvent(getByTestId('base-notification-container'), 'layout', {
+      nativeEvent: { layout: { height: 120, width: 300, x: 0, y: 0 } },
+    });
 
     await act(async () => {
       jest.runAllTimers();

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -195,7 +195,7 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
     : description;
   const hasDescription = resolvedDescription.length > 0;
   const shouldTopAlign =
-    (titleLineCount !== null && titleLineCount > 1 && hasDescription) ||
+    (titleLineCount !== null && titleLineCount > 1) ||
     (descriptionLineCount !== null && descriptionLineCount > 1);
   const animatedStyle = useAnimatedStyle(() => ({
     top: topInsetOffset.value,
@@ -393,13 +393,16 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
       const heightChanged = measuredHeightRef.current !== height;
       measuredHeightRef.current = height;
 
-      if (hasEnteredRef.current && !heightChanged) {
+      if (hasEnteredRef.current) {
+        if (heightChanged) {
+          notificationHeight.value = height;
+        }
         return;
       }
 
       startEnterAnimation(height);
     },
-    [isVisible, startEnterAnimation],
+    [isVisible, notificationHeight, startEnterAnimation],
   );
 
   if (!isVisible) {

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -1,8 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Dimensions,
   LayoutChangeEvent,
   StyleProp,
+  TextLayoutEvent,
   TouchableOpacity,
   View,
   ViewStyle,
@@ -33,12 +40,12 @@ import {
 
 import { strings } from '../../../../locales/i18n';
 import { useStyles } from '../../hooks';
-import { ToastSelectorsIDs } from '../../components/Toast/ToastModal.testIds';
 import {
   NOTIFICATION_SPRING_CONFIG,
   NOTIFICATION_TOP_PADDING,
   NOTIFICATION_VISIBILITY_DURATION,
 } from './BaseNotification.constants';
+import { BaseNotificationTestIds } from './BaseNotification.testIds';
 
 import styleSheet from './BaseNotification.styles';
 import {
@@ -144,6 +151,12 @@ export const getDescription = (
   return strings(`notifications.${status}_message`);
 };
 
+/**
+ * @deprecated Please update your code to use `Toast` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/src/components/Toast/Toast.tsx}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#toast-component Migration docs}
+ */
 const BaseNotification: React.FC<BaseNotificationProps> = ({
   status,
   data,
@@ -159,6 +172,10 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const { top: topInset } = useSafeAreaInsets();
   const safeData: BaseNotificationData = data ?? {};
   const { description = null, title = null } = safeData;
+  const [descriptionLineCount, setDescriptionLineCount] = useState<
+    number | null
+  >(null);
+  const [titleLineCount, setTitleLineCount] = useState<number | null>(null);
 
   const notificationHeight = useSharedValue(screenHeight);
   const translateYProgress = useSharedValue(
@@ -176,6 +193,10 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const resolvedDescription = !description
     ? getDescription(status, safeData)
     : description;
+  const hasDescription = resolvedDescription.length > 0;
+  const shouldTopAlign =
+    (titleLineCount !== null && titleLineCount > 1 && hasDescription) ||
+    (descriptionLineCount !== null && descriptionLineCount > 1);
   const animatedStyle = useAnimatedStyle(() => ({
     top: topInsetOffset.value,
     transform: [{ translateY: translateYProgress.value }],
@@ -183,16 +204,35 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const baseStyle: StyleProp<ViewStyle> = useMemo(
     () => [
       styles.base,
+      shouldTopAlign && styles.baseTopAligned,
       hasCloseIconButton && styles.baseWithCloseIconButton,
       animatedStyle,
     ],
     [
       styles.base,
+      styles.baseTopAligned,
       styles.baseWithCloseIconButton,
       animatedStyle,
       hasCloseIconButton,
+      shouldTopAlign,
     ],
   );
+
+  const handleTitleTextLayout = (event: TextLayoutEvent) => {
+    const lineCount = event.nativeEvent.lines.length;
+
+    setTitleLineCount((current) =>
+      current === lineCount ? current : lineCount,
+    );
+  };
+
+  const handleDescriptionTextLayout = (event: TextLayoutEvent) => {
+    const lineCount = event.nativeEvent.lines.length;
+
+    setDescriptionLineCount((current) =>
+      current === lineCount ? current : lineCount,
+    );
+  };
 
   const handleDismissComplete = useCallback(() => {
     if (dismissCompleteCalledRef.current) {
@@ -257,6 +297,9 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   }, [topInset, topInsetOffset]);
 
   useEffect(() => {
+    setDescriptionLineCount(null);
+    setTitleLineCount(null);
+
     const statusChanged = prevStatusRef.current !== status;
     const visibilityChanged = prevIsVisibleRef.current !== isVisible;
     const wasVisible = prevIsVisibleRef.current;
@@ -293,10 +336,12 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
 
     startEnterAnimation(measuredHeightRef.current);
   }, [
+    description,
     handleDismissComplete,
     isVisible,
     startEnterAnimation,
     status,
+    title,
     translateYProgress,
   ]);
 
@@ -368,29 +413,42 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
       testID="base-notification-container"
     >
       <TouchableOpacity
-        style={styles.pressableContent}
+        style={[
+          styles.pressableContent,
+          shouldTopAlign && styles.pressableContentTopAligned,
+        ]}
         onPress={onPress}
         activeOpacity={0.8}
         disabled={!onPress}
       >
-        <View style={styles.flashIcon}>{getIcon(status)}</View>
-        <View style={styles.flashLabel}>
+        <View>{getIcon(status)}</View>
+        <View
+          style={[
+            styles.flashLabel,
+            shouldTopAlign && styles.flashLabelTopAligned,
+          ]}
+          testID={BaseNotificationTestIds.CONTAINER}
+        >
           <Text
             variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Bold}
+            fontWeight={FontWeight.Medium}
             color={TextColor.TextDefault}
             style={styles.flashTitle}
-            testID={ToastSelectorsIDs.NOTIFICATION_TITLE}
+            testID={BaseNotificationTestIds.NOTIFICATION_TITLE}
+            onTextLayout={handleTitleTextLayout}
           >
             {!title ? getTitle(status, safeData) : title}
           </Text>
-          <Text
-            variant={TextVariant.BodySm}
-            color={TextColor.TextDefault}
-            style={styles.flashText}
-          >
-            {resolvedDescription}
-          </Text>
+          {hasDescription ? (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              style={styles.flashText}
+              onTextLayout={handleDescriptionTextLayout}
+            >
+              {resolvedDescription}
+            </Text>
+          ) : null}
         </View>
       </TouchableOpacity>
       {autoDismiss && (
@@ -398,6 +456,7 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
           iconName={IconName.Close}
           size={ButtonIconSize.Md}
           onPress={handleManualDismiss}
+          style={shouldTopAlign ? styles.closeButton : undefined}
           testID="base-notification-close"
         />
       )}

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -21,6 +21,7 @@ import Animated, {
   useSharedValue,
   withDelay,
   withSpring,
+  withTiming,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
@@ -153,7 +154,9 @@ export const getDescription = (
 
 /**
  * @deprecated Please update your code to use `Toast` from `@metamask/design-system-react-native`.
+ *
  * The API may have changed — compare props before migrating.
+ *
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react/src/components/Toast/Toast.tsx}
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#toast-component Migration docs}
  */
@@ -271,11 +274,28 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
       translateYProgress.value = withSpring(
         visibleTranslateY,
         NOTIFICATION_SPRING_CONFIG,
-        () => {
+        (finished) => {
+          if (!finished) {
+            return;
+          }
+
           translateYProgress.value = withDelay(
             dismissDurationMs,
-            withSpring(hiddenTranslateY, NOTIFICATION_SPRING_CONFIG, () => {
-              runOnJS(handleDismissComplete)();
+            withTiming(visibleTranslateY, { duration: 0 }, (isFinished) => {
+              if (!isFinished) {
+                return;
+              }
+
+              translateYProgress.value = withSpring(
+                getHiddenTranslateY(
+                  notificationHeight.value,
+                  topInsetOffset.value,
+                ),
+                NOTIFICATION_SPRING_CONFIG,
+                () => {
+                  runOnJS(handleDismissComplete)();
+                },
+              );
             }),
           );
         },

--- a/app/components/UI/Notification/TransactionNotification/index.test.js
+++ b/app/components/UI/Notification/TransactionNotification/index.test.js
@@ -73,6 +73,20 @@ const baseProps = {
   animatedTimingStart: jest.fn(),
 };
 
+const renderTransactionNotification = ({
+  status = 'confirmed',
+  smartTransactions = [],
+  props = {},
+} = {}) => {
+  const store = configureStore(createState({ status, smartTransactions }));
+
+  return render(
+    <Provider store={store}>
+      <TransactionNotification {...baseProps} {...props} />
+    </Provider>,
+  );
+};
+
 describe('TransactionNotification', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -88,21 +102,12 @@ describe('TransactionNotification', () => {
 
   it('invokes onDismissComplete and renders nothing for submitted smart transactions', async () => {
     const onDismissComplete = jest.fn();
-    const store = configureStore(
-      createState({
-        status: 'submitted',
-        smartTransactions: [{ txHash: TRANSACTION_HASH }],
-      }),
-    );
 
-    const { queryByTestId } = render(
-      <Provider store={store}>
-        <TransactionNotification
-          {...baseProps}
-          onDismissComplete={onDismissComplete}
-        />
-      </Provider>,
-    );
+    const { queryByTestId } = renderTransactionNotification({
+      status: 'submitted',
+      smartTransactions: [{ txHash: TRANSACTION_HASH }],
+      props: { onDismissComplete },
+    });
 
     await waitFor(() => {
       expect(onDismissComplete).toHaveBeenCalledTimes(1);
@@ -113,16 +118,11 @@ describe('TransactionNotification', () => {
 
   it('passes dismiss props to BaseNotification for standard transactions', async () => {
     const onDismissComplete = jest.fn();
-    const store = configureStore(createState({ status: 'confirmed' }));
 
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <TransactionNotification
-          {...baseProps}
-          onDismissComplete={onDismissComplete}
-        />
-      </Provider>,
-    );
+    const { getByTestId } = renderTransactionNotification({
+      status: 'confirmed',
+      props: { onDismissComplete },
+    });
 
     await waitFor(() => {
       expect(getByTestId('base-notification')).toBeOnTheScreen();
@@ -132,5 +132,31 @@ describe('TransactionNotification', () => {
 
     expect(notification.props.onDismissComplete).toBe(onDismissComplete);
     expect(notification.props.dismissDuration).toBe(4000);
+  });
+
+  it('keeps submitted notifications visible when no matching smart transaction exists', async () => {
+    const { getByTestId } = renderTransactionNotification({
+      status: 'submitted',
+      smartTransactions: [],
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('base-notification')).toBeOnTheScreen();
+    });
+  });
+
+  it('invokes onClose after mount for standard transactions', async () => {
+    const onClose = jest.fn();
+
+    renderTransactionNotification({
+      status: 'confirmed',
+      props: { onClose },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -3061,6 +3061,27 @@ describe('Onboarding', () => {
 
       backHandlerSpy.mockRestore();
     });
+
+    it('displays wallet reset notification when delete param is present', async () => {
+      mockRoute.params = { delete: true };
+
+      const { getByText } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(getByText(strings('onboarding.success'))).toBeOnTheScreen();
+      expect(getByText(strings('onboarding.your_wallet'))).toBeOnTheScreen();
+
+      mockRoute.params = {};
+    });
   });
 
   describe('disableBackPress', () => {
@@ -3467,6 +3488,32 @@ describe('Onboarding', () => {
           "We're investigating this problem. Try creating your wallet again.",
         ),
       ).toBeTruthy();
+    });
+
+    it('hides the notification after the dismiss animation completes', async () => {
+      const { getByText, queryByText, getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(getByText('Error report sent')).toBeOnTheScreen();
+
+      fireEvent(getByTestId('base-notification-container'), 'layout', {
+        nativeEvent: { layout: { height: 100, width: 300, x: 0, y: 0 } },
+      });
+
+      await act(async () => {
+        jest.runAllTimers();
+      });
+
+      expect(queryByText('Error report sent')).not.toBeOnTheScreen();
     });
   });
 });


### PR DESCRIPTION
## **Description**

### 1. What is the reason for this change?

#33096 moved `BaseNotification` to the top of the screen and added iOS-style spring animation. #33101 wired consumers and onboarding. This PR completes the UX update by aligning the notification's **visual design** with current design patterns and fixing **layout alignment** when titles or descriptions wrap to multiple lines.

This is **PR 3 of 3** in a stacked series:
- **#33096** — `BaseNotification` core animation & lifecycle
- **#33101** — consumer wiring + onboarding integration
- **#33097** (this PR) — visual polish

This remains a short-term improvement to the legacy component. Long term, `BaseNotification` should be deprecated in favor of the MMDS Toast component.

### 2. What are the key improvements?

**Layout & styling**
- Added conditional top alignment for multi-line content.
- Added a light mode shadow with `background.default` and dark mode `background.section`.
- Increased border radius from **8 → 16**.
- Updated spacing, gap, and typography (`FontWeight.Medium`, `TextVariant`, `TextColor`) to match current design patterns.

**Tests**
- Expanded coverage for theme-conditional styles, multi-line layout alignment, onboarding dismiss flows, and additional `TransactionNotification` paths.

**Stacked on**
- Requires #33101 (`toast/base-notification-wiring`).

### 3. Which features are impacted?

Same surfaces as PR 1 & 2 — visual/layout changes only, no new call sites:
- Transaction notifications
- Simple notifications
- Onboarding banners (wallet reset, error reporting)

## **Changelog**

CHANGELOG entry: Updated transaction and onboarding notification toasts with iOS-style animation and visual polish

## **Related issues**



## **Manual testing steps**

```gherkin
Feature: Base Notification visual polish

  Scenario: Single-line notification is vertically centered
    Given the user has a funded wallet on mainnet
    And the branch is built on top of toast/base-notification-wiring
    And a transaction notification with a short title and description is triggered
    When the notification is visible
    Then the icon, title, and description are vertically centered within the banner

  Scenario: Multi-line content is top-aligned
    Given the user has a funded wallet on mainnet
    And a notification is triggered with a long title or description that wraps
    When the notification is visible
    Then the icon and text content align to the top of the banner
    And the close button offset matches the top-aligned layout

  Scenario: Light theme styling
    Given the app appearance is set to light mode
    And a transaction notification is triggered
    When the notification is visible
    Then the banner uses the light-mode background and shadow treatment

  Scenario: Dark theme styling
    Given the app appearance is set to dark mode
    And a transaction notification is triggered
    When the notification is visible
    Then the banner uses the dark-mode section background without the light-mode shadow
```

## **Screenshots/Recordings**

**All transaction states**

### **Before**

<video src="https://github.com/user-attachments/assets/6111536e-f649-431f-81ec-ef67d7958a21" controls width="320"></video>

### **After**

<video src="https://github.com/user-attachments/assets/37f7771e-455d-4742-8c30-cce6a693d5b8" controls width="320"></video>

**Onboarding notification**

### **Before**

Recording pending — legacy bottom-anchored onboarding notification

### **After**

<video src="https://github.com/user-attachments/assets/c1cb9894-782e-4ef7-8550-dd02d593e172" controls width="320"></video>

**Simple notification**

### **Before**

Recording pending — legacy bottom-anchored simple notification

### **After**

<video src="https://github.com/MetaMask/metamask-mobile/releases/download/pr-33097-videos-1783671104/simple-notification-after.mov" controls width="320"></video>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to a legacy toast component with no auth or data-path changes; risk is limited to notification display and dismiss timing regressions.
> 
> **Overview**
> **BaseNotification** gets visual polish and layout fixes for wrapped title/description text, plus broader test coverage on consumers.
> 
> **Styling** uses theme-aware backgrounds (light `background.default` + medium shadow, dark `background.section`), **16px** radius, **gap** spacing, and higher **zIndex/elevation**. Title weight moves to **Medium**; description uses **TextAlternative** and is omitted when empty.
> 
> **Layout** measures title/description line counts via `onTextLayout` and switches row/label/close-button styles to **top alignment** when either wraps past one line.
> 
> **Animation/lifecycle**: auto-dismiss exit uses a **withTiming** bridge before the hide spring; **title/description** changes restart the dismiss timer; post-enter **layout height** updates no longer re-trigger enter. A **@deprecated** JSDoc points to MMDS **Toast**. Test IDs move to **BaseNotification.testIds**.
> 
> Tests add theme style checks, multi-line alignment, dismiss-once behavior, **TransactionNotification** helpers/scenarios, and onboarding wallet-reset + dismiss-after-animation cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baeb4a9e127d81ae9a89b60817a360e1a24ef134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->