### PR TITLE
chore(ramps): prune dead Routes.DEPOSIT stack constants

### DIFF
--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -41,9 +41,8 @@ describe('MainNavigator Route Constants', () => {
     expect(Routes.RAMP.ORDER_DETAILS).toBeDefined();
   });
 
-  it('has deposit routes defined', () => {
-    expect(Routes.DEPOSIT.ID).toBeDefined();
-    expect(Routes.DEPOSIT.ORDER_DETAILS).toBeDefined();
+  it('has legacy deposit order details route defined', () => {
+    expect(Routes.DEPOSIT.ORDER_DETAILS).toBe('DepositOrderDetails');
   });
 
   it('has bridge routes defined', () => {

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -60,35 +60,13 @@ const Routes = {
       PHONE_COUNTRY_SELECTOR: 'RampPhoneCountrySelectorModal',
     },
   },
+  /**
+   * Legacy Deposit order details only.
+   * The standalone Deposit navigator stack was removed with UB2 (#31768 / TRAM-3559).
+   * Keep the screen-name string stable for Activity / order-history navigation.
+   */
   DEPOSIT: {
-    ID: 'Deposit',
-    ROOT: 'DepositRoot',
-    BUILD_QUOTE: 'BuildQuote',
-    ENTER_EMAIL: 'EnterEmail',
-    OTP_CODE: 'OtpCode',
-    VERIFY_IDENTITY: 'VerifyIdentity',
-    BASIC_INFO: 'BasicInfo',
-    ENTER_ADDRESS: 'EnterAddress',
-    KYC_PROCESSING: 'KycProcessing',
-    ORDER_PROCESSING: 'OrderProcessing',
     ORDER_DETAILS: 'DepositOrderDetails',
-    BANK_DETAILS: 'BankDetails',
-    ADDITIONAL_VERIFICATION: 'AdditionalVerification',
-    MODALS: {
-      ID: 'DepositModals',
-      TOKEN_SELECTOR: 'DepositTokenSelectorModal',
-      REGION_SELECTOR: 'DepositRegionSelectorModal',
-      PAYMENT_METHOD_SELECTOR: 'DepositPaymentMethodSelectorModal',
-      UNSUPPORTED_REGION: 'DepositUnsupportedRegionModal',
-      UNSUPPORTED_STATE: 'DepositUnsupportedStateModal',
-      STATE_SELECTOR: 'DepositStateSelectorModal',
-      WEBVIEW: 'DepositWebviewModal',
-      KYC_WEBVIEW: 'DepositKycWebviewModal',
-      INCOMPATIBLE_ACCOUNT_TOKEN: 'IncompatibleAccountTokenModal',
-      SSN_INFO: 'SsnInfoModal',
-      CONFIGURATION: 'DepositConfigurationModal',
-      ERROR_DETAILS: 'DepositErrorDetailsModal',
-    },
   },
   HW: {
     CONNECT: 'ConnectHardwareWalletFlow',


### PR DESCRIPTION
## **Description**

Prune leftover `Routes.DEPOSIT.*` navigator keys after the Deposit stack was deleted (#31768 / TRAM-3559). Only `ORDER_DETAILS` (`DepositOrderDetails`) remains — still used by Activity and MainNavigator for historical Deposit fiat orders.

Part of TRAM-3755 cleanup plan (P1). Independent of TRAM-3674 buy-routing PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

Refs: TRAM-3755

## **Manual testing steps**

```gherkin
Feature: Legacy deposit order details still open

  Scenario: open a historical Deposit order from Activity
    Given the user has a persisted DEPOSIT fiat order in Activity
    When the user taps the order
    Then DepositOrderDetails opens via Routes.DEPOSIT.ORDER_DETAILS
```

### Harness evidence (local)

```bash
yarn jest \
  app/components/Nav/Main/MainNavigator.test.js \
  app/components/Views/ActivityList/ActivityList.test.tsx \
  app/components/UI/Ramp/Views/OrderDetails/DepositOrderDetails/DepositOrderDetails.test.tsx \
  --runInBand
```

Result: **3 suites passed** (ActivityList, MainNavigator constants, DepositOrderDetails).

## **Screenshots/Recordings**

### **Before**

N/A — constant cleanup only

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — route constant prune only
- [x] I've tested with a power user scenario
  - N/A
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings or screenshots.

Made with [Cursor](https://cursor.com)