### PR TITLE
fix(money): use branded mUSD casing in transaction detail steps (MUSD-1122)

### DIFF
--- a/app/components/UI/Earn/constants/musd.test.ts
+++ b/app/components/UI/Earn/constants/musd.test.ts
@@ -1,6 +1,6 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import {
-  getMusdDisplaySymbol,
+  getTokenDisplaySymbol,
   isMusdOnMoneyAccountChain,
   isMusdToken,
   isMusdTokenOnChain,
@@ -52,11 +52,11 @@ describe('isMusdToken', () => {
   });
 });
 
-describe('getMusdDisplaySymbol', () => {
+describe('getTokenDisplaySymbol', () => {
   const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
 
   it('returns the branded mUSD symbol for the mUSD address with registry symbol MUSD', () => {
-    const result = getMusdDisplaySymbol(MUSD_ADDRESS, 'MUSD');
+    const result = getTokenDisplaySymbol(MUSD_ADDRESS, 'MUSD');
 
     expect(result).toBe(MUSD_TOKEN.symbol);
   });
@@ -64,7 +64,7 @@ describe('getMusdDisplaySymbol', () => {
   it('returns the branded mUSD symbol for the mUSD address with mixed case', () => {
     const mixedCaseAddress = '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA';
 
-    const result = getMusdDisplaySymbol(mixedCaseAddress, 'MUSD');
+    const result = getTokenDisplaySymbol(mixedCaseAddress, 'MUSD');
 
     expect(result).toBe('mUSD');
   });
@@ -72,13 +72,13 @@ describe('getMusdDisplaySymbol', () => {
   it('passes the symbol through for a non-mUSD address', () => {
     const otherAddress = '0x1234567890123456789012345678901234567890';
 
-    const result = getMusdDisplaySymbol(otherAddress, 'USDC');
+    const result = getTokenDisplaySymbol(otherAddress, 'USDC');
 
     expect(result).toBe('USDC');
   });
 
   it('passes the symbol through for an undefined address', () => {
-    const result = getMusdDisplaySymbol(undefined, 'USDC');
+    const result = getTokenDisplaySymbol(undefined, 'USDC');
 
     expect(result).toBe('USDC');
   });
@@ -86,7 +86,7 @@ describe('getMusdDisplaySymbol', () => {
   it('returns undefined for a non-mUSD address without a symbol', () => {
     const otherAddress = '0x1234567890123456789012345678901234567890';
 
-    const result = getMusdDisplaySymbol(otherAddress, undefined);
+    const result = getTokenDisplaySymbol(otherAddress, undefined);
 
     expect(result).toBeUndefined();
   });

--- a/app/components/UI/Earn/constants/musd.test.ts
+++ b/app/components/UI/Earn/constants/musd.test.ts
@@ -1,8 +1,10 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import {
+  getMusdDisplaySymbol,
   isMusdOnMoneyAccountChain,
   isMusdToken,
   isMusdTokenOnChain,
+  MUSD_TOKEN,
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
 } from './musd';
 
@@ -47,6 +49,46 @@ describe('isMusdToken', () => {
     const result = isMusdToken('');
 
     expect(result).toBe(false);
+  });
+});
+
+describe('getMusdDisplaySymbol', () => {
+  const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+
+  it('returns the branded mUSD symbol for the mUSD address with registry symbol MUSD', () => {
+    const result = getMusdDisplaySymbol(MUSD_ADDRESS, 'MUSD');
+
+    expect(result).toBe(MUSD_TOKEN.symbol);
+  });
+
+  it('returns the branded mUSD symbol for the mUSD address with mixed case', () => {
+    const mixedCaseAddress = '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA';
+
+    const result = getMusdDisplaySymbol(mixedCaseAddress, 'MUSD');
+
+    expect(result).toBe('mUSD');
+  });
+
+  it('passes the symbol through for a non-mUSD address', () => {
+    const otherAddress = '0x1234567890123456789012345678901234567890';
+
+    const result = getMusdDisplaySymbol(otherAddress, 'USDC');
+
+    expect(result).toBe('USDC');
+  });
+
+  it('passes the symbol through for an undefined address', () => {
+    const result = getMusdDisplaySymbol(undefined, 'USDC');
+
+    expect(result).toBe('USDC');
+  });
+
+  it('returns undefined for a non-mUSD address without a symbol', () => {
+    const otherAddress = '0x1234567890123456789012345678901234567890';
+
+    const result = getMusdDisplaySymbol(otherAddress, undefined);
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -51,11 +51,12 @@ export const isMusdToken = (address?: string): boolean => {
 };
 
 /**
- * mUSD may be registered in the token registry with the uppercase symbol
- * "MUSD" (e.g. via token detection); canonicalise it to the branded "mUSD"
- * so UI never leaks the registry casing.
+ * Resolves the display symbol for a token, special-casing tokens whose
+ * registry symbol differs from the branded casing. mUSD may be registered
+ * with the uppercase symbol "MUSD" (e.g. via token detection); canonicalise
+ * it to the branded "mUSD" so UI never leaks the registry casing.
  */
-export const getMusdDisplaySymbol = (
+export const getTokenDisplaySymbol = (
   address?: string,
   symbol?: string,
 ): string | undefined => (isMusdToken(address) ? MUSD_TOKEN.symbol : symbol);

--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -51,6 +51,16 @@ export const isMusdToken = (address?: string): boolean => {
 };
 
 /**
+ * mUSD may be registered in the token registry with the uppercase symbol
+ * "MUSD" (e.g. via token detection); canonicalise it to the branded "mUSD"
+ * so UI never leaks the registry casing.
+ */
+export const getMusdDisplaySymbol = (
+  address?: string,
+  symbol?: string,
+): string | undefined => (isMusdToken(address) ? MUSD_TOKEN.symbol : symbol);
+
+/**
  * Like {@link isMusdToken} but also requires `chainId` to be a chain where
  * mUSD is actually deployed. Prevents a same-address token on an unsupported
  * chain from being misclassified as mUSD.

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
@@ -80,6 +80,29 @@ describe('TransactionDetailsPaidWithRow', () => {
     expect(getByText(TOKEN_SYMBOL_MOCK)).toBeDefined();
   });
 
+  it('renders branded mUSD symbol when registry token at the mUSD address has symbol MUSD', () => {
+    const musdAddress = '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA';
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        metamaskPay: {
+          chainId: CHAIN_ID_MOCK,
+          tokenAddress: musdAddress,
+        },
+      } as unknown as TransactionMeta,
+    });
+    useTokenWithBalanceMock.mockReturnValue({
+      address: musdAddress,
+      chainId: CHAIN_ID_MOCK,
+      decimals: 6,
+      symbol: 'MUSD',
+    } as unknown as ReturnType<typeof useTokenWithBalance>);
+
+    const { getByText, queryByText } = render();
+
+    expect(getByText('mUSD')).toBeDefined();
+    expect(queryByText('MUSD')).toBeNull();
+  });
+
   it('renders token icon', () => {
     const { getByTestId } = render();
     expect(getByTestId('token-icon')).toBeDefined();

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -13,7 +13,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useFiatOrderStatus } from '../../../hooks/activity/useFiatOrderStatus';
 import PaymentMethodIcon from '../../../../../UI/Ramp/Aggregator/components/PaymentMethodIcon';
-import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
+import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { PaymentType } from '@consensys/on-ramp-sdk';
 import { useTheme } from '../../../../../../util/theme';
 
@@ -89,7 +89,7 @@ export function TransactionDetailsPaidWithRow() {
 
   const displayText = isFiatDeposit
     ? (paymentMethodName ?? '')
-    : (getMusdDisplaySymbol(tokenAddress, token?.symbol) ?? '');
+    : (getTokenDisplaySymbol(tokenAddress, token?.symbol) ?? '');
 
   return (
     <TransactionDetailsRow label={label}>

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -13,6 +13,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useFiatOrderStatus } from '../../../hooks/activity/useFiatOrderStatus';
 import PaymentMethodIcon from '../../../../../UI/Ramp/Aggregator/components/PaymentMethodIcon';
+import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { PaymentType } from '@consensys/on-ramp-sdk';
 import { useTheme } from '../../../../../../util/theme';
 
@@ -88,7 +89,7 @@ export function TransactionDetailsPaidWithRow() {
 
   const displayText = isFiatDeposit
     ? (paymentMethodName ?? '')
-    : (token?.symbol ?? '');
+    : (getMusdDisplaySymbol(tokenAddress, token?.symbol) ?? '');
 
   return (
     <TransactionDetailsRow label={label}>

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
@@ -31,7 +31,7 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-function render() {
+function render(to = '0x999') {
   return renderWithProvider(
     <ApprovalSummaryLine
       transactionMeta={
@@ -41,7 +41,7 @@ function render() {
           hash: '0x456',
           submittedTime: 1755719285723,
           type: TransactionType.tokenMethodApprove,
-          txParams: { from: '0x123', to: '0x999' },
+          txParams: { from: '0x123', to },
         } as unknown as TransactionMeta
       }
     />,
@@ -106,6 +106,31 @@ describe('ApprovalSummaryLine', () => {
     render();
 
     expect(useTokenWithBalanceMock).toHaveBeenCalledWith('0x999', '0x1');
+  });
+
+  it('renders branded mUSD symbol when registry token at the mUSD address has symbol MUSD', () => {
+    useTokenWithBalanceMock.mockReturnValue({ symbol: 'MUSD' } as ReturnType<
+      typeof useTokenWithBalance
+    >);
+
+    const { getByText, queryByText } = render(
+      '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA',
+    );
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_approval', {
+          approveSymbol: 'mUSD',
+        }),
+      ),
+    ).toBeDefined();
+    expect(
+      queryByText(
+        strings('transaction_details.summary_title.bridge_approval', {
+          approveSymbol: 'MUSD',
+        }),
+      ),
+    ).toBeNull();
   });
 
   it('renders loading title when token symbol is unavailable', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.tsx
@@ -3,7 +3,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
-import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
+import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 
 export function ApprovalSummaryLine({
@@ -18,7 +18,7 @@ export function ApprovalSummaryLine({
     transactionMeta.chainId,
   );
 
-  const approveSymbol = getMusdDisplaySymbol(tokenAddress, token?.symbol);
+  const approveSymbol = getTokenDisplaySymbol(tokenAddress, token?.symbol);
 
   const title = approveSymbol
     ? strings('transaction_details.summary_title.bridge_approval', {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.tsx
@@ -3,6 +3,7 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
+import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 
 export function ApprovalSummaryLine({
@@ -17,9 +18,11 @@ export function ApprovalSummaryLine({
     transactionMeta.chainId,
   );
 
-  const title = token?.symbol
+  const approveSymbol = getMusdDisplaySymbol(tokenAddress, token?.symbol);
+
+  const title = approveSymbol
     ? strings('transaction_details.summary_title.bridge_approval', {
-        approveSymbol: token.symbol,
+        approveSymbol,
       })
     : strings('transaction_details.summary_title.bridge_approval_loading');
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
@@ -33,7 +33,10 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-function render(parentType: TransactionType = TransactionType.perpsDeposit) {
+function render(
+  parentType: TransactionType = TransactionType.perpsDeposit,
+  tokenAddress = '0x123',
+) {
   return renderWithProvider(
     <DepositSummaryLine
       transactionMeta={
@@ -51,7 +54,7 @@ function render(parentType: TransactionType = TransactionType.perpsDeposit) {
           chainId: '0x1',
           type: parentType,
           metamaskPay: {
-            tokenAddress: '0x123',
+            tokenAddress,
             chainId: '0x1',
           },
         } as unknown as TransactionMeta
@@ -128,6 +131,34 @@ describe('DepositSummaryLine', () => {
         }),
       ),
     ).toBeDefined();
+  });
+
+  it('renders branded mUSD symbol when registry token at the mUSD address has symbol MUSD', () => {
+    useTokenWithBalanceMock.mockReturnValue({ symbol: 'MUSD' } as ReturnType<
+      typeof useTokenWithBalance
+    >);
+
+    const { getByText, queryByText } = render(
+      TransactionType.perpsDeposit,
+      '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA',
+    );
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_send', {
+          sourceSymbol: 'mUSD',
+          sourceChain: 'Ethereum',
+        }),
+      ),
+    ).toBeDefined();
+    expect(
+      queryByText(
+        strings('transaction_details.summary_title.bridge_send', {
+          sourceSymbol: 'MUSD',
+          sourceChain: 'Ethereum',
+        }),
+      ),
+    ).toBeNull();
   });
 
   it('renders loading title when token or network unavailable', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
@@ -7,7 +7,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
-import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
+import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 
 export function DepositSummaryLine({
@@ -30,7 +30,7 @@ export function DepositSummaryLine({
     TransactionType.musdConversion,
   ]);
 
-  const sourceSymbol = getMusdDisplaySymbol(tokenAddress, sourceToken?.symbol);
+  const sourceSymbol = getTokenDisplaySymbol(tokenAddress, sourceToken?.symbol);
 
   const title =
     sourceSymbol && sourceNetworkName

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
@@ -7,6 +7,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
+import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 
 export function DepositSummaryLine({
@@ -29,14 +30,16 @@ export function DepositSummaryLine({
     TransactionType.musdConversion,
   ]);
 
+  const sourceSymbol = getMusdDisplaySymbol(tokenAddress, sourceToken?.symbol);
+
   const title =
-    sourceToken?.symbol && sourceNetworkName
+    sourceSymbol && sourceNetworkName
       ? strings(
           isMusdConversion
             ? 'transaction_details.summary_title.musd_convert_send'
             : 'transaction_details.summary_title.bridge_send',
           {
-            sourceSymbol: sourceToken.symbol,
+            sourceSymbol,
             sourceChain: sourceNetworkName,
           },
         )

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
@@ -202,6 +202,46 @@ describe('ReceiveSummaryLine', () => {
     ).toBeDefined();
   });
 
+  it('renders branded mUSD symbol for predict withdraw when registry token at the mUSD address has symbol MUSD', () => {
+    useNetworkNameMock.mockImplementation((chainId?: Hex) =>
+      chainId === '0x1' ? 'Ethereum' : 'Polygon',
+    );
+    jest
+      .mocked(useTokenWithBalance)
+      .mockReturnValue({ symbol: 'MUSD' } as ReturnType<
+        typeof useTokenWithBalance
+      >);
+
+    const { getByText, queryByText } = render({
+      id: 'tx-id',
+      chainId: '0x89' as Hex,
+      hash: '0x123',
+      submittedTime: 1755719285723,
+      type: TransactionType.predictWithdraw,
+      metamaskPay: {
+        chainId: '0x1' as Hex,
+        tokenAddress: '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA' as Hex,
+      },
+    } as Partial<TransactionMeta>);
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_receive', {
+          targetSymbol: 'mUSD',
+          targetChain: 'Ethereum',
+        }),
+      ),
+    ).toBeDefined();
+    expect(
+      queryByText(
+        strings('transaction_details.summary_title.bridge_receive', {
+          targetSymbol: 'MUSD',
+          targetChain: 'Ethereum',
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it('renders perps withdraw title with mUSD and destination network', () => {
     useNetworkNameMock.mockImplementation((chainId?: Hex) =>
       chainId === '0xmonad' ? 'Monad' : 'Arbitrum',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -9,7 +9,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { POLYGON_PUSD } from '../../../constants/predict';
-import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
+import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 
@@ -65,7 +65,7 @@ export function ReceiveSummaryLine({
     targetSymbol = POLYGON_PUSD.symbol;
   } else if (isPredictWithdraw) {
     targetSymbol =
-      getMusdDisplaySymbol(sourceTokenAddress, sourceToken?.symbol) ??
+      getTokenDisplaySymbol(sourceTokenAddress, sourceToken?.symbol) ??
       'Unknown';
     finalTargetNetworkName = sourceNetworkName;
     receiveChainId = sourceChainId ?? '0x0';

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -9,6 +9,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { POLYGON_PUSD } from '../../../constants/predict';
+import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 import { TransactionSummaryLine } from './transaction-summary-line';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 
@@ -63,7 +64,9 @@ export function ReceiveSummaryLine({
   } else if (isPredictDeposit) {
     targetSymbol = POLYGON_PUSD.symbol;
   } else if (isPredictWithdraw) {
-    targetSymbol = sourceToken?.symbol ?? 'Unknown';
+    targetSymbol =
+      getMusdDisplaySymbol(sourceTokenAddress, sourceToken?.symbol) ??
+      'Unknown';
     finalTargetNetworkName = sourceNetworkName;
     receiveChainId = sourceChainId ?? '0x0';
   }

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
@@ -115,6 +115,39 @@ describe('SourceHashSummaryLine', () => {
     ).toBeDefined();
   });
 
+  it('renders branded mUSD symbol when registry token at the mUSD address has symbol MUSD', () => {
+    useTokenWithBalanceMock.mockReturnValue({ symbol: 'MUSD' } as ReturnType<
+      typeof useTokenWithBalance
+    >);
+
+    const { getByText, queryByText } = render({
+      id: 'parent-id',
+      chainId: '0x1' as Hex,
+      submittedTime: 1755719285723,
+      metamaskPay: {
+        tokenAddress: '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA' as Hex,
+        chainId: '0x1' as Hex,
+      },
+    } as Partial<TransactionMeta>);
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_send', {
+          sourceSymbol: 'mUSD',
+          sourceChain: 'Ethereum',
+        }),
+      ),
+    ).toBeDefined();
+    expect(
+      queryByText(
+        strings('transaction_details.summary_title.bridge_send', {
+          sourceSymbol: 'MUSD',
+          sourceChain: 'Ethereum',
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it('navigates to block explorer when button is pressed', () => {
     const { getByTestId } = render();
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
@@ -11,6 +11,7 @@ import { TransactionSummaryLine } from './transaction-summary-line';
 import { hasTransactionType } from '../../../utils/transaction';
 import { POLYGON_PUSD } from '../../../constants/predict';
 import { ARBITRUM_USDC } from '../../../constants/perps';
+import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 
 export function SourceHashSummaryLine({
   parentTransaction,
@@ -42,6 +43,11 @@ export function SourceHashSummaryLine({
   const chainId =
     isPredictWithdraw || isPerpsWithdraw ? targetChainId : sourceTokenChainId;
 
+  const sourceSymbol = getMusdDisplaySymbol(
+    sourceTokenAddress,
+    sourceToken?.symbol,
+  );
+
   let title = strings('transaction_details.summary_title.bridge_send_loading');
 
   if (isPerpsWithdraw) {
@@ -49,9 +55,9 @@ export function SourceHashSummaryLine({
       sourceSymbol: ARBITRUM_USDC.symbol,
       sourceChain: targetNetworkName,
     });
-  } else if (sourceToken?.symbol && sourceNetworkName) {
+  } else if (sourceSymbol && sourceNetworkName) {
     title = strings('transaction_details.summary_title.bridge_send', {
-      sourceSymbol: sourceToken.symbol,
+      sourceSymbol,
       sourceChain: sourceNetworkName,
     });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
@@ -11,7 +11,7 @@ import { TransactionSummaryLine } from './transaction-summary-line';
 import { hasTransactionType } from '../../../utils/transaction';
 import { POLYGON_PUSD } from '../../../constants/predict';
 import { ARBITRUM_USDC } from '../../../constants/perps';
-import { getMusdDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
+import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';
 
 export function SourceHashSummaryLine({
   parentTransaction,
@@ -43,7 +43,7 @@ export function SourceHashSummaryLine({
   const chainId =
     isPredictWithdraw || isPerpsWithdraw ? targetChainId : sourceTokenChainId;
 
-  const sourceSymbol = getMusdDisplaySymbol(
+  const sourceSymbol = getTokenDisplaySymbol(
     sourceTokenAddress,
     sourceToken?.symbol,
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The transaction details page (Money account activity) interpolates the raw TokensController registry symbol into the step descriptions and the "Paid with" row. mUSD can land in the registry with the uppercase symbol `MUSD` (token detection / token API) while Money flows register it as the branded `mUSD`, so depending on which write wins the page shows "Bridge MUSD from Ethereum" / "Paid with MUSD" and can visibly blink from `MUSD` to `mUSD` when the registry entry updates.

This PR canonicalises the mUSD symbol at display time, keyed on the token **address** (stable identity) rather than the registry casing:

- New `getMusdDisplaySymbol(address, symbol)` helper next to the existing `isMusdToken` in `app/components/UI/Earn/constants/musd.ts` — returns the branded `mUSD` for the mUSD token address, passes every other symbol through untouched.
- Applied at the five places on the transaction details page that render a registry symbol as text: `deposit-summary-line`, `source-hash-summary-line`, `receive-summary-line` (predictWithdraw branch), `approval-summary-line`, and `transaction-details-paid-with-row`.

Display-layer only: no hook, selector, or controller changes, and non-mUSD tokens are byte-identical to before. This mirrors the canonicalisation already done in `useMoneyTransactionDisplayInfo`.

Not included: the ticket's third AC (row jitter when the block-explorer icon appears) requires changing the shared `ProgressListItem` used by other confirmation screens and will be handled separately.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed transaction details showing the mUSD token symbol with incorrect casing (MUSD) in step descriptions and the Paid with row

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1122

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: mUSD symbol casing on transaction details

  Scenario: user opens a pending mUSD deposit from the Money activity list
    Given the user has a Money account deposit that bridges mUSD from Ethereum to Monad

    When user opens the transaction from the activity list
    Then the step description reads "Bridge mUSD from Ethereum" (never "MUSD") from the first render, with no casing blink

  Scenario: user checks the Paid with row on a transaction paid with mUSD
    Given a transaction whose payment token is mUSD

    When user opens the transaction details
    Then the "Paid with" row shows "mUSD"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/231c7beb-2596-48c8-8952-46a129cfb318


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only string mapping in confirmation activity UI; no auth, data, or controller changes.
> 
> **Overview**
> Adds **`getTokenDisplaySymbol`** in `musd.ts` so the mUSD contract address always renders as branded **`mUSD`**, even when the token registry reports **`MUSD`**.
> 
> Transaction details now use that helper instead of raw registry symbols in the **Paid with** row and in summary steps (approval, deposit, receive for predict withdraw, and source-hash send titles). Other tokens are unchanged.
> 
> Unit tests cover the helper and each updated screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c738a581c4499adbe8d6bbe17a2c69ebd438b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->