### PR TITLE
chore(nav): type Rewards nested navigator with NavigatorScreenParams

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -42,9 +42,10 @@ import useRewardsToast from './hooks/useRewardsToast';
 import { strings } from '../../../../locales/i18n';
 import PerpsTradingCampaignWinningView from './Views/PerpsTradingCampaignWinningView';
 import { getActiveRouteNameFromNavigationState } from './utils';
+import type { RewardsStackParamList } from './types/navigation';
 
 let sessionNotificationsNudgeShown = false;
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<RewardsStackParamList>();
 
 const RewardsNavigator: React.FC = () => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
@@ -23,6 +23,7 @@ import { buildCampaignOutcomeToastCompositeKey } from '../../../../reducers/rewa
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { navigateToRewardsRoute } from '../utils';
 import useRewardsToast from './useRewardsToast';
+import type { RewardsStackParamList } from '../types/navigation';
 
 export interface CampaignOutcomeToastConfig {
   campaignType: CampaignType;
@@ -120,8 +121,8 @@ export function useCampaignOutcomeToast(
         : getNonWinnerNavigation(targetCampaign);
     navigateToRewardsRoute(
       navigation,
-      nav.route,
-      nav.params as Record<string, unknown>,
+      nav.route as keyof RewardsStackParamList,
+      nav.params as never,
     );
   }, [
     variant,

--- a/app/components/UI/Rewards/types/navigation.ts
+++ b/app/components/UI/Rewards/types/navigation.ts
@@ -1,3 +1,4 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
 import type { RewardsSelectSheetParams } from '../components/RewardsSelectSheet';
 
 export interface RewardsOndoCampaignDetailsParams {
@@ -81,8 +82,12 @@ export interface RewardsPredictThePitchCampaignStatsParams {
   campaignId: string;
 }
 
-/** Param list for screens registered in RewardsNavigator. */
-export interface RewardsNavigationParamList {
+/**
+ * Param list for screens registered in `RewardsNavigator`.
+ */
+// ParamListBase requires `type`; `interface` cannot satisfy it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type RewardsStackParamList = {
   ReferralRewardsView: undefined;
   RewardsSettingsView: undefined;
   RewardsVipSplashView: undefined;
@@ -116,5 +121,15 @@ export interface RewardsNavigationParamList {
   RewardsPredictThePitchCampaignPortfolioView: RewardsPredictThePitchCampaignPortfolioParams;
   RewardsPredictThePitchCampaignWinning: RewardsPredictThePitchCampaignWinningParams;
   RewardsPredictThePitchCampaignStats: RewardsPredictThePitchCampaignStatsParams;
+};
+
+/**
+ * Feature-level Rewards navigation params: stack screens, flat modal sheet,
+ * and the typed `RewardsFlow` entry for cross-stack navigation.
+ */
+// Intersection (`&`) requires `type`; `interface` cannot express this.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type RewardsNavigationParamList = RewardsStackParamList & {
   RewardsSelectSheet: RewardsSelectSheetParams;
-}
+  RewardsFlow: NavigatorScreenParams<RewardsStackParamList> | undefined;
+};

--- a/app/components/UI/Rewards/utils.test.ts
+++ b/app/components/UI/Rewards/utils.test.ts
@@ -255,15 +255,15 @@ describe('Rewards Utils', () => {
 
       navigateToRewardsRoute(
         { navigate: mockNavigate },
-        'RewardsSettingsView',
+        'RewardsCampaignMechanics',
         {
-          foo: 'bar',
+          campaignId: 'campaign-1',
         },
       );
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
-        screen: 'RewardsSettingsView',
-        params: { foo: 'bar' },
+        screen: 'RewardsCampaignMechanics',
+        params: { campaignId: 'campaign-1' },
       });
     });
   });

--- a/app/components/UI/Rewards/utils.ts
+++ b/app/components/UI/Rewards/utils.ts
@@ -9,10 +9,14 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 import Logger from '../../../util/Logger';
 import { strings } from '../../../../locales/i18n';
 import { isEvmAccountType } from '@metamask/keyring-api';
-import type { NavigationProp } from '@react-navigation/native';
+import type {
+  NavigationProp,
+  NavigatorScreenParams,
+} from '@react-navigation/native';
 import { isSolanaAccount } from '../../../core/Multichain/utils';
 import { getAddressAccountType } from '../../../util/address';
 import Routes from '../../../constants/navigation/Routes';
+import type { RewardsStackParamList } from './types/navigation';
 
 // Initialize dayjs with relativeTime plugin
 dayjs.extend(relativeTime);
@@ -178,12 +182,15 @@ export const getActiveRouteNameFromNavigationState = (
  * @param screen - The destination route name inside the rewards flow.
  * @param params - Optional params forwarded to the destination screen.
  */
-export const navigateToRewardsRoute = (
+export const navigateToRewardsRoute = <S extends keyof RewardsStackParamList>(
   navigation: Pick<NavigationProp<ReactNavigation.RootParamList>, 'navigate'>,
-  screen: string,
-  params?: Record<string, unknown>,
+  screen: S,
+  params?: RewardsStackParamList[S],
 ): void => {
-  navigation.navigate(Routes.REWARDS_FLOW, { screen, params });
+  navigation.navigate(Routes.REWARDS_FLOW, {
+    screen,
+    params,
+  } as NavigatorScreenParams<RewardsStackParamList>);
 };
 
 type RewardsFlowExitNavigation = Pick<

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -266,7 +266,10 @@ import type {
 
 // Rewards params
 import { BenefitFullViewRouteParams } from '../../components/UI/Rewards/Views/BenefitFullView.types.ts';
-import type { RewardsNavigationParamList } from '../../components/UI/Rewards/types/navigation';
+import type {
+  RewardsNavigationParamList,
+  RewardsStackParamList,
+} from '../../components/UI/Rewards/types/navigation';
 
 // Webview params
 import type {
@@ -485,7 +488,7 @@ export type RootStackParamList = {
   TransactionDetails: TransactionDetailsParams | undefined;
   ActivityDetails: ActivityDetailsParams;
   RewardsView: undefined;
-  RewardsFlow: NestedNavigationParams | undefined;
+  RewardsFlow: NavigatorScreenParams<RewardsStackParamList> | undefined;
   ReferralRewardsView: undefined;
   RewardsSettingsView: undefined;
   RewardsDashboard: undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Introduce `RewardsStackParamList` for screens inside `RewardsNavigator`.
- Keep `RewardsNavigationParamList` as the feature-level type (stack + `RewardsSelectSheet` + root `RewardsFlow` entry).
- Update `RootStackParamList.RewardsFlow` to `NavigatorScreenParams<RewardsStackParamList> | undefined`.
- Wire `RewardsNavigator` to `RewardsStackParamList` and tighten `navigateToRewardsRoute` generics.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-674

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->
N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only navigation refactor with no intended runtime behavior change; main follow-up is fixing any new TypeScript errors at call sites that pass invalid route names or params.
> 
> **Overview**
> Adds **compile-time typing** for Rewards nested navigation so stack screens, params, and the root `RewardsFlow` entry align with React Navigation’s nested navigator pattern.
> 
> **`RewardsStackParamList`** is introduced for screens registered in `RewardsNavigator`, and **`RewardsNavigator`** is wired to `createNativeStackNavigator<RewardsStackParamList>()`. **`RewardsNavigationParamList`** becomes the feature-level map: stack routes plus `RewardsSelectSheet` and a typed **`RewardsFlow`** entry using `NavigatorScreenParams<RewardsStackParamList>`.
> 
> On the app root, **`RootStackParamList.RewardsFlow`** is updated from loose `NestedNavigationParams` to **`NavigatorScreenParams<RewardsStackParamList>`**. **`navigateToRewardsRoute`** is generic over `keyof RewardsStackParamList` so `screen` and `params` are checked per route; campaign outcome toast navigation uses narrow casts where routes still come from config objects. The **`navigateToRewardsRoute`** unit test now asserts a typed campaign screen and `campaignId` params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f267111299efdccfbc1830a3d11e5f2c30bd66ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->