### PR TITLE
ci: bump actions/* dependencies to Node24-compatible majors

### DIFF
--- a/.github/actions/android-play-store-manifest-check/action.yml
+++ b/.github/actions/android-play-store-manifest-check/action.yml
@@ -16,7 +16,7 @@ runs:
     # Third-party actions such as android-actions/setup-android are not allowlisted for this org;
     # install SDK components with Google's cmdline-tools + sdkmanager (same packages as android/build.gradle).
     - name: Cache Gradle
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches
@@ -27,7 +27,7 @@ runs:
 
     - name: Cache Android SDK
       id: android-sdk-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/android-sdk
         key: ${{ runner.os }}-android-sdk-manifest-v2-cmd11076708-api35-ndk26.1-cmake322
@@ -82,7 +82,7 @@ runs:
 
     - name: Restore .metamask folder
       id: restore-metamask
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .metamask
         key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -121,7 +121,7 @@ runs:
 
     - name: Cache bundletool
       id: bundletool-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/bundletool-all.jar
         key: bundletool-1.18.3-jar

--- a/.github/actions/android-play-store-manifest-check/action.yml
+++ b/.github/actions/android-play-store-manifest-check/action.yml
@@ -16,7 +16,7 @@ runs:
     # Third-party actions such as android-actions/setup-android are not allowlisted for this org;
     # install SDK components with Google's cmdline-tools + sdkmanager (same packages as android/build.gradle).
     - name: Cache Gradle
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           ~/.gradle/caches
@@ -27,7 +27,7 @@ runs:
 
     - name: Cache Android SDK
       id: android-sdk-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/android-sdk
         key: ${{ runner.os }}-android-sdk-manifest-v2-cmd11076708-api35-ndk26.1-cmake322
@@ -82,7 +82,7 @@ runs:
 
     - name: Restore .metamask folder
       id: restore-metamask
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: .metamask
         key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -121,7 +121,7 @@ runs:
 
     - name: Cache bundletool
       id: bundletool-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/bundletool-all.jar
         key: bundletool-1.18.3-jar

--- a/.github/actions/android-play-store-manifest-check/action.yml
+++ b/.github/actions/android-play-store-manifest-check/action.yml
@@ -93,7 +93,7 @@ runs:
       run: yarn install:foundryup
 
     - name: Install Yarn dependencies with retry
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 3

--- a/.github/actions/find-reusable-build/action.yml
+++ b/.github/actions/find-reusable-build/action.yml
@@ -82,7 +82,7 @@ runs:
   steps:
     - name: Search prior runs for matching fingerprint
       id: lookup
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       continue-on-error: true
       env:
         TARGET_FINGERPRINT: ${{ inputs.fingerprint }}

--- a/.github/actions/post-build-source-hash/action.yml
+++ b/.github/actions/post-build-source-hash/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Post commit status
       if: ${{ inputs.post-status == 'true' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       continue-on-error: true
       env:
         FINGERPRINT: ${{ steps.generate-fingerprint.outputs.fingerprint }}

--- a/.github/actions/setup-ci-js-deps/action.yml
+++ b/.github/actions/setup-ci-js-deps/action.yml
@@ -51,7 +51,7 @@ runs:
     # artifact; run install when starting from a clean workspace.
     - name: Install Yarn dependencies with retry
       if: ${{ steps.check-deps.outputs.needs-install == 'true' }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 10
         max_attempts: 3

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -191,7 +191,7 @@ runs:
     - name: Restore Android system image from cache
       if: ${{ inputs.platform == 'android' && inputs.setup-simulator == 'true' && inputs.runner_provider != 'namespace' }}
       id: android-system-image-cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: /opt/android-sdk/system-images/android-${{ inputs.android-api-level }}/${{ inputs.android-tag }}/${{ inputs.android-abi }}
         key: android-system-image-v1-${{ runner.os }}-api${{ inputs.android-api-level }}-${{ inputs.android-tag }}-${{ inputs.android-abi }}
@@ -248,7 +248,7 @@ runs:
           github.event_name != 'merge_group' &&
           github.ref == 'refs/heads/main'
         }}
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         path: /opt/android-sdk/system-images/android-${{ inputs.android-api-level }}/${{ inputs.android-tag }}/${{ inputs.android-abi }}
         key: android-system-image-v1-${{ runner.os }}-api${{ inputs.android-api-level }}-${{ inputs.android-tag }}-${{ inputs.android-abi }}
@@ -323,7 +323,7 @@ runs:
 
     - name: Restore Yarn cache
       if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           node_modules
@@ -371,7 +371,7 @@ runs:
 
     - name: Restore Bundler cache
       if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ios/vendor/bundle
         key: ${{ inputs.cache-prefix }}-bundler-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('ios/Gemfile.lock') }}
@@ -429,7 +429,7 @@ runs:
     - name: Restore CocoaPods specs cache
       if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
       id: cocoapods-specs-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.cocoapods/repos
         key: ${{ runner.os }}-cocoapods-specs-${{ hashFiles('ios/Podfile.lock') }}

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -155,7 +155,7 @@ runs:
       # Skip apt-get install on namespace — libpulse0 / libglu1-mesa / libnss3 / libxss1
       # are baked into the metamask-android-build image.
       if: ${{ inputs.platform == 'android' && inputs.setup-simulator == 'true' && runner.os == 'Linux' && inputs.runner_provider != 'namespace' }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         timeout_minutes: 5
         max_attempts: 3
@@ -314,7 +314,7 @@ runs:
 
     - name: Corepack
       id: corepack
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
         max_attempts: 3
@@ -335,7 +335,7 @@ runs:
 
     - name: Install JavaScript dependencies with retry
       id: yarn-install
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
         max_attempts: 3
@@ -439,7 +439,7 @@ runs:
 
     - name: Install CocoaPods via bundler
       if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
       with:
         timeout_minutes: ${{ fromJSON(inputs.pod-install-timeout-minutes) }}
         max_attempts: 3

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -191,7 +191,7 @@ runs:
     - name: Restore Android system image from cache
       if: ${{ inputs.platform == 'android' && inputs.setup-simulator == 'true' && inputs.runner_provider != 'namespace' }}
       id: android-system-image-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /opt/android-sdk/system-images/android-${{ inputs.android-api-level }}/${{ inputs.android-tag }}/${{ inputs.android-abi }}
         key: android-system-image-v1-${{ runner.os }}-api${{ inputs.android-api-level }}-${{ inputs.android-tag }}-${{ inputs.android-abi }}
@@ -248,7 +248,7 @@ runs:
           github.event_name != 'merge_group' &&
           github.ref == 'refs/heads/main'
         }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /opt/android-sdk/system-images/android-${{ inputs.android-api-level }}/${{ inputs.android-tag }}/${{ inputs.android-abi }}
         key: android-system-image-v1-${{ runner.os }}-api${{ inputs.android-api-level }}-${{ inputs.android-tag }}-${{ inputs.android-abi }}
@@ -323,7 +323,7 @@ runs:
 
     - name: Restore Yarn cache
       if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           node_modules
@@ -371,7 +371,7 @@ runs:
 
     - name: Restore Bundler cache
       if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ios/vendor/bundle
         key: ${{ inputs.cache-prefix }}-bundler-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('ios/Gemfile.lock') }}
@@ -429,7 +429,7 @@ runs:
     - name: Restore CocoaPods specs cache
       if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
       id: cocoapods-specs-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cocoapods/repos
         key: ${{ runner.os }}-cocoapods-specs-${{ hashFiles('ios/Podfile.lock') }}

--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -35,7 +35,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -25,12 +25,12 @@ jobs:
             issues: write
             pull_requests: write
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             fetch-depth: 0 # This is needed to checkout all branches
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -28,7 +28,7 @@ jobs:
       is_ota: ${{ steps.out.outputs.is_ota }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: out
         shell: bash

--- a/.github/workflows/auto-draft-prs.yml
+++ b/.github/workflows/auto-draft-prs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Convert PR to Draft and Add Label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             // Convert PR to draft

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -221,7 +221,7 @@ jobs:
         id: download-reusable-metadata
         if: ${{ steps.find-reusable-build.outputs.found == 'true' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.E2E_BUILD_METADATA_ARTIFACT }}
           path: .e2e-reusable-metadata/android
@@ -278,7 +278,7 @@ jobs:
         id: download-reusable-apk
         if: ${{ steps.validate-reusable-metadata.outputs.valid == 'true' && inputs.include_arm64 == false }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: ${{ steps.determine-target-paths.outputs.apk-target-path }}
@@ -290,7 +290,7 @@ jobs:
         id: download-reusable-test-apk
         if: ${{ steps.validate-reusable-metadata.outputs.valid == 'true' && inputs.include_arm64 == false }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release-androidTest.apk
           path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
@@ -437,7 +437,7 @@ jobs:
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' }}
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -683,7 +683,7 @@ jobs:
       - name: Upload Android APK (current)
         id: upload-apk
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}${{ inputs.include_arm64 && '-arm64' || '' }}-release.apk
           path: ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
@@ -714,7 +714,7 @@ jobs:
       - name: Upload Android build metadata (current)
         id: upload-metadata
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.E2E_BUILD_METADATA_ARTIFACT }}
           path: .e2e-build-metadata/android.json
@@ -725,7 +725,7 @@ jobs:
       - name: Upload Android Test APK (current)
         id: upload-test-apk
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}${{ inputs.include_arm64 && '-arm64' || '' }}-release-androidTest.apk
           path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -437,7 +437,7 @@ jobs:
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' }}
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -444,7 +444,7 @@ jobs:
 
       - name: Setup project dependencies with retry (native-build path)
         if: ${{ steps.gate.outputs.needs-native-build == 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -455,7 +455,7 @@ jobs:
 
       - name: Setup project dependencies with retry (reuse-hit path)
         if: ${{ steps.gate.outputs.needs-native-build != 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -110,13 +110,13 @@ jobs:
 
     steps:
       - name: Download with-SRP APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
           path: artifacts/with-srp
 
       - name: Download without-SRP APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
           path: artifacts/without-srp

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -394,7 +394,7 @@ jobs:
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build == 'true' }}
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -426,7 +426,7 @@ jobs:
 
       - name: Restore yarn cache (reuse-hit path)
         if: ${{ inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build != 'true' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -447,7 +447,7 @@ jobs:
       - name: Restore .metamask folder (reuse-hit path)
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build != 'true' }}
         id: restore-metamask-lean
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -491,7 +491,7 @@ jobs:
       - name: Restore iOS app matching fingerprint from branch cache
         if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' }}
         id: cache-restore
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -500,7 +500,7 @@ jobs:
       - name: Restore iOS app matching fingerprint from main cache
         if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' && steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main' }}
         id: cache-restore-main
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -168,7 +168,7 @@ jobs:
         id: download-reusable-metadata
         if: ${{ steps.find-reusable-build.outputs.found == 'true' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.E2E_BUILD_METADATA_ARTIFACT }}
           path: .e2e-reusable-metadata/ios
@@ -225,7 +225,7 @@ jobs:
         id: download-reusable-app
         if: ${{ steps.validate-reusable-metadata.outputs.valid == 'true' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -394,7 +394,7 @@ jobs:
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build == 'true' }}
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -426,7 +426,7 @@ jobs:
 
       - name: Restore yarn cache (reuse-hit path)
         if: ${{ inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build != 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -447,7 +447,7 @@ jobs:
       - name: Restore .metamask folder (reuse-hit path)
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' && steps.gate.outputs.needs-native-build != 'true' }}
         id: restore-metamask-lean
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -491,7 +491,7 @@ jobs:
       - name: Restore iOS app matching fingerprint from branch cache
         if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' }}
         id: cache-restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -500,7 +500,7 @@ jobs:
       - name: Restore iOS app matching fingerprint from main cache
         if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' && steps.cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main' }}
         id: cache-restore-main
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -685,7 +685,7 @@ jobs:
       - name: Upload iOS APP Artifact (Simulator) (current)
         id: upload-app
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -707,7 +707,7 @@ jobs:
       - name: Upload iOS build metadata (current)
         id: upload-metadata
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.E2E_BUILD_METADATA_ARTIFACT }}
           path: .e2e-build-metadata/ios.json
@@ -733,7 +733,7 @@ jobs:
       - name: Upload iOS Source Map (current)
         id: upload-sourcemap
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-index.js.map
           path: sourcemaps/ios/index.js.map

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -402,7 +402,7 @@ jobs:
       # Run project setup with retry for better resilience
       - name: Setup project dependencies with retry
         if: ${{ steps.gate.outputs.needs-native-build == 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -434,7 +434,7 @@ jobs:
 
       - name: Install JS dependencies (reuse-hit path)
         if: ${{ steps.gate.outputs.needs-native-build != 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -454,7 +454,7 @@ jobs:
 
       - name: Run lightweight project setup (reuse-hit path)
         if: ${{ steps.gate.outputs.needs-native-build != 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/build-ios-upload-to-browserstack.yml
+++ b/.github/workflows/build-ios-upload-to-browserstack.yml
@@ -131,13 +131,13 @@ jobs:
 
     steps:
       - name: Download with-SRP IPA
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-ipa-${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
           path: artifacts/with-srp
 
       - name: Download without-SRP IPA
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-ipa-${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
           path: artifacts/without-srp

--- a/.github/workflows/build-rc-auto.yml
+++ b/.github/workflows/build-rc-auto.yml
@@ -50,7 +50,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -166,11 +166,11 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-and-find-pr.outputs.branch-name }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -179,7 +179,7 @@ jobs:
 
       - name: Download build environment artifacts
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: build-env-main-rc-*
           path: build-env-artifacts
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload test plan JSON artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-plan-${{ needs.validate-and-find-pr.outputs.semver }}
           path: release-test-plan.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: Restore node_modules cache
         if: ${{ needs.prepare.outputs.should_cache == 'true' }}
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             node_modules
@@ -532,7 +532,7 @@ jobs:
           env.CONFIGURATION != 'Debug' &&
           env.METAMASK_BUILD_TYPE == 'main' &&
           env.METAMASK_ENVIRONMENT == 'production'
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/bundletool-all.jar
           key: bundletool-1.18.3-jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,7 +396,7 @@ jobs:
         if: matrix.platform == 'ios'
         env:
           BUNDLE_GEMFILE: ios/Gemfile
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -509,7 +509,7 @@ jobs:
           # download missing components, causing CXX1300. RN's CMakeLists.txt files
           # only require >= 3.13, so 3.22.1 is fully sufficient.
           CMAKE_VERSION: '3.22.1'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 55
           max_attempts: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,13 +131,13 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.source_branch }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
           ref: ${{ inputs.source_branch }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -214,7 +214,7 @@ jobs:
         with:
           ref: ${{ inputs.source_branch }}
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           ref: ${{ inputs.source_branch }}
@@ -242,7 +242,7 @@ jobs:
 
       # Node first so we can download/extract/verify; no yarn install here.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -258,7 +258,7 @@ jobs:
 
       - name: Restore node_modules cache
         if: ${{ needs.prepare.outputs.should_cache == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -271,7 +271,7 @@ jobs:
       # All other branches: download tarball artifact from setup-dependencies job.
       - name: Download node_modules tarball
         if: ${{ needs.prepare.outputs.should_cache != 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: node-modules-${{ inputs.build_name }}-${{ matrix.platform }}
 
@@ -422,7 +422,7 @@ jobs:
 
       - name: Setup Java
         if: matrix.platform == 'android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -532,7 +532,7 @@ jobs:
           env.CONFIGURATION != 'Debug' &&
           env.METAMASK_BUILD_TYPE == 'main' &&
           env.METAMASK_ENVIRONMENT == 'production'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.temp }}/bundletool-all.jar
           key: bundletool-1.18.3-jar
@@ -554,7 +554,7 @@ jobs:
           inputs.build_name == 'main-rc' &&
           env.CONFIGURATION != 'Debug' &&
           env.METAMASK_BUILD_TYPE == 'main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-play-store-check-slack
           path: android-play-store-check-slack.md
@@ -570,7 +570,7 @@ jobs:
       # Upload build artifacts (only if build succeeded)
       - name: Upload iOS simulator app
         if: matrix.platform == 'ios' && env.IS_SIM_BUILD == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-app-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_simulator_path }}
@@ -578,7 +578,7 @@ jobs:
 
       - name: Upload iOS IPA
         if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-ipa-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_ipa_path }}
@@ -586,7 +586,7 @@ jobs:
 
       - name: Upload iOS xcarchive
         if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-xcarchive-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_archive_path }}
@@ -594,7 +594,7 @@ jobs:
 
       - name: Upload iOS sourcemap
         if: matrix.platform == 'ios' && (env.IS_SIM_BUILD != 'true' || env.IS_DEVICE_BUILD == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-sourcemaps-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.ios_sourcemap_path }}
@@ -603,7 +603,7 @@ jobs:
       # Dev builds (CONFIGURATION=Debug): APK + test APK (for E2E)
       - name: Upload Android APK (dev)
         if: matrix.platform == 'android' && env.CONFIGURATION == 'Debug'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-apk-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_apk_path }}
@@ -611,7 +611,7 @@ jobs:
 
       - name: Upload Android test APK (dev)
         if: matrix.platform == 'android' && env.CONFIGURATION == 'Debug' && steps.rename.outputs.android_test_apk_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-test-apk-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_test_apk_path }}
@@ -620,7 +620,7 @@ jobs:
       # Release builds: APK and AAB as separate artifacts
       - name: Upload Android APK (release)
         if: matrix.platform == 'android' && env.CONFIGURATION != 'Debug'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-apk-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_apk_path }}
@@ -632,7 +632,7 @@ jobs:
           env.CONFIGURATION != 'Debug' &&
           env.METAMASK_ENVIRONMENT == 'production' &&
           steps.rename.outputs.android_aab_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-aab-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_aab_path }}
@@ -640,7 +640,7 @@ jobs:
 
       - name: Upload Android sourcemaps
         if: matrix.platform == 'android' && env.CONFIGURATION != 'Debug'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-sourcemaps-${{ inputs.build_name }}
           path: ${{ steps.rename.outputs.android_sourcemap_dir }}
@@ -648,7 +648,7 @@ jobs:
 
       - name: Upload build environment JSON
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-env-${{ inputs.build_name }}-${{ matrix.platform }}
           path: build-env.json
@@ -672,7 +672,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.prepare.outputs.checkout_ref_for_setup }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 1
@@ -693,7 +693,7 @@ jobs:
         run: ./scripts/set-build-version.sh "$BUILD_NUMBER"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -16,7 +16,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install dependencies from cache with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/check-feature-flag-registry-drift.yml
+++ b/.github/workflows/check-feature-flag-registry-drift.yml
@@ -29,7 +29,7 @@ jobs:
           cache: "yarn"
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/check-feature-flag-registry-drift.yml
+++ b/.github/workflows/check-feature-flag-registry-drift.yml
@@ -20,10 +20,10 @@ jobs:
       has-drift: ${{ steps.check.outputs.HAS_DRIFT }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
@@ -58,14 +58,14 @@ jobs:
 
       - name: Upload drift report
         if: steps.check.outputs.HAS_DRIFT == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: drift-report
           path: report.json
 
       - name: Upload updated registry
         if: steps.check.outputs.HAS_DRIFT == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: updated-registry
           path: tests/feature-flags/feature-flag-registry.ts

--- a/.github/workflows/check-feature-flag-registry.yml
+++ b/.github/workflows/check-feature-flag-registry.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-feature-flag-registry.yml
+++ b/.github/workflows/check-feature-flag-registry.yml
@@ -35,7 +35,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install CI script dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -28,7 +28,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -36,12 +36,12 @@ jobs:
     steps:
       - name: Checkout repository
         # WARNING: do NOT add `ref:` here — pull_request_target must stay on the base branch.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -46,7 +46,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           command: yarn install --immutable
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           BUNDLE_GEMFILE: ios/Gemfile
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -95,14 +95,14 @@ jobs:
 
       - name: Install Foundry if cache missed
         if: steps.restore-metamask.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
           command: yarn install:foundryup
       - name: Clean state and following up dependencies installation with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 20
           max_attempts: 3
@@ -148,7 +148,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -193,7 +193,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: ${{ inputs.runner_provider != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -202,7 +202,7 @@ jobs:
       - name: Clean state and following up dependencies installation
         run: yarn setup:github-ci --node
       - name: Deduplicate dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -242,7 +242,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: ${{ inputs.runner_provider != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -251,7 +251,7 @@ jobs:
       - name: Clean state and following up dependencies installation
         run: yarn setup:github-ci --node
       - name: Run @lavamoat/git-safe-dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -298,7 +298,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: ${{ inputs.runner_provider != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -365,7 +365,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: ${{ inputs.runner_provider != 'namespace' && 'yarn' || '' }}
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           command: yarn install --immutable
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -562,7 +562,7 @@ jobs:
           retention-days: 7
       - name: Upload iOS bundle (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-bundle
           path: ios/main.jsbundle
@@ -601,7 +601,7 @@ jobs:
           path: ios
       - name: Download iOS bundle (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-bundle
           path: ios
@@ -671,7 +671,7 @@ jobs:
         run: tar -czf ci-js-deps.tar.gz node_modules app/util/termsOfUse/termsOfUseContent.ts
       - name: Upload CI JS deps artifact
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-js-deps
           path: ci-js-deps.tar.gz
@@ -701,7 +701,7 @@ jobs:
         id: download-ci-js-deps
         if: ${{ inputs.runner_provider != 'namespace' && needs.prepare-ci-js-deps.result == 'success' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ci-js-deps
           path: .
@@ -736,7 +736,7 @@ jobs:
           retention-days: 7
       - name: Upload coverage unit shard (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-unit-${{ matrix.shard }}
           path: ./tests/coverage/
@@ -770,7 +770,7 @@ jobs:
         id: download-ci-js-deps
         if: ${{ inputs.runner_provider != 'namespace' && needs.prepare-ci-js-deps.result == 'success' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ci-js-deps
           path: .
@@ -788,7 +788,7 @@ jobs:
           path: tests/coverage/
       - name: Download coverage shards (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage-*
           path: tests/coverage/
@@ -836,7 +836,7 @@ jobs:
           retention-days: 7
       - name: Upload lcov.info (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lcov.info
           path: ./tests/merged-coverage/lcov.info
@@ -852,7 +852,7 @@ jobs:
           retention-days: 7
       - name: Upload cv-test-stats (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cv-test-stats
           path: ./cv-test-stats.json
@@ -868,7 +868,7 @@ jobs:
           retention-days: 7
       - name: Upload unit-test-stats (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-stats
           path: ./unit-test-stats.json
@@ -886,7 +886,7 @@ jobs:
           retention-days: 7
       - name: Upload cv-test-coverage-html (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cv-test-coverage-html
           path: ./tests/coverage-cv-lcov/
@@ -902,7 +902,7 @@ jobs:
           retention-days: 7
       - name: Upload cv-test-coverage-summary (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cv-test-coverage-summary
           path: ./tests/coverage-cv-lcov/coverage-summary.json
@@ -920,7 +920,7 @@ jobs:
           retention-days: 7
       - name: Upload unit-test-coverage-summary (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-coverage-summary
           path: ./tests/coverage-unit-lcov/coverage-summary.json
@@ -958,7 +958,7 @@ jobs:
         id: download-ci-js-deps
         if: ${{ inputs.runner_provider != 'namespace' && needs.prepare-ci-js-deps.result == 'success' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ci-js-deps
           path: .
@@ -994,7 +994,7 @@ jobs:
           retention-days: 7
       - name: Upload coverage CV shard (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-cv-${{ matrix.shard }}
           path: ./tests/coverage/
@@ -1155,7 +1155,7 @@ jobs:
         # uploaded by the earliest attempt is always the one shards will use.
         if: ${{ steps.fetch.outputs.available == 'true' }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-timings-${{ github.run_id }}
           path: ./e2e-timings.json
@@ -1355,7 +1355,7 @@ jobs:
       - name: Download fixture validation results (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-e2e-main-validate-e2e-fixtures-junit-results
           path: fixture-results/
@@ -1406,7 +1406,7 @@ jobs:
           path: coverage/
       - name: Download lcov.info (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: lcov.info
           path: coverage/
@@ -1529,7 +1529,7 @@ jobs:
       actions: write
     steps:
       - name: Delete CI JS deps artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -23,7 +23,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -13,12 +13,12 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/commit-build-version.yml
+++ b/.github/workflows/commit-build-version.yml
@@ -40,7 +40,7 @@ jobs:
           token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
           permissions: |
             contents: write
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.base-branch }}

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.extract_version.outputs.version
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         if: steps.extract_version.outputs.version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies with retry
         if: steps.extract_version.outputs.version
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}  # Explicitly specifies the tag ref
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -83,7 +83,7 @@ jobs:
       previous_ref: ${{ steps.out.outputs.previous_ref }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: out
         shell: bash
@@ -156,7 +156,7 @@ jobs:
 
       - name: Checkout release branch (OTA hotfix — OTA_VERSION only)
         if: needs.resolve-bases.outputs.is_ota == 'true' && steps.ota_release_pr.outputs.exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: release/${{ inputs.semver-version }}-ota
           token: ${{ steps.get-token.outputs.token }}
@@ -191,7 +191,7 @@ jobs:
       # tag match exactly (both v<X.Y.Z>). The `-ota` suffix is a branch-name convention only.
       - name: Checkout github-tools (release changelog)
         if: needs.resolve-bases.outputs.is_ota == 'true' && steps.ota_release_pr.outputs.exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: MetaMask/github-tools
           path: github-tools

--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -67,7 +67,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           # Use installation token to ensure that the commit later can trigger status check workflows

--- a/.github/workflows/crowdin-rc-upload-sources.yml
+++ b/.github/workflows/crowdin-rc-upload-sources.yml
@@ -20,7 +20,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # Use installation token to ensure that the commit later can trigger status check workflows
           token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/crowdin_download_translations.yml
+++ b/.github/workflows/crowdin_download_translations.yml
@@ -22,7 +22,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # Use installation token to ensure that the commit later can trigger status check workflows
           token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/crowdin_upload_sources.yml
+++ b/.github/workflows/crowdin_upload_sources.yml
@@ -22,7 +22,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # Use installation token to ensure that the commit later can trigger status check workflows
           token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build and load
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5

--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -52,13 +52,13 @@ jobs:
       GIT_BRANCH: ${{ github.ref_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.TARGET_COMMIT_HASH }}
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -70,7 +70,7 @@ jobs:
           validation-context: artifact
 
       - name: Download node_modules artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
 

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/flaky-unit-test-detection.yml
+++ b/.github/workflows/flaky-unit-test-detection.yml
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/flaky-unit-test-detection.yml
+++ b/.github/workflows/flaky-unit-test-detection.yml
@@ -61,7 +61,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install CI script dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -73,7 +73,7 @@ jobs:
     if: success()
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2
@@ -83,7 +83,7 @@ jobs:
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
       - name: Download iOS xcarchive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-xcarchive-main-rc
           path: ./build-artifacts/
@@ -112,7 +112,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2
@@ -122,7 +122,7 @@ jobs:
       - name: Install sentry-cli
         run: curl -sL https://sentry.io/get-cli/ | bash
       - name: Download Android APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: android-apk-main-rc
           path: ./build-artifacts/

--- a/.github/workflows/nightly-temp-branch-sync.yml
+++ b/.github/workflows/nightly-temp-branch-sync.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history so we can work with branches
           fetch-depth: 0

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -108,7 +108,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -87,11 +87,11 @@ jobs:
         device: ${{ fromJson(inputs.device_matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore node_modules cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -102,7 +102,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -117,7 +117,7 @@ jobs:
         ## This installs dependencies and creates the node_modules state file
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -285,7 +285,7 @@ jobs:
           echo "✅ ${{ inputs.build_type }} tests completed for ${{ inputs.platform }} on ${{ matrix.device.name }}"
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ inputs.platform }}-${{ inputs.build_type == 'onboarding' && 'onboarding-flow' || inputs.build_type }}-test-results-${{ matrix.device.name }}-${{ matrix.device.os_version }}

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -117,7 +117,7 @@ jobs:
         ## This installs dependencies and creates the node_modules state file
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}

--- a/.github/workflows/post-release-cut-testflight.yml
+++ b/.github/workflows/post-release-cut-testflight.yml
@@ -44,7 +44,7 @@ jobs:
       bumped: ${{ steps.version.outputs.bumped }}
     steps:
       - name: Checkout pushed commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2

--- a/.github/workflows/prod-build-env-notify.yml
+++ b/.github/workflows/prod-build-env-notify.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download build-env artifact from triggering workflow
         continue-on-error: true
         id: download-artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: build-env-main-prod-${{ github.event.workflow_run.name == 'Runway iOS Production' && 'ios' || 'android' }}
           path: build-env-artifacts

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -79,7 +79,7 @@ jobs:
       commit_sha: ${{ steps.resolve-pr.outputs.commit_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -212,12 +212,12 @@ jobs:
       build_name: ${{ steps.config.outputs.build_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-pr.outputs.commit_sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -266,20 +266,20 @@ jobs:
       BASE_ARTIFACT_NAME: ${{ needs.setup-dependencies-base.outputs.artifact-name }}
     steps:
       - name: Checkout target commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-pr.outputs.commit_sha }}
           fetch-depth: 1
 
       - name: Checkout base branch snapshot
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.BASE_BRANCH_REF }}
           path: main
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -291,7 +291,7 @@ jobs:
           validation-context: PR commit
 
       - name: Download node_modules artifact (PR commit)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.PR_ARTIFACT_NAME }}
 
@@ -327,7 +327,7 @@ jobs:
           validation-context: base branch
 
       - name: Download node_modules artifact (base branch)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.BASE_ARTIFACT_NAME }}
           path: main

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -27,14 +27,14 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Upload QA stats artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: qa-stats
           path: ./qa-stats.json
           if-no-files-found: error
 
       - name: Upload feature flag coverage report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: feature-flag-coverage-report
           path: ./tests/artifacts/feature-flag-coverage-report.json

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ inputs.runner_provider == 'namespace' }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Setup E2E environment (Android)
@@ -108,7 +108,7 @@ jobs:
 
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/mms-ffmpeg
           key: brew-ffmpeg-${{ runner.os }}-v1
@@ -151,13 +151,13 @@ jobs:
             inputs.runner_provider == 'namespace' &&
             steps.download-android-apk-namespace.outcome != 'success'
           }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
       - name: Download Android build artifacts (current)
         if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
@@ -170,7 +170,7 @@ jobs:
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
       - name: Download iOS build artifacts (current)
         if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
@@ -223,7 +223,7 @@ jobs:
 
       - name: Restore WDA DerivedData cache
         if: ${{ inputs.platform == 'ios' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/appium-wda
           key: wda-derived-data-xcuitest-${{ steps.xcuitest-version.outputs.version }}-${{ steps.xcode-version.outputs.version }}-${{ runner.os }}
@@ -337,7 +337,7 @@ jobs:
           retention-days: 7
       - name: Upload Playwright HTML report (current)
         if: ${{ always() && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: appium-smoke-report-${{ inputs.test-suite-name }}
           path: tests/test-reports/appium-smoke-report/${{ inputs.test-suite-name }}/
@@ -356,7 +356,7 @@ jobs:
           retention-days: 7
       - name: Upload Playwright JSON report (current)
         if: ${{ always() && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-json-report-${{ inputs.test-suite-name }}
           path: tests/test-reports/playwright-json/playwright-report.json
@@ -373,7 +373,7 @@ jobs:
           retention-days: 7
       - name: Upload failure screen recordings (current)
         if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: appium-smoke-videos-${{ inputs.test-suite-name }}
           path: tests/test-reports/appium-smoke-videos/${{ inputs.test-suite-name }}/

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/mms-ffmpeg
           key: brew-ffmpeg-${{ runner.os }}-v1
@@ -223,7 +223,7 @@ jobs:
 
       - name: Restore WDA DerivedData cache
         if: ${{ inputs.platform == 'ios' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/appium-wda
           key: wda-derived-data-xcuitest-${{ steps.xcuitest-version.outputs.version }}-${{ steps.xcode-version.outputs.version }}-${{ runner.os }}

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
           clean: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.16.0'
           cache: 'yarn'
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload API specs test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-specs-test-results
           path: tests/reports/
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload API specs screenshots
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-specs-screenshots
           path: tests/artifacts/

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -61,7 +61,7 @@ jobs:
           corepack prepare yarn@4.14.1 --activate
 
       - name: Install JavaScript dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         env:
           NODE_OPTIONS: --max-old-space-size=4096
         with:

--- a/.github/workflows/run-e2e-regression-tests-android.yml
+++ b/.github/workflows/run-e2e-regression-tests-android.yml
@@ -192,7 +192,7 @@ jobs:
         if: ${{ inputs.runner_provider == 'namespace' }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download shards test artifacts (XMLs + Screenshots) (Namespace)
@@ -204,7 +204,7 @@ jobs:
           pattern: '*-android-*-test-*'
       - name: Download shards test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: all-test-artifacts/
@@ -230,7 +230,7 @@ jobs:
           retention-days: 7
       - name: Upload all test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: e2e-regression-android-all-test-artifacts

--- a/.github/workflows/run-e2e-regression-tests-ios.yml
+++ b/.github/workflows/run-e2e-regression-tests-ios.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ inputs.runner_provider == 'namespace' }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
 
       - name: Download shards test artifacts (XMLs + Screenshots) (Namespace)
@@ -203,7 +203,7 @@ jobs:
           pattern: '*-ios-*-test-*'
       - name: Download shards test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: all-test-artifacts/
@@ -229,7 +229,7 @@ jobs:
           retention-days: 7
       - name: Upload all test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: e2e-regression-ios-all-test-artifacts

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -259,7 +259,7 @@ jobs:
           pattern: 'test-e2e-main-*-android-*'
       - name: Download shards test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: all-test-artifacts/
@@ -284,7 +284,7 @@ jobs:
           retention-days: 7
       - name: Upload all test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-smoke-android-all-test-artifacts
           path: all-test-artifacts/
@@ -319,7 +319,7 @@ jobs:
           retention-days: 7
       - name: Upload JSON test report (current)
         if: ${{ steps.create-json-report.outcome == 'success' && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-e2e-android-json-report
           path: test/test-results/test-runs-android.json

--- a/.github/workflows/run-e2e-smoke-tests-android.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Install CI script dependencies
         continue-on-error: true
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -271,7 +271,7 @@ jobs:
           pattern: 'test-e2e-main-*-ios-*'
       - name: Download shards test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           path: all-test-artifacts/
@@ -296,7 +296,7 @@ jobs:
           retention-days: 7
       - name: Upload all test artifacts (XMLs + Screenshots) (current)
         if: ${{ inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-smoke-ios-all-test-artifacts
           path: all-test-artifacts/
@@ -331,7 +331,7 @@ jobs:
           retention-days: 7
       - name: Upload JSON test report (current)
         if: ${{ steps.create-json-report.outcome == 'success' && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-e2e-ios-json-report
           path: test/test-results/test-runs-ios.json

--- a/.github/workflows/run-e2e-smoke-tests-ios.yml
+++ b/.github/workflows/run-e2e-smoke-tests-ios.yml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Install CI script dependencies
         continue-on-error: true
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -249,13 +249,13 @@ jobs:
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release-androidTest.apk
       - name: Download Android app APK (current)
         if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
       - name: Download Android test APK (current)
         if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release-androidTest.apk
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release-androidTest.apk
@@ -285,7 +285,7 @@ jobs:
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
       - name: Download iOS build artifacts (current)
         if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
@@ -348,7 +348,7 @@ jobs:
         if: ${{ github.run_attempt > 1 && inputs.runner_provider != 'namespace' }}
         id: download-previous-results-current
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-junit-results
           path: ./previous-test-results/
@@ -378,7 +378,7 @@ jobs:
         if: ${{ inputs.runner_provider != 'namespace' }}
         id: download-frozen-timings-current
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: e2e-timings-${{ github.run_id }}
           path: ./e2e-timings/
@@ -438,7 +438,7 @@ jobs:
           retention-days: 7
       - name: Upload JUnit XML results (current)
         if: ${{ always() && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-junit-results
           path: tests/reports/
@@ -453,7 +453,7 @@ jobs:
           retention-days: 7
       - name: Upload Screenshots (current)
         if: ${{ failure() && inputs.runner_provider != 'namespace' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-screenshots
           path: tests/artifacts/

--- a/.github/workflows/run-performance-e2e-experimental.yml
+++ b/.github/workflows/run-performance-e2e-experimental.yml
@@ -37,7 +37,7 @@ jobs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -31,7 +31,7 @@ jobs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -174,7 +174,7 @@ jobs:
       ios_matrix: ${{ steps.read-matrix.outputs.ios_matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Select Devices
         id: read-matrix
@@ -499,7 +499,7 @@ jobs:
       browserstack-playground-url: ${{ steps.upload-playground.outputs.browserstack-url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Fetch playground APK from GitHub Releases
         env:
@@ -585,10 +585,10 @@ jobs:
     if: always()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download All Test Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: '*-test-results-*'
           path: ./test-results
@@ -605,7 +605,7 @@ jobs:
           echo "Aggregation completed"
 
       - name: Upload Final Combined Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: aggregated-reports
           path: |
@@ -621,10 +621,10 @@ jobs:
     if: always() && !cancelled() && inputs.pr_number != ''
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Aggregated Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: aggregated-reports
           path: ./aggregated-reports
@@ -682,10 +682,10 @@ jobs:
     if: always()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Aggregated Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: aggregated-reports
           path: ./aggregated-reports

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -84,10 +84,10 @@ jobs:
       BROWSERSTACK_ANDROID_APP_URL: ${{ needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_android }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -98,7 +98,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -113,7 +113,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -165,7 +165,7 @@ jobs:
         run: yarn run-system-tests:android-login
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: system-test-report-android-login
@@ -174,7 +174,7 @@ jobs:
           retention-days: 7
 
       - name: Upload visual regression artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: visual-regression-android-login
@@ -194,10 +194,10 @@ jobs:
       BROWSERSTACK_ANDROID_CLEAN_APP_URL: ${{ needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url || inputs.browserstack_clean_app_url_android }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -208,7 +208,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -223,7 +223,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -273,7 +273,7 @@ jobs:
         run: yarn run-system-tests:android-onboarding
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: system-test-report-android-onboarding
@@ -293,10 +293,10 @@ jobs:
       BROWSERSTACK_IOS_APP_URL: ${{ needs.trigger-ios-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_ios }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -307,7 +307,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -322,7 +322,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -374,7 +374,7 @@ jobs:
         run: yarn run-system-tests:ios-login
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: system-test-report-ios-login
@@ -383,7 +383,7 @@ jobs:
           retention-days: 7
 
       - name: Upload visual regression artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: visual-regression-ios-login
@@ -403,10 +403,10 @@ jobs:
       BROWSERSTACK_IOS_CLEAN_APP_URL: ${{ needs.trigger-ios-dual-versions.outputs.without-srp-browserstack-url || inputs.browserstack_clean_app_url_ios }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -417,7 +417,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -432,7 +432,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -482,7 +482,7 @@ jobs:
         run: yarn run-system-tests:ios-onboarding
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: system-test-report-ios-onboarding
@@ -501,7 +501,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all test reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: system-test-report-*
           path: all-reports

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -104,7 +104,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -214,7 +214,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -313,7 +313,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -423,7 +423,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -113,7 +113,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -223,7 +223,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -296,7 +296,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -322,7 +322,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -406,7 +406,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Restore node_modules cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -432,7 +432,7 @@ jobs:
 
       - name: Restore .metamask folder
         id: restore-metamask
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}

--- a/.github/workflows/runway-ota-resolve-context.yml
+++ b/.github/workflows/runway-ota-resolve-context.yml
@@ -56,13 +56,13 @@ jobs:
       ota_bump: ${{ steps.decide.outputs.ota_bump }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_branch || github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Install Foundry if cache missed
         if: ${{ inputs.platform != '' && (inputs.runner_provider == 'namespace' || steps.restore-metamask.outputs.cache-hit != 'true') }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -193,7 +193,7 @@ jobs:
           command: yarn install:foundryup
 
       - name: Setup project
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         if: inputs.platform != ''
         with:
           timeout_minutes: 10

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -110,7 +110,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules && 'recursive' || false }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           ref: ${{ inputs.ref }}
@@ -129,7 +129,7 @@ jobs:
 
       # iOS: Only Node + Ruby needed (setup runs gem/bundle install, no pods/Xcode). Full iOS env is in build job.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: ${{ inputs.runner_provider == 'namespace' && '' || (inputs.platform == 'android' && 'yarn' || (inputs.platform == 'ios' && 'yarn') || '') }}
@@ -178,7 +178,7 @@ jobs:
       - name: Restore .metamask folder
         id: restore-metamask
         if: ${{ inputs.runner_provider != 'namespace' && inputs.platform != '' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -245,7 +245,7 @@ jobs:
 
       - name: Save node_modules cache
         if: inputs.use-cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             node_modules
@@ -285,7 +285,7 @@ jobs:
 
       - name: Upload node_modules tarball
         if: inputs.upload-artifact && inputs.use-tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact-name }}
           path: node-modules-${{ inputs.platform }}.tar.zst
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload node_modules artifact (zip)
         if: inputs.upload-artifact && !inputs.use-tarball
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact-name }}
           path: |

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Restore .metamask folder
         id: restore-metamask
         if: ${{ inputs.runner_provider != 'namespace' && inputs.platform != '' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -245,7 +245,7 @@ jobs:
 
       - name: Save node_modules cache
         if: inputs.use-cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: |
             node_modules

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -46,7 +46,7 @@ jobs:
     name: Post Slack Notification
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_branch }}
           fetch-depth: 0
@@ -54,12 +54,12 @@ jobs:
       - name: Download Android Play Store check report (optional)
         id: download-play-store-check
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: android-play-store-check-slack
           path: android-play-store-check-out
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -19,7 +19,7 @@ jobs:
       stable-version: ${{ steps.resolve-stable-version.outputs.stable_version }}
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Configure Git
           run: |

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Generate Attributions
         run: yarn build:attribution
       - name: Cache attributions file
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -158,7 +158,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Restore attributions file
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -40,7 +40,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: React to the comment
         run: |
           gh api \
@@ -64,14 +64,14 @@ jobs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -96,14 +96,14 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -117,7 +117,7 @@ jobs:
       - name: Generate Attributions
         run: yarn build:attribution
       - name: Cache attributions file
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -145,7 +145,7 @@ jobs:
             contents: write
             pull_requests: write
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Use installation token to ensure that the commit later can trigger status check workflows
           token: ${{ steps.get-token.outputs.token }}
@@ -158,7 +158,7 @@ jobs:
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Restore attributions file
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: attribution.txt
           key: cache-build-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -227,7 +227,7 @@ jobs:
             metadata: read
             contents: write
             pull_requests: write
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post comment if the update failed

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -76,7 +76,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Yarn dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -108,7 +108,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install dependencies from cache with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -213,7 +213,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.BRANCH }}
 
       - name: Restore .metamask folder (Foundry download cache for install:foundryup)
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -257,7 +257,7 @@ jobs:
           PREBUILT_IOS_APP_PATH: artifacts/main-e2e-MetaMask.app
 
       - name: Cache updated fixture
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -285,7 +285,7 @@ jobs:
           PR_NUMBER: ${{ needs.prepare.outputs.PR_NUMBER }}
 
       - name: Restore updated fixture
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get PR details
         id: pr
@@ -90,7 +90,7 @@ jobs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
       PR_NUMBER: ${{ inputs.pr_number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Determine whether this PR is from a fork
         id: is-fork
@@ -111,7 +111,7 @@ jobs:
       PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
       RUN_ID: ${{ steps.validate-ci.outputs.RUN_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -208,12 +208,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.BRANCH }}
 
       - name: Restore .metamask folder (Foundry download cache for install:foundryup)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
@@ -257,7 +257,7 @@ jobs:
           PREBUILT_IOS_APP_PATH: artifacts/main-e2e-MetaMask.app
 
       - name: Cache updated fixture
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -276,7 +276,7 @@ jobs:
     if: ${{ !cancelled() && needs.update-fixtures.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -285,7 +285,7 @@ jobs:
           PR_NUMBER: ${{ needs.prepare.outputs.PR_NUMBER }}
 
       - name: Restore updated fixture
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: tests/framework/fixtures/json/default-fixture.json
           key: fixture-${{ needs.prepare.outputs.COMMIT_SHA }}
@@ -302,7 +302,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.fixture-changes.outputs.HAS_CHANGES == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: yarn
@@ -372,7 +372,7 @@ jobs:
       - is-fork-pull-request
       - check-status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Post comment if the update failed
         run: |

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -64,14 +64,14 @@ jobs:
             pull_requests: write
 
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
           token: ${{ steps.get-token.outputs.token }}
           fetch-depth: 0
 
       - name: Checkout github-tools
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: MetaMask/github-tools
           path: github-tools

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-build' || 'ghcr.io/cirruslabs/macos-runner:tahoe-xl' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -89,7 +89,7 @@ jobs:
           bundler-cache: true
 
       - name: Download iOS IPA artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-ipa-${{ inputs.build_name }}
 


### PR DESCRIPTION
# PR Title

ci: bump actions/* dependencies to Node24-compatible majors


## **Description**

<!-- mms-check: type=text required=true -->

GitHub Actions runs have started warning that `actions/checkout@v4` (and several other first-party actions) still run on the Node.js 20 runtime, which GitHub is deprecating: runners will force Node24 by default starting June 16, 2026, and the Node20 binary is removed from runners entirely on September 16, 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

This PR bumps every outdated first-party `actions/*` dependency across `.github/workflows/**` and `.github/actions/**` to the first major version that declares `runs.using: node24`, so our CI stops warning and keeps working once GitHub removes Node20:

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v3, v4 | **v6** |
| `actions/setup-node` | v3, v4 | **v6** |
| `actions/cache` (+ `/restore`, `/save`) | v3, v4 | **v6** |
| `actions/upload-artifact` | v4, v4.5.0, v6 | **v7** |
| `actions/download-artifact` | v4, v6 | **v7** |
| `actions/setup-java` (tag-pinned instance only) | v4 | **v5** |
| `actions/github-script` | v6, v7 | **v9** |

This is a purely mechanical version bump (~280 line changes across 58 files) - no `with:` inputs were changed, since none of the current usages are affected by the breaking changes documented in the respective release notes (e.g. `download-artifact`'s v8 ESM/digest-check changes, `upload-artifact`'s v7 opt-in direct-upload path, `cache`'s v6 ESM-only npm package which only affects direct importers of `@actions/cache`, not `uses:` consumers).

Two `actions/setup-java@<sha>` instances that are pinned to a commit SHA (in `.github/actions/setup-e2e-env/action.yml` and `.github/actions/android-play-store-manifest-check/action.yml`) were intentionally left untouched.

CI on this branch confirmed that after the `actions/*` bump above, the only remaining Node20 deprecation annotation was for the third-party `nick-fields/retry` action (45 occurrences, pinned to a commit SHA). Since `nick-fields/retry@v4.0.0` is a pure Node24 runtime bump with no input changes, it's included here too so this PR is fully warning-free.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #9827

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - this is a CI-only dependency bump. Verification is that all CI checks on this PR itself pass (checkout, setup-node, cache, artifact upload/download, and github-script steps all execute successfully across the workflow runs).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
