### PR TITLE
chore(ramp): migrate Deposit analytics ramp_type to UNIFIED_BUY_2 (TRAM-3755)

### DIFF
--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -231,7 +231,7 @@ const V2BankDetails = () => {
       await confirmPayment(order.providerOrderId, paymentMethodId);
 
       trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-        ramp_type: 'DEPOSIT',
+        ramp_type: 'UNIFIED_BUY_2',
         provider_order_id: order.providerOrderId,
         amount_source: Number(order.fiatAmount),
         amount_destination: Number(order.cryptoAmount),

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.test.tsx
@@ -395,7 +395,7 @@ describe('V2BasicInfo', () => {
         'RAMPS_BASIC_INFO_ENTERED',
         expect.objectContaining({
           region: 'US',
-          ramp_type: 'DEPOSIT',
+          ramp_type: 'UNIFIED_BUY_2',
         }),
       );
     });

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
@@ -92,7 +92,7 @@ const V2BasicInfo = (): React.JSX.Element => {
 
   // Headless deposit (TRAM-3623): tag RAMPS_BASIC_INFO_ENTERED with
   // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when this screen is
-  // part of a headless buy flow; keep 'DEPOSIT' otherwise.
+  // part of a headless buy flow; keep 'UNIFIED_BUY_2' otherwise.
   const { headlessDepositRampProps } = useHeadlessRampProps(headlessSessionId);
 
   const firstNameInputRef = useRef<TextInput>(null);

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.test.tsx
@@ -222,7 +222,7 @@ describe('V2EnterAddress', () => {
           'RAMPS_ADDRESS_ENTERED',
           expect.objectContaining({
             region: 'US',
-            ramp_type: 'DEPOSIT',
+            ramp_type: 'UNIFIED_BUY_2',
           }),
         );
       }

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
@@ -67,7 +67,7 @@ const V2EnterAddress = (): React.JSX.Element => {
 
   // Headless deposit (TRAM-3623): tag RAMPS_ADDRESS_ENTERED with
   // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when this screen is
-  // part of a headless buy flow; keep 'DEPOSIT' otherwise.
+  // part of a headless buy flow; keep 'UNIFIED_BUY_2' otherwise.
   const { headlessDepositRampProps } = useHeadlessRampProps(headlessSessionId);
 
   const transakRoutingConfig = useMemo(

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
@@ -231,7 +231,7 @@ describe('V2KycProcessing', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_KYC_APPLICATION_APPROVED',
         expect.objectContaining({
-          ramp_type: 'DEPOSIT',
+          ramp_type: 'UNIFIED_BUY_2',
         }),
       );
     });
@@ -259,7 +259,7 @@ describe('V2KycProcessing', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_KYC_APPLICATION_FAILED',
         expect.objectContaining({
-          ramp_type: 'DEPOSIT',
+          ramp_type: 'UNIFIED_BUY_2',
         }),
       );
     });

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
@@ -49,7 +49,7 @@ const V2KycProcessing = () => {
 
   // Headless deposit (TRAM-3623): flip the KYC outcome events to
   // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when in a headless
-  // flow; keep 'DEPOSIT' otherwise.
+  // flow; keep 'UNIFIED_BUY_2' otherwise.
   const { headlessDepositRampProps } = useHeadlessRampProps(headlessSessionId);
 
   const {

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
@@ -103,7 +103,7 @@ const V2OtpCode = () => {
   // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when a headless session
   // drives the flow, sourced from the per-screen `headlessSessionId`. Two
   // variants because some events default to 'UNIFIED_BUY_2' and others (OTP_*)
-  // to 'DEPOSIT' when not headless.
+  // to 'UNIFIED_BUY_2' when not headless.
   const { headlessRampProps, headlessDepositRampProps } =
     useHeadlessRampProps(headlessSessionId);
 

--- a/app/components/UI/Ramp/headless/useHeadlessRampProps.test.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessRampProps.test.ts
@@ -21,7 +21,7 @@ describe('useHeadlessRampProps', () => {
       ramp_type: 'UNIFIED_BUY_2',
     });
     expect(result.current.headlessDepositRampProps).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
     });
     // No session lookup happens for non-headless traffic.
     expect(getSessionMock).toHaveBeenCalledWith(undefined);

--- a/app/components/UI/Ramp/headless/useHeadlessRampProps.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessRampProps.ts
@@ -3,41 +3,31 @@ import { getSession } from './sessionRegistry';
 import type { RampSurface } from '../types/depositAnalytics';
 
 /**
- * Analytics ramp-type/surface props for a NativeFlow screen, in the two shapes
- * the funnel needs (TRAM-3623).
+ * Analytics ramp-type/surface props for a NativeFlow screen (TRAM-3623 /
+ * TRAM-3755).
  *
  * The emitted analytics property is always `ramp_surface`; only the internal
  * session param that seeds it is named `rampSurface`.
+ *
+ * Non-headless traffic uses `ramp_type: 'UNIFIED_BUY_2'`. Headless sessions
+ * flip to `'HEADLESS'` plus the seeded surface.
+ *
+ * `headlessDepositRampProps` is kept as an alias of `headlessRampProps` for
+ * existing Email/OTP/KYC call sites — the former Deposit funnel literal is gone.
  */
 export interface HeadlessRampProps {
-  /**
-   * For events whose non-headless `ramp_type` is `'UNIFIED_BUY_2'` (most
-   * NativeFlow emits). Flips to `'HEADLESS'` plus the seeded surface when a
-   * headless session drives the flow.
-   */
   headlessRampProps:
     | { ramp_type: 'HEADLESS'; ramp_surface?: RampSurface }
     | { ramp_type: 'UNIFIED_BUY_2' };
-  /**
-   * For events whose non-headless `ramp_type` is `'DEPOSIT'` (EMAIL_SUBMITTED,
-   * OTP_*, BASIC_INFO_ENTERED, ADDRESS_ENTERED, KYC outcomes). Flips to
-   * `'HEADLESS'` plus the seeded surface on the headless path.
-   */
-  headlessDepositRampProps:
-    | { ramp_type: 'HEADLESS'; ramp_surface?: RampSurface }
-    | { ramp_type: 'DEPOSIT' };
+  /** Alias of {@link HeadlessRampProps.headlessRampProps} (TRAM-3755). */
+  headlessDepositRampProps: HeadlessRampProps['headlessRampProps'];
 }
 
 /**
- * Shared headless analytics tagging for the NativeFlow screens (TRAM-3623).
- * Centralizes deriving the two prop objects from
- * `getSession(headlessSessionId)?.params`: with a `headlessSessionId` the
- * emits are tagged `ramp_type: 'HEADLESS'` plus the seeded `ramp_surface`,
- * otherwise they keep their original UB2 / DEPOSIT literal and no surface so
- * non-headless traffic is unaffected.
+ * Shared headless analytics tagging for NativeFlow screens.
  *
  * @param headlessSessionId - Session id from navigation params, or `undefined`
- * for regular (non-headless) UB2 / Deposit traffic.
+ * for regular (non-headless) UNIFIED_BUY_2 traffic.
  */
 export function useHeadlessRampProps(
   headlessSessionId: string | undefined,
@@ -52,15 +42,8 @@ export function useHeadlessRampProps(
     [headlessSessionId, headlessSurface],
   );
 
-  const headlessDepositRampProps = useMemo<
-    HeadlessRampProps['headlessDepositRampProps']
-  >(
-    () =>
-      headlessSessionId
-        ? { ramp_type: 'HEADLESS', ramp_surface: headlessSurface }
-        : { ramp_type: 'DEPOSIT' },
-    [headlessSessionId, headlessSurface],
-  );
-
-  return { headlessRampProps, headlessDepositRampProps };
+  return {
+    headlessRampProps,
+    headlessDepositRampProps: headlessRampProps,
+  };
 }

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -344,7 +344,7 @@ describe('useTransakRouting', () => {
       );
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_KYC_STARTED',
-        expect.objectContaining({ ramp_type: 'DEPOSIT' }),
+        expect.objectContaining({ ramp_type: 'UNIFIED_BUY_2' }),
       );
       // Non-headless stays DEPOSIT and carries no surface (TRAM-3623).
       expect(mockTrackEvent).not.toHaveBeenCalledWith(
@@ -808,7 +808,10 @@ describe('useTransakRouting', () => {
       // Non-headless IDPROOF KYC_STARTED stays DEPOSIT (TRAM-3623).
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_KYC_STARTED',
-        expect.objectContaining({ ramp_type: 'DEPOSIT', kyc_type: 'STANDARD' }),
+        expect.objectContaining({
+          ramp_type: 'UNIFIED_BUY_2',
+          kyc_type: 'STANDARD',
+        }),
       );
       expect(mockTrackEvent).not.toHaveBeenCalledWith(
         'RAMPS_KYC_STARTED',

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -550,7 +550,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
             emitTerminalOrderAnalyticsFromCallback(rampsOrder);
           } else {
             trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-              ramp_type: wasHeadless ? 'HEADLESS' : 'DEPOSIT',
+              ramp_type: wasHeadless ? 'HEADLESS' : 'UNIFIED_BUY_2',
               ramp_surface: rampSurface,
               provider_order_id: rampsOrder.providerOrderId,
               amount_source: Number(rampsOrder.fiatAmount),
@@ -867,10 +867,10 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           case 'NOT_SUBMITTED': {
             // Snapshot the headless session BEFORE navigating so KYC_STARTED
             // carries `ramp_type: 'HEADLESS'` + the seeded `ramp_surface`
-            // (TRAM-3623); the regular flow keeps `'DEPOSIT'`.
+            // (TRAM-3623); the regular flow keeps `'UNIFIED_BUY_2'`.
             const kycStartedSession = getSession(headlessSessionId);
             trackEvent('RAMPS_KYC_STARTED', {
-              ramp_type: kycStartedSession ? 'HEADLESS' : 'DEPOSIT',
+              ramp_type: kycStartedSession ? 'HEADLESS' : 'UNIFIED_BUY_2',
               ramp_surface: kycStartedSession?.params?.rampSurface,
               kyc_type: requirements.kycType || '',
               region: regionIsoCode,
@@ -916,7 +916,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
               // (TRAM-3623): HEADLESS + ramp_surface on the headless path.
               const idProofKycSession = getSession(headlessSessionId);
               trackEvent('RAMPS_KYC_STARTED', {
-                ramp_type: idProofKycSession ? 'HEADLESS' : 'DEPOSIT',
+                ramp_type: idProofKycSession ? 'HEADLESS' : 'UNIFIED_BUY_2',
                 ramp_surface: idProofKycSession?.params?.rampSurface,
                 kyc_type: 'STANDARD',
                 region: regionIsoCode,

--- a/app/components/UI/Ramp/types/depositAnalytics.ts
+++ b/app/components/UI/Ramp/types/depositAnalytics.ts
@@ -1,7 +1,7 @@
 /**
  * Headless ramps surface the event was triggered from. Set on every event on
  * the headless deposit path (TRAM-3623) so the funnel can be sliced by product
- * feature. Optional and empty for non-headless (UB2 / native Deposit) events.
+ * feature. Optional and empty for non-headless UNIFIED_BUY_2 events.
  */
 export const RAMP_SURFACE = {
   MONEY_ACCOUNT: 'money_account',
@@ -35,7 +35,7 @@ interface RampsButtonClicked {
 
 interface RampsDepositCashButtonClicked {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'UNIFIED_BUY_2';
   user_id?: string;
   region: string;
   location: string;
@@ -44,7 +44,7 @@ interface RampsDepositCashButtonClicked {
 
 interface RampsPaymentMethodSelected {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   region: string;
@@ -69,7 +69,7 @@ interface RampsTokenSelected {
 
 interface RampsRegionSelected {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'UNIFIED_BUY_2';
   user_id?: string;
   region: string;
   is_authenticated: boolean;
@@ -77,7 +77,7 @@ interface RampsRegionSelected {
 
 interface RampsOrderProposed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
@@ -95,7 +95,7 @@ interface RampsOrderProposed {
 
 interface RampsOrderSelected {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
@@ -115,7 +115,7 @@ interface RampsOrderSelected {
 
 interface RampsOrderFailed extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
@@ -133,7 +133,7 @@ interface RampsOrderFailed extends ProviderOrderId {
 
 interface RampsEmailSubmitted {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
 }
@@ -141,7 +141,7 @@ interface RampsEmailSubmitted {
 interface RampsOtpConfirmed {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
 }
@@ -149,7 +149,7 @@ interface RampsOtpConfirmed {
 interface RampsOtpFailed extends ProviderOrderId {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   error_message?: string;
@@ -158,7 +158,7 @@ interface RampsOtpFailed extends ProviderOrderId {
 interface RampsOtpResent {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
 }
@@ -166,7 +166,7 @@ interface RampsOtpResent {
 interface RampsKycStarted {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
@@ -175,7 +175,7 @@ interface RampsKycStarted {
 interface RampsBasicInfoEntered {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
@@ -184,7 +184,7 @@ interface RampsBasicInfoEntered {
 interface RampsAddressEntered {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
@@ -192,7 +192,7 @@ interface RampsAddressEntered {
 
 interface RampsTransactionConfirmed extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
@@ -213,7 +213,7 @@ interface RampsTransactionConfirmed extends ProviderOrderId {
 
 interface RampsTransactionCompleted extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2';
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -233,7 +233,7 @@ interface RampsTransactionCompleted extends ProviderOrderId {
 
 interface RampsTransactionFailed extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
@@ -256,7 +256,7 @@ interface RampsTransactionFailed extends ProviderOrderId {
 
 interface RampsKycApplicationFailed extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
@@ -266,7 +266,7 @@ interface RampsKycApplicationFailed extends ProviderOrderId {
 
 interface RampsKycApplicationApproved extends ProviderOrderId {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
   ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
@@ -274,14 +274,14 @@ interface RampsKycApplicationApproved extends ProviderOrderId {
 
 interface RampsPaymentMethodAdded {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'UNIFIED_BUY_2';
   user_id?: string;
   payment_method_id: string;
 }
 
 interface RampsTokenSelectorClicked {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'UNIFIED_BUY_2';
   user_id?: string;
   region?: string;
   location: string;

--- a/app/components/UI/Ramp/utils/getDepositAnalyticsPayload.test.ts
+++ b/app/components/UI/Ramp/utils/getDepositAnalyticsPayload.test.ts
@@ -29,7 +29,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_COMPLETED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,
@@ -84,7 +84,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_FAILED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,
@@ -117,7 +117,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_FAILED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,
@@ -158,7 +158,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_COMPLETED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 250.75,
       amount_destination: 0.135,
@@ -256,7 +256,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_COMPLETED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,
@@ -291,7 +291,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_COMPLETED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,
@@ -326,7 +326,7 @@ describe('getDepositAnalyticsPayload', () => {
 
     expect(eventName).toBe('RAMPS_TRANSACTION_COMPLETED');
     expect(params).toEqual({
-      ramp_type: 'DEPOSIT',
+      ramp_type: 'UNIFIED_BUY_2',
       provider_order_id: '123',
       amount_source: 100,
       amount_destination: 0.05,

--- a/app/components/UI/Ramp/utils/getDepositAnalyticsPayload.ts
+++ b/app/components/UI/Ramp/utils/getDepositAnalyticsPayload.ts
@@ -13,15 +13,12 @@ import { selectNetworkConfigurationsByCaipChainId } from '../../../../selectors/
  * payload for an order processed by the global FiatOrders observer
  * (`app/components/UI/Ramp/index.tsx`).
  *
- * TRAM-3623 scope note: this is the DEPOSIT path only. The observer polls the
- * redux `fiatOrders` store (`getPendingOrders`), which is fed exclusively by
- * `addFiatOrder` (native Deposit via `useHandleNewOrder`, plus the aggregator
- * paths). Headless buy orders are added through
- * `RampsController.addOrder` (`useTransakRouting` -> `useRampsOrders`) and never
- * enter the redux store, so they do not flow through this observer. Headless
- * terminal success/failure are emitted directly by `useTransakRouting`
- * (`RAMPS_TRANSACTION_CONFIRMED` / `RAMPS_ORDER_FAILED`). Hence `ramp_type`
- * stays hardcoded `'DEPOSIT'` here and no `ramp_surface` is emitted.
+ * TRAM-3755: this observer path covers legacy/native orders in the redux
+ * `fiatOrders` store (`getPendingOrders`), fed by `addFiatOrder`. Headless buy
+ * orders go through `RampsController.addOrder` and emit terminal analytics from
+ * `useTransakRouting` instead. Non-headless terminal events here use
+ * `ramp_type: 'UNIFIED_BUY_2'` (Deposit funnel literal retired) and no
+ * `ramp_surface`.
  */
 function getDepositAnalyticsPayload(
   fiatOrder: FiatOrder,
@@ -67,7 +64,7 @@ function getDepositAnalyticsPayload(
   };
 
   const baseAnalyticsData = {
-    ramp_type: 'DEPOSIT' as const,
+    ramp_type: 'UNIFIED_BUY_2' as const,
     // TRAM-3696: join key back to the provider order. Never emit empty string.
     ...((order.providerOrderId || fiatOrder.id) && {
       provider_order_id: order.providerOrderId || fiatOrder.id,


### PR DESCRIPTION
## Summary
- Retire live `ramp_type: 'DEPOSIT'` emits after Deposit funnel removal (TRAM-3755).
- Non-headless NativeFlow / Transak / BankDetails / fiat-order observer terminal events now use `UNIFIED_BUY_2`; headless stays `HEADLESS`.
- `useHeadlessRampProps.headlessDepositRampProps` aliases UB2 props (call-site churn avoided).
- Type unions for funnel events updated; `DEPOSIT` kept only on broad button/token selected unions for historical Segment compat.

**Jira:** [TRAM-3755](https://consensyssoftware.atlassian.net/browse/TRAM-3755)

## Test plan
- [x] `yarn jest` focused suites (6 PASS):
  - `useHeadlessRampProps.test.ts`
  - `getDepositAnalyticsPayload.test.ts`
  - `BasicInfo.test.tsx` / `EnterAddress.test.tsx` / `KycProcessing.test.tsx`
  - `useTransakRouting.test.ts`
- [ ] Spot-check Segment: KYC / OTP / BankDetails / transaction confirmed paths emit `UNIFIED_BUY_2` (not `DEPOSIT`) off headless
- [ ] Headless Money/Perps/Predict still emit `HEADLESS` + `ramp_surface`

## Risk
Low–medium analytics tagging change only — no UX/routing. Dashboard queries filtering `ramp_type = DEPOSIT` for post-cutover mobile traffic will undercount until updated to `UNIFIED_BUY_2`.


Made with [Cursor](https://cursor.com)

[TRAM-3755]: https://consensyssoftware.atlassian.net/browse/TRAM-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ