### PR TITLE
chore(card): type Card navigators with feature param lists (Phase 3)

### DIFF
--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
@@ -42,7 +42,7 @@ import {
 import Routes from '../../../../../constants/navigation/Routes';
 import { mapCaipChainIdToChainName } from '../../util/mapCaipChainIdToChainName';
 
-interface AddFundsModalNavigationDetails {
+export interface AddFundsModalNavigationDetails {
   priorityToken?: CardFundingToken;
 }
 

--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
@@ -48,7 +48,7 @@ import {
 import { useCardHomeData } from '../../hooks/useCardHomeData';
 import MoneyBalanceIcon from '../../../../../images/money-balance.svg';
 
-interface AssetSelectionModalNavigationDetails {
+export interface AssetSelectionModalNavigationDetails {
   navigateToCardHomeOnPriorityToken?: boolean;
   selectionOnly?: boolean;
   onTokenSelect?: (token: CardFundingToken) => void;

--- a/app/components/UI/Card/components/Onboarding/ConfirmModal.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmModal.tsx
@@ -22,7 +22,7 @@ import { ModalAction } from '../../../Rewards/components/RewardsBottomSheetModal
 import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 
-interface ConfirmModalParams {
+export interface ConfirmModalParams {
   title: string;
   description: string;
   icon: IconName;

--- a/app/components/UI/Card/components/Onboarding/RegionSelectorModal.tsx
+++ b/app/components/UI/Card/components/Onboarding/RegionSelectorModal.tsx
@@ -47,7 +47,7 @@ export const clearOnValueChange = () => {
   onValueChangeCallback = null;
 };
 
-interface RegionSelectorModalParams {
+export interface RegionSelectorModalParams {
   regions: Region[];
   renderAreaCode?: boolean;
   selectedRegionKey?: string | null;

--- a/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.tsx
+++ b/app/components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.tsx
@@ -26,7 +26,7 @@ import useAuthentication from '../../../../../core/Authentication/hooks/useAuthe
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { CardHomeSelectors } from '../../Views/CardHome/CardHome.testIds';
 
-interface PasswordBottomSheetParams {
+export interface PasswordBottomSheetParams {
   onSuccess: () => void;
   description?: string;
 }

--- a/app/components/UI/Card/routes/index.tsx
+++ b/app/components/UI/Card/routes/index.tsx
@@ -38,9 +38,15 @@ import {
   clearNativeStackNavigatorOptions,
   transparentModalScreenOptions,
 } from '../../../../constants/navigation/clearStackNavigatorOptions';
+import type {
+  CardModalsNavigationParamList,
+  CardRootParamList,
+  CardScreensStackParamList,
+} from '../types/navigation';
 
-const Stack = createNativeStackNavigator();
-const ModalsStack = createNativeStackNavigator();
+const ScreensStack = createNativeStackNavigator<CardScreensStackParamList>();
+const RootStack = createNativeStackNavigator<CardRootParamList>();
+const ModalsStack = createNativeStackNavigator<CardModalsNavigationParamList>();
 
 // All Card main screens render their own header via HeaderStandard, so hide
 // the navigator chrome by default.
@@ -51,7 +57,9 @@ const mainScreenOptions: NativeStackNavigationOptions = { headerShown: false };
 const spendingLimitScreenOptions = ({
   route,
 }: {
-  route: { params?: { flow?: 'manage' | 'enable' | 'onboarding' } };
+  route: {
+    params?: CardScreensStackParamList['CardSpendingLimit'];
+  };
 }): NativeStackNavigationOptions => ({
   headerShown: false,
   gestureEnabled: route.params?.flow !== 'onboarding',
@@ -68,37 +76,43 @@ const MainRoutes = () => {
   );
 
   return (
-    <Stack.Navigator
+    <ScreensStack.Navigator
       initialRouteName={initialRouteName}
       screenOptions={mainScreenOptions}
     >
-      <Stack.Screen name={Routes.CARD.HOME} component={CardHome} />
-      <Stack.Screen name={Routes.CARD.WELCOME} component={CardWelcome} />
-      <Stack.Screen
+      <ScreensStack.Screen name={Routes.CARD.HOME} component={CardHome} />
+      <ScreensStack.Screen name={Routes.CARD.WELCOME} component={CardWelcome} />
+      <ScreensStack.Screen
         name={Routes.CARD.CHOOSE_YOUR_CARD}
         component={ChooseYourCard}
       />
-      <Stack.Screen name={Routes.CARD.REVIEW_ORDER} component={ReviewOrder} />
-      <Stack.Screen
+      <ScreensStack.Screen
+        name={Routes.CARD.REVIEW_ORDER}
+        component={ReviewOrder}
+      />
+      <ScreensStack.Screen
         name={Routes.CARD.ORDER_COMPLETED}
         component={OrderCompleted}
       />
-      <Stack.Screen name={Routes.CARD.CASHBACK} component={Cashback} />
-      <Stack.Screen name={Routes.CARD.CREDIT_REDEEM} component={CreditRedeem} />
-      <Stack.Screen
+      <ScreensStack.Screen name={Routes.CARD.CASHBACK} component={Cashback} />
+      <ScreensStack.Screen
+        name={Routes.CARD.CREDIT_REDEEM}
+        component={CreditRedeem}
+      />
+      <ScreensStack.Screen
         name={Routes.CARD.AUTHENTICATION}
         component={CardAuthentication}
       />
-      <Stack.Screen
+      <ScreensStack.Screen
         name={Routes.CARD.SPENDING_LIMIT}
         component={SpendingLimit}
         options={spendingLimitScreenOptions}
       />
-      <Stack.Screen
+      <ScreensStack.Screen
         name={Routes.CARD.ONBOARDING.ROOT}
         component={OnboardingNavigator}
       />
-    </Stack.Navigator>
+    </ScreensStack.Navigator>
   );
 };
 
@@ -169,12 +183,12 @@ const CardModalsRoutes = () => (
 );
 
 const CardRoutes = () => (
-  <Stack.Navigator
+  <RootStack.Navigator
     initialRouteName={Routes.CARD.HOME}
     screenOptions={{ headerShown: false }}
   >
-    <Stack.Screen name={Routes.CARD.HOME} component={MainRoutes} />
-    <Stack.Screen
+    <RootStack.Screen name={Routes.CARD.HOME} component={MainRoutes} />
+    <RootStack.Screen
       name={Routes.CARD.MODALS.ID}
       component={CardModalsRoutes}
       options={{
@@ -182,7 +196,7 @@ const CardRoutes = () => (
         ...transparentModalScreenOptions,
       }}
     />
-  </Stack.Navigator>
+  </RootStack.Navigator>
 );
 
 export default withCardSDK(CardRoutes);

--- a/app/components/UI/Card/types/navigation.ts
+++ b/app/components/UI/Card/types/navigation.ts
@@ -1,0 +1,104 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
+import type { AddFundsModalNavigationDetails } from '../components/AddFundsBottomSheet/AddFundsBottomSheet';
+import type { AssetSelectionModalNavigationDetails } from '../components/AssetSelectionBottomSheet/AssetSelectionBottomSheet';
+import type { RegionSelectorModalParams } from '../components/Onboarding/RegionSelectorModal';
+import type { ConfirmModalParams } from '../components/Onboarding/ConfirmModal';
+import type { PasswordBottomSheetParams } from '../components/PasswordBottomSheet/PasswordBottomSheet';
+import type { DaimoPayModalParams } from '../components/DaimoPayModal/DaimoPayModal';
+import type { CreditBalanceTooltipParams } from '../components/CreditBalanceTooltipSheet/CreditBalanceTooltipSheet';
+import type { MoneyUnlinkCardSheetRouteParams } from '../components/MoneyUnlinkCardSheet/MoneyUnlinkCardSheet';
+import type { ChooseYourCardParams } from '../Views/ChooseYourCard/ChooseYourCard';
+import type { ReviewOrderParams } from '../Views/ReviewOrder/ReviewOrder';
+import type { OrderCompletedParams } from '../Views/OrderCompleted/OrderCompleted';
+import type { CardFundingToken, CardUserPhase } from '../types';
+
+/**
+ * Nested-navigation params for Card container screens navigated via
+ * `navigate(container, { screen, params })`.
+ *
+ * Kept local to avoid a circular import with NavigationService/types.
+ */
+interface CardNestedNavigationParams {
+  screen?: string;
+  params?: object;
+}
+
+/**
+ * Param list for screens inside the Card main stack (`MainRoutes`).
+ */
+// ParamListBase requires `type`; `interface` cannot satisfy it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type CardScreensStackParamList = {
+  CardHome: undefined;
+  CardWelcome: undefined;
+  ChooseYourCard: ChooseYourCardParams | undefined;
+  ReviewOrder: ReviewOrderParams | undefined;
+  OrderCompleted: OrderCompletedParams | undefined;
+  CardCashback: undefined;
+  CardCreditRedeem: undefined;
+  CardAuthentication:
+    | {
+        showAuthPrompt?: boolean;
+        postAuthRedirect?: { screen: string; params?: object };
+      }
+    | undefined;
+  CardSpendingLimit:
+    | {
+        flow?: 'manage' | 'enable' | 'onboarding' | 'enable_card';
+        selectedToken?: CardFundingToken;
+      }
+    | undefined;
+  CardOnboarding:
+    | (CardNestedNavigationParams & { cardUserPhase?: CardUserPhase })
+    | undefined;
+};
+
+/**
+ * Param list for screens inside the Card modal stack (`CardModalsRoutes`).
+ */
+// ParamListBase requires `type`; `interface` cannot satisfy it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type CardModalsNavigationParamList = {
+  CardAddFundsModal: AddFundsModalNavigationDetails | undefined;
+  CardAssetSelectionModal: AssetSelectionModalNavigationDetails | undefined;
+  CardRegionSelectionModal: RegionSelectorModalParams;
+  CardConfirmModal: ConfirmModalParams;
+  CardPasswordModal: PasswordBottomSheetParams;
+  CardRecurringFeeModal: undefined;
+  CardDaimoPayModal: DaimoPayModalParams;
+  CardViewPinModal: { imageUrl: string };
+  CardSpendingLimitOptionsModal: {
+    currentLimitType: 'full' | 'restricted';
+    currentCustomLimit: string;
+    callerRoute: string;
+    callerParams?: Record<string, unknown>;
+  };
+  CardWaitlistFormModal: { url: string };
+  CardForgotPasswordModal: { location?: 'us' | 'international' } | undefined;
+  CardCreditBalanceTooltipModal: CreditBalanceTooltipParams | undefined;
+  CardCreditRefundTooltipModal: { isMoneyAccount?: boolean } | undefined;
+  CardUnlinkMoneyAccountSheet: MoneyUnlinkCardSheetRouteParams | undefined;
+};
+
+/**
+ * Param list for the outer Card root stack (`CardRoutes`): main screens + modals.
+ */
+// ParamListBase requires `type`; `interface` cannot satisfy it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type CardRootParamList = {
+  CardHome: NavigatorScreenParams<CardScreensStackParamList> | undefined;
+  CardModals: NavigatorScreenParams<CardModalsNavigationParamList> | undefined;
+};
+
+/**
+ * Feature-level Card navigation params for nested `CardScreens` / `CardModals` entry.
+ */
+// Intersection (`&`) requires `type`; `interface` cannot express this.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type CardNavigationParamList = CardScreensStackParamList &
+  CardModalsNavigationParamList & {
+    CardScreens: NavigatorScreenParams<CardRootParamList> | undefined;
+    CardModals:
+      | NavigatorScreenParams<CardModalsNavigationParamList>
+      | undefined;
+  };

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -74,6 +74,11 @@ import type {
   PerpsStackParamList,
 } from '../../components/UI/Perps/types/navigation';
 import type { MoneyNavigationParamList } from '../../components/UI/Money/types/navigation';
+import type {
+  CardModalsNavigationParamList,
+  CardRootParamList,
+  CardScreensStackParamList,
+} from '../../components/UI/Card/types/navigation';
 import type { TrendingTokensFullViewParams } from '../../components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView';
 import type { MarketInsightsRouteParams } from '../../components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView';
 import type { MoreTokenActionsMenuParams } from '../../components/UI/TokenDetails/components/MoreTokenActionsMenu';
@@ -81,8 +86,6 @@ import type { SecurityBadgeBottomSheetParams } from '../../components/UI/TokenDe
 import type { MAPickerSheetParams } from '../../components/UI/Charts/AdvancedChart/MAPickerSheet';
 import type { AgenticCliApprovalParams } from '../../components/Views/AgenticCliApproval/types';
 import type { AgenticCliDashboardWebviewParams } from '../../components/Views/AgenticCliDashboardWebview/types';
-import type { CreditBalanceTooltipParams } from '../../components/UI/Card/components/CreditBalanceTooltipSheet/CreditBalanceTooltipSheet';
-import type { MoneyUnlinkCardSheetRouteParams } from '../../components/UI/Card/components/MoneyUnlinkCardSheet/MoneyUnlinkCardSheet';
 import type { MoneyDeeplinkModalParams } from '../../components/UI/Money/components/MoneyDeeplinkModal/MoneyDeeplinkModal';
 import type { TradingSignalsSetupParams } from '../../components/Views/SocialLeaderboard/components/TradingSignalsSetupBottomSheet/TradingSignalsSetupBottomSheet';
 import type { ExploreFeedRouteParams } from '../../components/Views/TrendingView/TrendingView';
@@ -198,9 +201,6 @@ import type {
 } from '../../components/Views/RevealPrivateCredential/RevealPrivateCredential.types';
 
 // Card params
-import type { CardConfirmModalParams } from '../../components/UI/Card/Card.types';
-import type { ShippingAddress } from '../../components/UI/Card/util/buildUserAddress';
-
 // Account actions params
 import type {
   AccountActionsParams,
@@ -927,25 +927,17 @@ export type RootStackParamList = {
   ///: END:ONLY_INCLUDE_IF
 
   // Card routes
-  CardScreens: undefined;
-  CardHome: undefined;
-  CardWelcome: undefined;
-  CardAuthentication: { showAuthPrompt?: boolean } | undefined;
-  CardSpendingLimit: { flow: string } | undefined;
-  ChooseYourCard:
-    | { flow: string; shippingAddress?: ShippingAddress }
-    | undefined;
-  CardCashback: undefined;
-  CardCreditRedeem: undefined;
-  ReviewOrder: undefined;
-  OrderCompleted:
-    | {
-        paymentMethod?: string;
-        transactionHash?: string;
-        fromUpgrade?: boolean;
-      }
-    | undefined;
-  CardOnboarding: undefined;
+  CardScreens: NavigatorScreenParams<CardRootParamList> | undefined;
+  CardHome: CardScreensStackParamList['CardHome'];
+  CardWelcome: CardScreensStackParamList['CardWelcome'];
+  CardAuthentication: CardScreensStackParamList['CardAuthentication'];
+  CardSpendingLimit: CardScreensStackParamList['CardSpendingLimit'];
+  ChooseYourCard: CardScreensStackParamList['ChooseYourCard'];
+  CardCashback: CardScreensStackParamList['CardCashback'];
+  CardCreditRedeem: CardScreensStackParamList['CardCreditRedeem'];
+  ReviewOrder: CardScreensStackParamList['ReviewOrder'];
+  OrderCompleted: CardScreensStackParamList['OrderCompleted'];
+  CardOnboarding: CardScreensStackParamList['CardOnboarding'];
   CardOnboardingSignUp: undefined;
   CardOnboardingConfirmEmail: undefined;
   CardOnboardingSetPhoneNumber: undefined;
@@ -957,26 +949,21 @@ export type RootStackParamList = {
   CardOnboardingComplete: undefined;
   CardOnboardingKYCFailed: undefined;
   CardOnboardingKYCPending: undefined;
-  CardModals: NestedNavigationParams | undefined;
-  CardAddFundsModal: undefined;
-  CardAssetSelectionModal: undefined;
-  CardRegionSelectionModal: undefined;
-  CardConfirmModal: CardConfirmModalParams | undefined;
-  CardPasswordModal: undefined;
-  CardRecurringFeeModal: undefined;
-  CardDaimoPayModal: undefined;
-  CardViewPinModal: { imageUrl: string };
-  CardSpendingLimitOptionsModal: {
-    currentLimitType: 'full' | 'restricted';
-    currentCustomLimit: string;
-    callerRoute: string;
-    callerParams?: Record<string, unknown>;
-  };
-  CardWaitlistFormModal: { url: string };
-  CardForgotPasswordModal: { location?: 'us' | 'international' } | undefined;
-  CardCreditBalanceTooltipModal: CreditBalanceTooltipParams | undefined;
-  CardCreditRefundTooltipModal: { isMoneyAccount?: boolean } | undefined;
-  CardUnlinkMoneyAccountSheet: MoneyUnlinkCardSheetRouteParams | undefined;
+  CardModals: NavigatorScreenParams<CardModalsNavigationParamList> | undefined;
+  CardAddFundsModal: CardModalsNavigationParamList['CardAddFundsModal'];
+  CardAssetSelectionModal: CardModalsNavigationParamList['CardAssetSelectionModal'];
+  CardRegionSelectionModal: CardModalsNavigationParamList['CardRegionSelectionModal'];
+  CardConfirmModal: CardModalsNavigationParamList['CardConfirmModal'];
+  CardPasswordModal: CardModalsNavigationParamList['CardPasswordModal'];
+  CardRecurringFeeModal: CardModalsNavigationParamList['CardRecurringFeeModal'];
+  CardDaimoPayModal: CardModalsNavigationParamList['CardDaimoPayModal'];
+  CardViewPinModal: CardModalsNavigationParamList['CardViewPinModal'];
+  CardSpendingLimitOptionsModal: CardModalsNavigationParamList['CardSpendingLimitOptionsModal'];
+  CardWaitlistFormModal: CardModalsNavigationParamList['CardWaitlistFormModal'];
+  CardForgotPasswordModal: CardModalsNavigationParamList['CardForgotPasswordModal'];
+  CardCreditBalanceTooltipModal: CardModalsNavigationParamList['CardCreditBalanceTooltipModal'];
+  CardCreditRefundTooltipModal: CardModalsNavigationParamList['CardCreditRefundTooltipModal'];
+  CardUnlinkMoneyAccountSheet: CardModalsNavigationParamList['CardUnlinkMoneyAccountSheet'];
 
   // Send routes
   Recipient: SendRecipientParams | undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->
**Phase 3 of the incremental React Navigation typing migration — Card feature.**
Card’s nested navigators (`CardScreens` / `CardModals`) were still loosely typed (`undefined` / `NestedNavigationParams`), so nested `navigate(container, { screen, params })` calls for Card could not be checked against real screen param shapes. This PR introduces feature-level param lists and wires them into the Card navigators and `RootStackParamList`, following the same pattern used for Perps / Rewards / Predict.
This is **types-only** — no intentional runtime navigation behavior change.

### What changed
**Feature param lists (`app/components/UI/Card/types/navigation.ts`)**
- `CardScreensStackParamList` — main stack screens (`MainRoutes`): Home, Welcome, ChooseYourCard, ReviewOrder, OrderCompleted, Cashback, CreditRedeem, Authentication, SpendingLimit, Onboarding
- `CardModalsNavigationParamList` — modal stack screens (`CardModalsRoutes`)
- `CardRootParamList` — outer `CardRoutes` stack (`CardHome` → nested main stack, `CardModals` → modal stack)
- `CardNavigationParamList` — feature union + nested `CardScreens` / `CardModals` entries

**Navigators (`app/components/UI/Card/routes/index.tsx`)**
- Split the previously shared untyped `Stack` into typed `ScreensStack` (`CardScreensStackParamList`) and `RootStack` (`CardRootParamList`)
- Kept `ModalsStack` typed with `CardModalsNavigationParamList`

**Root stack (`app/core/NavigationService/types.ts`)**
- `CardScreens` → `NavigatorScreenParams<CardRootParamList>`
- `CardModals` → `NavigatorScreenParams<CardModalsNavigationParamList>`
- Leaf Card screen/modal routes now reference the feature param lists instead of ad-hoc / `undefined` shapes

**Call-site cleanup**
- Exported modal param types from AddFunds / AssetSelection / RegionSelector / ConfirmModal / Password bottom sheets so the modal param list stays in sync with what each screen reads


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:https://consensyssoftware.atlassian.net/browse/MCWP-674

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

n/a type changes only

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
n/a type changes only

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only navigation typing and export visibility changes; no deliberate behavior changes, though stricter param types may surface existing navigate() mismatches at build time.
> 
> **Overview**
> **Phase 3** adds strict React Navigation typing for Card, matching the Perps / Rewards / Predict pattern. There is **no intended runtime navigation change**.
> 
> A new `app/components/UI/Card/types/navigation.ts` defines **`CardScreensStackParamList`**, **`CardModalsNavigationParamList`**, **`CardRootParamList`**, and **`CardNavigationParamList`**, with screen params pulled from existing view/modal types (and newly **exported** modal param interfaces on Add Funds, Asset Selection, Region Selector, Confirm, and Password sheets).
> 
> In **`Card/routes/index.tsx`**, the shared untyped stack is split into typed **`ScreensStack`**, **`RootStack`**, and **`ModalsStack`**; **`spendingLimitScreenOptions`** now keys off **`CardScreensStackParamList['CardSpendingLimit']`** (including broader `flow` values such as `enable_card`).
> 
> **`RootStackParamList`** in **`NavigationService/types.ts`** now types **`CardScreens`** / **`CardModals`** with **`NavigatorScreenParams<…>`** and points leaf Card routes at the feature lists instead of **`undefined`**, loose **`NestedNavigationParams`**, or duplicated ad-hoc shapes (e.g. **`CardConfirmModal`**, **`ChooseYourCard`**, **`OrderCompleted`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79be098ecdff2721251b2ace82d5e64718ebb68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->