### PR TITLE
feat: musd-1127 hide txn confirm toast for first money deposit

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyFirstTimeDepositTracker.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyFirstTimeDepositTracker.test.ts
@@ -6,8 +6,7 @@ import {
 } from '@metamask/transaction-controller';
 import { useMoneyFirstTimeDepositTracker } from './useMoneyFirstTimeDepositTracker';
 import { store } from '../../../../store';
-import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
-import { hasPriorMoneyDeposit } from '../utils/firstTimeDeposit';
+import { shouldShowMoneyFirstTimeDepositAnimation } from '../utils/firstTimeDeposit';
 import Routes from '../../../../constants/navigation/Routes';
 import Engine from '../../../../core/Engine';
 
@@ -21,20 +20,8 @@ jest.mock('../../../../store', () => ({
   store: { getState: jest.fn() },
 }));
 
-jest.mock('../selectors/featureFlags', () => ({
-  selectMoneyFirstTimeDepositAnimationEnabledFlag: jest.fn(),
-}));
-
 jest.mock('../utils/firstTimeDeposit', () => ({
-  hasPriorMoneyDeposit: jest.fn(),
-}));
-
-jest.mock('../utils/moneyTransactionGuards', () => ({
-  isMoneyDepositTx: jest.fn(
-    (tx: { type: string; nestedTransactions?: { type: string }[] }) =>
-      tx.type === 'moneyAccountDeposit' ||
-      tx.nestedTransactions?.some((n) => n.type === 'moneyAccountDeposit'),
-  ),
+  shouldShowMoneyFirstTimeDepositAnimation: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -44,9 +31,7 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-const mockedFlagSelector =
-  selectMoneyFirstTimeDepositAnimationEnabledFlag as unknown as jest.Mock;
-const mockedHasPrior = hasPriorMoneyDeposit as jest.Mock;
+const mockedShouldShow = shouldShowMoneyFirstTimeDepositAnimation as jest.Mock;
 const mockedGetState = store.getState as jest.Mock;
 const mockedSubscribe = Engine.controllerMessenger.subscribe as jest.Mock;
 const mockedUnsubscribe = Engine.controllerMessenger.unsubscribe as jest.Mock;
@@ -71,8 +56,7 @@ describe('useMoneyFirstTimeDepositTracker', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetState.mockReturnValue({});
-    mockedFlagSelector.mockReturnValue(true);
-    mockedHasPrior.mockReturnValue(false);
+    mockedShouldShow.mockReturnValue(true);
   });
 
   it('subscribes to TransactionController:transactionConfirmed on mount', () => {
@@ -110,34 +94,12 @@ describe('useMoneyFirstTimeDepositTracker', () => {
       );
     });
 
+    expect(mockedShouldShow).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('does not navigate when tx is not a money deposit', () => {
-    renderHook(() => useMoneyFirstTimeDepositTracker());
-    const callback = captureSubscribedCallback();
-
-    act(() => {
-      callback(makeTx('tx-1', TransactionType.contractInteraction));
-    });
-
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('does not navigate when feature flag is disabled', () => {
-    mockedFlagSelector.mockReturnValue(false);
-    renderHook(() => useMoneyFirstTimeDepositTracker());
-    const callback = captureSubscribedCallback();
-
-    act(() => {
-      callback(makeTx('tx-1', TransactionType.moneyAccountDeposit));
-    });
-
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('does not navigate when prior money deposit exists', () => {
-    mockedHasPrior.mockReturnValue(true);
+  it('does not navigate when the animation predicate rejects the tx', () => {
+    mockedShouldShow.mockReturnValue(false);
     renderHook(() => useMoneyFirstTimeDepositTracker());
     const callback = captureSubscribedCallback();
 
@@ -160,42 +122,17 @@ describe('useMoneyFirstTimeDepositTracker', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.FIRST_TIME_DEPOSIT);
   });
 
-  it('navigates directly to first-time deposit for eligible nested batch deposit', () => {
+  it('passes current state and tx to the animation predicate', () => {
+    const state = { marker: true };
+    mockedGetState.mockReturnValue(state);
     renderHook(() => useMoneyFirstTimeDepositTracker());
     const callback = captureSubscribedCallback();
-
-    const batchTx = {
-      ...makeTx('batch-1', TransactionType.batch),
-      nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
-    } as unknown as TransactionMeta;
+    const tx = makeTx('tx-42', TransactionType.moneyAccountDeposit);
 
     act(() => {
-      callback(batchTx);
+      callback(tx);
     });
 
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.FIRST_TIME_DEPOSIT);
-  });
-
-  it('passes current tx id to hasPriorMoneyDeposit', () => {
-    renderHook(() => useMoneyFirstTimeDepositTracker());
-    const callback = captureSubscribedCallback();
-
-    act(() => {
-      callback(makeTx('tx-42', TransactionType.moneyAccountDeposit));
-    });
-
-    expect(mockedHasPrior).toHaveBeenCalledWith(expect.anything(), 'tx-42');
-  });
-
-  it('reads state imperatively via store.getState', () => {
-    renderHook(() => useMoneyFirstTimeDepositTracker());
-    const callback = captureSubscribedCallback();
-
-    act(() => {
-      callback(makeTx('tx-1', TransactionType.moneyAccountDeposit));
-    });
-
-    expect(mockedGetState).toHaveBeenCalledTimes(1);
+    expect(mockedShouldShow).toHaveBeenCalledWith(state, tx);
   });
 });

--- a/app/components/UI/Money/hooks/useMoneyFirstTimeDepositTracker.ts
+++ b/app/components/UI/Money/hooks/useMoneyFirstTimeDepositTracker.ts
@@ -7,9 +7,7 @@ import {
 import Engine from '../../../../core/Engine';
 import Routes from '../../../../constants/navigation/Routes';
 import { store } from '../../../../store';
-import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
-import { isMoneyDepositTx } from '../utils/moneyTransactionGuards';
-import { hasPriorMoneyDeposit } from '../utils/firstTimeDeposit';
+import { shouldShowMoneyFirstTimeDepositAnimation } from '../utils/firstTimeDeposit';
 
 export const useMoneyFirstTimeDepositTracker = () => {
   const navigation = useNavigation();
@@ -18,13 +16,7 @@ export const useMoneyFirstTimeDepositTracker = () => {
     const handleTransactionConfirmed = (tx: TransactionMeta) => {
       if (tx.status !== TransactionStatus.confirmed) return;
 
-      const state = store.getState();
-
-      if (
-        !isMoneyDepositTx(tx) ||
-        !selectMoneyFirstTimeDepositAnimationEnabledFlag(state) ||
-        hasPriorMoneyDeposit(state, tx.id)
-      ) {
+      if (!shouldShowMoneyFirstTimeDepositAnimation(store.getState(), tx)) {
         return;
       }
 

--- a/app/components/UI/Money/hooks/useMoneyToasts.tsx
+++ b/app/components/UI/Money/hooks/useMoneyToasts.tsx
@@ -151,6 +151,7 @@ const toastStyles = StyleSheet.create({
 
 const useMoneyToasts = (): {
   showToast: (config: MoneyToastOptions) => void;
+  closeToast: () => void;
   MoneyToastOptions: MoneyToastOptionsConfig;
 } => {
   const { toastRef } = useContext(ToastContext);
@@ -427,7 +428,7 @@ const useMoneyToasts = (): {
     moneyBaseToastOptions.success,
   ]);
 
-  return { showToast, MoneyToastOptions };
+  return { showToast, closeToast, MoneyToastOptions };
 };
 
 export default useMoneyToasts;

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -17,6 +17,7 @@ import {
   clearMoneyAccountDepositIntent,
   getMoneyAccountDepositIntent,
 } from './useMoneyAccount';
+import { shouldShowMoneyFirstTimeDepositAnimation } from '../utils/firstTimeDeposit';
 import { getMemoizedInternalAccountByAddress } from '../../../../selectors/accountsController';
 import { selectAccountToGroupMap } from '../../../../selectors/multichainAccounts/accountTreeController';
 import Routes from '../../../../constants/navigation/Routes';
@@ -33,6 +34,10 @@ jest.mock('./useMoneyAccount', () => ({
   __esModule: true,
   getMoneyAccountDepositIntent: jest.fn(),
   clearMoneyAccountDepositIntent: jest.fn(),
+}));
+
+jest.mock('../utils/firstTimeDeposit', () => ({
+  shouldShowMoneyFirstTimeDepositAnimation: jest.fn(() => false),
 }));
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
@@ -174,6 +179,7 @@ const buildTxMeta = (overrides: Partial<TransactionMeta>): TransactionMeta =>
 
 describe('useMoneyTransactionStatus', () => {
   const mockShowToast = jest.fn();
+  const mockCloseToast = jest.fn();
 
   const baseInProgressToast = {
     variant: ToastVariants.Icon as const,
@@ -262,6 +268,7 @@ describe('useMoneyTransactionStatus', () => {
     Object.assign(NavigationService.navigation, { navigate: mockNavigate });
     mockUseMoneyToasts.mockReturnValue({
       showToast: mockShowToast,
+      closeToast: mockCloseToast,
       MoneyToastOptions: moneyToastOptions,
     });
   });
@@ -434,6 +441,138 @@ describe('useMoneyTransactionStatus', () => {
       expect(depositSuccessFn).toHaveBeenCalledWith(
         expect.objectContaining({ intent: 'addMusd' }),
       );
+    });
+
+    it('suppresses the success toast when the first-time deposit animation will show', () => {
+      jest
+        .mocked(shouldShowMoneyFirstTimeDepositAnimation)
+        .mockReturnValueOnce(true);
+
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          batchId: '0xBATCH_FIRST_DEPOSIT',
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(depositSuccessFn).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('closes the displayed in-progress toast when the success toast is suppressed', () => {
+      jest
+        .mocked(shouldShowMoneyFirstTimeDepositAnimation)
+        .mockReturnValueOnce(true);
+
+      const { statusUpdatedHandler, confirmedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.approved,
+        }),
+      });
+      jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+      expect(mockShowToast).toHaveBeenCalledWith(baseInProgressToast);
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(mockCloseToast).toHaveBeenCalledTimes(1);
+      expect(depositSuccessFn).not.toHaveBeenCalled();
+    });
+
+    it('does not close the toast when the in-progress toast never displayed', () => {
+      jest
+        .mocked(shouldShowMoneyFirstTimeDepositAnimation)
+        .mockReturnValueOnce(true);
+
+      const { statusUpdatedHandler, confirmedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.approved,
+        }),
+      });
+
+      // Confirmation arrives before the in-progress deferral elapses.
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(mockCloseToast).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('still clears the batch intent when the success toast is suppressed', () => {
+      jest
+        .mocked(shouldShowMoneyFirstTimeDepositAnimation)
+        .mockReturnValueOnce(true);
+
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          batchId: '0xBATCH_FIRST_DEPOSIT',
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(clearMoneyAccountDepositIntent).toHaveBeenCalledWith(
+        '0xBATCH_FIRST_DEPOSIT',
+      );
+    });
+
+    it('shows the success toast when the animation will not show', () => {
+      jest
+        .mocked(shouldShowMoneyFirstTimeDepositAnimation)
+        .mockReturnValueOnce(false);
+
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          batchId: '0xBATCH_LATER_DEPOSIT',
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(depositSuccessFn).toHaveBeenCalledTimes(1);
+      expect(mockShowToast).toHaveBeenCalledWith(baseSuccessToast);
     });
 
     it('forwards intent to deposit.failed on failed', () => {

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -42,6 +42,7 @@ import {
   perpsPredictServiceFamily,
   resolveMoneyDepositIntent,
 } from '../utils/moneyTransactionGuards';
+import { shouldShowMoneyFirstTimeDepositAnimation } from '../utils/firstTimeDeposit';
 import useMoneyToasts from './useMoneyToasts';
 import {
   clearMoneyAccountDepositIntent,
@@ -185,7 +186,7 @@ function latestTransactionMeta(
 }
 
 export const useMoneyTransactionStatus = () => {
-  const { showToast, MoneyToastOptions } = useMoneyToasts();
+  const { showToast, closeToast, MoneyToastOptions } = useMoneyToasts();
   const shownToastsRef = useRef<Set<string>>(new Set());
   const pendingInProgressRef = useRef<
     Map<string, ReturnType<typeof setTimeout>>
@@ -274,6 +275,13 @@ export const useMoneyTransactionStatus = () => {
       const isSend = isPerpsPredictMoneyDeposit(transactionMeta);
       const isReceive = isPerpsPredictMoneyWithdraw(transactionMeta);
       if (!isMoneyAccountTx(transactionMeta) && !isSend && !isReceive) return;
+      // The in-progress toast has no timeout and is normally dismissed by the
+      // final toast replacing it. It has actually been displayed only if its
+      // key was reserved and its deferral timer already fired.
+      const inProgressToastDisplayed =
+        shownToastsRef.current.has(
+          `${transactionMeta.id}-${IN_PROGRESS_KEY}`,
+        ) && !pendingInProgress.has(transactionMeta.id);
       cancelPendingInProgress(transactionMeta.id);
       if (!reserveToastKey(transactionMeta.id, CONFIRMED_KEY)) return;
       const onPress = () =>
@@ -333,10 +341,24 @@ export const useMoneyTransactionStatus = () => {
           : undefined;
 
       if (isMoneyDepositTx(transactionMeta)) {
-        const intent = resolveDepositIntent(transactionMeta);
-        showToast(
-          MoneyToastOptions.deposit.success({ amountFiat, intent, onPress }),
-        );
+        // A first deposit is confirmed by the full-page animation takeover
+        // instead of a toast, so the lingering in-progress toast must be
+        // closed explicitly rather than replaced by the success toast.
+        if (
+          shouldShowMoneyFirstTimeDepositAnimation(
+            store.getState(),
+            transactionMeta,
+          )
+        ) {
+          if (inProgressToastDisplayed) {
+            closeToast();
+          }
+        } else {
+          const intent = resolveDepositIntent(transactionMeta);
+          showToast(
+            MoneyToastOptions.deposit.success({ amountFiat, intent, onPress }),
+          );
+        }
         clearMoneyAccountDepositIntent(transactionMeta.batchId);
       } else {
         const destination =
@@ -407,5 +429,6 @@ export const useMoneyTransactionStatus = () => {
     MoneyToastOptions.withdraw,
     MoneyToastOptions.send,
     showToast,
+    closeToast,
   ]);
 };

--- a/app/components/UI/Money/utils/firstTimeDeposit.test.ts
+++ b/app/components/UI/Money/utils/firstTimeDeposit.test.ts
@@ -3,16 +3,29 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { hasPriorMoneyDeposit } from './firstTimeDeposit';
+import {
+  hasPriorMoneyDeposit,
+  shouldShowMoneyFirstTimeDepositAnimation,
+} from './firstTimeDeposit';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
+import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
 
 jest.mock('../../../../selectors/transactionController', () => ({
   selectNonReplacedTransactions: jest.fn(),
 }));
 
+jest.mock('../selectors/featureFlags', () => ({
+  selectMoneyFirstTimeDepositAnimationEnabledFlag: jest.fn(),
+}));
+
 const mockedSelectNonReplacedTransactions =
   selectNonReplacedTransactions as unknown as jest.MockedFunction<
     (state: unknown) => TransactionMeta[]
+  >;
+
+const mockedFlagSelector =
+  selectMoneyFirstTimeDepositAnimationEnabledFlag as unknown as jest.MockedFunction<
+    (state: unknown) => boolean
   >;
 
 const baseTx = {
@@ -91,6 +104,63 @@ describe('hasPriorMoneyDeposit', () => {
     ]);
 
     const result = hasPriorMoneyDeposit(mockState, 'current-tx');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('shouldShowMoneyFirstTimeDepositAnimation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFlagSelector.mockReturnValue(true);
+    mockedSelectNonReplacedTransactions.mockReturnValue([]);
+  });
+
+  it('returns true for a first money deposit with the feature enabled', () => {
+    const tx = makeTx('current-tx', TransactionType.moneyAccountDeposit);
+    mockedSelectNonReplacedTransactions.mockReturnValue([tx]);
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true for a first nested batch money deposit', () => {
+    const tx = makeTx('current-tx', TransactionType.batch, [
+      { type: TransactionType.moneyAccountDeposit },
+    ]);
+    mockedSelectNonReplacedTransactions.mockReturnValue([tx]);
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the transaction is not a money deposit', () => {
+    const tx = makeTx('current-tx', TransactionType.contractInteraction);
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the feature flag is disabled', () => {
+    mockedFlagSelector.mockReturnValue(false);
+    const tx = makeTx('current-tx', TransactionType.moneyAccountDeposit);
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when a prior money deposit exists', () => {
+    const tx = makeTx('current-tx', TransactionType.moneyAccountDeposit);
+    mockedSelectNonReplacedTransactions.mockReturnValue([
+      tx,
+      makeTx('prior-tx', TransactionType.moneyAccountDeposit),
+    ]);
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
 
     expect(result).toBe(false);
   });

--- a/app/components/UI/Money/utils/firstTimeDeposit.ts
+++ b/app/components/UI/Money/utils/firstTimeDeposit.ts
@@ -1,6 +1,10 @@
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
 import { RootState } from '../../../../reducers';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
+import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
 import { isMoneyDepositTx } from './moneyTransactionGuards';
 
 /**
@@ -18,5 +22,21 @@ export function hasPriorMoneyDeposit(
       tx.id !== currentTxId &&
       isMoneyDepositTx(tx) &&
       tx.status === TransactionStatus.confirmed,
+  );
+}
+
+/**
+ * Returns true if confirming `tx` should trigger the first-time deposit full-page
+ * animation takeover. We use this both to decide whether to show the first
+ * deposit animation, and to whether to hide the successful deposit toast.
+ **/
+export function shouldShowMoneyFirstTimeDepositAnimation(
+  state: RootState,
+  tx: TransactionMeta,
+): boolean {
+  return (
+    isMoneyDepositTx(tx) &&
+    selectMoneyFirstTimeDepositAnimationEnabledFlag(state) &&
+    !hasPriorMoneyDeposit(state, tx.id)
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
We show a special modal when the user makes the firs tmoney account deposit. This was interacting weirdly with the txn success toast.

To fix this, we now don't show the txn confirmation toast for the first deposit made to the money account. I've extracted and then used the predicate that controls the modal - so the two should always be in sync.

The txn pending, and txn failed toasts are still shown.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix confirmation toast overlapping modal on first money account deposit

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1127

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money account

  Scenario: user makes the first deposit to their money account
    Given they have no existing money account transactions in the txn controller

    When user makes a deposit
    Then they don't see a success toast but _do_ see the custom first deposit modal
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/cd6fac36-8caf-49f0-85c3-6b353dd25d8b


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/0c02b06c-e585-4276-852d-2e70f893ade5



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Money UI/toast behavior with shared eligibility logic and broad test coverage; no auth, payments, or persistence changes.
> 
> **Overview**
> Fixes overlap between the first-money-deposit full-page experience and the deposit **success** toast by routing both flows through one shared predicate.
> 
> Adds **`shouldShowMoneyFirstTimeDepositAnimation`** in `firstTimeDeposit.ts` (money deposit + feature flag + no prior confirmed deposit). **`useMoneyFirstTimeDepositTracker`** now calls that helper instead of duplicating guards. On confirmed deposits, **`useMoneyTransactionStatus`** skips the success toast when the predicate is true, explicitly **`closeToast`** if an in-progress toast was already shown, and still clears batch deposit intent. **`useMoneyToasts`** exposes **`closeToast`** for that dismissal. In-progress and failed deposit toasts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50b36fa1af8d088eac195f8b582c8adf17f5ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->