### PR TITLE
fix(money): sync activity list row status with transaction toasts (MUSD-1129)

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -7,6 +7,7 @@ import {
 import { renderHook } from '@testing-library/react-hooks';
 import { ethers } from 'ethers';
 import Engine from '../../../../core/Engine';
+import EngineService from '../../../../core/EngineService';
 import {
   useMoneyTransactionStatus,
   formatMusdAmountForToast,
@@ -40,6 +41,10 @@ import { NotificationMoment } from '../../../../util/haptics';
 import { TOAST_TRACKING_CLEANUP_DELAY_MS } from '../../Earn/constants/musd';
 
 jest.mock('../../../../core/Engine');
+jest.mock('../../../../core/EngineService', () => ({
+  __esModule: true,
+  default: { flushState: jest.fn() },
+}));
 jest.mock('./useMoneyToasts');
 jest.mock('../../../../core/NavigationService/NavigationService', () => ({
   navigation: { navigate: jest.fn() },
@@ -1610,6 +1615,110 @@ describe('useMoneyTransactionStatus', () => {
 
       expect(withdrawSuccessFn).toHaveBeenCalledTimes(1);
       expect(withdrawSuccessFn.mock.calls[0][0].amountFiat).toContain('33.33');
+    });
+  });
+
+  describe('activity row sync (engine state flush)', () => {
+    const mockFlushState = jest.mocked(EngineService.flushState);
+
+    it('flushes engine state when a Money Account tx status updates', () => {
+      const { statusUpdatedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.approved,
+        }),
+      });
+
+      expect(mockFlushState).toHaveBeenCalledTimes(1);
+    });
+
+    it('flushes engine state when a Money Account tx confirms', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            data: encodeWithdrawData(BigInt(1_000_000)),
+          },
+        }),
+      );
+
+      expect(mockFlushState).toHaveBeenCalledTimes(1);
+    });
+
+    it('flushes engine state when a Money Account tx fails or drops', () => {
+      const { statusUpdatedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.failed,
+        }),
+      });
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          id: 'tx-id-2',
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.dropped,
+        }),
+      });
+
+      expect(mockFlushState).toHaveBeenCalledTimes(2);
+    });
+
+    it('flushes engine state for a perps/predict Money transfer', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.perpsDeposit,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: MUSD_ADDRESS,
+            chainId: CHAIN_IDS.MONAD,
+            targetFiat: '100',
+          },
+        } as unknown as Partial<TransactionMeta>),
+      );
+
+      expect(mockFlushState).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not flush for transactions outside the Money activity list', () => {
+      const { statusUpdatedHandler, confirmedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          type: TransactionType.simpleSend,
+          status: TransactionStatus.approved,
+        }),
+      });
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.simpleSend,
+          status: TransactionStatus.confirmed,
+        }),
+      );
+
+      expect(mockFlushState).not.toHaveBeenCalled();
+    });
+
+    it('does not flush on a transactionConfirmed event carrying a non-confirmed status', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.submitted,
+        }),
+      );
+
+      expect(mockFlushState).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -9,6 +9,7 @@ import { ethers } from 'ethers';
 import { useEffect, useRef } from 'react';
 import Routes from '../../../../constants/navigation/Routes';
 import Engine from '../../../../core/Engine';
+import EngineService from '../../../../core/EngineService';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
 import Logger from '../../../../util/Logger';
 import { fromTokenMinimalUnitString } from '../../../../util/number/bigint';
@@ -36,6 +37,7 @@ import { TELLER_ABI } from '../utils/moneyAccountTransactions';
 import {
   isMoneyAccountTx,
   isMoneyDepositTx,
+  isPerpsPredictMoneyActivity,
   isPerpsPredictMoneyDeposit,
   isPerpsPredictMoneyWithdraw,
   nestedTxWithType,
@@ -182,6 +184,20 @@ function latestTransactionMeta(
   return Engine.context.TransactionController.state.transactions.find(
     (tx) => tx.id === transactionId,
   );
+}
+
+// Activity rows render transaction status from the Redux copy of
+// TransactionController state, which trails these messenger events behind
+// EngineService's update batcher; under a busy JS thread the rows visibly lag
+// the toasts. Flushing here makes rows update in the same frame as the toast.
+function flushActivityState(transactionMeta: TransactionMeta) {
+  if (
+    !isMoneyAccountTx(transactionMeta) &&
+    !isPerpsPredictMoneyActivity(transactionMeta)
+  ) {
+    return;
+  }
+  EngineService.flushState();
 }
 
 export const useMoneyTransactionStatus = () => {
@@ -354,6 +370,7 @@ export const useMoneyTransactionStatus = () => {
     }: {
       transactionMeta: TransactionMeta;
     }) => {
+      flushActivityState(transactionMeta);
       switch (transactionMeta.status) {
         case TransactionStatus.approved:
           showInProgressFor(transactionMeta);
@@ -376,6 +393,7 @@ export const useMoneyTransactionStatus = () => {
 
     const handleTransactionConfirmed = (transactionMeta: TransactionMeta) => {
       if (transactionMeta.status !== TransactionStatus.confirmed) return;
+      flushActivityState(transactionMeta);
       showConfirmedFor(transactionMeta);
     };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a Money transaction changes status (pending → confirmed or pending → failed), the toast reflects the new status immediately but the activity list row keeps showing the previous status until the user interacts with the app (refresh, navigation).

The toast and the row read the same `TransactionController` status through two different transports. The toast subscribes directly to controller messenger events (`TransactionController:transactionStatusUpdated` / `transactionConfirmed`) and fires synchronously with the controller state change. The row renders from the Redux copy of controller state, which only receives updates through `EngineService`'s update batcher — a 250 ms `setTimeout` that is a floor, not a ceiling: right after a confirmation the JS thread is busy (post-balance updates, balance refetches, the toast itself), so the Redux dispatch and the re-render of the Money screens visibly trail the toast. Only `ApprovalController` gets an immediate flush today.

The fix flushes the batched engine state (`EngineService.flushState()`) for Money-relevant transactions (`isMoneyAccountTx` / `isPerpsPredictMoneyActivity`) at the moment their status events arrive — the same events that trigger the toasts — so the activity rows update in the same frame as the toast. This mirrors the existing `flushState()` usage in the mUSD conversion flow (`useMusdConversion`) and the MetaMask Pay confirmation hooks (`useTransactionPayToken`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where Money activity list rows kept showing the previous transaction status after the status-change toast had already appeared

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1129

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money activity list row status stays in sync with toasts

  Scenario: user deposits into the Money account
    Given the user has a Money account and is on the Money home screen

    When the user completes a deposit and the transaction confirms
    Then the "Added funds" toast appears
    And the activity row flips from "Depositing" to "Deposited" in the same moment, without refreshing or navigating

  Scenario: user's Money transaction fails
    Given the user has a pending Money transaction visible in the activity list

    When the transaction fails
    Then the failure toast appears
    And the activity row shows the failed state in sync with the toast
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/fc0455eb-7cc7-4cef-a4ba-f9d75283662c


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Money activity transaction handlers with existing guard helpers; mirrors flush patterns used elsewhere and is covered by new unit tests.
> 
> **Overview**
> Money activity rows were updating from Redux behind `EngineService`'s batched engine updates while status toasts reacted immediately to `TransactionController` messenger events, so list labels could lag behind toasts after confirm or fail.
> 
> **`useMoneyTransactionStatus`** now calls **`EngineService.flushState()`** via **`flushActivityState`** at the start of **`transactionStatusUpdated`** and **`transactionConfirmed`** handlers when the tx is a Money account tx (`isMoneyAccountTx`) or a perps/predict Money activity row (`isPerpsPredictMoneyActivity`). Non-Money txs and **`transactionConfirmed`** payloads that are not actually **`confirmed`** skip the flush.
> 
> Unit tests mock **`EngineService.flushState`** and assert flush on Money status/confirm/fail paths, perps/predict Money transfers, and no flush for **`simpleSend`** or bogus confirmed events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77ed7bf4059be51b51688de93df81db3d2b6a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->