### PR TITLE
fix(predict): Fix sports card outcome ordering

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx
@@ -311,6 +311,112 @@ describe('FeaturedCarouselSportCard', () => {
     expect(getByText('40%')).toBeOnTheScreen();
   });
 
+  it('renders UCL outcomes in home-draw-away league order', () => {
+    const market = createMockSportMarket();
+
+    const { getByTestId } = renderWithProvider(
+      <FeaturedCarouselSportCard market={market} index={0} />,
+      { state: initialState },
+    );
+
+    expect(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 0)),
+    ).toHaveTextContent('Lakers');
+    expect(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 2)),
+    ).toHaveTextContent('Celtics');
+  });
+
+  it('renders WNBA outcomes in away-home league order', () => {
+    const market = createMockSportMarket({
+      game: createMockGame({
+        league: 'wnba',
+        score: { away: 49, home: 59, raw: '49-59' },
+        awayTeam: {
+          id: 'portland-fire',
+          name: 'Portland Fire',
+          logo: 'https://example.com/portland-fire.png',
+          abbreviation: 'POR',
+          color: 'orange',
+          alias: 'PortlandFire',
+        },
+        homeTeam: {
+          id: 'connecticut-sun',
+          name: 'Connecticut Sun',
+          logo: 'https://example.com/connecticut-sun.png',
+          abbreviation: 'CONN',
+          color: 'red',
+          alias: 'Sun',
+        },
+      }),
+      outcomes: [
+        createMockOutcome([
+          { id: 'portland-token', title: 'Portland Fire', price: 0.16 },
+          { id: 'connecticut-token', title: 'Connecticut Sun', price: 0.85 },
+        ]),
+      ],
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <FeaturedCarouselSportCard market={market} index={0} />,
+      { state: initialState },
+    );
+
+    expect(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 0)),
+    ).toHaveTextContent('Portland Fire');
+    expect(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(0, 1)),
+    ).toHaveTextContent('Connecticut Sun');
+  });
+
+  it('opens the WNBA away outcome from the left carousel button', () => {
+    const market = createMockSportMarket({
+      game: createMockGame({
+        league: 'wnba',
+        awayTeam: {
+          id: 'portland-fire',
+          name: 'Portland Fire',
+          logo: 'https://example.com/portland-fire.png',
+          abbreviation: 'POR',
+          color: 'orange',
+          alias: 'PortlandFire',
+        },
+        homeTeam: {
+          id: 'connecticut-sun',
+          name: 'Connecticut Sun',
+          logo: 'https://example.com/connecticut-sun.png',
+          abbreviation: 'CONN',
+          color: 'red',
+          alias: 'Sun',
+        },
+      }),
+      outcomes: [
+        createMockOutcome([
+          { id: 'portland-token', title: 'Portland Fire', price: 0.16 },
+          { id: 'connecticut-token', title: 'Connecticut Sun', price: 0.85 },
+        ]),
+      ],
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <FeaturedCarouselSportCard market={market} index={0} />,
+      { state: initialState },
+    );
+
+    fireEvent.press(
+      getByTestId(FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(0, 0)),
+    );
+
+    expect(mockOpenBuySheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcomeToken: expect.objectContaining({
+          id: 'portland-token',
+        }),
+      }),
+    );
+  });
+
   it('renders draw button for UCL leagues', () => {
     const market = createMockSportMarket({
       game: createMockGame({ league: 'ucl' }),

--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
@@ -41,6 +41,7 @@ import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/fea
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
 import { isValidPrice } from '../../utils/prices';
+import { getLeagueTeamOrder } from '../../utils/gameParser';
 import FeaturedCarouselCardFooter from './FeaturedCarouselCardFooter';
 import FeaturedCarouselPayoutRow from './FeaturedCarouselPayoutRow';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
@@ -112,15 +113,26 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
       }),
     [game, market.outcomes, showDraw],
   );
-  const homeToken = buttonResolution.home?.token;
   const drawToken = buttonResolution.draw?.token;
-  const awayToken = buttonResolution.away?.token;
+  const isHomeFirst = getLeagueTeamOrder(game.league) === 'home-away';
+  const leftTeam = isHomeFirst ? game.homeTeam : game.awayTeam;
+  const rightTeam = isHomeFirst ? game.awayTeam : game.homeTeam;
+  const leftScore = isHomeFirst ? liveData.homeScore : liveData.awayScore;
+  const rightScore = isHomeFirst ? liveData.awayScore : liveData.homeScore;
+  const leftButtonResolution = isHomeFirst
+    ? buttonResolution.home
+    : buttonResolution.away;
+  const rightButtonResolution = isHomeFirst
+    ? buttonResolution.away
+    : buttonResolution.home;
+  const leftToken = leftButtonResolution?.token;
+  const rightToken = rightButtonResolution?.token;
   const tokenIds = useMemo(
     () =>
-      [homeToken, drawToken, awayToken]
+      [leftToken, drawToken, rightToken]
         .map((token) => token?.id)
         .filter((id): id is string => Boolean(id)),
-    [awayToken, drawToken, homeToken],
+    [drawToken, leftToken, rightToken],
   );
 
   const { getPrice } = useLiveMarketPrices(tokenIds, {
@@ -255,12 +267,12 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
               alignItems={BoxAlignItems.Center}
               twClassName="gap-2"
             >
-              {renderTeamLogo(game.homeTeam)}
+              {renderTeamLogo(leftTeam)}
               <Text
                 variant={TextVariant.DisplayMd}
                 color={TextColor.TextDefault}
               >
-                {liveData.homeScore}
+                {leftScore}
               </Text>
             </Box>
 
@@ -273,9 +285,9 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 variant={TextVariant.DisplayMd}
                 color={TextColor.TextDefault}
               >
-                {liveData.awayScore}
+                {rightScore}
               </Text>
-              {renderTeamLogo(game.awayTeam)}
+              {renderTeamLogo(rightTeam)}
             </Box>
           </Box>
 
@@ -290,11 +302,12 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 fontWeight={FontWeight.Medium}
                 color={TextColor.TextDefault}
                 numberOfLines={1}
+                testID={FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(index, 0)}
               >
-                {game.homeTeam.name}
+                {leftTeam.name}
               </Text>
-              {homeToken && (
-                <FeaturedCarouselPayoutRow price={getDisplayPrice(homeToken)} />
+              {leftToken && (
+                <FeaturedCarouselPayoutRow price={getDisplayPrice(leftToken)} />
               )}
             </Box>
 
@@ -304,25 +317,32 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 fontWeight={FontWeight.Medium}
                 color={TextColor.TextDefault}
                 numberOfLines={1}
+                testID={FEATURED_CAROUSEL_TEST_IDS.CARD_OUTCOME(
+                  index,
+                  drawToken ? 2 : 1,
+                )}
               >
-                {game.awayTeam.name}
+                {rightTeam.name}
               </Text>
-              {awayToken && (
-                <FeaturedCarouselPayoutRow price={getDisplayPrice(awayToken)} />
+              {rightToken && (
+                <FeaturedCarouselPayoutRow
+                  price={getDisplayPrice(rightToken)}
+                />
               )}
             </Box>
           </Box>
 
           <Box flexDirection={BoxFlexDirection.Row} twClassName="mt-3 gap-2">
-            {homeToken && (
+            {leftToken && (
               <Box twClassName="flex-1">
                 <Button
                   onPress={() =>
-                    handleBuy(homeToken, buttonResolution.home?.outcome)
+                    handleBuy(leftToken, leftButtonResolution?.outcome)
                   }
                   twClassName="bg-success-muted"
                   isFullWidth
                   size={ButtonBaseSize.Lg}
+                  testID={FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(index, 0)}
                 >
                   <Text
                     variant={TextVariant.BodyMd}
@@ -330,7 +350,7 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                     color={TextColor.SuccessDefault}
                   >
                     {formatPercentage(
-                      Math.round(getDisplayPrice(homeToken) * 100),
+                      Math.round(getDisplayPrice(leftToken) * 100),
                     )}
                   </Text>
                 </Button>
@@ -344,6 +364,7 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                   }
                   isFullWidth
                   size={ButtonBaseSize.Lg}
+                  testID={FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(index, 1)}
                 >
                   <Text
                     variant={TextVariant.BodyMd}
@@ -358,15 +379,19 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 </Button>
               </Box>
             )}
-            {awayToken && (
+            {rightToken && (
               <Box twClassName="flex-1">
                 <Button
                   onPress={() =>
-                    handleBuy(awayToken, buttonResolution.away?.outcome)
+                    handleBuy(rightToken, rightButtonResolution?.outcome)
                   }
                   twClassName="bg-success-muted"
                   isFullWidth
                   size={ButtonBaseSize.Lg}
+                  testID={FEATURED_CAROUSEL_TEST_IDS.CARD_BUY_BUTTON(
+                    index,
+                    drawToken ? 2 : 1,
+                  )}
                 >
                   <Text
                     variant={TextVariant.BodyMd}
@@ -374,7 +399,7 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                     color={TextColor.SuccessDefault}
                   >
                     {formatPercentage(
-                      Math.round(getDisplayPrice(awayToken) * 100),
+                      Math.round(getDisplayPrice(rightToken) * 100),
                     )}
                   </Text>
                 </Button>

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -130,6 +130,51 @@ const mockMarket: PredictMarketType = {
   },
 };
 
+const mockWnbaMarket: PredictMarketType = {
+  ...mockMarket,
+  id: 'test-market-wnba-1',
+  slug: 'wnba-por-con-2026-07-14',
+  title: 'Portland Fire vs Connecticut Sun',
+  description: 'WNBA matchup between Portland Fire and Connecticut Sun',
+  tags: ['WNBA'],
+  outcomes: [
+    {
+      ...mockMarket.outcomes[0],
+      id: 'outcome-wnba-moneyline',
+      sportsMarketType: 'moneyline',
+      tokens: [
+        { id: 'token-portland', title: 'Portland Fire', price: 0.16 },
+        { id: 'token-connecticut', title: 'Connecticut Sun', price: 0.85 },
+      ],
+    },
+  ],
+  game: {
+    ...(mockMarket.game as PredictMarketGame),
+    id: 'game-wnba-1',
+    league: 'wnba',
+    status: 'ongoing',
+    elapsed: '06:06',
+    period: 'Q3',
+    score: { away: 49, home: 59, raw: '49-59' },
+    awayTeam: {
+      id: 'portland-fire',
+      name: 'Portland Fire',
+      logo: 'https://example.com/portland-fire.png',
+      abbreviation: 'POR',
+      color: TEST_HEX_COLORS.CUSTOM_ORANGE,
+      alias: 'PortlandFire',
+    },
+    homeTeam: {
+      id: 'connecticut-sun',
+      name: 'Connecticut Sun',
+      logo: 'https://example.com/connecticut-sun.png',
+      abbreviation: 'CONN',
+      color: TEST_HEX_COLORS.PURE_RED,
+      alias: 'Sun',
+    },
+  },
+};
+
 const initialState = {
   engine: {
     backgroundState,
@@ -189,6 +234,64 @@ describe('PredictMarketSportCard', () => {
     expect(getByText('SPA 60¢')).toBeOnTheScreen();
     expect(getByText('DRAW 15¢')).toBeOnTheScreen();
     expect(getByText('ENG 62¢')).toBeOnTheScreen();
+  });
+
+  it('renders World Cup outcome buttons in home-draw-away league order', () => {
+    const { getAllByTestId } = renderWithProvider(
+      <PredictMarketSportCard market={mockMarket} testID="sport-market-card" />,
+      { state: initialState },
+    );
+
+    const buttonTestIds = getAllByTestId(
+      /sport-market-card-(home|draw|away)-button/,
+    ).map((button) => button.props.testID);
+
+    expect(buttonTestIds).toEqual([
+      'sport-market-card-home-button',
+      'sport-market-card-draw-button',
+      'sport-market-card-away-button',
+    ]);
+  });
+
+  it('renders WNBA outcome buttons in away-home league order', () => {
+    const { getAllByTestId, getByText } = renderWithProvider(
+      <PredictMarketSportCard
+        market={mockWnbaMarket}
+        testID="sport-market-card"
+      />,
+      { state: initialState },
+    );
+
+    const buttonTestIds = getAllByTestId(
+      /sport-market-card-(away|home)-button/,
+    ).map((button) => button.props.testID);
+
+    expect(buttonTestIds).toEqual([
+      'sport-market-card-away-button',
+      'sport-market-card-home-button',
+    ]);
+    expect(getByText('POR 16¢')).toBeOnTheScreen();
+    expect(getByText('CONN 85¢')).toBeOnTheScreen();
+  });
+
+  it('opens the WNBA away outcome from the left button', () => {
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketSportCard
+        market={mockWnbaMarket}
+        testID="sport-market-card"
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('sport-market-card-away-button'));
+
+    expect(mockOpenBuySheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcomeToken: expect.objectContaining({
+          id: 'token-portland',
+        }),
+      }),
+    );
   });
 
   it('keeps outcome button labels on one line and shrinks to fit to prevent truncation', () => {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -45,6 +45,7 @@ import PredictSportScoreboard from '../PredictSportScoreboard';
 import { isGameEnded } from '../../utils/scoreboard';
 import { isValidPrice } from '../../utils/prices';
 import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/featureFlags';
+import { getLeagueTeamOrder } from '../../utils/gameParser';
 
 interface PredictMarketSportCardProps {
   market: PredictMarketType;
@@ -91,37 +92,42 @@ const buildButtonItems = (
     game,
     showDraw,
   });
+  const isHomeFirst = getLeagueTeamOrder(game.league) === 'home-away';
+
+  const homeItem: SportOutcomeButtonItem | undefined = home
+    ? {
+        key: home.token.id,
+        label: getTeamButtonLabel(game.homeTeam),
+        token: home.token,
+        outcome: home.outcome,
+        teamColor: game.homeTeam.color,
+        variant: 'home',
+      }
+    : undefined;
+  const drawItem: SportOutcomeButtonItem | undefined = draw
+    ? {
+        key: draw.token.id,
+        label: 'Draw',
+        token: draw.token,
+        outcome: draw.outcome,
+        variant: 'draw',
+      }
+    : undefined;
+  const awayItem: SportOutcomeButtonItem | undefined = away
+    ? {
+        key: away.token.id,
+        label: getTeamButtonLabel(game.awayTeam),
+        token: away.token,
+        outcome: away.outcome,
+        teamColor: game.awayTeam.color,
+        variant: 'away',
+      }
+    : undefined;
 
   return compactButtonItems([
-    home
-      ? {
-          key: home.token.id,
-          label: getTeamButtonLabel(game.homeTeam),
-          token: home.token,
-          outcome: home.outcome,
-          teamColor: game.homeTeam.color,
-          variant: 'home',
-        }
-      : undefined,
-    draw
-      ? {
-          key: draw.token.id,
-          label: 'Draw',
-          token: draw.token,
-          outcome: draw.outcome,
-          variant: 'draw',
-        }
-      : undefined,
-    away
-      ? {
-          key: away.token.id,
-          label: getTeamButtonLabel(game.awayTeam),
-          token: away.token,
-          outcome: away.outcome,
-          teamColor: game.awayTeam.color,
-          variant: 'away',
-        }
-      : undefined,
+    isHomeFirst ? homeItem : awayItem,
+    drawItem,
+    isHomeFirst ? awayItem : homeItem,
   ]);
 };
 


### PR DESCRIPTION
## **Description**

Fixes inconsistent Predict sports market ordering by making sport cards use the canonical league display order from `getLeagueTeamOrder`.

Some leagues, including WNBA, NBA, NFL, MLB, and NHL, display competitors as away-home. The feed sport card and featured carousel were still rendering outcome buttons and carousel content as home-away, which made the card order disagree with the scoreboard, details screen, and Polymarket. This change keeps token/team resolution intact and only changes the visual slot order so the correct team, price, and buy action stay attached together.

## **Changelog**

CHANGELOG entry: Fixed inverted sports outcome buttons for leagues that display away teams first.

## **Related issues**

Refs: PRED-965

## **Manual testing steps**

```gherkin
Feature: Predict sports card outcome ordering

  Scenario: user views an away-home WNBA market in the Predict feed
    Given a WNBA game market is available in the Predict sports feed
    When the user views the sport card for that game
    Then the away team outcome appears before the home team outcome
    And tapping the away team outcome opens the buy sheet for the away team token

  Scenario: user views a home-away World Cup market in the Predict feed
    Given a World Cup game market is available in the Predict sports feed
    When the user views the sport card for that game
    Then the home team outcome remains before draw and away team outcomes
```

## **Screenshots/Recordings**

N/A - not captured locally. This change is covered by targeted component tests; attach before/after simulator screenshots before marking ready for review if visual evidence is required.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Test plan**

- `npx jest app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx --coverage=false`
- `npx jest app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx --coverage=false`
- IDE lint diagnostics on edited files: no errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reordering in Predict sport cards with existing resolution logic; behavior is covered by new component tests and does not touch auth or payments.
> 
> **Overview**
> Predict **feed sport cards** and **featured carousel sport cards** now lay out teams, scores, labels, and buy buttons using `getLeagueTeamOrder` instead of always showing home on the left and away on the right.
> 
> For **away-home** leagues (e.g. WNBA, NBA, NFL), the away side appears first; **home-draw-away** leagues (e.g. UCL, World Cup) keep home, then draw, then away. Token/outcome resolution is unchanged—only visual slot order and which button opens which token are remapped so they stay aligned.
> 
> **Tests** cover UCL vs WNBA ordering and that the left/first buy action still opens the correct away token for WNBA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c29ef92b9b3b2eee59ef1f457c54fd7a5d275eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->