### PR TITLE
fix(confirmations): use elevated surface color in ConfirmAlertModal for Pure Black

### DIFF
--- a/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.styles.ts
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 import Device from '../../../../../../util/device';
 
 const styleSheet = (params: { theme: Theme }) => {
@@ -8,7 +9,7 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     modalContainer: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
       paddingBottom: Device.isIphoneX() ? 20 : 0,

--- a/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/confirm-alert-modal/confirm-alert-modal.styles.ts
@@ -1,15 +1,25 @@
 import { StyleSheet } from 'react-native';
 
-import { Theme } from '../../../../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 import Device from '../../../../../../util/device';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     modalContainer: {
       backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
       paddingBottom: Device.isIphoneX() ? 20 : 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the `ConfirmAlertModal` (high-risk / Blockaid warnings) bottom sheet used `background.default`, which collapses visually against the elevated confirmation surface beneath it.

This change replaces `theme.colors.background.default` with `getElevatedSurfaceColor(theme)` on the modal container, matching other confirmation modals (e.g. `gas-fee-token-modal`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1093](https://consensyssoftware.atlassian.net/browse/TMCU-1093)

## **Manual testing steps**

```gherkin
Feature: ConfirmAlertModal Pure Black surface

  Scenario: elevated surface is used in Pure Black mode
    Given Pure Black mode is enabled
    And a confirmation flow triggers a high-risk / Blockaid alert
    When the ConfirmAlertModal bottom sheet is shown
    Then the modal background uses the elevated surface color (#1c1d1f)
    And it is visually distinct from the flat black confirmation screen behind it
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 3 24 51 PM" src="https://github.com/user-attachments/assets/3614bc29-f775-4530-b7a5-41e93bc58590" />

### **After**

<img width="350" alt="Screenshot 2026-07-14 at 3 35 59 PM" src="https://github.com/user-attachments/assets/c49aabe8-fbc9-453c-babd-c788148d9d1f" />

## **Pre-merge author checklist**

- [x] Followed contributor docs
- [x] Completed PR template
- [x] Included tests if applicable
- [x] Documented code with JSDoc if applicable
- [x] Applied right labels

#### Performance checks (if applicable)

N/A

## **Pre-merge reviewer checklist**

- [ ] Reviewer item

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3f14797-a9c5-4ee8-9837-1a1cebbb230a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3f14797-a9c5-4ee8-9837-1a1cebbb230a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1093]: https://consensyssoftware.atlassian.net/browse/TMCU-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ