### PR TITLE
test: Reduce flake for Snaps E2Es

### DIFF
--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -468,9 +468,12 @@ class TestSnaps {
       timeout: 15_000,
     });
     await this.blurActiveWebViewInput();
+    await Utilities.waitForElementToStopMoving(this.confirmSignatureButton, {
+      stableCount: 2,
+      timeout: 5_000,
+    });
     await Gestures.tap(this.confirmSignatureButton, {
       elemDescription: 'confirm snap signature',
-      checkStability: true,
     });
   }
 

--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -33,6 +33,27 @@ async function navigateFromBrowserToSnapSettings() {
   await SettingsView.tapSnaps();
 }
 
+/**
+ * Navigate from Snap settings to the browser
+ */
+async function navigateFromSnapSettingsToBrowser() {
+  await SnapSettingsView.tapBackButton();
+  await SnapSettingsView.tapListBackButton();
+
+  await Assertions.expectElementToBeVisible(SettingsView.title, {
+    timeout: 10000,
+    description: 'Settings view should be visible',
+  });
+  await SettingsView.tapBackButton();
+  await Assertions.expectElementToBeVisible(AccountMenu.container, {
+    timeout: 10000,
+    description: 'Account menu should be visible',
+  });
+  await AccountMenu.tapBack();
+
+  await navigateToBrowserView();
+}
+
 jest.setTimeout(150_000);
 
 describe(SmokeSnaps('Snap Management Tests'), () => {
@@ -67,13 +88,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
 
-        await SnapSettingsView.tapBackButton();
-        await SnapSettingsView.tapListBackButton();
-        // Settings → AccountsMenu → close SettingsFlow
-        await SettingsView.tapBackButton();
-        await AccountMenu.tapBack();
-
-        await navigateToBrowserView();
+        await navigateFromSnapSettingsToBrowser();
 
         await TestSnaps.tapButton('sendAlertButton');
 
@@ -98,13 +113,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
 
-        await SnapSettingsView.tapBackButton();
-        await SnapSettingsView.tapListBackButton();
-        // Settings → AccountsMenu → close SettingsFlow
-        await SettingsView.tapBackButton();
-        await AccountMenu.tapBack();
-
-        await navigateToBrowserView();
+        await navigateFromSnapSettingsToBrowser();
 
         await TestSnaps.tapButton('sendAlertButton');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Reduce two instances of flakyness in the Snaps tests:
1. Use `waitForElementToStopMoving` instead of `checkStability` because the latter would time out in CI
2. Add a re-usable `navigateFromSnapSettingsToBrowser` function with more assertions to ensure proper sequencing of actions

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
3. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page-object and spec changes; no production code paths affected.
> 
> **Overview**
> Hardens Snaps E2E flows that were flaky in CI without changing app behavior.
> 
> In **`approveNativeConfirmation`**, the confirm tap no longer relies on **`Gestures.tap`’s `checkStability`** (which was timing out). It now waits for the signature confirm button to settle with **`Utilities.waitForElementToStopMoving`** before a plain tap, after the existing toast-dismiss and WebView blur steps.
> 
> In **snap management** specs, the repeated “leave Snap settings and return to the browser” sequence is centralized in **`navigateFromSnapSettingsToBrowser`**, with explicit visibility checks on Settings and the account menu so navigation steps don’t race when synchronization is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939ed22a0bef12721a1491efaab93ef53156bf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->