### PR TITLE
chore: upgrade design system packages (v53.0.0)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.test.tsx
@@ -582,7 +582,7 @@ describe('PerpsOrderBookView', () => {
       expect(mockTrack).toHaveBeenCalled();
     });
 
-    it('switches to USD unit when USD toggle is pressed', () => {
+    it('switches to USD unit when USD toggle is pressed', async () => {
       const { getByTestId } = renderWithProvider(<PerpsOrderBookView />, {
         state: initialState,
       });
@@ -590,15 +590,23 @@ describe('PerpsOrderBookView', () => {
       const baseToggle = getByTestId(
         PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE_BASE,
       );
-      const usdToggle = getByTestId(
-        PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE_USD,
-      );
 
       fireEvent.press(baseToggle);
-      mockTrack.mockClear();
-      fireEvent.press(usdToggle);
 
-      expect(mockTrack).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(
+          getByTestId(PerpsOrderBookViewSelectorsIDs.TABLE).props.unit,
+        ).toBe('base');
+      });
+
+      mockTrack.mockClear();
+      fireEvent.press(
+        getByTestId(PerpsOrderBookViewSelectorsIDs.UNIT_TOGGLE_USD),
+      );
+
+      await waitFor(() => {
+        expect(mockTrack).toHaveBeenCalled();
+      });
     });
 
     it('starts with USD as default unit', () => {

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -341,7 +341,6 @@ function TradeWalletActions() {
           onPress={onBatchSell}
           testID={WalletActionsBottomSheetSelectorsIDs.BATCH_SELL_BUTTON}
           isDisabled={!isSwapsEnabled}
-          style={tw.style('bg-transparent')}
         />
       )}
       {AppConstants.SWAPS.ACTIVE && (
@@ -352,7 +351,6 @@ function TradeWalletActions() {
           onPress={goToSwaps}
           testID={WalletActionsBottomSheetSelectorsIDs.SWAP_BUTTON}
           isDisabled={!isSwapsEnabled}
-          style={tw.style('bg-transparent')}
         />
       )}
       {isPerpsEnabled && (
@@ -363,7 +361,6 @@ function TradeWalletActions() {
           onPress={onPerps}
           testID={WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON}
           isDisabled={!canSignTransactions}
-          style={tw.style('bg-transparent')}
         />
       )}
       {isPredictEnabled && (
@@ -374,7 +371,6 @@ function TradeWalletActions() {
           onPress={onPredict}
           testID={WalletActionsBottomSheetSelectorsIDs.PREDICT_BUTTON}
           isDisabled={!canSignTransactions}
-          style={tw.style('bg-transparent')}
         />
       )}
       {isEarnWalletActionEnabled && isEarnEligible && (
@@ -385,7 +381,6 @@ function TradeWalletActions() {
           onPress={onEarn}
           testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
           isDisabled={!canSignTransactions}
-          style={tw.style('bg-transparent')}
         />
       )}
     </>

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -341,6 +341,7 @@ function TradeWalletActions() {
           onPress={onBatchSell}
           testID={WalletActionsBottomSheetSelectorsIDs.BATCH_SELL_BUTTON}
           isDisabled={!isSwapsEnabled}
+          style={tw.style('bg-transparent')}
         />
       )}
       {AppConstants.SWAPS.ACTIVE && (
@@ -351,6 +352,7 @@ function TradeWalletActions() {
           onPress={goToSwaps}
           testID={WalletActionsBottomSheetSelectorsIDs.SWAP_BUTTON}
           isDisabled={!isSwapsEnabled}
+          style={tw.style('bg-transparent')}
         />
       )}
       {isPerpsEnabled && (
@@ -361,6 +363,7 @@ function TradeWalletActions() {
           onPress={onPerps}
           testID={WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON}
           isDisabled={!canSignTransactions}
+          style={tw.style('bg-transparent')}
         />
       )}
       {isPredictEnabled && (
@@ -371,6 +374,7 @@ function TradeWalletActions() {
           onPress={onPredict}
           testID={WalletActionsBottomSheetSelectorsIDs.PREDICT_BUTTON}
           isDisabled={!canSignTransactions}
+          style={tw.style('bg-transparent')}
         />
       )}
       {isEarnWalletActionEnabled && isEarnEligible && (
@@ -381,6 +385,7 @@ function TradeWalletActions() {
           onPress={onEarn}
           testID={WalletActionsBottomSheetSelectorsIDs.EARN_BUTTON}
           isDisabled={!canSignTransactions}
+          style={tw.style('bg-transparent')}
         />
       )}
     </>

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "@metamask/core-backend": "^6.3.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.34.0",
+    "@metamask/design-system-react-native": "^0.35.0",
     "@metamask/design-system-twrnc-preset": "^0.7.0",
     "@metamask/design-tokens": "^8.7.0",
     "@metamask/earn-controller": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8515,11 +8515,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.34.0":
-  version: 0.34.0
-  resolution: "@metamask/design-system-react-native@npm:0.34.0"
+"@metamask/design-system-react-native@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "@metamask/design-system-react-native@npm:0.35.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.28.0"
+    "@metamask/design-system-shared": "npm:^0.29.0"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
     "@metamask/design-system-twrnc-preset": ^0.7.0
@@ -8532,18 +8532,18 @@ __metadata:
     react-native-reanimated: ">=4.2.0"
     react-native-safe-area-context: ">=5.0.0"
     react-native-worklets: ">=0.7.4"
-  checksum: 10/c9538ebb2deb857fb02ba5ff60a7c14ee6d850803f535674981dba8d82ca4dde0aa9aaef932d362e41c0d2ec9e77a74cddcc21801c6b6b1ac8c6563794c42e48
+  checksum: 10/be185dd814064829e7ee382f804960a619b1d59b9a3c8b1952e9f3b07167820c3dd70e6106861060bb77c26f1832843f254ed4665e043fe94c4bd350fe87c26c
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "@metamask/design-system-shared@npm:0.28.0"
+"@metamask/design-system-shared@npm:^0.29.0":
+  version: 0.29.0
+  resolution: "@metamask/design-system-shared@npm:0.29.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/5a478a1e7da1648a8ecc9ed94d74ebbbc4ff34921f93d3bdd0f64fbe2bd048fe3f6a93ce7d8be8f928471b5630486899eccd0d83d1dfacef6a0087174ab34f52
+  checksum: 10/01d579341e7700d000e406535ff18a2185c69f96cfa0677acf362d42160fc89adec5dc956bde983153380d8c5e07da2f0c97557a80940cde50b7d3396e0e7721
   languageName: node
   linkType: hard
 
@@ -35762,7 +35762,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.34.0"
+    "@metamask/design-system-react-native": "npm:^0.35.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.7.0"
     "@metamask/design-tokens": "npm:^8.7.0"
     "@metamask/earn-controller": "npm:^12.1.0"


### PR DESCRIPTION
## **Description**

Upgrades design system packages to align with the [v53.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v53.0.0).

**Packages upgraded:**
- `@metamask/design-system-react-native`: `^0.34.0` → `^0.35.0`
- `@metamask/design-system-shared` (transitive): `^0.28.0` → `^0.29.0`

**Breaking changes addressed:**

None — this release contains no breaking changes for Mobile.

### Other breaking changes (no code changes needed)
- N/A — v53.0.0 is additive and bug-fix only for `@metamask/design-system-react-native`

**New additions available for future use:**
- `Slider`: Controlled range input with pan/tap gestures, optional range dots and labels, and hooks for non-linear scales

**Upstream fixes included in this release:**
- `ActionListItem`: Fixed painting `bg-default` on elevated surfaces in pure-black mode
- `FilterButton`: Fixed selected-state text appearing invisible in dark mode; now composes from `ButtonPrimary`, `ButtonSecondary`, and `ButtonTertiary`
- `ButtonBase`: Updated to merge `startIconProps.twClassName` and `endIconProps.twClassName` last

**Legacy component deprecations:**
- No new deprecations added — all matching legacy components in `app/component-library/` already have `@deprecated` JSDoc notices from prior upgrades

## **Changelog**

CHANGELOG entry: Upgrades design system libraries and adds pressed state to main trade wallet action menu

## **Related issues**

Fixes: N/A

## **Manual testing steps**

Feature: Design system upgrade to v53.0.0

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows
    Then the UI renders correctly with no visual regressions

  Scenario: FilterButton and ActionListItem surfaces render correctly
    Given I navigate to screens using filter buttons or action list items (e.g. Trending, Perps)
    When I interact with filter buttons in dark mode and action list items on elevated surfaces
    Then selected filter button text is visible and action list items inherit parent backgrounds correctly

## **Screenshots/Recordings**

### **Before**

No pressed state because of overriding styles in trade wallet action menu

https://github.com/user-attachments/assets/d4cac18b-9648-4aef-a4af-0ef7286adc94

### **After**

2 places where the `ActionListItem` is used work as expected

https://github.com/user-attachments/assets/c5b2f1ce-c943-4b46-8ff7-7d3a0d065f71

https://github.com/user-attachments/assets/d0c73d95-db0a-4535-8f31-770a7d923ed4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)