### PR TITLE
fix(activity): show one row for gasless sends with token gas fee

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.test.ts
@@ -7,6 +7,7 @@ import {
   selectTransactions,
   selectSwapsTransactions,
 } from '../../../../selectors/transactionController';
+import { selectIsActivityRedesignEnabled } from '../../../../selectors/featureFlagController/activityRedesign';
 import { selectTokens } from '../../../../selectors/tokensController';
 import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
@@ -14,6 +15,7 @@ import {
   selectConversionRate,
   selectCurrentCurrency,
 } from '../../../../selectors/currencyRateController';
+import { TransactionType } from '@metamask/transaction-controller';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -31,6 +33,13 @@ jest.mock('../../../../selectors/transactionController', () => ({
   selectTransactions: jest.fn(),
   selectSwapsTransactions: jest.fn(),
 }));
+
+jest.mock(
+  '../../../../selectors/featureFlagController/activityRedesign',
+  () => ({
+    selectIsActivityRedesignEnabled: jest.fn(),
+  }),
+);
 
 jest.mock('../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccount: jest.fn(),
@@ -128,10 +137,15 @@ const createAsset = (overrides: Partial<TokenI> = {}): TokenI => ({
   ...overrides,
 });
 
-const setupMocks = (transactions: unknown[] = []) => {
+const setupMocks = (
+  transactions: unknown[] = [],
+  { isActivityRedesignEnabled = false } = {},
+) => {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectTransactions) return transactions;
     if (selector === selectSwapsTransactions) return {};
+    if (selector === selectIsActivityRedesignEnabled)
+      return isActivityRedesignEnabled;
     if (selector === selectTokens) return [];
     if (selector === selectSelectedInternalAccount) {
       return { address: MOCK_ADDRESS, metadata: { importTime: 0 } };
@@ -326,6 +340,69 @@ describe('useTokenTransactions', () => {
       });
 
       expect(result.current.confirmedTxs.length).toBe(0);
+    });
+  });
+
+  describe('gas_payment fee legs', () => {
+    it('hides gas_payment transactions when activity redesign is on', async () => {
+      const send = createMockTransaction({
+        id: 'send',
+        type: TransactionType.simpleSend,
+        txParams: { from: MOCK_ADDRESS, to: MOCK_TOKEN_ADDRESS },
+      });
+      const fee = createMockTransaction({
+        id: 'fee',
+        type: TransactionType.gasPayment,
+        txParams: { from: MOCK_ADDRESS, to: MOCK_TOKEN_ADDRESS },
+      });
+      setupMocks([send, fee], { isActivityRedesignEnabled: true });
+
+      const asset = createAsset({
+        symbol: 'USDT',
+        isETH: false,
+        isNative: false,
+        address: MOCK_TOKEN_ADDRESS,
+      });
+
+      const { result } = renderHook(() => useTokenTransactions(asset));
+
+      await waitFor(() => {
+        expect(result.current.transactionsUpdated).toBe(true);
+      });
+
+      expect(result.current.transactions.map((tx) => tx.id)).toEqual(['send']);
+    });
+
+    it('keeps gas_payment transactions when activity redesign is off', async () => {
+      const send = createMockTransaction({
+        id: 'send',
+        type: TransactionType.simpleSend,
+        txParams: { from: MOCK_ADDRESS, to: MOCK_TOKEN_ADDRESS },
+      });
+      const fee = createMockTransaction({
+        id: 'fee',
+        type: TransactionType.gasPayment,
+        txParams: { from: MOCK_ADDRESS, to: MOCK_TOKEN_ADDRESS },
+      });
+      setupMocks([send, fee], { isActivityRedesignEnabled: false });
+
+      const asset = createAsset({
+        symbol: 'USDT',
+        isETH: false,
+        isNative: false,
+        address: MOCK_TOKEN_ADDRESS,
+      });
+
+      const { result } = renderHook(() => useTokenTransactions(asset));
+
+      await waitFor(() => {
+        expect(result.current.transactionsUpdated).toBe(true);
+      });
+
+      expect(result.current.transactions.map((tx) => tx.id).sort()).toEqual([
+        'fee',
+        'send',
+      ]);
     });
   });
 });

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -22,6 +22,8 @@ import {
   selectSwapsTransactions,
   selectTransactions,
 } from '../../../../selectors/transactionController';
+import { selectIsActivityRedesignEnabled } from '../../../../selectors/featureFlagController/activityRedesign';
+import { TransactionType } from '@metamask/transaction-controller';
 import { TOKEN_CATEGORY_HASH } from '../../../UI/TransactionElement/utils';
 import { isMusdClaimForCurrentView } from '../../Earn/utils/musd';
 import { isNonEvmChainId } from '../../../../core/Multichain/utils';
@@ -120,6 +122,9 @@ export const useTokenTransactions = (
   // Selectors
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const evmTransactions = useSelector(selectTransactions);
+  const isActivityRedesignEnabled = useSelector(
+    selectIsActivityRedesignEnabled,
+  );
   const swapsTransactions = useSelector(selectSwapsTransactions);
   const tokens = useSelector(selectTokens);
   const conversionRate = useSelector(selectConversionRate);
@@ -154,7 +159,13 @@ export const useTokenTransactions = (
 
   // Get all transactions (EVM or non-EVM)
   const allTransactions = useMemo(() => {
-    let transactions = evmTransactions;
+    // Redesign Activity hides gas_payment siblings and shows the fee on the
+    // primary row; keep token-details lists in sync when that flag is on.
+    let transactions = isActivityRedesignEnabled
+      ? evmTransactions.filter(
+          (tx: Transaction) => tx.type !== TransactionType.gasPayment,
+        )
+      : evmTransactions;
 
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     if (asset.chainId && isNonEvmChainId(asset.chainId)) {
@@ -258,6 +269,7 @@ export const useTokenTransactions = (
     return transactions;
   }, [
     evmTransactions,
+    isActivityRedesignEnabled,
     asset.chainId,
     asset.address,
     asset.symbol,

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -162,7 +162,8 @@ describe('AssetDetailsActivityListItem', () => {
       Routes.ACTIVITY_DETAILS,
       expect.objectContaining({
         chainId: 'eip155:1',
-        txIdentifier: '0xabc',
+        txIdentifier: 'tx-1',
+        preloadKey: expect.any(String),
       }),
     );
   });

--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.test.ts
@@ -342,4 +342,53 @@ describe('useActivityAmountsFiat', () => {
     // 2 SOL * multichain rate 4 -> $8
     expect(result.current.totalFiat).toBe('$8');
   });
+
+  it('prices a gasToken fee via token market rates and includes it in the total', () => {
+    const gasTokenAddress = '0x00000000000000000000000000000000000000aa';
+    const gasTokenFee: ActivityFee = {
+      type: 'gasToken',
+      amount: '1000000',
+      decimals: 6,
+      symbol: 'USDT',
+      assetId: `eip155:1/erc20:${gasTokenAddress}`,
+    };
+    const activity: ActivityListItem = {
+      ...activityWithTokenAndFees,
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        token: {
+          amount: '1000000',
+          assetId: `eip155:1/erc20:${tokenAddress}`,
+          decimals: 6,
+          direction: 'out',
+          symbol: 'USDC',
+        },
+        fees: [gasTokenFee],
+      },
+    };
+
+    mockUseSelectorState({
+      currentCurrency: 'usd',
+      conversionRate: 2,
+      contractExchangeRates: {
+        [tokenAddress]: { price: 3 },
+        [gasTokenAddress]: { price: 1 },
+      },
+      multichainAssetRates: {},
+    });
+
+    const { result } = renderHook(() => useActivityAmountsFiat(activity));
+
+    // Gas fee: 1 USDT * conversionRate 2 * marketRate 1 -> $2
+    expect(result.current.feeRows).toStrictEqual([
+      {
+        label: 'Gas fee',
+        value: '$2',
+        fee: gasTokenFee,
+      },
+    ]);
+    // Token $6 + gas-token fee $2
+    expect(result.current.totalFiat).toBe('$8');
+  });
 });

--- a/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityAmountsFiat.ts
@@ -127,7 +127,29 @@ function tokenToFiatNumber(
 function feeToFiatNumber(
   fee: ActivityFee,
   conversionRate: number | null | undefined,
+  hexChainId: Hex | undefined,
+  contractExchangeRates:
+    | Record<string, { price?: number | null } | undefined>
+    | undefined,
+  multichainAssetRates: MultichainAssetRates | undefined,
 ): number | undefined {
+  // ERC-20 gas payment: price via token market rates (same path as send amount).
+  if (fee.type === 'gasToken') {
+    return tokenToFiatNumber(
+      {
+        amount: fee.amount,
+        decimals: fee.decimals,
+        direction: 'out',
+        ...(fee.assetId ? { assetId: fee.assetId } : {}),
+        ...(fee.symbol ? { symbol: fee.symbol } : {}),
+      },
+      conversionRate,
+      hexChainId,
+      contractExchangeRates,
+      multichainAssetRates,
+    );
+  }
+
   if (!conversionRate || fee.amount === undefined) {
     return undefined;
   }
@@ -186,8 +208,12 @@ const RESOURCE_FEE_LABEL_BY_SYMBOL: Record<string, string> = {
  * in a recognized resource (Bandwidth/Energy) or, more generally, in a
  * non-native asset. Such fees get a distinct label so they don't duplicate the
  * native "Network fee" row, and are kept out of native-rate fiat conversion.
+ * ERC-20 `gasToken` fees are not resources — they use token market rates.
  */
 function isResourceFee(fee: ActivityFee): boolean {
+  if (fee.type === 'gasToken') {
+    return false;
+  }
   if (fee.symbol && fee.symbol.toUpperCase() in RESOURCE_FEE_LABEL_BY_SYMBOL) {
     return true;
   }
@@ -214,6 +240,8 @@ function getFeeLabel(fee: ActivityFee): string {
       return strings('activity_details.network_fee');
     case 'bridge':
       return strings('activity_details.bridge_fee');
+    case 'gasToken':
+      return strings('activity_details.gas_token_fee');
     default:
       return strings('activity_details.transaction_fee');
   }
@@ -269,7 +297,13 @@ export function useActivityAmountsFiat(
   let hasFee = false;
 
   for (const fee of fees) {
-    const feeFiat = feeToFiatNumber(fee, conversionRate);
+    const feeFiat = feeToFiatNumber(
+      fee,
+      conversionRate,
+      hexChainId,
+      contractExchangeRates,
+      multichainAssetRates,
+    );
     if (feeFiat !== undefined && currentCurrency) {
       hasFee = true;
       feeFiatTotal += feeFiat;

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
@@ -163,6 +163,181 @@ describe('useActivityDetailsItem', () => {
     expect(result.current).toBe(local);
   });
 
+  it('keeps the local item when only it carries a gas-token fee', () => {
+    const local = makeItem({
+      type: 'send',
+      hash: '0xgas',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [
+          { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+        ],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    const api = makeItem({
+      type: 'send',
+      hash: '0xgas',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [{ type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' }],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ local: [local], confirmed: [api] });
+
+    const { result } = renderHook(() => useActivityDetailsItem('0xgas'));
+    expect(result.current).toBe(local);
+  });
+
+  it('resolves a local item by TransactionMeta id when the display hash changed', () => {
+    const local = makeItem({
+      type: 'send',
+      hash: '0xnewhash',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-1', hash: '0xnewhash' },
+          initialTransaction: { id: 'meta-1', hash: '0xoldhash' },
+        },
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ local: [local] });
+
+    const { result } = renderHook(() => useActivityDetailsItem('meta-1'));
+    expect(result.current).toBe(local);
+  });
+
+  it('recovers a live local item via preloaded meta id after a hash mismatch', () => {
+    const live = makeItem({
+      type: 'send',
+      hash: '0xnewhash',
+      status: 'pending',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-2', hash: '0xnewhash' },
+          initialTransaction: { id: 'meta-2' },
+        },
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    const preloaded = makeItem({
+      type: 'send',
+      hash: '0xoldhash',
+      status: 'pending',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-2', hash: '0xoldhash' },
+          initialTransaction: { id: 'meta-2' },
+        },
+      },
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [
+          { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+        ],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ local: [live] });
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem('0xoldhash', 'eip155:1', preloaded),
+    );
+    expect(result.current).toBe(live);
+  });
+
+  it('falls back to a preloaded local snapshot when live lookup misses', () => {
+    const preloaded = makeItem({
+      type: 'send',
+      hash: '0xorphan',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-orphan', hash: '0xorphan' },
+          initialTransaction: { id: 'meta-orphan' },
+        },
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({});
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem('meta-orphan', 'eip155:1', preloaded),
+    );
+    expect(result.current).toBe(preloaded);
+  });
+
+  it('prefers a preloaded local gas-token fee over a native-only API copy when live local misses', () => {
+    const api = makeItem({
+      type: 'send',
+      hash: '0xshared',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [{ type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' }],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    const preloaded = makeItem({
+      type: 'send',
+      hash: '0xshared',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-gas', hash: '0xshared' },
+          initialTransaction: { id: 'meta-gas' },
+        },
+      },
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [
+          { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+        ],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ confirmed: [api] });
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem('meta-gas', 'eip155:1', preloaded),
+    );
+    expect(result.current).toBe(preloaded);
+  });
+
+  it('prefers the API copy over a preloaded local when the snapshot has no richer fees', () => {
+    const api = makeItem({
+      type: 'send',
+      hash: '0xshared2',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [{ type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' }],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    const preloaded = makeItem({
+      type: 'send',
+      hash: '0xshared2',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-plain', hash: '0xshared2' },
+          initialTransaction: { id: 'meta-plain' },
+        },
+      },
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [{ type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' }],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ confirmed: [api] });
+
+    const { result } = renderHook(() =>
+      useActivityDetailsItem('meta-plain', 'eip155:1', preloaded),
+    );
+    expect(result.current).toBe(api);
+  });
+
   it('returns the API item when there is no local match', () => {
     const api = makeItem({ type: 'swap', hash: '0xapi' });
     setSources({ confirmed: [api] });

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
@@ -190,6 +190,32 @@ describe('useActivityDetailsItem', () => {
     expect(result.current).toBe(local);
   });
 
+  it('prefers a richer API send over a local contractInteraction that only has a gas-token fee', () => {
+    const local = makeItem({
+      type: 'contractInteraction',
+      hash: '0xdegraded',
+      data: {
+        to: '0xto',
+        fees: [
+          { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+        ],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    const api = makeItem({
+      type: 'send',
+      hash: '0xdegraded',
+      data: {
+        from: '0xfrom',
+        to: '0xto',
+        fees: [{ type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' }],
+      },
+    } as Partial<ActivityListItem> & Pick<ActivityListItem, 'type' | 'hash'>);
+    setSources({ local: [local], confirmed: [api] });
+
+    const { result } = renderHook(() => useActivityDetailsItem('0xdegraded'));
+    expect(result.current).toBe(api);
+  });
+
   it('resolves a local item by TransactionMeta id when the display hash changed', () => {
     const local = makeItem({
       type: 'send',

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -3,8 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
-  isGasTokenFeeWithAmount,
-  isSpendingCapWithAmount,
+  preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the activity list's data sources; route-isolation backlog */
@@ -149,38 +148,6 @@ function getPreferredApiItem(
   return undefined;
 }
 
-function preferLocalOrApi(
-  localItem: ActivityListItem,
-  apiItem: ActivityListItem | undefined,
-): ActivityListItem {
-  if (!apiItem) {
-    return localItem;
-  }
-  const hasMatchingType = apiItem.type === localItem.type;
-  const isLocalLessCategorized =
-    localItem.type === 'contractInteraction' ||
-    localItem.type === 'swapIncomplete';
-  // Spending caps: the accounts API returns no calldata for an approve, so
-  // its confirmed copy has no cap amount. Keep the local copy (decoded from
-  // calldata) when only it carries the amount, so the details screen shows
-  // the cap.
-  const localHasRicherSpendingCap =
-    isSpendingCapWithAmount(localItem) && !isSpendingCapWithAmount(apiItem);
-  // Gasless/STX: local meta has selectedGasFeeToken; the accounts API only
-  // returns a native network fee. Prefer local so Details keep the gas-token
-  // fee (TMCU-1064).
-  const localHasGasTokenFee =
-    isGasTokenFeeWithAmount(localItem) && !isGasTokenFeeWithAmount(apiItem);
-  if (
-    (hasMatchingType || isLocalLessCategorized) &&
-    !localHasRicherSpendingCap &&
-    !localHasGasTokenFee
-  ) {
-    return apiItem;
-  }
-  return localItem;
-}
-
 export function useActivityDetailsItem(
   txIdentifier: string | undefined,
   chainId?: CaipChainId,
@@ -268,7 +235,7 @@ export function useActivityDetailsItem(
     }
 
     if (localItem) {
-      return preferLocalOrApi(localItem, apiItem);
+      return preferLocalOrApiActivityItem(localItem, apiItem);
     }
 
     // Live local missed (STX hash flip / TC prune) but we still have the
@@ -276,7 +243,7 @@ export function useActivityDetailsItem(
     // so a gas-token (or richer spending-cap) fee is not discarded for a
     // native-only API copy.
     if (preloadedResolvedItem?.raw?.type === 'localTransaction') {
-      return preferLocalOrApi(preloadedResolvedItem, apiItem);
+      return preferLocalOrApiActivityItem(preloadedResolvedItem, apiItem);
     }
 
     if (nonEvmItem) {

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CaipChainId } from '@metamask/utils';
 import {
   type ActivityListItem,
+  isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
@@ -15,9 +16,9 @@ import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformation
 
 /**
  * Re-resolves a single {@link ActivityListItem} by its transaction identifier
- * (hash), drawing from the same three sources that feed the activity list:
- * local EVM transactions, confirmed EVM transactions (API), and non-EVM
- * (keyring) transactions.
+ * (hash or local `TransactionMeta.id`), drawing from the same sources that feed
+ * the activity list: local EVM transactions, confirmed EVM transactions (API),
+ * and non-EVM (keyring) transactions.
  *
  * Mirrors the extension's `ui/pages/details/transaction-details.tsx` resolution:
  * a more-categorized API item takes precedence over a local item when the local
@@ -27,12 +28,13 @@ import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformation
  * `swap`). This keeps the details page in sync with the list, which dedups
  * confirmed swaps to the API copy.
  *
+ * Local gasless/STX rows may temporarily change their displayed hash while the
+ * meta `id` stays stable. Lookup therefore indexes local rows by meta id and
+ * both primary/initial hashes. A stashed preloaded local row bridges route
+ * params that still hold a superseded hash to the live meta by id.
+ *
  * When a `chainId` is provided, candidates are restricted to that chain first,
  * so a hash that collides across chains resolves to the correct transaction.
- *
- * NOTE: resolution is keyed on `hash`, so a pending local transaction that does
- * not yet have a hash cannot be addressed here — this matches the extension and
- * is acceptable for the foundation pass.
  */
 function buildItemsByHash(
   items: ActivityListItem[],
@@ -47,20 +49,67 @@ function buildItemsByHash(
   return byHash;
 }
 
+/** Keys that can address a local EVM Activity row (meta id + hashes). */
+export function getLocalActivityLookupKeys(item: ActivityListItem): string[] {
+  const keys = new Set<string>();
+  if (item.hash) {
+    keys.add(item.hash.toLowerCase());
+  }
+  if (item.raw?.type !== 'localTransaction') {
+    return [...keys];
+  }
+  const { primaryTransaction, initialTransaction } = item.raw.data;
+  for (const tx of [primaryTransaction, initialTransaction]) {
+    if (tx?.id) {
+      keys.add(tx.id.toLowerCase());
+    }
+    if (tx?.hash) {
+      keys.add(tx.hash.toLowerCase());
+    }
+  }
+  return [...keys];
+}
+
+function buildLocalItemsByLookupKey(
+  items: ActivityListItem[],
+): Map<string, ActivityListItem> {
+  const byKey = new Map<string, ActivityListItem>();
+  for (const item of items) {
+    for (const key of getLocalActivityLookupKeys(item)) {
+      if (!byKey.has(key)) {
+        byKey.set(key, item);
+      }
+    }
+  }
+  return byKey;
+}
+
+function isProviderBackedItem(item: ActivityListItem): boolean {
+  return (
+    item.raw?.type === 'perpsTransaction' ||
+    item.raw?.type === 'predictActivity'
+  );
+}
+
 function buildItemsByIdentifier(
   items: ActivityListItem[],
 ): Map<string, ActivityListItem> {
   const byIdentifier = buildItemsByHash(items);
   for (const item of items) {
-    const identifier =
+    const domainId =
       item.raw?.type === 'perpsTransaction' ||
       item.raw?.type === 'predictActivity' ||
       item.raw?.type === 'rampOrder'
         ? item.raw.data.id
         : undefined;
-    const normalizedIdentifier = identifier?.toLowerCase();
-    if (normalizedIdentifier && !byIdentifier.has(normalizedIdentifier)) {
-      byIdentifier.set(normalizedIdentifier, item);
+    const normalizedDomainId = domainId?.toLowerCase();
+    if (normalizedDomainId && !byIdentifier.has(normalizedDomainId)) {
+      byIdentifier.set(normalizedDomainId, item);
+    }
+    for (const key of getLocalActivityLookupKeys(item)) {
+      if (!byIdentifier.has(key)) {
+        byIdentifier.set(key, item);
+      }
     }
   }
   return byIdentifier;
@@ -77,6 +126,59 @@ function filterByChain(
   // navigation call site forwards the item's own `chainId`, so the strings
   // align. Avoids lowercasing case-sensitive references (e.g. Solana base58).
   return items.filter((item) => item.chainId === chainId);
+}
+
+function getPreferredApiItem(
+  apiByHash: Map<string, ActivityListItem>,
+  id: string,
+  ...candidates: (ActivityListItem | undefined)[]
+): ActivityListItem | undefined {
+  const direct = apiByHash.get(id);
+  if (direct) {
+    return direct;
+  }
+  for (const candidate of candidates) {
+    const hash = candidate?.hash?.toLowerCase();
+    if (hash) {
+      const byCandidateHash = apiByHash.get(hash);
+      if (byCandidateHash) {
+        return byCandidateHash;
+      }
+    }
+  }
+  return undefined;
+}
+
+function preferLocalOrApi(
+  localItem: ActivityListItem,
+  apiItem: ActivityListItem | undefined,
+): ActivityListItem {
+  if (!apiItem) {
+    return localItem;
+  }
+  const hasMatchingType = apiItem.type === localItem.type;
+  const isLocalLessCategorized =
+    localItem.type === 'contractInteraction' ||
+    localItem.type === 'swapIncomplete';
+  // Spending caps: the accounts API returns no calldata for an approve, so
+  // its confirmed copy has no cap amount. Keep the local copy (decoded from
+  // calldata) when only it carries the amount, so the details screen shows
+  // the cap.
+  const localHasRicherSpendingCap =
+    isSpendingCapWithAmount(localItem) && !isSpendingCapWithAmount(apiItem);
+  // Gasless/STX: local meta has selectedGasFeeToken; the accounts API only
+  // returns a native network fee. Prefer local so Details keep the gas-token
+  // fee (TMCU-1064).
+  const localHasGasTokenFee =
+    isGasTokenFeeWithAmount(localItem) && !isGasTokenFeeWithAmount(apiItem);
+  if (
+    (hasMatchingType || isLocalLessCategorized) &&
+    !localHasRicherSpendingCap &&
+    !localHasGasTokenFee
+  ) {
+    return apiItem;
+  }
+  return localItem;
 }
 
 export function useActivityDetailsItem(
@@ -101,9 +203,13 @@ export function useActivityDetailsItem(
     [nonEvmState?.transactions],
   );
 
-  const localByHash = useMemo(
-    () => buildItemsByHash(filterByChain(localActivityItems, chainId)),
+  const chainedLocalItems = useMemo(
+    () => filterByChain(localActivityItems, chainId),
     [localActivityItems, chainId],
+  );
+  const localByLookupKey = useMemo(
+    () => buildLocalItemsByLookupKey(chainedLocalItems),
+    [chainedLocalItems],
   );
   const apiByHash = useMemo(
     () => buildItemsByHash(filterByChain(confirmedEvmItems, chainId)),
@@ -131,47 +237,60 @@ export function useActivityDetailsItem(
       return undefined;
     }
 
-    const localItem = localByHash.get(id);
-    const apiItem = apiByHash.get(id);
-    const nonEvmItem = nonEvmByHash.get(id);
     const preloadedResolvedItem = preloadedByIdentifier.get(id);
-    const rampItem = rampByIdentifier.get(id);
 
-    if (preloadedResolvedItem) {
+    // Provider-backed rows can't be re-resolved from list sources — honor the
+    // hand-off first (also wins hash collisions with unrelated local txs).
+    if (preloadedResolvedItem && isProviderBackedItem(preloadedResolvedItem)) {
       return preloadedResolvedItem;
     }
+
+    const preloadedMetaId =
+      preloadedResolvedItem?.raw?.type === 'localTransaction'
+        ? preloadedResolvedItem.raw.data.primaryTransaction.id?.toLowerCase()
+        : undefined;
+    const localFromPreloadMeta = preloadedMetaId
+      ? localByLookupKey.get(preloadedMetaId)
+      : undefined;
+
+    const localItem = localByLookupKey.get(id) ?? localFromPreloadMeta;
+    const apiItem = getPreferredApiItem(
+      apiByHash,
+      id,
+      localItem,
+      preloadedResolvedItem,
+    );
+    const nonEvmItem = nonEvmByHash.get(id);
+    const rampItem = rampByIdentifier.get(id);
 
     if (rampItem) {
       return rampItem;
     }
 
     if (localItem) {
-      const hasMatchingType = apiItem?.type === localItem.type;
-      const isLocalLessCategorized =
-        localItem.type === 'contractInteraction' ||
-        localItem.type === 'swapIncomplete';
-      // Spending caps: the accounts API returns no calldata for an approve, so
-      // its confirmed copy has no cap amount. Keep the local copy (decoded from
-      // calldata) when only it carries the amount, so the details screen shows
-      // the cap
-      const localHasRicherSpendingCap =
-        !!apiItem &&
-        isSpendingCapWithAmount(localItem) &&
-        !isSpendingCapWithAmount(apiItem);
-      if (
-        apiItem &&
-        (hasMatchingType || isLocalLessCategorized) &&
-        !localHasRicherSpendingCap
-      ) {
-        return apiItem;
-      }
-      return localItem;
+      return preferLocalOrApi(localItem, apiItem);
     }
 
-    return nonEvmItem ?? apiItem ?? undefined;
+    // Live local missed (STX hash flip / TC prune) but we still have the
+    // stashed local snapshot from navigation — apply the same API preference
+    // so a gas-token (or richer spending-cap) fee is not discarded for a
+    // native-only API copy.
+    if (preloadedResolvedItem?.raw?.type === 'localTransaction') {
+      return preferLocalOrApi(preloadedResolvedItem, apiItem);
+    }
+
+    if (nonEvmItem) {
+      return nonEvmItem;
+    }
+
+    if (apiItem) {
+      return apiItem;
+    }
+
+    return preloadedResolvedItem;
   }, [
     txIdentifier,
-    localByHash,
+    localByLookupKey,
     apiByHash,
     nonEvmByHash,
     preloadedByIdentifier,

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -99,8 +99,8 @@ import {
   getActivityValue,
   getGroupedActivityListItemKey,
   groupActivityListItems,
-  isGasTokenFeeWithAmount,
-  isSpendingCapWithAmount,
+  isFailedOrCancelledTransfer,
+  preferLocalOrApiActivityItem,
   type ActivityKind,
   type GroupedActivityListItem,
 } from '../../../util/activity-adapters';
@@ -386,28 +386,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         if (!hash) continue;
         const confirmed = confirmedItemByHash.get(hash);
         if (!confirmed) continue;
-        const localOutCategorizesConfirmed =
-          confirmed.type !== localItem.type &&
-          localItem.type !== 'contractInteraction' &&
-          localItem.type !== 'swapIncomplete';
-        // Same-kind spending caps: the accounts API returns no calldata for an
-        // approve, so its confirmed copy has no cap amount. Prefer the local
-        // copy, which decodes the amount from calldata.
-        const localHasRicherSpendingCap =
-          confirmed.type === localItem.type &&
-          isSpendingCapWithAmount(localItem) &&
-          !isSpendingCapWithAmount(confirmed);
-        // Gasless/STX: local meta has selectedGasFeeToken; the accounts API
-        // only returns a native network fee. Prefer local so Details can show
-        // the gas-token fee (TMCU-1064).
-        const localHasGasTokenFee =
-          isGasTokenFeeWithAmount(localItem) &&
-          !isGasTokenFeeWithAmount(confirmed);
-        if (
-          localOutCategorizesConfirmed ||
-          localHasRicherSpendingCap ||
-          localHasGasTokenFee
-        ) {
+        if (preferLocalOrApiActivityItem(localItem, confirmed) === localItem) {
           localWinsHashes.add(hash);
         }
       }

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -99,6 +99,7 @@ import {
   getActivityValue,
   getGroupedActivityListItemKey,
   groupActivityListItems,
+  isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
   type ActivityKind,
   type GroupedActivityListItem,
@@ -396,7 +397,17 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           confirmed.type === localItem.type &&
           isSpendingCapWithAmount(localItem) &&
           !isSpendingCapWithAmount(confirmed);
-        if (localOutCategorizesConfirmed || localHasRicherSpendingCap) {
+        // Gasless/STX: local meta has selectedGasFeeToken; the accounts API
+        // only returns a native network fee. Prefer local so Details can show
+        // the gas-token fee (TMCU-1064).
+        const localHasGasTokenFee =
+          isGasTokenFeeWithAmount(localItem) &&
+          !isGasTokenFeeWithAmount(confirmed);
+        if (
+          localOutCategorizesConfirmed ||
+          localHasRicherSpendingCap ||
+          localHasGasTokenFee
+        ) {
           localWinsHashes.add(hash);
         }
       }

--- a/app/components/Views/ActivityList/getActivityDetailsRoute.test.ts
+++ b/app/components/Views/ActivityList/getActivityDetailsRoute.test.ts
@@ -25,38 +25,64 @@ describe('getActivityDetailsRoute', () => {
     });
   });
 
-  it('returns null when the row has no hash (e.g. a pending local tx)', () => {
+  it('returns null when the row has no hash and no local meta id', () => {
     expect(getActivityDetailsRoute(baseItem({ hash: undefined }))).toBeNull();
   });
 
-  it('routes a pending EVM local tx to ActivityDetails (its pending banner wires speed-up/cancel)', () => {
+  it('routes a pending EVM local tx by stable meta id and stashes a preload', () => {
     const pendingItem = baseItem({
       status: 'pending',
       raw: {
         type: 'localTransaction',
-        data: { primaryTransaction: { type: 'simpleSend' } },
+        data: {
+          primaryTransaction: { id: 'meta-pending-1', type: 'simpleSend' },
+        },
       },
     } as unknown as Partial<ActivityListItem>);
 
-    expect(getActivityDetailsRoute(pendingItem)).toEqual({
+    const route = getActivityDetailsRoute(pendingItem);
+
+    expect(route).toEqual({
       chainId: 'eip155:1',
-      txIdentifier: '0xabc',
+      txIdentifier: 'meta-pending-1',
+      preloadKey: expect.any(String),
     });
+    expect(getPreloadedActivityItem(route?.preloadKey)).toBe(pendingItem);
   });
 
-  it('routes a confirmed local tx to ActivityDetails', () => {
+  it('routes a confirmed local tx by stable meta id and stashes a preload', () => {
     const confirmedItem = baseItem({
       status: 'success',
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'meta-confirmed-1', type: 'simpleSend' },
+        },
+      },
+    } as unknown as Partial<ActivityListItem>);
+
+    const route = getActivityDetailsRoute(confirmedItem);
+
+    expect(route).toEqual({
+      chainId: 'eip155:1',
+      txIdentifier: 'meta-confirmed-1',
+      preloadKey: expect.any(String),
+    });
+    expect(getPreloadedActivityItem(route?.preloadKey)).toBe(confirmedItem);
+  });
+
+  it('falls back to hash when a local tx has no meta id', () => {
+    const localWithoutId = baseItem({
       raw: {
         type: 'localTransaction',
         data: { primaryTransaction: { type: 'simpleSend' } },
       },
     } as unknown as Partial<ActivityListItem>);
 
-    expect(getActivityDetailsRoute(confirmedItem)).toEqual({
-      chainId: 'eip155:1',
-      txIdentifier: '0xabc',
-    });
+    const route = getActivityDetailsRoute(localWithoutId);
+
+    expect(route?.txIdentifier).toBe('0xabc');
+    expect(route?.preloadKey).toBeDefined();
   });
 
   it('returns null for a bridge local transaction (keeps its dedicated screen)', () => {
@@ -72,7 +98,7 @@ describe('getActivityDetailsRoute', () => {
     expect(getActivityDetailsRoute(bridgeItem)).toBeNull();
   });
 
-  it('does not stash a preload key for plain EVM/non-EVM rows', () => {
+  it('does not stash a preload key for plain API EVM rows', () => {
     const route = getActivityDetailsRoute(baseItem());
     expect(route?.preloadKey).toBeUndefined();
   });

--- a/app/components/Views/ActivityList/getActivityDetailsRoute.ts
+++ b/app/components/Views/ActivityList/getActivityDetailsRoute.ts
@@ -16,31 +16,49 @@ function hasDedicatedDetailScreen(item: ActivityListItem): boolean {
   );
 }
 
+function getLocalTransactionMetaId(item: ActivityListItem): string | undefined {
+  if (item.raw?.type !== 'localTransaction') {
+    return undefined;
+  }
+  return item.raw.data.primaryTransaction?.id;
+}
+
 /**
  * Route params for opening a row in the redesigned `ActivityDetails` screen, or
- * `null` when it can't be shown there (no hash, or a bridge tx with its own
- * screen) — callers then fall back to their legacy detail flow. Shared so the
- * Activity list and per-asset lists route identically.
+ * `null` when it can't be shown there (no stable identifier, or a bridge tx with
+ * its own screen) — callers then fall back to their legacy detail flow. Shared
+ * so the Activity list and per-asset lists route identically.
  *
- * Side effect: stashes provider-backed rows (Perps/Predict) into
- * `preloadedActivityItemStore`, so call it only when about to navigate.
+ * Local EVM rows navigate by `TransactionMeta.id` (stable across STX hash
+ * assignment) and are stashed in `preloadedActivityItemStore` so Details can
+ * recover if the live hash temporarily diverges. Provider-backed rows
+ * (Perps/Predict) are also stashed. Call only when about to navigate.
  */
 export function getActivityDetailsRoute(
   item: ActivityListItem,
 ): ActivityDetailsParams | null {
-  if (!item.hash || hasDedicatedDetailScreen(item)) {
+  if (hasDedicatedDetailScreen(item)) {
+    return null;
+  }
+
+  const localMetaId = getLocalTransactionMetaId(item);
+  const txIdentifier = localMetaId ?? item.hash;
+  if (!txIdentifier) {
     return null;
   }
 
   const { raw } = item;
-  const preloadKey =
-    raw?.type === 'perpsTransaction' || raw?.type === 'predictActivity'
-      ? stashPreloadedActivityItem(item)
-      : undefined;
+  const shouldPreload =
+    raw?.type === 'perpsTransaction' ||
+    raw?.type === 'predictActivity' ||
+    raw?.type === 'localTransaction';
+  const preloadKey = shouldPreload
+    ? stashPreloadedActivityItem(item)
+    : undefined;
 
   return {
     chainId: item.chainId,
-    txIdentifier: item.hash,
+    txIdentifier,
     ...(preloadKey ? { preloadKey } : {}),
   };
 }

--- a/app/components/Views/ActivityList/preloadedActivityItemStore.ts
+++ b/app/components/Views/ActivityList/preloadedActivityItemStore.ts
@@ -1,12 +1,13 @@
 import type { ActivityListItem } from '../../../util/activity-adapters';
 
 /**
- * Transient hand-off for provider-backed Activity rows (Perps / Predict) that
- * can't be re-resolved by hash. The row is stashed before navigating and only
- * its unique key rides in the navigation params, so params stay serializable.
- * A per-navigation key (not chainId+hash) means a later open of the same tx
- * can't pick up a stale row. Not persisted — a cold start falls back to normal
- * resolution.
+ * Transient hand-off for Activity rows that may not re-resolve cleanly by hash
+ * alone: provider-backed rows (Perps / Predict) and local EVM rows (STX/gasless
+ * hash flips while `TransactionMeta.id` is stable). The row is stashed before
+ * navigating and only its unique key rides in the navigation params, so params
+ * stay serializable. A per-navigation key (not chainId+hash) means a later open
+ * of the same tx can't pick up a stale row. Not persisted — a cold start falls
+ * back to normal resolution.
  */
 
 // Cap the cache so it can't grow unbounded over a session.

--- a/app/components/Views/ActivityList/useTransactionsQuery.ts
+++ b/app/components/Views/ActivityList/useTransactionsQuery.ts
@@ -8,7 +8,7 @@ import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors
 import { selectAllConfiguredEvmCaipNetworks } from '../../../selectors/networkController';
 import { selectApiEvmTransactions } from './helpers/transformations';
 import { MINUTE } from '../../../constants/time';
-import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
+import { selectExcludedActivityTransactionHashes } from '../../../selectors/transactionController';
 
 export const useTransactionsQuery = () => {
   const groupEvmAccount = useSelector(
@@ -21,7 +21,7 @@ export const useTransactionsQuery = () => {
   // NetworkEnablementController so enabling/disabling a single network (e.g.
   // Predict enabling Polygon) never collapses the Activity feed to one network.
   const networks = useSelector(selectAllConfiguredEvmCaipNetworks);
-  const excludedTxHashes = useSelector(selectRequiredTransactionHashes);
+  const excludedTxHashes = useSelector(selectExcludedActivityTransactionHashes);
   const accountAddresses = evmAddress
     ? [toCaipAccountId(KnownCaipNamespace.Eip155, '0', evmAddress)]
     : [];

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.test.ts
@@ -7,7 +7,7 @@ import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors
 import { selectEvmEnabledCaipNetworks } from '../../../selectors/networkEnablementController';
 import { useTransactionsQuery } from './useTransactionsQuery';
 import { MINUTE } from '../../../constants/time';
-import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
+import { selectExcludedActivityTransactionHashes } from '../../../selectors/transactionController';
 
 jest.mock('@tanstack/react-query', () => ({
   useInfiniteQuery: jest.fn(),
@@ -41,7 +41,7 @@ jest.mock('../../../selectors/networkEnablementController', () => ({
 }));
 
 jest.mock('../../../selectors/transactionController', () => ({
-  selectRequiredTransactionHashes: jest.fn(),
+  selectExcludedActivityTransactionHashes: jest.fn(),
 }));
 
 const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
@@ -79,7 +79,7 @@ describe('useTransactionsQuery', () => {
       if (selector === selectEvmEnabledCaipNetworks) {
         return networks;
       }
-      if (selector === selectRequiredTransactionHashes) {
+      if (selector === selectExcludedActivityTransactionHashes) {
         return new Set<string>();
       }
       return undefined;

--- a/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.ts
+++ b/app/components/Views/UnifiedTransactionsView/useTransactionsQuery.ts
@@ -8,7 +8,7 @@ import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors
 import { selectEvmEnabledCaipNetworks } from '../../../selectors/networkEnablementController';
 import { selectTransactions } from './helpers/transformations';
 import { MINUTE } from '../../../constants/time';
-import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
+import { selectExcludedActivityTransactionHashes } from '../../../selectors/transactionController';
 
 export const useTransactionsQuery = () => {
   const groupEvmAccount = useSelector(
@@ -18,7 +18,7 @@ export const useTransactionsQuery = () => {
   /** Activity must load EVM history for the group's EVM account when e.g. Bitcoin is selected. */
   const evmAddress = (groupEvmAccount?.address ?? globalEvmAddress ?? '') || '';
   const networks = useSelector(selectEvmEnabledCaipNetworks);
-  const excludedTxHashes = useSelector(selectRequiredTransactionHashes);
+  const excludedTxHashes = useSelector(selectExcludedActivityTransactionHashes);
   const accountAddresses = evmAddress
     ? [toCaipAccountId(KnownCaipNamespace.Eip155, '0', evmAddress)]
     : [];

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -520,7 +520,7 @@ describe('TransactionController Selectors', () => {
 
       expect(
         selectLocalTransactions(state)
-          .map((tx) => tx.id)
+          .map((tx) => ('id' in tx ? tx.id : undefined))
           .sort(),
       ).toEqual(['fee', 'send']);
     });

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -15,6 +15,9 @@ import {
   selectRequiredTransactionIds,
   selectRequiredTransactionHashes,
   selectRequiredTransactions,
+  selectGasPaymentTransactionIds,
+  selectGasPaymentTransactionHashes,
+  selectExcludedActivityTransactionHashes,
   selectSwapsTransactions,
   selectTransactionBatchMetadataById,
   selectTransactionMetadataById,
@@ -218,6 +221,93 @@ describe('TransactionController Selectors', () => {
     });
   });
 
+  describe('selectGasPaymentTransactionIds', () => {
+    it('returns ids for gas_payment transactions', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'send',
+                  type: TransactionType.simpleSend,
+                },
+                {
+                  id: 'fee',
+                  type: TransactionType.gasPayment,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      expect(selectGasPaymentTransactionIds(state)).toStrictEqual(
+        new Set(['fee']),
+      );
+    });
+  });
+
+  describe('selectGasPaymentTransactionHashes', () => {
+    it('returns lower-cased hashes for gas_payment transactions', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'fee',
+                  type: TransactionType.gasPayment,
+                  hash: '0xABC',
+                },
+                {
+                  id: 'fee-pending',
+                  type: TransactionType.gasPayment,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      expect(selectGasPaymentTransactionHashes(state)).toStrictEqual(
+        new Set(['0xabc']),
+      );
+    });
+  });
+
+  describe('selectExcludedActivityTransactionHashes', () => {
+    it('unions required child hashes and gas_payment hashes', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'parent',
+                  requiredTransactionIds: ['child'],
+                },
+                {
+                  id: 'child',
+                  hash: '0xCHILD',
+                },
+                {
+                  id: 'fee',
+                  type: TransactionType.gasPayment,
+                  hash: '0xFEE',
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      expect(selectExcludedActivityTransactionHashes(state)).toStrictEqual(
+        new Set(['0xchild', '0xfee']),
+      );
+    });
+  });
+
   describe('selectRelatedChainIdsByTransactionId', () => {
     const buildState = (transactions: unknown[]) =>
       ({
@@ -334,6 +424,33 @@ describe('TransactionController Selectors', () => {
     it('filters required child transactions before nonce dedupe', () => {
       expect(selectLocalTransactions(buildLocalTxState())).toStrictEqual([
         expect.objectContaining({ id: 'parent' }),
+      ]);
+    });
+
+    it('filters gas_payment fee legs from the local activity list', () => {
+      const state = buildLocalTxState({
+        transactions: [
+          {
+            id: 'send',
+            chainId: '0x1',
+            time: 200,
+            type: TransactionType.simpleSend,
+            selectedGasFeeToken: '0xtoken',
+            txParams: { from: evmAddress, nonce: '0x1' },
+          },
+          {
+            id: 'fee',
+            chainId: '0x1',
+            time: 201,
+            type: TransactionType.gasPayment,
+            hash: '0xfee',
+            txParams: { from: evmAddress, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(selectLocalTransactions(state)).toStrictEqual([
+        expect.objectContaining({ id: 'send' }),
       ]);
     });
 

--- a/app/selectors/transactionController.test.ts
+++ b/app/selectors/transactionController.test.ts
@@ -47,6 +47,12 @@ jest.mock('./accountsController', () => ({
     state.fallbackEvmAddress,
 }));
 
+jest.mock('./featureFlagController/activityRedesign', () => ({
+  selectIsActivityRedesignEnabled: (state: {
+    isActivityRedesignEnabled?: boolean;
+  }) => state.isActivityRedesignEnabled ?? true,
+}));
+
 describe('TransactionController Selectors', () => {
   describe('selectTransactions', () => {
     it('returns transactions from TransactionController state', () => {
@@ -277,8 +283,9 @@ describe('TransactionController Selectors', () => {
   });
 
   describe('selectExcludedActivityTransactionHashes', () => {
-    it('unions required child hashes and gas_payment hashes', () => {
+    it('unions required child hashes and gas_payment hashes when redesign is on', () => {
       const state = {
+        isActivityRedesignEnabled: true,
         engine: {
           backgroundState: {
             TransactionController: {
@@ -304,6 +311,37 @@ describe('TransactionController Selectors', () => {
 
       expect(selectExcludedActivityTransactionHashes(state)).toStrictEqual(
         new Set(['0xchild', '0xfee']),
+      );
+    });
+
+    it('excludes only required hashes when activity redesign is off', () => {
+      const state = {
+        isActivityRedesignEnabled: false,
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  id: 'parent',
+                  requiredTransactionIds: ['child'],
+                },
+                {
+                  id: 'child',
+                  hash: '0xCHILD',
+                },
+                {
+                  id: 'fee',
+                  type: TransactionType.gasPayment,
+                  hash: '0xFEE',
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      expect(selectExcludedActivityTransactionHashes(state)).toStrictEqual(
+        new Set(['0xchild']),
       );
     });
   });
@@ -389,11 +427,14 @@ describe('TransactionController Selectors', () => {
     const buildLocalTxState = ({
       groupEvmAccount = { address: evmAddress },
       transactions,
+      isActivityRedesignEnabled = true,
     }: {
       groupEvmAccount?: { address: string } | null;
       transactions?: unknown[];
+      isActivityRedesignEnabled?: boolean;
     } = {}) =>
       ({
+        isActivityRedesignEnabled,
         engine: {
           backgroundState: {
             TransactionController: {
@@ -427,7 +468,7 @@ describe('TransactionController Selectors', () => {
       ]);
     });
 
-    it('filters gas_payment fee legs from the local activity list', () => {
+    it('filters gas_payment fee legs when activity redesign is on', () => {
       const state = buildLocalTxState({
         transactions: [
           {
@@ -452,6 +493,36 @@ describe('TransactionController Selectors', () => {
       expect(selectLocalTransactions(state)).toStrictEqual([
         expect.objectContaining({ id: 'send' }),
       ]);
+    });
+
+    it('keeps gas_payment fee legs when activity redesign is off', () => {
+      const state = buildLocalTxState({
+        isActivityRedesignEnabled: false,
+        transactions: [
+          {
+            id: 'send',
+            chainId: '0x1',
+            time: 200,
+            type: TransactionType.simpleSend,
+            selectedGasFeeToken: '0xtoken',
+            txParams: { from: evmAddress, nonce: '0x1' },
+          },
+          {
+            id: 'fee',
+            chainId: '0x1',
+            time: 201,
+            type: TransactionType.gasPayment,
+            hash: '0xfee',
+            txParams: { from: evmAddress, nonce: '0x2' },
+          },
+        ],
+      });
+
+      expect(
+        selectLocalTransactions(state)
+          .map((tx) => tx.id)
+          .sort(),
+      ).toEqual(['fee', 'send']);
     });
 
     it('returns no transactions when the selected group has no EVM account', () => {

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -162,6 +162,41 @@ export const selectRequiredTransactionHashes = createSelector(
     ),
 );
 
+/**
+ * STX gas-token fee legs (`TransactionType.gasPayment`) are batch siblings of
+ * the user action. Activity should not show them as separate rows (TMCU-1064).
+ */
+export const selectGasPaymentTransactionIds = createSelector(
+  selectTransactionsStrict,
+  (transactions) =>
+    new Set(
+      transactions
+        .filter((tx) => tx.type === TransactionType.gasPayment)
+        .map((tx) => tx.id),
+    ),
+);
+
+export const selectGasPaymentTransactionHashes = createSelector(
+  selectTransactionsStrict,
+  (transactions) =>
+    new Set(
+      transactions
+        .filter((tx) => tx.type === TransactionType.gasPayment)
+        .map((tx) => tx.hash?.toLowerCase())
+        .filter((hash): hash is string => Boolean(hash)),
+    ),
+);
+
+/**
+ * Hashes that Activity API feeds should drop: MetaMask Pay / required children
+ * plus gas-token fee payment legs.
+ */
+export const selectExcludedActivityTransactionHashes = createSelector(
+  [selectRequiredTransactionHashes, selectGasPaymentTransactionHashes],
+  (requiredHashes, gasPaymentHashes) =>
+    new Set([...requiredHashes, ...gasPaymentHashes]),
+);
+
 export const selectRelatedChainIdsByTransactionId = createSelector(
   selectTransactionsStrict,
   (transactions) => {
@@ -317,6 +352,7 @@ export const selectLocalTransactions = createDeepEqualSelector(
     selectSelectedAccountGroupEvmInternalAccount,
     selectEvmAddress,
     selectRequiredTransactionIds,
+    selectGasPaymentTransactionIds,
   ],
   (
     nonReplacedTransactions,
@@ -324,12 +360,14 @@ export const selectLocalTransactions = createDeepEqualSelector(
     groupEvmAccount,
     fallbackEvmAddress,
     requiredTransactionIds,
+    gasPaymentTransactionIds,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
     const transactions = nonReplacedTransactions.filter(
       (transaction) =>
         !requiredTransactionIds.has(transaction.id) &&
+        !gasPaymentTransactionIds.has(transaction.id) &&
         belongsToActiveAccount(transaction, activeEvmAddress),
     );
 
@@ -359,12 +397,14 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
     selectSelectedAccountGroupEvmInternalAccount,
     selectEvmAddress,
     selectRequiredTransactionIds,
+    selectGasPaymentTransactionIds,
   ],
   (
     transactions,
     groupEvmAccount,
     fallbackEvmAddress,
     requiredTransactionIds,
+    gasPaymentTransactionIds,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
@@ -372,6 +412,7 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
       (transaction) =>
         isReplacedTransaction(transaction) &&
         !requiredTransactionIds.has(transaction.id) &&
+        !gasPaymentTransactionIds.has(transaction.id) &&
         belongsToActiveAccount(transaction, activeEvmAddress),
     );
   },

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -7,6 +7,7 @@ import {
 } from './smartTransactionsController';
 import { selectEvmAddress } from './accountsController';
 import { selectSelectedAccountGroupEvmInternalAccount } from './multichainAccounts/accountTreeController';
+import { selectIsActivityRedesignEnabled } from './featureFlagController/activityRedesign';
 import {
   TransactionMeta,
   TransactionStatus,
@@ -164,37 +165,45 @@ export const selectRequiredTransactionHashes = createSelector(
 
 /**
  * STX gas-token fee legs (`TransactionType.gasPayment`) are batch siblings of
- * the user action. Activity should not show them as separate rows (TMCU-1064).
+ * the user action. Redesigned Activity hides them as separate rows (TMCU-1064).
  */
-export const selectGasPaymentTransactionIds = createSelector(
+export const selectGasPaymentTransactions = createSelector(
   selectTransactionsStrict,
   (transactions) =>
-    new Set(
-      transactions
-        .filter((tx) => tx.type === TransactionType.gasPayment)
-        .map((tx) => tx.id),
-    ),
+    transactions.filter((tx) => tx.type === TransactionType.gasPayment),
+);
+
+export const selectGasPaymentTransactionIds = createSelector(
+  selectGasPaymentTransactions,
+  (gasPaymentTransactions) =>
+    new Set(gasPaymentTransactions.map((tx) => tx.id)),
 );
 
 export const selectGasPaymentTransactionHashes = createSelector(
-  selectTransactionsStrict,
-  (transactions) =>
+  selectGasPaymentTransactions,
+  (gasPaymentTransactions) =>
     new Set(
-      transactions
-        .filter((tx) => tx.type === TransactionType.gasPayment)
+      gasPaymentTransactions
         .map((tx) => tx.hash?.toLowerCase())
         .filter((hash): hash is string => Boolean(hash)),
     ),
 );
 
 /**
- * Hashes that Activity API feeds should drop: MetaMask Pay / required children
- * plus gas-token fee payment legs.
+ * Hashes that Activity API feeds should drop: MetaMask Pay / required children,
+ * plus gas-token fee legs when redesigned Activity is enabled (legacy keeps
+ * fee legs visible — it has no compensating gasToken fee UI).
  */
 export const selectExcludedActivityTransactionHashes = createSelector(
-  [selectRequiredTransactionHashes, selectGasPaymentTransactionHashes],
-  (requiredHashes, gasPaymentHashes) =>
-    new Set([...requiredHashes, ...gasPaymentHashes]),
+  [
+    selectRequiredTransactionHashes,
+    selectGasPaymentTransactionHashes,
+    selectIsActivityRedesignEnabled,
+  ],
+  (requiredHashes, gasPaymentHashes, isActivityRedesignEnabled) =>
+    isActivityRedesignEnabled
+      ? new Set([...requiredHashes, ...gasPaymentHashes])
+      : new Set(requiredHashes),
 );
 
 export const selectRelatedChainIdsByTransactionId = createSelector(
@@ -353,6 +362,7 @@ export const selectLocalTransactions = createDeepEqualSelector(
     selectEvmAddress,
     selectRequiredTransactionIds,
     selectGasPaymentTransactionIds,
+    selectIsActivityRedesignEnabled,
   ],
   (
     nonReplacedTransactions,
@@ -361,15 +371,22 @@ export const selectLocalTransactions = createDeepEqualSelector(
     fallbackEvmAddress,
     requiredTransactionIds,
     gasPaymentTransactionIds,
+    isActivityRedesignEnabled,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
-    const transactions = nonReplacedTransactions.filter(
-      (transaction) =>
-        !requiredTransactionIds.has(transaction.id) &&
-        !gasPaymentTransactionIds.has(transaction.id) &&
-        belongsToActiveAccount(transaction, activeEvmAddress),
-    );
+    const transactions = nonReplacedTransactions.filter((transaction) => {
+      if (requiredTransactionIds.has(transaction.id)) {
+        return false;
+      }
+      if (
+        isActivityRedesignEnabled &&
+        gasPaymentTransactionIds.has(transaction.id)
+      ) {
+        return false;
+      }
+      return belongsToActiveAccount(transaction, activeEvmAddress);
+    });
 
     const pendingSmartTransactionsForActiveAddress =
       pendingSmartTransactions.filter((transaction) =>
@@ -398,6 +415,7 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
     selectEvmAddress,
     selectRequiredTransactionIds,
     selectGasPaymentTransactionIds,
+    selectIsActivityRedesignEnabled,
   ],
   (
     transactions,
@@ -405,16 +423,25 @@ export const selectReplacedLocalTransactions = createDeepEqualSelector(
     fallbackEvmAddress,
     requiredTransactionIds,
     gasPaymentTransactionIds,
+    isActivityRedesignEnabled,
   ) => {
     const activeEvmAddress = groupEvmAccount?.address ?? fallbackEvmAddress;
 
-    return transactions.filter(
-      (transaction) =>
-        isReplacedTransaction(transaction) &&
-        !requiredTransactionIds.has(transaction.id) &&
-        !gasPaymentTransactionIds.has(transaction.id) &&
-        belongsToActiveAccount(transaction, activeEvmAddress),
-    );
+    return transactions.filter((transaction) => {
+      if (!isReplacedTransaction(transaction)) {
+        return false;
+      }
+      if (requiredTransactionIds.has(transaction.id)) {
+        return false;
+      }
+      if (
+        isActivityRedesignEnabled &&
+        gasPaymentTransactionIds.has(transaction.id)
+      ) {
+        return false;
+      }
+      return belongsToActiveAccount(transaction, activeEvmAddress);
+    });
   },
 );
 

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   getActivityValue,
   getGroupedActivityListItemKey,
   groupActivityListItems,
+  isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
   shouldShowPlusSign,
 } from './activity-list-helpers';
@@ -93,6 +94,49 @@ describe('activity list helpers', () => {
         },
       });
       expect(isSpendingCapWithAmount(item)).toBe(false);
+    });
+  });
+
+  describe('isGasTokenFeeWithAmount', () => {
+    it('is true when fees include a gasToken fee with an amount', () => {
+      const item = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          fees: [
+            {
+              type: 'gasToken',
+              amount: '100',
+              decimals: 6,
+              symbol: 'USDC',
+            },
+          ],
+        },
+      });
+      expect(isGasTokenFeeWithAmount(item)).toBe(true);
+    });
+
+    it('is false when fees only include a native base fee', () => {
+      const item = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          fees: [
+            { type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' },
+          ],
+        },
+      });
+      expect(isGasTokenFeeWithAmount(item)).toBe(false);
+    });
+
+    it('is false when there are no fees', () => {
+      const item = makeItem({
+        type: 'send',
+        data: { from: '0xfrom', to: '0xto' },
+      });
+      expect(isGasTokenFeeWithAmount(item)).toBe(false);
     });
   });
 

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -140,6 +140,20 @@ describe('activity list helpers', () => {
       });
       expect(isGasTokenFeeWithAmount(item)).toBe(false);
     });
+
+    it('is false when gasToken amount is zero (decimal or hex)', () => {
+      for (const amount of ['0', '0x0']) {
+        const item = makeItem({
+          type: 'send',
+          data: {
+            from: '0xfrom',
+            to: '0xto',
+            fees: [{ type: 'gasToken', amount, decimals: 6, symbol: 'USDC' }],
+          },
+        });
+        expect(isGasTokenFeeWithAmount(item)).toBe(false);
+      }
+    });
   });
 
   describe('shouldPreferLocalActivityItem / preferLocalOrApiActivityItem', () => {
@@ -172,6 +186,7 @@ describe('activity list helpers', () => {
       const local = makeItem({
         type: 'contractInteraction',
         data: {
+          from: '0xfrom',
           to: '0xto',
           fees: [
             { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -9,6 +9,8 @@ import {
   groupActivityListItems,
   isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
+  preferLocalOrApiActivityItem,
+  shouldPreferLocalActivityItem,
   shouldShowPlusSign,
 } from './activity-list-helpers';
 
@@ -137,6 +139,57 @@ describe('activity list helpers', () => {
         data: { from: '0xfrom', to: '0xto' },
       });
       expect(isGasTokenFeeWithAmount(item)).toBe(false);
+    });
+  });
+
+  describe('shouldPreferLocalActivityItem / preferLocalOrApiActivityItem', () => {
+    it('prefers matching-type local when only it has a gas-token fee', () => {
+      const local = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          fees: [
+            { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+          ],
+        },
+      });
+      const api = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          fees: [
+            { type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' },
+          ],
+        },
+      });
+      expect(shouldPreferLocalActivityItem(local, api)).toBe(true);
+      expect(preferLocalOrApiActivityItem(local, api)).toBe(local);
+    });
+
+    it('does not let a gas-token local contractInteraction beat an API send', () => {
+      const local = makeItem({
+        type: 'contractInteraction',
+        data: {
+          to: '0xto',
+          fees: [
+            { type: 'gasToken', amount: '100', decimals: 6, symbol: 'USDT' },
+          ],
+        },
+      });
+      const api = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          fees: [
+            { type: 'base', amount: '21000', decimals: 18, symbol: 'ETH' },
+          ],
+        },
+      });
+      expect(shouldPreferLocalActivityItem(local, api)).toBe(false);
+      expect(preferLocalOrApiActivityItem(local, api)).toBe(api);
     });
   });
 

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -40,6 +40,53 @@ export function isGasTokenFeeWithAmount(item: ActivityListItem): boolean {
   );
 }
 
+/**
+ * Whether a local Activity row should win over a same-hash API/confirmed copy.
+ * Shared by the Activity list dedup and Activity Details resolution so the
+ * gas-token / spending-cap / out-categorize rules stay aligned (TMCU-1064).
+ *
+ * Gas-token preference requires matching types so a degraded local
+ * `contractInteraction` cannot permanently beat a richer API `send`/`swap`.
+ */
+export function shouldPreferLocalActivityItem(
+  localItem: ActivityListItem,
+  apiItem: ActivityListItem,
+): boolean {
+  const localOutCategorizesApi =
+    apiItem.type !== localItem.type &&
+    localItem.type !== 'contractInteraction' &&
+    localItem.type !== 'swapIncomplete';
+
+  const localHasRicherSpendingCap =
+    apiItem.type === localItem.type &&
+    isSpendingCapWithAmount(localItem) &&
+    !isSpendingCapWithAmount(apiItem);
+
+  const localHasGasTokenFee =
+    apiItem.type === localItem.type &&
+    isGasTokenFeeWithAmount(localItem) &&
+    !isGasTokenFeeWithAmount(apiItem);
+
+  return (
+    localOutCategorizesApi || localHasRicherSpendingCap || localHasGasTokenFee
+  );
+}
+
+/**
+ * Picks local vs API Activity for Details (and list-aligned resolution).
+ */
+export function preferLocalOrApiActivityItem(
+  localItem: ActivityListItem,
+  apiItem: ActivityListItem | undefined,
+): ActivityListItem {
+  if (!apiItem) {
+    return localItem;
+  }
+  return shouldPreferLocalActivityItem(localItem, apiItem)
+    ? localItem
+    : apiItem;
+}
+
 export type ActivityListFilter =
   | { assetId: CaipAssetType }
   | { networks: string[] };

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -27,16 +27,31 @@ export function isSpendingCapWithAmount(item: ActivityListItem): boolean {
 }
 
 /**
- * True when the item has a gas-token fee (ERC-20 gas payment) with an amount.
- * Used to prefer local Activity rows over confirmed API copies that only have
- * a native network fee (TMCU-1064).
+ * True when fee.amount is a non-zero integer (decimal or hex). Empty / invalid
+ * strings are treated as no amount.
+ */
+function hasNonZeroFeeAmount(amount: string | undefined): boolean {
+  if (!amount) {
+    return false;
+  }
+  try {
+    return BigInt(amount) > 0n;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when the item has a gas-token fee (ERC-20 gas payment) with a non-zero
+ * amount. Used to prefer local Activity rows over confirmed API copies that
+ * only have a native network fee (TMCU-1064).
  */
 export function isGasTokenFeeWithAmount(item: ActivityListItem): boolean {
   if (!('fees' in item.data) || !item.data.fees?.length) {
     return false;
   }
   return item.data.fees.some(
-    (fee) => fee.type === 'gasToken' && Boolean(fee.amount),
+    (fee) => fee.type === 'gasToken' && hasNonZeroFeeAmount(fee.amount),
   );
 }
 

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -26,6 +26,20 @@ export function isSpendingCapWithAmount(item: ActivityListItem): boolean {
   return Boolean(token?.amount || token?.isUnlimitedApproval);
 }
 
+/**
+ * True when the item has a gas-token fee (ERC-20 gas payment) with an amount.
+ * Used to prefer local Activity rows over confirmed API copies that only have
+ * a native network fee (TMCU-1064).
+ */
+export function isGasTokenFeeWithAmount(item: ActivityListItem): boolean {
+  if (!('fees' in item.data) || !item.data.fees?.length) {
+    return false;
+  }
+  return item.data.fees.some(
+    (fee) => fee.type === 'gasToken' && Boolean(fee.amount),
+  );
+}
+
 export type ActivityListFilter =
   | { assetId: CaipAssetType }
   | { networks: string[] };

--- a/app/util/activity-adapters/adapters/helpers.test.ts
+++ b/app/util/activity-adapters/adapters/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import {
+  getLocalActivityFees,
+  getLocalGasTokenFee,
   getLocalTransactionFees,
   getLocalTransactionStatus,
   getNetworkFeeAmount,
@@ -210,6 +212,183 @@ describe('getLocalTransactionFees', () => {
     } as unknown as Parameters<typeof getLocalTransactionFees>[0];
 
     expect(getLocalTransactionFees(group, nativeAsset, 'ETH')).toBeUndefined();
+  });
+});
+
+describe('getLocalGasTokenFee', () => {
+  const tokenAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+  it('builds a gasToken fee from selectedGasFeeToken + gasFeeTokens', () => {
+    const fee = getLocalGasTokenFee({
+      chainId: '0xe708',
+      selectedGasFeeToken: tokenAddress,
+      gasFeeTokens: [
+        {
+          tokenAddress,
+          amount: '0xde0b6b3a7640000',
+          decimals: 18,
+          symbol: 'mUSD',
+          balance: '0x0',
+          gas: '0x0',
+          maxFeePerGas: '0x0',
+          maxPriorityFeePerGas: '0x0',
+          rateWei: '0x0',
+          recipient: '0x1',
+        },
+      ],
+      txParams: {},
+    } as unknown as Parameters<typeof getLocalGasTokenFee>[0]);
+
+    expect(fee).toEqual(
+      expect.objectContaining({
+        type: 'gasToken',
+        amount: '1000000000000000000',
+        decimals: 18,
+        symbol: 'mUSD',
+        assetId: expect.stringContaining('erc20:'),
+      }),
+    );
+  });
+
+  it('returns undefined when no gas fee token is selected', () => {
+    expect(
+      getLocalGasTokenFee({
+        chainId: '0x1',
+        txParams: {},
+      } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the selected gas fee token amount is not a valid BigInt', () => {
+    expect(
+      getLocalGasTokenFee({
+        chainId: '0x1',
+        selectedGasFeeToken: tokenAddress,
+        gasFeeTokens: [
+          {
+            tokenAddress,
+            amount: 'not-a-number',
+            decimals: 18,
+            symbol: 'mUSD',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the selected gas fee token has no amount', () => {
+    expect(
+      getLocalGasTokenFee({
+        chainId: '0x1',
+        selectedGasFeeToken: tokenAddress,
+        gasFeeTokens: [
+          {
+            tokenAddress,
+            decimals: 18,
+            symbol: 'mUSD',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
+    ).toBeUndefined();
+  });
+});
+
+describe('getLocalActivityFees', () => {
+  const nativeAsset = {
+    decimals: 18,
+    symbol: 'ETH',
+    assetId: 'eip155:1/slip44:60',
+  };
+  const tokenAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+  it('returns only the gasToken fee when a gas fee token is selected (omits native base)', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1',
+        txReceipt: { gasUsed: '0x5208', effectiveGasPrice: '0x3b9aca00' },
+        selectedGasFeeToken: tokenAddress,
+        gasFeeTokens: [
+          {
+            tokenAddress,
+            amount: '0x64',
+            decimals: 18,
+            symbol: 'mUSD',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalActivityFees>[0];
+
+    expect(getLocalActivityFees(group, nativeAsset, 'ETH')).toEqual([
+      expect.objectContaining({
+        type: 'gasToken',
+        symbol: 'mUSD',
+        amount: '100',
+      }),
+    ]);
+  });
+
+  it('returns only the gasToken fee when there is no native receipt fee', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1',
+        txReceipt: {},
+        selectedGasFeeToken: tokenAddress,
+        gasFeeTokens: [
+          {
+            tokenAddress,
+            amount: '0x64',
+            decimals: 18,
+            symbol: 'mUSD',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalActivityFees>[0];
+
+    expect(getLocalActivityFees(group, nativeAsset, 'ETH')).toEqual([
+      expect.objectContaining({ type: 'gasToken', symbol: 'mUSD' }),
+    ]);
+  });
+
+  it('returns the native base fee when no gas fee token is selected', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1',
+        txReceipt: { gasUsed: '0x5208', effectiveGasPrice: '0x3b9aca00' },
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalActivityFees>[0];
+
+    expect(getLocalActivityFees(group, nativeAsset, 'ETH')).toEqual([
+      expect.objectContaining({ type: 'base', symbol: 'ETH' }),
+    ]);
   });
 });
 

--- a/app/util/activity-adapters/adapters/helpers.test.ts
+++ b/app/util/activity-adapters/adapters/helpers.test.ts
@@ -305,6 +305,56 @@ describe('getLocalGasTokenFee', () => {
       } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
     ).toBeUndefined();
   });
+
+  it('returns undefined when the native sentinel is selected as the gas fee token', () => {
+    const nativeSentinel = '0x0000000000000000000000000000000000000000';
+    expect(
+      getLocalGasTokenFee({
+        chainId: '0x1',
+        selectedGasFeeToken: nativeSentinel,
+        gasFeeTokens: [
+          {
+            tokenAddress: nativeSentinel,
+            amount: '0x64',
+            decimals: 18,
+            symbol: 'ETH',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the transaction failed and gas was never paid', () => {
+    expect(
+      getLocalGasTokenFee({
+        chainId: '0x1',
+        status: TransactionStatus.failed,
+        selectedGasFeeToken: tokenAddress,
+        gasFeeTokens: [
+          {
+            tokenAddress,
+            amount: '0x64',
+            decimals: 18,
+            symbol: 'mUSD',
+            balance: '0x0',
+            gas: '0x0',
+            maxFeePerGas: '0x0',
+            maxPriorityFeePerGas: '0x0',
+            rateWei: '0x0',
+            recipient: '0x1',
+          },
+        ],
+        txParams: {},
+      } as unknown as Parameters<typeof getLocalGasTokenFee>[0]),
+    ).toBeUndefined();
+  });
 });
 
 describe('getLocalActivityFees', () => {

--- a/app/util/activity-adapters/adapters/helpers.ts
+++ b/app/util/activity-adapters/adapters/helpers.ts
@@ -73,6 +73,65 @@ export function getLocalTransactionFees(
   ];
 }
 
+/**
+ * Fee paid with a selected gas fee token (ERC-20). Shown on the primary
+ * Activity row so STX `gas_payment` siblings can be hidden (TMCU-1064).
+ */
+export function getLocalGasTokenFee(
+  transaction: TransactionGroup['primaryTransaction'],
+  environment: ActivityAdapterEnvironment = mobileActivityAdapterEnvironment,
+): ActivityFee | undefined {
+  const { selectedGasFeeToken, gasFeeTokens, chainId } = transaction;
+  if (!selectedGasFeeToken || !gasFeeTokens?.length) {
+    return undefined;
+  }
+
+  const gasFeeToken = gasFeeTokens.find((token) =>
+    environment.equalsIgnoreCase(token.tokenAddress, selectedGasFeeToken),
+  );
+  if (!gasFeeToken?.amount) {
+    return undefined;
+  }
+
+  let amount: string;
+  try {
+    amount = BigInt(gasFeeToken.amount).toString(10);
+  } catch {
+    return undefined;
+  }
+
+  const assetId = environment.toAssetId(gasFeeToken.tokenAddress, chainId);
+
+  return {
+    type: 'gasToken',
+    amount,
+    decimals: gasFeeToken.decimals,
+    ...(gasFeeToken.symbol ? { symbol: gasFeeToken.symbol } : {}),
+    ...(assetId ? { assetId } : {}),
+  };
+}
+
+/**
+ * Fees for local Activity rows. When a gas fee token is selected, only that
+ * fee is shown (native base is omitted — the user paid with the token).
+ * Otherwise returns the native network fee.
+ */
+export function getLocalActivityFees(
+  transactionGroup: Pick<TransactionGroup, 'primaryTransaction'>,
+  nativeAsset: ActivityTokenMetadata | undefined,
+  nativeSymbol: string | undefined,
+  environment: ActivityAdapterEnvironment = mobileActivityAdapterEnvironment,
+): ActivityFee[] | undefined {
+  const gasTokenFee = getLocalGasTokenFee(
+    transactionGroup.primaryTransaction,
+    environment,
+  );
+  if (gasTokenFee) {
+    return [gasTokenFee];
+  }
+  return getLocalTransactionFees(transactionGroup, nativeAsset, nativeSymbol);
+}
+
 export function getApiTransactionFees(
   transaction: V1TransactionByHashResponse,
   nativeAsset: ActivityTokenMetadata | undefined,

--- a/app/util/activity-adapters/adapters/helpers.ts
+++ b/app/util/activity-adapters/adapters/helpers.ts
@@ -76,13 +76,35 @@ export function getLocalTransactionFees(
 /**
  * Fee paid with a selected gas fee token (ERC-20). Shown on the primary
  * Activity row so STX `gas_payment` siblings can be hidden (TMCU-1064).
+ *
+ * Skips the native sentinel (`0x000…000`) — confirmations may select it for
+ * STX while gas is still paid in native — and skips terminal-fail statuses so
+ * quoted unpaid gas is not shown on dropped/rejected/failed sends.
  */
 export function getLocalGasTokenFee(
   transaction: TransactionGroup['primaryTransaction'],
   environment: ActivityAdapterEnvironment = mobileActivityAdapterEnvironment,
 ): ActivityFee | undefined {
-  const { selectedGasFeeToken, gasFeeTokens, chainId } = transaction;
+  const { selectedGasFeeToken, gasFeeTokens, chainId, status } = transaction;
   if (!selectedGasFeeToken || !gasFeeTokens?.length) {
+    return undefined;
+  }
+
+  if (
+    environment.equalsIgnoreCase(
+      selectedGasFeeToken,
+      environment.nativeTokenAddress,
+    )
+  ) {
+    return undefined;
+  }
+
+  if (
+    status === TransactionStatus.failed ||
+    status === TransactionStatus.dropped ||
+    status === TransactionStatus.rejected ||
+    status === TransactionStatus.cancelled
+  ) {
     return undefined;
   }
 

--- a/app/util/activity-adapters/adapters/local-transaction.test.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.test.ts
@@ -1336,6 +1336,55 @@ describe('mapLocalTransaction', () => {
     );
   });
 
+  it('uses the gasToken fee amount for a gasless EIP-7702 smart account upgrade', () => {
+    const gasTokenAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+    const transaction = {
+      chainId: mainnet,
+      hash: '0xupgradegasless',
+      status: TransactionStatus.confirmed,
+      time: 1716367781000,
+      type: TransactionType.batch,
+      selectedGasFeeToken: gasTokenAddress,
+      gasFeeTokens: [
+        {
+          tokenAddress: gasTokenAddress,
+          amount: '0x64',
+          decimals: 18,
+          symbol: 'mUSD',
+          balance: '0x0',
+          gas: '0x0',
+          maxFeePerGas: '0x0',
+          maxPriorityFeePerGas: '0x0',
+          rateWei: '0x0',
+          recipient: '0x1',
+        },
+      ],
+      txParams: {
+        from,
+        to,
+        authorizationList: [{ address: to }],
+      },
+    } as unknown as Partial<TransactionMeta>;
+
+    const result = withoutRaw(mapLocalTransaction(makeGroup(transaction)));
+    expect(result.type).toBe('smartAccountUpgrade');
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          direction: 'out',
+          amount: '100',
+        }),
+        fees: [
+          expect.objectContaining({
+            type: 'gasToken',
+            amount: '100',
+            symbol: 'mUSD',
+          }),
+        ],
+      }),
+    );
+  });
+
   it('keeps the action label for a batch that also performs a recognised action', () => {
     const transaction = {
       chainId: mainnet,

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -527,7 +527,10 @@ export function mapLocalTransaction(
     }
     // No asset moves in an upgrade — the only ETH movement is gas, so the row
     // shows the gas paid as a native-asset amount (rendered like any other tx).
-    const gasAmount = fees?.find((fee) => fee.type === 'base')?.amount;
+    // Gasless upgrades may only carry a `gasToken` fee (no native `base`).
+    const gasAmount =
+      fees?.find((fee) => fee.type === 'base')?.amount ??
+      fees?.find((fee) => fee.type === 'gasToken')?.amount;
     return {
       type: 'smartAccountUpgrade',
       chainId,

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -24,7 +24,7 @@ import {
 } from './constants';
 import {
   getKnownTokenMetadata,
-  getLocalTransactionFees,
+  getLocalActivityFees,
   getLocalTransactionStatus,
   getTokenApprovalAmountFromData,
   isUnlimitedApprovalAmount,
@@ -60,12 +60,13 @@ export function mapLocalTransaction(
   const nativeSymbol =
     transactionGroup.nativeAssetSymbol ?? nativeAsset?.symbol;
 
-  // Base network (gas) fee in the chain's native token, derived from the tx
-  // receipt. Spread into `data` for types that surface fees in the UI.
-  const fees = getLocalTransactionFees(
+  // Native network fee (from receipt) plus optional ERC-20 gas-token fee when
+  // `selectedGasFeeToken` is set. Spread into `data` for types that surface fees.
+  const fees = getLocalActivityFees(
     transactionGroup,
     nativeAsset,
     nativeSymbol,
+    environment,
   );
 
   const getNativeToken = (

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -43,6 +43,7 @@ export {
   getGroupedActivityListItemKey,
   groupActivityListItems,
   isFailedOrCancelledTransfer,
+  isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
   shouldShowPlusSign,
   type GroupedActivityListItem,

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -45,6 +45,8 @@ export {
   isFailedOrCancelledTransfer,
   isGasTokenFeeWithAmount,
   isSpendingCapWithAmount,
+  preferLocalOrApiActivityItem,
+  shouldPreferLocalActivityItem,
   shouldShowPlusSign,
   type GroupedActivityListItem,
 } from './activity-list-helpers';

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10028,6 +10028,7 @@
     "bandwidth_fee": "Bandwidth",
     "energy_fee": "Energy",
     "bridge_fee": "Bridge fee",
+    "gas_token_fee": "Gas fee",
     "transaction_fee": "Transaction fee",
     "unknown_token": "Unknown",
     "total_amount": "Total amount",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### Reason

Gasless / smart-transaction sends pay network fee with an ERC-20 via a sibling `TransactionType.gasPayment` batch leg. Redesigned Activity only hid `requiredTransactionIds` children, so that fee leg appeared as a second row (often a contract interaction or zero-native send). Expected product behavior is a **single** Activity row that indicates gas was paid with the fee token ([TMCU-1064](https://consensyssoftware.atlassian.net/browse/TMCU-1064)).

Separately, pending / confirming Activity Details could briefly show “Transaction details are unavailable” (and related unstable pending identity) when STX assigned or swapped the on-chain hash while the screen was still keyed only on `item.hash` (which also fell back to client `TransactionMeta.id` / UUID). That Details navigation stability gap is tracked in [TMCU-1101](https://consensyssoftware.atlassian.net/browse/TMCU-1101). After confirm, preferring the accounts-API copy over local could also drop the token fee, and `gasToken` fees were skipped in fiat totals because they were treated like resource fees.

### Solution

1. **Hide gas-payment legs** ([TMCU-1064](https://consensyssoftware.atlassian.net/browse/TMCU-1064))
   - Selectors collect gas-payment ids/hashes and filter them from local Activity (+ related API exclusion hashes), same family as required-tx children.

2. **Surface fee on the primary send** ([TMCU-1064](https://consensyssoftware.atlassian.net/browse/TMCU-1064))
   - Local adapter builds a `gasToken` fee from `selectedGasFeeToken` / `gasFeeTokens`.
   - When a gas fee token is selected, Details shows that fee only (no duplicate native “Network fee”).
   - List + Details prefer the local row when only it carries a gas-token fee.

3. **Stabilize pending Details navigation** ([TMCU-1101](https://consensyssoftware.atlassian.net/browse/TMCU-1101))
   - Navigate local rows by stable `TransactionMeta.id` and stash a local preload.
   - Resolve by meta id + primary/initial hashes; bridge superseded hashes via preload.
   - Prefer preloaded local over native-only API when live local briefly misses.

4. **Fiat total for gas-token fees**
   - Price `gasToken` fees via token market rates and include them in total fiat.

5. **Hardening**
   - Guard invalid/missing gas fee token `amount` so `BigInt` cannot throw during Activity mapping.

Covered with unit tests for selectors, fee helpers, Activity Details resolution, route params, and fiat totals.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed gasless sends showing two Activity rows and losing the token gas fee on Details; fixed Activity Details becoming unavailable while a transaction is pending/confirming

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: https://consensyssoftware.atlassian.net/browse/TMCU-1064
Refs: https://consensyssoftware.atlassian.net/browse/TMCU-1101

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Gasless send Activity (TMCU-1064) and Details stability (TMCU-1101)

  Scenario: gasless send shows a single Activity row with token gas fee
    Given the user can send with gas paid in an ERC-20 (e.g. USDT) on Ethereum or Linea
    And redesign Activity / Activity Details is enabled

    When the user confirms a gasless send of a different token (e.g. USDC or mUSD)
    And opens Activity while the transaction is pending

    Then exactly one pending row appears for the send (no separate gas_payment / interaction row)
    And opening Details shows the send amount and a Gas fee denominated in the fee token
    And Details does not show a separate native Network fee for that gasless payment
    And Details does not flash “Transaction details are unavailable” while pending

    When the transaction confirms
    And the user reopens Details (or keeps Details open through confirmation)

    Then there is still a single confirmed Activity row
    And Details remains available through confirmation
    And Details continues to show the Gas fee in the fee token while local meta (or preload preference) is available

  Scenario: native-gas send is unchanged
    Given the user sends with native gas (ETH)

    When the transaction appears in Activity
    Then a single row is shown
    And Details shows the native Network fee only (no gasToken fee row)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bb409a25-fa57-41d6-9ab0-a8957eef2450" />


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f0a2e418-39df-49f1-877f-9ab9bcb99773

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-1064]: https://consensyssoftware.atlassian.net/browse/TMCU-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-1101]: https://consensyssoftware.atlassian.net/browse/TMCU-1101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Activity list/dedup, navigation params, transaction selectors, and fiat fee logic across multiple user-facing flows; changes are gated by the activity redesign flag but still affect pending details resolution for all local EVM rows.
> 
> **Overview**
> **Gasless sends** no longer appear as two Activity rows when redesign is on: `gasPayment` batch legs are filtered from local lists, token-details transactions, and API exclusion hashes (via `selectExcludedActivityTransactionHashes`), while the primary row carries a **`gasToken` fee** built from `selectedGasFeeToken` / `gasFeeTokens` (replacing duplicate native network fee on that path).
> 
> **Activity Details** is stabilized for pending STX/hash churn: local rows navigate by stable **`TransactionMeta.id`**, stash a **preload** snapshot, and resolve by meta id plus primary/initial hashes; shared **`preferLocalOrApiActivityItem`** keeps list dedup and details aligned when only local has the gas-token fee. **`gasToken` fees** are priced via token market rates in fiat totals and labeled with a new **Gas fee** string.
> 
> Legacy behavior is preserved when activity redesign is off (fee legs remain visible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e63e1a1f8548134819207ed2d163b51e31286f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->