### PR TITLE
refactor: simplify layout nesting for backup, import, and password screens

### DIFF
--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -777,247 +777,241 @@ const ChoosePassword = () => {
             contentContainerStyle={tw.style('flex-1 px-4')}
             keyboardShouldPersistTaps="handled"
           >
-            <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1">
-              <Box
-                flexDirection={BoxFlexDirection.Column}
-                twClassName="flex-1"
-                gap={4}
-                testID={ChoosePasswordSelectorsIDs.CONTAINER_ID}
-              >
-                <Box flexDirection={BoxFlexDirection.Column} gap={1}>
-                  <Text
-                    variant={TextVariant.DisplayMd}
-                    color={TextColor.TextDefault}
-                  >
-                    {strings('choose_password.title')}
-                  </Text>
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    color={TextColor.TextAlternative}
-                  >
-                    {getOauth2LoginSuccess() ? (
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        color={TextColor.TextAlternative}
-                      >
-                        {Platform.OS === 'ios' && getOauth2LoginSuccess()
-                          ? strings(
-                              'choose_password.description_social_login_update_ios',
-                            )
-                          : strings(
-                              'choose_password.description_social_login_update',
-                            )}
-                        {Platform.OS === 'android' && (
-                          <Text
-                            variant={TextVariant.BodyMd}
-                            color={TextColor.WarningDefault}
-                          >
-                            {' '}
-                            {strings(
-                              'choose_password.description_social_login_update_bold',
-                            )}
-                          </Text>
-                        )}
-                      </Text>
-                    ) : (
-                      strings('choose_password.description')
-                    )}
-                  </Text>
-                </Box>
-
-                <Box
-                  flexDirection={BoxFlexDirection.Column}
-                  twClassName="relative"
-                  gap={2}
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              twClassName="flex-1"
+              gap={4}
+              testID={ChoosePasswordSelectorsIDs.CONTAINER_ID}
+            >
+              <Box flexDirection={BoxFlexDirection.Column} gap={1}>
+                <Text
+                  variant={TextVariant.DisplayMd}
+                  color={TextColor.TextDefault}
                 >
-                  <Label
-                    fontWeight={FontWeight.Medium}
-                    color={TextColor.TextDefault}
-                    twClassName="-mb-1"
-                  >
-                    {strings('choose_password.password')}
-                  </Label>
-                  <TextField
-                    autoFocus
-                    value={password}
-                    onChangeText={onPasswordChange}
-                    onFocus={() => setIsPasswordFieldFocused(true)}
-                    onBlur={() => setIsPasswordFieldFocused(false)}
-                    isError={isPasswordTooShort}
-                    endAccessory={
-                      <TouchableOpacity
-                        testID={
-                          ChoosePasswordSelectorsIDs.NEW_PASSWORD_SHOW_ICON_ID
-                        }
-                        onPress={() => toggleShowPassword(0)}
-                      >
-                        <Icon
-                          name={
-                            showPasswordIndex.includes(0)
-                              ? IconName.Eye
-                              : IconName.EyeSlash
-                          }
-                          size={IconSize.Lg}
-                          color={IconColor.IconAlternative}
-                        />
-                      </TouchableOpacity>
-                    }
-                    inputProps={{
-                      secureTextEntry: showPasswordIndex.includes(0),
-                      testID: ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-                      accessibilityLabel:
-                        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-                      onSubmitEditing: jumpToConfirmPassword,
-                      autoComplete: 'password-new',
-                      returnKeyType: 'next',
-                      autoCapitalize: 'none',
-                      keyboardAppearance: themeAppearance,
-                    }}
-                  />
-                  <Text
-                    variant={TextVariant.BodySm}
-                    color={
-                      isPasswordTooShort
-                        ? TextColor.ErrorDefault
-                        : TextColor.TextAlternative
-                    }
-                  >
-                    {strings('choose_password.must_be_at_least', {
-                      number: MIN_PASSWORD_LENGTH,
-                    })}
-                  </Text>
-                </Box>
-
-                <Box
-                  flexDirection={BoxFlexDirection.Column}
-                  twClassName="relative"
-                  gap={2}
+                  {strings('choose_password.title')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
-                  <Label
-                    fontWeight={FontWeight.Medium}
-                    color={TextColor.TextDefault}
-                    twClassName="-mb-1"
-                  >
-                    {strings('choose_password.confirm_password')}
-                  </Label>
-                  <TextField
-                    inputRef={confirmPasswordInputRef}
-                    value={confirmPassword}
-                    onChangeText={setConfirmPasswordValue}
-                    endAccessory={
-                      <TouchableOpacity
-                        testID={
-                          ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_SHOW_ICON_ID
-                        }
-                        disabled={password === ''}
-                        onPress={() => toggleShowPassword(1)}
-                      >
-                        <Icon
-                          name={
-                            showPasswordIndex.includes(1)
-                              ? IconName.Eye
-                              : IconName.EyeSlash
-                          }
-                          size={IconSize.Lg}
-                          color={IconColor.IconAlternative}
-                        />
-                      </TouchableOpacity>
-                    }
-                    isDisabled={password === ''}
-                    isError={checkError()}
-                    inputProps={{
-                      secureTextEntry: showPasswordIndex.includes(1),
-                      testID:
-                        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-                      accessibilityLabel:
-                        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-                      autoComplete: 'password-new',
-                      onSubmitEditing: Keyboard.dismiss,
-                      returnKeyType: 'done',
-                      autoCapitalize: 'none',
-                      keyboardAppearance: themeAppearance,
-                    }}
-                  />
-                  {checkError() && (
+                  {getOauth2LoginSuccess() ? (
                     <Text
-                      variant={TextVariant.BodySm}
-                      color={TextColor.ErrorDefault}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
                     >
-                      {strings('choose_password.password_error')}
-                    </Text>
-                  )}
-                </Box>
-
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Start}
-                  justifyContent={BoxJustifyContent.Start}
-                  gap={2}
-                  twClassName="mt-2 bg-section rounded-lg p-4"
-                >
-                  <Checkbox
-                    onChange={setSelection}
-                    isSelected={marketingOptInChecked}
-                    testID={ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID}
-                    accessibilityLabel={
-                      ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID
-                    }
-                  />
-                  <TouchableOpacity
-                    onPress={setSelection}
-                    testID={ChoosePasswordSelectorsIDs.CHECKBOX_TEXT_ID}
-                    style={tw.style(
-                      'flex-row items-start justify-start flex-wrap w-[90%] -mt-1.5',
-                    )}
-                  >
-                    <Text
-                      variant={TextVariant.BodySm}
-                      color={TextColor.TextDefault}
-                    >
-                      {getOauth2LoginSuccess() ? (
-                        strings('choose_password.marketing_opt_in_description')
-                      ) : (
-                        <Text
-                          variant={TextVariant.BodySm}
-                          color={TextColor.TextAlternative}
-                        >
-                          {strings(
-                            'choose_password.loose_password_description',
+                      {Platform.OS === 'ios' && getOauth2LoginSuccess()
+                        ? strings(
+                            'choose_password.description_social_login_update_ios',
+                          )
+                        : strings(
+                            'choose_password.description_social_login_update',
                           )}
-                          <Text
-                            variant={TextVariant.BodySm}
-                            color={TextColor.PrimaryDefault}
-                            onPress={learnMore}
-                            testID={
-                              ChoosePasswordSelectorsIDs.LEARN_MORE_LINK_ID
-                            }
-                          >
-                            {' '}
-                            {strings('reset_password.learn_more')}
-                          </Text>
+                      {Platform.OS === 'android' && (
+                        <Text
+                          variant={TextVariant.BodyMd}
+                          color={TextColor.WarningDefault}
+                        >
+                          {' '}
+                          {strings(
+                            'choose_password.description_social_login_update_bold',
+                          )}
                         </Text>
                       )}
                     </Text>
-                  </TouchableOpacity>
-                </Box>
+                  ) : (
+                    strings('choose_password.description')
+                  )}
+                </Text>
+              </Box>
 
-                <Box
-                  flexDirection={BoxFlexDirection.Column}
-                  twClassName="w-full mt-auto"
-                  gap={4}
-                  style={tw.style(Platform.OS === 'android' ? 'mb-6' : 'mb-4')}
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                twClassName="relative"
+                gap={2}
+              >
+                <Label
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                  twClassName="-mb-1"
                 >
-                  <Button
-                    variant={ButtonVariant.Primary}
-                    onPress={onPressCreate}
-                    isDisabled={!canSubmit}
-                    isFullWidth
-                    size={ButtonSize.Lg}
-                    testID={ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID}
+                  {strings('choose_password.password')}
+                </Label>
+                <TextField
+                  autoFocus
+                  value={password}
+                  onChangeText={onPasswordChange}
+                  onFocus={() => setIsPasswordFieldFocused(true)}
+                  onBlur={() => setIsPasswordFieldFocused(false)}
+                  isError={isPasswordTooShort}
+                  endAccessory={
+                    <TouchableOpacity
+                      testID={
+                        ChoosePasswordSelectorsIDs.NEW_PASSWORD_SHOW_ICON_ID
+                      }
+                      onPress={() => toggleShowPassword(0)}
+                    >
+                      <Icon
+                        name={
+                          showPasswordIndex.includes(0)
+                            ? IconName.Eye
+                            : IconName.EyeSlash
+                        }
+                        size={IconSize.Lg}
+                        color={IconColor.IconAlternative}
+                      />
+                    </TouchableOpacity>
+                  }
+                  inputProps={{
+                    secureTextEntry: showPasswordIndex.includes(0),
+                    testID: ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+                    accessibilityLabel:
+                      ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+                    onSubmitEditing: jumpToConfirmPassword,
+                    autoComplete: 'password-new',
+                    returnKeyType: 'next',
+                    autoCapitalize: 'none',
+                    keyboardAppearance: themeAppearance,
+                  }}
+                />
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={
+                    isPasswordTooShort
+                      ? TextColor.ErrorDefault
+                      : TextColor.TextAlternative
+                  }
+                >
+                  {strings('choose_password.must_be_at_least', {
+                    number: MIN_PASSWORD_LENGTH,
+                  })}
+                </Text>
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                twClassName="relative"
+                gap={2}
+              >
+                <Label
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
+                  twClassName="-mb-1"
+                >
+                  {strings('choose_password.confirm_password')}
+                </Label>
+                <TextField
+                  inputRef={confirmPasswordInputRef}
+                  value={confirmPassword}
+                  onChangeText={setConfirmPasswordValue}
+                  endAccessory={
+                    <TouchableOpacity
+                      testID={
+                        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_SHOW_ICON_ID
+                      }
+                      disabled={password === ''}
+                      onPress={() => toggleShowPassword(1)}
+                    >
+                      <Icon
+                        name={
+                          showPasswordIndex.includes(1)
+                            ? IconName.Eye
+                            : IconName.EyeSlash
+                        }
+                        size={IconSize.Lg}
+                        color={IconColor.IconAlternative}
+                      />
+                    </TouchableOpacity>
+                  }
+                  isDisabled={password === ''}
+                  isError={checkError()}
+                  inputProps={{
+                    secureTextEntry: showPasswordIndex.includes(1),
+                    testID:
+                      ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+                    accessibilityLabel:
+                      ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+                    autoComplete: 'password-new',
+                    onSubmitEditing: Keyboard.dismiss,
+                    returnKeyType: 'done',
+                    autoCapitalize: 'none',
+                    keyboardAppearance: themeAppearance,
+                  }}
+                />
+                {checkError() && (
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.ErrorDefault}
                   >
-                    {strings('choose_password.create_password_cta')}
-                  </Button>
-                </Box>
+                    {strings('choose_password.password_error')}
+                  </Text>
+                )}
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Start}
+                justifyContent={BoxJustifyContent.Start}
+                gap={2}
+                twClassName="mt-2 bg-section rounded-lg p-4"
+              >
+                <Checkbox
+                  onChange={setSelection}
+                  isSelected={marketingOptInChecked}
+                  testID={ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID}
+                  accessibilityLabel={
+                    ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID
+                  }
+                />
+                <TouchableOpacity
+                  onPress={setSelection}
+                  testID={ChoosePasswordSelectorsIDs.CHECKBOX_TEXT_ID}
+                  style={tw.style(
+                    'flex-row items-start justify-start flex-wrap w-[90%] -mt-1.5',
+                  )}
+                >
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextDefault}
+                  >
+                    {getOauth2LoginSuccess() ? (
+                      strings('choose_password.marketing_opt_in_description')
+                    ) : (
+                      <Text
+                        variant={TextVariant.BodySm}
+                        color={TextColor.TextAlternative}
+                      >
+                        {strings('choose_password.loose_password_description')}
+                        <Text
+                          variant={TextVariant.BodySm}
+                          color={TextColor.PrimaryDefault}
+                          onPress={learnMore}
+                          testID={ChoosePasswordSelectorsIDs.LEARN_MORE_LINK_ID}
+                        >
+                          {' '}
+                          {strings('reset_password.learn_more')}
+                        </Text>
+                      </Text>
+                    )}
+                  </Text>
+                </TouchableOpacity>
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                twClassName="w-full mt-auto"
+                gap={4}
+                style={tw.style(Platform.OS === 'android' ? 'mb-6' : 'mb-4')}
+              >
+                <Button
+                  variant={ButtonVariant.Primary}
+                  onPress={onPressCreate}
+                  isDisabled={!canSubmit}
+                  isFullWidth
+                  size={ButtonSize.Lg}
+                  testID={ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID}
+                >
+                  {strings('choose_password.create_password_cta')}
+                </Button>
               </Box>
             </Box>
           </KeyboardAwareScrollView>

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -598,7 +598,7 @@ const ImportFromSecretRecoveryPhrase = ({
           ]}
         >
           {currentStep === 0 && (
-            <>
+            <Box twClassName="gap-y-1.5">
               <Text
                 variant={TextVariant.DisplayMd}
                 color={TextColor.TextDefault}
@@ -606,68 +606,66 @@ const ImportFromSecretRecoveryPhrase = ({
               >
                 {strings('import_from_seed.title')}
               </Text>
-              <Box twClassName="mt-1.5">
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                  twClassName="gap-1"
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                twClassName="gap-1"
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    color={TextColor.TextAlternative}
-                  >
-                    {strings(
-                      'import_from_seed.enter_your_secret_recovery_phrase',
-                    )}
-                    {isAddDeviceSyncEnabled && (
-                      <>
-                        {' '}
-                        {strings('import_from_seed.or')}{' '}
-                        <Text
-                          variant={TextVariant.BodyMd}
-                          color={TextColor.PrimaryDefault}
-                          onPress={() =>
-                            navigation.navigate(
-                              Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
-                            )
-                          }
-                        >
-                          {strings(
-                            'import_from_seed.import_wallet_from_extension',
-                          )}
-                        </Text>
-                      </>
-                    )}
-                  </Text>
-                  {!isAddDeviceSyncEnabled && (
-                    <TouchableOpacity
-                      onPress={showWhatIsSeedPhrase}
-                      testID={
-                        ImportFromSeedSelectorsIDs.WHAT_IS_SEEDPHRASE_LINK_ID
-                      }
-                    >
-                      <Icon
-                        name={IconName.Info}
-                        size={IconSize.Md}
-                        color={colors.icon.alternative}
-                      />
-                    </TouchableOpacity>
+                  {strings(
+                    'import_from_seed.enter_your_secret_recovery_phrase',
                   )}
-                </Box>
-                <SrpInputGrid
-                  ref={srpInputGridRef}
-                  seedPhrase={seedPhrase}
-                  onSeedPhraseChange={setSeedPhrase}
-                  onError={setError}
-                  externalError={error}
-                  testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
-                  placeholderText={strings('import_from_seed.srp_placeholder')}
-                  uniqueId={uniqueId}
-                  onCurrentWordChange={setCurrentInputWord}
-                  autoFocus={false}
-                />
+                  {isAddDeviceSyncEnabled && (
+                    <>
+                      {' '}
+                      {strings('import_from_seed.or')}{' '}
+                      <Text
+                        variant={TextVariant.BodyMd}
+                        color={TextColor.PrimaryDefault}
+                        onPress={() =>
+                          navigation.navigate(
+                            Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
+                          )
+                        }
+                      >
+                        {strings(
+                          'import_from_seed.import_wallet_from_extension',
+                        )}
+                      </Text>
+                    </>
+                  )}
+                </Text>
+                {!isAddDeviceSyncEnabled && (
+                  <TouchableOpacity
+                    onPress={showWhatIsSeedPhrase}
+                    testID={
+                      ImportFromSeedSelectorsIDs.WHAT_IS_SEEDPHRASE_LINK_ID
+                    }
+                  >
+                    <Icon
+                      name={IconName.Info}
+                      size={IconSize.Md}
+                      color={colors.icon.alternative}
+                    />
+                  </TouchableOpacity>
+                )}
               </Box>
-            </>
+              <SrpInputGrid
+                ref={srpInputGridRef}
+                seedPhrase={seedPhrase}
+                onSeedPhraseChange={setSeedPhrase}
+                onError={setError}
+                externalError={error}
+                testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
+                placeholderText={strings('import_from_seed.srp_placeholder')}
+                uniqueId={uniqueId}
+                onCurrentWordChange={setCurrentInputWord}
+                autoFocus={false}
+              />
+            </Box>
           )}
 
           {currentStep === 1 && (

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -598,7 +598,7 @@ const ImportFromSecretRecoveryPhrase = ({
           ]}
         >
           {currentStep === 0 && (
-            <Box twClassName="gap-y-1.5">
+            <>
               <Text
                 variant={TextVariant.DisplayMd}
                 color={TextColor.TextDefault}
@@ -606,66 +606,68 @@ const ImportFromSecretRecoveryPhrase = ({
               >
                 {strings('import_from_seed.title')}
               </Text>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                twClassName="gap-1"
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextAlternative}
+              <Box twClassName="mt-1.5">
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  twClassName="gap-1"
                 >
-                  {strings(
-                    'import_from_seed.enter_your_secret_recovery_phrase',
-                  )}
-                  {isAddDeviceSyncEnabled && (
-                    <>
-                      {' '}
-                      {strings('import_from_seed.or')}{' '}
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        color={TextColor.PrimaryDefault}
-                        onPress={() =>
-                          navigation.navigate(
-                            Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
-                          )
-                        }
-                      >
-                        {strings(
-                          'import_from_seed.import_wallet_from_extension',
-                        )}
-                      </Text>
-                    </>
-                  )}
-                </Text>
-                {!isAddDeviceSyncEnabled && (
-                  <TouchableOpacity
-                    onPress={showWhatIsSeedPhrase}
-                    testID={
-                      ImportFromSeedSelectorsIDs.WHAT_IS_SEEDPHRASE_LINK_ID
-                    }
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
                   >
-                    <Icon
-                      name={IconName.Info}
-                      size={IconSize.Md}
-                      color={colors.icon.alternative}
-                    />
-                  </TouchableOpacity>
-                )}
+                    {strings(
+                      'import_from_seed.enter_your_secret_recovery_phrase',
+                    )}
+                    {isAddDeviceSyncEnabled && (
+                      <>
+                        {' '}
+                        {strings('import_from_seed.or')}{' '}
+                        <Text
+                          variant={TextVariant.BodyMd}
+                          color={TextColor.PrimaryDefault}
+                          onPress={() =>
+                            navigation.navigate(
+                              Routes.ONBOARDING.ADD_DEVICE_TO_WALLET,
+                            )
+                          }
+                        >
+                          {strings(
+                            'import_from_seed.import_wallet_from_extension',
+                          )}
+                        </Text>
+                      </>
+                    )}
+                  </Text>
+                  {!isAddDeviceSyncEnabled && (
+                    <TouchableOpacity
+                      onPress={showWhatIsSeedPhrase}
+                      testID={
+                        ImportFromSeedSelectorsIDs.WHAT_IS_SEEDPHRASE_LINK_ID
+                      }
+                    >
+                      <Icon
+                        name={IconName.Info}
+                        size={IconSize.Md}
+                        color={colors.icon.alternative}
+                      />
+                    </TouchableOpacity>
+                  )}
+                </Box>
+                <SrpInputGrid
+                  ref={srpInputGridRef}
+                  seedPhrase={seedPhrase}
+                  onSeedPhraseChange={setSeedPhrase}
+                  onError={setError}
+                  externalError={error}
+                  testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
+                  placeholderText={strings('import_from_seed.srp_placeholder')}
+                  uniqueId={uniqueId}
+                  onCurrentWordChange={setCurrentInputWord}
+                  autoFocus={false}
+                />
               </Box>
-              <SrpInputGrid
-                ref={srpInputGridRef}
-                seedPhrase={seedPhrase}
-                onSeedPhraseChange={setSeedPhrase}
-                onError={setError}
-                externalError={error}
-                testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
-                placeholderText={strings('import_from_seed.srp_placeholder')}
-                uniqueId={uniqueId}
-                onCurrentWordChange={setCurrentInputWord}
-                autoFocus={false}
-              />
-            </Box>
+            </>
           )}
 
           {currentStep === 1 && (

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -268,11 +268,7 @@ const ManualBackupStep1 = () => {
             marginBottom={5}
             twClassName="flex-1"
           >
-            <Box
-              marginBottom={2}
-              justifyContent={BoxJustifyContent.Center}
-              twClassName="flex-1"
-            >
+            <Box marginBottom={2}>
               <Label color={TextColor.TextDefault}>
                 {strings('manual_backup_step_1.before_continiuing')}
               </Label>
@@ -303,11 +299,7 @@ const ManualBackupStep1 = () => {
               )}
             </Box>
           </Box>
-          <Box
-            marginTop={0}
-            justifyContent={BoxJustifyContent.End}
-            twClassName="flex-1"
-          >
+          <Box justifyContent={BoxJustifyContent.End} twClassName="flex-1">
             <Button
               variant={ButtonVariant.Primary}
               onPress={tryUnlock}
@@ -326,75 +318,68 @@ const ManualBackupStep1 = () => {
 
   const renderSeedphraseView = () => (
     <Box twClassName="flex-1 justify-between">
-      <Box twClassName="flex-1">
-        <Box
-          twClassName="flex-1 flex-col gap-4"
-          testID={ManualBackUpStepsSelectorsIDs.STEP_1_CONTAINER}
-        >
-          <Text variant={TextVariant.DisplayMd} color={TextColor.TextDefault}>
-            {strings('manual_backup_step_1.action')}
+      <Box
+        twClassName="flex-1 flex-col gap-4"
+        testID={ManualBackUpStepsSelectorsIDs.STEP_1_CONTAINER}
+      >
+        <Text variant={TextVariant.DisplayMd} color={TextColor.TextDefault}>
+          {strings('manual_backup_step_1.action')}
+        </Text>
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          {strings('manual_backup_step_1.info-1')}{' '}
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.PrimaryDefault}
+            onPress={showWhatIsSeedphrase}
+          >
+            {strings('manual_backup_step_1.info-2')}{' '}
           </Text>
-          <Box justifyContent={BoxJustifyContent.Start}>
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {strings('manual_backup_step_1.info-1')}{' '}
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.PrimaryDefault}
-                onPress={showWhatIsSeedphrase}
-              >
-                {strings('manual_backup_step_1.info-2')}{' '}
-              </Text>
-              {strings('manual_backup_step_1.info-3')}{' '}
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                {strings('manual_backup_step_1.info-4')}
-              </Text>
-            </Text>
+          {strings('manual_backup_step_1.info-3')}{' '}
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+          >
+            {strings('manual_backup_step_1.info-4')}
+          </Text>
+        </Text>
+        {seedPhraseHidden ? (
+          <Box twClassName="bg-default rounded-lg flex-row border border-default min-h-[230px]">
+            {renderSeedPhraseConcealer()}
           </Box>
-          {seedPhraseHidden ? (
-            <Box twClassName="bg-default rounded-lg flex-row border border-default min-h-[230px]">
-              {renderSeedPhraseConcealer()}
-            </Box>
-          ) : (
-            <Box twClassName="p-4 bg-muted rounded-[10px] min-h-[232px]">
-              <FlatList
-                data={words}
-                numColumns={3}
-                keyExtractor={(_, index) => index.toString()}
-                renderItem={({ item, index }) => (
-                  <Box twClassName="flex-row items-center h-10 border border-muted rounded-lg px-2 py-1 bg-default flex-1 m-1 gap-x-1.5">
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextAlternative}
-                      maxFontSizeMultiplier={1}
-                    >
-                      {index + 1}.
-                    </Text>
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      color={TextColor.TextDefault}
-                      key={index}
-                      numberOfLines={1}
-                      adjustsFontSizeToFit
-                      minimumFontScale={0.7}
-                      style={tw.style('flex-1')}
-                      testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
-                      maxFontSizeMultiplier={1}
-                    >
-                      {item}
-                    </Text>
-                  </Box>
-                )}
-              />
-            </Box>
-          )}
-        </Box>
+        ) : (
+          <Box twClassName="p-4 bg-muted rounded-[10px] min-h-[232px]">
+            <FlatList
+              data={words}
+              numColumns={3}
+              keyExtractor={(_, index) => index.toString()}
+              renderItem={({ item, index }) => (
+                <Box twClassName="flex-row items-center h-10 border border-muted rounded-lg px-2 py-1 bg-default flex-1 m-1 gap-x-1.5">
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
+                    maxFontSizeMultiplier={1}
+                  >
+                    {index + 1}.
+                  </Text>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                    key={index}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    minimumFontScale={0.7}
+                    style={tw.style('flex-1')}
+                    testID={`${ManualBackUpStepsSelectorsIDs.WORD_ITEM}-${index}`}
+                    maxFontSizeMultiplier={1}
+                  >
+                    {item}
+                  </Text>
+                </Box>
+              )}
+            />
+          </Box>
+        )}
       </Box>
       <Box
         twClassName={`px-0 gap-4 flex justify-center items-center ${Platform.OS === 'android' ? 'mb-4' : 'mb-0'}`}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Simplify onboarding screen DOM by removing redundant layout wrappers without changing UI or behavior.

Why: Deeply nested Box wrappers make onboarding screens harder to maintain and more brittle for E2E/component tests. This PR starts with the highest-priority (P1) onboarding screens.

What changed:

1) ManualBackupStep1: flattened confirm-password and seed-phrase views by removing unnecessary flex-1 / wrapper Box layers
2) ChoosePassword: merged duplicate nested flex-1 Box containers into one CONTAINER_ID wrapper.

No logic, copy and styling tokens were changed.

* Jira: https://consensyssoftware.atlassian.net/browse/TO-910
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Onboarding DOM simplification 

  Scenario: Manual backup step 1 looks unchanged
    Given I am on Manual Backup Step 1 (seed phrase view)
    When I reveal the seed phrase and scroll through the screen
    Then the layout, spacing, and buttons match the previous build
    When I navigate to the confirm-password view (if applicable)
    Then the password field, error state, and Confirm button layout are unchanged

  Scenario: Create password screen looks unchanged
    Given I am on Choose Password during wallet creation
    When I view the title, password fields, checkbox, and Create password CTA
    Then the layout and keyboard behavior match the previous build
    When I focus password fields and scroll on iOS and Android
    Then the submit button remains accessible and visually correct
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9d7a0b26-152f-4b6c-a760-d23e79c407a0


https://github.com/user-attachments/assets/ffac1ae7-a1ec-4ae4-8d76-f90631e015ef


https://github.com/user-attachments/assets/5fafae3d-9a70-41cb-9520-442ae417c1fb


https://github.com/user-attachments/assets/9da73c00-7f5b-4b3d-ad2b-c82c2ffe6fb5


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only JSX restructuring on onboarding screens; wallet/password logic is untouched, though layout regressions on small screens or with the keyboard should be spot-checked visually.
> 
> **Overview**
> Reduces **redundant `Box` nesting** on three P1 onboarding screens so the view trees are shallower and easier to maintain and test, without intended changes to copy, handlers, or `testID`s.
> 
> On **Choose Password**, duplicate nested `flex-1` containers are collapsed into a single column wrapper that keeps `CONTAINER_ID`, `gap`, and the same field/checkbox/CTA structure.
> 
> On **Import from SRP (step 0)**, the fragment and extra `mt-1.5` wrapper are replaced by one `gap-y-1.5` column that still groups title, description row, info/link, and `SrpInputGrid`.
> 
> On **Manual Backup Step 1**, extra `flex-1` / justify wrappers are removed in the confirm-password and seed-phrase layouts while preserving the same inputs, phrase grid/concealer, and bottom buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb642e84b7c736b79147e7e27367dbdef89712c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->