### PR TITLE
fix(confirmations): use elevated surface color for value detail modal in Pure Black

### DIFF
--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
@@ -62,8 +62,8 @@ const NativeValueDisplay: React.FC<PermitSimulationValueDisplayParams> = ({
 }) => {
   const [hasValueModalOpen, setHasValueModalOpen] = useState(false);
 
-  const { colors } = useTheme();
-  const styles = styleSheet(colors);
+  const theme = useTheme();
+  const styles = styleSheet(theme);
 
   const conversionRate = useSelector((state: RootState) =>
     selectConversionRateByChainId(state, chainId),

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.styles.ts
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.styles.ts
@@ -1,10 +1,16 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '../../../../../../../../../util/theme/models';
+import {
+  AppThemeKey,
+  Theme,
+} from '../../../../../../../../../util/theme/models';
 import {
   fontStyles,
   colors as importedColors,
 } from '../../../../../../../../../styles/common';
-import { getElevatedSurfaceColor } from '../../../../../../../../../util/theme/themeUtils';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../../../../util/theme/themeUtils';
 
 const styleSheet = (theme: Theme) => {
   const { colors } = theme;
@@ -65,6 +71,12 @@ const styleSheet = (theme: Theme) => {
     },
     valueModal: {
       backgroundColor: getElevatedSurfaceColor(theme),
+      ...(isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark
+        ? {
+            borderWidth: 1,
+            borderColor: colors.border.muted,
+          }
+        : null),
       paddingTop: 24,
       paddingBottom: 34,
       paddingHorizontal: 16,

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.styles.ts
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.styles.ts
@@ -1,12 +1,15 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '@metamask/design-tokens';
+import { Theme } from '../../../../../../../../../util/theme/models';
 import {
   fontStyles,
   colors as importedColors,
 } from '../../../../../../../../../styles/common';
+import { getElevatedSurfaceColor } from '../../../../../../../../../util/theme/themeUtils';
 
-const styleSheet = (colors: Theme['colors']) =>
-  StyleSheet.create({
+const styleSheet = (theme: Theme) => {
+  const { colors } = theme;
+
+  return StyleSheet.create({
     wrapper: {
       marginLeft: 'auto',
       maxWidth: '100%',
@@ -61,7 +64,7 @@ const styleSheet = (colors: Theme['colors']) =>
       color: colors.error.default,
     },
     valueModal: {
-      backgroundColor: colors.background.muted,
+      backgroundColor: getElevatedSurfaceColor(theme),
       paddingTop: 24,
       paddingBottom: 34,
       paddingHorizontal: 16,
@@ -94,5 +97,6 @@ const styleSheet = (colors: Theme['colors']) =>
       textAlign: 'center',
     },
   });
+};
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
@@ -99,9 +99,9 @@ const SimulationValueDisplay: React.FC<SimulationValueDisplayParams> = ({
 }) => {
   const [hasValueModalOpen, setHasValueModalOpen] = useState(false);
 
-  const { colors } = useTheme();
+  const theme = useTheme();
 
-  const styles = styleSheet(colors);
+  const styles = styleSheet(theme);
 
   const contractExchangeRates = useSelector((state: RootState) =>
     selectContractExchangeRatesByChainId(state, chainId),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the typed-sign simulation **ValueDisplay** and **NativeValueDisplay** detail bottom sheets used `background.muted` on the modal container while stacked on an elevated confirmation surface, producing a visible mismatched background patch.

This change replaces the hardcoded `background.muted` with `getElevatedSurfaceColor(theme)` so the modal background matches the elevated confirmation surface when Pure Black is enabled. When Pure Black is off, behavior is unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1096](https://consensyssoftware.atlassian.net/browse/TMCU-1096)

## **Manual testing steps**

```gherkin
Feature: Pure Black value detail modal background

  Scenario: value detail bottom sheet matches elevated confirmation surface in Pure Black
    Given Pure Black mode is enabled
    And the user opens a typed-sign v3/v4 confirmation with simulation value details

    When the user taps a value row to open the detail bottom sheet
    Then the bottom sheet background matches the elevated confirmation surface without a muted background patch
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 3 17 21 PM" src="https://github.com/user-attachments/assets/0a3d96f5-a64e-4a27-862c-d57e03d625b7" />


### **After**

<img width="350" alt="Screenshot 2026-07-14 at 3 17 16 PM" src="https://github.com/user-attachments/assets/112960cf-0325-4212-9c97-e57b8a13ca86" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880d4d44-2d5b-4828-938a-9d6b6ab0cff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880d4d44-2d5b-4828-938a-9d6b6ab0cff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1096]: https://consensyssoftware.atlassian.net/browse/TMCU-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ