### PR TITLE
fix(confirmations): use elevated surface for AlertModal in Pure Black mode

### DIFF
--- a/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.styles.ts
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 import Device from '../../../../../../util/device';
 
 const styleSheet = (params: { theme: Theme }) => {
@@ -8,7 +9,7 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     modalContainer: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
       paddingBottom: Device.isIphoneX() ? 20 : 0,

--- a/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/alert-modal/alert-modal.styles.ts
@@ -1,15 +1,25 @@
 import { StyleSheet } from 'react-native';
 
-import { Theme } from '../../../../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 import Device from '../../../../../../util/device';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     modalContainer: {
       backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       borderTopLeftRadius: 8,
       borderTopRightRadius: 8,
       paddingBottom: Device.isIphoneX() ? 20 : 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the confirmations `AlertModal` bottom sheet used `background.default` (`#000000`) while displayed over an elevated confirmation screen, causing the modal to appear as a flat black sheet with no visual separation from the screen behind it.

This change replaces `theme.colors.background.default` with `getElevatedSurfaceColor(theme)` on the modal container, matching the pattern used by other elevated surfaces in the confirmations flow (e.g. `BottomSheetDialog`, `Tooltip`, `expandable`).

The `error.muted` child patches (`content` and `checkboxContainer`) are left unchanged per the ticket scope.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1091

## **Manual testing steps**

```gherkin
Feature: AlertModal Pure Black elevated surface

  Scenario: AlertModal shows elevated background in Pure Black mode
    Given Pure Black mode is enabled
    And a confirmation screen is open
    When user triggers a confirmation alert that opens AlertModal
    Then the bottom sheet background uses the elevated surface color (#1c1d1f) instead of flat black (#000000)
```

N/A for automated cloud-agent environment — visual verification requires a device/simulator with Pure Black enabled.

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 4 14 16 PM" src="https://github.com/user-attachments/assets/1423d6df-5f0e-4d7f-be51-483c2494a15f" />

### **After**

<img width="350" alt="Screenshot 2026-07-14 at 4 13 26 PM" src="https://github.com/user-attachments/assets/e0d869aa-f042-4f65-a752-cce8a12e720f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76ef850d-f99a-4feb-8a10-b453b89e0720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76ef850d-f99a-4feb-8a10-b453b89e0720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

