### PR TITLE
chore: migrate Jest preset to @react-native/jest-preset

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,10 @@ process.env.MM_CARD_BAANX_API_CLIENT_KEY = 'test-api-key';
 const isReassureRun = process.env.REASSURE === 'true';
 
 const config = {
-  preset: 'react-native',
+  // RN 0.85 removes the bundled 'react-native' Jest preset in favor of the
+  // extracted '@react-native/jest-preset' package (functionally identical on
+  // RN 0.83). Landed pre-upgrade so the RN 0.85 upgrade PR stays minimal.
+  preset: '@react-native/jest-preset',
   setupFilesAfterEnv: ['<rootDir>/app/util/test/testSetup.js'],
   testEnvironment: 'jest-environment-node',
   transformIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -599,6 +599,7 @@
     "@open-rpc/schema-utils-js": "^1.16.2",
     "@open-rpc/test-coverage": "^2.2.2",
     "@playwright/test": "^1.57.0",
+    "@react-native/jest-preset": "0.85.3",
     "@react-native/metro-config": "0.83.0",
     "@storybook/addon-controls": "^7.5.1",
     "@storybook/addon-ondevice-controls": "^6.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13264,6 +13264,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/jest-preset@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/jest-preset@npm:0.85.3"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^29.7.0"
+    "@react-native/js-polyfills": "npm:0.85.3"
+    babel-jest: "npm:^29.7.0"
+    jest-environment-node: "npm:^29.7.0"
+    regenerator-runtime: "npm:^0.13.2"
+  peerDependencies:
+    react: ^19.2.3
+  checksum: 10/663cfa48b0a9b18d965d6d107cb9a799262326ab7b17bb508ba27f98be23e01301f02cce290256ca2c3e844da752bfdb8f485c94821f96ac1ec59486c9dbb4ef
+  languageName: node
+  linkType: hard
+
 "@react-native/js-polyfills@npm:0.83.0":
   version: 0.83.0
   resolution: "@react-native/js-polyfills@npm:0.83.0"
@@ -13275,6 +13290,13 @@ __metadata:
   version: 0.83.6
   resolution: "@react-native/js-polyfills@npm:0.83.6"
   checksum: 10/455dd7f69ec7b187790c3a2db1bc128199cf340ea36702ebaaee87d37c20dbbcbf75c69c0c91e82f4b320af9bb7a70fe537b0842454f2add2040902edfdaf164
+  languageName: node
+  linkType: hard
+
+"@react-native/js-polyfills@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/js-polyfills@npm:0.85.3"
+  checksum: 10/17eedd2497c128f5c575f3804e2f23c441285e88a64522d740809588d93d11aade5069b3f20edec43715a8aecc3b90e816847e3ff91565bd35a9b692701265a1
   languageName: node
   linkType: hard
 
@@ -35965,6 +35987,7 @@ __metadata:
     "@react-native-masked-view/masked-view": "npm:^0.3.1"
     "@react-native/babel-preset": "npm:0.83.0"
     "@react-native/eslint-config": "npm:0.83.0"
+    "@react-native/jest-preset": "npm:0.85.3"
     "@react-native/metro-config": "npm:0.83.0"
     "@react-native/typescript-config": "npm:0.83.0"
     "@react-navigation/bottom-tabs": "npm:^6.5.0"


### PR DESCRIPTION

  ## **Description**

  <!-- mms-check: type=text required=true -->

  RN 0.85 removes the Jest preset bundled inside the `react-native` package (`preset: 'react-native'`) — after the upgrade, every unit test would
  fail to run. The preset was extracted into a standalone `@react-native/jest-preset` package (first published at 0.85.0).

  This PR migrates us to the extracted preset ahead of the upgrade (Wave 1 of the RN 0.85 pre-upgrade PR ladder):

  - Adds `@react-native/jest-preset` pinned to **0.85.3** — exactly the RN version the upgrade targets, so the upgrade PR needs no follow-up bump
  here.
  - Switches `jest.config.js` `preset: 'react-native'` → `'@react-native/jest-preset'`.

  **Why this is safe on RN 0.83.6 today:** the 0.85.3 package contents were diffed against RN 0.83.6's bundled `jest/` directory — `resolver.js`,
  `react-native-env.js`, and all mocks are byte-identical; `setup.js` differs only in module paths being package-qualified
  (`react-native/Libraries/...` instead of `../Libraries/...`), resolved against whichever RN version is installed. No other config in the repo uses
   the old preset, and no app code imports `react-native/jest/*`. Verified locally with 20 suites / 226 tests green (component-library,
  native-mock-heavy UI components, and util suites); full unit test suite runs in CI on this PR.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  CHANGELOG entry: null

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Refs: <link to RN 0.85 upgrade ticket/epic>

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  Test-infrastructure-only change — no app runtime code touched. The unit test suite itself is the verification:

  ```gherkin
  Feature: Jest unit test suite runs on the extracted preset

    Scenario: developer runs the unit test suite
      Given the branch is checked out and yarn setup has completed

      When the developer runs "yarn test:unit"
      Then all unit tests pass identically to main
      And no test setup/mock resolution errors occur
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  ### **Before**

  N/A — tooling-only change, no UI impact. Evidence is the green unit-test CI check.

  ### **After**

  N/A — see above.

  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
  Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling
  guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external
  contributors.

  #### Performance checks (if applicable)

  - [ ] I've tested on Android
  - [ ] I've tested with a power user scenario
  - [ ] I've instrumented key operations with Sentry traces for production performance metrics

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such
  as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-tooling-only change; risk is limited to CI/local unit test behavior, with no production app code touched.
> 
> **Overview**
> Prepares for React Native 0.85 by moving unit tests off the deprecated `preset: 'react-native'` bundled in the `react-native` package.
> 
> **`jest.config.js`** now uses `@react-native/jest-preset`, with a short comment that this matches the RN 0.85 extraction and was landed early so the upgrade PR stays small. **`package.json`** adds **`@react-native/jest-preset@0.85.3`** as a devDependency (aligned with the target RN version); **`yarn.lock`** records that package and its **`@react-native/js-polyfills@0.85.3`** dependency. No app runtime or custom Jest setup files beyond the preset string change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbbabaf2eaa736c8622cc29216a2890e9875ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->