### PR TITLE
test: Update Predict E2E to wait for top toast dismiss before back tap

### DIFF
--- a/tests/page-objects/wallet/ToastModal.ts
+++ b/tests/page-objects/wallet/ToastModal.ts
@@ -50,8 +50,9 @@ class ToastModal {
   }
 
   /**
-   * If a bottom toast is visible, waits for it to disappear. Otherwise returns
+   * If a toast is visible, waits for it to disappear. Otherwise returns
    * immediately. Never fails the test when no toast is shown or dismiss is slow.
+   * Used before tapping header back controls that top toasts can cover.
    */
   async waitForToastToDismiss(
     options: {

--- a/tests/smoke-appium/predict/predict-cash-out.spec.ts
+++ b/tests/smoke-appium/predict/predict-cash-out.spec.ts
@@ -30,6 +30,8 @@ import {
   remoteFeatureFlagPerpsDisabledForPredictSmoke,
 } from './helpers/predict-helpers.js';
 import { resolveE2EWaitTimeoutMs } from '../../framework/Constants.js';
+import ToastModal from '../../page-objects/wallet/ToastModal.js';
+import { waitForWalletHomePlaywright } from '../../flows/wallet.flow.js';
 
 /*
 Test Scenario: Cash out on open position - Spurs vs. Pelicans
@@ -125,7 +127,13 @@ appiumTest.describe(SmokePredictions('Predictions'), () => {
           await POLYMARKET_REMOVE_CASHED_OUT_POSITION_MOCKS(mockServer);
           await POLYMARKET_UPDATE_USDC_BALANCE_MOCKS(mockServer, 'cash-out');
 
+          // Top toast covers the market-details back control until it auto-dismisses.
+          await ToastModal.waitForToastToDismiss();
           await PredictDetailsPage.tapBackButton();
+          // Wait for wallet home before scrolling — Android scrollIntoView
+          // fails with getElementRect(elementId=undefined) if wallet-scroll-view
+          // is not yet in the hierarchy after market-details pop.
+          await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
           await WalletView.scrollAndTapPredictionsSection();
           await WalletView.tapOnAvailableBalance();
           await Assertions.expectTextDisplayed(positionDetails.newBalance, {

--- a/tests/smoke-appium/predict/predict-claim-positions-market-details.spec.ts
+++ b/tests/smoke-appium/predict/predict-claim-positions-market-details.spec.ts
@@ -4,6 +4,7 @@ import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import Assertions from '../../framework/Assertions.js';
 import WalletView from '../../page-objects/wallet/WalletView.js';
+import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage.js';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
 import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBottomSheet.js';
@@ -90,6 +91,8 @@ appiumTest.describe(SmokePredictions('Claim winnings:'), () => {
                 'Claim button on market details should not be visible',
             },
           );
+          // Top claim toast covers the market-details back control until dismissed.
+          await ToastModal.waitForToastToDismiss();
           await PredictDetailsPage.tapBackButton();
 
           await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));

--- a/tests/smoke-appium/predict/predict-open-position.spec.ts
+++ b/tests/smoke-appium/predict/predict-open-position.spec.ts
@@ -19,12 +19,15 @@ import {
   POLYMARKET_LEGACY_SAFE_ACCOUNT_MOCKS,
 } from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
 import WalletView from '../../page-objects/wallet/WalletView.js';
+import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import { predictOpenPositionAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-open-position.analytics.js';
 import {
   loginForPredictTests,
   remoteFeatureFlagPerpsDisabledForPredictSmoke,
 } from './helpers/predict-helpers.js';
 import { CELTICS_NETS_POSITION_ID } from '../../api-mocking/mock-responses/polymarket/polymarket-constants.js';
+import { waitForWalletHomePlaywright } from '../../flows/wallet.flow.js';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants.js';
 
 /*
 Test Scenario: Open position on Celtics vs. Nets market
@@ -119,11 +122,18 @@ appiumTest.describe(SmokePredictions('Predictions'), () => {
 
           await PredictDetailsPage.tapOpenPosition();
 
+          // Top toast covers the market-details back control until it auto-dismisses.
+          await ToastModal.waitForToastToDismiss();
           await PredictDetailsPage.tapBackButton();
+          await PredictMarketList.waitForScreenToDisplay({
+            description:
+              'Predict market list should be visible after opening position',
+          });
           await Assertions.expectTextDisplayed(positionDetails.newBalance, {
             description: `USDC balance should display ${positionDetails.newBalance} after opening position`,
           });
           await PredictMarketList.tapBackButton();
+          await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
 
           await WalletView.scrollAndTapPredictionsPosition(
             positionDetails.name,
@@ -144,6 +154,7 @@ appiumTest.describe(SmokePredictions('Predictions'), () => {
           );
 
           await PredictDetailsPage.tapBackButton();
+          await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
           await WalletView.scrollAndTapPredictionsSection();
           await Assertions.expectTextDisplayed(positionDetails.newBalance);
         },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Top toasts cover Predict market-details back controls in Appium smokes, and Android scroll fails if wallet home is not mounted yet after popping market details.

**1. What is the reason for the change?**

Open-position, cash-out, and claim-from-market-details Appium smokes can flake when a top toast occludes the header back control, or when scroll runs before wallet home is in the hierarchy (`getElementRect(elementId=undefined)`).

**2. What is the improvement/solution?**

- Wait for `ToastModal.waitForToastToDismiss()` before tapping back after open/cash-out/claim actions
- Wait for wallet home (and market list where needed) before scrolling to Predictions
- Clarify `waitForToastToDismiss` docs for top-toast coverage of header back controls

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — test-only Appium smoke stability; no linked ticket

Refs: https://github.com/MetaMask/metamask-mobile/pull/32933

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — automation-only change; covered by Predict Appium smoke specs (`predict-open-position`, `predict-cash-out`, `predict-claim-positions-market-details`).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — test-only change

### **After**

N/A — test-only change

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only E2E timing and documentation; no production app behavior changes.
> 
> **Overview**
> Stabilizes Predict Appium smokes by sequencing navigation after success toasts and screen transitions.
> 
> **Toast + back:** Open-position, cash-out, and claim-from-market-details specs now call **`ToastModal.waitForToastToDismiss()`** before **`tapBackButton()`**, because top toasts can cover the market-details header back control. **`ToastModal`** JSDoc is updated to describe that pattern (not only “bottom” toasts).
> 
> **Wallet home / list:** Cash-out and open-position flows add **`waitForWalletHomePlaywright`** before scrolling the Predictions section on wallet home, avoiding Android **`getElementRect(elementId=undefined)`** when **`wallet-scroll-view`** is not mounted yet. Open-position also waits for the market list after the first back and again for wallet home before later scroll steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5940ade115ed2dce5ad810cc60aba79cf92ee586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->