### PR TITLE
fix(TMCU-1048): Remove redundant useElevatedSurface from MMDS BottomSheet callsites

### DIFF
--- a/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/ConfirmTurnOnBackupAndSyncModal.tsx
+++ b/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/ConfirmTurnOnBackupAndSyncModal.tsx
@@ -15,15 +15,12 @@ import { ConfirmTurnOnBackupAndSyncModalNavigateParams } from '../BackupAndSyncT
 import { InteractionManager } from 'react-native';
 import useThunkDispatch from '../../../hooks/useThunkDispatch';
 
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
-
 const ConfirmTurnOnBackupAndSyncModal = () => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const { enableBackupAndSync, trackEnableBackupAndSyncEvent } =
     useParams<ConfirmTurnOnBackupAndSyncModalNavigateParams>();
 
   const dispatch = useThunkDispatch();
-  const surfaceClass = useElevatedSurface();
 
   const enableBasicFunctionality = async () => {
     await dispatch(toggleBasicFunctionality(true));
@@ -54,7 +51,7 @@ const ConfirmTurnOnBackupAndSyncModal = () => {
   };
 
   return (
-    <BottomSheet ref={bottomSheetRef} twClassName={surfaceClass}>
+    <BottomSheet ref={bottomSheetRef}>
       <ModalContent
         title={turnContent.bottomSheetTitle}
         message={turnContent.bottomSheetMessage}

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
@@ -22,7 +22,6 @@ import { RootState } from '../../../../reducers';
 import { useDispatch, useSelector } from 'react-redux';
 import { setMultichainAccountsIntroModalSeen } from '../../../../actions/user';
 import { LEARN_MORE_BOTTOM_SHEET_TEST_IDS } from './LearnMoreBottomSheet.testIds';
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
 
 interface LearnMoreBottomSheetProps {
   onClose?: () => void;
@@ -40,7 +39,6 @@ const LearnMoreBottomSheet: React.FC<LearnMoreBottomSheetProps> = ({
   const isBasicFunctionalityEnabled = useSelector(
     (state: RootState) => state?.settings?.basicFunctionalityEnabled,
   );
-  const surfaceClass = useElevatedSurface();
 
   const handleBack = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -68,7 +66,6 @@ const LearnMoreBottomSheet: React.FC<LearnMoreBottomSheetProps> = ({
       ref={sheetRef}
       onClose={onClose}
       testID={LEARN_MORE_BOTTOM_SHEET_TEST_IDS.BOTTOM_SHEET}
-      twClassName={surfaceClass}
     >
       <View style={styles.container}>
         <View style={styles.header}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface styling internally. This PR removes the redundant `useElevatedSurface()` shim and `twClassName` prop from the two remaining accounts-engineer callsites scoped in TMCU-1048.

**Changes:**
- `ConfirmTurnOnBackupAndSyncModal` — removed `useElevatedSurface` import/usage and `twClassName` on `BottomSheet`
- `LearnMoreBottomSheet` — removed `useElevatedSurface` import/usage and `twClassName` on `BottomSheet`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1048

## **Manual testing steps**

```gherkin
Feature: Pure black elevated surface on MMDS BottomSheet

  Scenario: Backup and sync confirm sheet renders with correct surface
    Given the app is in dark mode with pure black preview enabled
    When the user opens the backup and sync confirmation bottom sheet
    Then the bottom sheet surface should use the elevated background (not collapse into pure black)

  Scenario: Multichain intro learn-more sheet renders with correct surface
    Given the app is in dark mode with pure black preview enabled
    When the user opens the multichain accounts learn-more bottom sheet
    Then the bottom sheet surface should use the elevated background (not collapse into pure black)
```

N/A for automated cloud-agent environment — visual QA requires device/simulator with pure black preview enabled.

## **Screenshots/Recordings**

N/A — visual surface change only; requires device QA with pure black preview enabled per acceptance criteria.

### **Before**

N/A

### **After**

Backup and Sync BottomSheet background color still works as expected

<img width="403" height="374" alt="Screenshot 2026-07-13 at 11 25 33 AM" src="https://github.com/user-attachments/assets/6b74972e-712c-43b1-a2a9-1d9bdf32782a" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-162f7e2d-b583-4006-8d0c-5e899ef8902f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-162f7e2d-b583-4006-8d0c-5e899ef8902f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

