### PR TITLE
fix(predict): use correct payload for dynamic market subscriptions cp-8.3.0

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -549,6 +549,23 @@ describe('WebSocketManager', () => {
       );
     });
 
+    it('sends dynamic subscription message for tokens added to an open connection', () => {
+      const manager = WebSocketManager.getInstance();
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      const market = mockWebSocketInstances[0];
+      market.simulateOpen();
+      market.send.mockClear();
+
+      manager.subscribeToMarketPrices(['token2'], jest.fn());
+
+      expect(market.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          operation: 'subscribe',
+          assets_ids: ['token2'],
+        }),
+      );
+    });
+
     it('calls callback with price updates for subscribed tokens', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
@@ -799,6 +816,23 @@ describe('WebSocketManager', () => {
         JSON.stringify({
           type: 'market',
           assets_ids: ['token1'],
+        }),
+      );
+    });
+
+    it('sends dynamic subscription message for an orderbook added to an open connection', () => {
+      const manager = WebSocketManager.getInstance();
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      const market = getMarketInstance();
+      market.simulateOpen();
+      market.send.mockClear();
+
+      manager.subscribeToOrderbook('token2', jest.fn());
+
+      expect(market.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          operation: 'subscribe',
+          assets_ids: ['token2'],
         }),
       );
     });

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -788,7 +788,7 @@ export class WebSocketManager {
 
   private ensureMarketConnection(tokenIds: string[]): void {
     if (this.marketWs?.readyState === WebSocket.OPEN) {
-      this.sendMarketSubscribe(tokenIds);
+      this.sendMarketSubscriptionUpdate(tokenIds);
       return;
     }
     if (this.marketWs?.readyState === WebSocket.CONNECTING) {
@@ -961,7 +961,7 @@ export class WebSocketManager {
     this.scheduleOrderbookEmit(data.asset_id);
   }
 
-  private sendMarketSubscribe(tokenIds: string[]): void {
+  private sendInitialMarketSubscription(tokenIds: string[]): void {
     if (this.marketWs?.readyState !== WebSocket.OPEN) {
       return;
     }
@@ -969,6 +969,19 @@ export class WebSocketManager {
     this.marketWs.send(
       JSON.stringify({
         type: 'market',
+        assets_ids: tokenIds,
+      }),
+    );
+  }
+
+  private sendMarketSubscriptionUpdate(tokenIds: string[]): void {
+    if (this.marketWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.marketWs.send(
+      JSON.stringify({
+        operation: 'subscribe',
         assets_ids: tokenIds,
       }),
     );
@@ -1008,7 +1021,7 @@ export class WebSocketManager {
     });
 
     if (allTokenIds.size > 0) {
-      this.sendMarketSubscribe(Array.from(allTokenIds));
+      this.sendInitialMarketSubscription(Array.from(allTokenIds));
     }
   }
 


### PR DESCRIPTION
## **Description**

Fixes live price updates for market tokens added after the Polymarket WebSocket connection is already open.

Initial and reconnect subscriptions continue using the market connection payload, while dynamic token additions now use Polymarket's `subscribe` operation. Previously, dynamically added tokens were sent using the initial connection payload and were not subscribed, preventing components such as moneyline cards and charts from receiving updates.

Regression tests cover dynamic price and orderbook subscriptions while preserving initial and reconnect behavior.

## **Changelog**

CHANGELOG entry: Fixed live prediction market prices not updating for dynamically subscribed markets

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/PRED-1092

## **Manual testing steps**

```gherkin
Feature: Live prediction market prices

  Scenario: Receive updates for tokens added to an open WebSocket connection
    Given a prediction game details page is open
    And the market WebSocket connection is already active

    When moneyline tokens are added to the connection
    Then the moneyline card displays live price updates
    And the moneyline chart displays live price updates
```

Automated verification:

`npx jest app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts --coverage=false`

## **Screenshots/Recordings**

N/A — this change fixes the WebSocket subscription payload and has no visual changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted WebSocket subscription payload fix in Predict Polymarket provider with tests; initial/reconnect behavior unchanged.
> 
> **Overview**
> **Fixes live prediction market prices** when tokens are subscribed after the Polymarket market WebSocket is already open (e.g. moneyline cards/charts on game details).
> 
> `WebSocketManager` now sends **`{ type: 'market', assets_ids }`** only for the first connection and reconnect resubscribe, and **`{ operation: 'subscribe', assets_ids }`** when price or orderbook subscriptions are added on an open socket. Previously, dynamic adds reused the initial payload and Polymarket did not subscribe those assets.
> 
> Regression tests assert the subscribe payload for late-added market prices and orderbooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7484e4dfe74fab24bba0adfe6980415d83f4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->