### PR TITLE
fix: Wire BaseNotification consumers and onboarding overlays (2/3)

### DIFF
--- a/app/components/UI/Notification/SimpleNotification/index.js
+++ b/app/components/UI/Notification/SimpleNotification/index.js
@@ -1,62 +1,32 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import Animated from 'react-native-reanimated';
 import BaseNotification from '../../../../component-library/components-temp/BaseNotification';
-import Device from '../../../../util/device';
-import ElevatedView from 'react-native-elevated-view';
-import { colors as importedColors } from '../../../../styles/common';
-
-const styles = StyleSheet.create({
-  modalTypeViewBrowser: {
-    bottom: Device.isIphoneX() ? 70 : 60,
-  },
-  elevatedView: {
-    backgroundColor: importedColors.transparent,
-  },
-  notificationContainer: {
-    position: 'absolute',
-    bottom: 0,
-    paddingBottom: Device.isIphoneX() ? 20 : 10,
-    left: 0,
-    right: 0,
-    backgroundColor: importedColors.transparent,
-  },
-});
 
 function SimpleNotification({
-  isInBrowserView,
-  notificationAnimated,
   hideCurrentNotification,
+  onDismissComplete,
+  dismissDuration,
   currentNotification,
 }) {
   return (
-    <Animated.View
-      style={[
-        styles.notificationContainer,
-        isInBrowserView && styles.modalTypeViewBrowser,
-        { transform: [{ translateY: notificationAnimated }] },
-      ]}
-    >
-      <ElevatedView style={styles.elevatedView} elevation={100}>
-        <BaseNotification
-          status={currentNotification.status}
-          data={{
-            title: currentNotification.title,
-            description: currentNotification.description,
-          }}
-          onHide={hideCurrentNotification}
-        />
-      </ElevatedView>
-    </Animated.View>
+    <BaseNotification
+      status={currentNotification.status}
+      data={{
+        title: currentNotification.title,
+        description: currentNotification.description,
+      }}
+      onHide={hideCurrentNotification}
+      onDismissComplete={onDismissComplete}
+      dismissDuration={dismissDuration}
+    />
   );
 }
 
 SimpleNotification.propTypes = {
-  isInBrowserView: PropTypes.bool,
-  notificationAnimated: PropTypes.object,
   currentNotification: PropTypes.object,
   hideCurrentNotification: PropTypes.func,
+  onDismissComplete: PropTypes.func,
+  dismissDuration: PropTypes.number,
 };
 
 export default SimpleNotification;

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -2,31 +2,23 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { StyleSheet, View, Text, Dimensions } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useSharedValue } from 'react-native-reanimated';
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
 import { renderFromWei, fastSplit } from '../../../../util/number';
 import { validateTransactionActionBalance } from '../../../../util/transactions';
-import {
-  fontStyles,
-  colors as importedColors,
-} from '../../../../styles/common';
+import { fontStyles } from '../../../../styles/common';
 import decodeTransaction from '../../TransactionElement/utils';
 import TransactionActionContent from '../../TransactionActionModal/TransactionActionContent';
 import ActionContent from '../../ActionModal/ActionContent';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import TransactionDetails from '../../TransactionElement/TransactionDetails';
 import BaseNotification from '../../../../component-library/components-temp/BaseNotification';
-import Device from '../../../../util/device';
-import ElevatedView from 'react-native-elevated-view';
+import { NOTIFICATION_MODAL_OVERLAY_ELEVATION } from '../../../../component-library/components-temp/BaseNotification/BaseNotification.constants';
 import { CANCEL_RATE, SPEED_UP_RATE } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
 import { collectibleContractsSelector } from '../../../../reducers/collectibles';
 import { useTheme } from '../../../../util/theme';
-import {
-  getElevatedSurfaceColor,
-  isPureBlackEnabled,
-} from '../../../../util/theme/themeUtils';
 import {
   selectChainId,
   selectTickerByChainId,
@@ -45,10 +37,8 @@ const WINDOW_WIDTH = Dimensions.get('window').width;
 const ACTION_CANCEL = 'cancel';
 const ACTION_SPEEDUP = 'speedup';
 
-const createStyles = (theme) => {
-  const { colors } = theme;
-
-  return StyleSheet.create({
+const createStyles = (colors) =>
+  StyleSheet.create({
     absoluteFill: {
       ...StyleSheet.absoluteFillObject,
     },
@@ -66,17 +56,6 @@ const createStyles = (theme) => {
       color: colors.text.default,
       ...fontStyles.bold,
     },
-    notification: {
-      position: 'absolute',
-      bottom: 0,
-      paddingBottom: Device.isIphoneX() ? 20 : 10,
-      left: 0,
-      right: 0,
-      backgroundColor: importedColors.transparent,
-    },
-    modalTypeViewBrowser: {
-      bottom: Device.isIphoneX() ? 70 : 60,
-    },
     closeIcon: {
       paddingTop: 4,
       position: 'absolute',
@@ -91,6 +70,8 @@ const createStyles = (theme) => {
       width: '200%',
       flexDirection: 'row',
       backgroundColor: colors.overlay.default,
+      zIndex: NOTIFICATION_MODAL_OVERLAY_ELEVATION,
+      elevation: NOTIFICATION_MODAL_OVERLAY_ELEVATION,
     },
     modalOverlay: {
       justifyContent: 'center',
@@ -100,25 +81,17 @@ const createStyles = (theme) => {
     modalContainer: {
       width: '90%',
       borderRadius: 10,
-      backgroundColor: getElevatedSurfaceColor(theme),
-      ...(isPureBlackEnabled && {
-        borderWidth: 1,
-        borderColor: colors.border.muted,
-      }),
-    },
-    elevatedView: {
-      backgroundColor: importedColors.transparent,
+      backgroundColor: colors.background.default,
     },
   });
-};
 
 function TransactionNotification(props) {
   const {
     accounts,
     currentNotification,
-    isInBrowserView,
-    notificationAnimated,
     onClose,
+    onDismissComplete,
+    dismissDuration,
     transactions,
     animatedTimingStart,
     smartTransactions,
@@ -138,8 +111,8 @@ function TransactionNotification(props) {
   const actionXAnimated = useSharedValue(0);
   const detailsAnimated = useSharedValue(0);
 
-  const theme = useTheme();
-  const styles = createStyles(theme);
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
 
   const detailsFadeIn = useCallback(async () => {
     setTransactionDetailsIsVisible(true);
@@ -286,39 +259,36 @@ function TransactionNotification(props) {
 
   useEffect(() => onCloseNotification(), [onCloseNotification]);
 
+  const shouldSkipSubmittedSmartTransaction =
+    tx.status === 'submitted' &&
+    smartTransactions.some((stx) => stx.txHash === tx.hash);
+
+  useEffect(() => {
+    if (shouldSkipSubmittedSmartTransaction) {
+      onDismissComplete?.();
+    }
+  }, [onDismissComplete, shouldSkipSubmittedSmartTransaction]);
+
   // Don't show submitted notification for STX b/c we only know when it's confirmed,
   // o/w a submitted notification will show up after it's confirmed, then a confirmed notification will show up immediately after
-  if (tx.status === 'submitted') {
-    const smartTx = smartTransactions.find((stx) => stx.txHash === tx.hash);
-    if (smartTx) {
-      return null;
-    }
+  if (shouldSkipSubmittedSmartTransaction) {
+    return null;
   }
 
   return (
     <>
-      <Animated.View
-        style={[
-          styles.notification,
-          isInBrowserView && styles.modalTypeViewBrowser,
-          {
-            transform: [{ translateY: notificationAnimated }],
-          },
-        ]}
-      >
-        <ElevatedView style={styles.elevatedView} elevation={100}>
-          <BaseNotification
-            status={currentNotification.status}
-            data={{
-              ...tx?.txParams,
-              ...currentNotification.transaction,
-              title: transactionElement?.notificationKey,
-            }}
-            onPress={detailsFadeIn}
-            onHide={onCloseNotification}
-          />
-        </ElevatedView>
-      </Animated.View>
+      <BaseNotification
+        status={currentNotification.status}
+        data={{
+          ...tx?.txParams,
+          ...currentNotification.transaction,
+          title: transactionElement?.notificationKey,
+        }}
+        onPress={detailsFadeIn}
+        onHide={onCloseNotification}
+        onDismissComplete={onDismissComplete}
+        dismissDuration={dismissDuration}
+      />
       {transactionDetailsIsVisible && (
         <View style={styles.modalsContainer}>
           <View style={[styles.modalOverlay]}>
@@ -380,9 +350,9 @@ function TransactionNotification(props) {
 }
 
 TransactionNotification.propTypes = {
-  isInBrowserView: PropTypes.bool,
-  notificationAnimated: PropTypes.object,
   onClose: PropTypes.func,
+  onDismissComplete: PropTypes.func,
+  dismissDuration: PropTypes.number,
   animatedTimingStart: PropTypes.func,
   currentNotification: PropTypes.object,
   swapsTransactions: PropTypes.object,

--- a/app/components/UI/Notification/TransactionNotification/index.test.js
+++ b/app/components/UI/Notification/TransactionNotification/index.test.js
@@ -1,0 +1,136 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { act, render, waitFor } from '@testing-library/react-native';
+import TransactionNotification from './index';
+import configureStore from '../../../../util/test/configureStore';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+
+jest.mock('../../TransactionElement/utils', () => ({
+  __esModule: true,
+  default: jest.fn(() =>
+    Promise.resolve([
+      { notificationKey: 'notification-key', actionKey: 'action-key' },
+      {},
+    ]),
+  ),
+}));
+
+jest.mock(
+  '../../../../component-library/components-temp/BaseNotification',
+  () => {
+    const ReactMock = require('react');
+    const { View } = require('react-native');
+
+    return function MockBaseNotification(props) {
+      return ReactMock.createElement(View, {
+        testID: 'base-notification',
+        ...props,
+      });
+    };
+  },
+);
+
+const TRANSACTION_ID = 'tx-1';
+const TRANSACTION_HASH = '0xabc';
+
+const createState = ({ status, smartTransactions = [] } = {}) => ({
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      TransactionController: {
+        ...backgroundState.TransactionController,
+        transactions: [
+          {
+            id: TRANSACTION_ID,
+            hash: TRANSACTION_HASH,
+            status,
+            chainId: '0x1',
+            txParams: { gasPrice: '0x1' },
+          },
+        ],
+      },
+      SmartTransactionsController: {
+        ...backgroundState.SmartTransactionsController,
+        smartTransactionsState: {
+          ...backgroundState.SmartTransactionsController.smartTransactionsState,
+          smartTransactions: {
+            '0x1': smartTransactions,
+          },
+        },
+      },
+    },
+  },
+});
+
+const baseProps = {
+  currentNotification: {
+    status: 'submitted',
+    transaction: { id: TRANSACTION_ID },
+  },
+  onClose: jest.fn(),
+  onDismissComplete: jest.fn(),
+  dismissDuration: 4000,
+  animatedTimingStart: jest.fn(),
+};
+
+describe('TransactionNotification', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('invokes onDismissComplete and renders nothing for submitted smart transactions', async () => {
+    const onDismissComplete = jest.fn();
+    const store = configureStore(
+      createState({
+        status: 'submitted',
+        smartTransactions: [{ txHash: TRANSACTION_HASH }],
+      }),
+    );
+
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <TransactionNotification
+          {...baseProps}
+          onDismissComplete={onDismissComplete}
+        />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(onDismissComplete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(queryByTestId('base-notification')).toBeNull();
+  });
+
+  it('passes dismiss props to BaseNotification for standard transactions', async () => {
+    const onDismissComplete = jest.fn();
+    const store = configureStore(createState({ status: 'confirmed' }));
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <TransactionNotification
+          {...baseProps}
+          onDismissComplete={onDismissComplete}
+        />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('base-notification')).toBeOnTheScreen();
+    });
+
+    const notification = getByTestId('base-notification');
+
+    expect(notification.props.onDismissComplete).toBe(onDismissComplete);
+    expect(notification.props.dismissDuration).toBe(4000);
+  });
+});

--- a/app/components/UI/Notification/index.js
+++ b/app/components/UI/Notification/index.js
@@ -1,7 +1,6 @@
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useNavigationState } from '@react-navigation/native';
 import {
   removeCurrentNotification,
   hideCurrentNotification,
@@ -11,18 +10,10 @@ import TransactionNotification from './TransactionNotification';
 import SimpleNotification from './SimpleNotification';
 import { currentNotificationSelector } from '../../../reducers/notification';
 
-import { findRouteNameFromNavigatorState } from '../../../util/general';
 import usePrevious from '../../hooks/usePrevious';
-import {
-  useSharedValue,
-  withTiming,
-  Easing,
-  runOnJS,
-} from 'react-native-reanimated';
+import { withTiming, Easing, runOnJS } from 'react-native-reanimated';
 
 const { TRANSACTION, SIMPLE } = NotificationTypes;
-
-const BROWSER_ROUTE = 'BrowserView';
 
 function Notification({
   currentNotification,
@@ -30,10 +21,21 @@ function Notification({
   hideCurrentNotification,
   removeCurrentNotification,
 }) {
-  const notificationAnimated = useSharedValue(200);
-  const routes = useNavigationState((state) => state.routes);
-
   const prevNotificationIsVisible = usePrevious(currentNotificationIsVisible);
+  const dismissCompleteRef = useRef(false);
+
+  const handleDismissComplete = useCallback(() => {
+    if (dismissCompleteRef.current) {
+      return;
+    }
+
+    dismissCompleteRef.current = true;
+    removeCurrentNotification();
+  }, [removeCurrentNotification]);
+
+  useEffect(() => {
+    dismissCompleteRef.current = false;
+  }, [currentNotification?.id]);
 
   const animatedTimingStart = useCallback((animatedRef, toValue, callback) => {
     animatedRef.value = withTiming(
@@ -43,44 +45,46 @@ function Notification({
     );
   }, []);
 
-  const isInBrowserView = useMemo(
-    () => findRouteNameFromNavigatorState(routes) === BROWSER_ROUTE,
-    [routes],
-  );
-
   useEffect(
     () => () => {
-      animatedTimingStart(notificationAnimated, 200, removeCurrentNotification);
       hideCurrentNotification();
+      handleDismissComplete();
     },
-    [
-      notificationAnimated,
-      animatedTimingStart,
-      hideCurrentNotification,
-      removeCurrentNotification,
-    ],
+    [hideCurrentNotification, handleDismissComplete],
   );
 
   useEffect(() => {
     if (!prevNotificationIsVisible && currentNotificationIsVisible) {
-      animatedTimingStart(notificationAnimated, 0);
       hideCurrentNotification();
-      setTimeout(() => {
-        animatedTimingStart(
-          notificationAnimated,
-          200,
-          removeCurrentNotification,
-        );
-      }, currentNotification.autodismiss || 5000);
     }
   }, [
-    animatedTimingStart,
     hideCurrentNotification,
-    removeCurrentNotification,
     currentNotificationIsVisible,
     prevNotificationIsVisible,
-    currentNotification.autodismiss,
-    notificationAnimated,
+  ]);
+
+  useEffect(() => {
+    if (!currentNotification?.id) {
+      return;
+    }
+
+    const dismissDuration = currentNotification.autodismiss || 5000;
+    // BaseNotification normally dequeues via onDismissComplete after its exit
+    // animation. Keep this fallback so the Redux queue still advances if that
+    // callback never fires (for example, interrupted animations or unmount edge
+    // cases). The extra second gives the animation time to finish first.
+    const timeoutId = setTimeout(() => {
+      handleDismissComplete();
+    }, dismissDuration + 1000);
+
+    return () => clearTimeout(timeoutId);
+  }, [
+    currentNotification?.id,
+    currentNotification?.autodismiss,
+    currentNotification?.status,
+    currentNotification?.title,
+    currentNotification?.description,
+    handleDismissComplete,
   ]);
 
   if (!currentNotification?.type) return null;
@@ -88,8 +92,8 @@ function Notification({
     return (
       <TransactionNotification
         onClose={hideCurrentNotification}
-        isInBrowserView={isInBrowserView}
-        notificationAnimated={notificationAnimated}
+        onDismissComplete={handleDismissComplete}
+        dismissDuration={currentNotification.autodismiss}
         animatedTimingStart={animatedTimingStart}
         currentNotification={currentNotification}
       />
@@ -97,8 +101,9 @@ function Notification({
   if (currentNotification.type === SIMPLE)
     return (
       <SimpleNotification
-        isInBrowserView={isInBrowserView}
-        notificationAnimated={notificationAnimated}
+        onDismissComplete={handleDismissComplete}
+        dismissDuration={currentNotification.autodismiss}
+        hideCurrentNotification={hideCurrentNotification}
         currentNotification={currentNotification}
       />
     );

--- a/app/components/UI/Notification/index.js
+++ b/app/components/UI/Notification/index.js
@@ -34,8 +34,18 @@ function Notification({
   }, [removeCurrentNotification]);
 
   useEffect(() => {
+    if (!currentNotification?.id) {
+      return;
+    }
+
     dismissCompleteRef.current = false;
-  }, [currentNotification?.id]);
+  }, [
+    currentNotification?.id,
+    currentNotification?.autodismiss,
+    currentNotification?.status,
+    currentNotification?.title,
+    currentNotification?.description,
+  ]);
 
   const animatedTimingStart = useCallback((animatedRef, toValue, callback) => {
     animatedRef.value = withTiming(

--- a/app/components/UI/Notification/index.test.js
+++ b/app/components/UI/Notification/index.test.js
@@ -155,6 +155,48 @@ describe('Notification', () => {
     jest.useRealTimers();
   });
 
+  it('dequeues success notification after pending with the same id was dismissed', () => {
+    jest.useFakeTimers();
+    const { getByTestId, dispatchSpy, rerender, store } = renderNotification({
+      id: 'notification-1',
+      ...simpleNotification,
+      status: 'pending',
+      autodismiss: 1000,
+    });
+
+    act(() => {
+      getByTestId('simple-notification').props.onDismissComplete();
+    });
+
+    act(() => {
+      store.dispatch({
+        type: ACTIONS.MODIFY_OR_SHOW_SIMPLE_NOTIFICATION,
+        id: 'notification-1',
+        status: 'success',
+        title: simpleNotification.title,
+        description: simpleNotification.description,
+        autodismiss: 1000,
+      });
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Notification />
+      </Provider>,
+    );
+
+    act(() => {
+      getByTestId('simple-notification').props.onDismissComplete();
+    });
+
+    expect(
+      dispatchSpy.mock.calls.filter(
+        ([action]) => action.type === ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+      ),
+    ).toHaveLength(2);
+    jest.useRealTimers();
+  });
+
   it('dequeues only once when dismiss complete is invoked twice', () => {
     jest.useFakeTimers();
     const { getByTestId, dispatchSpy } = renderNotification({

--- a/app/components/UI/Notification/index.test.js
+++ b/app/components/UI/Notification/index.test.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { act, render } from '@testing-library/react-native';
+import Notification from './index';
+import configureStore from '../../../util/test/configureStore';
+import { NotificationTypes } from '../../../util/notifications';
+import { ACTIONS } from '../../../reducers/notification';
+
+function mockNotificationChild(testID) {
+  const ReactMock = require('react');
+  const { View } = require('react-native');
+
+  return function MockNotification(props) {
+    return ReactMock.createElement(View, {
+      testID,
+      onDismissComplete: props.onDismissComplete,
+    });
+  };
+}
+
+jest.mock('./TransactionNotification', () =>
+  mockNotificationChild('transaction-notification'),
+);
+jest.mock('./SimpleNotification', () =>
+  mockNotificationChild('simple-notification'),
+);
+
+const createNotificationState = (notification) => ({
+  notification: {
+    notifications: notification ? [notification] : [],
+  },
+});
+
+const simpleNotification = {
+  type: NotificationTypes.SIMPLE,
+  isVisible: true,
+  status: 'success',
+  title: 'Test title',
+  description: 'Test description',
+};
+
+const renderNotification = (notification) => {
+  const store = configureStore(createNotificationState(notification));
+  const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+  const view = render(
+    <Provider store={store}>
+      <Notification />
+    </Provider>,
+  );
+
+  return { ...view, dispatchSpy, store };
+};
+
+describe('Notification', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches hide and remove actions when the component unmounts', () => {
+    const { unmount, dispatchSpy } = renderNotification(simpleNotification);
+
+    unmount();
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: ACTIONS.HIDE_CURRENT_NOTIFICATION,
+    });
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+    });
+  });
+
+  it('dequeues only once when unmounting after dismiss complete', () => {
+    const { getByTestId, unmount, dispatchSpy } =
+      renderNotification(simpleNotification);
+
+    act(() => {
+      getByTestId('simple-notification').props.onDismissComplete();
+    });
+
+    unmount();
+
+    expect(
+      dispatchSpy.mock.calls.filter(
+        ([action]) => action.type === ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('dequeues the current notification when the fallback timer expires', () => {
+    jest.useFakeTimers();
+    const { dispatchSpy } = renderNotification({
+      id: 'notification-1',
+      ...simpleNotification,
+      autodismiss: 1000,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+    });
+    jest.useRealTimers();
+  });
+
+  it('restarts the fallback timer when notification status changes', () => {
+    jest.useFakeTimers();
+    const { dispatchSpy, rerender, store } = renderNotification({
+      id: 'notification-1',
+      ...simpleNotification,
+      status: 'pending',
+      autodismiss: 1000,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    act(() => {
+      store.dispatch({
+        type: ACTIONS.MODIFY_OR_SHOW_SIMPLE_NOTIFICATION,
+        id: 'notification-1',
+        status: 'success',
+        title: simpleNotification.title,
+        description: simpleNotification.description,
+        autodismiss: 1000,
+      });
+    });
+
+    rerender(
+      <Provider store={store}>
+        <Notification />
+      </Provider>,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    expect(
+      dispatchSpy.mock.calls.filter(
+        ([action]) => action.type === ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+      ),
+    ).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+    });
+    jest.useRealTimers();
+  });
+
+  it('dequeues only once when dismiss complete is invoked twice', () => {
+    jest.useFakeTimers();
+    const { getByTestId, dispatchSpy } = renderNotification({
+      id: 'notification-1',
+      ...simpleNotification,
+      autodismiss: 1000,
+    });
+
+    const notification = getByTestId('simple-notification');
+
+    act(() => {
+      notification.props.onDismissComplete();
+      notification.props.onDismissComplete();
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(
+      dispatchSpy.mock.calls.filter(
+        ([action]) => action.type === ACTIONS.REMOVE_CURRENT_NOTIFICATION,
+      ),
+    ).toHaveLength(1);
+    jest.useRealTimers();
+  });
+});

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -11,10 +11,11 @@ import {
   BackHandler,
   ScrollView,
   InteractionManager,
-  Animated,
-  Easing,
   Platform,
+  StyleSheet,
+  View,
 } from 'react-native';
+import { FullWindowOverlay } from 'react-native-screens';
 import { captureException } from '@sentry/react-native';
 import { colors as importedColors } from '../../../styles/common';
 import { strings } from '../../../../locales/i18n';
@@ -22,7 +23,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import FadeOutOverlay from '../../UI/FadeOutOverlay';
 import Device from '../../../util/device';
 import BaseNotification from '../../../component-library/components-temp/BaseNotification';
-import ElevatedView from 'react-native-elevated-view';
 import { loadingSet, loadingUnset } from '../../../actions/user';
 import {
   saveOnboardingEvent as saveEvent,
@@ -150,6 +150,14 @@ interface OnboardingRouteParams {
   showErrorReportSentToast?: boolean;
 }
 
+const styles = StyleSheet.create({
+  androidNotificationOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 999,
+    elevation: 999,
+  },
+});
+
 const Onboarding = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const onboardingVersion = useMemo(
@@ -209,7 +217,8 @@ const Onboarding = () => {
     startFoxAnimation: undefined,
   });
 
-  const notificationAnimated = useRef(new Animated.Value(100)).current;
+  const [onboardingNotificationVisible, setOnboardingNotificationVisible] =
+    useState(false);
 
   const onboardingTraceCtx = useRef<TraceContext>(undefined);
   const socialLoginTraceCtx = useRef<TraceContext>(undefined);
@@ -227,19 +236,6 @@ const Onboarding = () => {
   const mounted = useRef<boolean>(false);
   const hasCheckedVaultBackup = useRef<boolean>(false);
   const warningCallback = useRef<() => boolean>(() => true);
-  const notificationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const animatedTimingStart = useCallback(
-    (animatedRef: Animated.Value, toValue: number): void => {
-      Animated.timing(animatedRef, {
-        toValue,
-        duration: 500,
-        easing: Easing.linear,
-        useNativeDriver: true,
-      }).start();
-    },
-    [],
-  );
 
   const disableBackPress = useCallback((): void => {
     // Disable back press
@@ -248,12 +244,9 @@ const Onboarding = () => {
   }, []);
 
   const showNotification = useCallback((): void => {
-    animatedTimingStart(notificationAnimated, 0);
-    notificationTimer.current = setTimeout(() => {
-      animatedTimingStart(notificationAnimated, 200);
-    }, 4000);
+    setOnboardingNotificationVisible(true);
     disableBackPress();
-  }, [animatedTimingStart, notificationAnimated, disableBackPress]);
+  }, [disableBackPress]);
 
   const updateNavBar = useCallback((): void => {
     navigation.setOptions({
@@ -1089,8 +1082,13 @@ const Onboarding = () => {
 
   const handleSimpleNotification =
     useCallback((): React.ReactElement | null => {
-      if (!route?.params?.delete && !route?.params?.showErrorReportSentToast)
+      if (!route?.params?.delete && !route?.params?.showErrorReportSentToast) {
         return null;
+      }
+
+      if (!onboardingNotificationVisible) {
+        return null;
+      }
 
       const notificationData = route?.params?.showErrorReportSentToast
         ? {
@@ -1104,29 +1102,47 @@ const Onboarding = () => {
             description: strings('onboarding.your_wallet'),
           };
 
+      const notificationContent = (
+        <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+          <BaseNotification
+            isVisible={onboardingNotificationVisible}
+            dismissDuration={4000}
+            onDismissComplete={() => setOnboardingNotificationVisible(false)}
+            status="success"
+            data={notificationData}
+          />
+        </View>
+      );
+
+      if (Platform.OS === 'ios') {
+        return (
+          <FullWindowOverlay>
+            {/*
+              iOS: portal to a UIWindow so top-anchored animation is not
+              affected by onboarding layout siblings lower in the tree.
+            */}
+            {notificationContent}
+          </FullWindowOverlay>
+        );
+      }
+
       return (
-        <Animated.View
-          style={[
-            tw.style('flex-row items-end', { flex: 0.1 }),
-            { transform: [{ translateY: notificationAnimated }] },
-          ]}
+        <View
+          pointerEvents="box-none"
+          style={styles.androidNotificationOverlay}
         >
-          <ElevatedView
-            style={tw.style(
-              'absolute bottom-0 left-0 right-0 bg-transparent',
-              Device.isIphoneX() ? 'pb-5' : 'pb-[10px]',
-            )}
-            elevation={100}
-          >
-            <BaseNotification status="success" data={notificationData} />
-          </ElevatedView>
-        </Animated.View>
+          {/*
+            Android: FullWindowOverlay stays in the normal view hierarchy, so
+            keep the toast as the last SafeAreaView child with absolute fill
+            and elevation to render above the ScrollView.
+          */}
+          {notificationContent}
+        </View>
       );
     }, [
       route?.params?.delete,
       route?.params?.showErrorReportSentToast,
-      notificationAnimated,
-      tw,
+      onboardingNotificationVisible,
     ]);
 
   useEffect(() => {
@@ -1156,9 +1172,6 @@ const Onboarding = () => {
 
     return () => {
       mounted.current = false;
-      if (notificationTimer.current) {
-        clearTimeout(notificationTimer.current);
-      }
       unsetLoading();
       InteractionManager.runAfterInteractions(PreventScreenshot.allow);
     };
@@ -1237,14 +1250,14 @@ const Onboarding = () => {
           <FoxAnimation hasFooter={false} trigger={startFoxAnimation} />
         )}
 
-        <Box>{handleSimpleNotification()}</Box>
-
         <FastOnboarding
           onPressContinueWithGoogle={onPressContinueWithGoogle}
           onPressContinueWithApple={onPressContinueWithApple}
           onPressImport={onPressImport}
           onPressCreate={onPressCreate}
         />
+
+        {handleSimpleNotification()}
       </SafeAreaView>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## **Description**

### 1. What is the reason for this change?

#33096 adds spring animation and dismiss lifecycle to `BaseNotification`. This PR wires that API into the notification stack and onboarding so the new top-anchored behavior works end-to-end.

This is **PR 2 of 3** in a stacked series:
- **#33096** — `BaseNotification` core animation & lifecycle
- **#33101** (this PR) — consumer wiring + onboarding integration
- **#33097** — visual polish (spacing, colors, multi-line alignment)

### 2. What are the key improvements?

**Notification stack**
- `Notification` drops browser-route `translateY` animation and advances the Redux queue via `onDismissComplete`.
- Added a fallback dequeue timer so the queue does not get stuck if the callback never fires.
- `SimpleNotification` and `TransactionNotification` render `BaseNotification` directly (no `ElevatedView`).
- Submitted smart txs call `onDismissComplete` without showing the banner.

**Onboarding**
- Uses `FullWindowOverlay` on iOS and a high-elevation overlay on Android so top animation is not clipped by layout siblings.

**Tests**
- Queue dequeue edge cases, smart-tx skip paths, and transaction notification consumer behavior.

### 3. Which features are impacted?

- Transaction notifications
- Simple notifications
- Onboarding banners (wallet reset, error reporting)

**Note:** Visual styling is unchanged from current production in this PR (polish lands in #33097).

## **Changelog**

CHANGELOG entry: null

## **Related issues**



## **Manual testing steps**

```gherkin
Feature: Base Notification spring animation

  Scenario: Transaction notification slides in from the top
    Given the user has a funded wallet on mainnet
    And the user is on the wallet home screen
    When the user sends a transaction and the pending notification appears
    Then the notification slides in from the top of the screen with spring animation
    And the notification appears below the safe area

  Scenario: Transaction notification auto-dismisses
    Given a transaction notification is visible on the wallet home screen
    When the dismiss duration elapses
    Then the notification slides out toward the top with spring animation
    And the next queued notification can appear

  Scenario: Onboarding wallet-reset notification on Android
    Given the user completes wallet reset during onboarding on an Android device or emulator
    When the success notification is shown
    Then the notification renders above the onboarding ScrollView
    And the notification slides in from the top with spring animation

  Scenario: Manual dismiss via close button
    Given a notification with auto-dismiss is visible
    When the user taps the close button
    Then the notification dismisses with the exit spring animation
```

## **Screenshots/Recordings**

**Transaction notification (spring animation — visual polish in #33097)**

### **Before**

<video src="https://github.com/user-attachments/assets/6111536e-f649-431f-81ec-ef67d7958a21" controls width="320"></video>

### **After**

<video src="https://github.com/user-attachments/assets/37f7771e-455d-4742-8c30-cce6a693d5b8" controls width="320"></video>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global notification queue timing and transaction/smart-tx visibility paths; regressions could stall or skip banners, though behavior is covered by new tests.
> 
> **Overview**
> Wires **PR 1’s** `BaseNotification` dismiss API through the global notification stack and onboarding so top-anchored spring animations can drive queue advancement end-to-end.
> 
> The root **`Notification`** container no longer slides banners with browser-route `translateY` or parent `Animated`/`ElevatedView` wrappers. It passes **`onDismissComplete`** and **`dismissDuration`** into **`SimpleNotification`** and **`TransactionNotification`**, which now render **`BaseNotification`** directly. Redux dequeue happens when dismiss completes (guarded so **`removeCurrentNotification`** runs once), with a **fallback timer** (`autodismiss + 1s`) if the callback never fires. Pending→success updates with the same id reset that guard and restart the fallback.
> 
> **`TransactionNotification`** skips the submitted smart-tx banner by calling **`onDismissComplete`** instead of showing UI; transaction detail modals keep overlay **`zIndex`/`elevation`** from shared constants.
> 
> **Onboarding** drops custom bottom **`Animated`** toasts for **`BaseNotification`** with **`isVisible`**, **`FullWindowOverlay`** on iOS, and a high-elevation absolute overlay on Android so the toast isn’t clipped by **`ScrollView`** siblings.
> 
> Adds unit tests for queue dequeue edge cases, smart-tx skip, and consumer prop wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc87464c5e2798585c65178941df80dc5f884c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->