### PR TITLE
chore(send): type Send navigator with feature param list (Phase 3)

### DIFF
--- a/app/components/Views/confirmations/components/send/send.tsx
+++ b/app/components/Views/confirmations/components/send/send.tsx
@@ -11,8 +11,9 @@ import { Amount } from './amount';
 import { Asset } from './asset';
 import { Recipient } from './recipient';
 import { useEmptyNavHeaderForConfirmations } from '../../hooks/ui/useEmptyNavHeaderForConfirmations';
+import type { SendStackParamList } from './types/navigation';
 
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<SendStackParamList>();
 
 // With native-stack, custom React headers rendered by the navigator linger on
 // screen during the push/pop animation. Each send screen instead renders its

--- a/app/components/Views/confirmations/components/send/types/navigation.ts
+++ b/app/components/Views/confirmations/components/send/types/navigation.ts
@@ -1,0 +1,50 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
+import type { Nft } from '@metamask/assets-controllers';
+import type { ConfirmationParams } from '../../confirm/confirm-component';
+import type { AssetType } from '../../../types/token';
+import type {
+  PredefinedRecipient,
+  SendNavigationParams,
+} from '../../../utils/send';
+
+/**
+ * Params shared by screens inside the redesigned Send stack.
+ *
+ * Includes modern send-flow fields (`asset` / `location` / `predefinedRecipient`)
+ * and legacy deeplink `txMeta` still passed into nested screens.
+ */
+export type SendScreenRouteParams =
+  | {
+      asset?: AssetType | Nft;
+      location?: string;
+      predefinedRecipient?: PredefinedRecipient;
+      txMeta?: Record<string, unknown>;
+    }
+  | undefined;
+
+/**
+ * Param list for screens inside the Send stack (`Send`).
+ */
+// ParamListBase requires `type`; `interface` cannot satisfy it.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SendStackParamList = {
+  Amount: SendScreenRouteParams;
+  Asset: SendScreenRouteParams;
+  Recipient: SendScreenRouteParams;
+  RedesignedConfirmations: ConfirmationParams | undefined;
+};
+
+/**
+ * Feature-level Send navigation params for nested `Send` entry.
+ *
+ * `SendNavigationParams` is the shape used by `handleSendPageNavigation` when
+ * choosing the initial nested screen; callers still navigate via
+ * `{ screen, params }`.
+ */
+// Intersection (`&`) requires `type`; `interface` cannot express this.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SendNavigationParamList = SendStackParamList & {
+  Send: NavigatorScreenParams<SendStackParamList> | undefined;
+};
+
+export type { SendNavigationParams, PredefinedRecipient };

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -134,10 +134,8 @@ import type {
   SendFlowParams,
   SendAmountParams,
   SendConfirmParams,
-  SendRecipientParams,
-  SendAssetParams,
-  SendParams,
 } from '../../components/Views/SendFlow/SendFlow.types';
+import type { SendStackParamList } from '../../components/Views/confirmations/components/send/types/navigation';
 
 // Predict params
 import type {
@@ -595,7 +593,7 @@ export type RootStackParamList = {
 
   // Send flow routes
   SendTo: SendFlowParams | undefined;
-  Amount: SendAmountParams | undefined;
+  Amount: SendAmountParams | SendStackParamList['Amount'];
   Confirm: SendConfirmParams | undefined;
 
   // Account backup routes
@@ -979,9 +977,9 @@ export type RootStackParamList = {
   CardUnlinkMoneyAccountSheet: MoneyUnlinkCardSheetRouteParams | undefined;
 
   // Send routes
-  Recipient: SendRecipientParams | undefined;
-  Asset: AssetViewParams | SendAssetParams | undefined;
-  Send: NestedNavigationParams | SendParams | undefined;
+  Recipient: SendStackParamList['Recipient'];
+  Asset: AssetViewParams | SendStackParamList['Asset'];
+  Send: NavigatorScreenParams<SendStackParamList> | undefined;
 
   // Add asset routes
   AddAsset: AddAssetParams | undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->
**Phase 3 of the incremental React Navigation typing migration — Send feature.**

The redesigned Send stack (`Routes.SEND.DEFAULT`) was loosely typed as `NestedNavigationParams | SendParams`, so nested `navigate('Send', { screen, params })` calls could not be checked against real screen param shapes. Call sites already navigate with `{ screen, params }` (Amount / Asset / Recipient / RedesignedConfirmations); this PR aligns the types with that runtime pattern.

This is **types-only** — no intentional runtime navigation behavior change.

### What changed
**Feature param lists (`app/components/Views/confirmations/components/send/types/navigation.ts`)**
- `SendStackParamList` — Amount, Asset, Recipient, RedesignedConfirmations
- `SendScreenRouteParams` — shared screen params (`asset`, `location`, `predefinedRecipient`, legacy `txMeta`)
- `SendNavigationParamList` — feature union + nested `Send` entry
- `RedesignedConfirmations` typed as `ConfirmationParams | undefined`

**Navigator (`app/components/Views/confirmations/components/send/send.tsx`)**
- `createNativeStackNavigator<SendStackParamList>()`

**Root stack (`app/core/NavigationService/types.ts`)**
- `Send` → `NavigatorScreenParams<SendStackParamList>` (replaces `NestedNavigationParams | SendParams`)
- Leaf `Amount` / `Recipient` / `Asset` routes reference `SendStackParamList` (`Asset` still unions with `AssetViewParams` for the token-details route of the same name)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null 

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:https://consensyssoftware.atlassian.net/browse/MCWP-674

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->
N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->
N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Types-only change with no runtime navigation logic; low risk aside from possible compile-time breakage at mismatched call sites.
> 
> **Overview**
> **Phase 3** of the React Navigation typing migration for the redesigned Send flow: navigation is now described with explicit param lists instead of loose `NestedNavigationParams` / legacy Send types.
> 
> A new **`types/navigation.ts`** defines `SendStackParamList` (Amount, Asset, Recipient, RedesignedConfirmations), shared `SendScreenRouteParams` (asset, location, predefinedRecipient, legacy `txMeta`), and `SendNavigationParamList` for nested `Send` entry. The Send stack in **`send.tsx`** is wired as `createNativeStackNavigator<SendStackParamList>()`.
> 
> **`RootStackParamList`** in `NavigationService/types.ts` now types **`Send`** as `NavigatorScreenParams<SendStackParamList>` and aligns root-level **Amount**, **Recipient**, and **Asset** with those screen params (`Asset` still unions `AssetViewParams` for the token-details route). Unused `SendRecipientParams`, `SendAssetParams`, and `SendParams` imports are dropped.
> 
> No intentional runtime navigation behavior change—compile-time safety only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1414b9b27001a3187be219108b2b687cc5fbe85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->