### PR TITLE
fix(confirmations): use elevated surface for CustomNonceModal in Pure Black

### DIFF
--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/custom-nonce-modal.styles.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/custom-nonce-modal.styles.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Style coverage for CustomNonceModal Pure Black stopgaps (TMCU-1017).
+ * Remove this file during the pure black cleanup or when CustomNonceModal
+ * migrates to MMDS BottomSheet and no longer owns local StyleSheet logic.
+ */
+import { brandColor, darkTheme, lightTheme } from '@metamask/design-tokens';
+import { AppThemeKey } from '../../../../../../util/theme/models';
+import { createStyles } from './index';
+
+let mockIsPureBlackEnabled = false;
+
+jest.mock('../../../../../../util/theme/pureBlackPreview', () => ({
+  get isPureBlackEnabled() {
+    return mockIsPureBlackEnabled;
+  },
+}));
+
+const createTheme = (themeAppearance: AppThemeKey.light | AppThemeKey.dark) => {
+  const base = themeAppearance === AppThemeKey.dark ? darkTheme : lightTheme;
+
+  return {
+    colors: base.colors,
+    themeAppearance,
+    typography: base.typography,
+    shadows: base.shadows,
+    brandColors: brandColor,
+  };
+};
+
+describe('CustomNonceModal styles', () => {
+  beforeEach(() => {
+    mockIsPureBlackEnabled = false;
+  });
+
+  describe('modal container', () => {
+    it('uses default background without pure black borders', () => {
+      const theme = createTheme(AppThemeKey.dark);
+      const styles = createStyles(theme);
+
+      expect(styles.modal.backgroundColor).toBe(
+        theme.colors.background.default,
+      );
+      expect(styles.modal.borderTopWidth).toBeUndefined();
+      expect(styles.modal.borderColor).toBeUndefined();
+    });
+
+    it('uses elevated surface and muted borders in pure black dark mode', () => {
+      mockIsPureBlackEnabled = true;
+      const theme = createTheme(AppThemeKey.dark);
+      const styles = createStyles(theme);
+
+      expect(styles.modal.backgroundColor).toBe(
+        theme.colors.background.alternative,
+      );
+      expect(styles.modal.borderTopWidth).toBe(1);
+      expect(styles.modal.borderLeftWidth).toBe(1);
+      expect(styles.modal.borderRightWidth).toBe(1);
+      expect(styles.modal.borderColor).toBe(theme.colors.border.muted);
+    });
+
+    it('keeps default background in pure black light mode', () => {
+      mockIsPureBlackEnabled = true;
+      const theme = createTheme(AppThemeKey.light);
+      const styles = createStyles(theme);
+
+      expect(styles.modal.backgroundColor).toBe(
+        theme.colors.background.default,
+      );
+      expect(styles.modal.borderTopWidth).toBeUndefined();
+    });
+  });
+
+  describe('nonce warning', () => {
+    it('uses muted warning fill when pure black preview is off', () => {
+      const theme = createTheme(AppThemeKey.dark);
+      const styles = createStyles(theme);
+
+      expect(styles.nonceWarning.backgroundColor).toBe(
+        theme.colors.warning.muted,
+      );
+      expect(styles.nonceWarning.borderColor).toBe(
+        theme.colors.warning.default,
+      );
+    });
+
+    it('omits muted warning fill in pure black mode', () => {
+      mockIsPureBlackEnabled = true;
+      const theme = createTheme(AppThemeKey.dark);
+      const styles = createStyles(theme);
+
+      expect(styles.nonceWarning.backgroundColor).toBeUndefined();
+      expect(styles.nonceWarning.borderColor).toBe(
+        theme.colors.warning.default,
+      );
+    });
+  });
+});

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
@@ -1,28 +1,50 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { fontStyles } from '../../../../../../styles/common';
 import { strings } from '../../../../../../../locales/i18n';
-import {
-  Modal,
-  StyleSheet,
-  View,
-  TextInput,
-  TouchableOpacity,
-} from 'react-native';
+import { StyleSheet, View, TextInput, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import ModalDragger from '../../../../../Base/ModalDragger';
 import Text from '../../../../../Base/Text';
 import StyledButton from '../../../../../UI/StyledButton';
+import Modal from 'react-native-modal';
 import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
-import { BottomSheet } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../../util/theme';
+import { AppThemeKey } from '../../../../../../util/theme/models';
 import { isNumber } from '../../../../../../util/number';
 import {
+  getElevatedSurfaceColor,
   isPureBlackEnabled,
-  useElevatedSurface,
 } from '../../../../../../util/theme/themeUtils';
 
-const createStyles = (colors) =>
-  StyleSheet.create({
+const createStyles = (theme) => {
+  const { colors } = theme;
+
+  return StyleSheet.create({
+    bottomModal: {
+      justifyContent: 'flex-end',
+      margin: 0,
+    },
+    keyboardAwareWrapper: {
+      flex: 1,
+      justifyContent: 'flex-end',
+    },
+    modal: {
+      minHeight: 200,
+      backgroundColor: getElevatedSurfaceColor(theme),
+      ...(isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark
+        ? {
+            borderTopWidth: 1,
+            borderLeftWidth: 1,
+            borderRightWidth: 1,
+            borderColor: colors.border.muted,
+          }
+        : null),
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 20,
+    },
     modalContainer: {
       margin: 24,
     },
@@ -87,7 +109,6 @@ const createStyles = (colors) =>
     actionRow: {
       flexDirection: 'row',
       marginBottom: 15,
-      paddingHorizontal: 16,
     },
     actionButton: {
       flex: 1,
@@ -105,13 +126,13 @@ const createStyles = (colors) =>
       color: colors.primary.default,
     },
   });
+};
 
 const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
   const [nonce, onChangeText] = React.useState(nonceValue);
-  const bottomSheetRef = useRef(null);
-  const { colors, themeAppearance } = useTheme();
-  const surfaceClass = useElevatedSurface();
-  const styles = createStyles(colors);
+  const theme = useTheme();
+  const { colors, themeAppearance } = theme;
+  const styles = createStyles(theme);
 
   const incrementDecrementNonce = (isDecrement) => {
     const currentNonce = Number(nonce);
@@ -121,127 +142,132 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
     onChangeText(clampedValue);
   };
 
-  const handleClose = () => {
-    bottomSheetRef.current?.onCloseBottomSheet();
-  };
-
   const saveAndClose = () => {
     const numberNonce = Number(nonce);
     save(numberNonce);
-    bottomSheetRef.current?.onCloseBottomSheet();
+    close();
   };
 
   const displayWarning = String(proposedNonce) !== String(nonce);
 
   return (
     <Modal
-      visible
-      transparent
-      animationType="none"
-      statusBarTranslucent
-      onRequestClose={handleClose}
+      isVisible
+      animationIn="slideInUp"
+      animationOut="slideOutDown"
+      style={styles.bottomModal}
+      backdropColor={colors.overlay.default}
+      backdropOpacity={1}
+      animationInTiming={600}
+      animationOutTiming={600}
+      onBackdropPress={close}
+      onBackButtonPress={close}
+      onSwipeComplete={close}
+      swipeDirection={'down'}
+      propagateSwipe
+      useNativeDriver
     >
-      <BottomSheet
-        ref={bottomSheetRef}
-        onClose={close}
-        twClassName={surfaceClass}
-        testID="custom-nonce-modal"
+      <KeyboardAwareScrollView
+        contentContainerStyle={styles.keyboardAwareWrapper}
       >
-        <View style={styles.modalContainer}>
-          <Text bold centered style={styles.title}>
-            {strings('transaction.edit_transaction_nonce')}
-          </Text>
-          <View style={styles.nonceInputContainer}>
-            <TextInput
-              // disable keyboard for now
-              showSoftInputOnFocus={false}
-              keyboardType="numeric"
-              // autoFocus
-              autoCapitalize="none"
-              autoCorrect={false}
-              onChangeText={(text) => {
-                if (isNumber(text)) {
-                  onChangeText(text);
-                }
-              }}
-              placeholder={String(proposedNonce)}
-              placeholderTextColor={colors.text.muted}
-              spellCheck={false}
-              editable
-              style={styles.nonceInput}
-              value={String(nonce)}
-              numberOfLines={1}
-              onSubmitEditing={saveAndClose}
-              keyboardAppearance={themeAppearance}
-            />
-          </View>
-          <Text centered style={styles.currentSuggested}>
-            {strings('transaction.current_suggested_nonce')}{' '}
-            <Text bold>{proposedNonce}</Text>
-          </Text>
-          <View style={styles.incrementDecrementNonceContainer}>
-            <TouchableOpacity
-              style={styles.incrementHit}
-              onPress={() => incrementDecrementNonce(true)}
-              testID={'decrement-nonce'}
-            >
-              <EvilIcons
-                name="minus"
-                size={64}
-                style={styles.incrementDecrementIcon}
+        <SafeAreaView style={styles.modal}>
+          <ModalDragger />
+          <View style={styles.modalContainer}>
+            <Text bold centered style={styles.title}>
+              {strings('transaction.edit_transaction_nonce')}
+            </Text>
+            <View style={styles.nonceInputContainer}>
+              <TextInput
+                // disable keyboard for now
+                showSoftInputOnFocus={false}
+                keyboardType="numeric"
+                // autoFocus
+                autoCapitalize="none"
+                autoCorrect={false}
+                onChangeText={(text) => {
+                  if (isNumber(text)) {
+                    onChangeText(text);
+                  }
+                }}
+                placeholder={String(proposedNonce)}
+                placeholderTextColor={colors.text.muted}
+                spellCheck={false}
+                editable
+                style={styles.nonceInput}
+                value={String(nonce)}
+                numberOfLines={1}
+                onSubmitEditing={saveAndClose}
+                keyboardAppearance={themeAppearance}
               />
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.incrementHit}
-              onPress={() => incrementDecrementNonce(false)}
-              testID={'increment-nonce'}
-            >
-              <EvilIcons
-                name="plus"
-                size={64}
-                style={styles.incrementDecrementIcon}
-              />
-            </TouchableOpacity>
-          </View>
-          <View style={styles.descWarningContainer}>
-            {displayWarning ? (
-              <View style={styles.nonceWarning}>
-                <Icon
-                  name="exclamation-circle"
-                  color={colors.warning.default}
-                  size={16}
-                  style={styles.icon}
+            </View>
+            <Text centered style={styles.currentSuggested}>
+              {strings('transaction.current_suggested_nonce')}{' '}
+              <Text bold>{proposedNonce}</Text>
+            </Text>
+            <View style={styles.incrementDecrementNonceContainer}>
+              <TouchableOpacity
+                style={styles.incrementHit}
+                onPress={() => incrementDecrementNonce(true)}
+                testID={'decrement-nonce'}
+              >
+                <EvilIcons
+                  name="minus"
+                  size={64}
+                  style={styles.incrementDecrementIcon}
                 />
-                <Text style={styles.nonceWarningText}>
-                  {strings('transaction.nonce_warning')}
-                </Text>
-              </View>
-            ) : null}
-            <Text bold style={styles.desc}>
-              {strings('transaction.this_is_an_advanced')}
-            </Text>
-            <Text style={styles.desc}>
-              {strings('transaction.think_of_the_nonce')}
-            </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.incrementHit}
+                onPress={() => incrementDecrementNonce(false)}
+                testID={'increment-nonce'}
+              >
+                <EvilIcons
+                  name="plus"
+                  size={64}
+                  style={styles.incrementDecrementIcon}
+                />
+              </TouchableOpacity>
+            </View>
+            <View style={styles.descWarningContainer}>
+              {displayWarning ? (
+                <View style={styles.nonceWarning}>
+                  <Icon
+                    name="exclamation-circle"
+                    color={colors.warning.default}
+                    size={16}
+                    style={styles.icon}
+                  />
+                  <Text style={styles.nonceWarningText}>
+                    {strings('transaction.nonce_warning')}
+                  </Text>
+                </View>
+              ) : null}
+              <Text bold style={styles.desc}>
+                {strings('transaction.this_is_an_advanced')}
+              </Text>
+              <Text style={styles.desc}>
+                {strings('transaction.think_of_the_nonce')}
+              </Text>
+            </View>
           </View>
-        </View>
-        <View style={styles.actionRow}>
-          <StyledButton
-            type={'normal'}
-            containerStyle={styles.actionButton}
-            onPress={handleClose}
-          >
-            {strings('transaction.cancel')}
-          </StyledButton>
-          <StyledButton
-            type={'blue'}
-            onPress={saveAndClose}
-            containerStyle={styles.actionButton}
-          >
-            {strings('transaction.save')}
-          </StyledButton>
-        </View>
-      </BottomSheet>
+          <View style={styles.actionRow}>
+            <StyledButton
+              type={'normal'}
+              containerStyle={styles.actionButton}
+              onPress={close}
+            >
+              {strings('transaction.cancel')}
+            </StyledButton>
+            <StyledButton
+              type={'blue'}
+              onPress={() => saveAndClose(nonce)}
+              containerStyle={styles.actionButton}
+            >
+              {strings('transaction.save')}
+            </StyledButton>
+          </View>
+        </SafeAreaView>
+      </KeyboardAwareScrollView>
     </Modal>
   );
 };

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
@@ -1,7 +1,13 @@
 import React, { useRef } from 'react';
 import { fontStyles } from '../../../../../../styles/common';
 import { strings } from '../../../../../../../locales/i18n';
-import { StyleSheet, View, TextInput, TouchableOpacity } from 'react-native';
+import {
+  Modal,
+  StyleSheet,
+  View,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
 import Text from '../../../../../Base/Text';
 import StyledButton from '../../../../../UI/StyledButton';
 import PropTypes from 'prop-types';
@@ -128,12 +134,19 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
   const displayWarning = String(proposedNonce) !== String(nonce);
 
   return (
-    <BottomSheet
-      ref={bottomSheetRef}
-      onClose={close}
-      twClassName={surfaceClass}
-      testID="custom-nonce-modal"
+    <Modal
+      visible
+      transparent
+      animationType="none"
+      statusBarTranslucent
+      onRequestClose={handleClose}
     >
+      <BottomSheet
+        ref={bottomSheetRef}
+        onClose={close}
+        twClassName={surfaceClass}
+        testID="custom-nonce-modal"
+      >
       <View style={styles.modalContainer}>
         <Text bold centered style={styles.title}>
           {strings('transaction.edit_transaction_nonce')}
@@ -228,7 +241,8 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
           {strings('transaction.save')}
         </StyledButton>
       </View>
-    </BottomSheet>
+      </BottomSheet>
+    </Modal>
   );
 };
 

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
@@ -19,7 +19,9 @@ import {
   isPureBlackEnabled,
 } from '../../../../../../util/theme/themeUtils';
 
-const createStyles = (theme) => {
+// TODO(Pure Black): Remove createStyles export and dedicated styles tests once
+// pure black ships by default or this modal migrates to MMDS BottomSheet.
+export const createStyles = (theme) => {
   const { colors } = theme;
 
   return StyleSheet.create({

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
@@ -147,100 +147,100 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
         twClassName={surfaceClass}
         testID="custom-nonce-modal"
       >
-      <View style={styles.modalContainer}>
-        <Text bold centered style={styles.title}>
-          {strings('transaction.edit_transaction_nonce')}
-        </Text>
-        <View style={styles.nonceInputContainer}>
-          <TextInput
-            // disable keyboard for now
-            showSoftInputOnFocus={false}
-            keyboardType="numeric"
-            // autoFocus
-            autoCapitalize="none"
-            autoCorrect={false}
-            onChangeText={(text) => {
-              if (isNumber(text)) {
-                onChangeText(text);
-              }
-            }}
-            placeholder={String(proposedNonce)}
-            placeholderTextColor={colors.text.muted}
-            spellCheck={false}
-            editable
-            style={styles.nonceInput}
-            value={String(nonce)}
-            numberOfLines={1}
-            onSubmitEditing={saveAndClose}
-            keyboardAppearance={themeAppearance}
-          />
-        </View>
-        <Text centered style={styles.currentSuggested}>
-          {strings('transaction.current_suggested_nonce')}{' '}
-          <Text bold>{proposedNonce}</Text>
-        </Text>
-        <View style={styles.incrementDecrementNonceContainer}>
-          <TouchableOpacity
-            style={styles.incrementHit}
-            onPress={() => incrementDecrementNonce(true)}
-            testID={'decrement-nonce'}
-          >
-            <EvilIcons
-              name="minus"
-              size={64}
-              style={styles.incrementDecrementIcon}
+        <View style={styles.modalContainer}>
+          <Text bold centered style={styles.title}>
+            {strings('transaction.edit_transaction_nonce')}
+          </Text>
+          <View style={styles.nonceInputContainer}>
+            <TextInput
+              // disable keyboard for now
+              showSoftInputOnFocus={false}
+              keyboardType="numeric"
+              // autoFocus
+              autoCapitalize="none"
+              autoCorrect={false}
+              onChangeText={(text) => {
+                if (isNumber(text)) {
+                  onChangeText(text);
+                }
+              }}
+              placeholder={String(proposedNonce)}
+              placeholderTextColor={colors.text.muted}
+              spellCheck={false}
+              editable
+              style={styles.nonceInput}
+              value={String(nonce)}
+              numberOfLines={1}
+              onSubmitEditing={saveAndClose}
+              keyboardAppearance={themeAppearance}
             />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.incrementHit}
-            onPress={() => incrementDecrementNonce(false)}
-            testID={'increment-nonce'}
-          >
-            <EvilIcons
-              name="plus"
-              size={64}
-              style={styles.incrementDecrementIcon}
-            />
-          </TouchableOpacity>
-        </View>
-        <View style={styles.descWarningContainer}>
-          {displayWarning ? (
-            <View style={styles.nonceWarning}>
-              <Icon
-                name="exclamation-circle"
-                color={colors.warning.default}
-                size={16}
-                style={styles.icon}
+          </View>
+          <Text centered style={styles.currentSuggested}>
+            {strings('transaction.current_suggested_nonce')}{' '}
+            <Text bold>{proposedNonce}</Text>
+          </Text>
+          <View style={styles.incrementDecrementNonceContainer}>
+            <TouchableOpacity
+              style={styles.incrementHit}
+              onPress={() => incrementDecrementNonce(true)}
+              testID={'decrement-nonce'}
+            >
+              <EvilIcons
+                name="minus"
+                size={64}
+                style={styles.incrementDecrementIcon}
               />
-              <Text style={styles.nonceWarningText}>
-                {strings('transaction.nonce_warning')}
-              </Text>
-            </View>
-          ) : null}
-          <Text bold style={styles.desc}>
-            {strings('transaction.this_is_an_advanced')}
-          </Text>
-          <Text style={styles.desc}>
-            {strings('transaction.think_of_the_nonce')}
-          </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.incrementHit}
+              onPress={() => incrementDecrementNonce(false)}
+              testID={'increment-nonce'}
+            >
+              <EvilIcons
+                name="plus"
+                size={64}
+                style={styles.incrementDecrementIcon}
+              />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.descWarningContainer}>
+            {displayWarning ? (
+              <View style={styles.nonceWarning}>
+                <Icon
+                  name="exclamation-circle"
+                  color={colors.warning.default}
+                  size={16}
+                  style={styles.icon}
+                />
+                <Text style={styles.nonceWarningText}>
+                  {strings('transaction.nonce_warning')}
+                </Text>
+              </View>
+            ) : null}
+            <Text bold style={styles.desc}>
+              {strings('transaction.this_is_an_advanced')}
+            </Text>
+            <Text style={styles.desc}>
+              {strings('transaction.think_of_the_nonce')}
+            </Text>
+          </View>
         </View>
-      </View>
-      <View style={styles.actionRow}>
-        <StyledButton
-          type={'normal'}
-          containerStyle={styles.actionButton}
-          onPress={handleClose}
-        >
-          {strings('transaction.cancel')}
-        </StyledButton>
-        <StyledButton
-          type={'blue'}
-          onPress={saveAndClose}
-          containerStyle={styles.actionButton}
-        >
-          {strings('transaction.save')}
-        </StyledButton>
-      </View>
+        <View style={styles.actionRow}>
+          <StyledButton
+            type={'normal'}
+            containerStyle={styles.actionButton}
+            onPress={handleClose}
+          >
+            {strings('transaction.cancel')}
+          </StyledButton>
+          <StyledButton
+            type={'blue'}
+            onPress={saveAndClose}
+            containerStyle={styles.actionButton}
+          >
+            {strings('transaction.save')}
+          </StyledButton>
+        </View>
       </BottomSheet>
     </Modal>
   );

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.js
@@ -1,35 +1,22 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { fontStyles } from '../../../../../../styles/common';
 import { strings } from '../../../../../../../locales/i18n';
 import { StyleSheet, View, TextInput, TouchableOpacity } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import ModalDragger from '../../../../../Base/ModalDragger';
 import Text from '../../../../../Base/Text';
 import StyledButton from '../../../../../UI/StyledButton';
-import Modal from 'react-native-modal';
 import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
+import { BottomSheet } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../../util/theme';
 import { isNumber } from '../../../../../../util/number';
+import {
+  isPureBlackEnabled,
+  useElevatedSurface,
+} from '../../../../../../util/theme/themeUtils';
 
 const createStyles = (colors) =>
   StyleSheet.create({
-    bottomModal: {
-      justifyContent: 'flex-end',
-      margin: 0,
-    },
-    keyboardAwareWrapper: {
-      flex: 1,
-      justifyContent: 'flex-end',
-    },
-    modal: {
-      minHeight: 200,
-      backgroundColor: colors.background.default,
-      borderTopLeftRadius: 20,
-      borderTopRightRadius: 20,
-    },
     modalContainer: {
       margin: 24,
     },
@@ -73,7 +60,7 @@ const createStyles = (colors) =>
     nonceWarning: {
       borderWidth: 1,
       borderColor: colors.warning.default,
-      backgroundColor: colors.warning.muted,
+      ...(isPureBlackEnabled ? {} : { backgroundColor: colors.warning.muted }),
       padding: 16,
       display: 'flex',
       flexDirection: 'row',
@@ -94,6 +81,7 @@ const createStyles = (colors) =>
     actionRow: {
       flexDirection: 'row',
       marginBottom: 15,
+      paddingHorizontal: 16,
     },
     actionButton: {
       flex: 1,
@@ -114,7 +102,9 @@ const createStyles = (colors) =>
 
 const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
   const [nonce, onChangeText] = React.useState(nonceValue);
+  const bottomSheetRef = useRef(null);
   const { colors, themeAppearance } = useTheme();
+  const surfaceClass = useElevatedSurface();
   const styles = createStyles(colors);
 
   const incrementDecrementNonce = (isDecrement) => {
@@ -125,133 +115,120 @@ const CustomModalNonce = ({ proposedNonce, nonceValue, close, save }) => {
     onChangeText(clampedValue);
   };
 
+  const handleClose = () => {
+    bottomSheetRef.current?.onCloseBottomSheet();
+  };
+
   const saveAndClose = () => {
     const numberNonce = Number(nonce);
     save(numberNonce);
-    close();
+    bottomSheetRef.current?.onCloseBottomSheet();
   };
 
   const displayWarning = String(proposedNonce) !== String(nonce);
 
   return (
-    <Modal
-      isVisible
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      style={styles.bottomModal}
-      backdropColor={colors.overlay.default}
-      backdropOpacity={1}
-      animationInTiming={600}
-      animationOutTiming={600}
-      onBackdropPress={close}
-      onBackButtonPress={close}
-      onSwipeComplete={close}
-      swipeDirection={'down'}
-      propagateSwipe
-      useNativeDriver
+    <BottomSheet
+      ref={bottomSheetRef}
+      onClose={close}
+      twClassName={surfaceClass}
+      testID="custom-nonce-modal"
     >
-      <KeyboardAwareScrollView
-        contentContainerStyle={styles.keyboardAwareWrapper}
-      >
-        <SafeAreaView style={styles.modal}>
-          <ModalDragger />
-          <View style={styles.modalContainer}>
-            <Text bold centered style={styles.title}>
-              {strings('transaction.edit_transaction_nonce')}
-            </Text>
-            <View style={styles.nonceInputContainer}>
-              <TextInput
-                // disable keyboard for now
-                showSoftInputOnFocus={false}
-                keyboardType="numeric"
-                // autoFocus
-                autoCapitalize="none"
-                autoCorrect={false}
-                onChangeText={(text) => {
-                  if (isNumber(text)) {
-                    onChangeText(text);
-                  }
-                }}
-                placeholder={String(proposedNonce)}
-                placeholderTextColor={colors.text.muted}
-                spellCheck={false}
-                editable
-                style={styles.nonceInput}
-                value={String(nonce)}
-                numberOfLines={1}
-                onSubmitEditing={saveAndClose}
-                keyboardAppearance={themeAppearance}
+      <View style={styles.modalContainer}>
+        <Text bold centered style={styles.title}>
+          {strings('transaction.edit_transaction_nonce')}
+        </Text>
+        <View style={styles.nonceInputContainer}>
+          <TextInput
+            // disable keyboard for now
+            showSoftInputOnFocus={false}
+            keyboardType="numeric"
+            // autoFocus
+            autoCapitalize="none"
+            autoCorrect={false}
+            onChangeText={(text) => {
+              if (isNumber(text)) {
+                onChangeText(text);
+              }
+            }}
+            placeholder={String(proposedNonce)}
+            placeholderTextColor={colors.text.muted}
+            spellCheck={false}
+            editable
+            style={styles.nonceInput}
+            value={String(nonce)}
+            numberOfLines={1}
+            onSubmitEditing={saveAndClose}
+            keyboardAppearance={themeAppearance}
+          />
+        </View>
+        <Text centered style={styles.currentSuggested}>
+          {strings('transaction.current_suggested_nonce')}{' '}
+          <Text bold>{proposedNonce}</Text>
+        </Text>
+        <View style={styles.incrementDecrementNonceContainer}>
+          <TouchableOpacity
+            style={styles.incrementHit}
+            onPress={() => incrementDecrementNonce(true)}
+            testID={'decrement-nonce'}
+          >
+            <EvilIcons
+              name="minus"
+              size={64}
+              style={styles.incrementDecrementIcon}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.incrementHit}
+            onPress={() => incrementDecrementNonce(false)}
+            testID={'increment-nonce'}
+          >
+            <EvilIcons
+              name="plus"
+              size={64}
+              style={styles.incrementDecrementIcon}
+            />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.descWarningContainer}>
+          {displayWarning ? (
+            <View style={styles.nonceWarning}>
+              <Icon
+                name="exclamation-circle"
+                color={colors.warning.default}
+                size={16}
+                style={styles.icon}
               />
-            </View>
-            <Text centered style={styles.currentSuggested}>
-              {strings('transaction.current_suggested_nonce')}{' '}
-              <Text bold>{proposedNonce}</Text>
-            </Text>
-            <View style={styles.incrementDecrementNonceContainer}>
-              <TouchableOpacity
-                style={styles.incrementHit}
-                onPress={() => incrementDecrementNonce(true)}
-                testID={'decrement-nonce'}
-              >
-                <EvilIcons
-                  name="minus"
-                  size={64}
-                  style={styles.incrementDecrementIcon}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.incrementHit}
-                onPress={() => incrementDecrementNonce(false)}
-                testID={'increment-nonce'}
-              >
-                <EvilIcons
-                  name="plus"
-                  size={64}
-                  style={styles.incrementDecrementIcon}
-                />
-              </TouchableOpacity>
-            </View>
-            <View style={styles.descWarningContainer}>
-              {displayWarning ? (
-                <View style={styles.nonceWarning}>
-                  <Icon
-                    name="exclamation-circle"
-                    color={colors.warning.default}
-                    size={16}
-                    style={styles.icon}
-                  />
-                  <Text style={styles.nonceWarningText}>
-                    {strings('transaction.nonce_warning')}
-                  </Text>
-                </View>
-              ) : null}
-              <Text bold style={styles.desc}>
-                {strings('transaction.this_is_an_advanced')}
-              </Text>
-              <Text style={styles.desc}>
-                {strings('transaction.think_of_the_nonce')}
+              <Text style={styles.nonceWarningText}>
+                {strings('transaction.nonce_warning')}
               </Text>
             </View>
-          </View>
-          <View style={styles.actionRow}>
-            <StyledButton
-              type={'normal'}
-              containerStyle={styles.actionButton}
-              onPress={close}
-            >
-              {strings('transaction.cancel')}
-            </StyledButton>
-            <StyledButton
-              type={'blue'}
-              onPress={() => saveAndClose(nonce)}
-              containerStyle={styles.actionButton}
-            >
-              {strings('transaction.save')}
-            </StyledButton>
-          </View>
-        </SafeAreaView>
-      </KeyboardAwareScrollView>
-    </Modal>
+          ) : null}
+          <Text bold style={styles.desc}>
+            {strings('transaction.this_is_an_advanced')}
+          </Text>
+          <Text style={styles.desc}>
+            {strings('transaction.think_of_the_nonce')}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.actionRow}>
+        <StyledButton
+          type={'normal'}
+          containerStyle={styles.actionButton}
+          onPress={handleClose}
+        >
+          {strings('transaction.cancel')}
+        </StyledButton>
+        <StyledButton
+          type={'blue'}
+          onPress={saveAndClose}
+          containerStyle={styles.actionButton}
+        >
+          {strings('transaction.save')}
+        </StyledButton>
+      </View>
+    </BottomSheet>
   );
 };
 

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
@@ -3,6 +3,39 @@ import { render, screen, fireEvent } from '@testing-library/react-native';
 import CustomNonceModal from '.';
 import { ThemeContext, mockTheme } from '../../../../../../util/theme';
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  const MockBottomSheet = ReactActual.forwardRef(
+    ({ children, onClose, testID }, ref) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: () => {
+          onClose?.();
+        },
+        onOpenBottomSheet: jest.fn(),
+      }));
+
+      return ReactActual.createElement(
+        View,
+        { testID: testID ?? 'mock-bottom-sheet' },
+        children,
+      );
+    },
+  );
+
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+  };
+});
+
+jest.mock('../../../../../../util/theme/themeUtils', () => ({
+  ...jest.requireActual('../../../../../../util/theme/themeUtils'),
+  useElevatedSurface: () => 'bg-default',
+}));
+
 const PROPOSED_NONCE = 26;
 const saveMock = jest.fn();
 const closeMock = jest.fn();
@@ -18,11 +51,17 @@ const renderComponent = (props = {}) =>
       />
     </ThemeContext.Provider>,
   );
+
 describe('CustomNonceModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders correctly', () => {
     renderComponent();
     expect(screen.getByTestId('increment-nonce')).toBeOnTheScreen();
     expect(screen.getByTestId('decrement-nonce')).toBeOnTheScreen();
+    expect(screen.getByTestId('custom-nonce-modal')).toBeOnTheScreen();
   });
 
   it('handles only numeric inputs', () => {
@@ -56,5 +95,18 @@ describe('CustomNonceModal', () => {
 
     fireEvent.press(decrementButton);
     expect(screen.getByDisplayValue(String(0))).toBeTruthy();
+  });
+
+  it('calls close when cancel is pressed', () => {
+    renderComponent();
+    fireEvent.press(screen.getByText('Cancel'));
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls save and close when save is pressed', () => {
+    renderComponent();
+    fireEvent.press(screen.getByText('Save'));
+    expect(saveMock).toHaveBeenCalledWith(PROPOSED_NONCE);
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
@@ -9,7 +9,18 @@ jest.mock('@metamask/design-system-react-native', () => {
   const { View } = jest.requireActual('react-native');
 
   const MockBottomSheet = ReactActual.forwardRef(
-    ({ children, onClose, testID }, ref) => {
+    (
+      {
+        children,
+        onClose,
+        testID,
+      }: {
+        children: React.ReactNode;
+        onClose?: () => void;
+        testID?: string;
+      },
+      ref: React.Ref<{ onCloseBottomSheet: () => void }>,
+    ) => {
       ReactActual.useImperativeHandle(ref, () => ({
         onCloseBottomSheet: () => {
           onClose?.();

--- a/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/CustomNonceModal/index.test.tsx
@@ -3,50 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react-native';
 import CustomNonceModal from '.';
 import { ThemeContext, mockTheme } from '../../../../../../util/theme';
 
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-
-  const MockBottomSheet = ReactActual.forwardRef(
-    (
-      {
-        children,
-        onClose,
-        testID,
-      }: {
-        children: React.ReactNode;
-        onClose?: () => void;
-        testID?: string;
-      },
-      ref: React.Ref<{ onCloseBottomSheet: () => void }>,
-    ) => {
-      ReactActual.useImperativeHandle(ref, () => ({
-        onCloseBottomSheet: () => {
-          onClose?.();
-        },
-        onOpenBottomSheet: jest.fn(),
-      }));
-
-      return ReactActual.createElement(
-        View,
-        { testID: testID ?? 'mock-bottom-sheet' },
-        children,
-      );
-    },
-  );
-
-  return {
-    ...actual,
-    BottomSheet: MockBottomSheet,
-  };
-});
-
-jest.mock('../../../../../../util/theme/themeUtils', () => ({
-  ...jest.requireActual('../../../../../../util/theme/themeUtils'),
-  useElevatedSurface: () => 'bg-default',
-}));
-
 const PROPOSED_NONCE = 26;
 const saveMock = jest.fn();
 const closeMock = jest.fn();
@@ -72,7 +28,6 @@ describe('CustomNonceModal', () => {
     renderComponent();
     expect(screen.getByTestId('increment-nonce')).toBeOnTheScreen();
     expect(screen.getByTestId('decrement-nonce')).toBeOnTheScreen();
-    expect(screen.getByTestId('custom-nonce-modal')).toBeOnTheScreen();
   });
 
   it('handles only numeric inputs', () => {
@@ -106,18 +61,5 @@ describe('CustomNonceModal', () => {
 
     fireEvent.press(decrementButton);
     expect(screen.getByDisplayValue(String(0))).toBeTruthy();
-  });
-
-  it('calls close when cancel is pressed', () => {
-    renderComponent();
-    fireEvent.press(screen.getByText('Cancel'));
-    expect(closeMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls save and close when save is pressed', () => {
-    renderComponent();
-    fireEvent.press(screen.getByText('Save'));
-    expect(saveMock).toHaveBeenCalledWith(PROPOSED_NONCE);
-    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The **Edit transaction nonce** bottom sheet (`CustomNonceModal`) hardcoded `background.default` on its modal container. In Pure Black preview mode (`MM_PURE_BLACK_PREVIEW=true`), the sheet rendered as flat black (`#000000`) instead of using the elevated surface color (`background.alternative`) used elsewhere in the redesigned send/confirm flow.

This PR keeps the existing `react-native-modal` component structure and applies a minimal color-only fix:

- Use `getElevatedSurfaceColor(theme)` for the sheet container background instead of `colors.background.default`
- Add a subtle `border.muted` top border in Pure Black dark mode (matching other elevated surfaces)
- Omit `warning.muted` fill on the nonce warning box when Pure Black is enabled so child containers do not paint opaque patches over the elevated surface

No migration to MMDS `BottomSheet` or button refactors in this PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1017

## **Manual testing steps**

```gherkin
Feature: CustomNonceModal Pure Black elevated surface

  Scenario: Nonce editor sheet uses elevated surface in Pure Black dark mode
    Given MM_PURE_BLACK_PREVIEW="true" is set in .js.env and the app is rebuilt
    And Customize transaction nonce is enabled in Settings
    And the app is in Dark mode
    When the user initiates a send and opens Advanced details on the confirmation screen
    And taps the Nonce value to open the Edit transaction nonce sheet
    Then the sheet background uses the elevated surface (bg-alternative) instead of flat black
    And changing the nonce away from the suggested value shows a border-only warning (no muted fill patch) in Pure Black
```

## **Screenshots/Recordings**

### **Before**

<img width="412" height="671" alt="Screenshot 2026-07-14 at 1 59 48 PM" src="https://github.com/user-attachments/assets/f0f3d4f1-dfee-4f95-935f-23bada6464d5" />

### **After**

<img width="397" height="642" alt="Screenshot 2026-07-14 at 1 49 01 PM" src="https://github.com/user-attachments/assets/8144bf62-66a6-4889-81f2-2cabdda0da7b" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-446f68e6-5f6b-4781-a70a-f3f94a445c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-446f68e6-5f6b-4781-a70a-f3f94a445c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

