### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill

### DIFF
--- a/app/component-library/components-temp/Loader/Loader.styles.ts
+++ b/app/component-library/components-temp/Loader/Loader.styles.ts
@@ -18,7 +18,7 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     base: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       backgroundColor: colors.background.default,

--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.styles.ts
@@ -12,7 +12,7 @@ import { StyleSheet } from 'react-native';
 const styleSheet = () =>
   StyleSheet.create({
     base: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'flex-end',
     },
   });

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
@@ -35,7 +35,7 @@ const styleSheet = (params: {
       padding: 0,
     },
     underlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       flexDirection: 'row',
       backgroundColor: colors.background.muted,
     },

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
@@ -32,7 +32,7 @@ const styleSheet = (params: {
       style,
     ) as ViewStyle,
     underlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       flexDirection: 'row',
       backgroundColor: colors.background.muted,
     },

--- a/app/component-library/components/Overlay/Overlay.styles.ts
+++ b/app/component-library/components/Overlay/Overlay.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: { theme: Theme; vars: OverlayStyleSheetVars }) => {
   return StyleSheet.create({
     base: Object.assign(
       {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         backgroundColor: color || theme.colors.overlay.default,
       } as ViewStyle,
       style,

--- a/app/component-library/components/Skeleton/Skeleton.styles.ts
+++ b/app/component-library/components/Skeleton/Skeleton.styles.ts
@@ -31,7 +31,7 @@ const styleSheet = (params: { theme: Theme; vars: SkeletonStyleSheetVars }) => {
       style,
     ) as ViewStyle,
     background: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: 4,
     } as ViewStyle,

--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -55,7 +55,7 @@ const styleSheet = (params: { theme: Theme }) =>
       alignSelf: 'stretch',
     } as ViewStyle,
     noDataOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       zIndex: 2,

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -30,12 +30,12 @@ const styleSheet = (params: {
     },
     /** Same pattern as AdvancedChart: overlay does not participate in flex layout with AreaChart. */
     loadingOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },
     noDataOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
@@ -32,7 +32,7 @@ const styleSheet = (params: { theme: Theme }) =>
       borderRadius: 8,
     },
     hollowCircleContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -45,20 +45,20 @@ const createStyles = (colors: any) =>
       marginRight: 12,
     },
     absoluteFillWithCenter: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       alignItems: 'center',
       justifyContent: 'center',
     },
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     preCompletedContainerStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.default,
     },
     outerCircle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.inverse,
     },

--- a/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
 });

--- a/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
+++ b/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
@@ -53,7 +53,7 @@ export interface DaimoPayModalParams {
 
 const baseStyles = StyleSheet.create({
   absoluteFill: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
   },
 });
 

--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -66,7 +66,7 @@ const styleSheet = (params: {
     mediaPlayer: {
       minHeight: 10,
     },
-    imageFallBackTextContainer: StyleSheet.absoluteFillObject,
+    imageFallBackTextContainer: StyleSheet.absoluteFill,
     imageFallBackShowContainer: {
       bottom: 32,
     },

--- a/app/components/UI/DesignerMode/DesignerModeRN.tsx
+++ b/app/components/UI/DesignerMode/DesignerModeRN.tsx
@@ -1295,7 +1295,7 @@ function createDesignerStyles() {
 
     // Backdrop
     backdrop: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: C.backdrop,
     } as ViewStyle,
 

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   overlayCenter: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -370,7 +370,7 @@ export function HwQrScanner() {
     return (
       <>
         <Camera
-          style={StyleSheet.absoluteFillObject}
+          style={StyleSheet.absoluteFill}
           device={cameraDevice}
           isActive={isFocused && hasPermission}
           codeScanner={codeScanner}

--- a/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
+++ b/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
@@ -111,7 +111,7 @@ const MoneyFirstTimeDepositView = () => {
         dataBinding={AutoBind(true)}
         fit={Fit.Layout}
         layoutScaleFactor={PixelRatio.get()}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         onError={handleError}
         testID={MoneyFirstTimeDepositViewTestIds.RIVE_ANIMATION}
       />

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -438,7 +438,7 @@ const MoneyOnboardingView = () => {
         layoutScaleFactor={PixelRatio.get()}
         onStateChanged={handleStateChanged}
         onError={handleError}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
       />
       <MoneyOnboardingTextOverlay

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -50,7 +50,7 @@ const createStyles = (theme) => {
 
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     titleWrapper: {
       borderBottomWidth: StyleSheet.hairlineWidth,

--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
@@ -531,7 +531,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           {overlaySeries.map((series, index) => (
             <LineChart
               key={`${series.label}-${index}`}
-              style={StyleSheet.absoluteFillObject}
+              style={StyleSheet.absoluteFill}
               data={series.data.map((point) => point.value)}
               svg={{ stroke: series.color, strokeWidth: 2 }}
               contentInset={CHART_CONTENT_INSET}
@@ -543,7 +543,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           ))}
           {/* Tooltip overlay - rendered last to appear on top */}
           <LineChart
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             data={primaryChartData}
             svg={{ stroke: 'transparent', strokeWidth: 0 }}
             contentInset={CHART_CONTENT_INSET}

--- a/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
@@ -77,7 +77,7 @@ const createStyles = (
       zIndex: 2,
     },
     backgroundShapes: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       zIndex: 1,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/UI/ReusableModal/styles.ts
+++ b/app/components/UI/ReusableModal/styles.ts
@@ -16,10 +16,10 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     overlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.overlay.default,
     },
   });

--- a/app/components/UI/SlippageSlider/index.js
+++ b/app/components/UI/SlippageSlider/index.js
@@ -88,7 +88,7 @@ const createStyles = (colors, shadows) =>
       top: 4,
     },
     tooltipText: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       textAlign: 'center',
       ...fontStyles.normal,
       color: colors.overlay.inverse,

--- a/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
+++ b/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
@@ -47,7 +47,7 @@ const createStyles = (colors: ThemeColors) =>
       flex: 1,
     },
     tabImage: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       resizeMode: 'cover',
     },
     activeTab: {

--- a/app/components/UI/UrlAutocomplete/styles.ts
+++ b/app/components/UI/UrlAutocomplete/styles.ts
@@ -8,7 +8,7 @@ import {
 const styleSheet = ({ theme: { colors, typography } }: { theme: Theme }) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       // Hidden by default
       display: 'none',

--- a/app/components/UI/WebviewError/index.js
+++ b/app/components/UI/WebviewError/index.js
@@ -10,7 +10,7 @@ import { WebviewErrorSelectorsIDs } from './WebviewError.testIds';
 const createStyles = (colors) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -38,7 +38,7 @@ const styleSheet = (params: {
       marginBottom: 16,
     },
     shimmerOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: CARD_BORDER_RADIUS,
     },

--- a/app/components/Views/MediaPlayer/index.js
+++ b/app/components/Views/MediaPlayer/index.js
@@ -34,7 +34,7 @@ const styleSheet = ({ theme: { colors }, vars: { isPlaying } }) =>
       alignItems: 'center',
     },
     videoControlsStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -101,7 +101,7 @@ const NotifCard = ({
 
       {/* Border overlay — MaskedView fades the border top-to-transparent */}
       <MaskedView
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         maskElement={
           <LinearGradient
             colors={['black', 'black', 'transparent']}
@@ -112,7 +112,7 @@ const NotifCard = ({
       >
         <View
           style={[
-            StyleSheet.absoluteFillObject,
+            StyleSheet.absoluteFill,
             styles.border,
             { borderColor: mutedBorderColor },
           ]}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   layer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -449,13 +449,8 @@ function TradeWalletActions() {
 
   return (
     <View style={tw.style('flex-1 justify-end')}>
-      <Animated.View
-        style={[StyleSheet.absoluteFillObject, backdropAnimatedStyle]}
-      >
-        <Pressable
-          style={StyleSheet.absoluteFillObject}
-          onPress={handleNavigateBack}
-        >
+      <Animated.View style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleNavigateBack}>
           <OverlayWithHole
             width={windowWidth}
             height={windowHeight + insetsTop}


### PR DESCRIPTION
## **Description**                                                                                                                                
                                                                                                                                                    
  <!-- mms-check: type=text required=true -->                                                                                                       
                                                                                                                                                    
  `StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces all 39 usages across 30 files with      
  `StyleSheet.absoluteFill` as pre-upgrade work (Wave 1 of the RN 0.85 pre-upgrade PR ladder), so the actual upgrade PR stays as small as possible. 
                                                                                                                                                    
  On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill`                      
  (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread 
  usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.                                       
                                                                                                                                                    
  ## **Changelog**                                                                                                                               
                                                                                                                                                    
  <!-- mms-check: type=changelog required=true blocking=true -->                                                                                    
                                                                                                                                                    
  CHANGELOG entry: null                                                                                                                             
                                                                                                                                                    
  ## **Related issues**                                                                                                                          

  <!-- mms-check: type=issue-link required=true -->
                                                                                                                                                    
  Refs: 0.85 RN Upgrade (pre-upgrade step)                                                                                 
                                                                                                                                                    
  ## **Manual testing steps**                                                                                                                       
                                                                                                                                                    
  <!-- mms-check: type=manual-testing required=true -->                                                                                             
                                                                                                                                                    
  ```gherkin                                                                                                                                        
  Feature: Absolute-fill overlay styling (no-op refactor)                                                                                           
                                                                                                                                                    
    Scenario: user opens surfaces that use absolute-fill overlays                                                                                   
      Given the app is built from this branch                                                                                                       
                                                                                                                                                    
      When user opens a bottom sheet (e.g. account selector)                                                                                        
      Then the backdrop overlay covers the full screen behind the sheet                                                                             
                                                                                                                                                    
      When user views a token details page with the price chart loading                                                                             
      Then the chart skeleton/loading overlay renders full-size as before                                                                           
                                                                                                                                                    
      When user opens the in-app browser tabs view                                                                                                  
      Then tab thumbnails render with their overlays unchanged                                                                                      
  ```                                                                                                                                               
                                                                                                                                                    
  Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.                     
                                                                                                                                                    
  ## **Screenshots/Recordings**                                                                                                                     
                                                                                                                                                    
  <!-- mms-check: type=screenshot required=true -->                                                                                                 
                                                                                                                                                    
  ### **Before**                                                                                                                                 
                                                                                                                                                    
  N/A — pure rename of a deprecated alias to its identical replacement; no visual change.                                                           
                                                                                                                                                    
  ### **After**                                                                                                                                     
                                                                                                                                                    
  N/A — see above.                                                                                                                               
                                                                                                                                                    
  ## **Pre-merge author checklist**                                                                                                                 
                                                                                                                                                    
  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding                         
  Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).                                        
  - [x] I've completed the PR template to the best of my ability                                                                                    
  - [x] I've included tests if applicable                                                                                                           
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable                                                              
  - [x] I've applied the right labels on the PR (see [labeling                                                                                      
  guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external          
  contributors.                                                                                                                                     
                                                                                                                                                    
  #### Performance checks (if applicable)                                                                                                           
                                                                                                                                                 
  - [x] I've tested on Android
  - [ ] I've tested with a power user scenario
  - [x] I've instrumented key operations with Sentry traces for production performance metrics                                                      
                                                                                                                                                    
  ## **Pre-merge reviewer checklist**                                                                                                               
                                                                                                                                                    
  - [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).                                             
  - [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such 
  as recordings and or screenshots.                                                                                                                 
                                                                                                                                                    
  Notes:                                                                                                                                            
  - CHANGELOG entry: null — not end-user-facing; also apply the no-changelog label to satisfy the blocking check either way.                        
  - The "tests included" box is checked in the "consciously assessed" sense — no test changes are applicable since existing snapshot/unit tests     
  already cover these components and the objects are identical.                                                                                     
  - Replace the Refs: placeholder with the upgrade epic link before marking ready for review (the validator requires a value there).        

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Find-and-replace only; no logic or styling property changes, and the deprecated symbol is identical to its replacement on the current RN version.
> 
> **Overview**
> Replaces every `StyleSheet.absoluteFillObject` reference with `StyleSheet.absoluteFill` across **30 files** (component-library loaders/overlays, charts, modals, Money Rive screens, HW QR camera, trade wallet backdrop, etc.) as **Wave 1** prep for React Native **0.85**, where `absoluteFillObject` is removed.
> 
> Usage patterns are unchanged: spreads in `StyleSheet.create`, direct `style={...}` on `View`/`Camera`/`Rive`/`LineChart`, and inline styles. **TradeWalletActions** only swaps the API name; layout is the same.
> 
> On current RN **0.83.6**, `absoluteFillObject` is an alias of `absoluteFill`, so this is intended to be a **no-op** for layout and visuals until the upgrade lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af77f99fdd93e4ccb23021d6a2d9e1de1719f7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->