### PR TITLE
fix: musd-1128 prevent apy from disappearing

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -478,6 +478,7 @@ describe('MoneyHomeView', () => {
       apyDecimal: 0.05,
       apyPercent: 5,
       apyPercentFormatted: '5%',
+      isApyLoading: false,
       vaultApyQuery: {
         data: { apy: 0.05, timestamp: '2026-01-01T00:00:00Z' },
         isLoading: false,

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -126,7 +126,7 @@ const MoneyHomeView = () => {
   const {
     totalFiatFormatted,
     totalFiatRaw,
-    vaultApyQuery,
+    isApyLoading,
     isBalanceLoading,
     lastKnownTotalFiatFormatted,
     refetchBalance,
@@ -721,7 +721,7 @@ const MoneyHomeView = () => {
         <MoneyEarnings
           monthlyEarnings={monthlyEarnings}
           yearlyEarnings={yearlyEarnings}
-          isLoading={vaultApyQuery.isLoading || isBalanceLoading}
+          isLoading={isApyLoading || isBalanceLoading}
           onInfoPress={handleEarningsInfoPress}
           privacyMode={privacyMode}
         />
@@ -742,7 +742,7 @@ const MoneyHomeView = () => {
                   COMPONENT_NAMES.MONEY_HOW_IT_WORKS_SECTION_HEADER,
               })
             }
-            isLoading={vaultApyQuery.isLoading}
+            isLoading={isApyLoading}
           />
           <MoneyMusdTokenRow
             onPress={() =>

--- a/app/components/UI/Money/components/BalanceProjection/BalanceProjection.test.tsx
+++ b/app/components/UI/Money/components/BalanceProjection/BalanceProjection.test.tsx
@@ -53,7 +53,7 @@ function mockBalance({
   useMoneyAccountBalanceMock.mockReturnValue({
     apyDecimal,
     apyPercent,
-    vaultApyQuery: { isLoading },
+    isApyLoading: isLoading,
   } as unknown as ReturnType<typeof useMoneyAccountBalance>);
 }
 

--- a/app/components/UI/Money/components/BalanceProjection/BalanceProjection.tsx
+++ b/app/components/UI/Money/components/BalanceProjection/BalanceProjection.tsx
@@ -38,7 +38,7 @@ export function BalanceProjection({
   projectedYears,
 }: BalanceProjectionProps) {
   const navigation = useNavigation();
-  const { vaultApyQuery, apyDecimal, apyPercent } = useMoneyAccountBalance();
+  const { isApyLoading, apyDecimal, apyPercent } = useMoneyAccountBalance();
   const formatFiat = useFiatFormatter();
   const { trackTooltipClicked } = useMoneyAnalytics({
     screen_name: SCREEN_NAMES.MONEY_DEPOSIT,
@@ -83,7 +83,7 @@ export function BalanceProjection({
     });
   }, [navigation, trackTooltipClicked]);
 
-  if (vaultApyQuery.isLoading) {
+  if (isApyLoading) {
     return (
       <View testID="balance-projection-skeleton">
         <Skeleton height={20} width={160} />

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -122,10 +122,7 @@ const createBalanceMock = (
     apyDecimal: 0.04,
     apyPercent: 4,
     apyPercentFormatted: '4%',
-    vaultApyQuery: {
-      data: { apy: 0.04, timestamp: '2026-01-01T00:00:00Z' },
-      isLoading: false,
-    },
+    isApyLoading: false,
     moneyBalanceQuery: {
       data: {
         musdBalance: '1000000000',
@@ -577,10 +574,8 @@ describe('MoneyBalanceCard', () => {
     it('renders APY skeleton when APY is loading', () => {
       mockUseMoneyAccountBalance.mockReturnValue(
         createBalanceMock({
-          vaultApyQuery: {
-            data: undefined,
-            isLoading: true,
-          } as ReturnType<typeof useMoneyAccountBalance>['vaultApyQuery'],
+          apyPercent: undefined,
+          isApyLoading: true,
         }),
       );
 

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -61,7 +61,7 @@ const MoneyBalanceCard = () => {
     isBalanceFetchError,
     isBalanceFetching,
     refetchBalance,
-    vaultApyQuery,
+    isApyLoading,
   } = useMoneyAccountBalance();
   const { hasMoneyAccount } = useMoneyAccountInfo();
   const { navigateToMoneyHome } = useMoneyNavigation();
@@ -310,7 +310,7 @@ const MoneyBalanceCard = () => {
           twClassName="gap-2"
         >
           {renderBalanceSlot()}
-          {vaultApyQuery.isLoading ? (
+          {isApyLoading ? (
             <Skeleton
               height={20}
               width={60}

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -522,6 +522,141 @@ describe('useMoneyAccountBalance', () => {
     });
   });
 
+  // The data-service bridge can remove the vault APY query out from under an
+  // active observer (service-side cache GC publishes a "removed" event that
+  // `createUIQueryClient` honours), leaving the rebuilt query with
+  // `data: undefined` / `isLoading: true`. The hook carries the last live APY
+  // across such windows so the UI never loses an APY it has already shown.
+  describe('last-known APY carry', () => {
+    it('keeps the last live APY when the query transiently loses its data and reloads', () => {
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.05 },
+        isLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() => useMoneyAccountBalance());
+      expect(result.current.apyDecimal).toBe(0.05);
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+      rerender(undefined);
+
+      expect(result.current.apyDecimal).toBe(0.05);
+      expect(result.current.apyPercent).toBe(5);
+      expect(result.current.apyPercentFormatted).toBe('5%');
+    });
+
+    it('prefers the carried live APY over the fallback when the query later errors', () => {
+      setupDefaultSelectors({
+        remoteApyConfig: {
+          vaultApyFallback: 0.04,
+          vaultApyOverride: undefined,
+        },
+      });
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.05 },
+        isLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() => useMoneyAccountBalance());
+      expect(result.current.apyDecimal).toBe(0.05);
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+      rerender(undefined);
+
+      expect(result.current.apyDecimal).toBe(0.05);
+    });
+
+    it('still yields to vaultApyOverride when a carried value exists', () => {
+      setupDefaultSelectors({
+        remoteApyConfig: {
+          vaultApyFallback: undefined,
+          vaultApyOverride: 0.08,
+        },
+      });
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.05 },
+        isLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() => useMoneyAccountBalance());
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: true,
+      });
+      rerender(undefined);
+
+      expect(result.current.apyDecimal).toBe(0.08);
+    });
+
+    it('updates the carried value when a fresh live APY arrives', () => {
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.05 },
+        isLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() => useMoneyAccountBalance());
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.06 },
+        isLoading: false,
+      });
+      rerender(undefined);
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: true,
+      });
+      rerender(undefined);
+
+      expect(result.current.apyDecimal).toBe(0.06);
+    });
+  });
+
+  describe('isApyLoading', () => {
+    it('is true while the query loads with no APY available from any source', () => {
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: true,
+      });
+
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.isApyLoading).toBe(true);
+    });
+
+    it('is false once the query has settled with data', () => {
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.isApyLoading).toBe(false);
+    });
+
+    it('is false while the query reloads with a carried last-known APY', () => {
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: { apy: 0.05 },
+        isLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() => useMoneyAccountBalance());
+
+      setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+        data: undefined,
+        isLoading: true,
+      });
+      rerender(undefined);
+
+      expect(result.current.isApyLoading).toBe(false);
+    });
+  });
+
   it('collapses sub-cent total fiat to $0.00 when both balances are 1 minimal unit', () => {
     setupDefaultQueries({
       data: {

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   type MoneyAccountBalanceResponse,
   type NormalizedVaultApyResponse,
@@ -52,6 +52,15 @@ interface UseMoneyAccountBalanceResult {
   apyDecimal: number | undefined;
   apyPercent: number | undefined;
   apyPercentFormatted: string | undefined;
+  /**
+   * True while the APY query is loading and no APY of any kind is available
+   * (no live value, no carried last-known value, no override, no fallback).
+   * Prefer this over `vaultApyQuery.isLoading` for skeletons: the raw flag
+   * flips back to true whenever the bridge bug (see the last-known carry
+   * below) rebuilds the query, which would flicker UI that already has an
+   * APY to show.
+   */
+  isApyLoading: boolean;
 }
 
 const useMoneyAccountBalance = (
@@ -197,7 +206,22 @@ const useMoneyAccountBalance = (
     ? lastKnownBalance.value
     : undefined;
 
-  const serviceApy = vaultApyQuery.data?.apy;
+  const liveServiceApy = vaultApyQuery.data?.apy;
+
+  // Currently `BaseDataService` in core clears cached data every 5 minutes
+  // even if it's actively observed. When the component using this hook re-renders
+  // this lead to `data:undefined` being returned.
+  //
+  // This should be properly fixed in core - but for the time being we've
+  // created this ref which holds onto the last known value - so in cases
+  // where we lose the underlying data we still render the last good value.
+  const lastKnownServiceApyRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (liveServiceApy !== undefined) {
+      lastKnownServiceApyRef.current = liveServiceApy;
+    }
+  }, [liveServiceApy]);
+  const serviceApy = liveServiceApy ?? lastKnownServiceApyRef.current;
 
   // During first load with no cache, do not show fallback to avoid flicker.
   // Show fallback on explicit APY query errors (service outage path) or when
@@ -224,6 +248,8 @@ const useMoneyAccountBalance = (
   const apyPercentFormatted =
     apyPercent !== undefined ? `${apyPercent}%` : undefined;
 
+  const isApyLoading = vaultApyQuery.isLoading && apyDecimal === undefined;
+
   return {
     moneyBalanceQuery,
     vaultApyQuery,
@@ -242,6 +268,7 @@ const useMoneyAccountBalance = (
     apyDecimal,
     apyPercent,
     apyPercentFormatted,
+    isApyLoading,
   };
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This is a fix to prevent the APY row from disappearing after users sat on the money home page for a while.

The root cause of that bug is that the @metamask/react-data-query library removes data from its cache even when UI components still observe that data. Because the money home re-renders every 30s when balances are fetched, when this data is removed the APY would disappear. We poll for APY every 5 minutes, so it would eventually re-appear - but there was a gap where no data exists.

I think the long term fix is to prevent the core library from removing observed data from the cache - but in the interest of fixing this user facing bug, we are now storing the most recently observed APY value in component state and using that if the value disappears.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix disappearing money account APY row

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1128

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how APY is derived and when loading skeletons show across Money surfaces; incorrect carry or loading logic could misstate APY briefly, but scope is localized with new tests.
> 
> **Overview**
> Fixes the Money home APY row vanishing after users stay on the screen while the vault APY query cache is cleared under active observers (react-data-query / `BaseDataService` behavior).
> 
> **`useMoneyAccountBalance`** now keeps the last successful live vault APY in a ref and uses it when query `data` drops to `undefined`, while still honoring override/fallback rules. It exposes **`isApyLoading`** (loading only when no APY is available from any source) so skeletons do not flicker during transient reloads.
> 
> **Money home**, **balance card**, and **balance projection** switch from `vaultApyQuery.isLoading` to `isApyLoading`. Hook tests cover last-known carry, override precedence, and loading semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89323919a3cd063ed149f3ed65df22af6a8aec66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->