### PR TITLE
ci: verbose setup during CI

### DIFF
--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,16 +1,18 @@
 /* eslint-disable import-x/no-nodejs-modules */
 import fs from 'fs';
-import { $ } from 'execa';
+import { $ as runScript } from 'execa';
 import { Listr } from 'listr2';
 import path from 'path';
 
 const IS_CI = process.env.CI;
 const IS_OSX = process.platform === 'darwin';
+
 // iOS builds are enabled by default on macOS only but can be enabled or disabled explicitly
 let BUILD_IOS = IS_OSX;
 let IS_NODE = false;
 let BUILD_ANDROID = true
 let INSTALL_PODS;
+let VERBOSE = IS_CI;
 // GitHub CI pipeline flag - defaults to false
 let GITHUB_CI = false;
 const args = process.argv.slice(2) || [];
@@ -37,6 +39,9 @@ for (const arg of args) {
     case '--build-on-github-ci':
       GITHUB_CI = true;
       continue;
+    case '--verbose':
+      VERBOSE = true;
+      continue;
     default:
       throw new Error(`Unrecognized CLI arg ${arg}`);
   }
@@ -47,6 +52,7 @@ if (INSTALL_PODS === undefined) {
 if (INSTALL_PODS && !BUILD_IOS) {
   throw new Error('Cannot install pods if iOS setup has been skipped');
 }
+const $  = runScript(VERBOSE ? {stdio: 'inherit'} : undefined);
 
 const rendererOptions = {
   collapseErrors: false,
@@ -384,6 +390,7 @@ const concurrentTasks = {
 const tasks = new Listr([prepareDependenciesTask, concurrentTasks], {
   concurrent: false,
   exitOnError: true,
+  renderer: VERBOSE ? 'verbose' : 'default',
   rendererOptions,
 });
 


### PR DESCRIPTION
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The setup script has been updated to use a verbose logger in CI, and to forward logs from each sub-step to the parent process. This will make it easier to understand delays and diagnose problems.

This verbose mode is also usable locally with the new `--verbose` flag.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Run `yarn setup` locally to confirm that it works the same as before.

Try `yarn setup --verbose` to test the new verbose mode (or just look in the CI logs for this PR).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/CI tooling only; no app runtime, auth, or data-path changes.
> 
> **Overview**
> **`scripts/setup.mjs`** turns on verbose setup logging when `CI` is set, and adds a **`--verbose`** flag for the same behavior locally.
> 
> When verbose is on, **execa** runs with **`stdio: 'inherit'`** so sub-step output (yarn, pods, etc.) streams to the parent instead of being hidden behind Listr’s default UI. The root **Listr** task list also switches from the default renderer to **`verbose`**, so CI logs show more detail for stalls and failures.
> 
> Default local runs without **`--verbose`** stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5c91241b8c287f92de735f140f863fc69059ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->