### PR TITLE
fix(assets): remove useElevatedSurface shim from Assets MMDS BottomSheets

### DIFF
--- a/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
+++ b/app/components/UI/NftGrid/NftGridItemBottomSheet.tsx
@@ -14,7 +14,6 @@ import { strings } from '../../../../locales/i18n';
 import { Nft } from '@metamask/assets-controllers';
 import Engine from '../../../core/Engine';
 import { toHex } from '@metamask/controller-utils';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 interface NftGridItemBottomSheetProps {
   isVisible: boolean;
@@ -28,7 +27,6 @@ const NftGridItemBottomSheet: React.FC<NftGridItemBottomSheetProps> = ({
   nft,
 }) => {
   const sheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
 
   const handleSheetClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -77,11 +75,7 @@ const NftGridItemBottomSheet: React.FC<NftGridItemBottomSheetProps> = ({
   return (
     <View testID="nft-grid-item-bottom-sheet">
       <Modal visible transparent animationType="none" statusBarTranslucent>
-        <BottomSheet
-          ref={sheetRef}
-          onClose={onClose}
-          twClassName={surfaceClass}
-        >
+        <BottomSheet ref={sheetRef} onClose={onClose}>
           <BottomSheetHeader onClose={handleSheetClose}>
             <Text variant={TextVariant.HeadingMd}>
               {strings('wallet.collectible_action_title')}

--- a/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
+++ b/app/components/UI/TokenDetails/components/RwaUnavailableBottomSheet/RwaUnavailableBottomSheet.tsx
@@ -22,7 +22,6 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { strings } from '../../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 const ONDO_ELIGIBILITY_URL =
   'https://docs.ondo.finance/ondo-global-markets/eligibility';
@@ -44,7 +43,6 @@ const RwaUnavailableBottomSheet = forwardRef<
   const [isVisible, setIsVisible] = useState(false);
   const tw = useTailwind();
   const navigation = useNavigation<AppNavigationProp>();
-  const surfaceClass = useElevatedSurface();
 
   const handleSheetClosed = useCallback(() => {
     setIsVisible(false);
@@ -102,12 +100,7 @@ const RwaUnavailableBottomSheet = forwardRef<
   }
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      isInteractable
-      onClose={handleSheetClosed}
-      twClassName={surfaceClass}
-    >
+    <BottomSheet ref={sheetRef} isInteractable onClose={handleSheetClosed}>
       <BottomSheetHeader onClose={closeSheet}>
         {strings('rwa.unavailable.title')}
       </BottomSheetHeader>

--- a/app/components/UI/TokenDetails/components/ShareTokenBottomSheet.test.tsx
+++ b/app/components/UI/TokenDetails/components/ShareTokenBottomSheet.test.tsx
@@ -157,10 +157,6 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn((selector: (state: unknown) => unknown) => selector({})),
 }));
 
-jest.mock('../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 jest.mock('../../../../selectors/tokenRatesController', () => ({
   selectTokenMarketData: jest.fn(() => ({})),
 }));

--- a/app/components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx
+++ b/app/components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx
@@ -25,7 +25,6 @@ import {
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import i18n, { strings } from '../../../../../locales/i18n';
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
 import { RootState } from '../../../../reducers';
 import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
 import {
@@ -124,7 +123,6 @@ const ShareTokenBottomSheet = ({
   onClose,
 }: ShareTokenBottomSheetProps) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
-  const surfaceClass = useElevatedSurface();
 
   const isNonEvm = isNonEvmChainId(token.chainId as string);
   const checksumAddress = !isNonEvm
@@ -326,7 +324,6 @@ const ShareTokenBottomSheet = ({
     <BottomSheet
       ref={bottomSheetRef}
       onClose={onClose}
-      twClassName={surfaceClass}
       testID="share-token-sheet"
     >
       <BottomSheetHeader textProps={{ variant: TextVariant.HeadingLg }}>

--- a/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
+++ b/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
@@ -9,7 +9,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { Box, HeaderStandard } from '@metamask/design-system-react-native';
 import Device from '../../../../../util/device';
 import Cell, {
@@ -80,7 +79,6 @@ export default function NetworkListBottomSheet({
   displayEvmNetworksOnly?: boolean;
 }) {
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const networkConfigurations = useSelector(selectNetworkConfigurations);
   const getAccountByScope = useSelector(selectSelectedInternalAccountByScope);
 
@@ -140,7 +138,6 @@ export default function NetworkListBottomSheet({
       shouldNavigateBack={false}
       ref={sheetRef}
       onClose={() => setOpenNetworkSelector(false)}
-      style={tw.style(surfaceClass)}
       testID={NETWORK_LIST_BOTTOM_SHEET}
     >
       <HeaderStandard


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

MMDS `BottomSheet` (and component-library `BottomSheet`) now handle pure-black elevated surface internally. This PR removes the redundant `useElevatedSurface()` shim from Assets bottom sheet callsites as part of the Pure Black Background Schema cleanup (TMCU-622).

**Files updated (5):**
- `NetworkListBottomSheet` — removed `useElevatedSurface` from legacy component-library `BottomSheet` (kept existing component; no MMDS migration)
- `NftGridItemBottomSheet` — removed `twClassName={surfaceClass}`
- `RwaUnavailableBottomSheet` — removed `twClassName={surfaceClass}`
- `ShareTokenBottomSheet` — removed `twClassName={surfaceClass}`
- `ShareTokenBottomSheet.test.tsx` — removed `useElevatedSurface` mock

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1049](https://consensyssoftware.atlassian.net/browse/TMCU-1049)

Refs: [TMCU-622](https://consensyssoftware.atlassian.net/browse/TMCU-622) (Pure Black epic)

## **Manual testing steps**

N/A — mechanical removal of a deprecated theme shim. BottomSheet now owns elevated surface styling. No behavioral change expected with the pure-black flag off; with the flag on, bottom sheets should continue to render with elevated surfaces via MMDS / component-library internals.

Recommended QA (from ticket acceptance criteria):
- Verify add-asset network list, NFT item sheet, RWA unavailable sheet, and share-token sheet render correctly with pure-black flag on
- Verify no regression with pure-black flag off

```gherkin
Feature: Assets bottom sheets Pure Black surfaces

  Scenario: add-asset network list shows elevated surface
    Given MM_PURE_BLACK_PREVIEW="true" is set and the app is in Dark mode
    When the user opens Import Token or Import NFT and taps the network dropdown
    Then the "Select a network" bottom sheet has a visible elevated surface

  Scenario: NFT item actions sheet shows elevated surface
    Given MM_PURE_BLACK_PREVIEW="true" is set and the app is in Dark mode
    When the user long-presses an NFT and opens the actions bottom sheet
    Then the sheet has a visible elevated surface

  Scenario: RWA unavailable sheet shows elevated surface
    Given MM_PURE_BLACK_PREVIEW="true" is set and the app is in Dark mode
    When the user views a geo-restricted RWA token and the unavailable sheet opens
    Then the sheet has a visible elevated surface

  Scenario: Share token sheet shows elevated surface
    Given MM_PURE_BLACK_PREVIEW="true" is set and the app is in Dark mode
    When the user opens the share token bottom sheet
    Then the sheet has a visible elevated surface
```

## **Screenshots/Recordings**

N/A — no visual change expected; styling responsibility moved from callsite shim to BottomSheet.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[TMCU-1049]: https://consensyssoftware.atlassian.net/browse/TMCU-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-622]: https://consensyssoftware.atlassian.net/browse/TMCU-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ