### PR TITLE
fix(TMCU-1054): remove bg-default from NetworkVerificationInfo root

### DIFF
--- a/app/components/UI/NetworkVerificationInfo/NetworkVerificationInfo.styles.ts
+++ b/app/components/UI/NetworkVerificationInfo/NetworkVerificationInfo.styles.ts
@@ -12,7 +12,6 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     root: {
-      backgroundColor: colors.background.default,
       paddingHorizontal: 16,
     },
     accountCardWrapper: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The chainlist.org "Update network" approval sheet (`AddChainApproval` → `NetworkVerificationInfo`) showed visible surface banding in pure black dark mode. The scroll content container painted `bg-default` inside an elevated `BottomSheet`, creating a gray background mismatch against the sheet chrome.

This removes `backgroundColor: colors.background.default` from the `root` style in `NetworkVerificationInfo.styles.ts` so the parent `BottomSheet` owns the elevated surface. The bordered `accountCardWrapper` details box remains transparent as intended.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1054](https://consensyssoftware.atlassian.net/browse/TMCU-1054)

## **Manual testing steps**

```gherkin
Feature: Pure black chainlist update network sheet

  Scenario: Update network approval sheet has consistent elevated surface
    Given dark mode is enabled (pure black on by default)
    And the user has an existing network such as Arbitrum One

    When the user opens chainlist.org in the in-app browser
    And triggers update network settings for that network
    Then the approval bottom sheet shows a uniform elevated surface
    And the bordered network details container does not show a mismatched gray background
```

## **Screenshots/Recordings**



### **Before**

Visible gray `bg-default` banding inside the elevated bottom sheet on the network details scroll area.

<img width="391" height="572" alt="Screenshot 2026-07-13 at 2 52 49 PM" src="https://github.com/user-attachments/assets/14ea967e-7b06-4b57-b9d1-4ad532f256c1" />

### **After**

Network details scroll area inherits the elevated bottom sheet surface with no visible banding.

<img width="389" height="611" alt="Screenshot 2026-07-13 at 2 52 53 PM" src="https://github.com/user-attachments/assets/af97b553-6540-4d4a-95cf-0042e16ea73e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9e39713-0a9b-4b90-a59b-d97f8cb3312b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9e39713-0a9b-4b90-a59b-d97f8cb3312b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1054]: https://consensyssoftware.atlassian.net/browse/TMCU-1054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ