### PR TITLE
fix: import srp password keyboard done

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -12,6 +12,7 @@ import {
   TouchableOpacity,
   Animated,
   Dimensions,
+  Keyboard,
   Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -588,7 +589,7 @@ const ImportFromSecretRecoveryPhrase = ({
         keyboardShouldPersistTaps="always"
         keyboardDismissMode="none"
         showsVerticalScrollIndicator={false}
-        enabled={currentStep === 0}
+        enabled
       >
         <Animated.View
           style={[
@@ -703,7 +704,7 @@ const ImportFromSecretRecoveryPhrase = ({
                   onFocus={() => setIsPasswordFieldFocused(true)}
                   onBlur={() => setIsPasswordFieldFocused(false)}
                   secureTextEntry={showPasswordIndex.includes(0)}
-                  returnKeyType={'next'}
+                  returnKeyType="next"
                   autoCapitalize="none"
                   autoComplete="new-password"
                   keyboardAppearance={themeAppearance || 'light'}
@@ -757,11 +758,12 @@ const ImportFromSecretRecoveryPhrase = ({
                   onChangeText={onPasswordConfirmChange}
                   secureTextEntry={showPasswordIndex.includes(1)}
                   autoComplete="new-password"
-                  returnKeyType={'next'}
+                  returnKeyType="done"
                   autoCapitalize="none"
                   value={confirmPassword}
                   isError={isError}
                   keyboardAppearance={themeAppearance || 'light'}
+                  onSubmitEditing={Keyboard.dismiss}
                   endAccessory={
                     <Icon
                       name={
@@ -830,30 +832,31 @@ const ImportFromSecretRecoveryPhrase = ({
                   }
                 />
               </Box>
-
-              <SafeAreaView
-                edges={['bottom']}
-                style={tw.style(
-                  'w-full gap-y-4 mt-auto',
-                  Platform.OS === 'android' ? 'mb-6' : 'mb-4',
-                )}
-              >
-                <Button
-                  isLoading={loading}
-                  isFullWidth
-                  variant={ButtonVariant.Primary}
-                  onPress={onPressImport}
-                  size={ButtonSize.Lg}
-                  isDisabled={isContinueButtonDisabled}
-                  testID={ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID}
-                >
-                  {strings('import_from_seed.import_create_password_cta')}
-                </Button>
-              </SafeAreaView>
             </Box>
           )}
         </Animated.View>
       </KeyboardAwareScrollView>
+      {currentStep === 1 && (
+        <SafeAreaView
+          edges={['bottom']}
+          style={tw.style(
+            'px-4 w-full gap-y-4',
+            Platform.OS === 'android' ? 'mb-6' : 'mb-4',
+          )}
+        >
+          <Button
+            isLoading={loading}
+            isFullWidth
+            variant={ButtonVariant.Primary}
+            onPress={onPressImport}
+            size={ButtonSize.Lg}
+            isDisabled={isContinueButtonDisabled}
+            testID={ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID}
+          >
+            {strings('import_from_seed.import_create_password_cta')}
+          </Button>
+        </SafeAreaView>
+      )}
       {currentStep === 0 && (
         <SafeAreaView
           edges={['bottom']}

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -1431,6 +1431,16 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       expect(confirmPasswordInput).toHaveProp('secureTextEntry', false);
     });
 
+    it('shows Done keyboard action on confirm password field', async () => {
+      const { getByTestId } = await renderCreatePasswordUI();
+
+      const confirmPasswordInput = getByTestId(
+        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+      );
+
+      expect(confirmPasswordInput).toHaveProp('returnKeyType', 'done');
+    });
+
     it('error message is shown when passwords do not match', async () => {
       const { getByText, getByTestId } = await renderCreatePasswordUI();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
* Fixes the import-wallet password step where the keyboard had no Done action and could cover the Create password CTA.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed import wallet password screen keyboard missing Done action and blocking the Create password button

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-891

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Import wallet password keyboard UX

  Scenario: Confirm password keyboard shows Done and dismisses without blocking CTA
    Given the app is on a fresh onboarding state
    And the user navigates to Import wallet via Secret Recovery Phrase
    And the user enters a valid Secret Recovery Phrase and taps Continue

    When the user focuses the confirm password field
    Then the keyboard shows a Done action
    And tapping Done dismisses the keyboard
    And the Create password button remains visible and tappable

  Scenario: User can complete import after setting password
    Given the user is on the import wallet MetaMask password step
    And the user enters matching passwords that meet the minimum length
    And the user accepts the password recovery disclaimer

    When the user taps Create password
    Then the wallet import completes successfully
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/7dc52329-7d04-445b-bb3e-ccc30e7d70e2


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and keyboard layout only; wallet import logic is unchanged.
> 
> **Overview**
> Fixes onboarding **import wallet** step 1 (MetaMask password after SRP) so the keyboard is usable and the primary CTA stays reachable.
> 
> The confirm password field now uses **`returnKeyType="done"`** and **`onSubmitEditing={Keyboard.dismiss}`**, matching the create-password flow elsewhere. **`KeyboardAwareScrollView`** stays enabled on the password step (not only on step 0) so fields can scroll above the keyboard.
> 
> The **Create password** button is moved **outside** the scroll view into a bottom **`SafeAreaView`** when `currentStep === 1`, so it is no longer trapped inside scroll content that the keyboard could cover.
> 
> A unit test asserts the confirm field exposes **`returnKeyType` `done`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0e17538fdb223076f22b2f9bb31e6f37753943. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->