### PR TITLE
fix: money account deposit Max deposit flow cp-8.2.0

### DIFF
--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -24,10 +24,12 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
 import { useIsMoneyAccountFlagDefault } from '../../../hooks/pay/useIsMoneyAccountFlagDefault';
+import { usePayTokenAccountBalance } from '../../../hooks/pay/usePayTokenAccountBalance';
 
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../../../../util/navigation/navUtils');
 jest.mock('../../../hooks/pay/useIsMoneyAccountFlagDefault');
+jest.mock('../../../hooks/pay/usePayTokenAccountBalance');
 jest.mock('../../../../../UI/Money/hooks/useMoneyAccountBalance');
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -157,6 +159,10 @@ describe('PayWithRow', () => {
     jest
       .mocked(useTransactionPayAvailableTokens)
       .mockReturnValue({ availableTokens: [], hasTokens: true });
+    jest.mocked(usePayTokenAccountBalance).mockReturnValue({
+      balanceUsd: '0',
+      balanceRaw: '0',
+    });
   });
 
   it('renders selected pay token', async () => {
@@ -228,6 +234,21 @@ describe('PayWithRow', () => {
           mm_pay_token_list_opened: true,
         },
       });
+    });
+  });
+
+  describe('balance formatting', () => {
+    it('truncates balance to 2 decimal places with ROUND_DOWN', () => {
+      jest.mocked(usePayTokenAccountBalance).mockReturnValue({
+        balanceUsd: '1234.999',
+        balanceRaw: '0',
+      });
+
+      const { getByTestId } = render();
+      const balanceEl = getByTestId('pay-with-balance');
+
+      expect(balanceEl).toHaveTextContent('($1,234.99)');
+      expect(balanceEl).not.toHaveTextContent('1,235');
     });
   });
 

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -208,7 +208,10 @@ function PayWithRowInteractive() {
   }, [hasAccountNoFunds, isWithdraw, payToken, defaultWithdrawToken]);
 
   const balanceUsdFormatted = useMemo(
-    () => formatFiat(new BigNumber(accountBalanceUsd)),
+    () =>
+      formatFiat(
+        new BigNumber(accountBalanceUsd).decimalPlaces(2, BigNumber.ROUND_DOWN),
+      ),
     [formatFiat, accountBalanceUsd],
   );
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -1105,6 +1105,198 @@ describe('useTransactionCustomAmount', () => {
     });
   });
 
+  describe('money account deposit max precision', () => {
+    const depositTransactionMeta = {
+      type: TransactionType.moneyAccountDeposit,
+      batchId: '0xtestbatchid' as Hex,
+    };
+
+    beforeEach(() => {
+      jest.mocked(getMoneyAccountDepositIntent).mockReturnValue('convert');
+    });
+
+    it('updateTokenAmount uses full-precision amount from balanceRaw for 100% deposit', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result } = runHook({
+        transactionMeta: depositTransactionMeta,
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // Should use balanceRaw-derived value (1123456 × 10^-6 = 1.123456),
+      // NOT the lossy fiat roundtrip (2.24 ÷ 2 = 1.12)
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.123456');
+    });
+
+    it('updateTokenAmount uses fiat-derived amount for sub-100% deposit', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result } = runHook({
+        transactionMeta: depositTransactionMeta,
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(50);
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // 50% of 2.246912 rounded down = 1.12, ÷ 2 (fiat rate) = 0.56
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('0.56');
+    });
+
+    it('manual input clears the deposit max override', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result } = runHook({
+        transactionMeta: depositTransactionMeta,
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmount('7');
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // Manual input clears depositMaxHumanRef → uses fiat-derived amount
+      // amountFiat = 7, amountHuman = 7 ÷ 2 = 3.5
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('3.5');
+    });
+
+    it('does not set deposit max for non-deposit types at 100%', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result } = runHook(); // default = simpleSend
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // Non-deposit type → no depositMaxHumanRef → fiat-derived amount
+      // 100% of 2.246912 rounded down = 2.24, ÷ 2 = 1.12
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.12');
+    });
+
+    it('resets deposit max when payToken changes', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result, rerender } = runHook({
+        transactionMeta: depositTransactionMeta,
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      // Switch to a different token
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: '0xdifferent0000000000000000000000000000000' as Hex,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          decimals: 6,
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      await act(async () => {
+        rerender({});
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // payToken change resets depositMaxHumanRef → uses fiat-derived amount
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.12');
+    });
+
+    it('defaults to 6 decimals when payToken.decimals is undefined', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceUsd: '2.246912',
+          balanceRaw: '1123456',
+          chainId: '0x1' as Hex,
+        } as TransactionPaymentToken,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      const { result } = runHook({
+        transactionMeta: depositTransactionMeta,
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      await act(async () => {
+        result.current.updateTokenAmount();
+      });
+
+      // decimals defaults to 6: 1123456 × 10^-6 = 1.123456
+      expect(updateTransactionPayAmountMock).toHaveBeenCalledWith('1.123456');
+    });
+  });
+
   it('resets isMax to false when updating amount while isMaxAmount is true', async () => {
     useTransactionPayIsMaxAmountMock.mockReturnValue(true);
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -74,6 +74,7 @@ export function useTransactionCustomAmount({
   const [isTokenAmountUpdated, setIsTokenAmountUpdated] = useState(false);
   const [isPrefillPending, setIsPrefillPending] = useState(isAddMusdFlow);
   const hasPrefilled = useRef(false);
+  const depositMaxHumanRef = useRef<string | null>(null);
 
   const debounceSetAmountDelayed = useMemo(
     () =>
@@ -105,6 +106,7 @@ export function useTransactionCustomAmount({
     ? musdFiatRate
     : payTokenFiatRate;
   const balanceUsd = useTokenBalance(tokenFiatRate);
+  const { payToken } = useTransactionPayToken();
 
   const { updateTransactionPayAmount } = useUpdateTransactionPayAmount();
 
@@ -205,6 +207,8 @@ export function useTransactionCustomAmount({
         setIsMax(false);
       }
 
+      depositMaxHumanRef.current = null;
+
       setConfirmationMetric({
         properties: {
           mm_pay_amount_input_type: 'manual',
@@ -263,6 +267,18 @@ export function useTransactionCustomAmount({
         setIsMax(false);
       }
 
+      // For money account deposit max, store the full-precision human amount
+      // derived directly from the raw token balance. This bypasses the lossy
+      // fiat roundtrip (ROUND_DOWN → ÷ rate → × 10^decimals → ROUND_UP) that
+      // can inflate the required amount past the actual balance.
+      if (percentage === 100 && isMoneyAccountDeposit && payToken?.balanceRaw) {
+        depositMaxHumanRef.current = new BigNumber(payToken.balanceRaw)
+          .shiftedBy(-(payToken.decimals ?? 6))
+          .toString(10);
+      } else {
+        depositMaxHumanRef.current = null;
+      }
+
       setAmountFiat(newAmount);
     },
     [
@@ -272,6 +288,8 @@ export function useTransactionCustomAmount({
       isMoneyAccountWithdraw,
       isMoneyAccountDeposit,
       isAddMusdFlow,
+      payToken?.balanceRaw,
+      payToken?.decimals,
       setIsMax,
       setConfirmationMetric,
     ],
@@ -291,7 +309,8 @@ export function useTransactionCustomAmount({
   }, [isAddMusdFlow, balanceUsd, updatePendingAmountPercentage]);
 
   const updateTokenAmount = useCallback(async () => {
-    await updateTransactionPayAmount(amountHuman);
+    const effectiveHuman = depositMaxHumanRef.current ?? amountHuman;
+    await updateTransactionPayAmount(effectiveHuman);
     setIsTokenAmountUpdated(true);
   }, [amountHuman, updateTransactionPayAmount]);
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -108,6 +108,10 @@ export function useTransactionCustomAmount({
   const balanceUsd = useTokenBalance(tokenFiatRate);
   const { payToken } = useTransactionPayToken();
 
+  useEffect(() => {
+    depositMaxHumanRef.current = null;
+  }, [payToken?.address, payToken?.chainId]);
+
   const { updateTransactionPayAmount } = useUpdateTransactionPayAmount();
 
   // Gating mirrors useFiatBuyLimitAlert so the keypad cap and the limit alert agree.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Fix issue with Max deposit giving insufficient funds alert on money account.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1660

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit amount calculation for money account max flows; incorrect precision logic could still under- or over-deposit, but scope is limited to deposit max and display formatting with broad test coverage.
> 
> **Overview**
> Fixes **money account deposit “Max”** triggering insufficient-funds when fiat rounding made the requested token amount slightly larger than the wallet balance.
> 
> For **100% money account deposits**, `useTransactionCustomAmount` now keeps a `depositMaxHumanRef` derived from `payToken.balanceRaw` (with decimals) and passes that to `updateTransactionPayAmount` instead of the fiat-derived human amount. The override is cleared on manual input, non-deposit flows, sub-100% percentages, and when the pay token changes.
> 
> The **pay-with row** now formats the displayed USD balance with **2 decimal places and `ROUND_DOWN`**, so the UI does not round balances up (e.g. `$1,234.99` instead of `$1,235`).
> 
> Tests cover deposit max precision, override reset behavior, and balance formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4aaca24c695977efb9a8174edeace39de86025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->