### PR TITLE
fix(predict): stop reporting transient network errors to Sentry

### DIFF
--- a/app/components/UI/Predict/controllers/utils/withTrace.test.ts
+++ b/app/components/UI/Predict/controllers/utils/withTrace.test.ts
@@ -6,8 +6,14 @@ import {
   type TraceOperation,
   type TraceValue,
 } from '../../../../../util/trace';
-import { ensureError } from '../../utils/predictErrorHandler';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { ensureError, isNetworkError } from '../../utils/predictErrorHandler';
 import { type TraceableController, withTrace } from './withTrace';
+
+jest.mock('../../../../../core/SDKConnect/utils/DevLogger', () => ({
+  __esModule: true,
+  default: { log: jest.fn() },
+}));
 
 jest.mock('../../../../../util/Logger', () => ({
   __esModule: true,
@@ -23,6 +29,7 @@ jest.mock('../../../../../util/trace', () => ({
 jest.mock('../../utils/predictErrorHandler', () => ({
   __esModule: true,
   ensureError: jest.fn(),
+  isNetworkError: jest.fn(),
 }));
 
 interface ControllerState {
@@ -68,6 +75,8 @@ describe('withTrace', () => {
   const mockTrace = jest.mocked(trace);
   const mockEndTrace = jest.mocked(endTrace);
   const mockEnsureError = jest.mocked(ensureError);
+  const mockIsNetworkError = jest.mocked(isNetworkError);
+  const mockDevLogger = jest.mocked(DevLogger);
   const mockLogger = jest.mocked(Logger);
 
   beforeEach(() => {
@@ -75,6 +84,7 @@ describe('withTrace', () => {
     mockEnsureError.mockImplementation((error: unknown) =>
       error instanceof Error ? error : new Error(String(error)),
     );
+    mockIsNetworkError.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -163,6 +173,45 @@ describe('withTrace', () => {
       name: TRACE_NAME,
       id: 'getBalance-3000',
       data: { success: false, error: 'network failed' },
+    });
+  });
+
+  it('reports transient network errors to DevLogger instead of Sentry', async () => {
+    const controller = createController();
+    const thrownError = new Error(
+      'java.lang.RuntimeException: Cronet failed: net::ERR_NAME_NOT_RESOLVED',
+    );
+    const run = jest.fn(async () => {
+      throw thrownError;
+    });
+    mockIsNetworkError.mockReturnValue(true);
+    jest.spyOn(Date, 'now').mockReturnValueOnce(3000).mockReturnValueOnce(4000);
+
+    const resultPromise = withTrace(
+      controller,
+      {
+        method: 'getPositions',
+        trace: {
+          name: TRACE_NAME,
+          op: TRACE_OPERATION,
+        },
+      },
+      run,
+    );
+
+    await expect(resultPromise).rejects.toBe(thrownError);
+    // Still updates error state and re-throws so UI behaves the same...
+    expect(controller.state.lastError).toBe(thrownError.message);
+    // ...but does NOT report to Sentry.
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockDevLogger.log).toHaveBeenCalledWith(
+      'withTrace: network error in getPositions',
+      thrownError.message,
+    );
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TRACE_NAME,
+      id: 'getPositions-3000',
+      data: { success: false, error: thrownError.message },
     });
   });
 

--- a/app/components/UI/Predict/controllers/utils/withTrace.ts
+++ b/app/components/UI/Predict/controllers/utils/withTrace.ts
@@ -6,7 +6,8 @@ import {
   type TraceOperation,
   type TraceValue,
 } from '../../../../../util/trace';
-import { ensureError } from '../../utils/predictErrorHandler';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
+import { ensureError, isNetworkError } from '../../utils/predictErrorHandler';
 
 /**
  * Minimal interface a controller must satisfy to use withTrace.
@@ -104,10 +105,18 @@ export async function withTrace<T>(
 
     traceResultData = { success: false, error: errorMessage };
 
-    Logger.error(
-      ensureError(error),
-      controller.getErrorContext(method, errorContext),
-    );
+    // Transient connectivity failures (DNS errors, timeouts, offline,
+    // geo/ISP blocking) are driven by the user's network conditions and are
+    // not actionable crashes. Log them as breadcrumbs instead of reporting
+    // them to Sentry to avoid polling-driven error noise.
+    if (isNetworkError(error)) {
+      DevLogger.log(`withTrace: network error in ${method}`, errorMessage);
+    } else {
+      Logger.error(
+        ensureError(error),
+        controller.getErrorContext(method, errorContext),
+      );
+    }
 
     throw error;
   } finally {

--- a/app/components/UI/Predict/utils/predictErrorHandler.test.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.test.ts
@@ -4,6 +4,7 @@ import { PREDICT_ERROR_CODES } from '../constants/errors';
 import { Side } from '../types';
 import {
   ensureError,
+  isNetworkError,
   createDepositErrorToast,
   parseErrorMessage,
   checkPlaceOrderError,
@@ -87,6 +88,43 @@ describe('predictErrorHandler', () => {
 
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toBe('[object Object]');
+    });
+  });
+
+  describe('isNetworkError', () => {
+    it.each([
+      'java.lang.RuntimeException: Cronet failed: Exception in CronetUrlRequest: net::ERR_CONNECTION_TIMED_OUT',
+      'Cronet failed: net::ERR_NAME_NOT_RESOLVED',
+      'net::ERR_INTERNET_DISCONNECTED',
+      'TypeError: Network request failed',
+      'Failed to fetch',
+      'The connection timed out',
+      'Connection was reset',
+      'Request timeout',
+      'The Internet connection appears to be offline.',
+      'Network is unreachable',
+      'Could not resolve host: example.com',
+    ])('returns true for connectivity failure: %s', (message) => {
+      expect(isNetworkError(new Error(message))).toBe(true);
+    });
+
+    it('matches network errors passed as plain strings', () => {
+      expect(isNetworkError('net::ERR_CONNECTION_REFUSED')).toBe(true);
+    });
+
+    it.each([
+      'Failed to get positions',
+      'Address is required',
+      'Order not fully filled',
+      'Unexpected token in JSON',
+      '',
+    ])('returns false for non-network error: %s', (message) => {
+      expect(isNetworkError(new Error(message))).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(isNetworkError(null)).toBe(false);
+      expect(isNetworkError(undefined)).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/utils/predictErrorHandler.test.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.test.ts
@@ -97,7 +97,6 @@ describe('predictErrorHandler', () => {
       'Cronet failed: net::ERR_NAME_NOT_RESOLVED',
       'net::ERR_INTERNET_DISCONNECTED',
       'TypeError: Network request failed',
-      'Failed to fetch',
       'The connection timed out',
       'Connection was reset',
       'Request timeout',
@@ -113,7 +112,11 @@ describe('predictErrorHandler', () => {
     });
 
     it.each([
+      // App-level HTTP/logic errors must still reach Sentry, including
+      // "Failed to fetch X" messages for non-OK responses.
       'Failed to get positions',
+      'Failed to fetch related tags',
+      'Failed to fetch carousel data',
       'Address is required',
       'Order not fully filled',
       'Unexpected token in JSON',

--- a/app/components/UI/Predict/utils/predictErrorHandler.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.ts
@@ -24,6 +24,49 @@ export function ensureError(error: unknown): Error {
   return new Error(String(error));
 }
 
+/**
+ * Patterns that identify transient connectivity failures rather than
+ * application bugs. These surface differently across transports
+ * (Android Cronet via nitro-fetch, RN default fetch, iOS URLSession) so we
+ * match on the substrings each of them emits.
+ *
+ * Reported as breadcrumbs/warnings instead of Sentry errors, since they are
+ * driven by the user's network conditions (DNS failures, timeouts, offline,
+ * geo/ISP blocking) and are not actionable as crashes.
+ */
+const NETWORK_ERROR_PATTERNS: RegExp[] = [
+  // Chromium/Cronet (Android nitro-fetch) net::ERR_* codes
+  /net::ERR_/iu,
+  /Cronet failed/iu,
+  // React Native default fetch (OkHttp / iOS)
+  /Network request failed/iu,
+  /Failed to fetch/iu,
+  // Common cross-platform connectivity phrases
+  /connection (was |)(timed out|refused|reset|closed)/iu,
+  /request tim(ed |e)?out/iu,
+  /timeout/iu,
+  /network is unreachable/iu,
+  /(the )?internet connection appears to be offline/iu,
+  /name (not resolved|resolution failed)/iu,
+  /could not (connect|resolve host)/iu,
+];
+
+/**
+ * Determines whether an error represents a transient network/connectivity
+ * failure (as opposed to an application bug). Used to avoid reporting
+ * unactionable connectivity noise to Sentry.
+ *
+ * @param error - The caught error (Error, string, or unknown)
+ * @returns true when the error looks like a connectivity failure
+ */
+export function isNetworkError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!message) {
+    return false;
+  }
+  return NETWORK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
 export function createDepositErrorToast(
   theme: {
     colors: { error: { default: string }; accent04: { normal: string } };

--- a/app/components/UI/Predict/utils/predictErrorHandler.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.ts
@@ -38,9 +38,11 @@ const NETWORK_ERROR_PATTERNS: RegExp[] = [
   // Chromium/Cronet (Android nitro-fetch) net::ERR_* codes
   /net::ERR_/iu,
   /Cronet failed/iu,
-  // React Native default fetch (OkHttp / iOS)
+  // React Native default fetch (OkHttp / iOS). Note: we intentionally do NOT
+  // match the browser-only "Failed to fetch" phrasing here, because the Predict
+  // providers throw many app-level errors like "Failed to fetch related tags"
+  // for non-OK HTTP responses, which are actionable and must reach Sentry.
   /Network request failed/iu,
-  /Failed to fetch/iu,
   // Common cross-platform connectivity phrases
   /connection (was |)(timed out|refused|reset|closed)/iu,
   /request tim(ed |e)?out/iu,


### PR DESCRIPTION
## **Description**

`PredictController`'s `withTrace` wrapper reported **every** failure to Sentry via `Logger.error` → `captureException`, including transient connectivity failures that are driven by the user's network conditions rather than app bugs.

On Android, release `8.2.0` shipped the nitro-fetch integration (`react-native-l-fetch`), which uses **Cronet** as the HTTP transport. Cronet surfaces network drops as `java.lang.RuntimeException: Cronet failed: net::ERR_*` (e.g. `ERR_NAME_NOT_RESOLVED`, `ERR_CONNECTION_TIMED_OUT`) — a new error fingerprint. Combined with the frequent Predict positions polling (`getPositions`, `staleTime: 5_000`), this generated significant Sentry noise from users with flaky connectivity or geo/ISP-blocked Polymarket domains.

**Solution:** Add `isNetworkError()` to classify transport-level connectivity failures (Cronet `net::ERR_*`, RN `Network request failed`/`Failed to fetch`, timeouts, offline, DNS resolution failures). In `withTrace`, these are now routed to `DevLogger` (breadcrumb) instead of Sentry. Error-state updates and the re-throw are unchanged, so **UI behavior is identical** — only unactionable Sentry noise is suppressed. Genuine bugs (parse/logic errors, non-network exceptions) are still reported.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [METAMASK-MOBILE-601M](https://metamask.sentry.io/issues/7605515084/?project=2299799)

## **Manual testing steps**

```gherkin
Feature: Predict network error handling

  Scenario: Transient network failure while fetching positions is not sent to Sentry
    Given I am on an Android device with the Predict feature enabled
    And the device has no network connectivity (airplane mode) or DNS resolution fails
    When the Predict positions view polls getPositions and the request fails with net::ERR_*
    Then the UI error state updates as before
    And no error event is reported to Sentry (a DevLogger breadcrumb is logged instead)

  Scenario: Non-network errors are still reported
    Given the Predict positions request fails with a non-network error (e.g. non-JSON response)
    When getPositions throws
    Then the error is still reported to Sentry via Logger.error
```

Unit tests cover both paths:
- `app/components/UI/Predict/utils/predictErrorHandler.test.ts` — `isNetworkError` positive/negative/null cases.
- `app/components/UI/Predict/controllers/utils/withTrace.test.ts` — asserts a Cronet `net::ERR_NAME_NOT_RESOLVED` is logged to `DevLogger` (not Sentry) while still updating `lastError` and re-throwing.

## **Screenshots/Recordings**

N/A — no user-facing UI changes; this only affects error reporting/telemetry.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change in Predict tracing; no auth or data-path changes, with explicit safeguards so non-network failures still reach Sentry.
> 
> **Overview**
> Adds **`isNetworkError()`** in `predictErrorHandler` to classify transport-level connectivity failures (Cronet `net::ERR_*`, RN `Network request failed`, timeouts, offline/DNS) via message regexes, while **excluding** app-level strings like `Failed to fetch …` so those still go to Sentry.
> 
> **`withTrace`** now branches on that helper: transient network failures are logged with **`DevLogger`** only; other errors still use **`Logger.error`** (Sentry). Error state updates, re-throw, and trace `endTrace` failure data are unchanged, so UI behavior stays the same.
> 
> Unit tests cover `isNetworkError` positive/negative cases and a Cronet DNS failure path in `withTrace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbed5f93b86745c3cf3432992b8cb75c514fe40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->