### PR TITLE
chore(pure-black): delete useElevatedSurface shim from themeUtils (TMCU-1051)

### DIFF
--- a/app/component-library/components-temp/ActionListItem/ActionListItem.tsx
+++ b/app/component-library/components-temp/ActionListItem/ActionListItem.tsx
@@ -18,7 +18,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // Internal dependencies
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 import { ActionListItemProps } from './ActionListItem.types';
 
 /**
@@ -39,7 +38,6 @@ const ActionListItem: React.FC<ActionListItemProps> = ({
   ...pressableProps
 }) => {
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
 
   // Render label based on type
   const renderLabel = () => {
@@ -100,11 +98,11 @@ const ActionListItem: React.FC<ActionListItemProps> = ({
   const getStyle = useCallback(
     ({ pressed }: { pressed: boolean }) =>
       tw.style(
-        `${surfaceClass} px-4 py-3`,
+        'px-4 py-3',
         pressed && !isDisabled && 'bg-default-pressed',
         isDisabled && 'opacity-50',
       ),
-    [tw, isDisabled, surfaceClass],
+    [tw, isDisabled],
   );
 
   return (

--- a/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
@@ -36,7 +36,6 @@ import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
 import { formatTokenBalance } from '../../utils';
 import { BatchSellDestinationTokenSelectorModalSelectorsIDs } from './BatchSellDestinationTokenSelectorModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 const getTokenKey = (token: BridgeToken) => `${token.chainId}:${token.address}`;
 
@@ -87,7 +86,6 @@ export function BatchSellDestinationTokenSelectorModal() {
     chainIds:
       destinationChainIds ?? (sourceChainId ? [sourceChainId] : undefined),
   });
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -106,7 +104,7 @@ export function BatchSellDestinationTokenSelectorModal() {
       ref={sheetRef}
       goBack={navigation.goBack}
       testID={BatchSellDestinationTokenSelectorModalSelectorsIDs.SHEET}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellDestinationTokenSelectorModal/index.tsx
@@ -104,7 +104,6 @@ export function BatchSellDestinationTokenSelectorModal() {
       ref={sheetRef}
       goBack={navigation.goBack}
       testID={BatchSellDestinationTokenSelectorModalSelectorsIDs.SHEET}
-     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
@@ -48,7 +48,6 @@ import { useSubmitBatchSellTx } from '../../hooks/useSubmitBatchSellTx';
 import type { BridgeToken } from '../../types';
 import { BatchSellQuoteDetails } from '../BatchSellQuoteDetailsModal';
 import { BatchSellFinalReviewModalSelectorsIDs } from './BatchSellFinalReviewModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useTrackBatchSellReviewModalSubmitted } from '../../hooks/useTrackBatchSellReviewModalSubmitted';
 
 const MAX_VISIBLE_SOURCE_TOKEN_AVATARS = 5;
@@ -305,7 +304,6 @@ export function BatchSellFinalReviewModal() {
     isGasless: batchSellQuoteData.isGasless,
     networkFee: batchSellQuoteData.networkFee,
   });
-  const surfaceClass = useElevatedSurface();
   const sheetRef = useRef<BottomSheetRef>(null);
   const [isTokenDetailsExpanded, setIsTokenDetailsExpanded] = useState(false);
   const trackBatchSellReviewModalSubmitted =
@@ -433,7 +431,7 @@ export function BatchSellFinalReviewModal() {
       ref={sheetRef}
       testID={BatchSellFinalReviewModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
@@ -431,7 +431,6 @@ export function BatchSellFinalReviewModal() {
       ref={sheetRef}
       testID={BatchSellFinalReviewModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
@@ -27,7 +27,6 @@ export function BatchSellMinimumReceivedInfoModal() {
     <BottomSheet
       testID={BatchSellMinimumReceivedInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-     
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellMinimumReceivedInfoModal/index.tsx
@@ -15,7 +15,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { BatchSellMinimumReceivedInfoModalSelectorsIDs } from './BatchSellMinimumReceivedInfoModal.testIds';
 import { BatchSellMinimumReceivedInfoModalParams } from './BatchSellMinimumReceivedInfoModal.types';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellMinimumReceivedInfoModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
@@ -23,13 +22,12 @@ export function BatchSellMinimumReceivedInfoModal() {
   const handleBack = sourceModal
     ? () => navigation.replace(sourceModal.screen, sourceModal.params)
     : undefined;
-  const surfaceClass = useElevatedSurface();
 
   return (
     <BottomSheet
       testID={BatchSellMinimumReceivedInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
@@ -27,7 +27,6 @@ export function BatchSellNetworkFeeInfoModal() {
     <BottomSheet
       testID={BatchSellNetworkFeeInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-     
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellNetworkFeeInfoModal/index.tsx
@@ -15,7 +15,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { BatchSellNetworkFeeInfoModalSelectorsIDs } from './BatchSellNetworkFeeInfoModal.testIds';
 import { BatchSellNetworkFeeInfoModalParams } from './BatchSellNetworkFeeInfoModal.types';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellNetworkFeeInfoModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
@@ -23,13 +22,12 @@ export function BatchSellNetworkFeeInfoModal() {
   const handleBack = sourceModal
     ? () => navigation.replace(sourceModal.screen, sourceModal.params)
     : undefined;
-  const surfaceClass = useElevatedSurface();
 
   return (
     <BottomSheet
       testID={BatchSellNetworkFeeInfoModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onBack={handleBack}

--- a/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
@@ -17,12 +17,10 @@ import {
 import { BatchSellQuoteDetails } from './BatchSellQuoteDetails';
 import { BatchSellQuoteDetailsModalSelectorsIDs } from './BatchSellQuoteDetailsModal.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export function BatchSellQuoteDetailsModal() {
   const navigation = useNavigation<AppStackNavigationProp>();
   const sourceTokens = useSelector(selectBatchSellSourceTokens);
-  const surfaceClass = useElevatedSurface();
   const batchSellQuoteData = useBatchSellQuoteData({
     shouldUpdateBatchSellTrades: false,
   });
@@ -49,7 +47,7 @@ export function BatchSellQuoteDetailsModal() {
     <BottomSheet
       testID={BatchSellQuoteDetailsModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onClose={navigation.goBack}

--- a/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellQuoteDetailsModal/index.tsx
@@ -47,7 +47,6 @@ export function BatchSellQuoteDetailsModal() {
     <BottomSheet
       testID={BatchSellQuoteDetailsModalSelectorsIDs.SHEET}
       goBack={navigation.goBack}
-     
     >
       <BottomSheetHeader
         onClose={navigation.goBack}

--- a/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
+++ b/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
@@ -49,7 +49,6 @@ export function HighRateAlertModal() {
       ref={sheetRef}
       goBack={goBack}
       testID={HighRateAlertModalSelectorsIDs.SHEET}
-     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
+++ b/app/components/UI/Bridge/components/HighRateAlertModal/index.tsx
@@ -19,7 +19,6 @@ import {
   useSwapBridgeNavigation,
 } from '../../hooks/useSwapBridgeNavigation';
 import { HighRateAlertModalSelectorsIDs } from './HighRateAlertModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export interface HighRateAlertModalParams {
   sourceToken: BridgeToken;
@@ -34,7 +33,6 @@ export function HighRateAlertModal() {
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'BatchSell',
   });
-  const surfaceClass = useElevatedSurface();
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -51,7 +49,7 @@ export function HighRateAlertModal() {
       ref={sheetRef}
       goBack={goBack}
       testID={HighRateAlertModalSelectorsIDs.SHEET}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -25,7 +25,6 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export interface MissingPriceModalParams {
   location: MetaMetricsSwapsEventSource;
@@ -36,7 +35,6 @@ export const MissingPriceModal = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const [loading, setLoading] = useState(false);
   const { location } = useParams<MissingPriceModalParams>();
-  const surfaceClass = useElevatedSurface();
   const sourceToken = useSelector(selectSourceToken);
   const tokenBalance = useLatestBalance({
     address: sourceToken?.address,
@@ -69,7 +67,7 @@ export const MissingPriceModal = () => {
     <BottomSheet
       ref={sheetRef}
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -64,11 +64,7 @@ export const MissingPriceModal = () => {
   }, [confirmBridge]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-     
-    >
+    <BottomSheet ref={sheetRef} goBack={navigation.goBack}>
       <BottomSheetHeader
         onClose={handleClose}
         closeButtonProps={{

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -19,7 +19,6 @@ import {
   BottomSheet,
   BottomSheetRef,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const PriceImpactModal = () => {
   const { goBack } = useNavigation();
@@ -43,7 +42,6 @@ export const PriceImpactModal = () => {
   const priceImpactViewData = usePriceImpactViewData(
     activeQuote?.quote.priceData?.priceImpact,
   );
-  const surfaceClass = useElevatedSurface();
 
   const isDangerousPriceImpact = useMemo(
     () =>
@@ -68,7 +66,7 @@ export const PriceImpactModal = () => {
   }, [confirmBridge]);
 
   return (
-    <BottomSheet ref={sheetRef} goBack={goBack} twClassName={surfaceClass}>
+    <BottomSheet ref={sheetRef} goBack={goBack}>
       <PriceImpactHeader
         onClose={handleClose}
         iconName={priceImpactViewData.icon?.name}

--- a/app/components/UI/Card/components/MoneyUnlinkCardSheet/MoneyUnlinkCardSheet.tsx
+++ b/app/components/UI/Card/components/MoneyUnlinkCardSheet/MoneyUnlinkCardSheet.tsx
@@ -13,7 +13,6 @@ import {
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { useMoneyAccountCardLinkage } from '../../hooks/useMoneyAccountCardLinkage';
 import { CardEntryPoint } from '../../util/metrics';
 import { MoneyUnlinkCardSheetTestIds } from './MoneyUnlinkCardSheet.testIds';
@@ -27,7 +26,6 @@ const MoneyUnlinkCardSheet = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const route = useRoute();
-  const surfaceClass = useElevatedSurface();
   const { confirmLinkInBackground } = useMoneyAccountCardLinkage();
   const routeParams = route.params as
     | MoneyUnlinkCardSheetRouteParams
@@ -59,7 +57,6 @@ const MoneyUnlinkCardSheet = () => {
       goBack={handleGoBack}
       testID={MoneyUnlinkCardSheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
     >
       <BottomSheetHeader
         onClose={handleClose}

--- a/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
+++ b/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
@@ -9,7 +9,6 @@ import { parseCaipChainId } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { useSelector } from 'react-redux';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // external dependencies
 import { strings } from '../../../../locales/i18n';
@@ -63,7 +62,6 @@ const CustomNetworkSelector = ({
 }: CustomNetworkSelectorProps) => {
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, {});
-  const tw = useTailwind();
   const { navigate } = useNavigation();
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -182,7 +180,6 @@ const CustomNetworkSelector = ({
       createAvatarProps,
       selectedChainIdCaip,
       showFiatOnTestnets,
-      tw,
     ],
   );
 

--- a/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
+++ b/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
@@ -42,7 +42,6 @@ import { useNetworksToUse } from '../../hooks/useNetworksToUse/useNetworksToUse'
 import AccountGroupBalancePerChain from '../Assets/components/Balance/AccountGroupBalancePerChain';
 // internal dependencies
 import createStyles from './CustomNetworkSelector.styles';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 import {
   CustomNetworkItem,
@@ -65,7 +64,6 @@ const CustomNetworkSelector = ({
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, {});
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const { navigate } = useNavigation();
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -168,7 +166,6 @@ const CustomNetworkSelector = ({
               caipChainId,
               isSelected,
             )}
-            style={tw.style(surfaceClass)}
           >
             {(!isTestNet(chainId) || showFiatOnTestnets) && (
               <AccountGroupBalancePerChain caipChainId={caipChainId} />
@@ -185,7 +182,6 @@ const CustomNetworkSelector = ({
       createAvatarProps,
       selectedChainIdCaip,
       showFiatOnTestnets,
-      surfaceClass,
       tw,
     ],
   );

--- a/app/components/UI/FundActionMenu/FundActionMenu.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.tsx
@@ -31,12 +31,9 @@ import type {
 } from './FundActionMenu.types';
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../Ramp/hooks/useRampsButtonClickData';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
-
 const FundActionMenu = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
   const route = useRoute<FundActionMenuRouteProp>();
 
   const customOnBuy = route.params?.onBuy;
@@ -170,7 +167,6 @@ const FundActionMenu = () => {
       ref={sheetRef}
       goBack={navigation.goBack}
       testID="fund-action-menu-bottom-sheet"
-      twClassName={surfaceClass}
     >
       <Box twClassName="py-4">
         {actionConfigs.map(

--- a/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/ConfirmTurnOnBackupAndSyncModal.tsx
+++ b/app/components/UI/Identity/ConfirmTurnOnBackupAndSyncModal/ConfirmTurnOnBackupAndSyncModal.tsx
@@ -15,15 +15,12 @@ import { ConfirmTurnOnBackupAndSyncModalNavigateParams } from '../BackupAndSyncT
 import { InteractionManager } from 'react-native';
 import useThunkDispatch from '../../../hooks/useThunkDispatch';
 
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
-
 const ConfirmTurnOnBackupAndSyncModal = () => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const { enableBackupAndSync, trackEnableBackupAndSyncEvent } =
     useParams<ConfirmTurnOnBackupAndSyncModalNavigateParams>();
 
   const dispatch = useThunkDispatch();
-  const surfaceClass = useElevatedSurface();
 
   const enableBasicFunctionality = async () => {
     await dispatch(toggleBasicFunctionality(true));
@@ -54,7 +51,7 @@ const ConfirmTurnOnBackupAndSyncModal = () => {
   };
 
   return (
-    <BottomSheet ref={bottomSheetRef} twClassName={surfaceClass}>
+    <BottomSheet ref={bottomSheetRef}>
       <ModalContent
         title={turnContent.bottomSheetTitle}
         message={turnContent.bottomSheetMessage}

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
@@ -64,7 +64,6 @@ import { strings } from '../../../../locales/i18n';
 import TagColored, {
   TagColor,
 } from '../../../component-library/components-temp/TagColored';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 const SELECTION_DEBOUNCE_DELAY = 150;
 
@@ -117,7 +116,6 @@ const NetworkMultiSelectList = ({
 
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
 
   const processedNetworks = useMemo(
     (): ProcessedNetwork[] =>
@@ -331,7 +329,7 @@ const NetworkMultiSelectList = ({
             disabled={isDisabled}
             showButtonIcon={showButtonIcon}
             buttonProps={createButtonProps(network)}
-            style={tw.style(`${surfaceClass} items-center`)}
+            style={tw.style('items-center')}
             testID={NETWORK_MULTI_SELECTOR_TEST_IDS.NETWORK_LIST_ITEM(
               caipChainId,
               isSelected,
@@ -361,7 +359,6 @@ const NetworkMultiSelectList = ({
       isGasFeesSponsoredNetworkEnabled,
       isHardwareWallet,
       styles.noNetworkFeeContainer,
-      surfaceClass,
       tw,
       styles.networkNameText,
     ],

--- a/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
+++ b/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
@@ -75,11 +75,7 @@ const NftGridItemBottomSheet: React.FC<NftGridItemBottomSheetProps> = ({
   return (
     <View testID="nft-grid-item-bottom-sheet">
       <Modal visible transparent animationType="none" statusBarTranslucent>
-        <BottomSheet
-          ref={sheetRef}
-          onClose={onClose}
-         
-        >
+        <BottomSheet ref={sheetRef} onClose={onClose}>
           <BottomSheetHeader onClose={handleSheetClose}>
             <Text variant={TextVariant.HeadingMd}>
               {strings('wallet.collectible_action_title')}

--- a/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
+++ b/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
@@ -14,7 +14,6 @@ import { strings } from '../../../../locales/i18n';
 import { Nft } from '@metamask/assets-controllers';
 import Engine from '../../../core/Engine';
 import { toHex } from '@metamask/controller-utils';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 interface NftGridItemBottomSheetProps {
   isVisible: boolean;
@@ -28,7 +27,6 @@ const NftGridItemBottomSheet: React.FC<NftGridItemBottomSheetProps> = ({
   nft,
 }) => {
   const sheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
 
   const handleSheetClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -80,7 +78,7 @@ const NftGridItemBottomSheet: React.FC<NftGridItemBottomSheetProps> = ({
         <BottomSheet
           ref={sheetRef}
           onClose={onClose}
-          twClassName={surfaceClass}
+         
         >
           <BottomSheetHeader onClose={handleSheetClose}>
             <Text variant={TextVariant.HeadingMd}>

--- a/app/components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx
@@ -8,7 +8,6 @@ import {
   IconSize,
   ListItem,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import type { PerpsActionSheetProps } from './PerpsActionSheet.types';
 
 function PerpsActionSheet<T extends string>({
@@ -20,7 +19,6 @@ function PerpsActionSheet<T extends string>({
   sheetRef: externalSheetRef,
   testID,
 }: PerpsActionSheetProps<T>) {
-  const surfaceClass = useElevatedSurface();
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
 
@@ -46,7 +44,6 @@ function PerpsActionSheet<T extends string>({
       ref={sheetRef}
       goBack={!externalSheetRef ? onClose : undefined}
       onClose={externalSheetRef ? onClose : undefined}
-      twClassName={surfaceClass}
       testID={testID}
     >
       <BottomSheetHeader onClose={handleClose}>{title}</BottomSheetHeader>

--- a/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.test.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import PerpsAdjustMarginActionSheet from './PerpsAdjustMarginActionSheet';
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 jest.mock('@metamask/design-system-react-native', () => {
   const MockReact = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
@@ -4,10 +4,6 @@ import PerpsModifyActionSheet from './PerpsModifyActionSheet';
 import { type Position } from '@metamask/perps-controller';
 import { PerpsModifyActionSheetSelectorsIDs } from '../../Perps.testIds';
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 jest.mock('@metamask/design-system-react-native', () => {
   const MockReact = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');

--- a/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
+++ b/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
@@ -99,12 +99,7 @@ const RwaUnavailableBottomSheet = forwardRef<
   }
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      isInteractable
-      onClose={handleSheetClosed}
-     
-    >
+    <BottomSheet ref={sheetRef} isInteractable onClose={handleSheetClosed}>
       <BottomSheetHeader onClose={closeSheet}>
         {strings('rwa.unavailable.title')}
       </BottomSheetHeader>

--- a/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
+++ b/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
@@ -21,7 +21,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 const ONDO_ELIGIBILITY_URL =
   'https://docs.ondo.finance/ondo-global-markets/eligibility';
@@ -43,7 +42,6 @@ const RwaUnavailableBottomSheet = forwardRef<
   const [isVisible, setIsVisible] = useState(false);
   const tw = useTailwind();
   const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
 
   const handleSheetClosed = useCallback(() => {
     setIsVisible(false);
@@ -105,7 +103,7 @@ const RwaUnavailableBottomSheet = forwardRef<
       ref={sheetRef}
       isInteractable
       onClose={handleSheetClosed}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader onClose={closeSheet}>
         {strings('rwa.unavailable.title')}

--- a/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
+++ b/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
@@ -7,7 +7,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { Box, HeaderStandard } from '@metamask/design-system-react-native';
 import Device from '../../../../../util/device';
 import Cell, {
@@ -42,7 +41,6 @@ export default function NetworkListBottomSheet({
   displayEvmNetworksOnly?: boolean;
 }) {
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const networkConfigurations = useSelector(selectNetworkConfigurations);
   const getAccountByScope = useSelector(selectSelectedInternalAccountByScope);
 
@@ -80,7 +78,6 @@ export default function NetworkListBottomSheet({
       ref={sheetRef}
       onClose={() => setOpenNetworkSelector(false)}
       style={tw.style(
-        surfaceClass,
         `max-h-[${Math.round(Device.getDeviceHeight() * 0.7)}px]`,
       )}
       testID={NETWORK_LIST_BOTTOM_SHEET}

--- a/app/components/Views/AddressSelector/AddressSelector.tsx
+++ b/app/components/Views/AddressSelector/AddressSelector.tsx
@@ -40,7 +40,6 @@ import { createAccountSelectorNavDetails } from '../AccountSelector';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { strings } from '../../../../locales/i18n';
 import { AddressSelectorSelectors } from './AddressSelector.testIds';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 export const createAddressSelectorNavDetails =
   createNavigationDetails<AddressSelectorParams>(
@@ -73,7 +72,6 @@ const AddressSelector = () => {
   );
 
   const accountName = useAccountName();
-  const surfaceClass = useElevatedSurface();
   const selectedCaipChainId = isCaipChainId(selectedChainId)
     ? selectedChainId
     : toEvmCaipChainId(selectedChainId);
@@ -157,7 +155,7 @@ const AddressSelector = () => {
       ref={sheetRef}
       isFullscreen
       goBack={navigation.goBack}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         {strings('address_selector.select_an_address')}

--- a/app/components/Views/AddressSelector/AddressSelector.tsx
+++ b/app/components/Views/AddressSelector/AddressSelector.tsx
@@ -151,12 +151,7 @@ const AddressSelector = () => {
   }, [internalAccountsSpreadByScopes, isEvmOnly, displayOnlyCaipChainIds]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      isFullscreen
-      goBack={navigation.goBack}
-     
-    >
+    <BottomSheet ref={sheetRef} isFullscreen goBack={navigation.goBack}>
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         {strings('address_selector.select_an_address')}
       </BottomSheetHeader>

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.tsx
@@ -22,7 +22,6 @@ import { RootState } from '../../../../reducers';
 import { useDispatch, useSelector } from 'react-redux';
 import { setMultichainAccountsIntroModalSeen } from '../../../../actions/user';
 import { LEARN_MORE_BOTTOM_SHEET_TEST_IDS } from './LearnMoreBottomSheet.testIds';
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
 
 interface LearnMoreBottomSheetProps {
   onClose?: () => void;
@@ -40,7 +39,6 @@ const LearnMoreBottomSheet: React.FC<LearnMoreBottomSheetProps> = ({
   const isBasicFunctionalityEnabled = useSelector(
     (state: RootState) => state?.settings?.basicFunctionalityEnabled,
   );
-  const surfaceClass = useElevatedSurface();
 
   const handleBack = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -68,7 +66,6 @@ const LearnMoreBottomSheet: React.FC<LearnMoreBottomSheetProps> = ({
       ref={sheetRef}
       onClose={onClose}
       testID={LEARN_MORE_BOTTOM_SHEET_TEST_IDS.BOTTOM_SHEET}
-      twClassName={surfaceClass}
     >
       <View style={styles.container}>
         <View style={styles.header}>

--- a/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
+++ b/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
@@ -14,7 +14,6 @@ import {
 import { strings } from '../../../../../locales/i18n';
 
 import { NetworksManagementViewSelectorsIDs } from '../NetworksManagementView.testIds';
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
 
 interface DeleteNetworkModalProps {
   networkName: string;
@@ -38,15 +37,12 @@ const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
       testID: NetworksManagementViewSelectorsIDs.DELETE_CONFIRM_BUTTON,
     };
 
-    const surfaceClass = useElevatedSurface();
-
     return (
       <BottomSheet
         ref={ref}
         onClose={onClose}
         goBack={onClose}
         testID={NetworksManagementViewSelectorsIDs.DELETE_MODAL}
-        twClassName={surfaceClass}
       >
         <BottomSheetHeader onClose={onClose}>
           {`${strings('app_settings.delete')} ${networkName} ${strings('app_settings.network')}`}

--- a/app/components/Views/OnboardingSheet/index.tsx
+++ b/app/components/Views/OnboardingSheet/index.tsx
@@ -2,8 +2,6 @@ import React, { useCallback, useRef } from 'react';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 import { AppThemeKey } from '../../../util/theme/models';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
-
 import GoogleIcon from 'images/google.svg';
 import AppleIcon from 'images/apple.svg';
 import AppleWhiteIcon from 'images/apple-white.svg';
@@ -111,15 +109,10 @@ const OnboardingSheet = () => {
   };
 
   const { themeAppearance } = useTheme();
-  const surfaceClass = useElevatedSurface();
   const isDark = themeAppearance === AppThemeKey.dark;
 
   return (
-    <BottomSheet
-      goBack={navigation.goBack}
-      ref={sheetRef}
-      twClassName={surfaceClass}
-    >
+    <BottomSheet goBack={navigation.goBack} ref={sheetRef}>
       <Box
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Center}

--- a/app/components/Views/SelectSRP/SelectSRPBottomSheet.tsx
+++ b/app/components/Views/SelectSRP/SelectSRPBottomSheet.tsx
@@ -11,22 +11,15 @@ import SelectSRP from './SelectSRP';
 import { strings } from '../../../../locales/i18n';
 import { SelectSRPBottomSheetTestIds } from './SelectSRPBottomSheet.testIds';
 import { goBackIfFocused } from './SelectSRPBottomSheet.utils';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
-
 export const SelectSRPBottomSheet = () => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
   const goBack = useCallback(() => {
     goBackIfFocused(navigation);
   }, [navigation]);
 
   return (
-    <BottomSheet
-      ref={bottomSheetRef}
-      goBack={goBack}
-      twClassName={surfaceClass}
-    >
+    <BottomSheet ref={bottomSheetRef} goBack={goBack}>
       <BottomSheetHeader
         onBack={goBack}
         backButtonProps={{

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -17,7 +17,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import { QuickBuyEventProperties, QuickBuyEventValues } from './analytics';
 import { useSocialLeaderboardAnalytics } from '../../../analytics';
 import { TOP_TRADERS_QUICK_BUY_FEATURES } from './features';
@@ -95,7 +94,6 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   // with the sheet instead of running its horizontal screen-exit transition.
   const [isClosing, setIsClosing] = useState(false);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
-  const surfaceClass = useElevatedSurface();
 
   const directionSV = useSharedValue<ScreenDirection>(1);
   // Suppresses the enter animation on the initial screen when the sheet opens;
@@ -180,7 +178,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     <BottomSheetDialog
       ref={bottomSheetRef}
       onClose={onClose}
-      twClassName={surfaceClass}
+     
     >
       {isContentReady ? (
         <QuickBuyProvider

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -175,11 +175,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     activeScreen === 'amount' || activeScreen === 'priceImpactConfirm';
 
   return (
-    <BottomSheetDialog
-      ref={bottomSheetRef}
-      onClose={onClose}
-     
-    >
+    <BottomSheetDialog ref={bottomSheetRef} onClose={onClose}>
       {isContentReady ? (
         <QuickBuyProvider
           target={target}

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -24,6 +24,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useTheme } from '../../../util/theme';
+import { AppThemeKey } from '../../../util/theme/models';
 import { useParams } from '../../../util/navigation/navUtils';
 
 import {
@@ -39,10 +40,7 @@ import {
   usePureBlack,
   useTailwind,
 } from '@metamask/design-system-twrnc-preset';
-import {
-  getElevatedSurfaceColor,
-  useElevatedSurface,
-} from '../../../util/theme/themeUtils';
+import { getElevatedSurfaceColor } from '../../../util/theme/themeUtils';
 import { BatchSellMetricsLocation } from '@metamask/bridge-controller';
 import {
   useSafeAreaFrame,
@@ -118,10 +116,13 @@ function TradeWalletActions() {
   const insetsTop = Platform.OS === 'android' ? insets.top : 0;
 
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const isPureBlack = usePureBlack();
   const theme = useTheme();
   const { colors } = theme;
+  const surfaceClass =
+    isPureBlack && theme.themeAppearance === AppThemeKey.dark
+      ? 'bg-alternative'
+      : 'bg-default';
 
   const backdropOpacity = useSharedValue(0);
   const backdropAnimatedStyle = useAnimatedStyle(() => ({

--- a/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
@@ -40,7 +40,6 @@ import {
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import stylesheet from './AccountSelector.styles';
 
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const ACCOUNT_SELECTOR_TEST_IDS = {
   PILL: 'account-selector-pill',
@@ -68,7 +67,6 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
 }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
   const { styles } = useStyles(stylesheet, {});
 
   const internalAccountsById = useSelector(selectInternalAccountsById);
@@ -229,7 +227,7 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
             isFullscreen
             keyboardAvoidingViewEnabled={false}
             onClose={handleSheetClosed}
-            twClassName={surfaceClass}
+           
           >
             <HeaderStandard
               title={selectorTitle}

--- a/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
@@ -40,7 +40,6 @@ import {
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import stylesheet from './AccountSelector.styles';
 
-
 export const ACCOUNT_SELECTOR_TEST_IDS = {
   PILL: 'account-selector-pill',
   MODAL: 'account-selector-modal',
@@ -227,7 +226,6 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
             isFullscreen
             keyboardAvoidingViewEnabled={false}
             onClose={handleSheetClosed}
-           
           >
             <HeaderStandard
               title={selectorTitle}

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
@@ -42,7 +42,6 @@ export function PayWithBottomSheet() {
       goBack={handleGoBack}
       testID={PAY_WITH_BOTTOM_SHEET_TEST_ID}
       keyboardAvoidingViewEnabled={false}
-     
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSm}>{title}</Text>

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.tsx
@@ -14,7 +14,6 @@ import { useDismissOnPaymentChange } from '../../../hooks/pay/useDismissOnPaymen
 import { usePayWithSections } from '../../../hooks/pay/usePayWithSections';
 import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 export const PAY_WITH_BOTTOM_SHEET_TEST_ID = 'pay-with-bottom-sheet';
 
@@ -23,7 +22,6 @@ export function PayWithBottomSheet() {
   const navigation = useNavigation();
   const { sections } = usePayWithSections();
   const transactionMeta = useTransactionMetadataRequest();
-  const surfaceClass = useElevatedSurface();
   useDismissOnPaymentChange({ dismissOnPayTokenChange: false });
   const isWithdraw = isTransactionPayWithdraw(transactionMeta);
   const title = isWithdraw
@@ -44,7 +42,7 @@ export function PayWithBottomSheet() {
       goBack={handleGoBack}
       testID={PAY_WITH_BOTTOM_SHEET_TEST_ID}
       keyboardAvoidingViewEnabled={false}
-      twClassName={surfaceClass}
+     
     >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingSm}>{title}</Text>

--- a/app/components/Views/confirmations/components/rows/account-picker-row/account-picker-row.tsx
+++ b/app/components/Views/confirmations/components/rows/account-picker-row/account-picker-row.tsx
@@ -175,7 +175,6 @@ export function AccountPickerRowContent<T extends SubAccountBase>({
               isFullscreen
               keyboardAvoidingViewEnabled={false}
               onClose={handleSheetClosed}
-             
             >
               <HeaderStandard title={title} onClose={handleModalRequestClose} />
               <View style={styles.searchContainer}>

--- a/app/components/Views/confirmations/components/rows/account-picker-row/account-picker-row.tsx
+++ b/app/components/Views/confirmations/components/rows/account-picker-row/account-picker-row.tsx
@@ -26,7 +26,6 @@ import Icon, {
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../../../component-library/hooks/useStyles';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import { strings } from '../../../../../../../locales/i18n';
 import stylesheet from './account-picker-row.styles';
 
@@ -63,7 +62,6 @@ export function AccountPickerRowContent<T extends SubAccountBase>({
 }: AccountPickerRowContentProps<T>) {
   const { styles } = useStyles(stylesheet, {});
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
   const [isPickerVisible, setIsPickerVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -177,7 +175,7 @@ export function AccountPickerRowContent<T extends SubAccountBase>({
               isFullscreen
               keyboardAvoidingViewEnabled={false}
               onClose={handleSheetClosed}
-              twClassName={surfaceClass}
+             
             >
               <HeaderStandard title={title} onClose={handleModalRequestClose} />
               <View style={styles.searchContainer}>

--- a/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
@@ -55,10 +55,6 @@ jest.mock('../../../../../../component-library/hooks/useStyles', () => ({
   }),
 }));
 
-jest.mock('../../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'surface-elevated',
-}));
-
 jest.mock('../../../../../../component-library/components/Icons/Icon', () => {
   const RN = jest.requireActual('react-native');
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.test.tsx
@@ -59,10 +59,6 @@ jest.mock('../../../../../../component-library/hooks/useStyles', () => ({
   }),
 }));
 
-jest.mock('../../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'surface-elevated',
-}));
-
 jest.mock('../../../../../../component-library/components/Icons/Icon', () => {
   const RN = jest.requireActual('react-native');
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/app/components/Views/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
+++ b/app/components/Views/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
@@ -124,11 +124,7 @@ export const SendAlertModal = ({
 
   return (
     <Modal visible transparent animationType="none">
-      <BottomSheet
-        ref={bottomSheetRef}
-        onClose={onClose}
-       
-      >
+      <BottomSheet ref={bottomSheetRef} onClose={onClose}>
         <PageNavigation
           alerts={alerts}
           selectedIndex={safeIndex}

--- a/app/components/Views/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
+++ b/app/components/Views/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
@@ -24,7 +24,6 @@ import {
 } from '../../../../../../component-library/components/Buttons/Button';
 import type { SendAlert } from '../../../hooks/send/alerts/types';
 import { SendAlertModalProps } from './send-alert-modal.types';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 
 function PageNavigation({
   alerts,
@@ -83,7 +82,6 @@ export const SendAlertModal = ({
   onClose,
 }: SendAlertModalProps) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const alertKeys = alerts.map((a) => a.key).join('|');
@@ -129,7 +127,7 @@ export const SendAlertModal = ({
       <BottomSheet
         ref={bottomSheetRef}
         onClose={onClose}
-        twClassName={surfaceClass}
+       
       >
         <PageNavigation
           alerts={alerts}

--- a/app/util/theme/themeUtils.test.tsx
+++ b/app/util/theme/themeUtils.test.tsx
@@ -11,6 +11,10 @@ jest.mock('./pureBlackPreview', () => ({
 
 import { getElevatedSurfaceColor, isPureBlackEnabled } from './themeUtils';
 
+beforeEach(() => {
+  mockIsPureBlackEnabled = false;
+});
+
 const createTheme = (
   themeAppearance: AppThemeKey.light | AppThemeKey.dark,
 ): Theme => {
@@ -32,10 +36,6 @@ describe('isPureBlackEnabled re-export', () => {
 });
 
 describe('getElevatedSurfaceColor', () => {
-  beforeEach(() => {
-    mockIsPureBlackEnabled = false;
-  });
-
   it('returns default background when pure black preview is off', () => {
     const theme = createTheme(AppThemeKey.dark);
 

--- a/app/util/theme/themeUtils.test.tsx
+++ b/app/util/theme/themeUtils.test.tsx
@@ -1,7 +1,4 @@
-import React from 'react';
 import { brandColor, darkTheme, lightTheme } from '@metamask/design-tokens';
-import { renderHook } from '@testing-library/react-native';
-import { ThemeContext } from './index';
 import { AppThemeKey, Theme } from './models';
 
 let mockIsPureBlackEnabled = false;
@@ -12,11 +9,7 @@ jest.mock('./pureBlackPreview', () => ({
   },
 }));
 
-import {
-  getElevatedSurfaceColor,
-  isPureBlackEnabled,
-  useElevatedSurface,
-} from './themeUtils';
+import { getElevatedSurfaceColor, isPureBlackEnabled } from './themeUtils';
 
 const createTheme = (
   themeAppearance: AppThemeKey.light | AppThemeKey.dark,
@@ -31,11 +24,6 @@ const createTheme = (
     brandColors: brandColor,
   };
 };
-
-const createWrapper =
-  (theme: Theme) =>
-  ({ children }: { children: React.ReactNode }) =>
-    React.createElement(ThemeContext.Provider, { value: theme }, children);
 
 describe('isPureBlackEnabled re-export', () => {
   it('re-exports the pure black preview flag as a boolean', () => {
@@ -72,43 +60,5 @@ describe('getElevatedSurfaceColor', () => {
     const result = getElevatedSurfaceColor(theme);
 
     expect(result).toBe(theme.colors.background.default);
-  });
-});
-
-describe('useElevatedSurface', () => {
-  beforeEach(() => {
-    mockIsPureBlackEnabled = false;
-  });
-
-  it('returns bg-default when pure black preview is off', () => {
-    const theme = createTheme(AppThemeKey.dark);
-
-    const { result } = renderHook(() => useElevatedSurface(), {
-      wrapper: createWrapper(theme),
-    });
-
-    expect(result.current).toBe('bg-default');
-  });
-
-  it('returns bg-alternative for dark mode when pure black preview is on', () => {
-    mockIsPureBlackEnabled = true;
-    const theme = createTheme(AppThemeKey.dark);
-
-    const { result } = renderHook(() => useElevatedSurface(), {
-      wrapper: createWrapper(theme),
-    });
-
-    expect(result.current).toBe('bg-alternative');
-  });
-
-  it('returns bg-default for light mode when pure black preview is on', () => {
-    mockIsPureBlackEnabled = true;
-    const theme = createTheme(AppThemeKey.light);
-
-    const { result } = renderHook(() => useElevatedSurface(), {
-      wrapper: createWrapper(theme),
-    });
-
-    expect(result.current).toBe('bg-default');
   });
 });

--- a/app/util/theme/themeUtils.ts
+++ b/app/util/theme/themeUtils.ts
@@ -1,31 +1,29 @@
-import { useTheme } from './index';
 import { AppThemeKey, Theme } from './models';
 import { isPureBlackEnabled } from './pureBlackPreview';
 
 export { isPureBlackEnabled };
 
-// Stopgap surface helper for the MM_PURE_BLACK_PREVIEW rollout.
+// Legacy surface helper for non-MMDS components during the MM_PURE_BLACK_PREVIEW rollout.
 //
-// When pure black is OFF, returns `bg-default` (current behavior — no change
-// for normal light/dark mode users).
-//
+// When pure black is OFF, returns `theme.colors.background.default` (current behavior).
 // When pure black is ON:
-//   - dark  → `bg-section` (elevated `#1c1d1f` so surfaces don't collapse
-//             into the pure-black screen background)
-//   - light → `bg-default` (unchanged, light mode is unaffected)
+//   - dark  → `theme.colors.background.alternative` (elevated `#1c1d1f`)
+//   - light → `theme.colors.background.default` (unchanged)
 //
-// Remove these helpers once the MMDS package ships its own pure-black-aware
-// surface tokens and the flag is enabled by default.
+// Remaining legacy-only consumers (until migrated to MMDS surface tokens):
+// - `app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.styles.ts`
+// - `app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts`
+// - `app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.styles.ts`
+// - `app/components/UI/ActionModal/ActionContent/index.js`
+// - `app/components/UI/NetworkManager/index.styles.ts`
+// - `app/components/UI/NetworkMultiSelector/NetworkMultiSelector.styles.ts`
+// - `app/components/UI/Notification/TransactionNotification/index.js`
+// - `app/components/UI/SelectComponent/index.js`
+// - `app/components/Views/TradeWalletActions/TradeWalletActions.tsx`
 
 export const getElevatedSurfaceColor = (theme: Theme): string => {
   if (!isPureBlackEnabled) return theme.colors.background.default;
   return theme.themeAppearance === AppThemeKey.dark
     ? theme.colors.background.alternative
     : theme.colors.background.default;
-};
-
-export const useElevatedSurface = () => {
-  const { themeAppearance } = useTheme();
-  if (!isPureBlackEnabled) return 'bg-default';
-  return themeAppearance === AppThemeKey.dark ? 'bg-alternative' : 'bg-default';
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface styling internally. This PR completes the platform cleanup by deleting the stopgap `useElevatedSurface()` hook from `themeUtils.ts` and removing all remaining app callsites.

**Changes:**
- Deleted `useElevatedSurface()` from `app/util/theme/themeUtils.ts` and removed its unit tests
- Removed `twClassName={surfaceClass}` / `useElevatedSurface()` from 30+ MMDS BottomSheet callsites (Bridge, Confirmations, Perps, Accounts, Money, Core UX, etc.)
- Removed row-level surface fill from `ActionListItem`, `CustomNetworkSelector`, and `NetworkMultiSelectorList`
- Inlined elevated surface class logic in `TradeWalletActions` custom popup (non-MMDS component)
- Kept `getElevatedSurfaceColor()` with documented legacy-only consumers (BottomSheetDialog, Input, ModalConfirmation, ActionModal, NetworkManager, etc.)
- Dropped obsolete `useElevatedSurface` mocks from affected test files

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1051](https://consensyssoftware.atlassian.net/browse/TMCU-1051)

## **Manual testing steps**

```gherkin
Feature: Pure Black bottom sheets after useElevatedSurface removal

  Scenario: MMDS BottomSheet surfaces render correctly in Pure Black dark mode
    Given Pure Black preview is enabled (MM_PURE_BLACK_PREVIEW=true) and the app is in Dark mode

    When the user opens any MMDS BottomSheet (e.g. Fund Action Menu, Bridge modals, Perps action sheet, Account Selector)
    Then the BottomSheet displays a uniform elevated surface without visible black bands or mismatched row backgrounds

  Scenario: Trade Wallet Actions popup renders correctly in Pure Black dark mode
    Given Pure Black preview is enabled and the app is in Dark mode
    And the user is on the wallet asset overview

    When the user taps the Trade button to open Trade Wallet Actions
    Then the custom popup menu displays with correct elevated surface and border styling
```

N/A for automated cloud-agent environment — visual QA on device/simulator recommended.

## **Screenshots/Recordings**

### **Before**

N/A — removal-only cleanup; no visual regression expected since MMDS BottomSheet owns surface styling.

### **After**

N/A — visual QA on device/simulator with `MM_PURE_BLACK_PREVIEW=true` recommended.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable (N/A — removal-only change; legacy consumer list documented in themeUtils.ts)
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable (N/A — styling-only change)
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens (N/A — no performance-sensitive paths touched)
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example (N/A — no new traced operations)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6899939-ba78-43ed-885f-8398c66dfb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6899939-ba78-43ed-885f-8398c66dfb7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1051]: https://consensyssoftware.atlassian.net/browse/TMCU-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ