### PR TITLE
fix(perps): horizontally center candle period filter buttons

### DIFF
--- a/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
@@ -75,7 +75,7 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
         value={groupValue}
         onChange={handleFilterChange}
         variant={FilterButtonVariant.Primary}
-        twClassName="gap-1 self-center grow-0"
+        twClassName="gap-1 grow justify-center"
       >
         {DEFAULT_CANDLE_PERIODS.map((period) => (
           <FilterButton


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The candle period filter row on Perps market details (1min / 3min / 5min / 15min / More) was left-aligned because `FilterButtonGroup` is a full-width horizontal `ScrollView`, and `self-center` on its content container had no effect.

Updated the group `twClassName` to `grow justify-center` so the content container fills the row width and centers the filter buttons horizontally.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Perps chart candle period filters not being horizontally centered

## **Related issues**

Fixes: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps candle period filter alignment

  Scenario: user views the candle period filter on a market details chart
    Given the user has Perps enabled and opens a market details screen (e.g. ETH-USD)
    And the candlestick chart is visible

    When the user views the candle period filter row below the chart
    Then the 1min, 3min, 5min, 15min, and More controls are horizontally centered
    And selecting a period still updates the chart as before
    And tapping More still opens the candle period bottom sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-13 at 20 36 02" src="https://github.com/user-attachments/assets/ecd4ba21-c3d4-4f92-a121-74da058a3617" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-13 at 20 37 49" src="https://github.com/user-attachments/assets/097a4d96-be70-4e00-a7a3-de741272fe94" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line styling change in Perps UI with no logic, data, or auth impact.
> 
> **Overview**
> Centers the Perps chart candle period row (1min / 3min / 5min / 15min / More) by changing `FilterButtonGroup` layout classes from `self-center grow-0` to **`grow justify-center`**, so the group’s content container spans the row and flex-centers the buttons instead of staying left-aligned inside a full-width `ScrollView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12168c30cc1caffb01bb85cf009a18a0181b63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->