### PR TITLE
fix(swaps): clear stale quote before opening batch sell cp-8.3.0

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -15,6 +15,7 @@ import {
   BATCH_SELL_ASSET_PICKER_BANNER_TEST_ID,
 } from './BatchSellAssetPickerBanner';
 import { BATCH_SELL_ASSET_PICKER_BANNER_LOCATION } from './useBatchSellAssetPickerBanner';
+import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
 
 let mockBridgeFeatureFlags: {
   chainRanking?: { chainId: CaipChainId; name?: string }[];
@@ -189,6 +190,10 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     setIsSelectingToken: jest.fn(() => ({
       type: 'bridge/setIsSelectingToken',
     })),
+    setSourceAmount: jest.fn((amount: string | undefined) => ({
+      type: 'bridge/setSourceAmount',
+      payload: amount,
+    })),
     selectTokenSelectorNetworkFilter: jest.fn(
       (state: { bridge: { tokenSelectorNetworkFilter?: CaipChainId } }) =>
         state.bridge.tokenSelectorNetworkFilter,
@@ -275,6 +280,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
 }));
 
 const mockTrackEvent = jest.fn();
+const mockResetBridgeControllerState = jest.fn();
 jest.mock('../../../../../core/Engine', () => ({
   __esModule: true,
   default: {
@@ -282,6 +288,7 @@ jest.mock('../../../../../core/Engine', () => ({
       BridgeController: {
         trackUnifiedSwapBridgeEvent: (...args: unknown[]) =>
           mockTrackEvent(...args),
+        resetState: () => mockResetBridgeControllerState(),
       },
       AuthenticationController: {
         getBearerToken: jest.fn().mockResolvedValue('bearer-token'),

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/useBatchSellAssetPickerBanner.ts
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/useBatchSellAssetPickerBanner.ts
@@ -1,8 +1,10 @@
 import { useCallback, useState } from 'react';
 import { StackActions, useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { BatchSellMetricsLocation } from '@metamask/bridge-controller';
 import Routes from '../../../../../constants/navigation/Routes';
+import Engine from '../../../../../core/Engine';
+import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
 import StorageWrapper from '../../../../../store/storage-wrapper';
 import { selectBatchSellEnabled } from '../../../../../selectors/featureFlagController/batchSell';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
@@ -28,6 +30,7 @@ export function useBatchSellAssetPickerBanner({
   pickerType,
 }: UseBatchSellAssetPickerBannerParams) {
   const navigation = useNavigation();
+  const dispatch = useDispatch();
   const isBatchSellEnabled = useSelector(selectBatchSellEnabled);
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
   const isHardwareWallet = selectedAddress
@@ -47,13 +50,15 @@ export function useBatchSellAssetPickerBanner({
 
   const handlePress = useCallback(() => {
     dismiss();
+    dispatch(setSourceAmount(undefined));
+    Engine.context.BridgeController.resetState();
     navigation.dispatch(
       StackActions.replace(Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT, {
         batchSellLocation: BATCH_SELL_ASSET_PICKER_BANNER_LOCATION,
         preserveBridgeState: true,
       }),
     );
-  }, [dismiss, navigation]);
+  }, [dismiss, dispatch, navigation]);
 
   return {
     dismiss,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Clears the entered Swaps amount and shared bridge quote state before opening Batch Sell from the source-token picker. Returning to Swaps now shows an empty amount rather than a stale quote stuck in a loading state; the selected source token remains unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Swaps getting stuck loading after opening Batch Sell

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/33222

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Open Batch Sell from Swaps

  Scenario: return to Swaps after requesting a Batch Sell quote
    Given I have entered a Swaps amount and received a quote
    And I open the source token picker

    When I select the Batch Sell banner
    And I obtain a Batch Sell quote
    And I return to Swaps
    Then the selected source token remains visible
    And the Swaps amount is empty
    And Swaps does not remain in a quote-loading state
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
