### PR TITLE
fix: guard Nitro Fetch headers check when Headers is unavailable

### DIFF
--- a/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch
+++ b/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch
@@ -1,0 +1,38 @@
+diff --git a/lib/module/fetch.js b/lib/module/fetch.js
+index be1800295cbd240ba44a54ace1ee350ad9b7e9b1..54aa28cfda8c3e3b47462ac5ed93090521a13b23 100644
+--- a/lib/module/fetch.js
++++ b/lib/module/fetch.js
+@@ -16,6 +16,6 @@ function headersToPairs(headers) {
+   if (!headers) return undefined;
+   const pairs = [];
+-  if (headers instanceof Headers) {
++  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+     headers.forEach((v, k) => pairs.push({
+       key: k,
+       value: v
+diff --git a/src/fetch.js b/src/fetch.js
+index 7209c6c14cb60ff22a699e409f67d61411229340..aaaab72c846b41daa4c2234d4422b8069ddc3751 100644
+--- a/src/fetch.js
++++ b/src/fetch.js
+@@ -13,7 +13,7 @@ function headersToPairs(headers) {
+   'worklet';
+   if (!headers) return undefined;
+   const pairs = [];
+-  if (headers instanceof Headers) {
++  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+     headers.forEach((v, k) => pairs.push({ key: k, value: v }));
+     return pairs;
+   }
+diff --git a/src/fetch.ts b/src/fetch.ts
+index 5b0a0a931aaf31783e11a31850ecb87e594ece45..5125521df6c960a4ec3b5daae8a9e9621a73100e 100644
+--- a/src/fetch.ts
++++ b/src/fetch.ts
+@@ -23,7 +23,7 @@ function headersToPairs(headers?: HeadersInit): NitroHeader[] | undefined {
+   'worklet';
+   if (!headers) return undefined;
+   const pairs: NitroHeader[] = [];
+-  if (headers instanceof Headers) {
++  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+     headers.forEach((v, k) => pairs.push({ key: k, value: v }));
+     return pairs;
+   }

--- a/app/core/NitroFetchDependency.test.ts
+++ b/app/core/NitroFetchDependency.test.ts
@@ -1,0 +1,65 @@
+interface NativeRequest {
+  headers?: { key: string; value: string }[];
+}
+
+const mockNativeRequest = jest.fn(async (_request: NativeRequest) => ({
+  url: 'https://example.com',
+  status: 200,
+  statusText: 'OK',
+  ok: true,
+  redirected: false,
+  headers: [],
+  bodyString: '',
+}));
+
+jest.mock('react-native-nitro-modules', () => ({
+  NitroModules: {
+    box: <Value>(value: Value) => value,
+    createHybridObject: (name: string) =>
+      name === 'NitroFetch'
+        ? {
+            createClient: () => ({ request: mockNativeRequest }),
+          }
+        : {},
+  },
+}));
+
+describe('react-native-nitro-fetch dependency patch', () => {
+  let headersDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    headersDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Headers');
+    mockNativeRequest.mockClear();
+  });
+
+  afterEach(() => {
+    if (headersDescriptor) {
+      Object.defineProperty(globalThis, 'Headers', headersDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, 'Headers');
+    }
+  });
+
+  it('passes record headers to the native request when global Headers is unavailable', async () => {
+    Object.defineProperty(globalThis, 'Headers', {
+      configurable: true,
+      value: undefined,
+    });
+    let dependencyFetch:
+      | typeof import('react-native-nitro-fetch').fetch
+      | undefined;
+
+    await jest.isolateModulesAsync(async () => {
+      dependencyFetch = (await import('react-native-nitro-fetch')).fetch;
+    });
+
+    await dependencyFetch?.('https://example.com', {
+      headers: { Authorization: 'Bearer test' },
+    });
+
+    const [nativeRequest] = mockNativeRequest.mock.calls[0];
+    expect(nativeRequest.headers).toEqual([
+      { key: 'Authorization', value: 'Bearer test' },
+    ]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -510,7 +510,7 @@
     "react-native-material-textfield": "0.16.1",
     "react-native-mmkv": "^3.2.0",
     "react-native-modal": "^14.0.0-rc.1",
-    "react-native-nitro-fetch": "1.3.3",
+    "react-native-nitro-fetch": "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch",
     "react-native-nitro-modules": "0.35.5",
     "react-native-nitro-text-decoder": "^0.2.0",
     "react-native-nitro-websockets": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36213,7 +36213,7 @@ __metadata:
     react-native-material-textfield: "npm:0.16.1"
     react-native-mmkv: "npm:^3.2.0"
     react-native-modal: "npm:^14.0.0-rc.1"
-    react-native-nitro-fetch: "npm:1.3.3"
+    react-native-nitro-fetch: "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch"
     react-native-nitro-modules: "npm:0.35.5"
     react-native-nitro-text-decoder: "npm:^0.2.0"
     react-native-nitro-websockets: "npm:^1.0.3"
@@ -40736,6 +40736,23 @@ __metadata:
     react-native-worklets:
       optional: true
   checksum: 10/cc7aecf2edd1ae8568e145e7959aa5f72d029f872a7bb2baac7eda24989fc27f98489cae6b550448f2b8e064ab30a8ab99843af37967f304c139740e17e7d904
+  languageName: node
+  linkType: hard
+
+"react-native-nitro-fetch@patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch":
+  version: 1.3.3
+  resolution: "react-native-nitro-fetch@patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch::version=1.3.3&hash=3bc776"
+  dependencies:
+    web-streams-polyfill: "npm:^4.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-nitro-modules: ^0.35.2
+    react-native-worklets: ^0.8.0
+  peerDependenciesMeta:
+    react-native-worklets:
+      optional: true
+  checksum: 10/1e6c3f1567cca3899884161fd0f62e4881af624cfa5556e50e7693b2d216baa74ea95c65b13614d9856a68ba800640593730af0722780a97e3ea3068d5360d89
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Before this change, a Nitro Fetch request could fail before reaching the native network client when React Native did not expose a global `Headers` constructor. The library evaluated `headers instanceof Headers` even for a normal plain-object header value, causing a `ReferenceError` instead of sending the request.

This was found in the Perps flow: the affected request supplied record-style headers, so Perps position setup stopped before its network call ran. The rest of the app could remain usable, which made the failure look like a Perps setup or fixture problem rather than a transport-layer bug.

This is distinct from [#32464](https://github.com/MetaMask/metamask-mobile/pull/32464): that PR fixed stale fetch routing that dropped `Content-Type`; this PR prevents a pre-request exception when the global `Headers` constructor is absent.

This PR keeps `react-native-nitro-fetch` at `1.3.3` and applies a Mobile-owned Yarn patch to all three shipped source variants. The patch checks that `Headers` exists before using `instanceof`; plain object headers continue to reach the native client. A focused regression imports the actual patched dependency with `globalThis.Headers` removed and proves the request is forwarded.

## **Changelog**

CHANGELOG entry: Fixed a crash that could prevent Perps network requests when the React Native Headers API was unavailable.

## **Related issues**

Refs: Internal Perps recipe-validation finding; no public tracking issue.

## **Manual testing steps**

N/A — this is a dependency-level runtime guard with no UI change. It is covered by a focused real-dependency regression:

```gherkin
Feature: Perps requests without the global Headers API

  Scenario: Forward plain record headers
    Given the Nitro Fetch dependency is loaded without global Headers
    When a Perps request passes headers as a plain object
    Then the native request receives those headers without throwing
```

Validated with:

- `yarn install --immutable --check-cache`
- `yarn jest app/core/NitroFetchDependency.test.ts`
- Full PR CI, security scans, and CodeQL

## **Screenshots/Recordings**

N/A — no visual behavior changed.

### **Before**

N/A — non-visual failure. A Perps request with plain-object headers threw while evaluating `headers instanceof Headers`; the native request was never called.

### **After**

N/A — non-visual fix. The focused regression removes `globalThis.Headers`, sends plain-object headers, and proves the native request receives them.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
  - Assessment: N/A for this dependency-level JavaScript guard; the real patched dependency is covered by the focused regression.
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - Assessment: N/A; behavior does not vary with wallet size or account count.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
  - Assessment: N/A; this guard introduces no new operation or production performance boundary.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
