### PR TITLE
fix: remove content background in Money Balance Info Sheet for Pure Black

### DIFF
--- a/app/components/UI/Money/components/MoneyBalanceInfoSheet/MoneyBalanceInfoSheet.styles.ts
+++ b/app/components/UI/Money/components/MoneyBalanceInfoSheet/MoneyBalanceInfoSheet.styles.ts
@@ -7,7 +7,6 @@ const styleSheet = (params: { theme: Theme }) =>
       paddingHorizontal: 16,
       paddingBottom: 16,
       gap: 16,
-      backgroundColor: params.theme.colors.background.default,
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes the explicit background color from the Money balance info sheet content so it inherits the `BottomSheet` surface from `@metamask/design-system-react-native`. This fixes the visible grey panel inside the sheet when Pure Black theme is enabled.

- Implementation: delete `backgroundColor: theme.colors.background.default` from `MoneyBalanceInfoSheet.styles.ts`.
- No functional changes; visual-only fix aligned with Pure Black guidance.

## **Changelog**

CHANGELOG entry: Fixed Money balance info sheet showing a grey content background in Pure Black by letting the sheet content be transparent and use the BottomSheet surface.

## **Related issues**

Refs: TMCU-622

## **Manual testing steps**

```gherkin
Feature: Money balance info sheet respects Pure Black theme

  Scenario: Viewing the Money balance info sheet in Pure Black
    Given the app is running with Pure Black enabled
    And I am on the Wallet home screen with the Money card visible
    When I tap the Money card info icon (i)
    Then the Money balance info sheet opens
    And the sheet content has no extra inner background
    And the sheet background matches the BottomSheet surface (pure black)
```

## **Screenshots/Recordings**

### **Before**

Grey inner panel visible inside the sheet (see UAT Fridays thread on 2026‑07‑10).

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 32 24" src="https://github.com/user-attachments/assets/6d28c488-18f7-46fa-875e-c00b47e618e9" />

### **After**

No inner panel; content sits directly on the BottomSheet surface in Pure Black.

<img width="350" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-10 at 13 41 36" src="https://github.com/user-attachments/assets/8642b0fd-cc4a-4251-813e-2517960f8ac9" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See `trace()` for usage and `addToken` for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C09AYKX30P3/p1783706615866509?thread_ts=1783706615.866509&cid=C09AYKX30P3)

<div><a href="https://cursor.com/agents/bc-1fc78755-9467-5ad2-9046-182ea886932c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fc78755-9467-5ad2-9046-182ea886932c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

