### PR TITLE
fix: cp-8.3.0 hide PayWithRow only for addMusd intent during keyboard input in MA deposit

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -1103,6 +1103,21 @@ describe('CustomAmountInfo', () => {
     });
   });
 
+  describe('PayWithRow visibility for moneyAccountDeposit', () => {
+    it('renders PayWithRow while keyboard is visible for non-addMusd moneyAccountDeposit', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+
+      const { getByTestId } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      expect(getByTestId('pay-with')).toBeOnTheScreen();
+    });
+  });
+
   describe('no-funds account with accountOverride', () => {
     function setupNoFundsWithOverride() {
       useTransactionMetadataRequestMock.mockReturnValue({

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -325,7 +325,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           style={styles.bottomBlock}
         >
           <AlertMessage alertMessage={alertMessage ?? headlessBuyError} />
-          {!isResultReady && !(isKeyboardVisible && isMoneyAccountDeposit) && (
+          {!isResultReady && !(isKeyboardVisible && isAddMusdIntent) && (
             <>
               {supportAccountSelection &&
                 !selectedFiatPaymentMethodId &&


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The guard that suppresses the pre-quote bottom block (containing `PayWithRow` and `PayAccountSelector`) used `isMoneyAccountDeposit` combined with `isKeyboardVisible`. This was too broad: the keyboard-first UX — where those rows should be hidden while the user types — applies only to the `addMusd` prefill intent. For `convert` and `card` money-account deposits the keyboard starts open, so `PayWithRow` and `PayAccountSelector` were never rendered while the user entered an amount.

The fix narrows the guard from `isMoneyAccountDeposit` to `isAddMusdIntent`, ensuring only the prefill flow hides the pre-quote block during keyboard input while other deposit flows continue to show `PayWithRow` normally.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug where PayWithRow was hidden during keyboard input for non-addMusd money account deposits (convert, card).

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/33018/files#r3550285150

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: PayWithRow visibility on money account deposit

  Scenario: user deposits via convert or card intent (non-addMusd)
    Given a moneyAccountDeposit transaction with no addMusd batchId (e.g., convert or card intent)
    And the user is on the custom amount input screen

    When the keyboard is visible (user is entering an amount)
    Then the PayWithRow should be visible
    And the PayAccountSelector should be visible when supportAccountSelection is true

  Scenario: user deposits via addMusd prefill intent
    Given a moneyAccountDeposit transaction with an addMusd batchId
    And the user is on the custom amount input screen

    When the keyboard is visible (prefill amount shown)
    Then the PayWithRow should NOT be visible (hidden until user presses Done)

    When the user presses Done
    Then the PayWithRow should become visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — the change affects conditional rendering logic; no visual regression in the addMusd flow and no change to layout or styling.

### **Before**

For non-addMusd moneyAccountDeposit (convert/card): `PayWithRow` and `PayAccountSelector` hidden while keyboard was open.

### **After**

For non-addMusd moneyAccountDeposit (convert/card): `PayWithRow` and `PayAccountSelector` render correctly while keyboard is open.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional rendering change in the custom amount confirmation screen with a targeted regression test; no auth, payment, or data-layer changes.
> 
> **Overview**
> **Fixes** money account deposit flows where `PayWithRow` and `PayAccountSelector` disappeared while the user typed an amount.
> 
> The pre-quote bottom block was hidden whenever the keyboard was visible **and** the transaction was any `moneyAccountDeposit`. That matched the **addMusd** prefill UX but broke **convert** and **card** deposits, which start with the keyboard open.
> 
> The hide guard in `custom-amount-info` now uses **`isAddMusdIntent`** (deposit intent from `batchId`) instead of **`isMoneyAccountDeposit`**, so only addMusd hides those rows during keyboard input; other deposit intents keep them visible.
> 
> A unit test asserts `PayWithRow` stays on screen for non-addMusd `moneyAccountDeposit` with the keyboard visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b397a9f8356480499f370e1ffe27c6fa9b53a707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->