### PR TITLE
fix(social): remove useElevatedSurface shim from Social & AI BottomSheets (TMCU-1050)

### DIFF
--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
@@ -14,7 +14,6 @@ import {
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 interface MarketInsightsDisclaimerBottomSheetProps {
   onClose: () => void;
@@ -24,7 +23,6 @@ const MarketInsightsDisclaimerBottomSheet: React.FC<
   MarketInsightsDisclaimerBottomSheetProps
 > = ({ onClose }) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     bottomSheetRef.current?.onCloseBottomSheet();
@@ -49,11 +47,7 @@ const MarketInsightsDisclaimerBottomSheet: React.FC<
         statusBarTranslucent
         onRequestClose={handleClose}
       >
-        <BottomSheet
-          ref={bottomSheetRef}
-          onClose={onClose}
-          twClassName={surfaceClass}
-        >
+        <BottomSheet ref={bottomSheetRef} onClose={onClose}>
           <BottomSheetHeader onClose={handleClose}>
             {strings('market_insights.disclaimer_modal.title')}
           </BottomSheetHeader>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -15,7 +15,6 @@ import type { LayoutChangeEvent } from 'react-native';
 import Animated, { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import {
   buildQuickBuySharedAnalyticsProperties,
   QuickBuyEventProperties,
@@ -99,7 +98,6 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   // True once a dismissal is requested via the CTA/Cancel so the content drops
   // with the sheet instead of running its horizontal screen-exit transition.
   const [isClosing, setIsClosing] = useState(false);
-  const surfaceClass = useElevatedSurface();
 
   const directionSV = useSharedValue<ScreenDirection>(1);
   // Suppresses the enter animation on the initial screen when the sheet opens;
@@ -192,11 +190,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const shouldLockHeight = lockedHeight !== null && !isDynamicHeightScreen;
 
   return (
-    <BottomSheetDialog
-      ref={bottomSheetRef}
-      onClose={onClose}
-      twClassName={surfaceClass}
-    >
+    <BottomSheetDialog ref={bottomSheetRef} onClose={onClose}>
       {isContentReady ? (
         <QuickBuyProvider
           target={target}


### PR DESCRIPTION
## **Description**

MMDS `BottomSheet` / `BottomSheetDialog` now handle pure-black elevated surface styling internally. This PR removes the redundant `useElevatedSurface()` shim from all Social & AI code-owner BottomSheets so they rely on the design-system components instead of duplicating surface logic.

**Updated files:**
- `app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx`
- `app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx`

No remaining `useElevatedSurface` usages in Social & AI code-owner folders (`SocialLeaderboard`, `MarketInsights`, `WhatsHappening`, `TopTraders`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1050

## **Manual testing steps**

```gherkin
Feature: Pure black Social & AI bottom sheets

  Scenario: Quick Buy sheet renders with correct elevated surface in pure black mode
    Given the app is running with MM_PURE_BLACK_PREVIEW enabled in dark mode
    And the user navigates to the Social Leaderboard

    When the user opens the Quick Buy bottom sheet for a trader position
    Then the sheet should display with the correct elevated surface background (not collapsing into the pure-black screen background)

  Scenario: Market Insights disclaimer sheet renders with correct elevated surface
    Given the app is running with MM_PURE_BLACK_PREVIEW enabled in dark mode
    And the user opens a Market Insights entry

    When the user opens the disclaimer bottom sheet
    Then the sheet should display with the correct elevated surface background
```

N/A for automated-only cleanup; visual QA recommended on device with pure black preview enabled.

## **Screenshots/Recordings**

N/A — internal styling cleanup with no user-facing copy or layout changes. Pure black visual QA should be done on device.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — removal-only change, no new APIs)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android (N/A — styling-only change)
- [x] I've tested with a power user scenario (N/A — no performance-sensitive paths touched)
- [x] I've instrumented key operations with Sentry traces for production performance metrics (N/A — no new traced operations)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
