### PR TITLE
chore: deprecate ActionModal and confirmations BottomModal

### DIFF
--- a/app/components/UI/ActionModal/index.js
+++ b/app/components/UI/ActionModal/index.js
@@ -14,6 +14,11 @@ const styles = StyleSheet.create({
 });
 
 /**
+ * @deprecated Please update your code to use `BottomSheet` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BottomSheet/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
+ *
  * View that renders an action modal
  *
  * @param {object} props

--- a/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
+++ b/app/components/Views/confirmations/components/UI/bottom-modal/bottom-modal.tsx
@@ -23,8 +23,10 @@ interface BottomModalProps {
 }
 
 /**
- * TODO replace BottomModal instances with BottomSheet
- * {@see {@link https://github.com/MetaMask/metamask-mobile/issues/12656}}
+ * @deprecated Please update your code to use `BottomSheet` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BottomSheet/README.md}
+ * @since @metamask/design-system-react-native@0.11.0
  */
 const BottomModal = ({
   avoidKeyboard,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Adds `@deprecated` JSDoc notices to legacy modal components so engineers migrating UI see the recommended replacement in IDE hints and documentation.

- `ActionModal` (`app/components/UI/ActionModal`) — points to `BottomSheet` from `@metamask/design-system-react-native`
- `BottomModal` in confirmations (`app/components/Views/confirmations/components/UI/bottom-modal`) — same replacement, replacing the prior TODO comment

Both notices link to the design system BottomSheet README. No migration guide exists yet; callers should compare props against the README before migrating.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #12656

## **Manual testing steps**

N/A — documentation-only JSDoc changes; no runtime behavior changed.

## **Screenshots/Recordings**

N/A — no visual changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)