### PR TITLE
fix: raw token amounts shown in asset details activity list

### DIFF
--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -10,6 +10,9 @@ import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { selectIsTransactionsRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
+import { selectAllTokens } from '../../../selectors/tokensController';
 import type { TransactionWithImportTime } from './AssetDetailsActivityListItem.utils';
 import { resolveActivityListItemTitle } from '../ActivityListItemRow/ActivityListItemRow';
 
@@ -70,10 +73,38 @@ const createTransaction = (
 describe('AssetDetailsActivityListItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectSelectedInternalAccount) {
         return { metadata: { importTime: 2000 } };
       }
+
+      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
+        return { address: '0x123' };
+      }
+
+      if (selector === selectEvmNetworkConfigurationsByChainId) {
+        return {
+          '0x1': {
+            nativeCurrency: 'ETH',
+          },
+        };
+      }
+
+      if (selector === selectAllTokens) {
+        return {
+          '0x1': {
+            '0x123': [
+              {
+                address: '0x456',
+                symbol: 'USDC',
+                decimals: 6,
+              },
+            ],
+          },
+        };
+      }
+
       return undefined;
     });
   });
@@ -109,8 +140,26 @@ describe('AssetDetailsActivityListItem', () => {
       if (selector === selectSelectedInternalAccount) {
         return { metadata: { importTime: null } };
       }
+
+      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
+        return { address: '0x123' };
+      }
+
+      if (selector === selectEvmNetworkConfigurationsByChainId) {
+        return {
+          '0x1': {
+            nativeCurrency: 'ETH',
+          },
+        };
+      }
+
+      if (selector === selectAllTokens) {
+        return {};
+      }
+
       return undefined;
     });
+
     const navigation = createNavigation();
     const transaction = createTransaction({ insertImportTime: true });
 
@@ -136,11 +185,30 @@ describe('AssetDetailsActivityListItem', () => {
       if (selector === selectSelectedInternalAccount) {
         return { metadata: { importTime: 2000 } };
       }
+
+      if (selector === selectSelectedAccountGroupEvmInternalAccount) {
+        return { address: '0x123' };
+      }
+
+      if (selector === selectEvmNetworkConfigurationsByChainId) {
+        return {
+          '0x1': {
+            nativeCurrency: 'ETH',
+          },
+        };
+      }
+
+      if (selector === selectAllTokens) {
+        return {};
+      }
+
       if (selector === selectIsTransactionsRedesignEnabled) {
         return true;
       }
+
       return undefined;
     });
+
     const navigation = createNavigation();
     const transaction = createTransaction();
 
@@ -205,5 +273,22 @@ describe('AssetDetailsActivityListItem', () => {
         }),
       }),
     );
+  });
+
+  it('renders successfully when token metadata is resolved from the selected account group EVM account', () => {
+    const navigation = createNavigation();
+    expect(() =>
+      render(
+        <AssetDetailsActivityListItem
+          transaction={createTransaction()}
+          index={0}
+          assetSymbol="ETH"
+          chainId="0x1"
+          navigation={navigation}
+          onSpeedUpAction={jest.fn()}
+          onCancelAction={jest.fn()}
+        />,
+      ),
+    ).not.toThrow();
   });
 });

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
@@ -22,6 +22,9 @@ import {
   mapTransactionToActivityItem,
   type TransactionWithImportTime,
 } from './AssetDetailsActivityListItem.utils';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../selectors/networkController';
+import { selectAllTokens } from '../../../selectors/tokensController';
+import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
 
 interface AssetDetailsActivityListItemProps {
   transaction: TransactionWithImportTime;
@@ -44,21 +47,63 @@ export const AssetDetailsActivityListItem = ({
   onSpeedUpAction,
   onCancelAction,
 }: AssetDetailsActivityListItemProps) => {
+  // Kept for importTime metadata
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
+  // Used for TokensController lookups (matches useLocalActivityItems)
+  const groupEvmAccount = useSelector(
+    selectSelectedAccountGroupEvmInternalAccount,
+  );
   const isTransactionsRedesignEnabled = useSelector(
     selectIsTransactionsRedesignEnabled,
   );
-  const accountImportTime = selectedInternalAccount?.metadata.importTime;
-  const activityItem = useMemo(
-    () =>
-      mapTransactionToActivityItem({
-        transaction: tx,
-        assetSymbol,
-        currentChainId,
-        tokenChainId,
-      }),
-    [assetSymbol, currentChainId, tokenChainId, tx],
+
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
   );
+  // allTokens: Record<chainId, Record<accountAddress, Token[]>>
+  const allTokens = useSelector(selectAllTokens) as unknown as Record<
+    string,
+    Record<string, { address: string; symbol?: string; decimals?: number }[]>
+  >;
+  const accountImportTime = selectedInternalAccount?.metadata.importTime;
+  const activityItem = useMemo(() => {
+    const resolvedChainId = (tx.chainId ?? tokenChainId ?? currentChainId) as
+      | Hex
+      | undefined;
+
+    const nativeAssetSymbol = resolvedChainId
+      ? networkConfigurations?.[resolvedChainId]?.nativeCurrency
+      : undefined;
+
+    // Token metadata for the tx's target contract, from TokensController —
+    // same enrichment as useLocalActivityItems.
+    const accountAddress = groupEvmAccount?.address?.toLowerCase();
+    const contractAddress = tx.txParams?.to?.toLowerCase();
+    const matchingToken =
+      resolvedChainId && accountAddress && contractAddress
+        ? (allTokens[resolvedChainId]?.[accountAddress] ?? []).find(
+            (t) => t.address?.toLowerCase() === contractAddress,
+          )
+        : undefined;
+
+    return mapTransactionToActivityItem({
+      transaction: tx,
+      assetSymbol: matchingToken?.symbol ?? assetSymbol,
+      assetDecimals: matchingToken?.decimals,
+      assetAddress: matchingToken ? contractAddress : undefined,
+      nativeAssetSymbol,
+      currentChainId,
+      tokenChainId,
+    });
+  }, [
+    allTokens,
+    assetSymbol,
+    currentChainId,
+    groupEvmAccount?.address,
+    networkConfigurations,
+    tokenChainId,
+    tx,
+  ]);
 
   const handlePress = useCallback(
     (item: ActivityListItem) => {

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.test.ts
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.test.ts
@@ -95,4 +95,140 @@ describe('AssetDetailsActivityListItem utils', () => {
       showCancelModal,
     });
   });
+
+  describe('contractTokenMetadata enrichment', () => {
+    const USDG_ADDRESS = '0x5fc5360d0400a0fd4f2af552add042d716f1d168';
+    const USDG_ADDRESS_CHECKSUMMED =
+      '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168';
+
+    const createTokenTransfer = (
+      overrides: Partial<TransactionWithImportTime> = {},
+    ) =>
+      createTransaction({
+        type: TransactionType.tokenMethodTransfer,
+        txParams: {
+          from: '0x123',
+          to: USDG_ADDRESS,
+          value: '0x0',
+          data: '0xa9059cbb0000000000000000000000000000000000000000000000000000000000000456',
+        },
+        ...overrides,
+      });
+
+    const expectLocalTransaction = (
+      item: ReturnType<typeof mapTransactionToActivityItem>,
+    ) => {
+      if (item.raw?.type !== 'localTransaction') {
+        throw new Error('Expected local transaction activity item');
+      }
+      return item.raw.data;
+    };
+
+    it('attaches contractTokenMetadata when the tx targets the asset contract', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTokenTransfer(),
+        assetSymbol: 'USDG',
+        assetDecimals: 6,
+        assetAddress: USDG_ADDRESS,
+        nativeAssetSymbol: 'ETH',
+        currentChainId: '0x1237',
+      });
+
+      const data = expectLocalTransaction(item);
+      expect(data.contractTokenMetadata).toStrictEqual({
+        symbol: 'USDG',
+        decimals: 6,
+      });
+    });
+
+    it('matches assetAddress case-insensitively (checksummed vs lowercase)', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTokenTransfer(),
+        assetSymbol: 'USDG',
+        assetDecimals: 6,
+        assetAddress: USDG_ADDRESS_CHECKSUMMED,
+        nativeAssetSymbol: 'ETH',
+        currentChainId: '0x1237',
+      });
+
+      expect(expectLocalTransaction(item).contractTokenMetadata).toStrictEqual({
+        symbol: 'USDG',
+        decimals: 6,
+      });
+    });
+
+    it('does not attach contractTokenMetadata when the tx targets another contract', () => {
+      const item = mapTransactionToActivityItem({
+        // to: 0x456 — e.g. a router/swap call on the asset page
+        transaction: createTransaction(),
+        assetSymbol: 'USDG',
+        assetDecimals: 6,
+        assetAddress: USDG_ADDRESS,
+        nativeAssetSymbol: 'ETH',
+        currentChainId: '0x1237',
+      });
+
+      expect(
+        expectLocalTransaction(item).contractTokenMetadata,
+      ).toBeUndefined();
+    });
+
+    it('does not attach contractTokenMetadata when assetAddress is not provided (legacy call)', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTokenTransfer(),
+        assetSymbol: 'USDG',
+        currentChainId: '0x1237',
+      });
+
+      expect(
+        expectLocalTransaction(item).contractTokenMetadata,
+      ).toBeUndefined();
+    });
+
+    it('does not attach contractTokenMetadata when txParams.to is undefined (contract deployment)', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTransaction({
+          txParams: { from: '0x123', value: '0x0' },
+        }),
+        assetSymbol: 'USDG',
+        assetDecimals: 6,
+        assetAddress: USDG_ADDRESS,
+        nativeAssetSymbol: 'ETH',
+        currentChainId: '0x1237',
+      });
+
+      expect(
+        expectLocalTransaction(item).contractTokenMetadata,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('nativeAssetSymbol resolution', () => {
+    it('uses the explicit nativeAssetSymbol when provided', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTransaction(),
+        assetSymbol: 'USDG',
+        nativeAssetSymbol: 'ETH',
+        currentChainId: '0x1237',
+      });
+
+      if (item.raw?.type !== 'localTransaction') {
+        throw new Error('Expected local transaction activity item');
+      }
+      expect(item.raw.data.nativeAssetSymbol).toBe('ETH');
+    });
+
+    it('falls back to assetSymbol when nativeAssetSymbol is absent (legacy behavior)', () => {
+      const item = mapTransactionToActivityItem({
+        transaction: createTransaction(),
+        assetSymbol: 'USDG',
+        currentChainId: '0x1237',
+      });
+
+      if (item.raw?.type !== 'localTransaction') {
+        throw new Error('Expected local transaction activity item');
+      }
+      expect(item.raw.data.nativeAssetSymbol).toBe('USDG');
+    });
+  });
 });

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
@@ -17,11 +17,17 @@ export { getActivityFromTo, getActivityValue };
 export const mapTransactionToActivityItem = ({
   transaction: tx,
   assetSymbol,
+  assetDecimals,
+  assetAddress,
+  nativeAssetSymbol,
   currentChainId,
   tokenChainId,
 }: {
   transaction: TransactionWithImportTime;
   assetSymbol?: string;
+  assetDecimals?: number;
+  assetAddress?: string;
+  nativeAssetSymbol?: string;
   currentChainId?: Hex;
   tokenChainId?: Hex;
 }) => {
@@ -34,10 +40,29 @@ export const mapTransactionToActivityItem = ({
       chainId: tx.txParams?.chainId ?? chainId,
     },
   };
+
+  // Attach the asset's metadata only when the tx targets its contract
+  // (transfer/approve: txParams.to === token address), mirroring the
+  // enrichment in useLocalActivityItems. Prevents mislabeling router/swap
+  // txs with this token's decimals.
+  const isAssetContractTx =
+    assetAddress !== undefined &&
+    transaction.txParams?.to?.toLowerCase() === assetAddress.toLowerCase();
+
   const transactionGroup: TransactionGroup = {
     initialTransaction: transaction,
     primaryTransaction: transaction,
-    nativeAssetSymbol: assetSymbol,
+    // Legacy callers passed the asset symbol here; keep that behavior when no
+    // explicit native symbol is provided.
+    nativeAssetSymbol: nativeAssetSymbol ?? assetSymbol,
+    ...(isAssetContractTx
+      ? {
+          contractTokenMetadata: {
+            symbol: assetSymbol,
+            decimals: assetDecimals,
+          },
+        }
+      : {}),
   };
 
   return mapLocalTransaction(transactionGroup);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Context

Token amounts on the asset details activity list rendered in raw base units
(e.g. `500 USDG` instead of `0.0005 USDG`) for any token absent from the
static registries (`STATIC_MAINNET_TOKEN_LIST`, `BRIDGE_CHAINID_COMMON_TOKEN_PAIR`).
The main activity tab was unaffected: `useLocalActivityItems` enriches groups
with `contractTokenMetadata` from TokensController, but the asset details path
called `mapLocalTransaction` bare. It also passed the asset's symbol as
`nativeAssetSymbol`, mislabeling native/fee legs.

### Changes

- `AssetDetailsActivityListItem`: resolve `symbol`/`decimals` from
  TokensController for the tx target contract (same pattern as the activity tab),
  and pass the chain's actual native currency.
- `mapTransactionToActivityItem`: new optional params feed
  `contractTokenMetadata`, gated on `txParams.to === assetAddress`.
  Legacy calls are byte-identical (`nativeAssetSymbol ?? assetSymbol` fallback).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix raw token amounts shown in asset details activity list

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1589

## **Manual testing steps**

- Send some token that don't have 18 decimals, such as USDG on Robinhood Chain or USDC on Polygon -> Then Activity row from the Token Page should display with correct decimal places.
- Send some token with 18 decimals as well as some native tokens (ex: ETH on Base) to verify there is no regression with other tokens.
- Check the "network activity tab" as well for each case to check that no regression is introduced there either.

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="356" alt="image" src="https://github.com/user-attachments/assets/1ef3bed4-9e97-4fca-9d2e-f37925cfdc27" />


### **After**

<!-- [screenshots/recordings] -->

<img width="356" alt="image" src="https://github.com/user-attachments/assets/40d31759-eb34-48c4-8922-39e4f58cd820" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI mapping and display logic with backward-compatible optional parameters and broad unit test coverage; no auth, signing, or persistence changes.
> 
> **Overview**
> Fixes **raw base-unit token amounts** (e.g. `500 USDG` instead of `0.0005 USDG`) on the asset details activity list for tokens not in static registries, by aligning enrichment with the main activity tab.
> 
> **`AssetDetailsActivityListItem`** now reads **TokensController** (`selectAllTokens`), the **selected account group EVM account**, and **network native currency** before mapping each row. It resolves symbol/decimals for the transaction’s `txParams.to` contract and passes the chain’s real native symbol instead of reusing the page asset symbol for fees.
> 
> **`mapTransactionToActivityItem`** accepts optional `assetDecimals`, `assetAddress`, and `nativeAssetSymbol`. It sets **`contractTokenMetadata`** only when `txParams.to` matches `assetAddress` (transfers/approves), avoiding wrong decimals on router/swap txs. Callers without the new args keep prior behavior via `nativeAssetSymbol ?? assetSymbol`.
> 
> Tests cover metadata gating, case-insensitive address matching, native symbol resolution, and updated component selector mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1815f48b3abad2ac150f3c51736fdd8f450262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->