### PR TITLE
fix(snaps): Add missing UI components

### DIFF
--- a/app/components/Snaps/SnapUIRenderer/components/divider.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/divider.ts
@@ -1,0 +1,12 @@
+import { DividerElement } from '@metamask/snaps-sdk/jsx';
+import { UIComponentFactory } from './types';
+
+export const divider: UIComponentFactory<DividerElement> = ({ theme }) => ({
+  element: 'Box',
+  props: {
+    style: {
+      height: 1,
+      backgroundColor: theme.colors.border.muted,
+    },
+  },
+});

--- a/app/components/Snaps/SnapUIRenderer/components/index.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/index.ts
@@ -30,6 +30,9 @@ import { dropdown } from './dropdown';
 import { radioGroup } from './radioGroup';
 import { dateTimePicker } from './date-time-picker';
 import { collapsibleSection } from './collapsible-section';
+import { checkbox } from './checkbox';
+import { divider } from './divider';
+import { italic } from './italic';
 
 export const COMPONENT_MAPPING = {
   Box: box,
@@ -63,5 +66,8 @@ export const COMPONENT_MAPPING = {
   Dropdown: dropdown,
   RadioGroup: radioGroup,
   DateTimePicker: dateTimePicker,
+  Checkbox: checkbox,
   CollapsibleSection: collapsibleSection,
+  Divider: divider,
+  Italic: italic,
 };

--- a/app/components/Snaps/SnapUIRenderer/components/italic.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/italic.ts
@@ -1,0 +1,24 @@
+import { ItalicElement, JSXElement } from '@metamask/snaps-sdk/jsx';
+import { getJsxChildren } from '@metamask/snaps-utils';
+import { NonEmptyArray } from '@metamask/utils';
+import { mapTextToTemplate } from '../utils';
+import { UIComponentFactory } from './types';
+import { TextVariant } from '../../../../component-library/components/Texts/Text';
+
+export const italic: UIComponentFactory<ItalicElement> = ({
+  element: e,
+  ...params
+}) => ({
+  element: 'Text',
+  children: mapTextToTemplate(
+    getJsxChildren(e) as NonEmptyArray<string | JSXElement>,
+    params,
+  ),
+  props: {
+    variant: TextVariant.BodyMD,
+    color: params.textColor,
+    numberOfLines: 0,
+    flexWrap: 'wrap',
+    style: { fontStyle: 'italic' },
+  },
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Add missing Snaps UI components that are available on extension: `Checkbox`, `Italic`, `Divider`. They were missed during the initial port. The only known missing component now is `FileInput`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

N/A

## **Screenshots/Recordings**

<img width="270" height="555" alt="Screenshot_1784018791" src="https://github.com/user-attachments/assets/a647cfb1-132d-43a2-920b-3b9d3e1ca583" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI mapping additions with no auth, data, or core flow changes.
> 
> **Overview**
> Completes the mobile Snap UI renderer parity with extension by wiring **Divider** and **Italic** into `COMPONENT_MAPPING` (along with **Checkbox**, which was already implemented but not exported in the mapping).
> 
> **Divider** renders as a 1px-tall `Box` using `theme.colors.border.muted`. **Italic** follows the same pattern as **Bold**: nested JSX/text via `mapTextToTemplate`, mapped to `Text` with `fontStyle: 'italic'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d514d68f82a17f52478dfc7465740ab4d4c7649d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->