### PR TITLE
fix(confirmations): use elevated surface for edit spending cap modal

### DIFF
--- a/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.styles.ts
@@ -1,13 +1,23 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '../../../../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     container: {
       backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       padding: 16,
       paddingBottom: 36,
       borderTopRightRadius: 16,

--- a/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.styles.ts
+++ b/app/components/Views/confirmations/components/modals/edit-spending-cap-modal/edit-spending-cap-modal.styles.ts
@@ -1,12 +1,13 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
 
   return StyleSheet.create({
     container: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
       padding: 16,
       paddingBottom: 36,
       borderTopRightRadius: 16,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the **Edit approval limit** bottom sheet (`EditSpendingCapModal`) used `background.default`, which collapsed visually against the elevated confirmation surface beneath it.

This change replaces `theme.colors.background.default` with `getElevatedSurfaceColor(theme)` on the modal container, matching other confirmation modals (e.g. `gas-fee-token-modal`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1090

## **Manual testing steps**

```gherkin
Feature: Edit spending cap modal Pure Black surface

  Scenario: user sees elevated surface on edit approval limit sheet
    Given Pure Black mode is enabled
    And the user has opened a token approval confirmation

    When the user taps to edit the spending cap / approval limit
    Then the bottom sheet background uses an elevated surface color
    And the sheet is visually distinct from the confirmation surface behind it
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 4 19 16 PM" src="https://github.com/user-attachments/assets/39072ab2-a57f-42aa-9b9c-2630c12c5163" />

### **After**

<img width="350" alt="Screenshot 2026-07-14 at 4 18 21 PM" src="https://github.com/user-attachments/assets/c66b7c04-0657-42c4-abb6-24cce2e93154" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7df1cb98-a812-45b2-ad9e-c6f5b410867f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7df1cb98-a812-45b2-ad9e-c6f5b410867f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

