### PR TITLE
fix(confirmations): use MMDS BottomSheet for Advanced details in Pure Black theme

### DIFF
--- a/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.styles.ts
@@ -21,10 +21,7 @@ const styleSheet = (params: {
       marginBottom: isCompact ? 0 : 8,
     },
     modalContent: {
-      backgroundColor: theme.colors.background.section,
       paddingBottom: 34,
-      borderTopLeftRadius: 8,
-      borderTopRightRadius: 8,
     },
     modalExpandedContent: {
       paddingHorizontal: 16,

--- a/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
@@ -60,7 +60,13 @@ const Expandable = ({
         {collapsedContent}
       </TouchableOpacity>
       {expanded && (
-        <Modal visible transparent animationType="none">
+        <Modal
+          visible
+          transparent
+          animationType="none"
+          presentationStyle="overFullScreen"
+          onRequestClose={handleClose}
+        >
           <BottomSheet
             ref={bottomSheetRef}
             onClose={handleSheetClosed}

--- a/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
+++ b/app/components/Views/confirmations/components/UI/expandable/expandable.tsx
@@ -1,9 +1,13 @@
-import React, { ReactNode, useState } from 'react';
-import { HeaderStandard } from '@metamask/design-system-react-native';
-import { TouchableOpacity, View } from 'react-native';
+import React, { ReactNode, useCallback, useRef, useState } from 'react';
+import {
+  BottomSheet,
+  BottomSheetRef,
+  HeaderStandard,
+} from '@metamask/design-system-react-native';
+import { Modal, TouchableOpacity, View } from 'react-native';
 
 import { useStyles } from '../../../../../../component-library/hooks';
-import BottomModal from '../bottom-modal';
+import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import CopyButton from '../copy-button';
 import styleSheet from './expandable.styles';
 
@@ -32,6 +36,16 @@ const Expandable = ({
 }: ExpandableProps) => {
   const { styles } = useStyles(styleSheet, { isCompact });
   const [expanded, setExpanded] = useState(false);
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+  const surfaceClass = useElevatedSurface();
+
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleSheetClosed = useCallback(() => {
+    setExpanded(false);
+  }, []);
 
   return (
     <>
@@ -46,25 +60,31 @@ const Expandable = ({
         {collapsedContent}
       </TouchableOpacity>
       {expanded && (
-        <BottomModal onClose={() => setExpanded(false)}>
-          <View style={styles.modalContent}>
-            <HeaderStandard
-              title={expandedContentTitle}
-              onClose={() => setExpanded(false)}
-              closeButtonProps={{
-                testID: collapseButtonTestID ?? 'collapseButtonTestID',
-              }}
-            />
-            <View style={styles.modalExpandedContent}>
-              {copyText && (
-                <View style={styles.copyButtonContainer}>
-                  <CopyButton copyText={copyText} />
-                </View>
-              )}
-              {expandedContent}
+        <Modal visible transparent animationType="none">
+          <BottomSheet
+            ref={bottomSheetRef}
+            onClose={handleSheetClosed}
+            twClassName={surfaceClass}
+          >
+            <View style={styles.modalContent}>
+              <HeaderStandard
+                title={expandedContentTitle}
+                onClose={handleClose}
+                closeButtonProps={{
+                  testID: collapseButtonTestID ?? 'collapseButtonTestID',
+                }}
+              />
+              <View style={styles.modalExpandedContent}>
+                {copyText && (
+                  <View style={styles.copyButtonContainer}>
+                    <CopyButton copyText={copyText} />
+                  </View>
+                )}
+                {expandedContent}
+              </View>
             </View>
-          </View>
-        </BottomModal>
+          </BottomSheet>
+        </Modal>
       )}
     </>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The Advanced details bottom sheet in the send flow (and other confirmation screens using `Expandable`) rendered with `bg-section` because the component used the legacy `BottomModal` with a hardcoded `theme.colors.background.section` background. In Pure Black theme, this caused a visible contrast mismatch against the surrounding page.

This change migrates `Expandable` to the MMDS `BottomSheet` component with `useElevatedSurface()`, which applies `bg-alternative` in Pure Black dark mode. This matches the pattern already used by `SendAlertModal` and `AccountSelector`.

Also restores Android hardware back dismissal by wiring `onRequestClose` on the `Modal` wrapper (matching `AccountSelector`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1059

## **Manual testing steps**

```gherkin
Feature: Advanced details bottom sheet background in Pure Black theme

  Scenario: Advanced details sheet uses correct background in Pure Black
    Given the app is set to Pure Black theme
    And the user starts the send flow

    When the user taps Advanced on the confirmation screen
    Then the Advanced details bottom sheet background matches the elevated surface (bg-alternative)
    And the sheet background does not appear as a mismatched bg-section tone

  Scenario: Android back dismisses Advanced details sheet
    Given the user has opened the Advanced details bottom sheet

    When the user presses the Android hardware back button
    Then the bottom sheet dismisses
```

N/A for automated device testing in this environment — unit tests for `Expandable` and `AdvancedDetailsRow` pass.

## **Screenshots/Recordings**

N/A — visual theme fix; requires device/simulator with Pure Black theme enabled to capture before/after screenshots.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00e982b9-7da5-4034-9da4-ec468ee031c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00e982b9-7da5-4034-9da4-ec468ee031c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

