### PR TITLE
fix: MUSD-1165 Inconsistency with asset names cp-8.3.0

### DIFF
--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
@@ -307,12 +307,12 @@ describe('MoneyPotentialEarningsView', () => {
   it('renders ALL eligible tokens, not limited to 5', () => {
     const { getByText } = renderWithProvider(<MoneyPotentialEarningsView />);
 
-    expect(getByText('USDC')).toBeOnTheScreen();
-    expect(getByText('USDT')).toBeOnTheScreen();
-    expect(getByText('DAI')).toBeOnTheScreen();
-    expect(getByText('WETH')).toBeOnTheScreen();
-    expect(getByText('LINK')).toBeOnTheScreen();
-    expect(getByText('UNI')).toBeOnTheScreen();
+    expect(getByText('USD Coin')).toBeOnTheScreen();
+    expect(getByText('Tether')).toBeOnTheScreen();
+    expect(getByText('Dai')).toBeOnTheScreen();
+    expect(getByText('Wrapped Ether')).toBeOnTheScreen();
+    expect(getByText('ChainLink')).toBeOnTheScreen();
+    expect(getByText('Uniswap')).toBeOnTheScreen();
   });
 
   it('renders the view without errors', () => {

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
@@ -520,7 +520,7 @@ describe('MoneyPotentialEarnings', () => {
       expect(
         getAllByText(strings('money.potential_earnings.no_fee')),
       ).toHaveLength(1);
-      expect(queryByText('USDT')).toBeOnTheScreen();
+      expect(queryByText('Tether')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
@@ -74,6 +74,21 @@ describe('PotentialEarningsTokenRow', () => {
     expect(getByText('USD Coin')).toBeOnTheScreen();
   });
 
+  it('falls back to the token symbol when name is empty', () => {
+    const noNameToken = makeToken({ name: '', symbol: 'USDC' });
+    const { getByText } = render(
+      <PotentialEarningsTokenRow
+        token={noNameToken}
+        hasSubsidizedFee={false}
+        apyDecimal={0.2}
+        onCardPress={jest.fn()}
+        onButtonPress={jest.fn()}
+      />,
+    );
+
+    expect(getByText('USDC')).toBeOnTheScreen();
+  });
+
   it('renders the token fiat balance', () => {
     const { getByText } = render(
       <PotentialEarningsTokenRow

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.test.tsx
@@ -60,7 +60,7 @@ describe('PotentialEarningsTokenRow', () => {
     mockMoneyFormatFiat.mockClear();
   });
 
-  it('renders the token symbol', () => {
+  it('renders the token name', () => {
     const { getByText } = render(
       <PotentialEarningsTokenRow
         token={MOCK_USDC}
@@ -71,7 +71,7 @@ describe('PotentialEarningsTokenRow', () => {
       />,
     );
 
-    expect(getByText('USDC')).toBeOnTheScreen();
+    expect(getByText('USD Coin')).toBeOnTheScreen();
   });
 
   it('renders the token fiat balance', () => {
@@ -193,7 +193,7 @@ describe('PotentialEarningsTokenRow', () => {
       />,
     );
 
-    fireEvent.press(getByText('USDC'));
+    fireEvent.press(getByText('USD Coin'));
 
     expect(mockOnPress).toHaveBeenCalledTimes(1);
   });

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
@@ -121,7 +121,7 @@ const PotentialEarningsTokenRow = ({
               twClassName="gap-1"
             >
               <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-                {token.name}
+                {token.name || token.symbol}
               </Text>
               {hasSubsidizedFee && (
                 <Box twClassName="rounded bg-primary-muted px-1.5">

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/PotentialEarningsTokenRow.tsx
@@ -121,7 +121,7 @@ const PotentialEarningsTokenRow = ({
               twClassName="gap-1"
             >
               <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-                {token.symbol}
+                {token.name}
               </Text>
               {hasSubsidizedFee && (
                 <Box twClassName="rounded bg-primary-muted px-1.5">


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The "Earn on your crypto" token rows on Money surfaces showed asset tickers (USDC, USDT, DAI) instead of full asset names, which was inconsistent with how the home page displays assets. Swapped the token row label to use `token.name` instead of `token.symbol`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed asset names on the "Earn on your crypto" rows to display full names instead of tickers, consistent with the home page

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1165: Inconsistency with asset names](https://consensyssoftware.atlassian.net/browse/MUSD-1165)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn on your crypto asset names

  Scenario: user views their eligible tokens on the Money potential earnings screen
    Given the user has eligible tokens including USDC, USDT, DAI, WETH, LINK, and UNI

    When user opens the "Earn on your crypto" / potential earnings view
    Then each token row displays the full asset name (e.g. "USD Coin", "Tether", "Dai") instead of the ticker
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
Token rows displayed asset symbols instead of names.
<!-- Token rows displayed tickers: USDC, USDT, DAI, WETH, LINK, UNI -->

### **After**

<!-- Token rows display full names: USD Coin, Tether, Dai, Wrapped Ether, ChainLink, Uniswap -->
<img width="491" height="1009" alt="image" src="https://github.com/user-attachments/assets/9517959e-61e0-42e5-9908-8cf98b57a6e3" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI label change in Money potential earnings with no auth, data, or business-logic impact beyond display text.
> 
> **Overview**
> **Earn on your crypto** token rows on Money surfaces now show **full asset names** (e.g. USD Coin, Tether) instead of tickers, matching how assets appear on the home page.
> 
> `PotentialEarningsTokenRow` labels use `token.name` with **`token.symbol` as fallback** when the name is missing. Tests were updated for the new copy and for the empty-name fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24eb3ee88498dfeeda5679564bfc948e6934dd6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->