### PR TITLE
fix: MUSD-1175 MetaMask Card "Avail. balance" incorrectly changes based on preferred fiat currency cp-8.3.0

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -2691,8 +2691,6 @@ describe('MoneyHomeView', () => {
     } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>;
 
     // EUR/ETH = 900, USD/ETH = 1000 -> fiat->USD factor is 1000/900 = 10/9.
-    // 90 EUR raw fiat converts to exactly 100 USD, proving the conversion (not
-    // a pass-through of balanceFiat) drives the rendered value.
     const eurCurrencyRatesState = {
       engine: {
         backgroundState: {
@@ -2716,7 +2714,7 @@ describe('MoneyHomeView', () => {
       );
     });
 
-    it('converts the primary token raw fiat number from the preferred currency to USD', () => {
+    it('converts a non-Money primary token raw fiat number to USD', () => {
       mockSelectIsCardholder.mockReturnValue(true);
       mockUseMoneyAccountCardLinkage.mockReturnValue(linkedCardLinkage);
       mockUseCardHomeData.mockReturnValue({
@@ -2724,6 +2722,29 @@ describe('MoneyHomeView', () => {
         primaryToken: {
           balanceFiat: '€90.00',
           rawFiatNumber: 90,
+          isMoneyAccountEntry: false,
+        } as unknown as ReturnType<
+          typeof useMoneyAccountCardLinkage
+        >['primaryMoneyAccount'],
+      });
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />, {
+        state: eurCurrencyRatesState,
+      });
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE),
+      ).toHaveTextContent('$100.00');
+    });
+
+    it('renders the Money Account USD raw fiat number without reconverting it', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue(linkedCardLinkage);
+      mockUseCardHomeData.mockReturnValue({
+        ...baseCardHomeData,
+        primaryToken: {
+          balanceFiat: '$100.00',
+          rawFiatNumber: 100,
           isMoneyAccountEntry: true,
         } as unknown as ReturnType<
           typeof useMoneyAccountCardLinkage
@@ -2754,15 +2775,13 @@ describe('MoneyHomeView', () => {
       ).toHaveTextContent('$0.00');
     });
 
-    it('falls back to formatted zero when the fiat→USD rate is unavailable', () => {
-      // rawFiatNumber is present, but currency rates haven't loaded — must not
-      // render an unconverted (wrong-currency) balance.
+    it('renders the Money Account USD balance when currency rates are unavailable', () => {
       mockSelectIsCardholder.mockReturnValue(true);
       mockUseMoneyAccountCardLinkage.mockReturnValue(linkedCardLinkage);
       mockUseCardHomeData.mockReturnValue({
         ...baseCardHomeData,
         primaryToken: {
-          balanceFiat: '€90.00',
+          balanceFiat: '$90.00',
           rawFiatNumber: 90,
           isMoneyAccountEntry: true,
         } as unknown as ReturnType<
@@ -2774,7 +2793,7 @@ describe('MoneyHomeView', () => {
 
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE),
-      ).toHaveTextContent('$0.00');
+      ).toHaveTextContent('$90.00');
     });
 
     it('masks the Card manage balance when privacy mode is on', () => {

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -660,17 +660,22 @@ const MoneyHomeView = () => {
 
   const { primaryToken: cardPrimaryToken } = useCardHomeData();
   const currencyRates = useSelector(selectCurrencyRates);
-  // The Card pipeline reports balanceFiat in the user's selected currency, but
-  // we want to show USD fiat values in this view.
+  // Money Account entries are already valued in USD. Other Card tokens report
+  // their fiat value in the user's selected currency.
   const cardBalanceUsd = useMemo(() => {
-    const usd = convertSelectedFiatToUsd(
-      cardPrimaryToken?.rawFiatNumber,
-      currencyRates,
-    );
+    const rawFiat = cardPrimaryToken?.rawFiatNumber;
+    const usd = cardPrimaryToken?.isMoneyAccountEntry
+      ? rawFiat
+      : convertSelectedFiatToUsd(rawFiat, currencyRates);
     return usd === undefined
       ? formattedZero
       : moneyFormatUsd(new BigNumber(usd));
-  }, [cardPrimaryToken?.rawFiatNumber, currencyRates, formattedZero]);
+  }, [
+    cardPrimaryToken?.isMoneyAccountEntry,
+    cardPrimaryToken?.rawFiatNumber,
+    currencyRates,
+    formattedZero,
+  ]);
 
   const cardState = deriveCardState({
     isCardholder,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.
Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixed bug where the Money Home Card "Avail. balance" was being converted incorrectly using the user's selected fiat currency. This fix removes the USD conversion of the Card balance when the `primaryToken` is the Money account/vmUSD token.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: fixed Card balance on Money Home to be in USD

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1175: MetaMask Card "Avail. balance" incorrectly changes based on preferred fiat currency](https://consensyssoftware.atlassian.net/browse/MUSD-1175)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Home Card available balance

  Scenario: user views Card balance with a non-USD preferred currency
    Given the user has a Card balance and a non-USD preferred fiat currency
    When the user opens the Money Home screen
    Then the Card available balance is displayed in USD
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Card balance isn't pinned to USD.

https://github.com/user-attachments/assets/6ce77e5e-f3c4-4595-9c45-8d785a155d3c

### **After**

Card balance is pinned to USD regardless of user's preferred currency.

https://github.com/user-attachments/assets/42e629b2-9564-442b-b1d2-a5d21e1d3696


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
