### PR TITLE
feat: update legend indicator subpane v2

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -815,6 +815,8 @@ export interface LegendIndicatorConfig {
   combineInOnePill?: boolean;
   /** Leading title when combineInOnePill is true (e.g. BB(20,2)). */
   title?: string;
+  /** When true, legend pills render in the study's own sub-pane instead of the main overlay. */
+  subPaneLegend?: boolean;
 }
 
 export interface LegendOverlayConfig {

--- a/app/components/UI/Charts/AdvancedChart/indicatorColors.ts
+++ b/app/components/UI/Charts/AdvancedChart/indicatorColors.ts
@@ -129,6 +129,7 @@ export const buildIndicatorLegendConfig = (
 
   return {
     MACD: {
+      subPaneLegend: true,
       plots: [
         { tvTitle: 'MACD', label: 'MACD(12,26)', color: colors.MACD.macd },
         { tvTitle: 'Signal', label: 'Signal', color: colors.MACD.signal },
@@ -141,6 +142,7 @@ export const buildIndicatorLegendConfig = (
       useIndex: true,
     },
     RSI: {
+      subPaneLegend: true,
       plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: colors.RSI.plot }],
       useIndex: true,
     },
@@ -168,6 +170,16 @@ export const getTokenDetailsLegendOverlay = (
   enabled: true,
   config: buildIndicatorLegendConfig(getIndicatorColorSet(themeAppearance)),
 });
+
+/**
+ * Sub-pane indicator names derived from legend config so there's a single
+ * source of truth — adding `subPaneLegend: true` to a new entry is enough.
+ */
+export const SUB_PANE_INDICATORS = Object.entries(
+  buildIndicatorLegendConfig(getIndicatorColorSet()),
+)
+  .filter(([, cfg]) => cfg.subPaneLegend === true)
+  .map(([name]) => name) as readonly string[];
 
 export const getIndicatorColorsForWebview = (
   themeAppearance: ChartThemeAppearance = AppThemeKey.dark,

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -2736,7 +2736,7 @@ function __resetVisibleRangeForTests() {
 // The overlay is a \`<div id="study-legend-overlay">\` injected into
 // #tv_chart_container that holds one \`.legend-pill\` per active indicator.
 // Theme-aware text colors are computed from CONFIG.theme; per-plot colors
-// come from CONFIG.indicatorColors.
+// come from the legend config supplied by RN.
 //
 // \`LEGEND_RENDERED\` is posted to RN once the overlay has settled (either
 // real values returned by chart.exportData() or after the retry timeout).
@@ -2752,16 +2752,14 @@ let exportGeneration = 0;
 let retryCount = 0;
 let timeoutId = null;
 let legendOverlayEnabled = false;
-let indicatorColors;
-/** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
+/** Typed legend config from RN — the single source of truth for legend rendering. */
 let legendConfig;
 /** Sub-pane overlay elements keyed by indicator name. */
 const subPaneOverlays = new Map();
 // ----- Lifecycle ---------------------------------------------------------
 /** Called once on chart-ready to set up the DOM container. */
-function setupLegendOverlay(config, colors) {
+function setupLegendOverlay(config) {
     legendOverlayEnabled = Boolean(config?.enabled);
-    indicatorColors = colors;
     legendConfig = config?.config;
     if (!legendOverlayEnabled)
         return;
@@ -2825,79 +2823,11 @@ function injectHideLegendButtonsCSS() {
 }
 // ----- Legend rebuild ---------------------------------------------------
 /**
- * Returns the per-indicator legend config. When RN supplied a typed config via
- * legendOverlay.config (the single source of truth), use it directly.
- * Otherwise fall back to a minimal built-in map derived from indicatorColors.
+ * Returns the per-indicator legend config supplied by RN via legendOverlay.config.
+ * Consumers must pass their own config — there is no built-in fallback.
  */
 function getPresetMap() {
-    if (legendConfig)
-        return legendConfig;
-    return buildFallbackPresetMap();
-}
-function buildFallbackPresetMap() {
-    const macd = indicatorColors?.MACD ?? {};
-    const rsi = indicatorColors?.RSI ?? {};
-    const bol = indicatorColors?.BOL ?? {};
-    const ma = indicatorColors?.MA ?? {};
-    return {
-        MACD: {
-            subPaneLegend: true,
-            plots: [
-                { tvTitle: 'MACD', label: 'MACD(12,26)', color: macd.macd ?? null },
-                { tvTitle: 'Signal', label: 'Signal', color: macd.signal ?? null },
-                {
-                    tvTitle: 'Histogram',
-                    label: 'Hist',
-                    color: macd.histogramPositive ?? null,
-                },
-            ],
-            useIndex: true,
-        },
-        RSI: {
-            subPaneLegend: true,
-            plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: rsi.plot ?? null }],
-            useIndex: true,
-        },
-        BOL: {
-            combineInOnePill: true,
-            title: 'BB(20,2)',
-            plots: [
-                { tvTitle: 'Upper', label: 'U:', color: bol.upper ?? null },
-                { tvTitle: 'Median', label: 'M:', color: bol.basis ?? null },
-                { tvTitle: 'Lower', label: 'L:', color: bol.lower ?? null },
-            ],
-            useIndex: true,
-        },
-        Volume: {
-            plots: [{ tvTitle: 'Vol', label: 'Vol', color: null }],
-            useIndex: true,
-        },
-        MA5: {
-            isMA: true,
-            useIndex: true,
-            plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: ma.MA5 ?? null }],
-        },
-        MA10: {
-            isMA: true,
-            useIndex: true,
-            plots: [{ tvTitle: 'Plot', label: 'MA(10)', color: ma.MA10 ?? null }],
-        },
-        MA20: {
-            isMA: true,
-            useIndex: true,
-            plots: [{ tvTitle: 'Plot', label: 'MA(20)', color: ma.MA20 ?? null }],
-        },
-        MA50: {
-            isMA: true,
-            useIndex: true,
-            plots: [{ tvTitle: 'Plot', label: 'MA(50)', color: ma.MA50 ?? null }],
-        },
-        MA200: {
-            isMA: true,
-            useIndex: true,
-            plots: [{ tvTitle: 'Plot', label: 'MA(200)', color: ma.MA200 ?? null }],
-        },
-    };
+    return legendConfig ?? {};
 }
 function getLegendAltColor() {
     const theme = getTheme();
@@ -3308,7 +3238,6 @@ function __resetLegendForTests() {
     retryCount = 0;
     clearTimer();
     legendOverlayEnabled = false;
-    indicatorColors = undefined;
     legendConfig = undefined;
     removeAllSubPaneOverlays();
 }
@@ -5045,7 +4974,7 @@ function bootstrap() {
                         flushPendingTheme();
                         applyScaleLayout();
                         applyVisualOverrides(config.visualOverrides);
-                        setupLegendOverlay(config.legendOverlay, config.indicatorColors);
+                        setupLegendOverlay(config.legendOverlay);
                         const chart = widget.activeChart();
                         // Match legacy onChartReady: when no explicit visible range
                         // was passed, pin a 2-bar gap on the right. TV's default is

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -166,6 +166,7 @@ const state = {
     rnBackedPagination: { enabled: false },
     hasExplicitCurrentPriceLine: false,
     hotReloadSeq: 0,
+    studyPaneIndex: new Map(),
     slbMode: false,
     slbCenteringPending: false,
     legendOwnsLayoutSettle: false,
@@ -350,6 +351,30 @@ function bumpHotReloadSeq() {
 function getHotReloadSeq() {
     return state.hotReloadSeq;
 }
+// ----- Study pane index (sub-pane tracking) -----------------------------------
+function getStudyPaneIndex(name) {
+    return state.studyPaneIndex.get(name);
+}
+function setStudyPaneIndex(name, idx) {
+    state.studyPaneIndex.set(name, idx);
+}
+function deleteStudyPaneIndex(name) {
+    state.studyPaneIndex.delete(name);
+}
+function getStudyPaneIndexMap() {
+    return state.studyPaneIndex;
+}
+/**
+ * After a sub-pane is removed, TradingView renumbers panes. Decrement all
+ * tracked indices above the removed pane so they stay in sync.
+ */
+function reindexPanesAfterRemoval(removedPaneIndex) {
+    for (const [name, idx] of state.studyPaneIndex) {
+        if (idx > removedPaneIndex) {
+            state.studyPaneIndex.set(name, idx - 1);
+        }
+    }
+}
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 function getSlbMode() {
     return state.slbMode;
@@ -406,6 +431,7 @@ function __resetStateForTests() {
     state.rnBackedPagination = { enabled: false };
     state.hasExplicitCurrentPriceLine = false;
     state.hotReloadSeq = 0;
+    state.studyPaneIndex = new Map();
     state.slbMode = false;
     state.slbCenteringPending = false;
     state.legendOwnsLayoutSettle = false;
@@ -2753,11 +2779,16 @@ let retryCount = 0;
 let timeoutId = null;
 let legendOverlayEnabled = false;
 let indicatorColors;
+/** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
+let legendConfig;
+/** Sub-pane overlay elements keyed by pane index. */
+const subPaneOverlays = new Map();
 // ----- Lifecycle ---------------------------------------------------------
 /** Called once on chart-ready to set up the DOM container. */
 function setupLegendOverlay(config, colors) {
     legendOverlayEnabled = Boolean(config?.enabled);
     indicatorColors = colors;
+    legendConfig = config?.config;
     if (!legendOverlayEnabled)
         return;
     createOverlayElement();
@@ -2774,6 +2805,7 @@ function attachLegendResizeListener(widget) {
             const el = document.getElementById(OVERLAY_ID);
             if (el)
                 updateLegendOverlayLayout();
+            repositionSubPaneOverlays(widget.activeChart());
         });
     }
     catch {
@@ -2817,25 +2849,25 @@ function injectHideLegendButtonsCSS() {
             '.legendElement .buttonsWrapper{display:none!important;}';
     targetDoc.head.appendChild(style);
 }
-function getMACDColors() {
-    return indicatorColors?.MACD ?? {};
+// ----- Legend rebuild ---------------------------------------------------
+/**
+ * Returns the per-indicator legend config. When RN supplied a typed config via
+ * legendOverlay.config (the single source of truth), use it directly.
+ * Otherwise fall back to a minimal built-in map derived from indicatorColors.
+ */
+function getPresetMap() {
+    if (legendConfig)
+        return legendConfig;
+    return buildFallbackPresetMap();
 }
-function getRSIColors() {
-    return indicatorColors?.RSI ?? {};
-}
-function getBOLColors() {
-    return indicatorColors?.BOL ?? {};
-}
-function getMAColors() {
-    return indicatorColors?.MA ?? {};
-}
-function buildPresetMap() {
-    const macd = getMACDColors();
-    const rsi = getRSIColors();
-    const bol = getBOLColors();
-    const ma = getMAColors();
+function buildFallbackPresetMap() {
+    const macd = indicatorColors?.MACD ?? {};
+    const rsi = indicatorColors?.RSI ?? {};
+    const bol = indicatorColors?.BOL ?? {};
+    const ma = indicatorColors?.MA ?? {};
     return {
         MACD: {
+            subPaneLegend: true,
             plots: [
                 { tvTitle: 'MACD', label: 'MACD(12,26)', color: macd.macd ?? null },
                 { tvTitle: 'Signal', label: 'Signal', color: macd.signal ?? null },
@@ -2848,6 +2880,7 @@ function buildPresetMap() {
             useIndex: true,
         },
         RSI: {
+            subPaneLegend: true,
             plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: rsi.plot ?? null }],
             useIndex: true,
         },
@@ -2915,7 +2948,7 @@ function wrapPill(innerHtml, color) {
 }
 function buildHTML(entries) {
     const altColor = getLegendAltColor();
-    const presets = buildPresetMap();
+    const presets = getPresetMap();
     const successColor = getTheme()?.successColor ?? 'rgb(38,166,154)';
     const pills = [];
     for (const entry of entries) {
@@ -3051,11 +3084,44 @@ function scheduleRetry(gen) {
     }, RETRY_DELAY_MS);
 }
 function renderOverlay(entries) {
-    const overlay = document.getElementById(OVERLAY_ID);
-    if (!overlay)
-        return;
-    overlay.innerHTML = buildHTML(entries);
+    const presets = getPresetMap();
+    const paneIndexMap = getStudyPaneIndexMap();
+    const mainEntries = [];
+    const subPaneGroups = new Map();
+    for (const entry of entries) {
+        const cfg = presets[entry.name];
+        const paneIdx = paneIndexMap.get(entry.name);
+        if (cfg?.subPaneLegend && paneIdx !== undefined) {
+            let group = subPaneGroups.get(paneIdx);
+            if (!group) {
+                group = [];
+                subPaneGroups.set(paneIdx, group);
+            }
+            group.push(entry);
+        }
+        else {
+            mainEntries.push(entry);
+        }
+    }
+    const mainOverlay = document.getElementById(OVERLAY_ID);
+    if (mainOverlay) {
+        mainOverlay.innerHTML = buildHTML(mainEntries);
+    }
+    const widget = getWidget();
+    const chart = widget?.activeChart();
+    const activePanes = new Set(subPaneGroups.keys());
+    for (const paneIdx of subPaneOverlays.keys()) {
+        if (!activePanes.has(paneIdx))
+            removeSubPaneOverlay(paneIdx);
+    }
+    for (const [paneIdx, group] of subPaneGroups) {
+        const overlay = ensureSubPaneOverlay(paneIdx, chart ?? undefined);
+        if (overlay)
+            overlay.innerHTML = buildHTML(group);
+    }
     updateLegendOverlayLayout();
+    if (chart)
+        repositionSubPaneOverlays(chart);
 }
 function refreshStudyLegendFromExport() {
     if (!legendOverlayEnabled)
@@ -3070,6 +3136,7 @@ function refreshStudyLegendFromExport() {
     const studyIds = Object.keys(studyIdMap);
     if (studyIds.length === 0) {
         overlay.innerHTML = '';
+        removeAllSubPaneOverlays();
         retryCount = 0;
         clearTimer();
         return;
@@ -3170,6 +3237,53 @@ function subscribeStudyDataLoaded(chart, studyId) {
     }
     scheduleLegendRefresh();
 }
+// ----- Sub-pane overlay management ----------------------------------------
+function subPaneOverlayId(paneIndex) {
+    return \`\${OVERLAY_ID}-pane-\${paneIndex}\`;
+}
+function getSubPaneTopPx(paneIndex, chart) {
+    const heights = chart.getAllPanesHeight();
+    let top = 0;
+    for (let i = 0; i < paneIndex && i < heights.length; i++) {
+        top += heights[i];
+    }
+    return top + 1;
+}
+function ensureSubPaneOverlay(paneIndex, chart) {
+    const existing = subPaneOverlays.get(paneIndex);
+    if (existing && document.contains(existing))
+        return existing;
+    const container = document.getElementById('tv_chart_container');
+    if (!container)
+        return null;
+    const div = document.createElement('div');
+    div.id = subPaneOverlayId(paneIndex);
+    const topPx = chart ? getSubPaneTopPx(paneIndex, chart) : 0;
+    div.style.cssText =
+        \`position:absolute;top:\${topPx}px;left:\${OVERLAY_LEFT_PX}px;z-index:5;\` +
+            \`pointer-events:none;display:flex;flex-wrap:wrap;align-items:flex-start;\` +
+            \`column-gap:8px;row-gap:2px;\`;
+    container.appendChild(div);
+    subPaneOverlays.set(paneIndex, div);
+    return div;
+}
+function removeSubPaneOverlay(paneIndex) {
+    const el = subPaneOverlays.get(paneIndex);
+    if (el) {
+        el.remove();
+        subPaneOverlays.delete(paneIndex);
+    }
+}
+function removeAllSubPaneOverlays() {
+    for (const el of subPaneOverlays.values())
+        el.remove();
+    subPaneOverlays.clear();
+}
+function repositionSubPaneOverlays(chart) {
+    for (const [paneIdx, el] of subPaneOverlays) {
+        el.style.top = \`\${getSubPaneTopPx(paneIdx, chart)}px\`;
+    }
+}
 // ----- Layout ------------------------------------------------------------
 function getMainPriceAxisLeftRelativeTo(el) {
     if (!el?.getBoundingClientRect)
@@ -3217,6 +3331,8 @@ function __resetLegendForTests() {
     clearTimer();
     legendOverlayEnabled = false;
     indicatorColors = undefined;
+    legendConfig = undefined;
+    removeAllSubPaneOverlays();
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/resize.ts
@@ -3247,6 +3363,65 @@ function scheduleChartWidgetResize() {
         setTimeout(run, 0);
     }
     setTimeout(run, 120);
+}
+
+;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
+// Sub-pane height ratio handler.
+//
+// Ported from chartLogic.js handleSetSubPaneLayout (~line 783) +
+// applySubPaneHeightRatio (~line 750). The consumer-supplied ratio
+// (subPaneHeightRatio prop) governs the size of RSI/MACD sub-panes.
+
+
+const MIN_MAIN_PX = 72;
+function hasActiveSubPaneIndicators() {
+    return getStudyPaneIndexMap().size > 0;
+}
+function applySubPaneHeightRatio(chart) {
+    const ratio = getSubPaneHeightRatio();
+    if (ratio === null)
+        return;
+    try {
+        const heights = chart.getAllPanesHeight();
+        if (heights.length < 2)
+            return;
+        const total = heights.reduce((sum, h) => sum + h, 0);
+        const bottomCount = heights.length - 1;
+        let bottomTotal = Math.round(total * ratio * bottomCount);
+        let main = total - bottomTotal;
+        if (main < MIN_MAIN_PX) {
+            main = MIN_MAIN_PX;
+            bottomTotal = total - main;
+        }
+        const newHeights = [main];
+        let remaining = bottomTotal;
+        for (let i = 0; i < bottomCount; i++) {
+            const h = i === bottomCount - 1
+                ? remaining
+                : Math.floor(bottomTotal / bottomCount);
+            newHeights.push(h);
+            remaining -= h;
+        }
+        chart.setAllPanesHeight(newHeights);
+    }
+    catch (error) {
+        reportErrorToRN(error);
+    }
+}
+function handleSetSubPaneLayout(payload) {
+    if (payload.heightRatio == null) {
+        setSubPaneHeightRatio(null);
+        return;
+    }
+    const ratio = payload.heightRatio;
+    if (typeof ratio !== 'number' || !(ratio > 0 && ratio <= 1)) {
+        return;
+    }
+    setSubPaneHeightRatio(ratio);
+    const widget = getWidget();
+    if (widget && isChartReady() && hasActiveSubPaneIndicators()) {
+        applySubPaneHeightRatio(widget.activeChart());
+    }
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/studies.ts
@@ -3292,6 +3467,7 @@ function macdPreset(colors) {
             'Histogram.color.0': c.histogramPositive,
             'Histogram.color.1': c.histogramNegative,
         },
+        paneTarget: 'sub',
     };
 }
 function rsiPreset(colors) {
@@ -3303,6 +3479,7 @@ function rsiPreset(colors) {
             'Plot.color': c.plot,
             'hlines background.visible': false,
         },
+        paneTarget: 'sub',
     };
 }
 function bolPreset(colors) {
@@ -3367,13 +3544,8 @@ function resolveStudyPreset(name, indicatorColors, inputsOverride) {
         }
     }
 }
-/** Sub-pane indicators always render in a dedicated pane below the main series. */
-const SUB_PANE_INDICATOR_NAMES = new Set([
-    'MACD',
-    'RSI',
-]);
-function isSubPaneIndicator(name) {
-    return SUB_PANE_INDICATOR_NAMES.has(name);
+function isSubPanePreset(preset) {
+    return preset.paneTarget === 'sub';
 }
 /**
  * Creates the indicator study on the given chart, returning the studyId once
@@ -3381,70 +3553,6 @@ function isSubPaneIndicator(name) {
  */
 function createIndicatorStudy(chart, preset) {
     return chart.createStudy(preset.studyName, false, false, preset.inputs, preset.overrides);
-}
-
-;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
-// Sub-pane height ratio handler.
-//
-// Ported from chartLogic.js handleSetSubPaneLayout (~line 783) +
-// applySubPaneHeightRatio (~line 750). The consumer-supplied ratio
-// (subPaneHeightRatio prop) governs the size of RSI/MACD sub-panes.
-
-
-
-const MIN_MAIN_PX = 72;
-function hasActiveSubPaneIndicators() {
-    for (const name of getActiveStudies().keys()) {
-        if (isSubPaneIndicator(name))
-            return true;
-    }
-    return false;
-}
-function applySubPaneHeightRatio(chart) {
-    const ratio = getSubPaneHeightRatio();
-    if (ratio === null)
-        return;
-    try {
-        const heights = chart.getAllPanesHeight();
-        if (heights.length < 2)
-            return;
-        const total = heights.reduce((sum, h) => sum + h, 0);
-        const bottomCount = heights.length - 1;
-        let bottomTotal = Math.round(total * ratio * bottomCount);
-        let main = total - bottomTotal;
-        if (main < MIN_MAIN_PX) {
-            main = MIN_MAIN_PX;
-            bottomTotal = total - main;
-        }
-        const newHeights = [main];
-        let remaining = bottomTotal;
-        for (let i = 0; i < bottomCount; i++) {
-            const h = i === bottomCount - 1
-                ? remaining
-                : Math.floor(bottomTotal / bottomCount);
-            newHeights.push(h);
-            remaining -= h;
-        }
-        chart.setAllPanesHeight(newHeights);
-    }
-    catch (error) {
-        reportErrorToRN(error);
-    }
-}
-function handleSetSubPaneLayout(payload) {
-    if (payload.heightRatio == null) {
-        setSubPaneHeightRatio(null);
-        return;
-    }
-    const ratio = payload.heightRatio;
-    if (typeof ratio !== 'number' || !(ratio > 0 && ratio <= 1)) {
-        return;
-    }
-    setSubPaneHeightRatio(ratio);
-    const widget = getWidget();
-    if (widget && isChartReady() && hasActiveSubPaneIndicators()) {
-        applySubPaneHeightRatio(widget.activeChart());
-    }
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/index.ts
@@ -3491,7 +3599,9 @@ function handleAddIndicator(payload, config) {
     createIndicatorStudy(chart, preset)
         .then((studyId) => {
         registerStudy('active', name, studyId);
-        if (isSubPaneIndicator(name)) {
+        if (isSubPanePreset(preset)) {
+            const paneIdx = chart.getAllPanesHeight().length - 1;
+            setStudyPaneIndex(name, paneIdx);
             applySubPaneHeightRatio(chart);
         }
         subscribeStudyDataLoaded(chart, studyId);
@@ -3518,12 +3628,19 @@ function handleRemoveIndicator(payload) {
     const studyId = unregisterStudy(name);
     if (!studyId)
         return;
+    const removedPaneIdx = getStudyPaneIndex(name);
+    const wasSubPane = removedPaneIdx !== undefined;
+    if (wasSubPane) {
+        removeSubPaneOverlay(removedPaneIdx);
+        deleteStudyPaneIndex(name);
+        reindexPanesAfterRemoval(removedPaneIdx);
+    }
     try {
         const chart = widget.activeChart();
         chart.removeEntity(studyId);
         scheduleLegendRefresh();
         postToRN('INDICATOR_REMOVED', { name });
-        if (isSubPaneIndicator(name) && hasActiveSubPaneIndicators()) {
+        if (wasSubPane && hasActiveSubPaneIndicators()) {
             applySubPaneHeightRatio(chart);
         }
     }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -3193,43 +3193,34 @@ function repositionSubPaneOverlays(chart) {
     }
 }
 // ----- Layout ------------------------------------------------------------
-function getMainPriceAxisLeftRelativeTo(el) {
-    if (!el?.getBoundingClientRect)
-        return null;
-    const orect = el.getBoundingClientRect();
-    let bestLeft = null;
-    let bestTop = Infinity;
-    eachChartDocument((doc) => {
-        const nodes = doc.querySelectorAll('.price-axis-container');
-        for (const node of Array.from(nodes)) {
-            const r = node.getBoundingClientRect();
-            if (r.width < 2 || r.height < 16)
-                continue;
-            if (r.top < bestTop) {
-                bestTop = r.top;
-                bestLeft = r.left - orect.left;
-            }
-        }
-    });
-    if (bestLeft === null || Number.isNaN(bestLeft))
-        return null;
-    const maxW = el.clientWidth;
-    if (maxW <= 0)
-        return null;
-    return Math.max(0, Math.min(bestLeft, maxW));
+const FALLBACK_SCALE_WIDTH = 48;
+const SCALE_GAP = 4;
+function getPriceScaleWidth() {
+    const widget = getWidget();
+    if (!widget)
+        return FALLBACK_SCALE_WIDTH;
+    const chart = widget.activeChart();
+    const panes = chart.getPanes?.();
+    if (!panes || panes.length === 0)
+        return FALLBACK_SCALE_WIDTH;
+    const scales = panes[0].getRightPriceScales?.();
+    const w = scales?.[0]?.width?.();
+    return w && w > 0 ? w : FALLBACK_SCALE_WIDTH;
 }
 function updateLegendOverlayLayout() {
-    const overlay = document.getElementById(OVERLAY_ID);
     const container = document.getElementById('tv_chart_container');
-    if (!overlay || !container)
+    if (!container)
         return;
-    const scaleGap = 4;
-    const boundaryLeft = getMainPriceAxisLeftRelativeTo(container);
-    if (boundaryLeft !== null && boundaryLeft > OVERLAY_LEFT_PX + scaleGap) {
-        overlay.style.maxWidth = \`\${boundaryLeft - OVERLAY_LEFT_PX - scaleGap}px\`;
-    }
-    else {
-        overlay.style.maxWidth = 'calc(100% - 56px)';
+    const containerWidth = container.clientWidth;
+    if (containerWidth <= 0)
+        return;
+    const scaleWidth = getPriceScaleWidth();
+    const maxWidth = \`\${containerWidth - OVERLAY_LEFT_PX - scaleWidth - SCALE_GAP}px\`;
+    const overlay = document.getElementById(OVERLAY_ID);
+    if (overlay)
+        overlay.style.maxWidth = maxWidth;
+    for (const el of subPaneOverlays.values()) {
+        el.style.maxWidth = maxWidth;
     }
 }
 /** Test-only: clear all module-local state between cases. */

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -166,7 +166,6 @@ const state = {
     rnBackedPagination: { enabled: false },
     hasExplicitCurrentPriceLine: false,
     hotReloadSeq: 0,
-    studyPaneIndex: new Map(),
     slbMode: false,
     slbCenteringPending: false,
     legendOwnsLayoutSettle: false,
@@ -351,30 +350,6 @@ function bumpHotReloadSeq() {
 function getHotReloadSeq() {
     return state.hotReloadSeq;
 }
-// ----- Study pane index (sub-pane tracking) -----------------------------------
-function getStudyPaneIndex(name) {
-    return state.studyPaneIndex.get(name);
-}
-function setStudyPaneIndex(name, idx) {
-    state.studyPaneIndex.set(name, idx);
-}
-function deleteStudyPaneIndex(name) {
-    state.studyPaneIndex.delete(name);
-}
-function getStudyPaneIndexMap() {
-    return state.studyPaneIndex;
-}
-/**
- * After a sub-pane is removed, TradingView renumbers panes. Decrement all
- * tracked indices above the removed pane so they stay in sync.
- */
-function reindexPanesAfterRemoval(removedPaneIndex) {
-    for (const [name, idx] of state.studyPaneIndex) {
-        if (idx > removedPaneIndex) {
-            state.studyPaneIndex.set(name, idx - 1);
-        }
-    }
-}
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 function getSlbMode() {
     return state.slbMode;
@@ -431,7 +406,6 @@ function __resetStateForTests() {
     state.rnBackedPagination = { enabled: false };
     state.hasExplicitCurrentPriceLine = false;
     state.hotReloadSeq = 0;
-    state.studyPaneIndex = new Map();
     state.slbMode = false;
     state.slbCenteringPending = false;
     state.legendOwnsLayoutSettle = false;
@@ -2781,7 +2755,7 @@ let legendOverlayEnabled = false;
 let indicatorColors;
 /** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
 let legendConfig;
-/** Sub-pane overlay elements keyed by pane index. */
+/** Sub-pane overlay elements keyed by indicator name. */
 const subPaneOverlays = new Map();
 // ----- Lifecycle ---------------------------------------------------------
 /** Called once on chart-ready to set up the DOM container. */
@@ -3085,39 +3059,37 @@ function scheduleRetry(gen) {
 }
 function renderOverlay(entries) {
     const presets = getPresetMap();
-    const paneIndexMap = getStudyPaneIndexMap();
+    const widget = getWidget();
+    const chart = widget?.activeChart();
+    const activeStudies = getActiveStudies();
     const mainEntries = [];
-    const subPaneGroups = new Map();
+    const subPaneEntries = [];
     for (const entry of entries) {
         const cfg = presets[entry.name];
-        const paneIdx = paneIndexMap.get(entry.name);
-        if (cfg?.subPaneLegend && paneIdx !== undefined) {
-            let group = subPaneGroups.get(paneIdx);
-            if (!group) {
-                group = [];
-                subPaneGroups.set(paneIdx, group);
+        if (cfg?.subPaneLegend && chart) {
+            const studyId = activeStudies.get(entry.name);
+            const study = studyId ? chart.getStudyById(studyId) : null;
+            const paneIdx = study?.paneIndex?.();
+            if (paneIdx !== undefined && paneIdx > 0) {
+                subPaneEntries.push({ name: entry.name, paneIdx, entry });
+                continue;
             }
-            group.push(entry);
         }
-        else {
-            mainEntries.push(entry);
-        }
+        mainEntries.push(entry);
     }
     const mainOverlay = document.getElementById(OVERLAY_ID);
     if (mainOverlay) {
         mainOverlay.innerHTML = buildHTML(mainEntries);
     }
-    const widget = getWidget();
-    const chart = widget?.activeChart();
-    const activePanes = new Set(subPaneGroups.keys());
-    for (const paneIdx of subPaneOverlays.keys()) {
-        if (!activePanes.has(paneIdx))
-            removeSubPaneOverlay(paneIdx);
+    const activeNames = new Set(subPaneEntries.map((s) => s.name));
+    for (const name of subPaneOverlays.keys()) {
+        if (!activeNames.has(name))
+            removeSubPaneOverlay(name);
     }
-    for (const [paneIdx, group] of subPaneGroups) {
-        const overlay = ensureSubPaneOverlay(paneIdx, chart ?? undefined);
+    for (const { name, paneIdx, entry } of subPaneEntries) {
+        const overlay = ensureSubPaneOverlay(name, paneIdx, chart ?? undefined);
         if (overlay)
-            overlay.innerHTML = buildHTML(group);
+            overlay.innerHTML = buildHTML([entry]);
     }
     updateLegendOverlayLayout();
     if (chart)
@@ -3238,8 +3210,8 @@ function subscribeStudyDataLoaded(chart, studyId) {
     scheduleLegendRefresh();
 }
 // ----- Sub-pane overlay management ----------------------------------------
-function subPaneOverlayId(paneIndex) {
-    return \`\${OVERLAY_ID}-pane-\${paneIndex}\`;
+function subPaneOverlayId(name) {
+    return \`\${OVERLAY_ID}-pane-\${name}\`;
 }
 function getSubPaneTopPx(paneIndex, chart) {
     const heights = chart.getAllPanesHeight();
@@ -3249,29 +3221,29 @@ function getSubPaneTopPx(paneIndex, chart) {
     }
     return top + 4;
 }
-function ensureSubPaneOverlay(paneIndex, chart) {
-    const existing = subPaneOverlays.get(paneIndex);
+function ensureSubPaneOverlay(name, paneIndex, chart) {
+    const existing = subPaneOverlays.get(name);
     if (existing && document.contains(existing))
         return existing;
     const container = document.getElementById('tv_chart_container');
     if (!container)
         return null;
     const div = document.createElement('div');
-    div.id = subPaneOverlayId(paneIndex);
+    div.id = subPaneOverlayId(name);
     const topPx = chart ? getSubPaneTopPx(paneIndex, chart) : 0;
     div.style.cssText =
         \`position:absolute;top:\${topPx}px;left:\${OVERLAY_LEFT_PX}px;z-index:5;\` +
             \`pointer-events:none;display:flex;flex-wrap:wrap;align-items:flex-start;\` +
             \`column-gap:8px;row-gap:2px;\`;
     container.appendChild(div);
-    subPaneOverlays.set(paneIndex, div);
+    subPaneOverlays.set(name, div);
     return div;
 }
-function removeSubPaneOverlay(paneIndex) {
-    const el = subPaneOverlays.get(paneIndex);
+function removeSubPaneOverlay(name) {
+    const el = subPaneOverlays.get(name);
     if (el) {
         el.remove();
-        subPaneOverlays.delete(paneIndex);
+        subPaneOverlays.delete(name);
     }
 }
 function removeAllSubPaneOverlays() {
@@ -3280,8 +3252,14 @@ function removeAllSubPaneOverlays() {
     subPaneOverlays.clear();
 }
 function repositionSubPaneOverlays(chart) {
-    for (const [paneIdx, el] of subPaneOverlays) {
-        el.style.top = \`\${getSubPaneTopPx(paneIdx, chart)}px\`;
+    const activeStudies = getActiveStudies();
+    for (const [name, el] of subPaneOverlays) {
+        const studyId = activeStudies.get(name);
+        const study = studyId ? chart.getStudyById(studyId) : null;
+        const paneIdx = study?.paneIndex?.();
+        if (paneIdx !== undefined && paneIdx > 0) {
+            el.style.top = \`\${getSubPaneTopPx(paneIdx, chart)}px\`;
+        }
     }
 }
 // ----- Layout ------------------------------------------------------------
@@ -3375,7 +3353,17 @@ function scheduleChartWidgetResize() {
 
 const MIN_MAIN_PX = 72;
 function hasActiveSubPaneIndicators() {
-    return getStudyPaneIndexMap().size > 0;
+    const widget = getWidget();
+    if (!widget)
+        return false;
+    const chart = widget.activeChart();
+    for (const studyId of getActiveStudies().values()) {
+        const study = chart.getStudyById(studyId);
+        const paneIdx = study?.paneIndex?.();
+        if (paneIdx !== undefined && paneIdx > 0)
+            return true;
+    }
+    return false;
 }
 function applySubPaneHeightRatio(chart) {
     const ratio = getSubPaneHeightRatio();
@@ -3600,8 +3588,6 @@ function handleAddIndicator(payload, config) {
         .then((studyId) => {
         registerStudy('active', name, studyId);
         if (isSubPanePreset(preset)) {
-            const paneIdx = chart.getAllPanesHeight().length - 1;
-            setStudyPaneIndex(name, paneIdx);
             applySubPaneHeightRatio(chart);
         }
         subscribeStudyDataLoaded(chart, studyId);
@@ -3628,15 +3614,14 @@ function handleRemoveIndicator(payload) {
     const studyId = unregisterStudy(name);
     if (!studyId)
         return;
-    const removedPaneIdx = getStudyPaneIndex(name);
-    const wasSubPane = removedPaneIdx !== undefined;
-    if (wasSubPane) {
-        removeSubPaneOverlay(removedPaneIdx);
-        deleteStudyPaneIndex(name);
-        reindexPanesAfterRemoval(removedPaneIdx);
-    }
     try {
         const chart = widget.activeChart();
+        const study = chart.getStudyById(studyId);
+        const paneIdx = study?.paneIndex?.();
+        const wasSubPane = paneIdx !== undefined && paneIdx > 0;
+        if (wasSubPane) {
+            removeSubPaneOverlay(name);
+        }
         chart.removeEntity(studyId);
         scheduleLegendRefresh();
         postToRN('INDICATOR_REMOVED', { name });

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -3247,7 +3247,7 @@ function getSubPaneTopPx(paneIndex, chart) {
     for (let i = 0; i < paneIndex && i < heights.length; i++) {
         top += heights[i];
     }
-    return top + 1;
+    return top + 4;
 }
 function ensureSubPaneOverlay(paneIndex, chart) {
     const existing = subPaneOverlays.get(paneIndex);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/bootstrap.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/bootstrap.ts
@@ -175,7 +175,7 @@ export function bootstrap(): ChartConfig {
               flushPendingTheme();
               applyScaleLayout();
               applyVisualOverrides(config.visualOverrides);
-              setupLegendOverlay(config.legendOverlay, config.indicatorColors);
+              setupLegendOverlay(config.legendOverlay);
               const chart = widget.activeChart();
               // Match legacy onChartReady: when no explicit visible range
               // was passed, pin a 2-bar gap on the right. TV's default is

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
@@ -52,8 +52,6 @@ interface CoreState {
   hasExplicitCurrentPriceLine: boolean;
   /** Sequence counter for setResolution callbacks; stale callbacks bail when mismatched. */
   hotReloadSeq: number;
-  /** Indicator name → pane index (0 = main). Only sub-pane studies are tracked. */
-  studyPaneIndex: Map<string, number>;
   /** SLB scoping flag — activates Strategy C (bulk back-fill) pagination. */
   slbMode: boolean;
   /**
@@ -101,7 +99,6 @@ const state: CoreState = {
   rnBackedPagination: { enabled: false },
   hasExplicitCurrentPriceLine: false,
   hotReloadSeq: 0,
-  studyPaneIndex: new Map(),
   slbMode: false,
   slbCenteringPending: false,
   legendOwnsLayoutSettle: false,
@@ -351,36 +348,6 @@ export function getHotReloadSeq(): number {
   return state.hotReloadSeq;
 }
 
-// ----- Study pane index (sub-pane tracking) -----------------------------------
-
-export function getStudyPaneIndex(name: string): number | undefined {
-  return state.studyPaneIndex.get(name);
-}
-
-export function setStudyPaneIndex(name: string, idx: number): void {
-  state.studyPaneIndex.set(name, idx);
-}
-
-export function deleteStudyPaneIndex(name: string): void {
-  state.studyPaneIndex.delete(name);
-}
-
-export function getStudyPaneIndexMap(): Map<string, number> {
-  return state.studyPaneIndex;
-}
-
-/**
- * After a sub-pane is removed, TradingView renumbers panes. Decrement all
- * tracked indices above the removed pane so they stay in sync.
- */
-export function reindexPanesAfterRemoval(removedPaneIndex: number): void {
-  for (const [name, idx] of state.studyPaneIndex) {
-    if (idx > removedPaneIndex) {
-      state.studyPaneIndex.set(name, idx - 1);
-    }
-  }
-}
-
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 
 export function getSlbMode(): boolean {
@@ -448,7 +415,6 @@ export function __resetStateForTests(): void {
   state.rnBackedPagination = { enabled: false };
   state.hasExplicitCurrentPriceLine = false;
   state.hotReloadSeq = 0;
-  state.studyPaneIndex = new Map();
   state.slbMode = false;
   state.slbCenteringPending = false;
   state.legendOwnsLayoutSettle = false;

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/state.ts
@@ -52,6 +52,8 @@ interface CoreState {
   hasExplicitCurrentPriceLine: boolean;
   /** Sequence counter for setResolution callbacks; stale callbacks bail when mismatched. */
   hotReloadSeq: number;
+  /** Indicator name → pane index (0 = main). Only sub-pane studies are tracked. */
+  studyPaneIndex: Map<string, number>;
   /** SLB scoping flag — activates Strategy C (bulk back-fill) pagination. */
   slbMode: boolean;
   /**
@@ -99,6 +101,7 @@ const state: CoreState = {
   rnBackedPagination: { enabled: false },
   hasExplicitCurrentPriceLine: false,
   hotReloadSeq: 0,
+  studyPaneIndex: new Map(),
   slbMode: false,
   slbCenteringPending: false,
   legendOwnsLayoutSettle: false,
@@ -348,6 +351,36 @@ export function getHotReloadSeq(): number {
   return state.hotReloadSeq;
 }
 
+// ----- Study pane index (sub-pane tracking) -----------------------------------
+
+export function getStudyPaneIndex(name: string): number | undefined {
+  return state.studyPaneIndex.get(name);
+}
+
+export function setStudyPaneIndex(name: string, idx: number): void {
+  state.studyPaneIndex.set(name, idx);
+}
+
+export function deleteStudyPaneIndex(name: string): void {
+  state.studyPaneIndex.delete(name);
+}
+
+export function getStudyPaneIndexMap(): Map<string, number> {
+  return state.studyPaneIndex;
+}
+
+/**
+ * After a sub-pane is removed, TradingView renumbers panes. Decrement all
+ * tracked indices above the removed pane so they stay in sync.
+ */
+export function reindexPanesAfterRemoval(removedPaneIndex: number): void {
+  for (const [name, idx] of state.studyPaneIndex) {
+    if (idx > removedPaneIndex) {
+      state.studyPaneIndex.set(name, idx - 1);
+    }
+  }
+}
+
 // ----- SLB (Social Leaderboard) mode -----------------------------------------
 
 export function getSlbMode(): boolean {
@@ -415,6 +448,7 @@ export function __resetStateForTests(): void {
   state.rnBackedPagination = { enabled: false };
   state.hasExplicitCurrentPriceLine = false;
   state.hotReloadSeq = 0;
+  state.studyPaneIndex = new Map();
   state.slbMode = false;
   state.slbCenteringPending = false;
   state.legendOwnsLayoutSettle = false;

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
@@ -63,6 +63,22 @@ export type IndicatorName =
   | 'MA20'
   | 'MA50';
 
+export interface LegendPlotCfg {
+  tvTitle: string;
+  label: string;
+  color: string | null;
+}
+
+export interface LegendIndicatorCfg {
+  plots: LegendPlotCfg[];
+  isMA?: boolean;
+  useIndex?: boolean;
+  combineInOnePill?: boolean;
+  title?: string;
+  /** When true, legend pills render in the study's own sub-pane overlay. */
+  subPaneLegend?: boolean;
+}
+
 /**
  * Optional consumer-supplied legend overlay config inlined as
  * window.CONFIG.legendOverlay. When `enabled` is true the WebView builds a
@@ -70,8 +86,8 @@ export type IndicatorName =
  */
 export interface LegendOverlayConfig {
   enabled?: boolean;
-  /** Optional per-indicator override map; falls back to built-in presets. */
-  config?: Record<string, unknown>;
+  /** Per-indicator legend configuration supplied by RN. */
+  config?: Record<string, LegendIndicatorCfg>;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
@@ -219,6 +219,7 @@ export type StudyId = string; // NOSONAR — intentional semantic alias for Trad
 export interface TVStudy {
   onDataLoaded(): TVSubscription;
   applyOverrides?(overrides: Record<string, unknown>): void;
+  paneIndex?(): number;
 }
 
 export interface TVExportSchemaField {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/core/types.ts
@@ -204,6 +204,7 @@ export interface TVShapeCreateOptions {
 
 export interface TVPriceScale {
   getVisiblePriceRange(): { from: number; to: number } | null;
+  width?(): number;
   isInverted?(): boolean;
   getMode?(): number;
   setAutoScale?(enabled: boolean): void;
@@ -211,6 +212,7 @@ export interface TVPriceScale {
 
 export interface TVPane {
   getMainSourcePriceScale(): TVPriceScale | null;
+  getRightPriceScales?(): TVPriceScale[];
   getHeight(): number;
 }
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -16,7 +16,6 @@ import {
   registerStudy,
   setChartReady,
   setLegendOwnsLayoutSettle,
-  setStudyPaneIndex,
   setTheme,
   setVolumeStudyId,
   setWidget,
@@ -78,14 +77,25 @@ const makeExportData = (
 const makeChart = (
   exportDataResult?: TVExportData | Error,
   paneHeights: number[] = [300],
+  studyPaneMap: Record<string, number> = {},
 ): { chart: TVActiveChart; exportData: jest.Mock } => {
   const exportData =
     exportDataResult instanceof Error
       ? jest.fn().mockRejectedValue(exportDataResult)
       : jest.fn().mockResolvedValue(exportDataResult ?? makeExportData([], []));
+  const getStudyById = jest.fn().mockImplementation((id: string) => {
+    const paneIdx = studyPaneMap[id];
+    if (paneIdx !== undefined) {
+      return {
+        paneIndex: () => paneIdx,
+        onDataLoaded: () => ({ subscribe: jest.fn() }),
+      };
+    }
+    return null;
+  });
   const chart = {
     exportData,
-    getStudyById: jest.fn().mockReturnValue(null),
+    getStudyById,
     getAllPanesHeight: jest.fn().mockReturnValue(paneHeights),
   } as unknown as TVActiveChart;
   return { chart, exportData };
@@ -1164,13 +1174,14 @@ describe('legend', () => {
       setupReadyWidget(chart);
     };
 
-    it('routes sub-pane pills to a dedicated overlay when studyPaneIndex is set', async () => {
-      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+    it('routes sub-pane pills to a dedicated overlay when paneIndex() returns > 0', async () => {
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100], {
+        'sid-rsi': 1,
+        'sid-macd': 2,
+      });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
       registerStudy('active', 'MACD', 'sid-macd' as StudyId);
-      setStudyPaneIndex('RSI', 1);
-      setStudyPaneIndex('MACD', 2);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
@@ -1178,17 +1189,17 @@ describe('legend', () => {
       const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
       expect(mainOverlay.querySelectorAll('.legend-pill').length).toBe(0);
 
-      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-RSI`);
       expect(rsiOverlay).not.toBeNull();
       expect(rsiOverlay?.innerHTML).toContain('RSI(14)');
 
-      const macdOverlay = document.getElementById(`${OVERLAY_ID}-pane-2`);
+      const macdOverlay = document.getElementById(`${OVERLAY_ID}-pane-MACD`);
       expect(macdOverlay).not.toBeNull();
       expect(macdOverlay?.innerHTML).toContain('MACD(12,26)');
     });
 
-    it('falls back to main overlay when studyPaneIndex is not set', async () => {
-      const { chart } = makeChart(rsiMacdData);
+    it('falls back to main overlay when paneIndex() returns 0 (main pane)', async () => {
+      const { chart } = makeChart(rsiMacdData, [300], { 'sid-rsi': 0 });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
 
@@ -1197,25 +1208,25 @@ describe('legend', () => {
 
       const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
       expect(mainOverlay.innerHTML).toContain('RSI(14)');
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-RSI`)).toBeNull();
     });
 
     it('removes stale sub-pane overlays when their indicators are gone', async () => {
-      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100], {
+        'sid-rsi': 1,
+        'sid-macd': 2,
+      });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
       registerStudy('active', 'MACD', 'sid-macd' as StudyId);
-      setStudyPaneIndex('RSI', 1);
-      setStudyPaneIndex('MACD', 2);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
-      expect(document.getElementById(`${OVERLAY_ID}-pane-2`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-RSI`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-MACD`)).not.toBeNull();
 
       __resetStateForTests();
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
-      setStudyPaneIndex('RSI', 1);
 
       const rsiOnlyData = makeExportData(
         [
@@ -1224,14 +1235,16 @@ describe('legend', () => {
         ],
         [[1000, 65.0]],
       );
-      const { chart: rsiChart } = makeChart(rsiOnlyData, [300, 100]);
+      const { chart: rsiChart } = makeChart(rsiOnlyData, [300, 100], {
+        'sid-rsi': 1,
+      });
       setupReadyWidget(rsiChart);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
 
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
-      expect(document.getElementById(`${OVERLAY_ID}-pane-2`)).toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-RSI`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-MACD`)).toBeNull();
     });
 
     it('uses RN-supplied config over fallback presets', async () => {
@@ -1270,15 +1283,16 @@ describe('legend', () => {
     });
 
     it('sub-pane overlay positions use absolute top from cumulative pane heights', async () => {
-      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100], {
+        'sid-rsi': 1,
+      });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
-      setStudyPaneIndex('RSI', 1);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
 
-      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-RSI`);
       expect(rsiOverlay).not.toBeNull();
       expect(rsiOverlay?.style.top).toBe('304px');
     });
@@ -1292,11 +1306,10 @@ describe('legend', () => {
         ],
         [[1000, 42.0, 65.0]],
       );
-      const { chart } = makeChart(mixedData, [300, 100]);
+      const { chart } = makeChart(mixedData, [300, 100], { 'sid-rsi': 1 });
       setupWithConfig(chart, subPaneColors);
       registerStudy('ma', 'MA5', 'sid-ma5' as StudyId);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
-      setStudyPaneIndex('RSI', 1);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
@@ -1305,39 +1318,37 @@ describe('legend', () => {
       expect(mainOverlay.innerHTML).toContain('MA(5)');
       expect(mainOverlay.innerHTML).not.toContain('RSI(14)');
 
-      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-RSI`);
       expect(rsiOverlay?.innerHTML).toContain('RSI(14)');
     });
 
     it('__resetLegendForTests clears sub-pane overlays', () => {
-      const { chart } = makeChart(rsiMacdData);
+      const { chart } = makeChart(rsiMacdData, [300, 100], { 'sid-rsi': 1 });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
-      setStudyPaneIndex('RSI', 1);
 
       refreshStudyLegendFromExport();
 
       __resetLegendForTests();
 
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-RSI`)).toBeNull();
     });
 
     it('clears sub-pane overlays when all studies are removed', async () => {
-      const { chart } = makeChart(rsiMacdData, [300, 100]);
+      const { chart } = makeChart(rsiMacdData, [300, 100], { 'sid-macd': 1 });
       setupWithConfig(chart, subPaneColors);
       registerStudy('active', 'MACD', 'sid-macd' as StudyId);
-      setStudyPaneIndex('MACD', 1);
 
       refreshStudyLegendFromExport();
       await Promise.resolve();
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-MACD`)).not.toBeNull();
 
       __resetStateForTests();
       setupReadyWidget(chart);
 
       refreshStudyLegendFromExport();
 
-      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-MACD`)).toBeNull();
       const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
       expect(mainOverlay.innerHTML).toBe('');
     });

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -300,8 +300,12 @@ describe('legend', () => {
       }) as unknown as TVActiveChart;
 
     it('subscribes to panes_height_changed and triggers layout update', () => {
-      installContainer();
+      const container = installContainer();
       setupLegendOverlay({ enabled: true });
+      Object.defineProperty(container, 'clientWidth', {
+        value: 400,
+        configurable: true,
+      });
       let handler: (() => void) | undefined;
       const widget = {
         subscribe: jest.fn((_event: string, cb: () => void) => {
@@ -316,7 +320,8 @@ describe('legend', () => {
       );
       handler?.();
       const overlay = document.getElementById(OVERLAY_ID);
-      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+      // 400 - 8 - 48 (fallback, no widget set) - 4 = 340
+      expect(overlay?.style.maxWidth).toBe('340px');
     });
 
     it('does not throw when subscribe throws', () => {
@@ -890,12 +895,17 @@ describe('legend', () => {
       expect(() => updateLegendOverlayLayout()).not.toThrow();
     });
 
-    it('sets fallback max-width when no price-axis is found', () => {
-      installContainer();
+    it('uses fallback scale width when no widget and container has width', () => {
+      const container = installContainer();
       setupLegendOverlay({ enabled: true });
+      Object.defineProperty(container, 'clientWidth', {
+        value: 400,
+        configurable: true,
+      });
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
-      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+      // 400 - 8 - 48 (fallback) - 4 = 340
+      expect(overlay?.style.maxWidth).toBe('340px');
     });
 
     it('is a no-op when container element is missing', () => {
@@ -1079,122 +1089,110 @@ describe('legend', () => {
     });
   });
 
-  describe('updateLegendOverlayLayout with price-axis', () => {
-    it('computes pixel max-width from price-axis left boundary', () => {
+  describe('updateLegendOverlayLayout with price scale API', () => {
+    it('computes pixel max-width from price scale width', () => {
       const container = installContainer();
       setupLegendOverlay({ enabled: true });
-      const axisNode = document.createElement('div');
-      axisNode.classList.add('price-axis-container');
-      container.appendChild(axisNode);
 
       Object.defineProperty(container, 'clientWidth', {
         value: 400,
         configurable: true,
       });
-      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
-        left: 0,
-        top: 0,
-        right: 400,
-        bottom: 600,
-        width: 400,
-        height: 600,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      });
-      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
-        left: 350,
-        top: 0,
-        right: 400,
-        bottom: 600,
-        width: 50,
-        height: 600,
-        x: 350,
-        y: 0,
-        toJSON: () => ({}),
+
+      const priceScale = { width: () => 50 };
+      const chart = {
+        exportData: jest.fn().mockResolvedValue({ schema: [], data: [] }),
+        getStudyById: jest.fn().mockReturnValue(null),
+        getAllPanesHeight: jest.fn().mockReturnValue([400]),
+        getPanes: () => [
+          { getRightPriceScales: () => [priceScale], getHeight: () => 400 },
+        ],
+      } as unknown as TVActiveChart;
+      setWidget({
+        activeChart: () => chart,
+      } as unknown as TVChartingLibraryWidget);
+      setChartReady(true);
+
+      updateLegendOverlayLayout();
+      const overlay = document.getElementById(OVERLAY_ID);
+      // 400 (container) - 8 (left pad) - 50 (scale) - 4 (gap) = 338
+      expect(overlay?.style.maxWidth).toBe('338px');
+    });
+
+    it('uses fallback scale width when no widget is set', () => {
+      const container = installContainer();
+      setupLegendOverlay({ enabled: true });
+
+      Object.defineProperty(container, 'clientWidth', {
+        value: 400,
+        configurable: true,
       });
 
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
-      expect(overlay?.style.maxWidth).toBe('338px');
+      // 400 - 8 - 48 (fallback) - 4 = 340
+      expect(overlay?.style.maxWidth).toBe('340px');
     });
 
-    it('uses fallback max-width when container clientWidth is 0', () => {
+    it('does not set maxWidth when container clientWidth is 0', () => {
       const container = installContainer();
       setupLegendOverlay({ enabled: true });
-      const axisNode = document.createElement('div');
-      axisNode.classList.add('price-axis-container');
-      container.appendChild(axisNode);
 
       Object.defineProperty(container, 'clientWidth', {
         value: 0,
         configurable: true,
       });
-      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
-        left: 0,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        width: 0,
-        height: 0,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      });
-      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
-        left: 350,
-        top: 0,
-        right: 400,
-        bottom: 600,
-        width: 50,
-        height: 600,
-        x: 350,
-        y: 0,
-        toJSON: () => ({}),
-      });
 
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
-      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+      expect(overlay?.style.maxWidth).toBe('');
     });
 
-    it('uses fallback when price-axis is too small (width < 2)', () => {
+    it('applies maxWidth to sub-pane overlays too', async () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true });
-      const axisNode = document.createElement('div');
-      axisNode.classList.add('price-axis-container');
-      container.appendChild(axisNode);
+      const rsiData = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 55.5]],
+      );
+      setupLegendOverlay({
+        enabled: true,
+        config: {
+          RSI: {
+            subPaneLegend: true,
+            plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: null }],
+            useIndex: true,
+          },
+        },
+      });
 
       Object.defineProperty(container, 'clientWidth', {
         value: 400,
         configurable: true,
       });
-      jest.spyOn(container, 'getBoundingClientRect').mockReturnValue({
-        left: 0,
-        top: 0,
-        right: 400,
-        bottom: 600,
-        width: 400,
-        height: 600,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      });
-      jest.spyOn(axisNode, 'getBoundingClientRect').mockReturnValue({
-        left: 350,
-        top: 0,
-        right: 351,
-        bottom: 600,
-        width: 1,
-        height: 600,
-        x: 350,
-        y: 0,
-        toJSON: () => ({}),
-      });
+
+      const priceScale = { width: () => 50 };
+      const { chart } = makeChart(rsiData, [300, 100], { 'sid-rsi': 1 });
+      (chart as unknown as Record<string, unknown>).getPanes = () => [
+        { getRightPriceScales: () => [priceScale], getHeight: () => 300 },
+        { getRightPriceScales: () => [priceScale], getHeight: () => 100 },
+      ];
+      setWidget({
+        activeChart: () => chart,
+      } as unknown as TVChartingLibraryWidget);
+      setChartReady(true);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
 
       updateLegendOverlayLayout();
-      const overlay = document.getElementById(OVERLAY_ID);
-      expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+      const subOverlay = container.querySelector(
+        '[id^="study-legend-overlay-pane-"]',
+      );
+      expect(subOverlay).not.toBeNull();
+      expect((subOverlay as HTMLElement).style.maxWidth).toBe('338px');
     });
   });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -23,6 +23,7 @@ import {
 import type {
   ChartTheme,
   IndicatorColors,
+  LegendIndicatorCfg,
   StudyId,
   TVActiveChart,
   TVChartingLibraryWidget,
@@ -108,12 +109,109 @@ const setupReadyWidget = (chart: TVActiveChart): void => {
   setChartReady(true);
 };
 
+const defaultTestConfig: Record<string, LegendIndicatorCfg> = {
+  MACD: {
+    subPaneLegend: true,
+    plots: [
+      { tvTitle: 'MACD', label: 'MACD(12,26)', color: null },
+      { tvTitle: 'Signal', label: 'Signal', color: null },
+      { tvTitle: 'Histogram', label: 'Hist', color: null },
+    ],
+    useIndex: true,
+  },
+  RSI: {
+    subPaneLegend: true,
+    plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: null }],
+    useIndex: true,
+  },
+  BOL: {
+    combineInOnePill: true,
+    title: 'BB(20,2)',
+    plots: [
+      { tvTitle: 'Upper', label: 'U:', color: null },
+      { tvTitle: 'Median', label: 'M:', color: null },
+      { tvTitle: 'Lower', label: 'L:', color: null },
+    ],
+    useIndex: true,
+  },
+  Volume: {
+    plots: [{ tvTitle: 'Vol', label: 'Vol', color: null }],
+    useIndex: true,
+  },
+  MA5: {
+    isMA: true,
+    useIndex: true,
+    plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: null }],
+  },
+  MA10: {
+    isMA: true,
+    useIndex: true,
+    plots: [{ tvTitle: 'Plot', label: 'MA(10)', color: null }],
+  },
+  MA20: {
+    isMA: true,
+    useIndex: true,
+    plots: [{ tvTitle: 'Plot', label: 'MA(20)', color: null }],
+  },
+  MA50: {
+    isMA: true,
+    useIndex: true,
+    plots: [{ tvTitle: 'Plot', label: 'MA(50)', color: null }],
+  },
+  MA200: {
+    isMA: true,
+    useIndex: true,
+    plots: [{ tvTitle: 'Plot', label: 'MA(200)', color: null }],
+  },
+};
+
+const buildTestConfig = (
+  colors?: IndicatorColors,
+): Record<string, LegendIndicatorCfg> => {
+  if (!colors) return defaultTestConfig;
+  const macd = colors.MACD ?? {};
+  const rsi = colors.RSI ?? {};
+  return {
+    ...defaultTestConfig,
+    MACD: {
+      ...defaultTestConfig.MACD,
+      plots: [
+        {
+          tvTitle: 'MACD',
+          label: 'MACD(12,26)',
+          color: (macd as Record<string, string>).macd ?? null,
+        },
+        {
+          tvTitle: 'Signal',
+          label: 'Signal',
+          color: (macd as Record<string, string>).signal ?? null,
+        },
+        {
+          tvTitle: 'Histogram',
+          label: 'Hist',
+          color: (macd as Record<string, string>).histogramPositive ?? null,
+        },
+      ],
+    },
+    RSI: {
+      ...defaultTestConfig.RSI,
+      plots: [
+        {
+          tvTitle: 'Plot',
+          label: 'RSI(14)',
+          color: (rsi as Record<string, string>).plot ?? null,
+        },
+      ],
+    },
+  };
+};
+
 const enableOverlayWithStudies = (
   chart: TVActiveChart,
   colors?: IndicatorColors,
 ): void => {
   installContainer();
-  setupLegendOverlay({ enabled: true }, colors);
+  setupLegendOverlay({ enabled: true, config: buildTestConfig(colors) });
   setupReadyWidget(chart);
 };
 
@@ -140,19 +238,19 @@ describe('legend', () => {
   describe('setupLegendOverlay', () => {
     it('is a no-op when config is undefined', () => {
       installContainer();
-      setupLegendOverlay(undefined, undefined);
+      setupLegendOverlay(undefined);
       expect(document.getElementById(OVERLAY_ID)).toBeNull();
     });
 
     it('is a no-op when enabled is false', () => {
       installContainer();
-      setupLegendOverlay({ enabled: false }, undefined);
+      setupLegendOverlay({ enabled: false });
       expect(document.getElementById(OVERLAY_ID)).toBeNull();
     });
 
     it('creates the overlay element inside tv_chart_container', () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const overlay = document.getElementById(OVERLAY_ID);
       expect(overlay).not.toBeNull();
       expect(overlay?.parentElement).toBe(container);
@@ -160,26 +258,26 @@ describe('legend', () => {
 
     it('sets container position to relative', () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       expect(container.style.position).toBe('relative');
     });
 
     it('replaces an existing overlay if called twice', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
+      setupLegendOverlay({ enabled: true });
       expect(document.querySelectorAll(`#${OVERLAY_ID}`).length).toBe(1);
     });
 
     it('does nothing when tv_chart_container is missing', () => {
       document.body.innerHTML = '';
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       expect(document.getElementById(OVERLAY_ID)).toBeNull();
     });
 
     it('injects a style element to hide TV legend buttons', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const style = document.getElementById('mm-hide-legend-buttons');
       expect(style).not.toBeNull();
       expect(style?.textContent).toContain('display:none!important');
@@ -187,8 +285,8 @@ describe('legend', () => {
 
     it('does not duplicate the CSS style on second setup call', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
+      setupLegendOverlay({ enabled: true });
       expect(document.querySelectorAll('#mm-hide-legend-buttons').length).toBe(
         1,
       );
@@ -203,7 +301,7 @@ describe('legend', () => {
 
     it('subscribes to panes_height_changed and triggers layout update', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       let handler: (() => void) | undefined;
       const widget = {
         subscribe: jest.fn((_event: string, cb: () => void) => {
@@ -251,13 +349,13 @@ describe('legend', () => {
 
     it('is a no-op when widget is null', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       expect(() => refreshStudyLegendFromExport()).not.toThrow();
     });
 
     it('is a no-op when chart is not ready', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const { chart } = makeChart();
       setWidget({
         activeChart: () => chart,
@@ -794,7 +892,7 @@ describe('legend', () => {
 
     it('sets fallback max-width when no price-axis is found', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
       expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
@@ -984,7 +1082,7 @@ describe('legend', () => {
   describe('updateLegendOverlayLayout with price-axis', () => {
     it('computes pixel max-width from price-axis left boundary', () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const axisNode = document.createElement('div');
       axisNode.classList.add('price-axis-container');
       container.appendChild(axisNode);
@@ -1023,7 +1121,7 @@ describe('legend', () => {
 
     it('uses fallback max-width when container clientWidth is 0', () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const axisNode = document.createElement('div');
       axisNode.classList.add('price-axis-container');
       container.appendChild(axisNode);
@@ -1062,7 +1160,7 @@ describe('legend', () => {
 
     it('uses fallback when price-axis is too small (width < 2)', () => {
       const container = installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       const axisNode = document.createElement('div');
       axisNode.classList.add('price-axis-container');
       container.appendChild(axisNode);
@@ -1126,51 +1224,48 @@ describe('legend', () => {
       colors?: IndicatorColors,
     ) => {
       installContainer();
-      setupLegendOverlay(
-        {
-          enabled: true,
-          config: {
-            MACD: {
-              subPaneLegend: true,
-              plots: [
-                {
-                  tvTitle: 'MACD',
-                  label: 'MACD(12,26)',
-                  color: colors?.MACD?.macd ?? null,
-                },
-                {
-                  tvTitle: 'Signal',
-                  label: 'Signal',
-                  color: colors?.MACD?.signal ?? null,
-                },
-                {
-                  tvTitle: 'Histogram',
-                  label: 'Hist',
-                  color: colors?.MACD?.histogramPositive ?? null,
-                },
-              ],
-              useIndex: true,
-            },
-            RSI: {
-              subPaneLegend: true,
-              plots: [
-                {
-                  tvTitle: 'Plot',
-                  label: 'RSI(14)',
-                  color: colors?.RSI?.plot ?? null,
-                },
-              ],
-              useIndex: true,
-            },
-            MA5: {
-              isMA: true,
-              useIndex: true,
-              plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: null }],
-            },
+      setupLegendOverlay({
+        enabled: true,
+        config: {
+          MACD: {
+            subPaneLegend: true,
+            plots: [
+              {
+                tvTitle: 'MACD',
+                label: 'MACD(12,26)',
+                color: colors?.MACD?.macd ?? null,
+              },
+              {
+                tvTitle: 'Signal',
+                label: 'Signal',
+                color: colors?.MACD?.signal ?? null,
+              },
+              {
+                tvTitle: 'Histogram',
+                label: 'Hist',
+                color: colors?.MACD?.histogramPositive ?? null,
+              },
+            ],
+            useIndex: true,
+          },
+          RSI: {
+            subPaneLegend: true,
+            plots: [
+              {
+                tvTitle: 'Plot',
+                label: 'RSI(14)',
+                color: colors?.RSI?.plot ?? null,
+              },
+            ],
+            useIndex: true,
+          },
+          MA5: {
+            isMA: true,
+            useIndex: true,
+            plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: null }],
           },
         },
-        colors,
-      );
+      });
       setupReadyWidget(chart);
     };
 
@@ -1270,7 +1365,7 @@ describe('legend', () => {
       );
       const { chart } = makeChart(data);
       installContainer();
-      setupLegendOverlay({ enabled: true, config: customConfig }, undefined);
+      setupLegendOverlay({ enabled: true, config: customConfig });
       setupReadyWidget(chart);
       registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
 
@@ -1357,7 +1452,7 @@ describe('legend', () => {
   describe('__resetLegendForTests', () => {
     it('resets state so overlay can be re-enabled', () => {
       installContainer();
-      setupLegendOverlay({ enabled: true }, undefined);
+      setupLegendOverlay({ enabled: true });
       expect(document.getElementById(OVERLAY_ID)).not.toBeNull();
       __resetLegendForTests();
       refreshStudyLegendFromExport();

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -16,6 +16,7 @@ import {
   registerStudy,
   setChartReady,
   setLegendOwnsLayoutSettle,
+  setStudyPaneIndex,
   setTheme,
   setVolumeStudyId,
   setWidget,
@@ -76,6 +77,7 @@ const makeExportData = (
 
 const makeChart = (
   exportDataResult?: TVExportData | Error,
+  paneHeights: number[] = [300],
 ): { chart: TVActiveChart; exportData: jest.Mock } => {
   const exportData =
     exportDataResult instanceof Error
@@ -84,6 +86,7 @@ const makeChart = (
   const chart = {
     exportData,
     getStudyById: jest.fn().mockReturnValue(null),
+    getAllPanesHeight: jest.fn().mockReturnValue(paneHeights),
   } as unknown as TVActiveChart;
   return { chart, exportData };
 };
@@ -183,6 +186,11 @@ describe('legend', () => {
   });
 
   describe('attachLegendResizeListener', () => {
+    const mockActiveChart = () =>
+      ({
+        getAllPanesHeight: jest.fn().mockReturnValue([300]),
+      }) as unknown as TVActiveChart;
+
     it('subscribes to panes_height_changed and triggers layout update', () => {
       installContainer();
       setupLegendOverlay({ enabled: true }, undefined);
@@ -191,6 +199,7 @@ describe('legend', () => {
         subscribe: jest.fn((_event: string, cb: () => void) => {
           handler = cb;
         }),
+        activeChart: mockActiveChart,
       };
       attachLegendResizeListener(widget);
       expect(widget.subscribe).toHaveBeenCalledWith(
@@ -207,6 +216,7 @@ describe('legend', () => {
         subscribe: jest.fn(() => {
           throw new Error('not ready');
         }),
+        activeChart: mockActiveChart,
       };
       expect(() => attachLegendResizeListener(widget)).not.toThrow();
     });
@@ -217,6 +227,7 @@ describe('legend', () => {
         subscribe: jest.fn((_event: string, cb: () => void) => {
           handler = cb;
         }),
+        activeChart: mockActiveChart,
       };
       attachLegendResizeListener(widget);
       expect(() => handler?.()).not.toThrow();
@@ -997,7 +1008,6 @@ describe('legend', () => {
 
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
-      // boundaryLeft = 350 - 0 = 350; maxWidth = 350 - 8 - 4 = 338px
       expect(overlay?.style.maxWidth).toBe('338px');
     });
 
@@ -1077,6 +1087,259 @@ describe('legend', () => {
       updateLegendOverlayLayout();
       const overlay = document.getElementById(OVERLAY_ID);
       expect(overlay?.style.maxWidth).toBe('calc(100% - 56px)');
+    });
+  });
+
+  describe('per-pane sub-pane legends', () => {
+    const subPaneColors: IndicatorColors = {
+      RSI: { plot: 'rgb(170,0,0)' },
+      MACD: {
+        macd: 'rgb(0,170,0)',
+        signal: 'rgb(0,0,170)',
+        histogramPositive: 'rgb(170,170,170)',
+      },
+    };
+
+    const rsiMacdData = makeExportData(
+      [
+        { type: 'time' },
+        { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        { type: 'number', sourceId: 'sid-macd', plotTitle: 'MACD' },
+        { type: 'number', sourceId: 'sid-macd', plotTitle: 'Signal' },
+        { type: 'number', sourceId: 'sid-macd', plotTitle: 'Histogram' },
+      ],
+      [[1000, 65.0, 12.5, 11.3, 1.2]],
+    );
+
+    const setupWithConfig = (
+      chart: TVActiveChart,
+      colors?: IndicatorColors,
+    ) => {
+      installContainer();
+      setupLegendOverlay(
+        {
+          enabled: true,
+          config: {
+            MACD: {
+              subPaneLegend: true,
+              plots: [
+                {
+                  tvTitle: 'MACD',
+                  label: 'MACD(12,26)',
+                  color: colors?.MACD?.macd ?? null,
+                },
+                {
+                  tvTitle: 'Signal',
+                  label: 'Signal',
+                  color: colors?.MACD?.signal ?? null,
+                },
+                {
+                  tvTitle: 'Histogram',
+                  label: 'Hist',
+                  color: colors?.MACD?.histogramPositive ?? null,
+                },
+              ],
+              useIndex: true,
+            },
+            RSI: {
+              subPaneLegend: true,
+              plots: [
+                {
+                  tvTitle: 'Plot',
+                  label: 'RSI(14)',
+                  color: colors?.RSI?.plot ?? null,
+                },
+              ],
+              useIndex: true,
+            },
+            MA5: {
+              isMA: true,
+              useIndex: true,
+              plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: null }],
+            },
+          },
+        },
+        colors,
+      );
+      setupReadyWidget(chart);
+    };
+
+    it('routes sub-pane pills to a dedicated overlay when studyPaneIndex is set', async () => {
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      registerStudy('active', 'MACD', 'sid-macd' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+      setStudyPaneIndex('MACD', 2);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
+      expect(mainOverlay.querySelectorAll('.legend-pill').length).toBe(0);
+
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      expect(rsiOverlay).not.toBeNull();
+      expect(rsiOverlay?.innerHTML).toContain('RSI(14)');
+
+      const macdOverlay = document.getElementById(`${OVERLAY_ID}-pane-2`);
+      expect(macdOverlay).not.toBeNull();
+      expect(macdOverlay?.innerHTML).toContain('MACD(12,26)');
+    });
+
+    it('falls back to main overlay when studyPaneIndex is not set', async () => {
+      const { chart } = makeChart(rsiMacdData);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
+      expect(mainOverlay.innerHTML).toContain('RSI(14)');
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+    });
+
+    it('removes stale sub-pane overlays when their indicators are gone', async () => {
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      registerStudy('active', 'MACD', 'sid-macd' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+      setStudyPaneIndex('MACD', 2);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-2`)).not.toBeNull();
+
+      __resetStateForTests();
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+
+      const rsiOnlyData = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 65.0]],
+      );
+      const { chart: rsiChart } = makeChart(rsiOnlyData, [300, 100]);
+      setupReadyWidget(rsiChart);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-2`)).toBeNull();
+    });
+
+    it('uses RN-supplied config over fallback presets', async () => {
+      const customConfig = {
+        RSI: {
+          subPaneLegend: true,
+          plots: [
+            {
+              tvTitle: 'Plot',
+              label: 'CustomRSI(21)',
+              color: 'rgb(255,0,255)',
+            },
+          ],
+          useIndex: true,
+        },
+      };
+      const data = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 72.5]],
+      );
+      const { chart } = makeChart(data);
+      installContainer();
+      setupLegendOverlay({ enabled: true, config: customConfig }, undefined);
+      setupReadyWidget(chart);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      const overlay = document.getElementById(OVERLAY_ID) as HTMLElement;
+      expect(overlay.innerHTML).toContain('CustomRSI(21)');
+      expect(overlay.innerHTML).not.toContain('RSI(14)');
+    });
+
+    it('sub-pane overlay positions use absolute top from cumulative pane heights', async () => {
+      const { chart } = makeChart(rsiMacdData, [300, 100, 100]);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      expect(rsiOverlay).not.toBeNull();
+      expect(rsiOverlay?.style.top).toBe('301px');
+    });
+
+    it('keeps main-pane indicators in main overlay when sub-pane indicators exist', async () => {
+      const mixedData = makeExportData(
+        [
+          { type: 'time' },
+          { type: 'number', sourceId: 'sid-ma5', plotTitle: 'Plot' },
+          { type: 'number', sourceId: 'sid-rsi', plotTitle: 'Plot' },
+        ],
+        [[1000, 42.0, 65.0]],
+      );
+      const { chart } = makeChart(mixedData, [300, 100]);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('ma', 'MA5', 'sid-ma5' as StudyId);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+
+      const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
+      expect(mainOverlay.innerHTML).toContain('MA(5)');
+      expect(mainOverlay.innerHTML).not.toContain('RSI(14)');
+
+      const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
+      expect(rsiOverlay?.innerHTML).toContain('RSI(14)');
+    });
+
+    it('__resetLegendForTests clears sub-pane overlays', () => {
+      const { chart } = makeChart(rsiMacdData);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'RSI', 'sid-rsi' as StudyId);
+      setStudyPaneIndex('RSI', 1);
+
+      refreshStudyLegendFromExport();
+
+      __resetLegendForTests();
+
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+    });
+
+    it('clears sub-pane overlays when all studies are removed', async () => {
+      const { chart } = makeChart(rsiMacdData, [300, 100]);
+      setupWithConfig(chart, subPaneColors);
+      registerStudy('active', 'MACD', 'sid-macd' as StudyId);
+      setStudyPaneIndex('MACD', 1);
+
+      refreshStudyLegendFromExport();
+      await Promise.resolve();
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).not.toBeNull();
+
+      __resetStateForTests();
+      setupReadyWidget(chart);
+
+      refreshStudyLegendFromExport();
+
+      expect(document.getElementById(`${OVERLAY_ID}-pane-1`)).toBeNull();
+      const mainOverlay = document.getElementById(OVERLAY_ID) as HTMLElement;
+      expect(mainOverlay.innerHTML).toBe('');
     });
   });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/legend.test.ts
@@ -1280,7 +1280,7 @@ describe('legend', () => {
 
       const rsiOverlay = document.getElementById(`${OVERLAY_ID}-pane-1`);
       expect(rsiOverlay).not.toBeNull();
-      expect(rsiOverlay?.style.top).toBe('301px');
+      expect(rsiOverlay?.style.top).toBe('304px');
     });
 
     it('keeps main-pane indicators in main overlay when sub-pane indicators exist', async () => {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/studies.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/studies.test.ts
@@ -1,7 +1,7 @@
 import {
   createIndicatorStudy,
   getMAColor,
-  isSubPaneIndicator,
+  isSubPanePreset,
   MA_LENGTHS,
   resolveStudyPreset,
 } from '../studies';
@@ -71,12 +71,17 @@ describe('resolveStudyPreset', () => {
   });
 });
 
-describe('isSubPaneIndicator', () => {
-  it('returns true for MACD and RSI only', () => {
-    expect(isSubPaneIndicator('MACD')).toBe(true);
-    expect(isSubPaneIndicator('RSI')).toBe(true);
-    expect(isSubPaneIndicator('BOL')).toBe(false);
-    expect(isSubPaneIndicator('MA200')).toBe(false);
+describe('isSubPanePreset', () => {
+  it('returns true for presets with paneTarget sub', () => {
+    const macd = resolveStudyPreset('MACD', colors);
+    const rsi = resolveStudyPreset('RSI', colors);
+    const bol = resolveStudyPreset('BOL', colors);
+    const ma200 = resolveStudyPreset('MA200', colors);
+
+    expect(isSubPanePreset(macd)).toBe(true);
+    expect(isSubPanePreset(rsi)).toBe(true);
+    expect(isSubPanePreset(bol)).toBe(false);
+    expect(isSubPanePreset(ma200)).toBe(false);
   });
 });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/subPane.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/subPane.test.ts
@@ -11,6 +11,7 @@ import {
   getSubPaneHeightRatio,
   registerStudy,
   setChartReady,
+  setStudyPaneIndex,
   setWidget,
 } from '../../../core/state';
 import type {
@@ -39,8 +40,9 @@ describe('hasActiveSubPaneIndicators', () => {
     expect(hasActiveSubPaneIndicators()).toBe(false);
   });
 
-  it('true when MACD or RSI is active', () => {
+  it('true when a study has a pane index entry', () => {
     registerStudy('active', 'MACD', 'sid-1');
+    setStudyPaneIndex('MACD', 1);
     expect(hasActiveSubPaneIndicators()).toBe(true);
     __resetStateForTests();
     registerStudy('active', 'BOL', 'sid-2');
@@ -71,6 +73,7 @@ describe('handleSetSubPaneLayout', () => {
     } as unknown as TVChartingLibraryWidget);
     setChartReady(true);
     registerStudy('active', 'MACD', 'sid-1');
+    setStudyPaneIndex('MACD', 1);
 
     handleSetSubPaneLayout({ heightRatio: 0.2 });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/subPane.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/__tests__/subPane.test.ts
@@ -11,7 +11,6 @@ import {
   getSubPaneHeightRatio,
   registerStudy,
   setChartReady,
-  setStudyPaneIndex,
   setWidget,
 } from '../../../core/state';
 import type {
@@ -21,6 +20,7 @@ import type {
 
 const makeChart = (
   heights: number[],
+  studyPaneMap: Record<string, number> = {},
 ): {
   chart: TVActiveChart;
   setAll: jest.Mock;
@@ -29,6 +29,13 @@ const makeChart = (
   const chart = {
     getAllPanesHeight: () => heights,
     setAllPanesHeight: setAll,
+    getStudyById: jest.fn().mockImplementation((id: string) => {
+      const paneIdx = studyPaneMap[id];
+      if (paneIdx !== undefined) {
+        return { paneIndex: () => paneIdx };
+      }
+      return null;
+    }),
   } as unknown as TVActiveChart;
   return { chart, setAll };
 };
@@ -37,14 +44,30 @@ describe('hasActiveSubPaneIndicators', () => {
   beforeEach(() => __resetStateForTests());
 
   it('false when no studies registered', () => {
+    const { chart } = makeChart([300]);
+    setWidget({
+      activeChart: () => chart,
+    } as unknown as TVChartingLibraryWidget);
+    setChartReady(true);
     expect(hasActiveSubPaneIndicators()).toBe(false);
   });
 
-  it('true when a study has a pane index entry', () => {
+  it('true when a study has paneIndex > 0', () => {
+    const { chart } = makeChart([300, 100], { 'sid-1': 1 });
+    setWidget({
+      activeChart: () => chart,
+    } as unknown as TVChartingLibraryWidget);
+    setChartReady(true);
     registerStudy('active', 'MACD', 'sid-1');
-    setStudyPaneIndex('MACD', 1);
     expect(hasActiveSubPaneIndicators()).toBe(true);
-    __resetStateForTests();
+  });
+
+  it('false when study is on main pane (paneIndex 0)', () => {
+    const { chart } = makeChart([300], { 'sid-2': 0 });
+    setWidget({
+      activeChart: () => chart,
+    } as unknown as TVChartingLibraryWidget);
+    setChartReady(true);
     registerStudy('active', 'BOL', 'sid-2');
     expect(hasActiveSubPaneIndicators()).toBe(false);
   });
@@ -67,13 +90,12 @@ describe('handleSetSubPaneLayout', () => {
   });
 
   it('applies the ratio to an active chart when a sub-pane study exists', () => {
-    const { chart, setAll } = makeChart([400, 100]);
+    const { chart, setAll } = makeChart([400, 100], { 'sid-1': 1 });
     setWidget({
       activeChart: () => chart,
     } as unknown as TVChartingLibraryWidget);
     setChartReady(true);
     registerStudy('active', 'MACD', 'sid-1');
-    setStudyPaneIndex('MACD', 1);
 
     handleSetSubPaneLayout({ heightRatio: 0.2 });
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/index.ts
@@ -8,15 +8,11 @@
 
 import { postToRN, reportErrorToRN } from '../../core/bridge';
 import {
-  deleteStudyPaneIndex,
   getActiveStudies,
   getMaStudies,
-  getStudyPaneIndex,
   getWidget,
   isChartReady,
   registerStudy,
-  reindexPanesAfterRemoval,
-  setStudyPaneIndex,
   unregisterStudy,
 } from '../../core/state';
 import type { ChartConfig, StudyId, TVActiveChart } from '../../core/types';
@@ -79,8 +75,6 @@ export function handleAddIndicator(
     .then((studyId) => {
       registerStudy('active', name, studyId);
       if (isSubPanePreset(preset)) {
-        const paneIdx = chart.getAllPanesHeight().length - 1;
-        setStudyPaneIndex(name, paneIdx);
         applySubPaneHeightRatio(chart);
       }
       subscribeStudyDataLoaded(chart, studyId);
@@ -109,17 +103,18 @@ export function handleRemoveIndicator(
   const studyId = unregisterStudy(name);
   if (!studyId) return;
 
-  const removedPaneIdx = getStudyPaneIndex(name);
-  const wasSubPane = removedPaneIdx !== undefined;
-  if (wasSubPane) {
-    removeSubPaneOverlay(removedPaneIdx);
-    deleteStudyPaneIndex(name);
-    reindexPanesAfterRemoval(removedPaneIdx);
-  }
-
   try {
     const chart = widget.activeChart();
+    const study = chart.getStudyById(studyId);
+    const paneIdx = study?.paneIndex?.();
+    const wasSubPane = paneIdx !== undefined && paneIdx > 0;
+
+    if (wasSubPane) {
+      removeSubPaneOverlay(name);
+    }
+
     chart.removeEntity(studyId);
+
     scheduleLegendRefresh();
     postToRN('INDICATOR_REMOVED', { name });
     if (wasSubPane && hasActiveSubPaneIndicators()) {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/index.ts
@@ -8,11 +8,15 @@
 
 import { postToRN, reportErrorToRN } from '../../core/bridge';
 import {
+  deleteStudyPaneIndex,
   getActiveStudies,
   getMaStudies,
+  getStudyPaneIndex,
   getWidget,
   isChartReady,
   registerStudy,
+  reindexPanesAfterRemoval,
+  setStudyPaneIndex,
   unregisterStudy,
 } from '../../core/state';
 import type { ChartConfig, StudyId, TVActiveChart } from '../../core/types';
@@ -21,12 +25,16 @@ import type {
   RemoveIndicatorMessage,
   SetMAVisibilityMessage,
 } from '../../messages/contract';
-import { scheduleLegendRefresh, subscribeStudyDataLoaded } from './legend';
+import {
+  removeSubPaneOverlay,
+  scheduleLegendRefresh,
+  subscribeStudyDataLoaded,
+} from './legend';
 import { scheduleChartWidgetResize } from './resize';
 import { applySubPaneHeightRatio, hasActiveSubPaneIndicators } from './subPane';
 import {
   createIndicatorStudy,
-  isSubPaneIndicator,
+  isSubPanePreset,
   MA_LENGTHS,
   resolveStudyPreset,
 } from './studies';
@@ -70,7 +78,9 @@ export function handleAddIndicator(
   createIndicatorStudy(chart, preset)
     .then((studyId) => {
       registerStudy('active', name, studyId);
-      if (isSubPaneIndicator(name)) {
+      if (isSubPanePreset(preset)) {
+        const paneIdx = chart.getAllPanesHeight().length - 1;
+        setStudyPaneIndex(name, paneIdx);
         applySubPaneHeightRatio(chart);
       }
       subscribeStudyDataLoaded(chart, studyId);
@@ -99,12 +109,20 @@ export function handleRemoveIndicator(
   const studyId = unregisterStudy(name);
   if (!studyId) return;
 
+  const removedPaneIdx = getStudyPaneIndex(name);
+  const wasSubPane = removedPaneIdx !== undefined;
+  if (wasSubPane) {
+    removeSubPaneOverlay(removedPaneIdx);
+    deleteStudyPaneIndex(name);
+    reindexPanesAfterRemoval(removedPaneIdx);
+  }
+
   try {
     const chart = widget.activeChart();
     chart.removeEntity(studyId);
     scheduleLegendRefresh();
     postToRN('INDICATOR_REMOVED', { name });
-    if (isSubPaneIndicator(name) && hasActiveSubPaneIndicators()) {
+    if (wasSubPane && hasActiveSubPaneIndicators()) {
       applySubPaneHeightRatio(chart);
     }
   } catch (error) {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -31,6 +31,7 @@ import type {
   IndicatorColors,
   LegendIndicatorCfg,
   LegendOverlayConfig,
+  LegendPlotCfg,
   StudyId,
   TVActiveChart,
   TVExportData,
@@ -225,8 +226,8 @@ function isEmptyValue(v: string): boolean {
 }
 
 function plotValue(
-  cfg: IndicatorLegendCfg,
-  plotCfg: PlotCfg,
+  cfg: LegendIndicatorCfg,
+  plotCfg: LegendPlotCfg,
   plotIndex: number,
   values: StudyValueEntry[],
 ): string {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -562,7 +562,7 @@ function getSubPaneTopPx(paneIndex: number, chart: TVActiveChart): number {
   for (let i = 0; i < paneIndex && i < heights.length; i++) {
     top += heights[i];
   }
-  return top + 1;
+  return top + 4;
 }
 
 function ensureSubPaneOverlay(

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -19,6 +19,7 @@ import {
   getActiveStudies,
   getLegendStudyOrder,
   getMaStudies,
+  getStudyPaneIndexMap,
   getTheme,
   getVolumeStudyId,
   getWidget,
@@ -28,6 +29,7 @@ import {
 import { eachChartDocument } from '../../widget/tvDomHelpers';
 import type {
   IndicatorColors,
+  LegendIndicatorCfg,
   LegendOverlayConfig,
   StudyId,
   TVActiveChart,
@@ -45,6 +47,10 @@ let retryCount = 0;
 let timeoutId: ReturnType<typeof setTimeout> | null = null;
 let legendOverlayEnabled = false;
 let indicatorColors: IndicatorColors | undefined;
+/** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
+let legendConfig: Record<string, LegendIndicatorCfg> | undefined;
+/** Sub-pane overlay elements keyed by pane index. */
+const subPaneOverlays = new Map<number, HTMLDivElement>();
 
 // ----- Lifecycle ---------------------------------------------------------
 
@@ -55,6 +61,7 @@ export function setupLegendOverlay(
 ): void {
   legendOverlayEnabled = Boolean(config?.enabled);
   indicatorColors = colors;
+  legendConfig = config?.config;
   if (!legendOverlayEnabled) return;
   createOverlayElement();
   injectHideLegendButtonsCSS();
@@ -67,11 +74,13 @@ export function setupLegendOverlay(
  */
 export function attachLegendResizeListener(widget: {
   subscribe(event: 'panes_height_changed', handler: () => void): void;
+  activeChart(): TVActiveChart;
 }): void {
   try {
     widget.subscribe('panes_height_changed', () => {
       const el = document.getElementById(OVERLAY_ID);
       if (el) updateLegendOverlayLayout();
+      repositionSubPaneOverlays(widget.activeChart());
     });
   } catch {
     // TV may throw if subscribe isn't ready; safe to ignore.
@@ -115,40 +124,24 @@ function injectHideLegendButtonsCSS(): void {
 
 // ----- Legend rebuild ---------------------------------------------------
 
-interface PlotCfg {
-  tvTitle: string;
-  label: string;
-  color: string | null;
+/**
+ * Returns the per-indicator legend config. When RN supplied a typed config via
+ * legendOverlay.config (the single source of truth), use it directly.
+ * Otherwise fall back to a minimal built-in map derived from indicatorColors.
+ */
+function getPresetMap(): Record<string, LegendIndicatorCfg> {
+  if (legendConfig) return legendConfig;
+  return buildFallbackPresetMap();
 }
 
-interface IndicatorLegendCfg {
-  plots: PlotCfg[];
-  isMA?: boolean;
-  combineInOnePill?: boolean;
-  title?: string;
-  useIndex?: boolean;
-}
-
-function getMACDColors(): Record<string, string | undefined> {
-  return indicatorColors?.MACD ?? {};
-}
-function getRSIColors(): Record<string, string | undefined> {
-  return indicatorColors?.RSI ?? {};
-}
-function getBOLColors(): Record<string, string | undefined> {
-  return indicatorColors?.BOL ?? {};
-}
-function getMAColors(): Record<string, string | undefined> {
-  return indicatorColors?.MA ?? {};
-}
-
-function buildPresetMap(): Record<string, IndicatorLegendCfg> {
-  const macd = getMACDColors();
-  const rsi = getRSIColors();
-  const bol = getBOLColors();
-  const ma = getMAColors();
+function buildFallbackPresetMap(): Record<string, LegendIndicatorCfg> {
+  const macd = indicatorColors?.MACD ?? {};
+  const rsi = indicatorColors?.RSI ?? {};
+  const bol = indicatorColors?.BOL ?? {};
+  const ma = indicatorColors?.MA ?? {};
   return {
     MACD: {
+      subPaneLegend: true,
       plots: [
         { tvTitle: 'MACD', label: 'MACD(12,26)', color: macd.macd ?? null },
         { tvTitle: 'Signal', label: 'Signal', color: macd.signal ?? null },
@@ -161,6 +154,7 @@ function buildPresetMap(): Record<string, IndicatorLegendCfg> {
       useIndex: true,
     },
     RSI: {
+      subPaneLegend: true,
       plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: rsi.plot ?? null }],
       useIndex: true,
     },
@@ -250,7 +244,7 @@ function wrapPill(innerHtml: string, color?: string): string {
 
 function buildHTML(entries: StudyDataEntry[]): string {
   const altColor = getLegendAltColor();
-  const presets = buildPresetMap();
+  const presets = getPresetMap();
   const successColor = getTheme()?.successColor ?? 'rgb(38,166,154)';
   const pills: string[] = [];
 
@@ -386,10 +380,47 @@ function scheduleRetry(gen: number): void {
 }
 
 function renderOverlay(entries: StudyDataEntry[]): void {
-  const overlay = document.getElementById(OVERLAY_ID);
-  if (!overlay) return;
-  overlay.innerHTML = buildHTML(entries);
+  const presets = getPresetMap();
+  const paneIndexMap = getStudyPaneIndexMap();
+
+  const mainEntries: StudyDataEntry[] = [];
+  const subPaneGroups = new Map<number, StudyDataEntry[]>();
+
+  for (const entry of entries) {
+    const cfg = presets[entry.name];
+    const paneIdx = paneIndexMap.get(entry.name);
+    if (cfg?.subPaneLegend && paneIdx !== undefined) {
+      let group = subPaneGroups.get(paneIdx);
+      if (!group) {
+        group = [];
+        subPaneGroups.set(paneIdx, group);
+      }
+      group.push(entry);
+    } else {
+      mainEntries.push(entry);
+    }
+  }
+
+  const mainOverlay = document.getElementById(OVERLAY_ID);
+  if (mainOverlay) {
+    mainOverlay.innerHTML = buildHTML(mainEntries);
+  }
+
+  const widget = getWidget();
+  const chart = widget?.activeChart();
+
+  const activePanes = new Set(subPaneGroups.keys());
+  for (const paneIdx of subPaneOverlays.keys()) {
+    if (!activePanes.has(paneIdx)) removeSubPaneOverlay(paneIdx);
+  }
+
+  for (const [paneIdx, group] of subPaneGroups) {
+    const overlay = ensureSubPaneOverlay(paneIdx, chart ?? undefined);
+    if (overlay) overlay.innerHTML = buildHTML(group);
+  }
+
   updateLegendOverlayLayout();
+  if (chart) repositionSubPaneOverlays(chart);
 }
 
 export function refreshStudyLegendFromExport(): void {
@@ -403,6 +434,7 @@ export function refreshStudyLegendFromExport(): void {
   const studyIds = Object.keys(studyIdMap);
   if (studyIds.length === 0) {
     overlay.innerHTML = '';
+    removeAllSubPaneOverlays();
     retryCount = 0;
     clearTimer();
     return;
@@ -518,6 +550,62 @@ export function subscribeStudyDataLoaded(
   scheduleLegendRefresh();
 }
 
+// ----- Sub-pane overlay management ----------------------------------------
+
+function subPaneOverlayId(paneIndex: number): string {
+  return `${OVERLAY_ID}-pane-${paneIndex}`;
+}
+
+function getSubPaneTopPx(paneIndex: number, chart: TVActiveChart): number {
+  const heights = chart.getAllPanesHeight();
+  let top = 0;
+  for (let i = 0; i < paneIndex && i < heights.length; i++) {
+    top += heights[i];
+  }
+  return top + 1;
+}
+
+function ensureSubPaneOverlay(
+  paneIndex: number,
+  chart?: TVActiveChart,
+): HTMLDivElement | null {
+  const existing = subPaneOverlays.get(paneIndex);
+  if (existing && document.contains(existing)) return existing;
+
+  const container = document.getElementById('tv_chart_container');
+  if (!container) return null;
+
+  const div = document.createElement('div');
+  div.id = subPaneOverlayId(paneIndex);
+  const topPx = chart ? getSubPaneTopPx(paneIndex, chart) : 0;
+  div.style.cssText =
+    `position:absolute;top:${topPx}px;left:${OVERLAY_LEFT_PX}px;z-index:5;` +
+    `pointer-events:none;display:flex;flex-wrap:wrap;align-items:flex-start;` +
+    `column-gap:8px;row-gap:2px;`;
+  container.appendChild(div);
+  subPaneOverlays.set(paneIndex, div);
+  return div;
+}
+
+export function removeSubPaneOverlay(paneIndex: number): void {
+  const el = subPaneOverlays.get(paneIndex);
+  if (el) {
+    el.remove();
+    subPaneOverlays.delete(paneIndex);
+  }
+}
+
+function removeAllSubPaneOverlays(): void {
+  for (const el of subPaneOverlays.values()) el.remove();
+  subPaneOverlays.clear();
+}
+
+function repositionSubPaneOverlays(chart: TVActiveChart): void {
+  for (const [paneIdx, el] of subPaneOverlays) {
+    el.style.top = `${getSubPaneTopPx(paneIdx, chart)}px`;
+  }
+}
+
 // ----- Layout ------------------------------------------------------------
 
 function getMainPriceAxisLeftRelativeTo(el: HTMLElement): number | null {
@@ -562,4 +650,6 @@ export function __resetLegendForTests(): void {
   clearTimer();
   legendOverlayEnabled = false;
   indicatorColors = undefined;
+  legendConfig = undefined;
+  removeAllSubPaneOverlays();
 }

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -545,38 +545,34 @@ function repositionSubPaneOverlays(chart: TVActiveChart): void {
 
 // ----- Layout ------------------------------------------------------------
 
-function getMainPriceAxisLeftRelativeTo(el: HTMLElement): number | null {
-  if (!el?.getBoundingClientRect) return null;
-  const orect = el.getBoundingClientRect();
-  let bestLeft: number | null = null;
-  let bestTop = Infinity;
-  eachChartDocument((doc) => {
-    const nodes = doc.querySelectorAll('.price-axis-container');
-    for (const node of Array.from(nodes)) {
-      const r = node.getBoundingClientRect();
-      if (r.width < 2 || r.height < 16) continue;
-      if (r.top < bestTop) {
-        bestTop = r.top;
-        bestLeft = r.left - orect.left;
-      }
-    }
-  });
-  if (bestLeft === null || Number.isNaN(bestLeft)) return null;
-  const maxW = el.clientWidth;
-  if (maxW <= 0) return null;
-  return Math.max(0, Math.min(bestLeft, maxW));
+const FALLBACK_SCALE_WIDTH = 48;
+const SCALE_GAP = 4;
+
+function getPriceScaleWidth(): number {
+  const widget = getWidget();
+  if (!widget) return FALLBACK_SCALE_WIDTH;
+  const chart = widget.activeChart();
+  const panes = chart.getPanes?.();
+  if (!panes || panes.length === 0) return FALLBACK_SCALE_WIDTH;
+  const scales = panes[0].getRightPriceScales?.();
+  const w = scales?.[0]?.width?.();
+  return w && w > 0 ? w : FALLBACK_SCALE_WIDTH;
 }
 
 export function updateLegendOverlayLayout(): void {
-  const overlay = document.getElementById(OVERLAY_ID);
   const container = document.getElementById('tv_chart_container');
-  if (!overlay || !container) return;
-  const scaleGap = 4;
-  const boundaryLeft = getMainPriceAxisLeftRelativeTo(container);
-  if (boundaryLeft !== null && boundaryLeft > OVERLAY_LEFT_PX + scaleGap) {
-    overlay.style.maxWidth = `${boundaryLeft - OVERLAY_LEFT_PX - scaleGap}px`;
-  } else {
-    overlay.style.maxWidth = 'calc(100% - 56px)';
+  if (!container) return;
+  const containerWidth = container.clientWidth;
+  if (containerWidth <= 0) return;
+
+  const scaleWidth = getPriceScaleWidth();
+  const maxWidth = `${containerWidth - OVERLAY_LEFT_PX - scaleWidth - SCALE_GAP}px`;
+
+  const overlay = document.getElementById(OVERLAY_ID);
+  if (overlay) overlay.style.maxWidth = maxWidth;
+
+  for (const el of subPaneOverlays.values()) {
+    el.style.maxWidth = maxWidth;
   }
 }
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -19,7 +19,6 @@ import {
   getActiveStudies,
   getLegendStudyOrder,
   getMaStudies,
-  getStudyPaneIndexMap,
   getTheme,
   getVolumeStudyId,
   getWidget,
@@ -50,8 +49,8 @@ let legendOverlayEnabled = false;
 let indicatorColors: IndicatorColors | undefined;
 /** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
 let legendConfig: Record<string, LegendIndicatorCfg> | undefined;
-/** Sub-pane overlay elements keyed by pane index. */
-const subPaneOverlays = new Map<number, HTMLDivElement>();
+/** Sub-pane overlay elements keyed by indicator name. */
+const subPaneOverlays = new Map<string, HTMLDivElement>();
 
 // ----- Lifecycle ---------------------------------------------------------
 
@@ -382,24 +381,29 @@ function scheduleRetry(gen: number): void {
 
 function renderOverlay(entries: StudyDataEntry[]): void {
   const presets = getPresetMap();
-  const paneIndexMap = getStudyPaneIndexMap();
+  const widget = getWidget();
+  const chart = widget?.activeChart();
+  const activeStudies = getActiveStudies();
 
   const mainEntries: StudyDataEntry[] = [];
-  const subPaneGroups = new Map<number, StudyDataEntry[]>();
+  const subPaneEntries: {
+    name: string;
+    paneIdx: number;
+    entry: StudyDataEntry;
+  }[] = [];
 
   for (const entry of entries) {
     const cfg = presets[entry.name];
-    const paneIdx = paneIndexMap.get(entry.name);
-    if (cfg?.subPaneLegend && paneIdx !== undefined) {
-      let group = subPaneGroups.get(paneIdx);
-      if (!group) {
-        group = [];
-        subPaneGroups.set(paneIdx, group);
+    if (cfg?.subPaneLegend && chart) {
+      const studyId = activeStudies.get(entry.name);
+      const study = studyId ? chart.getStudyById(studyId) : null;
+      const paneIdx = study?.paneIndex?.();
+      if (paneIdx !== undefined && paneIdx > 0) {
+        subPaneEntries.push({ name: entry.name, paneIdx, entry });
+        continue;
       }
-      group.push(entry);
-    } else {
-      mainEntries.push(entry);
     }
+    mainEntries.push(entry);
   }
 
   const mainOverlay = document.getElementById(OVERLAY_ID);
@@ -407,17 +411,14 @@ function renderOverlay(entries: StudyDataEntry[]): void {
     mainOverlay.innerHTML = buildHTML(mainEntries);
   }
 
-  const widget = getWidget();
-  const chart = widget?.activeChart();
-
-  const activePanes = new Set(subPaneGroups.keys());
-  for (const paneIdx of subPaneOverlays.keys()) {
-    if (!activePanes.has(paneIdx)) removeSubPaneOverlay(paneIdx);
+  const activeNames = new Set(subPaneEntries.map((s) => s.name));
+  for (const name of subPaneOverlays.keys()) {
+    if (!activeNames.has(name)) removeSubPaneOverlay(name);
   }
 
-  for (const [paneIdx, group] of subPaneGroups) {
-    const overlay = ensureSubPaneOverlay(paneIdx, chart ?? undefined);
-    if (overlay) overlay.innerHTML = buildHTML(group);
+  for (const { name, paneIdx, entry } of subPaneEntries) {
+    const overlay = ensureSubPaneOverlay(name, paneIdx, chart ?? undefined);
+    if (overlay) overlay.innerHTML = buildHTML([entry]);
   }
 
   updateLegendOverlayLayout();
@@ -553,8 +554,8 @@ export function subscribeStudyDataLoaded(
 
 // ----- Sub-pane overlay management ----------------------------------------
 
-function subPaneOverlayId(paneIndex: number): string {
-  return `${OVERLAY_ID}-pane-${paneIndex}`;
+function subPaneOverlayId(name: string): string {
+  return `${OVERLAY_ID}-pane-${name}`;
 }
 
 function getSubPaneTopPx(paneIndex: number, chart: TVActiveChart): number {
@@ -567,32 +568,33 @@ function getSubPaneTopPx(paneIndex: number, chart: TVActiveChart): number {
 }
 
 function ensureSubPaneOverlay(
+  name: string,
   paneIndex: number,
   chart?: TVActiveChart,
 ): HTMLDivElement | null {
-  const existing = subPaneOverlays.get(paneIndex);
+  const existing = subPaneOverlays.get(name);
   if (existing && document.contains(existing)) return existing;
 
   const container = document.getElementById('tv_chart_container');
   if (!container) return null;
 
   const div = document.createElement('div');
-  div.id = subPaneOverlayId(paneIndex);
+  div.id = subPaneOverlayId(name);
   const topPx = chart ? getSubPaneTopPx(paneIndex, chart) : 0;
   div.style.cssText =
     `position:absolute;top:${topPx}px;left:${OVERLAY_LEFT_PX}px;z-index:5;` +
     `pointer-events:none;display:flex;flex-wrap:wrap;align-items:flex-start;` +
     `column-gap:8px;row-gap:2px;`;
   container.appendChild(div);
-  subPaneOverlays.set(paneIndex, div);
+  subPaneOverlays.set(name, div);
   return div;
 }
 
-export function removeSubPaneOverlay(paneIndex: number): void {
-  const el = subPaneOverlays.get(paneIndex);
+export function removeSubPaneOverlay(name: string): void {
+  const el = subPaneOverlays.get(name);
   if (el) {
     el.remove();
-    subPaneOverlays.delete(paneIndex);
+    subPaneOverlays.delete(name);
   }
 }
 
@@ -602,8 +604,14 @@ function removeAllSubPaneOverlays(): void {
 }
 
 function repositionSubPaneOverlays(chart: TVActiveChart): void {
-  for (const [paneIdx, el] of subPaneOverlays) {
-    el.style.top = `${getSubPaneTopPx(paneIdx, chart)}px`;
+  const activeStudies = getActiveStudies();
+  for (const [name, el] of subPaneOverlays) {
+    const studyId = activeStudies.get(name);
+    const study = studyId ? chart.getStudyById(studyId) : null;
+    const paneIdx = study?.paneIndex?.();
+    if (paneIdx !== undefined && paneIdx > 0) {
+      el.style.top = `${getSubPaneTopPx(paneIdx, chart)}px`;
+    }
   }
 }
 

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/legend.ts
@@ -8,7 +8,7 @@
 // The overlay is a `<div id="study-legend-overlay">` injected into
 // #tv_chart_container that holds one `.legend-pill` per active indicator.
 // Theme-aware text colors are computed from CONFIG.theme; per-plot colors
-// come from CONFIG.indicatorColors.
+// come from the legend config supplied by RN.
 //
 // `LEGEND_RENDERED` is posted to RN once the overlay has settled (either
 // real values returned by chart.exportData() or after the retry timeout).
@@ -27,7 +27,6 @@ import {
 } from '../../core/state';
 import { eachChartDocument } from '../../widget/tvDomHelpers';
 import type {
-  IndicatorColors,
   LegendIndicatorCfg,
   LegendOverlayConfig,
   LegendPlotCfg,
@@ -46,8 +45,7 @@ let exportGeneration = 0;
 let retryCount = 0;
 let timeoutId: ReturnType<typeof setTimeout> | null = null;
 let legendOverlayEnabled = false;
-let indicatorColors: IndicatorColors | undefined;
-/** Typed legend config from RN; when present, replaces the hardcoded buildPresetMap(). */
+/** Typed legend config from RN — the single source of truth for legend rendering. */
 let legendConfig: Record<string, LegendIndicatorCfg> | undefined;
 /** Sub-pane overlay elements keyed by indicator name. */
 const subPaneOverlays = new Map<string, HTMLDivElement>();
@@ -57,10 +55,8 @@ const subPaneOverlays = new Map<string, HTMLDivElement>();
 /** Called once on chart-ready to set up the DOM container. */
 export function setupLegendOverlay(
   config: LegendOverlayConfig | undefined,
-  colors: IndicatorColors | undefined,
 ): void {
   legendOverlayEnabled = Boolean(config?.enabled);
-  indicatorColors = colors;
   legendConfig = config?.config;
   if (!legendOverlayEnabled) return;
   createOverlayElement();
@@ -125,79 +121,11 @@ function injectHideLegendButtonsCSS(): void {
 // ----- Legend rebuild ---------------------------------------------------
 
 /**
- * Returns the per-indicator legend config. When RN supplied a typed config via
- * legendOverlay.config (the single source of truth), use it directly.
- * Otherwise fall back to a minimal built-in map derived from indicatorColors.
+ * Returns the per-indicator legend config supplied by RN via legendOverlay.config.
+ * Consumers must pass their own config — there is no built-in fallback.
  */
 function getPresetMap(): Record<string, LegendIndicatorCfg> {
-  if (legendConfig) return legendConfig;
-  return buildFallbackPresetMap();
-}
-
-function buildFallbackPresetMap(): Record<string, LegendIndicatorCfg> {
-  const macd = indicatorColors?.MACD ?? {};
-  const rsi = indicatorColors?.RSI ?? {};
-  const bol = indicatorColors?.BOL ?? {};
-  const ma = indicatorColors?.MA ?? {};
-  return {
-    MACD: {
-      subPaneLegend: true,
-      plots: [
-        { tvTitle: 'MACD', label: 'MACD(12,26)', color: macd.macd ?? null },
-        { tvTitle: 'Signal', label: 'Signal', color: macd.signal ?? null },
-        {
-          tvTitle: 'Histogram',
-          label: 'Hist',
-          color: macd.histogramPositive ?? null,
-        },
-      ],
-      useIndex: true,
-    },
-    RSI: {
-      subPaneLegend: true,
-      plots: [{ tvTitle: 'Plot', label: 'RSI(14)', color: rsi.plot ?? null }],
-      useIndex: true,
-    },
-    BOL: {
-      combineInOnePill: true,
-      title: 'BB(20,2)',
-      plots: [
-        { tvTitle: 'Upper', label: 'U:', color: bol.upper ?? null },
-        { tvTitle: 'Median', label: 'M:', color: bol.basis ?? null },
-        { tvTitle: 'Lower', label: 'L:', color: bol.lower ?? null },
-      ],
-      useIndex: true,
-    },
-    Volume: {
-      plots: [{ tvTitle: 'Vol', label: 'Vol', color: null }],
-      useIndex: true,
-    },
-    MA5: {
-      isMA: true,
-      useIndex: true,
-      plots: [{ tvTitle: 'Plot', label: 'MA(5)', color: ma.MA5 ?? null }],
-    },
-    MA10: {
-      isMA: true,
-      useIndex: true,
-      plots: [{ tvTitle: 'Plot', label: 'MA(10)', color: ma.MA10 ?? null }],
-    },
-    MA20: {
-      isMA: true,
-      useIndex: true,
-      plots: [{ tvTitle: 'Plot', label: 'MA(20)', color: ma.MA20 ?? null }],
-    },
-    MA50: {
-      isMA: true,
-      useIndex: true,
-      plots: [{ tvTitle: 'Plot', label: 'MA(50)', color: ma.MA50 ?? null }],
-    },
-    MA200: {
-      isMA: true,
-      useIndex: true,
-      plots: [{ tvTitle: 'Plot', label: 'MA(200)', color: ma.MA200 ?? null }],
-    },
-  };
+  return legendConfig ?? {};
 }
 
 function getLegendAltColor(): string {
@@ -658,7 +586,6 @@ export function __resetLegendForTests(): void {
   retryCount = 0;
   clearTimer();
   legendOverlayEnabled = false;
-  indicatorColors = undefined;
   legendConfig = undefined;
   removeAllSubPaneOverlays();
 }

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/studies.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/studies.ts
@@ -37,10 +37,12 @@ export function getMAColor(
   return DEFAULT_MA_COLORS[name] ?? DEFAULT_MA_COLORS.MA200;
 }
 
-interface StudyPreset {
+export interface StudyPreset {
   studyName: string;
   inputs: Record<string, unknown>;
   overrides: Record<string, unknown>;
+  /** 'sub' places the study in a dedicated pane below the main series. */
+  paneTarget?: 'main' | 'sub';
 }
 
 function macdPreset(colors: IndicatorColors | undefined): StudyPreset {
@@ -54,6 +56,7 @@ function macdPreset(colors: IndicatorColors | undefined): StudyPreset {
       'Histogram.color.0': c.histogramPositive,
       'Histogram.color.1': c.histogramNegative,
     },
+    paneTarget: 'sub',
   };
 }
 
@@ -66,6 +69,7 @@ function rsiPreset(colors: IndicatorColors | undefined): StudyPreset {
       'Plot.color': c.plot,
       'hlines background.visible': false,
     },
+    paneTarget: 'sub',
   };
 }
 
@@ -145,14 +149,8 @@ export function resolveStudyPreset(
   }
 }
 
-/** Sub-pane indicators always render in a dedicated pane below the main series. */
-export const SUB_PANE_INDICATOR_NAMES: ReadonlySet<string> = new Set([
-  'MACD',
-  'RSI',
-]);
-
-export function isSubPaneIndicator(name: string): boolean {
-  return SUB_PANE_INDICATOR_NAMES.has(name);
+export function isSubPanePreset(preset: StudyPreset): boolean {
+  return preset.paneTarget === 'sub';
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
@@ -6,7 +6,7 @@
 
 import { reportErrorToRN } from '../../core/bridge';
 import {
-  getActiveStudies,
+  getStudyPaneIndexMap,
   getSubPaneHeightRatio,
   getWidget,
   isChartReady,
@@ -14,15 +14,11 @@ import {
 } from '../../core/state';
 import type { TVActiveChart } from '../../core/types';
 import type { SetSubPaneLayoutMessage } from '../../messages/contract';
-import { isSubPaneIndicator } from './studies';
 
 const MIN_MAIN_PX = 72;
 
 export function hasActiveSubPaneIndicators(): boolean {
-  for (const name of getActiveStudies().keys()) {
-    if (isSubPaneIndicator(name)) return true;
-  }
-  return false;
+  return getStudyPaneIndexMap().size > 0;
 }
 
 export function applySubPaneHeightRatio(chart: TVActiveChart): void {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/features/indicators/subPane.ts
@@ -6,7 +6,7 @@
 
 import { reportErrorToRN } from '../../core/bridge';
 import {
-  getStudyPaneIndexMap,
+  getActiveStudies,
   getSubPaneHeightRatio,
   getWidget,
   isChartReady,
@@ -18,7 +18,15 @@ import type { SetSubPaneLayoutMessage } from '../../messages/contract';
 const MIN_MAIN_PX = 72;
 
 export function hasActiveSubPaneIndicators(): boolean {
-  return getStudyPaneIndexMap().size > 0;
+  const widget = getWidget();
+  if (!widget) return false;
+  const chart = widget.activeChart();
+  for (const studyId of getActiveStudies().values()) {
+    const study = chart.getStudyById(studyId);
+    const paneIdx = study?.paneIndex?.();
+    if (paneIdx !== undefined && paneIdx > 0) return true;
+  }
+  return false;
 }
 
 export function applySubPaneHeightRatio(chart: TVActiveChart): void {

--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -90,6 +90,6 @@ export type TokenDetailsExitAction =
 
 /**
  * Technical indicators that occupy a sub-pane below the main chart.
- * Keep in sync with SUB_PANE_INDICATOR_NAMES in webview/src/features/indicators/studies.ts.
+ * Derived from `buildIndicatorLegendConfig` — no manual sync needed.
  */
-export const SUB_PANE_INDICATORS = ['MACD', 'RSI'] as const;
+export { SUB_PANE_INDICATORS } from '../../Charts/AdvancedChart/indicatorColors';


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Moves RSI and MACD indicator legend pills from the shared top overlay into their own sub-pane overlays, so each indicator's legend renders inside its corresponding chart pane rather than being grouped at the top of the main chart.

The implementation is **config-driven and extensible** — adding a new sub-pane indicator (e.g. Stochastic, ATR, CCI) in the future requires only **2 file touches**:

1. **`studies.ts`** — add a preset with `paneTarget: 'sub'`
2. **`indicatorColors.ts`** — add a legend config entry with `subPaneLegend: true`

Everything else — sub-pane height management, legend pill placement, resize repositioning — is derived automatically from the TradingView `paneIndex()` API and the RN-supplied config.

### What changed

**Pane index management — now uses TradingView API directly:**
- Removed all manual `studyPaneIndex` bookkeeping from `core/state.ts` (the Map, get/set/delete/reindex functions)
- Sub-pane detection now queries `chart.getStudyById(studyId).paneIndex()` at call time — no stale state, no reindexing logic
- Legend overlays are keyed by indicator **name** (not numeric pane index), eliminating the stale-key bug when middle panes are removed

**Dead code cleanup — fallback preset map removed:**
- Removed `buildFallbackPresetMap()` (~60 lines of hardcoded indicator config) from `legend.ts`
- Removed the `indicatorColors` parameter from `setupLegendOverlay()` — consumers pass their config via `legendOverlay.config` exclusively
- `getPresetMap()` now returns `legendConfig ?? {}` — no hidden fallback, making the contract explicit for component consumers
- If a consumer doesn't want indicators, they simply omit `legendOverlay` and don't send `ADD_INDICATOR` messages

**Preset metadata (`studies.ts`):**
- Added `paneTarget` field to `StudyPreset` (`'main' | 'sub'`, defaults to `'main'`)
- Set `paneTarget: 'sub'` on MACD and RSI presets
- Replaced hardcoded `SUB_PANE_INDICATOR_NAMES` set with `isSubPanePreset()` that reads from preset metadata

**Config types (`AdvancedChart.types.ts`, `core/types.ts`, `indicatorColors.ts`):**
- Added `subPaneLegend` boolean to `LegendIndicatorConfig`
- Set `subPaneLegend: true` for MACD and RSI in `buildIndicatorLegendConfig()`
- Added `paneIndex?(): number` to `TVStudy` interface
- Typed `LegendOverlayConfig.config` properly so the WebView reads `subPaneLegend` and plot configs from RN-provided config

**DOM: per-pane overlay containers (`legend.ts`):**
- Main-pane pills continue rendering in `#study-legend-overlay`
- Sub-pane pills render in lazily-created `#study-legend-overlay-pane-{name}` containers positioned at each sub-pane's Y offset
- `ensureSubPaneOverlay(name)` creates overlays on demand; `removeSubPaneOverlay` / `removeAllSubPaneOverlays` handle cleanup
- `getSubPaneTopPx()` computes Y from cumulative `getAllPanesHeight()` sum + padding from the pane separator

**Render + layout (`legend.ts`):**
- `renderOverlay` partitions entries by live `paneIndex()` query, routing each group to the correct overlay
- `panes_height_changed` handler repositions all sub-pane overlays vertically on pane resize
- Stale overlays (indicators removed externally) are cleaned up automatically during render

**Sub-pane detection (`subPane.ts`):**
- `hasActiveSubPaneIndicators()` iterates active studies and queries `paneIndex()` API directly instead of reading from a manual Map

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Moved technical indicator legends (MACD, RSI) into their own chart sub-panes for improved readability


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3475

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Per-pane indicator legends

  Scenario: RSI legend renders in its own sub-pane
    Given user is on Token Details with RSI indicator enabled
    When the chart loads with RSI
    Then the RSI(14) legend pill appears inside the RSI sub-pane, not at the top of the main chart

  Scenario: MACD legend renders in its own sub-pane
    Given user is on Token Details with MACD indicator enabled
    When the chart loads with MACD
    Then the MACD(12,26), Signal, and Hist legend pills appear inside the MACD sub-pane with adequate padding from the separator

  Scenario: RSI + MACD both active
    Given user has both RSI and MACD indicators enabled
    When the chart loads
    Then RSI pills appear in the RSI pane and MACD pills appear in the MACD pane
    And main-pane legends (MA, BOL) remain at the top of the main chart

  Scenario: Remove upper sub-pane indicator (MACD added first, then RSI, remove MACD)
    Given user has MACD in pane 1 and RSI in pane 2
    When user removes the MACD indicator
    Then RSI shifts to pane 1 and its legend overlay repositions correctly
    And no stale overlays remain in the DOM

  Scenario: Toggle off sub-pane indicator
    Given user has MACD enabled and legend is visible in its sub-pane
    When user removes the MACD indicator
    Then the MACD sub-pane overlay is removed and main-pane legends are unaffected

  Scenario: Chart without indicators (consumer omits legendOverlay)
    Given a consumer renders AdvancedChart without legendOverlay prop
    When the chart loads
    Then no legend overlays are created and no fallback config is applied
```


## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Uploading Screen Recording 2026-07-10 at 12.56.43.mov…


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5a33014e-6dce-406c-8318-76f775ea5490



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart WebView legend and layout changes only; no auth or payment paths. Risk is mainly visual regressions (overlay position, width, stale pills) on Token Details charts.
> 
> **Overview**
> **MACD and RSI legend pills** now render in **per-pane DOM overlays** inside their TradingView sub-panes instead of the shared top `#study-legend-overlay`. Main-pane indicators (MA, BOL, etc.) stay in the top overlay.
> 
> The WebView **drops the hardcoded legend preset map** and **`indicatorColors` passed into `setupLegendOverlay`**; rendering uses **`legendOverlay.config` from RN only**. RN adds **`subPaneLegend`** on `LegendIndicatorConfig` (enabled for MACD/RSI) and exports **`SUB_PANE_INDICATORS`** from that config so Token Details no longer maintains a duplicate list.
> 
> **Sub-pane behavior** is driven by **`paneTarget: 'sub'`** on MACD/RSI study presets (`isSubPanePreset`) and live **`study.paneIndex()`** for routing, repositioning on `panes_height_changed`, and cleanup on remove—replacing name-based `SUB_PANE_INDICATOR_NAMES` / manual pane bookkeeping. **Legend max-width** now uses the main pane **price scale width API** instead of DOM price-axis probing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa19ace2d286039dd054b2aeba012292776b57ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->