### PR TITLE
fix: inject Sentry Debug IDs during Metro bundling

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -59,227 +59,232 @@ module.exports = function (baseConfig) {
         baseConfig,
         getExpoDefaultConfig(projectRoot, options),
       );
-  const {
-    resolver: { assetExts, sourceExts },
-  } = defaultConfig;
-  // IS_PERFORMANCE_TEST opts out of E2E startup overhead (ReadOnlyNetworkStore,
-  // command polling, Sentry mock) while keeping METAMASK_ENVIRONMENT='e2e' so
-  // the build still works on feature branches with e2e signing/secrets.
-  const isPerformanceTest = process.env.IS_PERFORMANCE_TEST === 'true';
-  const hasTestOverrides =
-    !isPerformanceTest && process.env.HAS_TEST_OVERRIDES === 'true';
+      const {
+        resolver: { assetExts, sourceExts },
+      } = defaultConfig;
+      // IS_PERFORMANCE_TEST opts out of E2E startup overhead (ReadOnlyNetworkStore,
+      // command polling, Sentry mock) while keeping METAMASK_ENVIRONMENT='e2e' so
+      // the build still works on feature branches with e2e signing/secrets.
+      const isPerformanceTest = process.env.IS_PERFORMANCE_TEST === 'true';
+      const hasTestOverrides =
+        !isPerformanceTest && process.env.HAS_TEST_OVERRIDES === 'true';
 
-  /**
-   * E2E Metro redirects under tests/module-mocking.
-   * Enables both: seedless-onboarding-controller + OAuthLoginHandlers mocks.
-   * True when HAS_TEST_OVERRIDES OR E2E_MOCK_OAUTH.
-   * Performance builds set E2E_MOCK_OAUTH=true to keep this mock active
-   * even though hasTestOverrides is false (preventing real OAuth calls to production).
-   */
-  const isE2EMockOAuth = process.env.E2E_MOCK_OAUTH === 'true';
+      /**
+       * E2E Metro redirects under tests/module-mocking.
+       * Enables both: seedless-onboarding-controller + OAuthLoginHandlers mocks.
+       * True when HAS_TEST_OVERRIDES OR E2E_MOCK_OAUTH.
+       * Performance builds set E2E_MOCK_OAUTH=true to keep this mock active
+       * even though hasTestOverrides is false (preventing real OAuth calls to production).
+       */
+      const isE2EMockOAuth = process.env.E2E_MOCK_OAUTH === 'true';
 
-  const e2eAllowsSeedlessOAuthMetroMocks = hasTestOverrides || isE2EMockOAuth;
+      const e2eAllowsSeedlessOAuthMetroMocks =
+        hasTestOverrides || isE2EMockOAuth;
 
-  // For less powerful machines, leave room to do other tasks. For instance,
-  // if you have 10 cores but only 16GB, only 3 workers would get used.
-  // Also forces maxWorkers value to be no less than 2, ensuring
-  // worker code runs concurrently and not on the main Metro process
-  //
-  // CI Override: Set METRO_MAX_WORKERS env var to limit workers on constrained runners
-  // Example: METRO_MAX_WORKERS=4 for 48GB runners to prevent OOM kills
-  const maxWorkers = process.env.METRO_MAX_WORKERS
-    ? Math.max(2, parseInt(process.env.METRO_MAX_WORKERS, 10))
-    : Math.ceil(
-        Math.max(
-          2,
-          os.availableParallelism() *
-            Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024)),
-        ),
-      );
-
-  return wrapWithReanimatedMetroConfig(
-    mergeConfig(defaultConfig, {
-      resolver: {
-        unstable_enablePackageExports: true,
-        assetExts: [...assetExts.filter((ext) => ext !== 'svg'), 'riv'],
-        sourceExts: [...sourceExts, 'svg', 'cjs', 'mjs'],
-        resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],
-        extraNodeModules: {
-          ...defaultConfig.resolver.extraNodeModules,
-          'node:crypto': require.resolve('react-native-crypto'),
-          crypto: require.resolve('react-native-crypto'),
-          stream: require.resolve('stream-browserify'),
-          _stream_transform: require.resolve('readable-stream/transform'),
-          _stream_readable: require.resolve('readable-stream/readable'),
-          _stream_writable: require.resolve('readable-stream/writable'),
-          _stream_duplex: require.resolve('readable-stream/duplex'),
-          _stream_passthrough: require.resolve('readable-stream/passthrough'),
-          http: require.resolve('@tradle/react-native-http'),
-          https: require.resolve('https-browserify'),
-          vm: require.resolve('vm-browserify'),
-          os: require.resolve('react-native-os'),
-          zlib: require.resolve('browserify-zlib'),
-          net: require.resolve('react-native-tcp-socket'),
-          fs: require.resolve('react-native-level-fs'),
-          images: path.resolve(__dirname, 'app/images'),
-          'base64-js': 'react-native-quick-base64',
-          base64: 'react-native-quick-base64',
-          'js-base64': 'react-native-quick-base64',
-          buffer: '@craftzdog/react-native-buffer',
-          'node:buffer': '@craftzdog/react-native-buffer',
-        },
-        resolveRequest: (context, moduleName, platform) => {
-          // MYXProvider is intentionally excluded from @metamask/perps-controller's
-          // published dist (extension-only). The dynamic import() uses webpackIgnore
-          // but babel's dynamicImportToRequire rewrites it to require(), causing Metro
-          // to resolve it statically. Return an empty module stub.
-          if (
-            moduleName === './providers/MYXProvider' &&
-            context.originModulePath?.includes('@metamask/perps-controller')
-          ) {
-            return { type: 'empty' };
-          }
-          // @metamask/perps-controller@9.2.1's CJS build (standaloneInfoClient.cjs,
-          // HyperLiquidClientService.cjs) contains a leftover absolute file:// require
-          // from the package's own CI build machine instead of `@nktkas/hyperliquid`
-          // (the ESM build correctly imports `@nktkas/hyperliquid`, confirming this is
-          // a CJS-transpile bug in the published package). Redirect to the real package
-          // until upstream ships a patched release.
-          if (
-            moduleName ===
-              'file:///home/runner/work/hyperliquid/hyperliquid/src/mod.ts' &&
-            context.originModulePath?.includes('@metamask/perps-controller')
-          ) {
-            return context.resolveRequest(
-              context,
-              '@nktkas/hyperliquid',
-              platform,
-            );
-          }
-          // @ledgerhq packages use exports field subpath mapping (e.g. ./signers/index -> ./lib/signers/index.js)
-          // which doesn't work with unstable_enablePackageExports: false — manually replicate the lib/ mapping
-          // Affected: domain-service, evm-tools, devices, cryptoassets-evm-signatures
-          const ledgerhqSubpathMatch = moduleName.match(
-            /^(@ledgerhq\/[^/]+)\/(.+)$/,
+      // For less powerful machines, leave room to do other tasks. For instance,
+      // if you have 10 cores but only 16GB, only 3 workers would get used.
+      // Also forces maxWorkers value to be no less than 2, ensuring
+      // worker code runs concurrently and not on the main Metro process
+      //
+      // CI Override: Set METRO_MAX_WORKERS env var to limit workers on constrained runners
+      // Example: METRO_MAX_WORKERS=4 for 48GB runners to prevent OOM kills
+      const maxWorkers = process.env.METRO_MAX_WORKERS
+        ? Math.max(2, parseInt(process.env.METRO_MAX_WORKERS, 10))
+        : Math.ceil(
+            Math.max(
+              2,
+              os.availableParallelism() *
+                Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024)),
+            ),
           );
-          if (ledgerhqSubpathMatch) {
-            const [, pkgName, subpath] = ledgerhqSubpathMatch;
-            try {
-              return {
-                filePath: require.resolve(`${pkgName}/lib/${subpath}`),
-                type: 'sourceFile',
-              };
-            } catch {
-              // fall through to default resolution if lib/ mapping doesn't exist
-            }
-          }
-          // Use axios browser build so Node-only deps (e.g. http2) are never pulled in
-          if (
-            moduleName === 'axios' ||
-            moduleName.includes('axios/dist/node/')
-          ) {
-            return {
-              filePath: require.resolve('axios/dist/browser/axios.cjs'),
-              type: 'sourceFile',
-            };
-          }
-          // Use contentful browser build so Node-only built-ins (tty, zlib, etc.) are never pulled in
-          if (moduleName === 'contentful') {
-            return {
-              filePath: require.resolve(
-                'contentful/dist/contentful.browser.js',
+
+      return wrapWithReanimatedMetroConfig(
+        mergeConfig(defaultConfig, {
+          resolver: {
+            unstable_enablePackageExports: true,
+            assetExts: [...assetExts.filter((ext) => ext !== 'svg'), 'riv'],
+            sourceExts: [...sourceExts, 'svg', 'cjs', 'mjs'],
+            resolverMainFields: ['sbmodern', 'react-native', 'browser', 'main'],
+            extraNodeModules: {
+              ...defaultConfig.resolver.extraNodeModules,
+              'node:crypto': require.resolve('react-native-crypto'),
+              crypto: require.resolve('react-native-crypto'),
+              stream: require.resolve('stream-browserify'),
+              _stream_transform: require.resolve('readable-stream/transform'),
+              _stream_readable: require.resolve('readable-stream/readable'),
+              _stream_writable: require.resolve('readable-stream/writable'),
+              _stream_duplex: require.resolve('readable-stream/duplex'),
+              _stream_passthrough: require.resolve(
+                'readable-stream/passthrough',
               ),
-              type: 'sourceFile',
-            };
-          }
-          if (hasTestOverrides) {
-            if (moduleName === '@sentry/react-native') {
-              return {
-                type: 'sourceFile',
-                filePath: path.resolve(
-                  __dirname,
-                  'tests/module-mocking/sentry/react-native.ts',
-                ),
-              };
-            }
-            if (moduleName === '@sentry/core') {
-              return {
-                type: 'sourceFile',
-                filePath: path.resolve(
-                  __dirname,
-                  'tests/module-mocking/sentry/core.ts',
-                ),
-              };
-            }
-          }
-          if (e2eAllowsSeedlessOAuthMetroMocks) {
-            if (
-              moduleName.endsWith(
-                'controllers/seedless-onboarding-controller',
-              ) ||
-              moduleName.endsWith(
-                'controllers/seedless-onboarding-controller/index',
-              ) ||
-              moduleName === './seedless-onboarding-controller' ||
-              moduleName === '../seedless-onboarding-controller'
-            ) {
-              return {
-                type: 'sourceFile',
-                filePath: path.resolve(
-                  __dirname,
-                  'tests/module-mocking/seedless/index.ts',
-                ),
-              };
-            }
-            // Skips native Google/Apple UI; tokens still hit auth server (see module mock).
-            if (
-              moduleName.endsWith('OAuthService/OAuthLoginHandlers') ||
-              moduleName.endsWith('OAuthService/OAuthLoginHandlers/index') ||
-              moduleName === './OAuthLoginHandlers' ||
-              moduleName === '../OAuthLoginHandlers'
-            ) {
-              return {
-                type: 'sourceFile',
-                filePath: path.resolve(
-                  __dirname,
-                  'tests/module-mocking/oauth/OAuthLoginHandlers/index.ts',
-                ),
-              };
-            }
-          }
-          return context.resolveRequest(context, moduleName, platform);
-        },
-      },
-      transformer: {
-        babelTransformerPath: require.resolve('./metro.transform.js'),
-        assetPlugins: [
-          'react-native-svg-asset-plugin',
-          'expo-asset/tools/hashAssetFiles',
-        ],
-        svgAssetPlugin: {
-          pngCacheDir: '.png-cache',
-          scales: [1],
-          output: {
-            compressionLevel: 6,
+              http: require.resolve('@tradle/react-native-http'),
+              https: require.resolve('https-browserify'),
+              vm: require.resolve('vm-browserify'),
+              os: require.resolve('react-native-os'),
+              zlib: require.resolve('browserify-zlib'),
+              net: require.resolve('react-native-tcp-socket'),
+              fs: require.resolve('react-native-level-fs'),
+              images: path.resolve(__dirname, 'app/images'),
+              'base64-js': 'react-native-quick-base64',
+              base64: 'react-native-quick-base64',
+              'js-base64': 'react-native-quick-base64',
+              buffer: '@craftzdog/react-native-buffer',
+              'node:buffer': '@craftzdog/react-native-buffer',
+            },
+            resolveRequest: (context, moduleName, platform) => {
+              // MYXProvider is intentionally excluded from @metamask/perps-controller's
+              // published dist (extension-only). The dynamic import() uses webpackIgnore
+              // but babel's dynamicImportToRequire rewrites it to require(), causing Metro
+              // to resolve it statically. Return an empty module stub.
+              if (
+                moduleName === './providers/MYXProvider' &&
+                context.originModulePath?.includes('@metamask/perps-controller')
+              ) {
+                return { type: 'empty' };
+              }
+              // @metamask/perps-controller@9.2.1's CJS build (standaloneInfoClient.cjs,
+              // HyperLiquidClientService.cjs) contains a leftover absolute file:// require
+              // from the package's own CI build machine instead of `@nktkas/hyperliquid`
+              // (the ESM build correctly imports `@nktkas/hyperliquid`, confirming this is
+              // a CJS-transpile bug in the published package). Redirect to the real package
+              // until upstream ships a patched release.
+              if (
+                moduleName ===
+                  'file:///home/runner/work/hyperliquid/hyperliquid/src/mod.ts' &&
+                context.originModulePath?.includes('@metamask/perps-controller')
+              ) {
+                return context.resolveRequest(
+                  context,
+                  '@nktkas/hyperliquid',
+                  platform,
+                );
+              }
+              // @ledgerhq packages use exports field subpath mapping (e.g. ./signers/index -> ./lib/signers/index.js)
+              // which doesn't work with unstable_enablePackageExports: false — manually replicate the lib/ mapping
+              // Affected: domain-service, evm-tools, devices, cryptoassets-evm-signatures
+              const ledgerhqSubpathMatch = moduleName.match(
+                /^(@ledgerhq\/[^/]+)\/(.+)$/,
+              );
+              if (ledgerhqSubpathMatch) {
+                const [, pkgName, subpath] = ledgerhqSubpathMatch;
+                try {
+                  return {
+                    filePath: require.resolve(`${pkgName}/lib/${subpath}`),
+                    type: 'sourceFile',
+                  };
+                } catch {
+                  // fall through to default resolution if lib/ mapping doesn't exist
+                }
+              }
+              // Use axios browser build so Node-only deps (e.g. http2) are never pulled in
+              if (
+                moduleName === 'axios' ||
+                moduleName.includes('axios/dist/node/')
+              ) {
+                return {
+                  filePath: require.resolve('axios/dist/browser/axios.cjs'),
+                  type: 'sourceFile',
+                };
+              }
+              // Use contentful browser build so Node-only built-ins (tty, zlib, etc.) are never pulled in
+              if (moduleName === 'contentful') {
+                return {
+                  filePath: require.resolve(
+                    'contentful/dist/contentful.browser.js',
+                  ),
+                  type: 'sourceFile',
+                };
+              }
+              if (hasTestOverrides) {
+                if (moduleName === '@sentry/react-native') {
+                  return {
+                    type: 'sourceFile',
+                    filePath: path.resolve(
+                      __dirname,
+                      'tests/module-mocking/sentry/react-native.ts',
+                    ),
+                  };
+                }
+                if (moduleName === '@sentry/core') {
+                  return {
+                    type: 'sourceFile',
+                    filePath: path.resolve(
+                      __dirname,
+                      'tests/module-mocking/sentry/core.ts',
+                    ),
+                  };
+                }
+              }
+              if (e2eAllowsSeedlessOAuthMetroMocks) {
+                if (
+                  moduleName.endsWith(
+                    'controllers/seedless-onboarding-controller',
+                  ) ||
+                  moduleName.endsWith(
+                    'controllers/seedless-onboarding-controller/index',
+                  ) ||
+                  moduleName === './seedless-onboarding-controller' ||
+                  moduleName === '../seedless-onboarding-controller'
+                ) {
+                  return {
+                    type: 'sourceFile',
+                    filePath: path.resolve(
+                      __dirname,
+                      'tests/module-mocking/seedless/index.ts',
+                    ),
+                  };
+                }
+                // Skips native Google/Apple UI; tokens still hit auth server (see module mock).
+                if (
+                  moduleName.endsWith('OAuthService/OAuthLoginHandlers') ||
+                  moduleName.endsWith(
+                    'OAuthService/OAuthLoginHandlers/index',
+                  ) ||
+                  moduleName === './OAuthLoginHandlers' ||
+                  moduleName === '../OAuthLoginHandlers'
+                ) {
+                  return {
+                    type: 'sourceFile',
+                    filePath: path.resolve(
+                      __dirname,
+                      'tests/module-mocking/oauth/OAuthLoginHandlers/index.ts',
+                    ),
+                  };
+                }
+              }
+              return context.resolveRequest(context, moduleName, platform);
+            },
           },
-        },
-        getTransformOptions: async () => ({
-          transform: {
-            experimentalImportSupport: true,
-            inlineRequires: true,
+          transformer: {
+            babelTransformerPath: require.resolve('./metro.transform.js'),
+            assetPlugins: [
+              'react-native-svg-asset-plugin',
+              'expo-asset/tools/hashAssetFiles',
+            ],
+            svgAssetPlugin: {
+              pngCacheDir: '.png-cache',
+              scales: [1],
+              output: {
+                compressionLevel: 6,
+              },
+            },
+            getTransformOptions: async () => ({
+              transform: {
+                experimentalImportSupport: true,
+                inlineRequires: true,
+              },
+            }),
           },
+          serializer: lockdownSerializer(
+            { hermesRuntime: true },
+            {
+              getPolyfills,
+            },
+          ),
+          resetCache: process.env.METRO_RESET_CACHE !== 'false',
+          maxWorkers,
         }),
-      },
-      serializer: lockdownSerializer(
-        { hermesRuntime: true },
-        {
-          getPolyfills,
-        },
-      ),
-      resetCache: process.env.METRO_RESET_CACHE !== 'false',
-      maxWorkers,
-    }),
-  );
+      );
     },
   });
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -6,8 +6,9 @@
  * @type {import('metro-config').MetroConfig}
  */
 
-const { getDefaultConfig } = require('expo/metro-config');
+const { getDefaultConfig: getExpoDefaultConfig } = require('expo/metro-config');
 const { mergeConfig } = require('@react-native/metro-config');
+const { getSentryExpoConfig } = require('@sentry/react-native/metro');
 const { lockdownSerializer } = require('@lavamoat/react-native-lockdown');
 
 // eslint-disable-next-line import-x/no-nodejs-modules
@@ -52,7 +53,12 @@ const {
 } = require('react-native-reanimated/metro-config');
 
 module.exports = function (baseConfig) {
-  const defaultConfig = mergeConfig(baseConfig, getDefaultConfig(__dirname));
+  return getSentryExpoConfig(__dirname, {
+    getDefaultConfig: (projectRoot, options) => {
+      const defaultConfig = mergeConfig(
+        baseConfig,
+        getExpoDefaultConfig(projectRoot, options),
+      );
   const {
     resolver: { assetExts, sourceExts },
   } = defaultConfig;
@@ -274,4 +280,6 @@ module.exports = function (baseConfig) {
       maxWorkers,
     }),
   );
+    },
+  });
 };


### PR DESCRIPTION
## **Description**

Sentry source maps stopped resolving correctly around 8.1.0. Production errors show minified bundle locations instead of original TypeScript files, and breadcrumbs no longer point to the originating source file.

The RN 0.81.5 upgrade bumped `@sentry/react-native` from 6.x to 7.x, which relies on **Debug IDs** injected at Metro bundle time to match runtime errors to uploaded source maps. Source maps were still uploaded on prod/RC builds, but bundles were built without Debug IDs because the Sentry Metro plugin was never wired up.

This PR wraps our existing Metro config with `getSentryExpoConfig` from `@sentry/react-native/metro`. We use `getSentryExpoConfig` (not `withSentryConfig`) so Debug IDs are injected via Expo's serialization plugin without replacing the LavaMoat `lockdownSerializer`.

**No changes to the Sentry upload pipeline are required.** Existing `sentry.gradle` upload, `copy-debugid.js`, and CI `SENTRY_DISABLE_AUTO_UPLOAD=false` when `upload_to_sentry: true` already handle Hermes map upload correctly once Metro injects Debug IDs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MCWP-717](https://consensyssoftware.atlassian.net/browse/MCWP-717)

## **Manual testing steps**

### Why these tests prove the fix

Sentry 7.x symbolication requires three things to line up:

1. **Debug ID in the packager source map and bundle** — injected by Metro (`getSentryExpoConfig`); this is what was missing before this PR.
2. **Debug ID copied to the Hermes composed map** — handled by existing `copy-debugid.js` in `sentry.gradle` at upload time (or manually for local builds with upload disabled).
3. **Source paths in the map** — must resolve to `app/` TypeScript files via `sentry-cli sourcemaps resolve`.

Before this PR, (1) was absent: maps uploaded to Sentry but could not be matched to runtime events. The tests below verify all three stages on a prod-equivalent Android build.

### CI verification (prod build with this branch)

- GitHub Actions run: https://github.com/MetaMask/metamask-mobile/actions/runs/29269869980
- Branch: `fix/sentry-sourcemaps`, `upload_to_sentry: true`
- Logs confirm:
  - `Copy debugId from packager source map to Hermes source map... Done.`
  - `Check generated source map for Debug ID: 567ef23c-9bb1-4083-9c9d-cc7bd7ae6e6f`
  - Source maps uploaded for release `io.metamask@8.4.0+4532`, dist `4532`

### Local verification (prod Android source maps — all steps passed)

Built locally with `yarn build:android:main:prod` on this branch. Source maps at `android/app/build/intermediates/sourcemaps/react/prodRelease/`.

```bash
SM_DIR="android/app/build/intermediates/sourcemaps/react/prodRelease"
BUNDLE="android/app/build/generated/assets/react/prodRelease/index.android.bundle"
MAP="$SM_DIR/index.android.bundle.map"

# 1. Debug ID present in packager map, Hermes map, and bundle
jq -r '.debugId // .debug_id' "$SM_DIR/index.android.bundle.packager.map"
jq -r '.debugId // .debug_id' "$MAP"
grep -oE 'sentry-dbid-[0-9a-f-]{36}' "$BUNDLE" | head -1
# → all three returned the same UUID

# 2. Source map contains real app paths
jq '[.sources[] | select(contains("/app/"))] | length' "$MAP"
# → 7015

# 3. Symbolication resolves to TypeScript source (Hermes bundles are one line — use column)
node_modules/@sentry/cli/bin/sentry-cli sourcemaps resolve \
  "$MAP" --line 1 --column 32721539
# → /app/core/ErrorHandler/ErrorHandler.ts:34:42 with source snippet
```

**Note:** Local builds default `SENTRY_DISABLE_AUTO_UPLOAD=true`, so `copy-debugid.js` does not run automatically. Run it manually if the Hermes map lacks a Debug ID after build:

```bash
node node_modules/@sentry/react-native/scripts/copy-debugid.js \
  "$SM_DIR/index.android.bundle.packager.map" "$MAP"
```

```gherkin
Feature: Sentry source map Debug ID injection

  Scenario: production Android bundle includes Debug ID and symbolicates
    Given the fix/sentry-sourcemaps branch is checked out
    And I run yarn build:android:main:prod

    When I inspect the prodRelease source maps and bundle

    Then the packager map contains a debugId UUID
    And the Hermes composed map contains the same debugId UUID
    And the bundle contains a matching sentry-dbid-<uuid> snippet
    And the Hermes map lists thousands of app/ source paths
    And sentry-cli sourcemaps resolve maps a bundle column to an app/ TypeScript file

  Scenario: CI prod upload includes Debug ID (already verified on this branch)
    Given a prod build runs with upload_to_sentry: true

    When the Android Gradle Sentry upload task runs

    Then copy-debugid.js copies debugId from packager to Hermes map
    And sentry-cli uploads source maps with the matching Debug ID
```

## **Screenshots/Recordings**

N/A — build pipeline / symbolication fix. Verification is via local source map inspection and CI upload logs (see Manual testing steps).

### **Before**

Example: [Sentry #7431996835](https://metamask.sentry.io/issues/7431996835/?project=2299799) — minified/unresolvable stack traces from ~8.1.0 onward (maps uploaded without Debug IDs).

### **After**

Local prod Android build on this branch:
- Debug ID present in packager map, Hermes map, and bundle (matching UUID)
- 7015 `app/` sources in the Hermes composed map
- `sentry-cli sourcemaps resolve` resolves to `/app/core/ErrorHandler/ErrorHandler.ts` with readable source

CI prod build (run 29269869980): source maps uploaded with Debug ID `567ef23c-9bb1-4083-9c9d-cc7bd7ae6e6f` for release `io.metamask@8.4.0+4532`.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MCWP-717]: https://consensyssoftware.atlassian.net/browse/MCWP-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ