### PR TITLE
fix(confirmations): use elevated surface for confirmation tooltip modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed confirmation tooltip bottom sheet surface mismatch in Pure Black theme (#TBD)
+
 ## [8.1.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed confirmation tooltip bottom sheet surface mismatch in Pure Black theme (#TBD)
-
 ## [8.1.1]
 
 ### Fixed

--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.styles.ts
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.styles.ts
@@ -1,14 +1,25 @@
 import { StyleSheet } from 'react-native';
 
-import { Theme } from '../../../../../../util/theme/models';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
 import { fontStyles } from '../../../../../../styles/common';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     modalView: {
-      backgroundColor: theme.colors.background.section,
+      backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       justifyContent: 'center',
       alignItems: 'center',
       borderRadius: 8,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This change updates `Tooltip.styles.ts` to use `getElevatedSurfaceColor(theme)` for the modal container, with a muted border in pure black dark mode — matching the elevated surface stopgap pattern used elsewhere (e.g. TMCU-1059 Advanced details / Expandable).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1097

## **Manual testing steps**

```gherkin
Feature: Confirmation tooltip surface in Pure Black mode

  Scenario: Tooltip bottom sheet matches elevated confirmation surface
    Given Pure Black preview is enabled and the app is in dark mode
    And the user opens a transaction confirmation with a tooltip info icon

    When the user taps the tooltip icon to open the bottom sheet
    Then the tooltip modal background matches the elevated confirmation surface without visible banding
```

## **Screenshots/Recordings**

### **Before**

<img width="400" height="242" alt="Screenshot 2026-07-13 at 10 00 00 PM" src="https://github.com/user-attachments/assets/004071c2-b7cd-4caa-be79-ff250fbdbbb3" />

### **After**

<img width="396" height="253" alt="Screenshot 2026-07-13 at 10 00 21 PM" src="https://github.com/user-attachments/assets/088e813f-29ec-4d99-a25d-2217bdfffe18" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — style-only change with no runtime performance impact.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dd470dd-d83f-4b27-9aac-47ae734c345f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dd470dd-d83f-4b27-9aac-47ae734c345f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

