### PR TITLE
fix(swaps): apply bottom safe area insets per layer on swap screen

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
@@ -53,7 +53,6 @@ export const createStyles = (params: { theme: Theme }) => {
     },
     scrollViewContent: {
       flexGrow: 1,
-      paddingBottom: 16,
     },
     loadingContainer: {
       paddingTop: 8,

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Box } from '../../../Box/Box';
 import {
   FlexDirection,
@@ -50,6 +51,7 @@ export const BridgeViewFooter = ({
   transactionActiveAbTests,
 }: Props) => {
   const { styles } = useStyles(createStyles);
+  const { bottom: bottomInset } = useSafeAreaInsets();
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
@@ -74,9 +76,14 @@ export const BridgeViewFooter = ({
     return null;
   }
 
+  const footerContainerStyle = [
+    styles.buttonContainer,
+    { paddingBottom: bottomInset },
+  ];
+
   if (needsNewQuote) {
     return (
-      <Box style={styles.buttonContainer}>
+      <Box style={footerContainerStyle}>
         <SwapsConfirmButton
           location={location}
           latestSourceBalance={latestSourceBalance}
@@ -99,7 +106,7 @@ export const BridgeViewFooter = ({
     isValidSourceAmount &&
     activeQuote &&
     quotesLastFetched && (
-      <Box style={styles.buttonContainer}>
+      <Box style={footerContainerStyle}>
         {isHardwareAddress && isSolanaSourced && (
           <BannerAlert
             severity={BannerAlertSeverity.Error}

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -49,6 +49,7 @@ import {
   selectIsNonEvmNonEvmBridge,
   selectQuoteStreamComplete,
   selectBridgeBalanceRefreshKey,
+  selectBridgeControllerState,
 } from '../../../../../core/redux/slices/bridge';
 import BannerBase from '../../../../../component-library/components/Banners/Banner/foundation/BannerBase';
 import { IconName as CLIconName } from '../../../../../component-library/components/Icons/Icon';
@@ -81,10 +82,11 @@ import { useSwitchTokens } from '../../hooks/useSwitchTokens';
 import {
   Pressable,
   ScrollView,
+  View,
   type NativeSyntheticEvent,
   type NativeScrollEvent,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
 import { isHardwareAccount } from '../../../../../util/address';
@@ -156,6 +158,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   );
 
   const { styles } = useStyles(createStyles);
+  const { bottom: bottomInset } = useSafeAreaInsets();
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const route = useRoute<RouteProp<{ params: BridgeRouteParams }, 'params'>>();
@@ -292,6 +295,35 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
 
   const isValidSourceAmount =
     sourceAmount !== undefined && sourceAmount !== '.' && sourceToken?.decimals;
+
+  const { quotesLastFetched } = useSelector(selectBridgeControllerState);
+
+  const isFooterVisible = useMemo(() => {
+    if (isLoading && !activeQuote && !needsNewQuote) {
+      return false;
+    }
+    if (needsNewQuote) {
+      return true;
+    }
+    if (!activeQuote) {
+      return false;
+    }
+    return Boolean(isValidSourceAmount && activeQuote && quotesLastFetched);
+  }, [
+    isLoading,
+    activeQuote,
+    needsNewQuote,
+    isValidSourceAmount,
+    quotesLastFetched,
+  ]);
+
+  const scrollContentContainerStyle = useMemo(
+    () => [
+      styles.scrollViewContent,
+      { paddingBottom: isFooterVisible ? 0 : bottomInset },
+    ],
+    [styles.scrollViewContent, isFooterVisible, bottomInset],
+  );
 
   const hasValidBridgeInputs =
     isValidSourceAmount &&
@@ -479,10 +511,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   );
 
   return (
-    <SafeAreaView
-      style={styles.screenWrapper}
-      edges={['bottom', 'left', 'right']}
-    >
+    <View style={styles.screenWrapper}>
       <HeaderStandard
         title={headerTitle}
         onBack={() => navigation.goBack()}
@@ -498,7 +527,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
             ref={scrollViewRef}
             testID={BridgeViewSelectorsIDs.BRIDGE_VIEW_SCROLL}
             style={styles.scrollView}
-            contentContainerStyle={styles.scrollViewContent}
+            contentContainerStyle={scrollContentContainerStyle}
             showsVerticalScrollIndicator={false}
             scrollEventThrottle={16}
             onScrollBeginDrag={
@@ -795,7 +824,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
           </SwapsKeypad>
         </Box>
       </ScreenView>
-    </SafeAreaView>
+    </View>
   );
 };
 


### PR DESCRIPTION
## **Description**

The Swap screen (`BridgeView`) wrapped the entire page in a `SafeAreaView`, which applied bottom safe-area padding globally. That caused extra spacing at the bottom of scrollable content and the quote footer, since individual layers also had their own padding.

This PR removes the page-level `SafeAreaView` and applies the bottom inset only where it's needed:

- **ScrollView** — applies `bottomInset` only when the quote footer is hidden (zero state with discovery feed). Removes the hardcoded `16px` `paddingBottom`.
- **BridgeViewFooter** — applies `bottomInset` directly when the Swap button and fee disclaimer are shown.
- **Keypad** — unchanged; `BottomSheetDialog` already handles bottom safe-area padding.

Top safe area continues to be handled by `HeaderStandard` (`includesTopInset`).

## **Changelog**

CHANGELOG entry: Fixed extra bottom spacing on the Swap screen so scrollable content and the quote footer align correctly with the home indicator.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-924

## **Manual testing steps**

```gherkin
Feature: Swap screen bottom safe area

  Scenario: Discovery feed scroll area respects home indicator
    Given the user is on the Swap screen with no amount entered
    And the discovery feed (Hot tokens / Trending / Stocks) is visible

    When the user scrolls to the bottom of the feed
    Then the last list item sits just above the home indicator
    And there is no extra gap below the content

  Scenario: Quote footer respects home indicator
    Given the user is on the Swap screen with a valid amount entered
    And an active quote is displayed

    When the quote footer with the Swap button and fee disclaimer is shown
    Then the footer content sits just above the home indicator
    And there is no extra gap below the fee disclaimer

  Scenario: Keypad respects home indicator
    Given the user is on the Swap screen

    When the user taps the source amount input to open the keypad
    Then the bottom row of keypad buttons sits just above the home indicator
    And there is no extra gap below the keypad
```

**Platforms tested:** iOS (iPhone 16 simulator)

## **Screenshots/Recordings**

### **Before**


### **After**

https://github.com/user-attachments/assets/00730ca7-146f-42cf-abc2-19f4e65dfa69

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable — N/A (layout-only change; no logic changes)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable — N/A
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operation with Sentry traces for production performance metrics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only safe-area padding changes on BridgeView with no auth, transaction, or business-logic changes; footer visibility logic is duplicated for scroll padding coordination.
> 
> **Overview**
> Fixes **double bottom spacing** on the Swap (`BridgeView`) screen by removing the page-level `SafeAreaView` and applying the home-indicator inset only on the layer that needs it.
> 
> The root wrapper is now a plain `View`; **top** safe area still comes from `HeaderStandard` (`includesTopInset`). **`BridgeViewFooter`** adds `paddingBottom` from `useSafeAreaInsets()` on the swap/confirm bar and fee disclaimer. The **`ScrollView`** uses a new `isFooterVisible` check (mirroring when the footer actually renders) so **`paddingBottom`** is the bottom inset only when the footer is hidden—e.g. zero state with the discovery feed—and **0** when the footer is shown, avoiding stacked padding. The fixed **16px** bottom padding on scroll content is removed from styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e2a5399c05e1fa2cc352b78c88dadc76a0bb3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->