### PR TITLE
fix(confirmations): use elevated surface color in AdvancedGasPriceModal

### DIFF
--- a/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.styles.test.ts
+++ b/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.styles.test.ts
@@ -1,0 +1,59 @@
+import { brandColor, darkTheme } from '@metamask/design-tokens';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+
+const MOCK_ELEVATED_SURFACE_COLOR = 'mock-elevated-surface-color';
+
+let mockIsPureBlackEnabled = false;
+
+jest.mock('../../../../../../util/theme/themeUtils', () => ({
+  get isPureBlackEnabled() {
+    return mockIsPureBlackEnabled;
+  },
+  getElevatedSurfaceColor: jest.fn(() => MOCK_ELEVATED_SURFACE_COLOR),
+}));
+
+import styleSheet from './advanced-gas-price-modal.styles';
+
+const darkThemeModel: Theme = {
+  colors: darkTheme.colors,
+  themeAppearance: AppThemeKey.dark,
+  typography: darkTheme.typography,
+  shadows: darkTheme.shadows,
+  brandColors: brandColor,
+};
+
+describe('advanced-gas-price-modal.styles', () => {
+  beforeEach(() => {
+    mockIsPureBlackEnabled = false;
+  });
+
+  it('uses elevated surface color for the modal container', () => {
+    const styles = styleSheet({
+      theme: darkThemeModel,
+    });
+
+    expect(styles.container.backgroundColor).toBe(MOCK_ELEVATED_SURFACE_COLOR);
+  });
+
+  it('does not apply muted border when pure black preview is off', () => {
+    const styles = styleSheet({
+      theme: darkThemeModel,
+    });
+
+    expect(styles.container.borderWidth).toBe(0);
+    expect(styles.container.borderColor).toBeUndefined();
+  });
+
+  it('applies muted border in pure black dark mode', () => {
+    mockIsPureBlackEnabled = true;
+
+    const styles = styleSheet({
+      theme: darkThemeModel,
+    });
+
+    expect(styles.container.borderWidth).toBe(1);
+    expect(styles.container.borderColor).toBe(
+      darkThemeModel.colors.border.muted,
+    );
+  });
+});

--- a/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/advanced-gas-price-modal/advanced-gas-price-modal.styles.ts
@@ -1,12 +1,23 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '../../../../../../util/theme/models';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     container: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       padding: 16,
       paddingBottom: 36,
       borderTopRightRadius: 16,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the Advanced gas price bottom sheet (`AdvancedGasPriceModal`) used `background.default` (`#000000`) on its container while stacked over an elevated confirmation surface, making the modal appear flat and indistinguishable from the parent.

This change replaces `theme.colors.background.default` with `getElevatedSurfaceColor(theme)` on the modal container, matching the pattern used by other confirmation gas modals (e.g. `gas-fee-token-modal`). A muted border is also applied in Pure Black dark mode for visual separation.

Fixes [TMCU-1092](https://consensyssoftware.atlassian.net/browse/TMCU-1092).

## **Changelog**

CHANGELOG entry: Fixed Advanced gas price bottom sheet background in Pure Black mode on transaction confirmations.

## **Related issues**

Fixes: [TMCU-1092](https://consensyssoftware.atlassian.net/browse/TMCU-1092)

## **Manual testing steps**

```gherkin
Feature: Advanced gas price modal Pure Black background

  Scenario: Advanced gas modal uses elevated surface in Pure Black mode
    Given Pure Black mode is enabled
    And the user opens a transaction confirmation on a legacy gas-price network
    When the user taps Edit network fee then Advanced
    Then the Advanced gas price bottom sheet background uses the elevated surface color
    And the modal is visually distinct from the confirmation surface beneath it
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 4 10 04 PM" src="https://github.com/user-attachments/assets/0a11ddb9-b5a1-4903-8443-f46d0d2ac0c9" />

### **After**

<img width="350" alt="Screenshot 2026-07-14 at 4 09 26 PM" src="https://github.com/user-attachments/assets/c3e2d31e-a1de-4c4b-bc8f-8b81095b4435" />

## **Pre-merge author checklist**

- [x] I have read the contributing guidelines and code of conduct.
- [x] I have completed the PR template to the best of my ability.
- [x] I have included tests if applicable.
- [x] I have documented code with JSDoc if applicable.
- [x] I have applied the right labels for this PR.

#### Performance checks (if applicable)

- [x] N/A — styling-only change with no performance impact.

## **Pre-merge reviewer checklist**

- [ ] Reviewer item
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f0b010-e0d2-445d-b878-920054bb0201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f0b010-e0d2-445d-b878-920054bb0201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1092]: https://consensyssoftware.atlassian.net/browse/TMCU-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-1092]: https://consensyssoftware.atlassian.net/browse/TMCU-1092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ