### PR TITLE
fix(money): pin activity list date headers to design format (MUSD-1125)

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -291,6 +291,44 @@ describe('MoneyActivityView', () => {
     expect(queryByTestId(MoneyActivityViewTestIds.PENDING_HEADER)).toBeNull();
   });
 
+  describe('date headers', () => {
+    function mockSettledTransactionAt(time: number) {
+      const settled = MOCK_DEPOSITS.filter(
+        (tx) => tx.id === 'money-tx-converted',
+      ).map((tx) => ({ ...tx, time }));
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: settled,
+        deposits: settled,
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+        mockDataEnabled: false,
+      });
+    }
+
+    it('renders the date header in the design format (Jan 26, 2026)', () => {
+      mockSettledTransactionAt(Date.UTC(2026, 0, 26, 12, 0, 0));
+
+      const { getByTestId } = renderWithProvider(<MoneyActivityView />);
+
+      expect(
+        getByTestId(MoneyActivityViewTestIds.DATE_HEADER),
+      ).toHaveTextContent('Jan 26, 2026');
+    });
+
+    it('labels the header with the same UTC day the row was bucketed under', () => {
+      // 02:00 UTC on Jan 26 is still Jan 25 in the jest timezone
+      // (America/Toronto); the header must name the UTC bucket day.
+      mockSettledTransactionAt(Date.UTC(2026, 0, 26, 2, 0, 0));
+
+      const { getByTestId } = renderWithProvider(<MoneyActivityView />);
+
+      expect(
+        getByTestId(MoneyActivityViewTestIds.DATE_HEADER),
+      ).toHaveTextContent('Jan 26, 2026');
+    });
+  });
+
   it('shows only deposit rows when the Deposits filter is selected', () => {
     const { getByTestId, queryByTestId } = renderWithProvider(
       <MoneyActivityView />,

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -24,8 +24,9 @@ import {
   TextVariant,
   FontWeight,
 } from '@metamask/design-system-react-native';
-import I18n, { strings } from '../../../../../../locales/i18n';
+import { strings } from '../../../../../../locales/i18n';
 import { useTheme } from '../../../../../util/theme';
+import { getIntlDateTimeFormatter } from '../../../../../util/intl';
 import MoneyActivityRow from '../../components/MoneyActivityRow/MoneyActivityRow';
 import MoneyActivityLoading from '../../components/MoneyActivityLoading/MoneyActivityLoading';
 import { useMoneyActivityItems } from '../../hooks/useMoneyActivityItems';
@@ -85,10 +86,17 @@ function dateKeyUtc(time: number): string {
   return new Date(time).toISOString().slice(0, 10);
 }
 
-function groupByDate(
-  items: MoneyActivityItem[],
-  locale: string,
-): ActivitySection[] {
+// Headers are pinned to en-US per the Money design spec ("Jan 26, 2026") and
+// rendered in UTC so the label always names the same day the row was bucketed
+// under by `dateKeyUtc`.
+const dateHeaderFormatter = getIntlDateTimeFormatter('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function groupByDate(items: MoneyActivityItem[]): ActivitySection[] {
   const groups = new Map<string, MoneyActivityItem[]>();
   for (const item of items) {
     const key = dateKeyUtc(item.time);
@@ -100,11 +108,7 @@ function groupByDate(
     }
   }
   return Array.from(groups.entries()).map(([dateKey, data]) => ({
-    title: new Date(`${dateKey}T00:00:00.000Z`).toLocaleDateString(locale, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    }),
+    title: dateHeaderFormatter.format(new Date(`${dateKey}T00:00:00.000Z`)),
     data,
   }));
 }
@@ -113,13 +117,10 @@ function groupByDate(
  * Builds the list sections: a single "Pending" bucket (in-flight rows) on top,
  * followed by the confirmed/failed rows grouped by date.
  */
-function buildSections(
-  items: MoneyActivityItem[],
-  locale: string,
-): ActivitySection[] {
+function buildSections(items: MoneyActivityItem[]): ActivitySection[] {
   const [pending, settled] = partition(items, isPendingItem);
 
-  const dateSections = groupByDate(settled, locale);
+  const dateSections = groupByDate(settled);
   if (pending.length === 0) {
     return dateSections;
   }
@@ -200,10 +201,7 @@ const MoneyActivityView = () => {
 
   const filtered = buckets[filter];
 
-  const sections = useMemo(
-    () => buildSections(filtered, I18n.locale),
-    [filtered],
-  );
+  const sections = useMemo(() => buildSections(filtered), [filtered]);
 
   const renderSectionHeader = ({ section }: { section: ActivitySection }) => (
     <Box twClassName="px-4 pt-2 pb-1 bg-default">


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money activity list date headers must match the design spec format `Jan 26, 2026` (abbreviated month, numeric day, full year). The previous implementation formatted headers with `toLocaleDateString(I18n.locale, ...)`, which deviated from the design in two ways:

1. **Locale drift** — the header followed the app language, so non-English locales rendered e.g. `26 ene 2026` instead of the design format. Headers are now pinned to `en-US`, consistent with how other Money surfaces format values (MUSD-1097).
2. **Timezone off-by-one** — rows are bucketed by UTC day (`dateKeyUtc`), but the header label rendered UTC midnight in the device's local timezone. In any UTC-negative timezone every header named the previous day (e.g. `May 9, 2026` on the May 10 bucket). The header formatter now renders in UTC so the label always names the same day the rows were bucketed under.

The formatter is built once at module scope via the repo's cached `getIntlDateTimeFormatter` helper. Row-level time formatting is untouched.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Money activity list date headers to consistently display in the Jan 26, 2026 format and to name the correct day in every timezone

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1125

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money activity list date headers

  Scenario: user views activity grouped by date
    Given the user has a Money account with settled activity on several days

    When user opens Money home and taps Activity
    Then each date section header displays as e.g. "Jan 26, 2026" (abbreviated month, numeric day, full year)

  Scenario: user views activity in a non-English app language
    Given the app language is set to Spanish

    When user opens the Money activity list
    Then date headers still display in the "Jan 26, 2026" format

  Scenario: user views activity in a UTC-negative timezone
    Given the device timezone is set to America/New_York
    And a transaction settled at 02:00 UTC on Jan 26

    When user opens the Money activity list
    Then the transaction's section header reads "Jan 26, 2026" (not "Jan 25, 2026")
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — text-format-only change; see manual testing steps.

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ef082dd6-1563-445f-9c23-a12196af2539" />


N/A — text-format-only change; see manual testing steps.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI-only change to section header strings in Money Activity; no auth, data, or transaction logic touched.
> 
> **Overview**
> Money activity **date section headers** now always show the design format **`Jan 26, 2026`**, independent of app language and device timezone.
> 
> `groupByDate` / `buildSections` no longer take `I18n.locale`. Headers are formatted with a module-scoped **`getIntlDateTimeFormatter('en-US', …, timeZone: 'UTC')`** so labels match the **UTC day** used by `dateKeyUtc` for bucketing (fixing off-by-one headers in UTC-negative timezones). Row-level time display is unchanged.
> 
> Tests cover the fixed string format and a case where local time is still the previous day but the header must read the UTC bucket day.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bc89a1054a50e7d1b305d1e97820c6a683eceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->