### PR TITLE
test: skip E2E test "Create wallet accounts - multi-SRP"

### DIFF
--- a/tests/smoke-appium/accounts/create-wallet-account.spec.ts
+++ b/tests/smoke-appium/accounts/create-wallet-account.spec.ts
@@ -14,81 +14,87 @@ import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import Assertions from '../../framework/Assertions.js';
 
-appiumTest.describe(SmokeAccounts('Create wallet accounts - multi-SRP'), () => {
-  appiumTest(
-    'creates accounts across multiple SRPs and verifies new account details',
-    async ({ driver: _driver, currentDeviceDetails }) => {
-      await withFixtures(
-        {
-          fixture: new FixtureBuilder()
-            .withTwoImportedHdKeyringsAndTwoDefaultAccounts()
-            .build(),
-          restartDevice: true,
-          currentDeviceDetails,
-        },
-        async () => {
-          await loginAndOpenAccountList({ scenarioType: 'e2e' });
+appiumTest.describe.skip(
+  SmokeAccounts('Create wallet accounts - multi-SRP'),
+  () => {
+    appiumTest(
+      'creates accounts across multiple SRPs and verifies new account details',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: new FixtureBuilder()
+              .withTwoImportedHdKeyringsAndTwoDefaultAccounts()
+              .build(),
+            restartDevice: true,
+            currentDeviceDetails,
+          },
+          async () => {
+            await loginAndOpenAccountList({ scenarioType: 'e2e' });
 
-          await AccountListBottomSheet.tapCreateAccount(0);
-          await AccountListBottomSheet.tapCreateAccount(1);
+            await AccountListBottomSheet.tapCreateAccount(0);
+            await AccountListBottomSheet.tapCreateAccount(1);
 
-          // Counting cells verifies accounts were created across both SRPs.
-          const expectedAccountCounts: Record<string, number> = {
-            'Account 2': 2,
-            'Account 3': 1,
-          };
-          for (const [accountName, expectedCount] of Object.entries(
-            expectedAccountCounts,
-          )) {
-            await assertAccountCount(accountName, expectedCount, 15_000);
-          }
+            // Counting cells verifies accounts were created across both SRPs.
+            const expectedAccountCounts: Record<string, number> = {
+              'Account 2': 2,
+              'Account 3': 1,
+            };
+            for (const [accountName, expectedCount] of Object.entries(
+              expectedAccountCounts,
+            )) {
+              await assertAccountCount(accountName, expectedCount, 15_000);
+            }
 
-          // Account 3 is created on the first SRP (near the top). Scrolling to the
-          // bottom first scrolls it off-screen and breaks Android taps.
-          await AccountListBottomSheet.expectAccountVisibleByNameV2(
-            'Account 3',
-            {
-              description: 'Account 3 should be visible after creation',
-              timeout: 15_000,
-            },
-          );
-          await AccountListBottomSheet.tapAccountByNameV2('Account 3', true);
-          await waitForWalletHomePlaywright();
-
-          await WalletView.tapIdenticon();
-          await AccountListBottomSheet.tapAccountEllipsisForAccountNameV2(
-            'Account 3',
-          );
-          await AccountDetails.tapNetworksLink();
-
-          for (const networkName of [
-            'Ethereum Main Network',
-            'Linea Main Network',
-            'Solana',
-          ]) {
-            await AddressList.expectNetworkDisplayed(networkName);
-          }
-
-          await AddressList.tapBackButton();
-          await AccountDetails.tapBackButton();
-
-          try {
-            await AccountListBottomSheet.waitForAccountListVisible(10_000);
+            // Account 3 is created on the first SRP (near the top). Scrolling to the
+            // bottom first scrolls it off-screen and breaks Android taps.
+            await AccountListBottomSheet.expectAccountVisibleByNameV2(
+              'Account 3',
+              {
+                description: 'Account 3 should be visible after creation',
+                timeout: 15_000,
+              },
+            );
             await AccountListBottomSheet.tapAccountByNameV2('Account 3', true);
-          } catch {
-            // Account list already dismissed — Account 3 remains selected.
-          }
+            await waitForWalletHomePlaywright();
 
-          await dismissToWalletHomePlaywright();
-          await Assertions.expectElementToHaveText(
-            WalletView.accountName,
-            'Account 3',
-            {
-              description: 'Selected account header should read Account 3',
-            },
-          );
-        },
-      );
-    },
-  );
-});
+            await WalletView.tapIdenticon();
+            await AccountListBottomSheet.tapAccountEllipsisForAccountNameV2(
+              'Account 3',
+            );
+            await AccountDetails.tapNetworksLink();
+
+            for (const networkName of [
+              'Ethereum Main Network',
+              'Linea Main Network',
+              'Solana',
+            ]) {
+              await AddressList.expectNetworkDisplayed(networkName);
+            }
+
+            await AddressList.tapBackButton();
+            await AccountDetails.tapBackButton();
+
+            try {
+              await AccountListBottomSheet.waitForAccountListVisible(10_000);
+              await AccountListBottomSheet.tapAccountByNameV2(
+                'Account 3',
+                true,
+              );
+            } catch {
+              // Account list already dismissed — Account 3 remains selected.
+            }
+
+            await dismissToWalletHomePlaywright();
+            await Assertions.expectElementToHaveText(
+              WalletView.accountName,
+              'Account 3',
+              {
+                description: 'Selected account header should read Account 3',
+              },
+            );
+          },
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Skip E2E test "Create wallet accounts - multi-SRP".

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: null

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that excludes one E2E scenario from execution; no production or wallet logic is modified.
> 
> **Overview**
> The smoke Appium suite **stops running** the **Create wallet accounts - multi-SRP** scenario by changing `appiumTest.describe` to **`appiumTest.describe.skip`** in `create-wallet-account.spec.ts`.
> 
> The test implementation is unchanged; only the describe wrapper and indentation differ, so CI will skip this flaky or blocked flow until it is re-enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad1dc650e688f06aad451e3ecc5aa0e240ca3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->