### PR TITLE
fix: spam warning modal not showing up cp-8.3.0

### DIFF
--- a/app/core/RPCMethods/spam.test.ts
+++ b/app/core/RPCMethods/spam.test.ts
@@ -1,4 +1,5 @@
 import configureMockStore from 'redux-mock-store';
+import { CommonActions } from '@react-navigation/native';
 
 import { NUMBER_OF_REJECTIONS_THRESHOLD } from '../redux/slices/originThrottling';
 import initialBackgroundState from '../../util/test/initial-background-state.json';
@@ -14,8 +15,15 @@ import {
 jest.mock('../NavigationService', () => ({
   navigation: {
     navigate: jest.fn(),
+    dispatch: jest.fn(),
   },
 }));
+
+const expectedSpamModalAction = (origin: string) =>
+  CommonActions.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+    screen: Routes.SHEET.ORIGIN_SPAM_MODAL,
+    params: { origin },
+  });
 
 const [BLOCKABLE_RPC_METHOD_MOCK] = BLOCKABLE_SPAM_RPC_METHODS;
 const SCAM_ORIGIN_MOCK = 'scam.origin';
@@ -181,12 +189,8 @@ describe('utils', () => {
         store,
       });
 
-      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
-        Routes.MODAL.ROOT_MODAL_FLOW,
-        {
-          screen: Routes.SHEET.ORIGIN_SPAM_MODAL,
-          params: { origin: SCAM_ORIGIN_MOCK },
-        },
+      expect(NavigationService.navigation.dispatch).toHaveBeenCalledWith(
+        expectedSpamModalAction(SCAM_ORIGIN_MOCK),
       );
     });
   });

--- a/app/core/RPCMethods/spam.ts
+++ b/app/core/RPCMethods/spam.ts
@@ -1,6 +1,7 @@
 import { Store } from 'redux';
 import { JsonRpcRequest } from '@metamask/utils';
 import { providerErrors } from '@metamask/rpc-errors';
+import { CommonActions } from '@react-navigation/native';
 
 import { containsUserRejectedError } from '../../util/middlewares';
 import Routes from '../../constants/navigation/Routes';
@@ -31,6 +32,25 @@ export type ExtendedJSONRPCRequest = JsonRpcRequest & { origin: string };
 export const SPAM_FILTER_ACTIVATED = providerErrors.unauthorized(
   'Request blocked due to spam filter.',
 );
+
+/**
+ * Presents the origin spam sheet.
+ *
+ * Uses `dispatch(CommonActions.navigate(...))` rather than `navigate(...)`
+ * because NavigationService defers `navigate`/`reset` behind
+ * requestAnimationFrame to avoid render-cycle timing issues. When triggered
+ * from the RPC/bridge context, that deferred callback can fail to fire, leaving
+ * the origin silently blocked with no visible sheet. `dispatch` is not deferred
+ * and runs synchronously, so the sheet reliably presents.
+ */
+function showOriginSpamModal(origin: string) {
+  NavigationService.navigation.dispatch(
+    CommonActions.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.ORIGIN_SPAM_MODAL,
+      params: { origin },
+    }),
+  );
+}
 
 export function validateOriginThrottling({
   req,
@@ -80,9 +100,6 @@ export function processOriginThrottlingRejection({
   store.dispatch(onRPCRequestRejectedByUser(req.origin));
 
   if (selectIsOriginBlockedForRPCRequests(store.getState(), req.origin)) {
-    NavigationService.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.ORIGIN_SPAM_MODAL,
-      params: { origin: req.origin },
-    });
+    showOriginSpamModal(req.origin);
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When a dapp origin triggers the spam filter (the user rejects the same blockable RPC request — e.g. `eth_sendTransaction` — 3 times within 30s), the app is supposed to present the "We've noticed multiple requests" origin spam sheet so the user understands they've been temporarily blocked and can dismiss the block.

In practice this sheet **intermittently failed to appear**, leaving the origin silently blocked for ~60s with no visible feedback: the button appeared unresponsive and there was no way to clear the block.

Root cause: `NavigationService` wraps `navigate`/`reset` in `requestAnimationFrame` (to avoid render-cycle timing issues). The origin-throttling middleware presents the spam sheet from the RPC/bridge context, and that deferred `requestAnimationFrame` callback can fail to fire in that context — so `navigate` never ran and the sheet never presented.

Fix: present the sheet via `NavigationService.navigation.dispatch(CommonActions.navigate(...))` instead of `navigate(...)`. `dispatch` is not deferred and runs synchronously, so the sheet reliably presents. The call is extracted into a small `showOriginSpamModal()` helper.

Android build: https://github.com/MetaMask/metamask-mobile/actions/runs/29127833732
iOS build: https://github.com/MetaMask/metamask-mobile/actions/runs/29127487237
## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where the spam warning modal ("We've noticed multiple requests") sometimes failed to appear after repeatedly canceling a dapp's requests, leaving the site silently blocked with no way to dismiss it.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:https://github.com/MetaMask/metamask-mobile/issues/32863

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Origin spam warning modal

  Scenario: Spam warning sheet appears after repeated cancels
    Given I have opened a dapp (e.g. https://metamask.github.io/test-dapp/) in a browser tab
    When I trigger a blockable request (e.g. tap "Send Eth") and cancel it 3 times within 30 seconds
    Then the "We've noticed multiple requests" spam warning sheet is presented

  Scenario: User can clear the block
    Given the spam warning sheet is presented
    When I tap "Cancel"
    Then the block is cleared and I can send requests again

  Scenario: User can keep the block
    Given the spam warning sheet is presented
    When I tap "Temporarily block this site"
    Then the site remains blocked for the throttling window
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

iOS
|BEFORE|AFTER|
|---|---|
|<img width="418" height="834" alt="Modal Before" src="https://github.com/user-attachments/assets/b323b8e3-3766-4914-a7c2-3ac8ed8d3a76" />|<img width="374" height="776" alt="modal after" src="https://github.com/user-attachments/assets/839eb8b9-c0be-4a28-ab25-d7c039b0fbea" />|

Android test
<img width="374" height="776" alt="Android test" src="https://github.com/user-attachments/assets/1a48c3ec-cd5c-483c-a518-eafe92f65c53" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized navigation change for one modal with updated unit tests; no auth or data-handling changes.
> 
> **Overview**
> Fixes the **origin spam warning sheet** sometimes not appearing after repeated user cancels on blockable RPC requests, which left the dapp **silently throttled** with no UI.
> 
> Presentation now goes through **`showOriginSpamModal`**, which calls **`NavigationService.navigation.dispatch(CommonActions.navigate(...))`** instead of **`navigate`**, because **`NavigationService` defers `navigate`/`reset` with `requestAnimationFrame`** and that callback can fail when the sheet is triggered from the **RPC/bridge** path.
> 
> Tests assert **`dispatch`** with the expected **`CommonActions.navigate`** payload to the origin spam modal route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df8ebfa0708f86b2d2e9c5729f04823679dd9f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->