### PR TITLE
fix(swaps): dismiss explorer picker before opening block explorer web view cp-8.2.0

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
@@ -16,7 +16,33 @@ jest.mock('../../../../../util/analytics/externalLinkTracking', () => ({
   trackBlockExplorerLinkClicked: jest.fn(),
 }));
 import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+
 const mockNavigate = jest.fn();
+const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => {
+  callback?.();
+});
+
+jest.mock(
+  '../../../../../component-library/components/BottomSheets/BottomSheet',
+  () => {
+    const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: forwardRef(
+        (
+          { children }: { children: React.ReactNode },
+          ref: React.Ref<unknown>,
+        ) => {
+          useImperativeHandle(ref, () => ({
+            onCloseBottomSheet: mockOnCloseBottomSheet,
+          }));
+          return <View testID="bottom-sheet">{children}</View>;
+        },
+      ),
+    };
+  },
+);
 
 const mockTx = {
   id: 'test-tx-id',
@@ -54,6 +80,9 @@ jest.mock('@react-navigation/native', () => {
 describe('BlockExplorersModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOnCloseBottomSheet.mockImplementation((callback?: () => void) => {
+      callback?.();
+    });
   });
 
   const mockState = {
@@ -150,6 +179,7 @@ describe('BlockExplorersModal', () => {
     const [srcExplorerButton] = getAllByText('Etherscan');
     fireEvent.press(srcExplorerButton);
 
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: expect.objectContaining({
@@ -178,6 +208,7 @@ describe('BlockExplorersModal', () => {
     const destExplorerButton = getByText('Optimistic');
     fireEvent.press(destExplorerButton);
 
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: expect.objectContaining({

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -1,6 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { StyleSheet } from 'react-native';
-import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheet, {
+  type BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import { Button, ButtonVariant } from '@metamask/design-system-react-native';
 import { Box } from '../../../Box/Box';
@@ -45,6 +47,7 @@ interface BlockExplorersModalRouteParams {
 
 const BlockExplorersModal = () => {
   const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<RouteProp<{ params: BlockExplorersModalRouteParams }, 'params'>>();
@@ -80,18 +83,24 @@ const BlockExplorersModal = () => {
         text,
         url,
       });
-      navigation.navigate(Routes.WEBVIEW.MAIN, {
-        screen: Routes.WEBVIEW.SIMPLE,
-        params: {
-          url,
-        },
+
+      // Dismiss the transparent modal stack before opening the in-app webview.
+      // Navigating while the modal is still presented leaves a touch-blocking
+      // overlay on top and freezes the app.
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.navigate(Routes.WEBVIEW.MAIN, {
+          screen: Routes.WEBVIEW.SIMPLE,
+          params: {
+            url,
+          },
+        });
       });
     },
     [trackEvent, createEventBuilder, navigation],
   );
 
   return (
-    <BottomSheet>
+    <BottomSheet ref={sheetRef}>
       <BottomSheetHeader>
         {strings('bridge_transaction_details.view_on_block_explorer')}
       </BottomSheetHeader>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After performing a bridge and clicking on the View on block explorer link for any network (either source or destination), the transaction details on the block explorer open, but the app freezes and it needs to be closed and reopen, as going back is not possible.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: -Fixed bridge transaction details freezing after tapping "View on block explorer" when selecting a source or destination chain explorer

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/33019

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: View on block explorer from bridge transaction details

  Scenario: user opens a bridge transaction on block explorer
    Given user has a completed cross-chain bridge transaction in Activity
    And user is on the bridge transaction details screen

    When user taps "View on block explorer"
    And user taps a source or destination chain explorer option
    Then the in-app webview opens for that transaction
    And tapping back returns the user to bridge transaction details without freezing the app
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-order change in bridge transaction details UI with matching unit tests; no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes bridge transaction details **freezing** after choosing a source or destination block explorer: the app opened the in-app webview while the explorer picker bottom sheet was still presented, leaving a touch-blocking overlay.
> 
> **`BlockExplorersModal`** now holds a `BottomSheet` ref and calls `onCloseBottomSheet` before navigating to the simple webview, so the transparent modal stack is dismissed first. Tests mock `BottomSheet` and assert the sheet closes once on both explorer button presses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d7c470343ebd8616db500629436b6928c4906e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->