### PR TITLE
fix(ramp): migrate sell amount keypad to MMDS BottomSheetDialog

### DIFF
--- a/app/components/Base/SelectorButton.tsx
+++ b/app/components/Base/SelectorButton.tsx
@@ -36,6 +36,11 @@ const createStyles = (colors: Theme['colors']) =>
     },
   });
 
+/**
+ * @deprecated Please update your code to use `SelectButton` from `@metamask/design-system-react-native`.
+ * The API may have changed — compare props before migrating.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/SelectButton/README.md}
+ */
 const SelectorButton: React.FC<SelectorButtonProps & TouchableOpacityProps> = ({
   onPress,
   disabled,

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
@@ -1,8 +1,8 @@
 import { Theme } from '../../../../../../util/theme/models';
 import { StyleSheet } from 'react-native';
 
-const styleSheet = (_params: { theme: Theme }) => {
-  return StyleSheet.create({
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
     viewContainer: {
       flex: 1,
     },
@@ -25,6 +25,5 @@ const styleSheet = (_params: { theme: Theme }) => {
       marginHorizontal: 0,
     },
   });
-};
 
 export default styleSheet;

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
@@ -1,10 +1,7 @@
 import { Theme } from '../../../../../../util/theme/models';
 import { StyleSheet } from 'react-native';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
-  const { colors } = theme;
-
+const styleSheet = (_params: { theme: Theme }) => {
   return StyleSheet.create({
     viewContainer: {
       flex: 1,
@@ -16,17 +13,6 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     spacer: {
       minWidth: 8,
-    },
-    keypadContainer: {
-      position: 'absolute',
-      bottom: 0,
-      left: 0,
-      right: 0,
-      paddingBottom: 50,
-      backgroundColor: colors.background.section,
-    },
-    keypad: {
-      paddingHorizontal: 16,
     },
     cta: {
       paddingTop: 12,

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.styles.ts
@@ -20,10 +20,6 @@ const styleSheet = (_params: { theme: Theme }) =>
     flexRow: {
       flexDirection: 'row',
     },
-    flagText: {
-      marginVertical: 3,
-      marginHorizontal: 0,
-    },
   });
 
 export default styleSheet;

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Limits, Payment } from '@consensys/on-ramp-sdk';
 import { act, fireEvent, screen } from '@testing-library/react-native';
-import { Pressable, Text } from 'react-native';
+import { BackHandler, Pressable, Text } from 'react-native';
 import type BN4 from 'bnjs4';
 import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import BuildQuote from './BuildQuote';
@@ -863,6 +863,127 @@ describe('BuildQuote View', () => {
       ).not.toBeOnTheScreen();
     });
 
+    it('dismisses the amount keypad when hardware back is pressed', () => {
+      let backPressHandler: (() => boolean | undefined) | undefined;
+      jest
+        .spyOn(BackHandler, 'addEventListener')
+        .mockImplementation((_event, handler) => {
+          backPressHandler = handler as () => boolean | undefined;
+          return { remove: jest.fn() };
+        });
+
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      let handled: boolean | undefined;
+      act(() => {
+        handled = backPressHandler?.();
+      });
+
+      expect(handled).toBe(true);
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('closes the amount keypad before opening the region selector', async () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      await act(async () =>
+        fireEvent.press(
+          getByRoleButton(mockUseRegionsValues.selectedRegion?.emoji),
+        ),
+      );
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith('RampModals', {
+        screen: 'RampRegionSelectorModal',
+        params: {
+          regions: mockRegionsData,
+        },
+      });
+    });
+
+    it('closes the amount keypad before opening the asset selector', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton(mockCryptoCurrenciesData[0].name));
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        ...createTokenSelectModalNavigationDetails({
+          tokens: mockCryptoCurrenciesData,
+        }),
+      );
+    });
+
+    it('closes the amount keypad before opening the payment method selector', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('Change'));
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'RampModals',
+        expect.objectContaining({
+          screen: 'RampPaymentMethodSelectorModal',
+        }),
+      );
+    });
+
+    it('removes the hardware back listener on unmount', () => {
+      const mockRemove = jest.fn();
+      jest
+        .spyOn(BackHandler, 'addEventListener')
+        .mockReturnValue({ remove: mockRemove });
+
+      const { unmount } = render(BuildQuote);
+      unmount();
+
+      expect(mockRemove).toHaveBeenCalled();
+    });
+
     it('does not reset the amount when switching assets in the buy flow', () => {
       const AssetSwitcher = () => {
         const [, setSelectedAssetVersion] = React.useState(0);
@@ -910,6 +1031,44 @@ describe('BuildQuote View', () => {
     beforeEach(() => {
       mockUseRampSDKValues.isBuy = false;
       mockUseRampSDKValues.isSell = true;
+    });
+
+    it('opens the amount keypad bottom sheet when the sell amount input is pressed', () => {
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+    });
+
+    it('closes the amount keypad before opening the fiat selector in sell mode', () => {
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(
+        getByRoleButton(mockFiatCurrenciesData[0].symbol),
+      );
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        ...createFiatSelectorModalNavigationDetails({
+          currencies: mockFiatCurrenciesData,
+        }),
+      );
     });
 
     it('updates the amount input', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -45,30 +45,6 @@ jest.mock('../../../../../../core/Engine', () => ({
   },
 }));
 
-// Mock MMDS BottomSheetDialog so children render synchronously in tests.
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
-  const MockReact = jest.requireActual('react');
-
-  return {
-    ...actual,
-    BottomSheetDialog: MockReact.forwardRef(
-      (
-        {
-          children,
-          onClose,
-        }: { children: React.ReactNode; onClose?: () => void },
-        dialogRef: React.Ref<{ onCloseDialog: () => void }>,
-      ) => {
-        MockReact.useImperativeHandle(dialogRef, () => ({
-          onCloseDialog: () => onClose?.(),
-        }));
-        return children;
-      },
-    ),
-  };
-});
-
 const getByRoleButton = (name?: string | RegExp) =>
   screen.getByRole('button', { name });
 
@@ -872,10 +848,16 @@ describe('BuildQuote View', () => {
 
       fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+      expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).toBeOnTheScreen();
 
       fireEvent.press(getByRoleButton('Done'));
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).not.toBeOnTheScreen();

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -336,6 +336,7 @@ describe('BuildQuote View', () => {
     mockPop.mockClear();
     mockTrackEvent.mockClear();
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {
@@ -876,9 +877,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -899,9 +898,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -928,9 +925,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -952,9 +947,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -1057,9 +1050,7 @@ describe('BuildQuote View', () => {
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
 
-      fireEvent.press(
-        getByRoleButton(mockFiatCurrenciesData[0].symbol),
-      );
+      fireEvent.press(getByRoleButton(mockFiatCurrenciesData[0].symbol));
 
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -786,9 +786,15 @@ describe('BuildQuote View', () => {
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
       fireEvent.press(getByRoleButton(`${symbol}${initialAmount}`));
       fireEvent.press(getByRoleButton(`${symbol}${quickAmount}`));
+      expect(getByRoleButton(`${symbol}${quickAmount}`)).toBeOnTheScreen();
       expect(
-        screen.queryAllByRole('button', { name: `${symbol}${quickAmount}` }),
-      ).toHaveLength(2);
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByRole('button', {
+          name: `${symbol}${mockUseLimitsInitialValues?.limits?.quickAmounts?.[1]}`,
+        }),
+      ).not.toBeOnTheScreen();
     });
 
     it('validates the max limit', () => {
@@ -855,6 +861,7 @@ describe('BuildQuote View', () => {
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).toBeOnTheScreen();
 
+      fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('Done'));
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
@@ -862,6 +869,32 @@ describe('BuildQuote View', () => {
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).not.toBeOnTheScreen();
+    });
+
+    it('replaces quick amounts with Done confirm when an amount is entered', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+      const quickAmount =
+        mockUseLimitsInitialValues?.limits?.quickAmounts?.[0]?.toString();
+
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
+
+      expect(getByRoleButton(`${denomSymbol}${quickAmount}`)).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('1'));
+
+      expect(
+        screen.queryByRole('button', {
+          name: `${denomSymbol}${quickAmount}`,
+        }),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
     });
 
     it('dismisses the amount keypad when hardware back is pressed', () => {
@@ -1148,10 +1181,53 @@ describe('BuildQuote View', () => {
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton('25%'));
       expect(getByRoleButton(`0.25 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByRole('button', { name: 'Max' }),
+      ).not.toBeOnTheScreen();
+    });
 
-      fireEvent.press(getByRoleButton(`0.25 ${symbol}`));
+    it('sets max amount from quick amount when amount is zero', () => {
+      render(BuildQuote);
+
+      mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
+        '1',
+        mockUseRampSDKValues.selectedAsset?.decimals || 18,
+      ) as BN4;
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
       fireEvent.press(getByRoleButton('Max'));
       expect(getByRoleButton(`1 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
+    it('replaces quick amounts with Done confirm when a sell amount is entered', () => {
+      mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
+        '1',
+        mockUseRampSDKValues.selectedAsset?.decimals || 18,
+      ) as BN4;
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+
+      expect(getByRoleButton('25%')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('1'));
+
+      expect(
+        screen.queryByRole('button', { name: '25%' }),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
     });
 
     it('updates the amount input up to the max considering gas for native asset', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -45,6 +45,30 @@ jest.mock('../../../../../../core/Engine', () => ({
   },
 }));
 
+// Mock MMDS BottomSheetDialog so children render synchronously in tests.
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const MockReact = jest.requireActual('react');
+
+  return {
+    ...actual,
+    BottomSheetDialog: MockReact.forwardRef(
+      (
+        {
+          children,
+          onClose,
+        }: { children: React.ReactNode; onClose?: () => void },
+        dialogRef: React.Ref<{ onCloseDialog: () => void }>,
+      ) => {
+        MockReact.useImperativeHandle(dialogRef, () => ({
+          onCloseDialog: () => onClose?.(),
+        }));
+        return children;
+      },
+    ),
+  };
+});
+
 const getByRoleButton = (name?: string | RegExp) =>
   screen.getByRole('button', { name });
 
@@ -999,7 +1023,6 @@ describe('BuildQuote View', () => {
     });
 
     it('updates the amount input up to the max considering gas for native asset', () => {
-      render(BuildQuote);
       const initialAmount = '0';
       const quickAmount = 'Max';
       mockUseRampSDKValues = {
@@ -1026,6 +1049,7 @@ describe('BuildQuote View', () => {
           mockUseRampSDKValues.selectedAsset?.decimals || 18,
         ) as BN4,
       };
+      render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton(quickAmount));
@@ -1033,7 +1057,6 @@ describe('BuildQuote View', () => {
     });
 
     it('updates the amount input up to the percentage considering gas', () => {
-      render(BuildQuote);
       const initialAmount = '0';
       mockUseRampSDKValues = {
         ...mockUseRampSDKInitialValues,
@@ -1059,6 +1082,7 @@ describe('BuildQuote View', () => {
           mockUseRampSDKValues.selectedAsset?.decimals || 18,
         ) as BN4,
       };
+      render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton('75%'));

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -44,6 +44,30 @@ jest.mock('../../../../../../core/Engine', () => ({
   },
 }));
 
+// Mock MMDS BottomSheetDialog so children render synchronously in tests.
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const MockReact = jest.requireActual('react');
+
+  return {
+    ...actual,
+    BottomSheetDialog: MockReact.forwardRef(
+      (
+        {
+          children,
+          onClose,
+        }: { children: React.ReactNode; onClose?: () => void },
+        dialogRef: React.Ref<{ onCloseDialog: () => void }>,
+      ) => {
+        MockReact.useImperativeHandle(dialogRef, () => ({
+          onCloseDialog: () => onClose?.(),
+        }));
+        return children;
+      },
+    ),
+  };
+});
+
 const getByRoleButton = (name?: string | RegExp) =>
   screen.getByRole('button', { name });
 
@@ -998,7 +1022,6 @@ describe('BuildQuote View', () => {
     });
 
     it('updates the amount input up to the max considering gas for native asset', () => {
-      render(BuildQuote);
       const initialAmount = '0';
       const quickAmount = 'Max';
       mockUseRampSDKValues = {
@@ -1025,6 +1048,7 @@ describe('BuildQuote View', () => {
           mockUseRampSDKValues.selectedAsset?.decimals || 18,
         ),
       };
+      render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton(quickAmount));
@@ -1032,7 +1056,6 @@ describe('BuildQuote View', () => {
     });
 
     it('updates the amount input up to the percentage considering gas', () => {
-      render(BuildQuote);
       const initialAmount = '0';
       mockUseRampSDKValues = {
         ...mockUseRampSDKInitialValues,
@@ -1058,6 +1081,7 @@ describe('BuildQuote View', () => {
           mockUseRampSDKValues.selectedAsset?.decimals || 18,
         ),
       };
+      render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton('75%'));

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -785,9 +785,15 @@ describe('BuildQuote View', () => {
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
       fireEvent.press(getByRoleButton(`${symbol}${initialAmount}`));
       fireEvent.press(getByRoleButton(`${symbol}${quickAmount}`));
+      expect(getByRoleButton(`${symbol}${quickAmount}`)).toBeOnTheScreen();
       expect(
-        screen.queryAllByRole('button', { name: `${symbol}${quickAmount}` }),
-      ).toHaveLength(2);
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByRole('button', {
+          name: `${symbol}${mockUseLimitsInitialValues?.limits?.quickAmounts?.[1]}`,
+        }),
+      ).not.toBeOnTheScreen();
     });
 
     it('validates the max limit', () => {
@@ -854,6 +860,7 @@ describe('BuildQuote View', () => {
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).toBeOnTheScreen();
 
+      fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('Done'));
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
@@ -861,6 +868,32 @@ describe('BuildQuote View', () => {
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).not.toBeOnTheScreen();
+    });
+
+    it('replaces quick amounts with Done confirm when an amount is entered', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+      const quickAmount =
+        mockUseLimitsInitialValues?.limits?.quickAmounts?.[0]?.toString();
+
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
+
+      expect(getByRoleButton(`${denomSymbol}${quickAmount}`)).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('1'));
+
+      expect(
+        screen.queryByRole('button', {
+          name: `${denomSymbol}${quickAmount}`,
+        }),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
     });
 
     it('dismisses the amount keypad when hardware back is pressed', () => {
@@ -1147,10 +1180,53 @@ describe('BuildQuote View', () => {
       fireEvent.press(getByRoleButton(`${initialAmount} ${symbol}`));
       fireEvent.press(getByRoleButton('25%'));
       expect(getByRoleButton(`0.25 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByRole('button', { name: 'Max' }),
+      ).not.toBeOnTheScreen();
+    });
 
-      fireEvent.press(getByRoleButton(`0.25 ${symbol}`));
+    it('sets max amount from quick amount when amount is zero', () => {
+      render(BuildQuote);
+
+      mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
+        '1',
+        mockUseRampSDKValues.selectedAsset?.decimals || 18,
+      ) as BN4;
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
       fireEvent.press(getByRoleButton('Max'));
       expect(getByRoleButton(`1 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
+    it('replaces quick amounts with Done confirm when a sell amount is entered', () => {
+      mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
+        '1',
+        mockUseRampSDKValues.selectedAsset?.decimals || 18,
+      ) as BN4;
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+
+      expect(getByRoleButton('25%')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('1'));
+
+      expect(
+        screen.queryByRole('button', { name: '25%' }),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON),
+      ).toBeOnTheScreen();
     });
 
     it('updates the amount input up to the max considering gas for native asset', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Limits, Payment } from '@consensys/on-ramp-sdk';
 import { act, fireEvent, screen } from '@testing-library/react-native';
-import { Pressable, Text } from 'react-native';
+import { BackHandler, Pressable, Text } from 'react-native';
 import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import BuildQuote from './BuildQuote';
 import useRegions from '../../hooks/useRegions';
@@ -862,6 +862,127 @@ describe('BuildQuote View', () => {
       ).not.toBeOnTheScreen();
     });
 
+    it('dismisses the amount keypad when hardware back is pressed', () => {
+      let backPressHandler: (() => boolean | undefined) | undefined;
+      jest
+        .spyOn(BackHandler, 'addEventListener')
+        .mockImplementation((_event, handler) => {
+          backPressHandler = handler as () => boolean | undefined;
+          return { remove: jest.fn() };
+        });
+
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      let handled: boolean | undefined;
+      act(() => {
+        handled = backPressHandler?.();
+      });
+
+      expect(handled).toBe(true);
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('closes the amount keypad before opening the region selector', async () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      await act(async () =>
+        fireEvent.press(
+          getByRoleButton(mockUseRegionsValues.selectedRegion?.emoji),
+        ),
+      );
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith('RampModals', {
+        screen: 'RampRegionSelectorModal',
+        params: {
+          regions: mockRegionsData,
+        },
+      });
+    });
+
+    it('closes the amount keypad before opening the asset selector', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton(mockCryptoCurrenciesData[0].name));
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        ...createTokenSelectModalNavigationDetails({
+          tokens: mockCryptoCurrenciesData,
+        }),
+      );
+    });
+
+    it('closes the amount keypad before opening the payment method selector', () => {
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      fireEvent.press(
+        getByRoleButton(`${denomSymbol}0`),
+      );
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton('Change'));
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'RampModals',
+        expect.objectContaining({
+          screen: 'RampPaymentMethodSelectorModal',
+        }),
+      );
+    });
+
+    it('removes the hardware back listener on unmount', () => {
+      const mockRemove = jest.fn();
+      jest
+        .spyOn(BackHandler, 'addEventListener')
+        .mockReturnValue({ remove: mockRemove });
+
+      const { unmount } = render(BuildQuote);
+      unmount();
+
+      expect(mockRemove).toHaveBeenCalled();
+    });
+
     it('does not reset the amount when switching assets in the buy flow', () => {
       const AssetSwitcher = () => {
         const [, setSelectedAssetVersion] = React.useState(0);
@@ -909,6 +1030,44 @@ describe('BuildQuote View', () => {
     beforeEach(() => {
       mockUseRampSDKValues.isBuy = false;
       mockUseRampSDKValues.isSell = true;
+    });
+
+    it('opens the amount keypad bottom sheet when the sell amount input is pressed', () => {
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+    });
+
+    it('closes the amount keypad before opening the fiat selector in sell mode', () => {
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+
+      fireEvent.press(
+        getByRoleButton(mockFiatCurrenciesData[0].symbol),
+      );
+
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
+      expect(mockNavigate).toHaveBeenCalledWith(
+        ...createFiatSelectorModalNavigationDetails({
+          currencies: mockFiatCurrenciesData,
+        }),
+      );
     });
 
     it('updates the amount input', () => {

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -1194,7 +1194,7 @@ describe('BuildQuote View', () => {
       mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
         '1',
         mockUseRampSDKValues.selectedAsset?.decimals || 18,
-      ) as BN4;
+      );
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
       fireEvent.press(getByRoleButton(`0 ${symbol}`));
       fireEvent.press(getByRoleButton('Max'));
@@ -1208,7 +1208,7 @@ describe('BuildQuote View', () => {
       mockUseBalanceValues.balanceBN = toTokenMinimalUnit(
         '1',
         mockUseRampSDKValues.selectedAsset?.decimals || 18,
-      ) as BN4;
+      );
       render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
 
@@ -1295,7 +1295,13 @@ describe('BuildQuote View', () => {
       fireEvent.press(getByRoleButton('75%'));
       expect(getByRoleButton(`0.73 ${symbol}`)).toBeTruthy();
 
-      fireEvent.press(getByRoleButton(`0.73 ${symbol}`));
+      // Quick percentages are replaced by Done once an amount is set.
+      for (let i = 0; i < 4; i++) {
+        fireEvent.press(
+          screen.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+        );
+      }
+
       fireEvent.press(getByRoleButton('50%'));
       expect(getByRoleButton(`0.5 ${symbol}`)).toBeTruthy();
     });

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -335,6 +335,7 @@ describe('BuildQuote View', () => {
     mockPop.mockClear();
     mockTrackEvent.mockClear();
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   beforeEach(() => {
@@ -875,9 +876,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -898,9 +897,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -927,9 +924,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -951,9 +946,7 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(
-        getByRoleButton(`${denomSymbol}0`),
-      );
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
@@ -1056,9 +1049,7 @@ describe('BuildQuote View', () => {
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
       ).toBeOnTheScreen();
 
-      fireEvent.press(
-        getByRoleButton(mockFiatCurrenciesData[0].symbol),
-      );
+      fireEvent.press(getByRoleButton(mockFiatCurrenciesData[0].symbol));
 
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -44,30 +44,6 @@ jest.mock('../../../../../../core/Engine', () => ({
   },
 }));
 
-// Mock MMDS BottomSheetDialog so children render synchronously in tests.
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
-  const MockReact = jest.requireActual('react');
-
-  return {
-    ...actual,
-    BottomSheetDialog: MockReact.forwardRef(
-      (
-        {
-          children,
-          onClose,
-        }: { children: React.ReactNode; onClose?: () => void },
-        dialogRef: React.Ref<{ onCloseDialog: () => void }>,
-      ) => {
-        MockReact.useImperativeHandle(dialogRef, () => ({
-          onCloseDialog: () => onClose?.(),
-        }));
-        return children;
-      },
-    ),
-  };
-});
-
 const getByRoleButton = (name?: string | RegExp) =>
   screen.getByRole('button', { name });
 
@@ -871,10 +847,16 @@ describe('BuildQuote View', () => {
 
       fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).toBeOnTheScreen();
+      expect(
         screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).toBeOnTheScreen();
 
       fireEvent.press(getByRoleButton('Done'));
+      expect(
+        screen.queryByTestId(BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET),
+      ).not.toBeOnTheScreen();
       expect(
         screen.queryByTestId(BuildQuoteSelectors.AMOUNT_INPUT_CURSOR),
       ).not.toBeOnTheScreen();

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
@@ -19,4 +19,5 @@ export const BuildQuoteSelectors = {
   MAX_LIMIT_ERROR: 'max-limit-error',
   INSUFFICIENT_BALANCE_ERROR: 'insufficient-balance-error',
   KEYPAD_DELETE_BUTTON: 'keypad-delete-button',
+  AMOUNT_KEYPAD_BOTTOM_SHEET: 'build-quote-amount-keypad-bottom-sheet',
 };

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds.ts
@@ -20,4 +20,5 @@ export const BuildQuoteSelectors = {
   INSUFFICIENT_BALANCE_ERROR: 'insufficient-balance-error',
   KEYPAD_DELETE_BUTTON: 'keypad-delete-button',
   AMOUNT_KEYPAD_BOTTOM_SHEET: 'build-quote-amount-keypad-bottom-sheet',
+  AMOUNT_KEYPAD_CONFIRM_BUTTON: 'build-quote-amount-keypad-confirm-button',
 };

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -1160,6 +1160,7 @@ const BuildQuote = () => {
 
       {isKeypadOpen ? (
         <BottomSheetDialog
+          testID={BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET}
           isInteractable={false}
           onClose={handleKeypadClose}
           onStartShouldSetResponder={() =>
@@ -1170,7 +1171,7 @@ const BuildQuote = () => {
             true
           }
         >
-          <Box twClassName="content-end gap-4 pt-4">
+          <Box twClassName="content-end px-4 gap-4 pt-4">
             <QuickAmounts
               isBuy={isBuy}
               onAmountPress={handleQuickAmountPress}
@@ -1188,16 +1189,14 @@ const BuildQuote = () => {
                 isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
               }
             />
-            <Box twClassName="px-4">
-              <Button
-                size={ButtonSize.Lg}
-                onPress={handleKeypadDone}
-                label={strings('fiat_on_ramp_aggregator.done')}
-                variant={ButtonVariants.Primary}
-                width={ButtonWidthTypes.Full}
-                accessibilityRole="button"
-              />
-            </Box>
+            <Button
+              size={ButtonSize.Lg}
+              onPress={handleKeypadDone}
+              label={strings('fiat_on_ramp_aggregator.done')}
+              variant={ButtonVariants.Primary}
+              width={ButtonWidthTypes.Full}
+              accessibilityRole="button"
+            />
           </Box>
         </BottomSheetDialog>
       ) : null}

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -15,7 +15,17 @@ import {
   AvatarTokenSize,
   BottomSheetDialog,
   Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   HeaderStandard,
+  IconName,
+  SelectButton,
+  SelectButtonSize,
+  SelectButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 
 import { useRampSDK } from '../../sdk';
@@ -28,8 +38,6 @@ import useLimits from '../../hooks/useLimits';
 import useBalance from '../../hooks/useBalance';
 import useAddressBalance from '../../../../../hooks/useAddressBalance/useAddressBalance';
 import { Asset } from '../../../../../hooks/useAddressBalance/useAddressBalance.types';
-
-import BaseSelectorButton from '../../../../../Base/SelectorButton';
 
 import ScreenLayout from '../../components/ScreenLayout';
 import Row from '../../components/Row';
@@ -87,16 +95,6 @@ import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
 import useIntentAmount from '../../hooks/useIntentAmount';
 import useERC20GasLimitEstimation from '../../hooks/useERC20GasLimitEstimation';
 
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import { BuildQuoteSelectors } from './BuildQuote.testIds';
 
 import { isNonEvmAddress } from '../../../../../../core/Multichain/utils';
@@ -106,10 +104,6 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { createUnsupportedRegionModalNavigationDetails } from '../../components/UnsupportedRegionModal';
 import { regex } from '../../../../../../util/regex';
 import { createBuySettingsModalNavigationDetails } from '../Modals/Settings/SettingsModal';
-
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SelectorButton = BaseSelectorButton as any;
 
 export interface BuildQuoteParams extends RampIntent {
   showBack?: boolean;
@@ -935,14 +929,17 @@ const BuildQuote = () => {
               {isFetchingRegions ? (
                 <SkeletonText thick />
               ) : (
-                <SelectorButton
-                  accessibilityRole="button"
-                  accessible
+                <SelectButton
+                  variant={SelectButtonVariant.Primary}
+                  size={SelectButtonSize.Sm}
+                  placeholder={strings(
+                    'fiat_on_ramp_aggregator.region.select_region',
+                  )}
+                  value={selectedRegion?.emoji}
                   onPress={handleChangeRegion}
                   testID={BuildQuoteSelectors.REGION_DROPDOWN}
-                >
-                  <Text style={styles.flagText}>{selectedRegion?.emoji}</Text>
-                </SelectorButton>
+                  accessibilityRole="button"
+                />
               )}
               {isSell ? (
                 <>
@@ -952,15 +949,16 @@ const BuildQuote = () => {
                   !selectedFiatCurrencyId ? (
                     <SkeletonText thick />
                   ) : (
-                    <SelectorButton
-                      accessibilityRole="button"
-                      accessible
+                    <SelectButton
+                      variant={SelectButtonVariant.Primary}
+                      size={SelectButtonSize.Sm}
+                      placeholder={strings(
+                        'fiat_on_ramp_aggregator.select_region_currency',
+                      )}
+                      value={currentFiatCurrency?.symbol}
                       onPress={handleFiatSelectorPress}
-                    >
-                      <Text variant={TextVariant.BodyLGMedium}>
-                        {currentFiatCurrency?.symbol}
-                      </Text>
-                    </SelectorButton>
+                      accessibilityRole="button"
+                    />
                   )}
                 </>
               ) : null}
@@ -1009,8 +1007,8 @@ const BuildQuote = () => {
                 <SkeletonText thin medium />
               ) : (
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {displayBalance !== null && (
                     <>
@@ -1048,7 +1046,10 @@ const BuildQuote = () => {
               !hasInsufficientBalance &&
               amountIsOverGas && (
                 <Row>
-                  <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.ErrorDefault}
+                  >
                     {strings('fiat_on_ramp_aggregator.enter_lower_gas_fees')}
                   </Text>
                 </Row>
@@ -1056,8 +1057,8 @@ const BuildQuote = () => {
             {hasInsufficientBalance && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.INSUFFICIENT_BALANCE_ERROR}
                 >
                   {strings('fiat_on_ramp_aggregator.insufficient_balance')}
@@ -1066,7 +1067,10 @@ const BuildQuote = () => {
             )}
             {!hasInsufficientBalance && hasInsufficientNativeBalanceForGas && (
               <Row>
-                <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings(
                     'fiat_on_ramp_aggregator.insufficient_native_balance',
                     { currency: nativeSymbol },
@@ -1077,8 +1081,8 @@ const BuildQuote = () => {
             {!hasInsufficientBalance && amountIsBelowMinimum && limits && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.MIN_LIMIT_ERROR}
                 >
                   {isBuy ? (
@@ -1096,8 +1100,8 @@ const BuildQuote = () => {
             {!hasInsufficientBalance && amountIsAboveMaximum && limits && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.MAX_LIMIT_ERROR}
                 >
                   {isBuy ? (
@@ -1146,14 +1150,14 @@ const BuildQuote = () => {
         <ScreenLayout.Content>
           <Row style={styles.cta}>
             <Button
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onPress={handleGetQuotePress}
-              label={strings('fiat_on_ramp_aggregator.get_quotes')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               isDisabled={amountNumber <= 0 || isFetching}
-              accessibilityRole="button"
-            />
+            >
+              {strings('fiat_on_ramp_aggregator.get_quotes')}
+            </Button>
           </Row>
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
@@ -1172,11 +1176,23 @@ const BuildQuote = () => {
           }
         >
           <Box twClassName="content-end px-4 gap-4 pt-4">
-            <QuickAmounts
-              isBuy={isBuy}
-              onAmountPress={handleQuickAmountPress}
-              amounts={quickAmounts}
-            />
+            {amount && amount !== '0' ? (
+              <Button
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Lg}
+                onPress={handleKeypadDone}
+                isFullWidth
+                testID={BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON}
+              >
+                {strings('fiat_on_ramp_aggregator.done')}
+              </Button>
+            ) : (
+              <QuickAmounts
+                isBuy={isBuy}
+                onAmountPress={handleQuickAmountPress}
+                amounts={quickAmounts}
+              />
+            )}
             <Keypad
               value={amount}
               onChange={handleKeypadChange}
@@ -1188,14 +1204,6 @@ const BuildQuote = () => {
               decimals={
                 isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
               }
-            />
-            <Button
-              size={ButtonSize.Lg}
-              onPress={handleKeypadDone}
-              label={strings('fiat_on_ramp_aggregator.done')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-              accessibilityRole="button"
             />
           </Box>
         </BottomSheetDialog>

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -5,12 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Pressable, View, BackHandler, LayoutChangeEvent } from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { Pressable, View, BackHandler } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
@@ -18,6 +13,8 @@ import BN4 from 'bnjs4';
 import {
   AvatarToken,
   AvatarTokenSize,
+  BottomSheetDialog,
+  Box,
   HeaderStandard,
 } from '@metamask/design-system-react-native';
 
@@ -137,14 +134,13 @@ const BuildQuote = () => {
   const { colors, themeAppearance } = theme;
   const trackEvent = useAnalytics();
   const [amountFocused, setAmountFocused] = useState(false);
+  const [isKeypadOpen, setIsKeypadOpen] = useState(false);
   const [amount, setAmount] = useState('0');
   const [amountNumber, setAmountNumber] = useState(0);
   const [amountBNMinimalUnit, setAmountBNMinimalUnit] = useState<BN4>();
   const [error, setError] = useState<string | null>(null);
   const [isKeyboardFreshlyOpened, setIsKeyboardFreshlyOpened] = useState(false);
   const [intentHandled, setIntentHandled] = useState(false);
-  const keyboardHeight = useRef(1000);
-  const keypadOffset = useSharedValue(1000);
   const nativeSymbol = useSelector(selectTicker);
   const networkConfigurationsByCaipChainId = useSelector(
     selectNetworkConfigurationsByCaipChainId,
@@ -244,6 +240,7 @@ const BuildQuote = () => {
     setAmountNumber(0);
     setAmountBNMinimalUnit(undefined);
     setAmountFocused(false);
+    setIsKeypadOpen(false);
     setIsKeyboardFreshlyOpened(false);
   }, []);
 
@@ -496,29 +493,15 @@ const BuildQuote = () => {
   }, [handleCancelPress, navigation]);
 
   /**
-   * * Keypad style, handlers and effects
-   */
-  const keypadContainerStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateY: withTiming(keypadOffset.value),
-      },
-    ],
-  }));
-
-  useEffect(() => {
-    keypadOffset.value = amountFocused ? 40 : keyboardHeight.current + 80;
-  }, [amountFocused, keyboardHeight, keypadOffset]);
-
-  /**
    * Back handler to dismiss keypad
    */
   useEffect(() => {
     const backHandler = BackHandler.addEventListener(
       'hardwareBackPress',
       () => {
-        if (amountFocused) {
+        if (amountFocused || isKeypadOpen) {
           setAmountFocused(false);
+          setIsKeypadOpen(false);
           setIsKeyboardFreshlyOpened(false);
           return true;
         }
@@ -526,14 +509,20 @@ const BuildQuote = () => {
     );
 
     return () => backHandler.remove();
-  }, [amountFocused]);
+  }, [amountFocused, isKeypadOpen]);
 
-  const handleKeypadDone = useCallback(() => {
+  const handleKeypadClose = useCallback(() => {
     setAmountFocused(false);
+    setIsKeypadOpen(false);
     setIsKeyboardFreshlyOpened(false);
   }, []);
+
+  const handleKeypadDone = useCallback(() => {
+    handleKeypadClose();
+  }, [handleKeypadClose]);
   const onAmountInputPress = useCallback(() => {
     setAmountFocused(true);
+    setIsKeypadOpen(true);
     setIsKeyboardFreshlyOpened(true);
   }, []);
 
@@ -611,17 +600,12 @@ const BuildQuote = () => {
     ],
   );
 
-  const onKeypadLayout = useCallback((event: LayoutChangeEvent) => {
-    const { height } = event.nativeEvent.layout;
-    keyboardHeight.current = height;
-  }, []);
-
   /**
    * * Region handlers
    */
 
   const handleChangeRegion = useCallback(() => {
-    setAmountFocused(false);
+    handleKeypadClose();
     if (regions && regions.length > 0) {
       navigateWithDetails(
         navigation,
@@ -630,50 +614,47 @@ const BuildQuote = () => {
         }),
       );
     }
-  }, [navigation, regions, setAmountFocused]);
+  }, [handleKeypadClose, navigation, regions]);
 
   /**
    * * CryptoCurrency handlers
    */
 
   const handleAssetSelectorPress = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createTokenSelectModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createTokenSelectModalNavigationDetails({
         tokens: cryptoCurrencies ?? [],
       }),
     );
-  }, [navigation, cryptoCurrencies]);
+  }, [handleKeypadClose, navigation, cryptoCurrencies]);
 
   /**
    * * FiatCurrency handlers
    */
 
   const handleFiatSelectorPress = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createFiatSelectorModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createFiatSelectorModalNavigationDetails({
         currencies: fiatCurrencies ?? [],
       }),
     );
-  }, [navigation, fiatCurrencies]);
+  }, [handleKeypadClose, navigation, fiatCurrencies]);
 
   /**
    * * PaymentMethod handlers
    */
 
   const handleShowPaymentMethodsModal = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createPaymentMethodSelectorModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createPaymentMethodSelectorModalNavigationDetails({
         paymentMethods,
         location: screenLocation,
       }),
     );
-  }, [navigation, paymentMethods, screenLocation]);
+  }, [handleKeypadClose, navigation, paymentMethods, screenLocation]);
 
   /**
    * * Get Quote handlers
@@ -1177,39 +1158,49 @@ const BuildQuote = () => {
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
 
-      <Animated.View
-        style={[styles.keypadContainer, keypadContainerStyle]}
-        onLayout={onKeypadLayout}
-      >
-        <QuickAmounts
-          isBuy={isBuy}
-          onAmountPress={handleQuickAmountPress}
-          amounts={quickAmounts}
-        />
-        <Keypad
-          style={styles.keypad}
-          value={amount}
-          onChange={handleKeypadChange}
-          currency={
-            isBuy
-              ? currentFiatCurrency?.symbol
-              : `${selectedAsset?.symbol}-crypto`
+      {isKeypadOpen ? (
+        <BottomSheetDialog
+          isInteractable={false}
+          onClose={handleKeypadClose}
+          onStartShouldSetResponder={() =>
+            // Prevents the native gesture system from bubbling up
+            // the event to BottomSheetDialog, causing keypad to close
+            // when user click anywhere inside the keypad area that is
+            // not a pressable component.
+            true
           }
-          decimals={
-            isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
-          }
-        />
-        <ScreenLayout.Content>
-          <Button
-            size={ButtonSize.Lg}
-            onPress={handleKeypadDone}
-            label={strings('fiat_on_ramp_aggregator.done')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-            accessibilityRole="button"
-          />
-        </ScreenLayout.Content>
-      </Animated.View>
+        >
+          <Box twClassName="content-end gap-4 pt-4">
+            <QuickAmounts
+              isBuy={isBuy}
+              onAmountPress={handleQuickAmountPress}
+              amounts={quickAmounts}
+            />
+            <Keypad
+              value={amount}
+              onChange={handleKeypadChange}
+              currency={
+                isBuy
+                  ? currentFiatCurrency?.symbol
+                  : `${selectedAsset?.symbol}-crypto`
+              }
+              decimals={
+                isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
+              }
+            />
+            <Box twClassName="px-4">
+              <Button
+                size={ButtonSize.Lg}
+                onPress={handleKeypadDone}
+                label={strings('fiat_on_ramp_aggregator.done')}
+                variant={ButtonVariants.Primary}
+                width={ButtonWidthTypes.Full}
+                accessibilityRole="button"
+              />
+            </Box>
+          </Box>
+        </BottomSheetDialog>
+      ) : null}
     </ScreenLayout>
   );
 };

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -624,8 +624,9 @@ const BuildQuote = () => {
 
   const handleAssetSelectorPress = useCallback(() => {
     handleKeypadClose();
-    navigation.navigate(
-      ...createTokenSelectModalNavigationDetails({
+    navigateWithDetails(
+      navigation,
+      createTokenSelectModalNavigationDetails({
         tokens: cryptoCurrencies ?? [],
       }),
     );
@@ -637,8 +638,9 @@ const BuildQuote = () => {
 
   const handleFiatSelectorPress = useCallback(() => {
     handleKeypadClose();
-    navigation.navigate(
-      ...createFiatSelectorModalNavigationDetails({
+    navigateWithDetails(
+      navigation,
+      createFiatSelectorModalNavigationDetails({
         currencies: fiatCurrencies ?? [],
       }),
     );
@@ -650,8 +652,9 @@ const BuildQuote = () => {
 
   const handleShowPaymentMethodsModal = useCallback(() => {
     handleKeypadClose();
-    navigation.navigate(
-      ...createPaymentMethodSelectorModalNavigationDetails({
+    navigateWithDetails(
+      navigation,
+      createPaymentMethodSelectorModalNavigationDetails({
         paymentMethods,
         location: screenLocation,
       }),

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -5,18 +5,15 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Pressable, View, BackHandler, LayoutChangeEvent } from 'react-native';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { Pressable, View, BackHandler } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
 import {
   AvatarToken,
   AvatarTokenSize,
+  BottomSheetDialog,
+  Box,
   HeaderStandard,
 } from '@metamask/design-system-react-native';
 
@@ -136,14 +133,13 @@ const BuildQuote = () => {
   const { colors, themeAppearance } = theme;
   const trackEvent = useAnalytics();
   const [amountFocused, setAmountFocused] = useState(false);
+  const [isKeypadOpen, setIsKeypadOpen] = useState(false);
   const [amount, setAmount] = useState('0');
   const [amountNumber, setAmountNumber] = useState(0);
   const [amountBNMinimalUnit, setAmountBNMinimalUnit] = useState<bigint>();
   const [error, setError] = useState<string | null>(null);
   const [isKeyboardFreshlyOpened, setIsKeyboardFreshlyOpened] = useState(false);
   const [intentHandled, setIntentHandled] = useState(false);
-  const keyboardHeight = useRef(1000);
-  const keypadOffset = useSharedValue(1000);
   const nativeSymbol = useSelector(selectTicker);
   const networkConfigurationsByCaipChainId = useSelector(
     selectNetworkConfigurationsByCaipChainId,
@@ -243,6 +239,7 @@ const BuildQuote = () => {
     setAmountNumber(0);
     setAmountBNMinimalUnit(undefined);
     setAmountFocused(false);
+    setIsKeypadOpen(false);
     setIsKeyboardFreshlyOpened(false);
   }, []);
 
@@ -502,29 +499,15 @@ const BuildQuote = () => {
   }, [handleCancelPress, navigation]);
 
   /**
-   * * Keypad style, handlers and effects
-   */
-  const keypadContainerStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateY: withTiming(keypadOffset.value),
-      },
-    ],
-  }));
-
-  useEffect(() => {
-    keypadOffset.value = amountFocused ? 40 : keyboardHeight.current + 80;
-  }, [amountFocused, keyboardHeight, keypadOffset]);
-
-  /**
    * Back handler to dismiss keypad
    */
   useEffect(() => {
     const backHandler = BackHandler.addEventListener(
       'hardwareBackPress',
       () => {
-        if (amountFocused) {
+        if (amountFocused || isKeypadOpen) {
           setAmountFocused(false);
+          setIsKeypadOpen(false);
           setIsKeyboardFreshlyOpened(false);
           return true;
         }
@@ -532,14 +515,20 @@ const BuildQuote = () => {
     );
 
     return () => backHandler.remove();
-  }, [amountFocused]);
+  }, [amountFocused, isKeypadOpen]);
 
-  const handleKeypadDone = useCallback(() => {
+  const handleKeypadClose = useCallback(() => {
     setAmountFocused(false);
+    setIsKeypadOpen(false);
     setIsKeyboardFreshlyOpened(false);
   }, []);
+
+  const handleKeypadDone = useCallback(() => {
+    handleKeypadClose();
+  }, [handleKeypadClose]);
   const onAmountInputPress = useCallback(() => {
     setAmountFocused(true);
+    setIsKeypadOpen(true);
     setIsKeyboardFreshlyOpened(true);
   }, []);
 
@@ -619,17 +608,12 @@ const BuildQuote = () => {
     ],
   );
 
-  const onKeypadLayout = useCallback((event: LayoutChangeEvent) => {
-    const { height } = event.nativeEvent.layout;
-    keyboardHeight.current = height;
-  }, []);
-
   /**
    * * Region handlers
    */
 
   const handleChangeRegion = useCallback(() => {
-    setAmountFocused(false);
+    handleKeypadClose();
     if (regions && regions.length > 0) {
       navigateWithDetails(
         navigation,
@@ -638,50 +622,47 @@ const BuildQuote = () => {
         }),
       );
     }
-  }, [navigation, regions, setAmountFocused]);
+  }, [handleKeypadClose, navigation, regions]);
 
   /**
    * * CryptoCurrency handlers
    */
 
   const handleAssetSelectorPress = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createTokenSelectModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createTokenSelectModalNavigationDetails({
         tokens: cryptoCurrencies ?? [],
       }),
     );
-  }, [navigation, cryptoCurrencies]);
+  }, [handleKeypadClose, navigation, cryptoCurrencies]);
 
   /**
    * * FiatCurrency handlers
    */
 
   const handleFiatSelectorPress = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createFiatSelectorModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createFiatSelectorModalNavigationDetails({
         currencies: fiatCurrencies ?? [],
       }),
     );
-  }, [navigation, fiatCurrencies]);
+  }, [handleKeypadClose, navigation, fiatCurrencies]);
 
   /**
    * * PaymentMethod handlers
    */
 
   const handleShowPaymentMethodsModal = useCallback(() => {
-    setAmountFocused(false);
-    navigateWithDetails(
-      navigation,
-      createPaymentMethodSelectorModalNavigationDetails({
+    handleKeypadClose();
+    navigation.navigate(
+      ...createPaymentMethodSelectorModalNavigationDetails({
         paymentMethods,
         location: screenLocation,
       }),
     );
-  }, [navigation, paymentMethods, screenLocation]);
+  }, [handleKeypadClose, navigation, paymentMethods, screenLocation]);
 
   /**
    * * Get Quote handlers
@@ -1186,39 +1167,49 @@ const BuildQuote = () => {
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
 
-      <Animated.View
-        style={[styles.keypadContainer, keypadContainerStyle]}
-        onLayout={onKeypadLayout}
-      >
-        <QuickAmounts
-          isBuy={isBuy}
-          onAmountPress={handleQuickAmountPress}
-          amounts={quickAmounts}
-        />
-        <Keypad
-          style={styles.keypad}
-          value={amount}
-          onChange={handleKeypadChange}
-          currency={
-            isBuy
-              ? currentFiatCurrency?.symbol
-              : `${selectedAsset?.symbol}-crypto`
+      {isKeypadOpen ? (
+        <BottomSheetDialog
+          isInteractable={false}
+          onClose={handleKeypadClose}
+          onStartShouldSetResponder={() =>
+            // Prevents the native gesture system from bubbling up
+            // the event to BottomSheetDialog, causing keypad to close
+            // when user click anywhere inside the keypad area that is
+            // not a pressable component.
+            true
           }
-          decimals={
-            isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
-          }
-        />
-        <ScreenLayout.Content>
-          <Button
-            size={ButtonSize.Lg}
-            onPress={handleKeypadDone}
-            label={strings('fiat_on_ramp_aggregator.done')}
-            variant={ButtonVariants.Primary}
-            width={ButtonWidthTypes.Full}
-            accessibilityRole="button"
-          />
-        </ScreenLayout.Content>
-      </Animated.View>
+        >
+          <Box twClassName="content-end gap-4 pt-4">
+            <QuickAmounts
+              isBuy={isBuy}
+              onAmountPress={handleQuickAmountPress}
+              amounts={quickAmounts}
+            />
+            <Keypad
+              value={amount}
+              onChange={handleKeypadChange}
+              currency={
+                isBuy
+                  ? currentFiatCurrency?.symbol
+                  : `${selectedAsset?.symbol}-crypto`
+              }
+              decimals={
+                isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
+              }
+            />
+            <Box twClassName="px-4">
+              <Button
+                size={ButtonSize.Lg}
+                onPress={handleKeypadDone}
+                label={strings('fiat_on_ramp_aggregator.done')}
+                variant={ButtonVariants.Primary}
+                width={ButtonWidthTypes.Full}
+                accessibilityRole="button"
+              />
+            </Box>
+          </Box>
+        </BottomSheetDialog>
+      ) : null}
     </ScreenLayout>
   );
 };

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -1169,6 +1169,7 @@ const BuildQuote = () => {
 
       {isKeypadOpen ? (
         <BottomSheetDialog
+          testID={BuildQuoteSelectors.AMOUNT_KEYPAD_BOTTOM_SHEET}
           isInteractable={false}
           onClose={handleKeypadClose}
           onStartShouldSetResponder={() =>
@@ -1179,7 +1180,7 @@ const BuildQuote = () => {
             true
           }
         >
-          <Box twClassName="content-end gap-4 pt-4">
+          <Box twClassName="content-end px-4 gap-4 pt-4">
             <QuickAmounts
               isBuy={isBuy}
               onAmountPress={handleQuickAmountPress}
@@ -1197,16 +1198,14 @@ const BuildQuote = () => {
                 isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
               }
             />
-            <Box twClassName="px-4">
-              <Button
-                size={ButtonSize.Lg}
-                onPress={handleKeypadDone}
-                label={strings('fiat_on_ramp_aggregator.done')}
-                variant={ButtonVariants.Primary}
-                width={ButtonWidthTypes.Full}
-                accessibilityRole="button"
-              />
-            </Box>
+            <Button
+              size={ButtonSize.Lg}
+              onPress={handleKeypadDone}
+              label={strings('fiat_on_ramp_aggregator.done')}
+              variant={ButtonVariants.Primary}
+              width={ButtonWidthTypes.Full}
+              accessibilityRole="button"
+            />
           </Box>
         </BottomSheetDialog>
       ) : null}

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -14,7 +14,17 @@ import {
   AvatarTokenSize,
   BottomSheetDialog,
   Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   HeaderStandard,
+  IconName,
+  SelectButton,
+  SelectButtonSize,
+  SelectButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 
 import { useRampSDK } from '../../sdk';
@@ -27,8 +37,6 @@ import useLimits from '../../hooks/useLimits';
 import useBalance from '../../hooks/useBalance';
 import useAddressBalance from '../../../../../hooks/useAddressBalance/useAddressBalance';
 import { Asset } from '../../../../../hooks/useAddressBalance/useAddressBalance.types';
-
-import BaseSelectorButton from '../../../../../Base/SelectorButton';
 
 import ScreenLayout from '../../components/ScreenLayout';
 import Row from '../../components/Row';
@@ -86,16 +94,6 @@ import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
 import useIntentAmount from '../../hooks/useIntentAmount';
 import useERC20GasLimitEstimation from '../../hooks/useERC20GasLimitEstimation';
 
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import { BuildQuoteSelectors } from './BuildQuote.testIds';
 
 import { isNonEvmAddress } from '../../../../../../core/Multichain/utils';
@@ -105,10 +103,6 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { createUnsupportedRegionModalNavigationDetails } from '../../components/UnsupportedRegionModal';
 import { regex } from '../../../../../../util/regex';
 import { createBuySettingsModalNavigationDetails } from '../Modals/Settings/SettingsModal';
-
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SelectorButton = BaseSelectorButton as any;
 
 export interface BuildQuoteParams extends RampIntent {
   showBack?: boolean;
@@ -944,14 +938,17 @@ const BuildQuote = () => {
               {isFetchingRegions ? (
                 <SkeletonText thick />
               ) : (
-                <SelectorButton
-                  accessibilityRole="button"
-                  accessible
+                <SelectButton
+                  variant={SelectButtonVariant.Primary}
+                  size={SelectButtonSize.Sm}
+                  placeholder={strings(
+                    'fiat_on_ramp_aggregator.region.select_region',
+                  )}
+                  value={selectedRegion?.emoji}
                   onPress={handleChangeRegion}
                   testID={BuildQuoteSelectors.REGION_DROPDOWN}
-                >
-                  <Text style={styles.flagText}>{selectedRegion?.emoji}</Text>
-                </SelectorButton>
+                  accessibilityRole="button"
+                />
               )}
               {isSell ? (
                 <>
@@ -961,15 +958,16 @@ const BuildQuote = () => {
                   !selectedFiatCurrencyId ? (
                     <SkeletonText thick />
                   ) : (
-                    <SelectorButton
-                      accessibilityRole="button"
-                      accessible
+                    <SelectButton
+                      variant={SelectButtonVariant.Primary}
+                      size={SelectButtonSize.Sm}
+                      placeholder={strings(
+                        'fiat_on_ramp_aggregator.select_region_currency',
+                      )}
+                      value={currentFiatCurrency?.symbol}
                       onPress={handleFiatSelectorPress}
-                    >
-                      <Text variant={TextVariant.BodyLGMedium}>
-                        {currentFiatCurrency?.symbol}
-                      </Text>
-                    </SelectorButton>
+                      accessibilityRole="button"
+                    />
                   )}
                 </>
               ) : null}
@@ -1018,8 +1016,8 @@ const BuildQuote = () => {
                 <SkeletonText thin medium />
               ) : (
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {displayBalance !== null && (
                     <>
@@ -1057,7 +1055,10 @@ const BuildQuote = () => {
               !hasInsufficientBalance &&
               amountIsOverGas && (
                 <Row>
-                  <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.ErrorDefault}
+                  >
                     {strings('fiat_on_ramp_aggregator.enter_lower_gas_fees')}
                   </Text>
                 </Row>
@@ -1065,8 +1066,8 @@ const BuildQuote = () => {
             {hasInsufficientBalance && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.INSUFFICIENT_BALANCE_ERROR}
                 >
                   {strings('fiat_on_ramp_aggregator.insufficient_balance')}
@@ -1075,7 +1076,10 @@ const BuildQuote = () => {
             )}
             {!hasInsufficientBalance && hasInsufficientNativeBalanceForGas && (
               <Row>
-                <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings(
                     'fiat_on_ramp_aggregator.insufficient_native_balance',
                     { currency: nativeSymbol },
@@ -1086,8 +1090,8 @@ const BuildQuote = () => {
             {!hasInsufficientBalance && amountIsBelowMinimum && limits && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.MIN_LIMIT_ERROR}
                 >
                   {isBuy ? (
@@ -1105,8 +1109,8 @@ const BuildQuote = () => {
             {!hasInsufficientBalance && amountIsAboveMaximum && limits && (
               <Row>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Error}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
                   testID={BuildQuoteSelectors.MAX_LIMIT_ERROR}
                 >
                   {isBuy ? (
@@ -1155,14 +1159,14 @@ const BuildQuote = () => {
         <ScreenLayout.Content>
           <Row style={styles.cta}>
             <Button
+              variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onPress={handleGetQuotePress}
-              label={strings('fiat_on_ramp_aggregator.get_quotes')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
+              isFullWidth
               isDisabled={amountNumber <= 0 || isFetching}
-              accessibilityRole="button"
-            />
+            >
+              {strings('fiat_on_ramp_aggregator.get_quotes')}
+            </Button>
           </Row>
         </ScreenLayout.Content>
       </ScreenLayout.Footer>
@@ -1181,11 +1185,23 @@ const BuildQuote = () => {
           }
         >
           <Box twClassName="content-end px-4 gap-4 pt-4">
-            <QuickAmounts
-              isBuy={isBuy}
-              onAmountPress={handleQuickAmountPress}
-              amounts={quickAmounts}
-            />
+            {amount && amount !== '0' ? (
+              <Button
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Lg}
+                onPress={handleKeypadDone}
+                isFullWidth
+                testID={BuildQuoteSelectors.AMOUNT_KEYPAD_CONFIRM_BUTTON}
+              >
+                {strings('fiat_on_ramp_aggregator.done')}
+              </Button>
+            ) : (
+              <QuickAmounts
+                isBuy={isBuy}
+                onAmountPress={handleQuickAmountPress}
+                amounts={quickAmounts}
+              />
+            )}
             <Keypad
               value={amount}
               onChange={handleKeypadChange}
@@ -1197,14 +1213,6 @@ const BuildQuote = () => {
               decimals={
                 isBuy ? currentFiatCurrency?.decimals : selectedAsset?.decimals
               }
-            />
-            <Button
-              size={ButtonSize.Lg}
-              onPress={handleKeypadDone}
-              label={strings('fiat_on_ramp_aggregator.done')}
-              variant={ButtonVariants.Primary}
-              width={ButtonWidthTypes.Full}
-              accessibilityRole="button"
             />
           </Box>
         </BottomSheetDialog>

--- a/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
@@ -23,6 +23,13 @@ import {
 
 const LOADING_ACCOUNT_LABEL = 'Account is loading...';
 
+/**
+ * Ramp account picker control built on MMDS `SelectButton`.
+ *
+ * For new generic select triggers, use `SelectButton` from
+ * `@metamask/design-system-react-native` directly instead of the deprecated
+ * `SelectorButton` from `app/components/Base/SelectorButton`.
+ */
 const AccountSelector = ({ isEvmOnly }: { isEvmOnly?: boolean }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const accountName = useAccountGroupName();

--- a/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/AccountSelector.tsx
@@ -1,35 +1,27 @@
-import React, { useCallback } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../../../util/navigation/navUtils';
 import { useSelector } from 'react-redux';
-
-import SelectorButton from '../../../../Base/SelectorButton';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import Avatar, {
-  AvatarVariant,
-  AvatarSize,
-} from '../../../../../component-library/components/Avatars/Avatar';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  SelectButton,
+  SelectButtonSize,
+  SelectButtonVariant,
+} from '@metamask/design-system-react-native';
 
 import { useAccountGroupName } from '../../../../hooks/multichainAccounts/useAccountGroupName';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
 import { BuildQuoteSelectors } from '../Views/BuildQuote/BuildQuote.testIds';
 import { createAccountSelectorNavDetails } from '../../../../Views/AccountSelector';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
+import {
+  type AccountAvatarVariant,
+  getAvatarAccountVariant,
+} from '../../../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 
-const styles = StyleSheet.create({
-  selector: {
-    flexShrink: 1,
-  },
-  accountText: {
-    flexShrink: 1,
-    marginVertical: 3,
-    marginHorizontal: 5,
-  },
-});
+const LOADING_ACCOUNT_LABEL = 'Account is loading...';
 
 const AccountSelector = ({ isEvmOnly }: { isEvmOnly?: boolean }) => {
   const navigation = useNavigation<AppNavigationProp>();
@@ -38,6 +30,10 @@ const AccountSelector = ({ isEvmOnly }: { isEvmOnly?: boolean }) => {
     selectSelectedInternalAccountFormattedAddress,
   );
   const accountAvatarType = useSelector(selectAvatarAccountType);
+  const accountAvatarVariant = useMemo(
+    () => getAvatarAccountVariant(accountAvatarType as AccountAvatarVariant),
+    [accountAvatarType],
+  );
 
   const openAccountSelector = useCallback(() => {
     navigateWithDetails(
@@ -50,32 +46,29 @@ const AccountSelector = ({ isEvmOnly }: { isEvmOnly?: boolean }) => {
   }, [isEvmOnly, navigation]);
 
   return (
-    <SelectorButton
+    <SelectButton
+      variant={SelectButtonVariant.Primary}
+      size={SelectButtonSize.Sm}
+      placeholder={LOADING_ACCOUNT_LABEL}
+      value={selectedAddress ? accountName : null}
       onPress={openAccountSelector}
-      style={styles.selector}
       testID={BuildQuoteSelectors.ACCOUNT_PICKER}
-    >
-      {selectedAddress ? (
-        <>
-          <Avatar
-            variant={AvatarVariant.Account}
-            size={AvatarSize.Xs}
-            accountAddress={selectedAddress}
-            type={accountAvatarType}
+      accessibilityRole="button"
+      twClassName="shrink min-w-0"
+      textProps={{
+        numberOfLines: 1,
+        ellipsizeMode: 'middle',
+      }}
+      startAccessory={
+        selectedAddress ? (
+          <AvatarAccount
+            address={selectedAddress}
+            size={AvatarAccountSize.Xs}
+            variant={accountAvatarVariant}
           />
-          <Text
-            variant={TextVariant.BodyMDMedium}
-            style={styles.accountText}
-            numberOfLines={1}
-            ellipsizeMode="middle"
-          >
-            {accountName}
-          </Text>
-        </>
-      ) : (
-        <Text variant={TextVariant.BodyMD}>Account is loading...</Text>
-      )}
-    </SelectorButton>
+        ) : undefined
+      }
+    />
   );
 };
 

--- a/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
@@ -5,22 +5,18 @@ import Button, {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
-import { useTheme } from '../../../../../util/theme';
-import { Colors } from '../../../../../util/theme/models';
 import { QuickAmount } from '../types';
 
 const INSET = 16;
-const createStyles = (colors: Colors) =>
-  StyleSheet.create({
-    content: {
-      backgroundColor: colors.background.section,
-      paddingVertical: 12,
-    },
-    amount: {
-      marginRight: 5,
-      minWidth: 78,
-    },
-  });
+const styles = StyleSheet.create({
+  content: {
+    paddingVertical: 12,
+  },
+  amount: {
+    marginRight: 5,
+    minWidth: 78,
+  },
+});
 
 interface AmountProps {
   amount: QuickAmount;
@@ -33,8 +29,6 @@ interface AmountProps {
 
 const Amount = ({ amount, onPress, isBuy, disabled }: AmountProps) => {
   const { value, isNative, label } = amount;
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
   const handlePress = useCallback(() => {
     onPress(amount);
   }, [onPress, amount]);
@@ -64,8 +58,6 @@ interface Props {
 }
 
 const QuickAmounts = ({ amounts, onAmountPress, isBuy, disabled }: Props) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
   return (
     <View style={styles.content}>
       <ScrollView

--- a/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
@@ -57,26 +57,24 @@ interface Props {
   onAmountPress: (amount: QuickAmount) => any;
 }
 
-const QuickAmounts = ({ amounts, onAmountPress, isBuy, disabled }: Props) => {
-  return (
-    <View style={styles.content}>
-      <ScrollView
-        horizontal
-        contentContainerStyle={{ paddingLeft: INSET, paddingRight: INSET }}
-        showsHorizontalScrollIndicator={false}
-      >
-        {amounts.map((amount, index: number) => (
-          <Amount
-            isBuy={isBuy}
-            amount={amount}
-            onPress={onAmountPress}
-            key={index}
-            disabled={disabled}
-          />
-        ))}
-      </ScrollView>
-    </View>
-  );
-};
+const QuickAmounts = ({ amounts, onAmountPress, isBuy, disabled }: Props) => (
+  <View style={styles.content}>
+    <ScrollView
+      horizontal
+      contentContainerStyle={{ paddingLeft: INSET, paddingRight: INSET }}
+      showsHorizontalScrollIndicator={false}
+    >
+      {amounts.map((amount, index: number) => (
+        <Amount
+          isBuy={isBuy}
+          amount={amount}
+          onPress={onAmountPress}
+          key={index}
+          disabled={disabled}
+        />
+      ))}
+    </ScrollView>
+  </View>
+);
 
 export default QuickAmounts;

--- a/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/QuickAmounts.tsx
@@ -1,28 +1,16 @@
 import React, { useCallback } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import Button, {
+import {
+  Box,
+  Button,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
+  ButtonVariant,
+  IconName,
+} from '@metamask/design-system-react-native';
 import { QuickAmount } from '../types';
-
-const INSET = 16;
-const styles = StyleSheet.create({
-  content: {
-    paddingVertical: 12,
-  },
-  amount: {
-    marginRight: 5,
-    minWidth: 78,
-  },
-});
 
 interface AmountProps {
   amount: QuickAmount;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onPress: (amount: QuickAmount) => any;
+  onPress: (amount: QuickAmount) => void;
   isBuy: boolean;
   disabled?: boolean;
 }
@@ -37,14 +25,16 @@ const Amount = ({ amount, onPress, isBuy, disabled }: AmountProps) => {
 
   return (
     <Button
-      variant={ButtonVariants.Secondary}
-      size={ButtonSize.Sm}
-      label={label}
+      variant={ButtonVariant.Secondary}
+      size={ButtonSize.Lg}
       onPress={handlePress}
-      style={styles.amount}
-      startIconName={showSparkleIcon ? IconName.Sparkle : undefined}
       isDisabled={disabled}
-    />
+      isFullWidth
+      twClassName="px-0 flex-1"
+      startIconName={showSparkleIcon ? IconName.Sparkle : undefined}
+    >
+      {label}
+    </Button>
   );
 };
 
@@ -52,29 +42,21 @@ interface Props {
   amounts: QuickAmount[];
   isBuy: boolean;
   disabled?: boolean;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onAmountPress: (amount: QuickAmount) => any;
+  onAmountPress: (amount: QuickAmount) => void;
 }
 
 const QuickAmounts = ({ amounts, onAmountPress, isBuy, disabled }: Props) => (
-  <View style={styles.content}>
-    <ScrollView
-      horizontal
-      contentContainerStyle={{ paddingLeft: INSET, paddingRight: INSET }}
-      showsHorizontalScrollIndicator={false}
-    >
-      {amounts.map((amount, index: number) => (
-        <Amount
-          isBuy={isBuy}
-          amount={amount}
-          onPress={onAmountPress}
-          key={index}
-          disabled={disabled}
-        />
-      ))}
-    </ScrollView>
-  </View>
+  <Box twClassName="flex-row gap-4">
+    {amounts.map((amount, index) => (
+      <Amount
+        isBuy={isBuy}
+        amount={amount}
+        onPress={onAmountPress}
+        key={index}
+        disabled={disabled}
+      />
+    ))}
+  </Box>
 );
 
 export default QuickAmounts;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Ramp Aggregator **Sell** (and **Buy**) amount entry used a custom `Animated.View` keypad overlay with Reanimated `translateY` animation and manual surface styling. This migrates the keypad to MMDS `BottomSheetDialog` from `@metamask/design-system-react-native`, following the Swaps numpad migration pattern in PR #33077.

Changes:
- Replace the inline animated keypad overlay with MMDS `BottomSheetDialog`
- Add `isKeypadOpen` state to manage bottom sheet lifecycle separately from amount highlight state
- Remove `keypadContainer` / Reanimated animation hacks from `BuildQuote.styles.ts`
- Remove custom section background from Aggregator `QuickAmounts` so MMDS owns the elevated surface
- Assert keypad sheet presence via `build-quote-amount-keypad-bottom-sheet` test ID
- Fix native-asset gas unit tests to render after mock setup (previously relied on always-mounted keypad DOM)

## **Changelog**

CHANGELOG entry: Align Sell BottomSheet with metamask design system

## **Related issues**

Fixes: [TMCU-1084](https://consensyssoftware.atlassian.net/browse/TMCU-1084)

## **Manual testing steps**

```gherkin
Feature: Ramp sell amount keypad

  Scenario: user opens sell amount keypad
    Given the user is on the Ramp Aggregator "Amount to sell" screen (Sell flow)
    When the user taps the Amount field
    Then the amount keypad opens in an MMDS BottomSheetDialog with quick amounts (25%/50%/75%/MAX for sell), numpad, and Done button
    And tapping Done or the backdrop dismisses the sheet

  Scenario: user enters sell amount via keypad
    Given the sell amount keypad is open
    When the user taps digits and Done
    Then the entered amount is reflected in the amount field and Get quotes enables when valid
```

## **Screenshots/Recordings**

N/A — UI migration to MMDS bottom sheet; QA screenshot requested in [TMCU-1084](https://consensyssoftware.atlassian.net/browse/TMCU-1084) (Sell screen with amount keypad open).

### **Before**

https://github.com/user-attachments/assets/bb66d7b5-2e81-4378-86d0-4132c5b53dc3

Comparing with swap

https://github.com/user-attachments/assets/820ffdd6-8ad3-4483-8fd4-bbccb1955095

### **After**

https://github.com/user-attachments/assets/ae1f4153-dab5-452f-aa8f-0e1c91c15dc4

Comparing with swap

https://github.com/user-attachments/assets/f936c58b-59fa-49d7-b90d-0fc0da771699

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-307d47af-2643-4b59-9698-b95154f035fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-307d47af-2643-4b59-9698-b95154f035fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1084]: https://consensyssoftware.atlassian.net/browse/TMCU-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ