### PR TITLE
feat: read stablecoins from stable-tokens LD flag in useTokenFiatRates cp-8.3.0

### DIFF
--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -6,31 +6,10 @@ import {
   selectCurrentCurrency,
 } from '../../../../../selectors/currencyRateController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+import { selectStablecoins } from '../../../../../selectors/featureFlagController/stableTokens';
 import { useMemo } from 'react';
 import { useDeepMemo } from '../useDeepMemo';
 import { toChecksumAddress } from '../../../../../util/address';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
-
-// Pending conversion to a remote feature flag
-const STABLECOINS: Record<Hex, Hex[]> = {
-  [CHAIN_IDS.MAINNET]: [
-    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // MUSD
-    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-    '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
-  ],
-  [CHAIN_IDS.ARBITRUM]: [
-    '0xaf88d065e77c8cc2239327c5edb3a432268e5831', // USDC
-  ],
-  [CHAIN_IDS.LINEA_MAINNET]: [
-    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // MUSD
-    '0x176211869ca2b568f2a7d4ee941e073a821ee1ff', // USDC
-    '0xa219439258ca9da29e9cc4ce5596924745e12b93', // USDT
-  ],
-  [CHAIN_IDS.POLYGON]: [
-    '0x2791bca1f2de4661ed88a30c99a7a9449aa84174', // USDC.e
-    '0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb', // pUSD
-  ],
-};
 
 export interface TokenFiatRateRequest {
   address: Hex;
@@ -43,6 +22,7 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
   const tokenMarketDataByAddressByChainId = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
   const networkConfigurations = useSelector(selectNetworkConfigurations);
+  const stablecoins = useSelector(selectStablecoins);
   const safeRequests = useDeepMemo(() => requests, [requests]);
 
   const result = useMemo(
@@ -51,7 +31,7 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
         const currency = currencyOverride ?? selectedCurrency;
         const isUsd = currency.toLowerCase() === 'usd';
 
-        const isStablecoin = STABLECOINS[chainId]?.includes(
+        const isStablecoin = stablecoins[chainId]?.includes(
           address.toLowerCase() as Hex,
         );
 
@@ -82,6 +62,7 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
       networkConfigurations,
       safeRequests,
       selectedCurrency,
+      stablecoins,
       tokenMarketDataByAddressByChainId,
     ],
   );

--- a/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.test.ts
@@ -12,7 +12,7 @@ import {
   selectDepositLimits,
 } from '../../../../../selectors/featureFlagController/confirmations';
 import { selectAccountOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
-import { isStablecoin } from '../../utils/token';
+import { isRouteToken } from '../../utils/relayFixedSpread';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 import { getMoneyAccountDepositIntent } from '../../../../UI/Money/hooks/useMoneyAccount';
@@ -33,9 +33,9 @@ jest.mock(
   }),
 );
 
-jest.mock('../../utils/token', () => ({
-  ...jest.requireActual('../../utils/token'),
-  isStablecoin: jest.fn(),
+jest.mock('../../utils/relayFixedSpread', () => ({
+  ...jest.requireActual('../../utils/relayFixedSpread'),
+  isRouteToken: jest.fn(),
 }));
 
 jest.mock('../pay/useTransactionPayToken');
@@ -60,7 +60,7 @@ const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
 const selectMetaMaskPayFlagsMock =
   selectMetaMaskPayFlags as unknown as jest.Mock;
 const selectDepositLimitsMock = selectDepositLimits as unknown as jest.Mock;
-const isStablecoinMock = isStablecoin as unknown as jest.Mock;
+const isRouteTokenMock = isRouteToken as unknown as jest.Mock;
 const selectAccountOverrideMock =
   selectAccountOverrideByTransactionId as unknown as jest.Mock;
 const getMoneyAccountDepositIntentMock = jest.mocked(
@@ -129,7 +129,7 @@ function setupMocks(
     },
   });
   selectDepositLimitsMock.mockReturnValue(depositLimits);
-  isStablecoinMock.mockReturnValue(stablecoin);
+  isRouteTokenMock.mockReturnValue(stablecoin);
   selectAccountOverrideMock.mockReturnValue(overrides.accountOverride);
   getMoneyAccountDepositIntentMock.mockReturnValue(
     depositIntent as ReturnType<typeof getMoneyAccountDepositIntent>,

--- a/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.ts
@@ -4,7 +4,6 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { Hex } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import {
   selectDepositLimits,
@@ -15,7 +14,7 @@ import {
 import { selectAccountOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
 import { RootState } from '../../../../../reducers';
 import { hasTransactionType } from '../../utils/transaction';
-import { isStablecoin } from '../../utils/token';
+import { isRouteToken } from '../../utils/relayFixedSpread';
 import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 
@@ -73,11 +72,10 @@ export function useDepositPrefillAmount(): DepositPrefillResult {
       return undefined;
     }
 
-    const stable = isStablecoin(
-      payToken.address as Hex,
-      payToken.chainId as Hex,
-      relayFixedSpread,
-    );
+    const stable = isRouteToken(relayFixedSpread, {
+      chainId: payToken.chainId,
+      address: payToken.address,
+    });
     const percentage = stable ? 100 : 50;
 
     const raw = new BigNumber(percentage)

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -45,7 +45,7 @@ import {
   selectMetaMaskPayFlags,
   selectDepositLimits,
 } from '../../../../../selectors/featureFlagController/confirmations';
-import { isStablecoin } from '../../utils/token';
+import { isRouteToken } from '../../utils/relayFixedSpread';
 import { getMoneyAccountDepositIntent } from '../../../../UI/Money/hooks/useMoneyAccount';
 
 jest.mock(
@@ -58,9 +58,9 @@ jest.mock(
     selectDepositLimits: jest.fn(),
   }),
 );
-jest.mock('../../utils/token', () => ({
-  ...jest.requireActual('../../utils/token'),
-  isStablecoin: jest.fn(),
+jest.mock('../../utils/relayFixedSpread', () => ({
+  ...jest.requireActual('../../utils/relayFixedSpread'),
+  isRouteToken: jest.fn(),
 }));
 jest.mock('../../../../UI/Money/hooks/useMoneyAccount', () => ({
   ...jest.requireActual('../../../../UI/Money/hooks/useMoneyAccount'),
@@ -221,7 +221,7 @@ describe('useTransactionCustomAmount', () => {
       },
     });
     (selectDepositLimits as unknown as jest.Mock).mockReturnValue({});
-    (isStablecoin as unknown as jest.Mock).mockReturnValue(false);
+    (isRouteToken as unknown as jest.Mock).mockReturnValue(false);
   });
 
   it('returns pending amount provided by updatePendingAmount', async () => {
@@ -1451,7 +1451,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('prefills stablecoin with 100% of balance', async () => {
-      (isStablecoin as unknown as jest.Mock).mockReturnValue(true);
+      (isRouteToken as unknown as jest.Mock).mockReturnValue(true);
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: TOKEN_ADDRESS_MOCK,
@@ -1472,7 +1472,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('prefills non-stablecoin with 50% of balance', async () => {
-      (isStablecoin as unknown as jest.Mock).mockReturnValue(false);
+      (isRouteToken as unknown as jest.Mock).mockReturnValue(false);
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: TOKEN_ADDRESS_MOCK,
@@ -1493,7 +1493,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('caps at deposit limit when balance exceeds it', async () => {
-      (isStablecoin as unknown as jest.Mock).mockReturnValue(true);
+      (isRouteToken as unknown as jest.Mock).mockReturnValue(true);
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: TOKEN_ADDRESS_MOCK,
@@ -1533,7 +1533,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('resets amountFiat to zero when switching to zero-balance token', async () => {
-      (isStablecoin as unknown as jest.Mock).mockReturnValue(true);
+      (isRouteToken as unknown as jest.Mock).mockReturnValue(true);
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: TOKEN_ADDRESS_MOCK,
@@ -1569,7 +1569,7 @@ describe('useTransactionCustomAmount', () => {
     });
 
     it('only prefills once even if balance changes', async () => {
-      (isStablecoin as unknown as jest.Mock).mockReturnValue(true);
+      (isRouteToken as unknown as jest.Mock).mockReturnValue(true);
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {
           address: TOKEN_ADDRESS_MOCK,

--- a/app/components/Views/confirmations/utils/relayFixedSpread.ts
+++ b/app/components/Views/confirmations/utils/relayFixedSpread.ts
@@ -244,6 +244,23 @@ export const isSubsidizedSource = (
  * Reserved for callsites that know the destination of the transaction being
  * built; not yet wired in to the MM Pay picker.
  */
+/**
+ * Returns true when the given token appears in any route as either source or
+ * target. Used to decide whether a pay token is a stablecoin for prefill
+ * percentage logic.
+ */
+export const isRouteToken = (
+  config: RelayFixedSpreadConfig,
+  endpoint: RouteEndpoint,
+): boolean =>
+  config.routes.some(
+    (route) =>
+      (addressesEqual(route.sourceChain, endpoint.chainId) &&
+        addressesEqual(route.sourceToken, endpoint.address)) ||
+      (addressesEqual(route.targetChain, endpoint.chainId) &&
+        addressesEqual(route.targetToken, endpoint.address)),
+  );
+
 export const isSubsidizedRoute = (
   config: RelayFixedSpreadConfig,
   source: RouteEndpoint,

--- a/app/components/Views/confirmations/utils/token.test.ts
+++ b/app/components/Views/confirmations/utils/token.test.ts
@@ -1,111 +1,84 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { isStablecoin } from './token';
-import { RelayFixedSpreadConfig } from './relayFixedSpread';
+import { isRouteToken, RelayFixedSpreadConfig } from './relayFixedSpread';
 
 const MOCK_CONFIG: RelayFixedSpreadConfig = {
   routes: [
     {
       sourceChain: CHAIN_IDS.MAINNET as Hex,
-      sourceToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Hex, // USDC
+      sourceToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Hex,
       targetChain: CHAIN_IDS.MAINNET as Hex,
-      targetToken: '0xdac17f958d2ee523a2206206994597c13d831ec7' as Hex, // USDT
+      targetToken: '0xdac17f958d2ee523a2206206994597c13d831ec7' as Hex,
     },
     {
       sourceChain: CHAIN_IDS.BSC as Hex,
-      sourceToken: '0x55d398326f99059ff775485246999027b3197955' as Hex, // USDT
+      sourceToken: '0x55d398326f99059ff775485246999027b3197955' as Hex,
       targetChain: CHAIN_IDS.BSC as Hex,
-      targetToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d' as Hex, // USDC
+      targetToken: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d' as Hex,
     },
     {
       sourceChain: CHAIN_IDS.LINEA_MAINNET as Hex,
-      sourceToken: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff' as Hex, // USDC
+      sourceToken: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff' as Hex,
       targetChain: CHAIN_IDS.LINEA_MAINNET as Hex,
-      targetToken: '0xa219439258ca9da29e9cc4ce5596924745e12b93' as Hex, // USDT
+      targetToken: '0xa219439258ca9da29e9cc4ce5596924745e12b93' as Hex,
     },
   ],
 };
 
 const EMPTY_CONFIG: RelayFixedSpreadConfig = { routes: [] };
 
-describe('isStablecoin', () => {
-  it('returns true for USDC on Ethereum (0x1)', () => {
+describe('isRouteToken', () => {
+  it('returns true for a source token', () => {
     expect(
-      isStablecoin(
-        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        CHAIN_IDS.MAINNET as Hex,
-        MOCK_CONFIG,
-      ),
+      isRouteToken(MOCK_CONFIG, {
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      }),
     ).toBe(true);
   });
 
-  it('returns true for USDT on BSC (0x38)', () => {
+  it('returns true for a target token', () => {
     expect(
-      isStablecoin(
-        '0x55d398326f99059ff775485246999027b3197955',
-        CHAIN_IDS.BSC as Hex,
-        MOCK_CONFIG,
-      ),
+      isRouteToken(MOCK_CONFIG, {
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      }),
     ).toBe(true);
   });
 
-  it('returns true for a target token in a route', () => {
+  it('returns false for unknown address', () => {
     expect(
-      isStablecoin(
-        '0xdac17f958d2ee523a2206206994597c13d831ec7',
-        CHAIN_IDS.MAINNET as Hex,
-        MOCK_CONFIG,
-      ),
-    ).toBe(true);
-  });
-
-  it('returns false for non-stablecoin address', () => {
-    expect(
-      isStablecoin(
-        '0x0000000000000000000000000000000000000001',
-        CHAIN_IDS.MAINNET as Hex,
-        MOCK_CONFIG,
-      ),
+      isRouteToken(MOCK_CONFIG, {
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0x0000000000000000000000000000000000000001',
+      }),
     ).toBe(false);
   });
 
   it('returns false for unknown chainId', () => {
     expect(
-      isStablecoin(
-        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        '0xfffff' as Hex,
-        MOCK_CONFIG,
-      ),
+      isRouteToken(MOCK_CONFIG, {
+        chainId: '0xfffff',
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      }),
     ).toBe(false);
   });
 
   it('returns false with empty config', () => {
     expect(
-      isStablecoin(
-        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        CHAIN_IDS.MAINNET as Hex,
-        EMPTY_CONFIG,
-      ),
+      isRouteToken(EMPTY_CONFIG, {
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      }),
     ).toBe(false);
   });
 
-  it('handles case-insensitive addresses (uppercase input)', () => {
+  it('handles case-insensitive addresses', () => {
     expect(
-      isStablecoin(
-        '0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
-        CHAIN_IDS.MAINNET as Hex,
-        MOCK_CONFIG,
-      ),
-    ).toBe(true);
-  });
-
-  it('matches lowercase route tokens against lowercase input', () => {
-    expect(
-      isStablecoin(
-        '0x176211869ca2b568f2a7d4ee941e073a821ee1ff',
-        CHAIN_IDS.LINEA_MAINNET as Hex,
-        MOCK_CONFIG,
-      ),
+      isRouteToken(MOCK_CONFIG, {
+        chainId: CHAIN_IDS.MAINNET,
+        address: '0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+      }),
     ).toBe(true);
   });
 });

--- a/app/components/Views/confirmations/utils/token.ts
+++ b/app/components/Views/confirmations/utils/token.ts
@@ -3,7 +3,6 @@ import { Hex } from '@metamask/utils';
 import { AssetsContractController } from '@metamask/assets-controllers';
 import { NetworkClientId } from '@metamask/network-controller';
 import { getTokenDetails } from '../../../../util/address';
-import { RelayFixedSpreadConfig } from './relayFixedSpread';
 
 export type TokenDetailsERC20 = Awaited<
   ReturnType<
@@ -27,19 +26,6 @@ export type TokenDetails =
   | TokenDetailsERC20
   | TokenDetailsERC721
   | TokenDetailsERC1155;
-
-export function isStablecoin(
-  address: string,
-  chainId: Hex,
-  config: RelayFixedSpreadConfig,
-): boolean {
-  const lowerAddress = address.toLowerCase();
-  return config.routes.some(
-    (route) =>
-      (route.sourceChain === chainId && route.sourceToken === lowerAddress) ||
-      (route.targetChain === chainId && route.targetToken === lowerAddress),
-  );
-}
 
 export const ERC20_DEFAULT_DECIMALS = 18;
 

--- a/app/selectors/featureFlagController/stableTokens/index.test.ts
+++ b/app/selectors/featureFlagController/stableTokens/index.test.ts
@@ -1,4 +1,5 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { Json } from '@metamask/utils';
 import { Hex } from '@metamask/utils';
 import { selectStablecoins, STABLE_TOKENS_FLAG } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
@@ -8,7 +9,7 @@ jest.mock('../../../core/Engine', () => ({
   init: () => mockedEngine.init(),
 }));
 
-const getMockedFeatureFlag = (value: unknown) => ({
+const getMockedFeatureFlag = (value: Json) => ({
   engine: {
     backgroundState: {
       RemoteFeatureFlagController: {

--- a/app/selectors/featureFlagController/stableTokens/index.test.ts
+++ b/app/selectors/featureFlagController/stableTokens/index.test.ts
@@ -1,6 +1,5 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import type { Json } from '@metamask/utils';
-import { Hex } from '@metamask/utils';
+import { type Json, Hex } from '@metamask/utils';
 import { selectStablecoins, STABLE_TOKENS_FLAG } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';

--- a/app/selectors/featureFlagController/stableTokens/index.test.ts
+++ b/app/selectors/featureFlagController/stableTokens/index.test.ts
@@ -1,0 +1,81 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { selectStablecoins, STABLE_TOKENS_FLAG } from '.';
+import mockedEngine from '../../../core/__mocks__/MockedEngine';
+import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
+
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
+
+const getMockedFeatureFlag = (value: unknown) => ({
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          [STABLE_TOKENS_FLAG]: value,
+        },
+        cacheTimestamp: 0,
+      },
+    },
+  },
+});
+
+describe('selectStablecoins', () => {
+  it('returns default stablecoins when flag state is undefined', () => {
+    const result = selectStablecoins(mockedUndefinedFlagsState);
+    expect(result[CHAIN_IDS.MAINNET as Hex]).toContain(
+      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    );
+  });
+
+  it('returns default stablecoins when no flags are set', () => {
+    const result = selectStablecoins(mockedEmptyFlagsState);
+    expect(result).toHaveProperty(CHAIN_IDS.MAINNET);
+    expect(result).toHaveProperty(CHAIN_IDS.ARBITRUM);
+    expect(result).toHaveProperty(CHAIN_IDS.LINEA_MAINNET);
+    expect(result).toHaveProperty(CHAIN_IDS.POLYGON);
+  });
+
+  it('returns flag value when set to a valid object', () => {
+    const flagValue = {
+      '0x1': ['0xaaa', '0xbbb'],
+      '0xa4b1': ['0xccc'],
+    };
+    const result = selectStablecoins(getMockedFeatureFlag(flagValue));
+    expect(result).toStrictEqual(flagValue);
+  });
+
+  it('normalizes addresses and chain IDs to lowercase', () => {
+    const result = selectStablecoins(
+      getMockedFeatureFlag({
+        '0xA4B1': ['0xAf88d065e77c8cC2239327C5EDb3A432268e5831'],
+      }),
+    );
+    expect(result).toStrictEqual({
+      '0xa4b1': ['0xaf88d065e77c8cc2239327c5edb3a432268e5831'],
+    });
+  });
+
+  it('skips non-array entries in flag value', () => {
+    const result = selectStablecoins(
+      getMockedFeatureFlag({
+        '0x1': ['0xaaa'],
+        '0xa4b1': 'not-an-array',
+      }),
+    );
+    expect(result).toStrictEqual({ '0x1': ['0xaaa'] });
+  });
+
+  it('returns default stablecoins when flag is an array', () => {
+    const result = selectStablecoins(
+      getMockedFeatureFlag(['not', 'an', 'object']),
+    );
+    expect(result).toHaveProperty(CHAIN_IDS.MAINNET);
+  });
+
+  it('returns default stablecoins when flag is a primitive', () => {
+    const result = selectStablecoins(getMockedFeatureFlag(true));
+    expect(result).toHaveProperty(CHAIN_IDS.MAINNET);
+  });
+});

--- a/app/selectors/featureFlagController/stableTokens/index.ts
+++ b/app/selectors/featureFlagController/stableTokens/index.ts
@@ -1,0 +1,55 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import type { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+export const STABLE_TOKENS_FLAG = 'stable-tokens' as const;
+
+const DEFAULT_STABLECOINS: Record<Hex, Hex[]> = {
+  [CHAIN_IDS.MAINNET]: [
+    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // MUSD
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+    '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+  ],
+  [CHAIN_IDS.ARBITRUM]: [
+    '0xaf88d065e77c8cc2239327c5edb3a432268e5831', // USDC
+  ],
+  [CHAIN_IDS.LINEA_MAINNET]: [
+    '0xaca92e438df0b2401ff60da7e4337b687a2435da', // MUSD
+    '0x176211869ca2b568f2a7d4ee941e073a821ee1ff', // USDC
+    '0xa219439258ca9da29e9cc4ce5596924745e12b93', // USDT
+  ],
+  [CHAIN_IDS.POLYGON]: [
+    '0x2791bca1f2de4661ed88a30c99a7a9449aa84174', // USDC.e
+    '0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb', // pUSD
+  ],
+};
+
+function normalizeStablecoins(
+  raw: Record<string, unknown>,
+): Record<Hex, Hex[]> {
+  return Object.entries(raw).reduce<Record<Hex, Hex[]>>(
+    (acc, [chainId, addresses]) => {
+      if (Array.isArray(addresses)) {
+        acc[chainId.toLowerCase() as Hex] = addresses.map(
+          (a: string) => a.toLowerCase() as Hex,
+        );
+      }
+      return acc;
+    },
+    {},
+  );
+}
+
+export const selectStablecoins = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): Record<Hex, Hex[]> => {
+    const flag = remoteFeatureFlags?.[STABLE_TOKENS_FLAG];
+
+    if (flag && typeof flag === 'object' && !Array.isArray(flag)) {
+      return normalizeStablecoins(flag as Record<string, unknown>);
+    }
+
+    return DEFAULT_STABLECOINS;
+  },
+);

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5553,6 +5553,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  'stable-tokens': {
+    name: 'stable-tokens',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {},
+    status: FeatureFlagStatus.Active,
+  },
+
   swapsSWAPS4543AbtestPostTradeModal: {
     name: 'swapsSWAPS4543AbtestPostTradeModal',
     type: FeatureFlagType.Remote,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10086,6 +10086,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/ramps-controller@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@metamask/ramps-controller@npm:17.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.3.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+  checksum: 10/45980e93d79bf72c00edc44e2cd075a738c44a1c0b3dd695a7bce688f7954f80f28988b56c7a5774b1747e335b66c16f6a7d36833030bf116cefafc7b2e5f223
+  languageName: node
+  linkType: hard
+
 "@metamask/react-data-query@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/react-data-query@npm:0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10086,19 +10086,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^17.0.0":
-  version: 17.0.0
-  resolution: "@metamask/ramps-controller@npm:17.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/profile-sync-controller": "npm:^28.3.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-  checksum: 10/45980e93d79bf72c00edc44e2cd075a738c44a1c0b3dd695a7bce688f7954f80f28988b56c7a5774b1747e335b66c16f6a7d36833030bf116cefafc7b2e5f223
-  languageName: node
-  linkType: hard
-
 "@metamask/react-data-query@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/react-data-query@npm:0.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

On MM Pay UI read stablecoins from stable-tokens LD flag.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1671

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how USD fiat rates and MM Pay deposit prefills are computed; wrong flag or route data could mis-price tokens or prefill amounts, though defaults mirror prior behavior.
> 
> **Overview**
> **Stablecoin fiat pricing** no longer uses a hardcoded per-chain address map in `useTokenFiatRates`. It now reads **`selectStablecoins`** from the remote **`stable-tokens`** LaunchDarkly flag (with the previous addresses as defaults and normalization for invalid flag shapes).
> 
> **Deposit prefill** (100% vs 50% of balance) switches from **`isStablecoin`** in `token.ts` to **`isRouteToken`** in `relayFixedSpread`, which treats a pay token as “stable” when it appears on any relay fixed-spread route as source or target. That helper is new; **`isStablecoin` is removed** from `token.ts`. Related hooks/tests are updated accordingly.
> 
> The **`stable-tokens`** flag is registered in the feature-flag registry (remote, not in prod by default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec93b9a870255b5715ac593494516dc151d2e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->