### PR TITLE
fix(confirmations): use elevated surface color for TextWithTooltip modal in Pure Black mode

### DIFF
--- a/app/components/Views/confirmations/components/UI/text-with-tooltip/text-with-tooltip.styles.ts
+++ b/app/components/Views/confirmations/components/UI/text-with-tooltip/text-with-tooltip.styles.ts
@@ -1,11 +1,17 @@
 import { StyleSheet } from 'react-native';
 
-import { Theme } from '../../../../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
+import { AppThemeKey, Theme } from '../../../../../../util/theme/models';
+import {
+  getElevatedSurfaceColor,
+  isPureBlackEnabled,
+} from '../../../../../../util/theme/themeUtils';
 import { fontStyles } from '../../../../../../styles/common';
 
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
+  const { colors } = theme;
+  const isPureBlackDark =
+    isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark;
 
   return StyleSheet.create({
     backIcon: {
@@ -13,8 +19,12 @@ const styleSheet = (params: { theme: Theme }) => {
       top: 10,
       position: 'absolute',
     },
+    // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
+    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
     container: {
       backgroundColor: getElevatedSurfaceColor(theme),
+      borderWidth: isPureBlackDark ? 1 : 0,
+      borderColor: isPureBlackDark ? colors.border.muted : undefined,
       paddingHorizontal: 8,
       paddingVertical: 8,
     },

--- a/app/components/Views/confirmations/components/UI/text-with-tooltip/text-with-tooltip.styles.ts
+++ b/app/components/Views/confirmations/components/UI/text-with-tooltip/text-with-tooltip.styles.ts
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import { Theme } from '../../../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 import { fontStyles } from '../../../../../../styles/common';
 
 const styleSheet = (params: { theme: Theme }) => {
@@ -13,7 +14,7 @@ const styleSheet = (params: { theme: Theme }) => {
       position: 'absolute',
     },
     container: {
-      backgroundColor: theme.colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
       paddingHorizontal: 8,
       paddingVertical: 8,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black mode, the TextWithTooltip info bottom sheet used `background.default`, which collapsed visually into the flat black confirmation surface beneath it. This change uses `getElevatedSurfaceColor(theme)` on the modal container so the bottom sheet renders with the correct elevated surface color in Pure Black dark mode, matching other confirmation UI components.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1094

## **Manual testing steps**

```gherkin
Feature: TextWithTooltip Pure Black elevated surface

  Scenario: tooltip bottom sheet uses elevated surface in Pure Black mode
    Given Pure Black mode is enabled
    And the app is in dark mode
    And a confirmation screen with a TextWithTooltip row is open

    When the user taps the tooltip/info value to open the bottom sheet
    Then the bottom sheet background is visibly elevated above the confirmation surface
    And it does not appear as flat black against the underlying screen
```

## **Screenshots/Recordings**

### **Before**

<img width="350" alt="Screenshot 2026-07-14 at 4 29 12 PM" src="https://github.com/user-attachments/assets/7703a71b-4fbd-4421-916c-f97e750c6c2a" />

### **After**

<img width="350" alt="Screenshot 2026-07-14 at 4 28 51 PM" src="https://github.com/user-attachments/assets/7818782c-72df-4873-b5c2-5c838eaafa44" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00b735aa-a6c1-4720-82d8-5f294aed4dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00b735aa-a6c1-4720-82d8-5f294aed4dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

