### PR TITLE
feat: sync V2 ramps orders with Backup & Sync

### DIFF
--- a/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.test.tsx
+++ b/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.test.tsx
@@ -20,6 +20,7 @@ const MOCK_STORE_STATE = {
         isBackupAndSyncEnabled: true,
         isAccountSyncingEnabled: false,
         isContactSyncingEnabled: false,
+        isRampsSyncingEnabled: false,
       },
       AuthenticationController: {
         isSignedIn: true,

--- a/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.testIds.ts
+++ b/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.testIds.ts
@@ -1,4 +1,5 @@
 export const BACKUP_AND_SYNC_FEATURES_TOGGLES_TEST_IDS = {
   TOGGLE_ACCOUNT_SYNCING: 'toggle-accountSyncing',
   TOGGLE_CONTACT_SYNCING: 'toggle-contactSyncing',
+  TOGGLE_RAMPS_SYNCING: 'toggle-rampsSyncing',
 } as const;

--- a/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.tsx
+++ b/app/components/UI/Identity/BackupAndSyncFeaturesToggles/BackupAndSyncFeaturesToggles.tsx
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 import {
   selectIsAccountSyncingEnabled,
   selectIsContactSyncingEnabled,
+  selectIsRampsSyncingEnabled,
   selectIsBackupAndSyncEnabled,
   selectIsBackupAndSyncUpdateLoading,
 } from '../../../../selectors/identity';
@@ -41,6 +42,14 @@ export const backupAndSyncFeaturesTogglesSections = [
     backupAndSyncfeatureKey: BACKUPANDSYNC_FEATURES.contactSyncing,
     featureReduxSelector: selectIsContactSyncingEnabled,
     testID: BACKUP_AND_SYNC_FEATURES_TOGGLES_TEST_IDS.TOGGLE_CONTACT_SYNCING,
+  },
+  {
+    id: 'ramps',
+    titleI18NKey: strings('backupAndSync.features.ramps'),
+    iconName: IconName.Card,
+    backupAndSyncfeatureKey: BACKUPANDSYNC_FEATURES.rampsSyncing,
+    featureReduxSelector: selectIsRampsSyncingEnabled,
+    testID: BACKUP_AND_SYNC_FEATURES_TOGGLES_TEST_IDS.TOGGLE_RAMPS_SYNCING,
   },
 ];
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -481,6 +481,20 @@ describe('Checkout', () => {
         });
       });
     });
+
+    it('does not register precreated order when network is missing', () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'MoonPay',
+        providerCode: 'moonpay',
+        walletAddress: '0xabcdef1234567890',
+        orderId: 'mp-order-99',
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      expect(mockAddPrecreatedOrder).not.toHaveBeenCalled();
+    });
   });
 
   describe('missing checkout URL', () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -392,16 +392,14 @@ const Checkout = () => {
   useEffect(() => {
     // For external-browser flows (e.g. PayPal), addPrecreatedOrder is called in
     // BuildQuote; the user never reaches Checkout. For WebView flows,
-    // providerCode and walletAddress are passed, so hasCallbackFlow is true
-    // and we can register. hasCallbackFlow being false means we lack the data
-    // required for addPrecreatedOrder anyway.
-    // Note: network/chainId is optional in addPrecreatedOrder; do not require it
-    // in the guard, otherwise orders with unusual chain ID formats (e.g. empty
-    // string from chainId.split(':')[1]) would silently skip registration here
-    // while external-browser flows would still register (BuildQuote passes
-    // chainId: network || undefined without requiring network).
+    // providerCode, walletAddress, and network are passed, so hasCallbackFlow is
+    // true and we can register. The controller requires a non-empty chain ID.
     const canRegister =
-      hasCallbackFlow && effectiveOrderId && providerCode && walletAddress;
+      hasCallbackFlow &&
+      effectiveOrderId &&
+      providerCode &&
+      walletAddress &&
+      network;
     if (!canRegister) return;
     if (registeredOrderIdsRef.current.has(effectiveOrderId)) return;
     registeredOrderIdsRef.current.add(effectiveOrderId);
@@ -409,7 +407,7 @@ const Checkout = () => {
       orderId: effectiveOrderId,
       providerCode,
       walletAddress,
-      chainId: network || undefined,
+      chainId: network,
     });
   }, [
     hasCallbackFlow,

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -345,12 +345,12 @@ export function useContinueWithQuote(
           );
 
         if (useExternalBrowser) {
-          if (effectiveOrderId && effectiveWallet) {
+          if (effectiveOrderId && effectiveWallet && network) {
             addPrecreatedOrder({
               orderId: effectiveOrderId,
               providerCode,
               walletAddress: effectiveWallet,
-              chainId: network || undefined,
+              chainId: network,
             });
           }
 

--- a/app/components/UI/Ramp/hooks/useRampsOrders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.ts
@@ -13,7 +13,7 @@ export interface AddPrecreatedOrderParams {
   orderId: string;
   providerCode: string;
   walletAddress: string;
-  chainId?: string;
+  chainId: string;
 }
 
 export interface UseRampsOrdersResult {

--- a/app/components/Views/Settings/Identity/BackupAndSyncSettings.view.test.tsx
+++ b/app/components/Views/Settings/Identity/BackupAndSyncSettings.view.test.tsx
@@ -88,4 +88,33 @@ describeForPlatforms('BackupAndSyncSettings identity sync toggles', () => {
 
     setFeatureSpy.mockRestore();
   });
+
+  it('disables ramps order sync through user storage', async () => {
+    const setFeatureSpy = jest.spyOn(
+      Engine.context.UserStorageController,
+      'setIsBackupAndSyncFeatureEnabled',
+    );
+    const { getByTestId } = renderBackupAndSyncSettings({
+      stateOptions: {
+        isRampsSyncingEnabled: true,
+      },
+    });
+
+    fireEvent(
+      getByTestId(
+        BACKUP_AND_SYNC_FEATURES_TOGGLES_TEST_IDS.TOGGLE_RAMPS_SYNCING,
+      ),
+      'onValueChange',
+      false,
+    );
+
+    await waitFor(() => {
+      expect(setFeatureSpy).toHaveBeenCalledWith(
+        BACKUPANDSYNC_FEATURES.rampsSyncing,
+        false,
+      );
+    });
+
+    setFeatureSpy.mockRestore();
+  });
 });

--- a/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
+++ b/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
@@ -81,4 +81,49 @@ describe('AuthenticationControllerInit', () => {
       );
     });
   });
+
+  it('clears persisted sessions minted for a different OIDC env', () => {
+    const prdJwt =
+      'aaa.' +
+      Buffer.from(
+        JSON.stringify({ iss: 'https://oidc.api.cx.metamask.io' }),
+      ).toString('base64url') +
+      '.bbb';
+
+    process.env.MM_DEV_API_ENV = 'dev';
+    const requestMock = getInitRequestMock();
+    requestMock.persistedState.AuthenticationController = {
+      isSignedIn: true,
+      srpSessionData: {
+        'entropy-1': {
+          token: {
+            accessToken: prdJwt,
+            expiresIn: 3600,
+            obtainedAt: Date.now(),
+          },
+          profile: {
+            identifierId: 'id',
+            profileId: 'profile',
+            metaMetricsId: 'mmid',
+          },
+        },
+      },
+    };
+
+    try {
+      authenticationControllerInit(requestMock);
+
+      expect(jest.mocked(AuthenticationController)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: expect.objectContaining({
+            isSignedIn: false,
+            srpSessionData: undefined,
+          }),
+          config: { env: 'dev' },
+        }),
+      );
+    } finally {
+      delete process.env.MM_DEV_API_ENV;
+    }
+  });
 });

--- a/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
+++ b/app/core/Engine/controllers/identity/authentication-controller-init.test.ts
@@ -104,6 +104,7 @@ describe('AuthenticationControllerInit', () => {
           profile: {
             identifierId: 'id',
             profileId: 'profile',
+            canonicalProfileId: 'canonical-profile',
             metaMetricsId: 'mmid',
           },
         },

--- a/app/core/Engine/controllers/identity/authentication-controller-init.ts
+++ b/app/core/Engine/controllers/identity/authentication-controller-init.ts
@@ -6,6 +6,7 @@ import {
 import { Platform } from '@metamask/profile-sync-controller/sdk';
 import { getVersion } from 'react-native-device-info';
 import { authEnv } from '../../../devApiEnv';
+import { sanitizePersistedAuthenticationState } from './sanitize-persisted-auth-state';
 
 /**
  * Initialize the authentication controller.
@@ -18,13 +19,17 @@ export const authenticationControllerInit: MessengerClientInitFunction<
   AuthenticationController,
   AuthenticationControllerMessenger
 > = ({ controllerMessenger, persistedState, analyticsId }) => {
+  const env = authEnv();
   const controller = new AuthenticationController({
     messenger: controllerMessenger,
 
     // @ts-expect-error: `AuthenticationController` does not accept partial state.
-    state: persistedState.AuthenticationController,
+    state: sanitizePersistedAuthenticationState(
+      persistedState.AuthenticationController,
+      env,
+    ),
 
-    config: { env: authEnv() },
+    config: { env },
 
     metametrics: {
       agent: Platform.MOBILE,

--- a/app/core/Engine/controllers/identity/sanitize-persisted-auth-state.ts
+++ b/app/core/Engine/controllers/identity/sanitize-persisted-auth-state.ts
@@ -1,0 +1,72 @@
+import {
+  Env,
+  getEnvUrls,
+  type LoginResponse,
+} from '@metamask/profile-sync-controller/sdk';
+import type { AuthenticationControllerState } from '@metamask/profile-sync-controller/auth';
+
+function decodeJwtIss(accessToken: string): string | null {
+  try {
+    const [, payload] = accessToken.split('.');
+    if (!payload) {
+      return null;
+    }
+    const normalized = payload.replace(/-/gu, '+').replace(/_/gu, '/');
+    const json =
+      typeof atob === 'function'
+        ? (JSON.parse(atob(normalized)) as { iss?: unknown })
+        : (JSON.parse(Buffer.from(normalized, 'base64').toString('utf8')) as {
+            iss?: unknown;
+          });
+    return typeof json.iss === 'string' ? json.iss : null;
+  } catch {
+    return null;
+  }
+}
+
+function sessionMatchesEnv(
+  session: LoginResponse | undefined,
+  expectedOidcIss: string,
+): boolean {
+  const accessToken = session?.token?.accessToken;
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    return false;
+  }
+  const iss = decodeJwtIss(accessToken);
+  return iss === expectedOidcIss;
+}
+
+/**
+ * Drop persisted Profile Sync sessions minted for a different OIDC env.
+ *
+ * Restarting alone is not enough: cached `srpSessionData` is reused until
+ * expiry, so a DEV JWT keeps getting attached after switching to PRD.
+ */
+export function sanitizePersistedAuthenticationState(
+  state: AuthenticationControllerState | undefined,
+  env: Env,
+): AuthenticationControllerState | undefined {
+  if (!state?.srpSessionData) {
+    return state;
+  }
+
+  const expectedOidcIss = getEnvUrls(env).oidcApiUrl;
+  const sessions = Object.values(state.srpSessionData);
+  const allMatch =
+    sessions.length > 0 &&
+    sessions.every((session) => sessionMatchesEnv(session, expectedOidcIss));
+
+  if (allMatch) {
+    return state;
+  }
+
+  console.warn(
+    `[authentication] Clearing persisted Profile Sync session(s) that were not minted for OIDC ${expectedOidcIss}. A fresh sign-in will mint a matching token.`,
+  );
+
+  return {
+    ...state,
+    isSignedIn: false,
+    srpSessionData: undefined,
+  };
+}

--- a/app/core/Engine/controllers/identity/sanitize-persisted-auth-state.ts
+++ b/app/core/Engine/controllers/identity/sanitize-persisted-auth-state.ts
@@ -43,9 +43,9 @@ function sessionMatchesEnv(
  * expiry, so a DEV JWT keeps getting attached after switching to PRD.
  */
 export function sanitizePersistedAuthenticationState(
-  state: AuthenticationControllerState | undefined,
+  state: Partial<AuthenticationControllerState> | undefined,
   env: Env,
-): AuthenticationControllerState | undefined {
+): Partial<AuthenticationControllerState> | undefined {
   if (!state?.srpSessionData) {
     return state;
   }

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.test.ts
@@ -70,6 +70,14 @@ jest.mock('../../../../components/UI/Ramp/debug/RampsDebugBridge', () => ({
   initRampsDebugBridge: jest.fn(),
 }));
 
+jest.mock('../../utils/analytics', () => ({
+  buildAndTrackEvent: jest.fn(),
+}));
+
+jest.mock('../../../../util/trace', () => ({
+  trace: jest.fn(),
+}));
+
 const getInitRampsDebugBridgeMock = (): jest.Mock =>
   (
     jest.requireMock(
@@ -116,10 +124,40 @@ describe('ramps controller init', () => {
 
     rampsControllerInit(initRequestMock);
 
-    const rampsControllerState =
-      rampsControllerClassMock.mock.calls[0][0].state;
+    const constructorArgs = rampsControllerClassMock.mock.calls[0][0];
 
-    expect(rampsControllerState).toEqual(defaultRampsControllerState);
+    expect(constructorArgs.state).toEqual(defaultRampsControllerState);
+    expect(constructorArgs.trace).toEqual(expect.any(Function));
+    expect(constructorArgs.onOrderSyncErroneousSituation).toEqual(
+      expect.any(Function),
+    );
+  });
+
+  it('tracks order sync erroneous situations', () => {
+    const { buildAndTrackEvent } = jest.requireMock(
+      '../../utils/analytics',
+    ) as {
+      buildAndTrackEvent: jest.Mock;
+    };
+    const { MetaMetricsEvents } = jest.requireActual(
+      '../../../Analytics',
+    ) as typeof import('../../../Analytics');
+
+    rampsControllerInit(initRequestMock);
+    const onOrderSyncErroneousSituation =
+      rampsControllerClassMock.mock.calls[0][0].onOrderSyncErroneousSituation;
+
+    onOrderSyncErroneousSituation?.('sync failed');
+
+    expect(buildAndTrackEvent).toHaveBeenCalledWith(
+      initRequestMock.initMessenger,
+      MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED.category,
+      {
+        feature_name: 'Ramps Order Sync',
+        action: 'Ramps Order Sync Erroneous Situation',
+        additional_description: 'sync failed',
+      },
+    );
   });
 
   it('uses initial state when initial state is passed in', () => {

--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -7,6 +7,9 @@ import {
 import type { RampsControllerInitMessenger } from '../../messengers/ramps-controller-messenger';
 import { handleOrderStatusChangedForNotifications } from './event-handlers/notification';
 import { handleOrderStatusChangedForMetrics } from './event-handlers/analytics';
+import { MetaMetricsEvents } from '../../../Analytics';
+import { trace } from '../../../../util/trace';
+import { buildAndTrackEvent } from '../../utils/analytics';
 
 /**
  * Opt-in for the Ramps WebSocket debug dashboard (`RAMPS_DEBUG_DASHBOARD=true` in `.js.env`).
@@ -36,6 +39,19 @@ export const rampsControllerInit: MessengerClientInitFunction<
   const controller = new RampsController({
     messenger: controllerMessenger,
     state: rampsControllerState,
+    // @ts-expect-error: Type of `TraceRequest` is different.
+    trace,
+    onOrderSyncErroneousSituation: (situationMessage) => {
+      buildAndTrackEvent(
+        initMessenger,
+        MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED.category,
+        {
+          feature_name: 'Ramps Order Sync',
+          action: 'Ramps Order Sync Erroneous Situation',
+          additional_description: situationMessage,
+        },
+      );
+    },
     // The all-providers widening is driven by the `moneyHeadlessAllProviders`
     // remote feature flag, which the controller reads itself through the
     // `RemoteFeatureFlagController:getState` messenger action per quote call.

--- a/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
+++ b/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
@@ -49,7 +49,6 @@ export function getRampsControllerMessenger(
       'UserStorageController:getState',
       'UserStorageController:performGetStorageAllFeatureEntries',
       'UserStorageController:performBatchSetStorage',
-      'UserStorageController:listEntropySources',
       'AuthenticationController:isSignedIn',
     ],
     events: [],

--- a/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
+++ b/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
@@ -46,6 +46,10 @@ export function getRampsControllerMessenger(
       // Spread the package-owned required list so new service actions
       // (e.g. getDefaultRedirectCallbackUrl) cannot be forgotten at upgrade.
       ...RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS,
+      'UserStorageController:getState',
+      'UserStorageController:performGetStorageAllFeatureEntries',
+      'UserStorageController:performBatchSetStorage',
+      'AuthenticationController:isSignedIn',
     ],
     events: [],
   });

--- a/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
+++ b/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
@@ -49,6 +49,7 @@ export function getRampsControllerMessenger(
       'UserStorageController:getState',
       'UserStorageController:performGetStorageAllFeatureEntries',
       'UserStorageController:performBatchSetStorage',
+      'UserStorageController:listEntropySources',
       'AuthenticationController:isSignedIn',
     ],
     events: [],

--- a/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
+++ b/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
@@ -12,6 +12,7 @@ import type {
   RemoteFeatureFlagControllerGetStateAction,
   RemoteFeatureFlagControllerStateChangeEvent,
 } from '@metamask/remote-feature-flag-controller';
+import { AnalyticsControllerActions } from '@metamask/analytics-controller';
 import { RootMessenger } from '../../types';
 
 type AllowedActions = MessengerActions<RampsControllerMessenger>;
@@ -61,9 +62,13 @@ export type RampsControllerInitMessenger = ReturnType<
   typeof getRampsControllerInitMessenger
 >;
 
+type RampsControllerInitMessengerActions =
+  | RemoteFeatureFlagControllerGetStateAction
+  | AnalyticsControllerActions;
+
 /**
  * Get the init messenger for the RampsController. Scoped to actions
- * needed during initialization (reading feature flags).
+ * needed during initialization (reading feature flags and analytics).
  *
  * @param rootMessenger - The root messenger.
  * @returns The RampsControllerInitMessenger.
@@ -71,7 +76,7 @@ export type RampsControllerInitMessenger = ReturnType<
 export function getRampsControllerInitMessenger(rootMessenger: RootMessenger) {
   const messenger = new Messenger<
     'RampsControllerInit',
-    RemoteFeatureFlagControllerGetStateAction,
+    RampsControllerInitMessengerActions,
     | RampsControllerOrderStatusChangedEvent
     | RemoteFeatureFlagControllerStateChangeEvent,
     RootMessenger
@@ -81,7 +86,10 @@ export function getRampsControllerInitMessenger(rootMessenger: RootMessenger) {
   });
 
   rootMessenger.delegate({
-    actions: ['RemoteFeatureFlagController:getState'],
+    actions: [
+      'RemoteFeatureFlagController:getState',
+      'AnalyticsController:trackEvent',
+    ],
     events: [
       'RampsController:orderStatusChanged',
       'RemoteFeatureFlagController:stateChange', // React when flags arrive (avoids race with async fetch)

--- a/app/selectors/identity/index.test.ts
+++ b/app/selectors/identity/index.test.ts
@@ -3,6 +3,7 @@ import {
   selectIsBackupAndSyncUpdateLoading,
   selectIsAccountSyncingEnabled,
   selectIsContactSyncingEnabled,
+  selectIsRampsSyncingEnabled,
   selectIsSignedIn,
   selectCanonicalProfileId,
   selectNeedsProfilePairing,
@@ -20,6 +21,8 @@ describe('Notification Selectors', () => {
         UserStorageController: {
           isBackupAndSyncEnabled: true,
           isAccountSyncingEnabled: true,
+          isContactSyncingEnabled: true,
+          isRampsSyncingEnabled: true,
           isBackupAndSyncUpdateLoading: false,
           isAccountSyncingReadyToBeDispatched: false,
         },
@@ -52,6 +55,13 @@ describe('Notification Selectors', () => {
     expect(selectIsContactSyncingEnabled(mockState)).toEqual(
       mockState.engine.backgroundState.UserStorageController
         .isContactSyncingEnabled,
+    );
+  });
+
+  it('selectIsRampsSyncingEnabled returns correct value', () => {
+    expect(selectIsRampsSyncingEnabled(mockState)).toEqual(
+      mockState.engine.backgroundState.UserStorageController
+        .isRampsSyncingEnabled,
     );
   });
 

--- a/app/selectors/identity/index.tsx
+++ b/app/selectors/identity/index.tsx
@@ -87,3 +87,9 @@ export const selectIsContactSyncingEnabled = createSelector(
   (userStorageControllerState: UserStorageState) =>
     userStorageControllerState?.isContactSyncingEnabled,
 );
+
+export const selectIsRampsSyncingEnabled = createSelector(
+  selectUserStorageControllerState,
+  (userStorageControllerState: UserStorageState) =>
+    userStorageControllerState?.isRampsSyncingEnabled,
+);

--- a/app/selectors/identity/index.tsx
+++ b/app/selectors/identity/index.tsx
@@ -91,5 +91,5 @@ export const selectIsContactSyncingEnabled = createSelector(
 export const selectIsRampsSyncingEnabled = createSelector(
   selectUserStorageControllerState,
   (userStorageControllerState: UserStorageState) =>
-    userStorageControllerState?.isRampsSyncingEnabled,
+    userStorageControllerState?.isRampsSyncingEnabled ?? true,
 );

--- a/app/util/activity-adapters/adapters/ramp-order-helpers.ts
+++ b/app/util/activity-adapters/adapters/ramp-order-helpers.ts
@@ -85,6 +85,18 @@ export function caipChainIdFromAssetId(
 }
 
 /**
+ * Placeholder values providers send in place of a real hash. `DUMMY_TX_ID` in
+ * particular has been observed on multiple completed orders, which collapsed
+ * distinct buys into a single Activity row.
+ */
+const RAMP_TX_HASH_PLACEHOLDERS = new Set([
+  '0x',
+  'dummy_tx_id',
+  'null',
+  'undefined',
+]);
+
+/**
  * Returns true when `txHash` looks like a real on-chain hash. Provider
  * placeholders such as `""`, `"0x"`, and all-zero hashes must not be used as
  * Activity row keys — they collide across orders in `mergeActivityItems`.
@@ -96,7 +108,7 @@ export function isPlausibleRampTxHash(
     return false;
   }
   const normalized = txHash.trim().toLowerCase();
-  if (!normalized || normalized === '0x') {
+  if (!normalized || RAMP_TX_HASH_PLACEHOLDERS.has(normalized)) {
     return false;
   }
   if (/^0x0+$/u.test(normalized)) {

--- a/app/util/activity-adapters/adapters/ramp-order.test.ts
+++ b/app/util/activity-adapters/adapters/ramp-order.test.ts
@@ -129,6 +129,12 @@ describe('mapRampOrder', () => {
     expect(mapRampOrder({ order })?.hash).toBe('order-1');
   });
 
+  it('falls back to order id when txHash is a placeholder dummy value', () => {
+    const order = { ...baseOrder, txHash: 'DUMMY_TX_ID' };
+
+    expect(mapRampOrder({ order })?.hash).toBe('order-1');
+  });
+
   it('returns null for excluded orders', () => {
     expect(
       mapRampOrder({

--- a/app/util/activity-adapters/adapters/ramp-order.ts
+++ b/app/util/activity-adapters/adapters/ramp-order.ts
@@ -72,16 +72,20 @@ export function mapRampOrder({
 
   const isSell = type === 'sell';
   const transactionHash = getRampOrderTransactionHash(order, type);
-  // Some Ramp orders exist before an on-chain tx hash is available. Use the
-  // order id for stable row identity, but those entries cannot dedup against an
-  // eventual EVM API copy until the real tx hash lands.
+  // Some Ramp orders exist before an on-chain tx hash is available (or only
+  // have a placeholder like DUMMY_TX_ID). Use the order id for stable row
+  // identity so Activity hash-dedup does not collapse distinct orders.
   const hash = transactionHash || order.id;
+  const timestamp =
+    typeof order.createdAt === 'number'
+      ? order.createdAt
+      : new Date(order.createdAt).getTime();
 
   return {
     type,
     chainId,
     status: mapRampOrderStatus(order.state),
-    timestamp: order.createdAt,
+    timestamp: Number.isFinite(timestamp) ? timestamp : 0,
     hash,
     raw: { type: 'rampOrder', data: order },
     data: {

--- a/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.test.ts
+++ b/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.test.ts
@@ -2,11 +2,13 @@ import { renderHookWithProvider } from '../../../test/renderWithProvider';
 import { useAutoSignIn, useAutoSignOut } from '../useAuthentication';
 import { useAccountSyncing } from '../useAccountSyncing';
 import { useContactSyncing } from '../useContactSyncing';
+import { useRampsOrderSyncing } from '../useRampsOrderSyncing';
 import { useIdentityEffects } from './useIdentityEffects';
 
 jest.mock('../useAuthentication');
 jest.mock('../useAccountSyncing');
 jest.mock('../useContactSyncing');
+jest.mock('../useRampsOrderSyncing');
 jest.mock('../useCanonicalProfileIdTrait');
 jest.mock('../../../../core/Braze/hooks', () => ({
   useBrazeIdentity: jest.fn(),
@@ -17,6 +19,7 @@ describe('useIdentityEffects', () => {
   const mockUseAutoSignOut = jest.mocked(useAutoSignOut);
   const mockUseAccountSyncing = jest.mocked(useAccountSyncing);
   const mockUseContactSyncing = jest.mocked(useContactSyncing);
+  const mockUseRampsOrderSyncing = jest.mocked(useRampsOrderSyncing);
 
   beforeEach(() => {
     mockUseAutoSignIn.mockReturnValue({
@@ -38,6 +41,11 @@ describe('useIdentityEffects', () => {
     mockUseContactSyncing.mockReturnValue({
       dispatchContactSyncing: jest.fn(),
       shouldDispatchContactSyncing: false,
+    });
+
+    mockUseRampsOrderSyncing.mockReturnValue({
+      dispatchRampsOrderSyncing: jest.fn(),
+      shouldDispatchRampsOrderSyncing: false,
     });
   });
 
@@ -121,6 +129,19 @@ describe('useIdentityEffects', () => {
     expect(dispatchContactSyncing).toHaveBeenCalled();
   });
 
+  it('dispatches ramps order syncing if shouldDispatchRampsOrderSyncing returns true', () => {
+    const dispatchRampsOrderSyncing = jest.fn();
+    const shouldDispatchRampsOrderSyncing = true;
+    mockUseRampsOrderSyncing.mockReturnValue({
+      dispatchRampsOrderSyncing,
+      shouldDispatchRampsOrderSyncing,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(dispatchRampsOrderSyncing).toHaveBeenCalled();
+  });
+
   it('does not dispatch account syncing if shouldDispatchAccountSyncing returns false', () => {
     const dispatchAccountSyncing = jest.fn();
     const shouldDispatchAccountSyncing = false;
@@ -145,5 +166,18 @@ describe('useIdentityEffects', () => {
     renderHookWithProvider(() => useIdentityEffects());
 
     expect(dispatchContactSyncing).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch ramps order syncing if shouldDispatchRampsOrderSyncing returns false', () => {
+    const dispatchRampsOrderSyncing = jest.fn();
+    const shouldDispatchRampsOrderSyncing = false;
+    mockUseRampsOrderSyncing.mockReturnValue({
+      dispatchRampsOrderSyncing,
+      shouldDispatchRampsOrderSyncing,
+    });
+
+    renderHookWithProvider(() => useIdentityEffects());
+
+    expect(dispatchRampsOrderSyncing).not.toHaveBeenCalled();
   });
 });

--- a/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.ts
+++ b/app/util/identity/hooks/useIdentityEffects/useIdentityEffects.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useAccountSyncing } from '../useAccountSyncing';
 import { useContactSyncing } from '../useContactSyncing';
+import { useRampsOrderSyncing } from '../useRampsOrderSyncing';
 import { useAutoSignIn, useAutoSignOut } from '../useAuthentication';
 import { useBrazeIdentity } from '../../../../core/Braze/hooks';
 import { useCanonicalProfileIdTrait } from '../useCanonicalProfileIdTrait';
@@ -16,6 +17,8 @@ export const useIdentityEffects = () => {
     useAccountSyncing();
   const { dispatchContactSyncing, shouldDispatchContactSyncing } =
     useContactSyncing();
+  const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
+    useRampsOrderSyncing();
   const { autoSignIn, shouldAutoSignIn } = useAutoSignIn();
   const { autoSignOut, shouldAutoSignOut } = useAutoSignOut();
 
@@ -36,6 +39,12 @@ export const useIdentityEffects = () => {
       dispatchContactSyncing();
     }
   }, [shouldDispatchContactSyncing, dispatchContactSyncing]);
+
+  useEffect(() => {
+    if (shouldDispatchRampsOrderSyncing) {
+      dispatchRampsOrderSyncing();
+    }
+  }, [shouldDispatchRampsOrderSyncing, dispatchRampsOrderSyncing]);
 
   /**
    * Authentication effects

--- a/app/util/identity/hooks/useRampsOrderSyncing/index.ts
+++ b/app/util/identity/hooks/useRampsOrderSyncing/index.ts
@@ -1,0 +1,4 @@
+export {
+  useRampsOrderSyncing,
+  useShouldDispatchRampsOrderSyncing,
+} from './useRampsOrderSyncing';

--- a/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.test.tsx
+++ b/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.test.tsx
@@ -1,0 +1,171 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../test/renderWithProvider';
+import {
+  useRampsOrderSyncing,
+  useShouldDispatchRampsOrderSyncing,
+} from './useRampsOrderSyncing';
+
+const mockSyncOrdersWithUserStorage = jest.fn<Promise<unknown>, []>();
+
+jest.mock('../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      RampsController: {
+        syncOrdersWithUserStorage: jest.fn(() =>
+          mockSyncOrdersWithUserStorage(),
+        ),
+      },
+    },
+  },
+}));
+
+interface ArrangeMocksMetamaskStateOverrides {
+  isSignedIn: boolean;
+  isBackupAndSyncEnabled: boolean;
+  isRampsSyncingEnabled: boolean;
+  isUnlocked: boolean;
+  useExternalServices: boolean;
+  completedOnboarding: boolean;
+}
+
+const arrangeMockState = (
+  stateOverrides: ArrangeMocksMetamaskStateOverrides,
+) => {
+  const state = {
+    engine: {
+      backgroundState: {
+        KeyringController: {
+          isUnlocked: stateOverrides.isUnlocked,
+          keyrings: [],
+        },
+        AuthenticationController: {
+          isSignedIn: stateOverrides.isSignedIn,
+        },
+        UserStorageController: {
+          isBackupAndSyncEnabled: stateOverrides.isBackupAndSyncEnabled,
+          isRampsSyncingEnabled: stateOverrides.isRampsSyncingEnabled,
+        },
+      },
+    },
+    settings: {
+      basicFunctionalityEnabled: stateOverrides.useExternalServices,
+    },
+    onboarding: {
+      completedOnboarding: stateOverrides.completedOnboarding,
+    },
+  };
+
+  return { state };
+};
+
+describe('useShouldDispatchRampsOrderSyncing()', () => {
+  const testCases = (() => {
+    const properties = [
+      'isSignedIn',
+      'isBackupAndSyncEnabled',
+      'isRampsSyncingEnabled',
+      'isUnlocked',
+      'useExternalServices',
+      'completedOnboarding',
+    ] as const;
+    const baseState = {
+      isSignedIn: true,
+      isBackupAndSyncEnabled: true,
+      isRampsSyncingEnabled: true,
+      isUnlocked: true,
+      useExternalServices: true,
+      completedOnboarding: true,
+    };
+
+    const failureStateCases: {
+      state: ArrangeMocksMetamaskStateOverrides;
+      failingField: string;
+    }[] = [];
+
+    properties.forEach((property) => {
+      const state = { ...baseState, [property]: false };
+      failureStateCases.push({ state, failingField: property });
+    });
+
+    const successTestCase = { state: baseState };
+
+    return { successTestCase, failureStateCases };
+  })();
+
+  it('should return true if all conditions are met', () => {
+    const { state } = arrangeMockState(testCases.successTestCase.state);
+    const hook = renderHookWithProvider(
+      () => useShouldDispatchRampsOrderSyncing(),
+      { state },
+    );
+    expect(hook.result.current).toBe(true);
+  });
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  it.each(testCases.failureStateCases)(
+    'should return false if not all conditions are met [%s = false]',
+    ({
+      state: failureState,
+    }: (typeof testCases)['failureStateCases'][number]) => {
+      const { state } = arrangeMockState(failureState);
+      const hook = renderHookWithProvider(
+        () => useShouldDispatchRampsOrderSyncing(),
+        { state },
+      );
+      expect(hook.result.current).toBe(false);
+    },
+  );
+});
+
+describe('useRampsOrderSyncing', () => {
+  const arrangeAndAct = (
+    stateOverrides: ArrangeMocksMetamaskStateOverrides,
+  ) => {
+    jest.clearAllMocks();
+    const { state } = arrangeMockState(stateOverrides);
+
+    const { result } = renderHookWithProvider(() => useRampsOrderSyncing(), {
+      state,
+    });
+    const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
+      result.current;
+
+    return { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing };
+  };
+
+  it('should dispatch if conditions are met', async () => {
+    const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
+      arrangeAndAct({
+        completedOnboarding: true,
+        isBackupAndSyncEnabled: true,
+        isRampsSyncingEnabled: true,
+        isSignedIn: true,
+        isUnlocked: true,
+        useExternalServices: true,
+      });
+
+    await act(async () => dispatchRampsOrderSyncing());
+
+    expect(mockSyncOrdersWithUserStorage).toHaveBeenCalled();
+    expect(shouldDispatchRampsOrderSyncing).toBe(true);
+  });
+
+  it('should not dispatch conditions are not met', async () => {
+    const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
+      arrangeAndAct({
+        completedOnboarding: true,
+        isBackupAndSyncEnabled: true,
+        isRampsSyncingEnabled: false,
+        isSignedIn: true,
+        isUnlocked: true,
+        useExternalServices: true,
+      });
+
+    await act(async () => dispatchRampsOrderSyncing());
+
+    expect(mockSyncOrdersWithUserStorage).not.toHaveBeenCalled();
+    expect(shouldDispatchRampsOrderSyncing).toBe(false);
+  });
+});

--- a/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.test.tsx
+++ b/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.test.tsx
@@ -93,7 +93,7 @@ describe('useShouldDispatchRampsOrderSyncing()', () => {
     return { successTestCase, failureStateCases };
   })();
 
-  it('should return true if all conditions are met', () => {
+  it('returns true if all conditions are met', () => {
     const { state } = arrangeMockState(testCases.successTestCase.state);
     const hook = renderHookWithProvider(
       () => useShouldDispatchRampsOrderSyncing(),
@@ -105,7 +105,7 @@ describe('useShouldDispatchRampsOrderSyncing()', () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   it.each(testCases.failureStateCases)(
-    'should return false if not all conditions are met [%s = false]',
+    'returns false if not all conditions are met [%s = false]',
     ({
       state: failureState,
     }: (typeof testCases)['failureStateCases'][number]) => {
@@ -135,7 +135,7 @@ describe('useRampsOrderSyncing', () => {
     return { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing };
   };
 
-  it('should dispatch if conditions are met', async () => {
+  it('dispatches if conditions are met', async () => {
     const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
       arrangeAndAct({
         completedOnboarding: true,
@@ -152,7 +152,7 @@ describe('useRampsOrderSyncing', () => {
     expect(shouldDispatchRampsOrderSyncing).toBe(true);
   });
 
-  it('should not dispatch conditions are not met', async () => {
+  it('does not dispatch if conditions are not met', async () => {
     const { dispatchRampsOrderSyncing, shouldDispatchRampsOrderSyncing } =
       arrangeAndAct({
         completedOnboarding: true,

--- a/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.ts
+++ b/app/util/identity/hooks/useRampsOrderSyncing/useRampsOrderSyncing.ts
@@ -1,0 +1,69 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectCompletedOnboarding } from '../../../../selectors/onboarding';
+import { selectIsUnlocked } from '../../../../selectors/keyringController';
+
+import Engine from '../../../../core/Engine';
+import {
+  selectIsBackupAndSyncEnabled,
+  selectIsRampsSyncingEnabled,
+  selectIsSignedIn,
+} from '../../../../selectors/identity';
+
+/**
+ * A utility used internally to decide if ramps order syncing should be dispatched.
+ * Considers factors like basic functionality, unlocked, finished onboarding,
+ * signed in, and ramps syncing feature flags.
+ *
+ * @returns Whether ramps order syncing can be performed.
+ */
+export const useShouldDispatchRampsOrderSyncing = () => {
+  const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
+  const isRampsSyncingEnabled = useSelector(selectIsRampsSyncingEnabled);
+  const basicFunctionality: boolean | undefined = useSelector(
+    selectBasicFunctionalityEnabled,
+  );
+  const isUnlocked: boolean | undefined = useSelector(selectIsUnlocked);
+  const isSignedIn = useSelector(selectIsSignedIn);
+  const completedOnboarding = useSelector(selectCompletedOnboarding);
+
+  const shouldDispatchRampsOrderSyncing: boolean = Boolean(
+    basicFunctionality &&
+      isBackupAndSyncEnabled &&
+      isRampsSyncingEnabled &&
+      isUnlocked &&
+      isSignedIn &&
+      completedOnboarding,
+  );
+
+  return shouldDispatchRampsOrderSyncing;
+};
+
+/**
+ * Custom hook to dispatch ramps order syncing.
+ *
+ * @returns An object containing the `dispatchRampsOrderSyncing` function and
+ * boolean `shouldDispatchRampsOrderSyncing`.
+ */
+export const useRampsOrderSyncing = () => {
+  const shouldDispatchRampsOrderSyncing = useShouldDispatchRampsOrderSyncing();
+
+  const dispatchRampsOrderSyncing = useCallback(() => {
+    const action = async () => {
+      if (!shouldDispatchRampsOrderSyncing) {
+        return;
+      }
+      await Engine.context.RampsController.syncOrdersWithUserStorage();
+    };
+    action().catch((error) => {
+      console.error('Error dispatching ramps order syncing:', error);
+    });
+  }, [shouldDispatchRampsOrderSyncing]);
+
+  return {
+    dispatchRampsOrderSyncing,
+    shouldDispatchRampsOrderSyncing,
+  };
+};

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -623,7 +623,8 @@
     "isBackupAndSyncUpdateLoading": false,
     "isAccountSyncingEnabled": true,
     "isContactSyncingEnabled": true,
-    "isContactSyncingInProgress": false
+    "isContactSyncingInProgress": false,
+    "isRampsSyncingEnabled": true
   },
   "MultichainBalancesController": {
     "balances": {}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8824,7 +8824,8 @@
     "privacyLink": "Learn how we protect your privacy",
     "features": {
       "accounts": "Accounts",
-      "contacts": "Contacts"
+      "contacts": "Contacts",
+      "ramps": "Buy & sell orders"
     },
     "manageWhatYouSync": {
       "title": "Manage what you sync",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
   "name": "metamask",
+  "previewBuilds": {
+    "@metamask/ramps-controller": {
+      "type": "breaking",
+      "previewVersion": "20.0.0-preview-8c482076b"
+    },
+    "@metamask/profile-sync-controller": {
+      "type": "breaking",
+      "previewVersion": "29.0.0-preview-8c482076b"
+    }
+  },
   "version": "8.9.0",
   "private": true,
   "repository": {
@@ -228,7 +238,10 @@
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@ledgerhq/context-module/ethers": "^6.16.0",
     "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0",
-    "@metamask/assets-controller@npm:^13.1.3": "patch:@metamask/assets-controller@npm%3A13.1.3#~/.yarn/patches/@metamask-assets-controller-npm-13.1.3-bb9a075a03.patch"
+    "@metamask/assets-controller@npm:^13.1.3": "patch:@metamask/assets-controller@npm%3A13.1.3#~/.yarn/patches/@metamask-assets-controller-npm-13.1.3-bb9a075a03.patch",
+    "metamask@workspace:./@metamask/ramps-controller": "npm:@metamask-previews/ramps-controller@20.0.0-preview-8c482076b",
+    "metamask@workspace:./@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@29.0.0-preview-8c482076b",
+    "@metamask/ramps-controller@^20.0.0": "npm:@metamask-previews/ramps-controller@20.0.0-preview-8c482076b"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -338,7 +351,7 @@
     "@metamask/preinstalled-example-snap": "^0.8.1",
     "@metamask/profile-metrics-controller": "^4.0.3",
     "@metamask/profile-sync-controller": "^29.0.0",
-    "@metamask/ramps-controller": "^19.0.0",
+    "@metamask/ramps-controller": "^20.0.0",
     "@metamask/react-data-query": "^0.2.2",
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/tests/api-mocking/mock-responses/defaults/user-storage.ts
+++ b/tests/api-mocking/mock-responses/defaults/user-storage.ts
@@ -148,6 +148,17 @@ export const USER_STORAGE_MOCK: MockEventsObject = {
       response: 'OK',
     },
     {
+      urlEndpoint:
+        /^https:\/\/user-storage\.api\.cx\.metamask\.io\/api\/v1\/userstorage\/rampsOrders\/[a-fA-F0-9]+$/,
+      responseCode: 200,
+      response: 'OK',
+    },
+    {
+      urlEndpoint: rampsOrdersStorageUrl,
+      responseCode: 200,
+      response: 'OK',
+    },
+    {
       urlEndpoint: assetsWatchlistUrl,
       responseCode: 200,
       response: 'OK',

--- a/tests/api-mocking/mock-responses/defaults/user-storage.ts
+++ b/tests/api-mocking/mock-responses/defaults/user-storage.ts
@@ -4,6 +4,7 @@ import {
   USER_STORAGE_GROUPS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_KEY,
 } from '@metamask/account-tree-controller';
+import { USER_STORAGE_RAMPS_ORDERS_FEATURE } from '@metamask/ramps-controller';
 import { DEFAULT_FIXTURE_ACCOUNT_CHECKSUM } from '../../../framework/fixtures/FixtureBuilder';
 
 const accountsStorageUrl = `https://user-storage.api.cx.metamask.io/api/v1/userstorage/${USER_STORAGE_FEATURE_NAMES.accounts}`;
@@ -13,6 +14,8 @@ const contactStorageUrl = `https://user-storage.api.cx.metamask.io/api/v1/userst
 const multichainWalletsUrl = `https://user-storage.api.cx.metamask.io/api/v1/userstorage/${USER_STORAGE_WALLETS_FEATURE_KEY}`;
 
 const multichainGroupsUrl = `https://user-storage.api.cx.metamask.io/api/v1/userstorage/${USER_STORAGE_GROUPS_FEATURE_KEY}`;
+
+const rampsOrdersStorageUrl = `https://user-storage.api.cx.metamask.io/api/v1/userstorage/${USER_STORAGE_RAMPS_ORDERS_FEATURE}`;
 
 const assetsWatchlistUrl =
   'https://user-storage.api.cx.metamask.io/api/v1/preferences/assets-watchlist';
@@ -80,6 +83,11 @@ export const USER_STORAGE_MOCK: MockEventsObject = {
     },
     {
       urlEndpoint: multichainGroupsUrl,
+      responseCode: 200,
+      response: [],
+    },
+    {
+      urlEndpoint: rampsOrdersStorageUrl,
       responseCode: 200,
       response: [],
     },

--- a/tests/component-view/presets/identity.ts
+++ b/tests/component-view/presets/identity.ts
@@ -30,6 +30,7 @@ interface InitialStateIdentityOptions {
   isBackupAndSyncEnabled?: boolean;
   isAccountSyncingEnabled?: boolean;
   isContactSyncingEnabled?: boolean;
+  isRampsSyncingEnabled?: boolean;
   addressBook?: AddressBookState;
 }
 
@@ -46,6 +47,7 @@ export const initialStateIdentity = (
     isBackupAndSyncEnabled = true,
     isAccountSyncingEnabled = true,
     isContactSyncingEnabled = true,
+    isRampsSyncingEnabled = true,
     addressBook = {},
   } = options;
 
@@ -72,6 +74,7 @@ export const initialStateIdentity = (
             isBackupAndSyncEnabled,
             isAccountSyncingEnabled,
             isContactSyncingEnabled,
+            isRampsSyncingEnabled,
             isBackupAndSyncUpdateLoading: false,
           },
           AddressBookController: {

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -1416,6 +1416,7 @@ class FixtureBuilder {
       isAccountSyncingEnabled: true,
       isContactSyncingEnabled: true,
       isContactSyncingInProgress: false,
+      isRampsSyncingEnabled: true,
     });
 
     // Enable basic functionality in settings (required for profile syncing)
@@ -1463,6 +1464,7 @@ class FixtureBuilder {
       isBackupAndSyncEnabled: false,
       isAccountSyncingEnabled: false,
       isContactSyncingEnabled: false,
+      isRampsSyncingEnabled: false,
       basicFunctionalityEnabled: false,
     });
 
@@ -1570,12 +1572,14 @@ class FixtureBuilder {
       isBackupAndSyncEnabled: true,
       isAccountSyncingEnabled: true,
       isContactSyncingEnabled: true,
+      isRampsSyncingEnabled: true,
     },
   ) {
     const {
       isBackupAndSyncEnabled = true,
       isAccountSyncingEnabled = true,
       isContactSyncingEnabled = true,
+      isRampsSyncingEnabled = true,
     } = options;
 
     // Backup and Sync Settings
@@ -1583,6 +1587,7 @@ class FixtureBuilder {
       isBackupAndSyncEnabled,
       isAccountSyncingEnabled,
       isContactSyncingEnabled,
+      isRampsSyncingEnabled,
       isBackupAndSyncUpdateLoading: false,
       isContactSyncingInProgress: false,
     };

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -288,6 +288,7 @@ export interface BackupAndSyncSettings {
   isBackupAndSyncEnabled: boolean;
   isAccountSyncingEnabled: boolean;
   isContactSyncingEnabled: boolean;
+  isRampsSyncingEnabled: boolean;
 }
 
 export interface LaunchArgs {

--- a/tests/page-objects/Settings/BackupAndSyncView.ts
+++ b/tests/page-objects/Settings/BackupAndSyncView.ts
@@ -22,6 +22,12 @@ class BackupAndSyncView {
     );
   }
 
+  get rampsSyncToggle(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      BackupAndSyncViewSelectorsIDs.RAMPS_SYNC_TOGGLE,
+    );
+  }
+
   async toggleBackupAndSync() {
     await Gestures.waitAndTap(this.backupAndSyncToggle, {
       elemDescription: 'Backup and Sync Toggle in Backup and Sync View',
@@ -37,6 +43,12 @@ class BackupAndSyncView {
   async toggleContactSync() {
     await Gestures.waitAndTap(this.contactSyncToggle, {
       elemDescription: 'Contacts Sync Toggle in Backup and Sync View',
+    });
+  }
+
+  async toggleRampsSync() {
+    await Gestures.waitAndTap(this.rampsSyncToggle, {
+      elemDescription: 'Ramps Order Sync Toggle in Backup and Sync View',
     });
   }
 }

--- a/tests/selectors/Settings/BackupAndSyncView.selectors.js
+++ b/tests/selectors/Settings/BackupAndSyncView.selectors.js
@@ -2,4 +2,5 @@ export const BackupAndSyncViewSelectorsIDs = {
   ACCOUNT_SYNC_TOGGLE: 'toggle-accountSyncing',
   BACKUP_AND_SYNC_TOGGLE: 'toggle-backupAndSync',
   CONTACTS_SYNC_TOGGLE: 'toggle-contactSyncing',
+  RAMPS_SYNC_TOGGLE: 'toggle-rampsSyncing',
 };

--- a/tests/smoke-appium/wallet/incoming-transactions.spec.ts
+++ b/tests/smoke-appium/wallet/incoming-transactions.spec.ts
@@ -154,6 +154,7 @@ function mergeTrustedSenderForIncomingNative(fixture: Fixture): void {
     isBackupAndSyncEnabled: false,
     isAccountSyncingEnabled: false,
     isContactSyncingEnabled: false,
+    isRampsSyncingEnabled: false,
   });
 
   merge(fixture.state.engine.backgroundState.AddressBookController, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9697,6 +9697,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/profile-sync-controller@npm:@metamask-previews/profile-sync-controller@29.0.0-preview-8c482076b":
+  version: 29.0.0-preview-8c482076b
+  resolution: "@metamask-previews/profile-sync-controller@npm:29.0.0-preview-8c482076b"
+  dependencies:
+    "@metamask/address-book-controller": "npm:^7.1.2"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/keyring-controller": "npm:^27.1.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/seedless-onboarding-controller": "npm:^10.1.1"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/utils": "npm:^11.11.0"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/hashes": "npm:^1.8.0"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    siwe: "npm:^2.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/956b9203032e598bf865cc70420c10e4d4c75015bf239d60c2e48a5405e138dc0eb5fd99e4acbbe21c9ab076ed861206587dfe24c9e29ff41f309972b7552f4d
+  languageName: node
+  linkType: hard
+
 "@metamask/profile-sync-controller@npm:^28.2.0, @metamask/profile-sync-controller@npm:^28.3.0":
   version: 28.3.0
   resolution: "@metamask/profile-sync-controller@npm:28.3.0"
@@ -9788,29 +9813,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^19.0.0":
-  version: 19.0.0
-  resolution: "@metamask/ramps-controller@npm:19.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/profile-sync-controller": "npm:^28.3.0"
-    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
-  checksum: 10/332c9f58fbc77ef53dbebb9488d65d1195d8c5afe43758a4f65e1cb36383bf181f9c9557a492fe740ce9ca198b35ae8b90d68cb5d152626a04349ca3502bf180
-  languageName: node
-  linkType: hard
-
-"@metamask/ramps-controller@npm:^20.0.0":
-  version: 20.0.0
-  resolution: "@metamask/ramps-controller@npm:20.0.0"
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@20.0.0-preview-8c482076b":
+  version: 20.0.0-preview-8c482076b
+  resolution: "@metamask-previews/ramps-controller@npm:20.0.0-preview-8c482076b"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/profile-sync-controller": "npm:^29.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
-  checksum: 10/5dceb58717d74553c13f628ca8bf1153d94f0b7b89611e1d1d645578afaf2c6c058a07aceb83184039a390e78419986e725f9c5d105d2c256f2726628b33685b
+    fast-deep-equal: "npm:^3.1.3"
+  checksum: 10/6e0cc664928f6d7910fcf829db1a0b04920c0234dbe659b1a44dab3daf9dd039fa5c5dae134c9a98df03d26a680ef7bf87508dcd716cbf31d95cec4e9a78896d
   languageName: node
   linkType: hard
 
@@ -35741,7 +35754,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^4.0.3"
     "@metamask/profile-sync-controller": "npm:^29.0.0"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^19.0.0"
+    "@metamask/ramps-controller": "npm:^20.0.0"
     "@metamask/react-data-query": "npm:^0.2.2"
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## **Description**

Syncs V2 buy/sell order history through Backup & Sync so orders created on Mobile can appear on other Mobile devices, Extension, and Portfolio for the same SRP/Profile Sync profile. It adds the **Buy & sell orders** setting, runs order sync after unlock when all identity and privacy gates are enabled, and keeps Activity rows distinct when providers reuse placeholder transaction hashes.

Missing ramps-sync toggle values on upgraded wallets default to enabled, matching new installs.

Companion PRs:
- Core: https://github.com/MetaMask/core/pull/9474
- Extension: https://github.com/MetaMask/metamask-extension/pull/44367
- Portfolio: https://github.com/consensys-vertical-apps/metamask-portfolio/pull/2053

Implementation notes:
- Delegates the User Storage and authentication messenger actions required by ramps-controller order sync.
- Calls `RampsController.syncOrdersWithUserStorage()` from `useIdentityEffects` after unlock.
- Falls back to order ID when `txHash` is missing or `DUMMY_TX_ID`, and normalizes `createdAt` for Activity sorting.
- Pins preview ramps/profile-sync controller builds until the companion Core changes are published.

## **Changelog**

CHANGELOG entry: Added Backup & Sync support for buy and sell order history

## **Related issues**

Refs: https://github.com/MetaMask/core/pull/9474

## **Manual testing steps**

```gherkin
Feature: Buy and sell order history sync

  Scenario: Sync a Mobile ramps order to another client
    Given two clients use the same signed-in SRP profile and environment
    And Backup & Sync and Buy & sell orders are enabled
    When a V2 buy or sell order is completed on Mobile
    And the other client is unlocked
    Then the order appears in the other client's order history

  Scenario: Disable ramps order syncing
    Given Backup & Sync is enabled
    When Buy & sell orders is disabled
    Then ramps orders are not pushed to or pulled from User Storage
```

Automated coverage includes order-sync gating, controller messenger wiring, Activity adapter fallback IDs, settings UI, and controller initialization.

## **Screenshots/Recordings**

N/A — the change adds another row using the existing Backup & Sync settings-toggle component and does not introduce a new layout or interaction pattern.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

The performance items were assessed as not applicable to this profile-sync integration; CI performance checks remain non-blocking.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Backup & Sync / User Storage for financial order history and expands RampsController messenger permissions, with preview controller package pins until Core publishes.
> 
> **Overview**
> Enables **Backup & Sync for V2 buy/sell order history** so Mobile orders can appear on other signed-in clients sharing the same profile.
> 
> Adds a **Buy & sell orders** toggle in Backup & Sync settings, a `useRampsOrderSyncing` hook that calls `RampsController.syncOrdersWithUserStorage()` when identity/privacy gates pass, and wires that into `useIdentityEffects`. Missing `isRampsSyncingEnabled` values default to **enabled** on upgrade.
> 
> Delegates User Storage and auth messenger actions to `RampsController`, tracks order-sync error situations, and requires a non-empty `chainId` when registering precreated orders. Also treats placeholder hashes like `DUMMY_TX_ID` as invalid Activity keys and normalizes `createdAt` timestamps so synced orders stay distinct and sortable.
> 
> Pins preview `@metamask/ramps-controller` / `@metamask/profile-sync-controller` builds until the companion Core release lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0609d3026e53fa705ec57373fff9593554c99676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->