### PR TITLE
fix: cp-8.3.0 convert pay-flow token amounts to USD instead of relabeling

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.test.ts
@@ -1,0 +1,282 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+
+import { useAssetFiatFormatter } from './useAssetFiatFormatter';
+import { useTransactionPayCurrency } from './useTransactionPayCurrency';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../selectors/currencyRateController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import { getIntlNumberFormatter } from '../../../../../util/intl';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('./useTransactionPayCurrency', () => ({
+  useTransactionPayCurrency: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/currencyRateController', () => ({
+  selectCurrentCurrency: jest.fn(),
+  selectCurrencyRates: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/networkController', () => ({
+  selectEvmNetworkConfigurationsByChainId: jest.fn(),
+}));
+
+jest.mock('../../../../../util/intl', () => ({
+  getIntlNumberFormatter: jest.fn(),
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  locale: 'en-US',
+  strings: jest.fn((key: string) => key),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+const mockUseTransactionPayCurrency = jest.mocked(useTransactionPayCurrency);
+const mockGetIntlNumberFormatter = jest.mocked(getIntlNumberFormatter);
+
+const mockFormatter = { format: jest.fn() };
+
+function buildState({
+  preferredCurrency = 'usd',
+  currencyRates = {} as Record<
+    string,
+    { conversionRate?: number; usdConversionRate?: number }
+  >,
+  networkConfigs = {} as Record<string, { nativeCurrency: string }>,
+} = {}) {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectCurrentCurrency) return preferredCurrency;
+    if (selector === selectCurrencyRates) return currencyRates;
+    if (selector === selectEvmNetworkConfigurationsByChainId)
+      return networkConfigs;
+    return undefined;
+  });
+}
+
+describe('useAssetFiatFormatter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseTransactionPayCurrency.mockReturnValue(undefined);
+    mockGetIntlNumberFormatter.mockReturnValue(
+      mockFormatter as unknown as ReturnType<typeof getIntlNumberFormatter>,
+    );
+    mockFormatter.format.mockImplementation((n) => `formatted:${String(n)}`);
+  });
+
+  describe('outside pay flow', () => {
+    it('formats using the preferred currency', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100', '0x1');
+
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ style: 'currency', currency: 'eur' }),
+      );
+      expect(mockFormatter.format).toHaveBeenCalledWith('100');
+      expect(output).toBe('formatted:100');
+    });
+
+    it('exposes the fiatCurrency being used', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      expect(result.current.fiatCurrency).toBe('eur');
+    });
+
+    it('uses minimumFractionDigits=0 for integer amounts', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      renderHook(() => useAssetFiatFormatter()).result.current.format(
+        '100',
+        '0x1',
+      );
+
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ minimumFractionDigits: 0 }),
+      );
+    });
+
+    it('uses minimumFractionDigits=2 for non-integer amounts', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      renderHook(() => useAssetFiatFormatter()).result.current.format(
+        '100.5',
+        '0x1',
+      );
+
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ minimumFractionDigits: 2 }),
+      );
+    });
+
+    it('treats undefined/null balances as zero', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      renderHook(() => useAssetFiatFormatter()).result.current.format(
+        undefined,
+        '0x1',
+      );
+
+      expect(mockFormatter.format).toHaveBeenCalledWith('0');
+    });
+  });
+
+  describe('pay flow (USD forced, preferred is EUR)', () => {
+    const eurUsdRates = {
+      ETH: { conversionRate: 2000, usdConversionRate: 2200 },
+    };
+    const ethChainConfig = { '0x1': { nativeCurrency: 'ETH' } };
+
+    beforeEach(() => {
+      mockUseTransactionPayCurrency.mockReturnValue('USD');
+    });
+
+    it('re-scales the amount by usdRate/preferredRate', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: eurUsdRates,
+        networkConfigs: ethChainConfig,
+      });
+
+      renderHook(() => useAssetFiatFormatter()).result.current.format(
+        '100',
+        '0x1',
+      );
+
+      // 100 EUR * (2200 USD/ETH / 2000 EUR/ETH) = 110 USD
+      expect(mockFormatter.format).toHaveBeenCalledWith('110');
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ currency: 'USD' }),
+      );
+    });
+
+    it('exposes fiatCurrency as USD', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: eurUsdRates,
+        networkConfigs: ethChainConfig,
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      expect(result.current.fiatCurrency).toBe('USD');
+    });
+
+    it('returns undefined when usdConversionRate is missing', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: { ETH: { conversionRate: 2000 } },
+        networkConfigs: ethChainConfig,
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100', '0x1');
+
+      expect(output).toBeUndefined();
+      expect(mockFormatter.format).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when preferred conversionRate is missing', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: { ETH: { usdConversionRate: 2200 } },
+        networkConfigs: ethChainConfig,
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100', '0x1');
+
+      expect(output).toBeUndefined();
+      expect(mockFormatter.format).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when chain has no EVM network config', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: eurUsdRates,
+        networkConfigs: {},
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100', '0x1');
+
+      expect(output).toBeUndefined();
+      expect(mockFormatter.format).not.toHaveBeenCalled();
+    });
+
+    it('formats zero even when rates or chain config are missing', () => {
+      buildState({
+        preferredCurrency: 'eur',
+        currencyRates: {},
+        networkConfigs: {},
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format(0, undefined);
+
+      expect(output).toBe('formatted:0');
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ currency: 'USD' }),
+      );
+    });
+  });
+
+  describe('pay flow (USD forced, preferred is already USD)', () => {
+    it('does not re-scale (identity), so numeric value is unchanged', () => {
+      mockUseTransactionPayCurrency.mockReturnValue('USD');
+      buildState({
+        preferredCurrency: 'usd',
+        currencyRates: {
+          ETH: { conversionRate: 2200, usdConversionRate: 2200 },
+        },
+        networkConfigs: { '0x1': { nativeCurrency: 'ETH' } },
+      });
+
+      renderHook(() => useAssetFiatFormatter()).result.current.format(
+        '100',
+        '0x1',
+      );
+
+      expect(mockFormatter.format).toHaveBeenCalledWith('100');
+    });
+
+    it('still formats when currency rates are missing (no conversion needed)', () => {
+      mockUseTransactionPayCurrency.mockReturnValue('USD');
+      buildState({
+        preferredCurrency: 'usd',
+        currencyRates: {},
+        networkConfigs: {},
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100', '0x1');
+
+      expect(output).toBe('formatted:100');
+    });
+  });
+
+  describe('formatter error fallback', () => {
+    it('falls back to `${value} ${currency}` when Intl throws', () => {
+      buildState({ preferredCurrency: 'eur' });
+      mockGetIntlNumberFormatter.mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('42', '0x1');
+
+      expect(output).toBe('42 eur');
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.test.ts
@@ -3,11 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useAssetFiatFormatter } from './useAssetFiatFormatter';
 import { useTransactionPayCurrency } from './useTransactionPayCurrency';
-import {
-  selectCurrencyRates,
-  selectCurrentCurrency,
-} from '../../../../../selectors/currencyRateController';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 
 jest.mock('react-redux', () => ({
@@ -20,11 +16,6 @@ jest.mock('./useTransactionPayCurrency', () => ({
 
 jest.mock('../../../../../selectors/currencyRateController', () => ({
   selectCurrentCurrency: jest.fn(),
-  selectCurrencyRates: jest.fn(),
-}));
-
-jest.mock('../../../../../selectors/networkController', () => ({
-  selectEvmNetworkConfigurationsByChainId: jest.fn(),
 }));
 
 jest.mock('../../../../../util/intl', () => ({
@@ -42,19 +33,9 @@ const mockGetIntlNumberFormatter = jest.mocked(getIntlNumberFormatter);
 
 const mockFormatter = { format: jest.fn() };
 
-function buildState({
-  preferredCurrency = 'usd',
-  currencyRates = {} as Record<
-    string,
-    { conversionRate?: number; usdConversionRate?: number }
-  >,
-  networkConfigs = {} as Record<string, { nativeCurrency: string }>,
-} = {}) {
+function buildState({ preferredCurrency = 'usd' } = {}) {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectCurrentCurrency) return preferredCurrency;
-    if (selector === selectCurrencyRates) return currencyRates;
-    if (selector === selectEvmNetworkConfigurationsByChainId)
-      return networkConfigs;
     return undefined;
   });
 }
@@ -69,12 +50,31 @@ describe('useAssetFiatFormatter', () => {
     mockFormatter.format.mockImplementation((n) => `formatted:${String(n)}`);
   });
 
-  describe('outside pay flow', () => {
-    it('formats using the preferred currency', () => {
+  describe('fiatCurrency selection', () => {
+    it('uses the preferred currency outside pay flow', () => {
       buildState({ preferredCurrency: 'eur' });
 
       const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('100', '0x1');
+
+      expect(result.current.fiatCurrency).toBe('eur');
+    });
+
+    it('uses the pay currency when useTransactionPayCurrency returns a value', () => {
+      buildState({ preferredCurrency: 'eur' });
+      mockUseTransactionPayCurrency.mockReturnValue('USD');
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+
+      expect(result.current.fiatCurrency).toBe('USD');
+    });
+  });
+
+  describe('format', () => {
+    it('formats a numeric amount using Intl currency', () => {
+      buildState({ preferredCurrency: 'eur' });
+
+      const { result } = renderHook(() => useAssetFiatFormatter());
+      const output = result.current.format('100');
 
       expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
         'en-US',
@@ -84,20 +84,24 @@ describe('useAssetFiatFormatter', () => {
       expect(output).toBe('formatted:100');
     });
 
-    it('exposes the fiatCurrency being used', () => {
+    it('formats with the pay currency when in pay flow', () => {
       buildState({ preferredCurrency: 'eur' });
+      mockUseTransactionPayCurrency.mockReturnValue('USD');
 
       const { result } = renderHook(() => useAssetFiatFormatter());
-      expect(result.current.fiatCurrency).toBe('eur');
+      result.current.format('110');
+
+      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
+        'en-US',
+        expect.objectContaining({ currency: 'USD' }),
+      );
+      expect(mockFormatter.format).toHaveBeenCalledWith('110');
     });
 
     it('uses minimumFractionDigits=0 for integer amounts', () => {
       buildState({ preferredCurrency: 'eur' });
 
-      renderHook(() => useAssetFiatFormatter()).result.current.format(
-        '100',
-        '0x1',
-      );
+      renderHook(() => useAssetFiatFormatter()).result.current.format('100');
 
       expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
         'en-US',
@@ -108,10 +112,7 @@ describe('useAssetFiatFormatter', () => {
     it('uses minimumFractionDigits=2 for non-integer amounts', () => {
       buildState({ preferredCurrency: 'eur' });
 
-      renderHook(() => useAssetFiatFormatter()).result.current.format(
-        '100.5',
-        '0x1',
-      );
+      renderHook(() => useAssetFiatFormatter()).result.current.format('100.5');
 
       expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
         'en-US',
@@ -119,154 +120,16 @@ describe('useAssetFiatFormatter', () => {
       );
     });
 
-    it('treats undefined/null balances as zero', () => {
+    it('returns undefined when input is undefined', () => {
       buildState({ preferredCurrency: 'eur' });
 
-      renderHook(() => useAssetFiatFormatter()).result.current.format(
-        undefined,
-        '0x1',
-      );
-
-      expect(mockFormatter.format).toHaveBeenCalledWith('0');
-    });
-  });
-
-  describe('pay flow (USD forced, preferred is EUR)', () => {
-    const eurUsdRates = {
-      ETH: { conversionRate: 2000, usdConversionRate: 2200 },
-    };
-    const ethChainConfig = { '0x1': { nativeCurrency: 'ETH' } };
-
-    beforeEach(() => {
-      mockUseTransactionPayCurrency.mockReturnValue('USD');
-    });
-
-    it('re-scales the amount by usdRate/preferredRate', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: eurUsdRates,
-        networkConfigs: ethChainConfig,
-      });
-
-      renderHook(() => useAssetFiatFormatter()).result.current.format(
-        '100',
-        '0x1',
-      );
-
-      // 100 EUR * (2200 USD/ETH / 2000 EUR/ETH) = 110 USD
-      expect(mockFormatter.format).toHaveBeenCalledWith('110');
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
-        'en-US',
-        expect.objectContaining({ currency: 'USD' }),
-      );
-    });
-
-    it('exposes fiatCurrency as USD', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: eurUsdRates,
-        networkConfigs: ethChainConfig,
-      });
-
       const { result } = renderHook(() => useAssetFiatFormatter());
-      expect(result.current.fiatCurrency).toBe('USD');
-    });
-
-    it('returns undefined when usdConversionRate is missing', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: { ETH: { conversionRate: 2000 } },
-        networkConfigs: ethChainConfig,
-      });
-
-      const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('100', '0x1');
+      const output = result.current.format(undefined);
 
       expect(output).toBeUndefined();
       expect(mockFormatter.format).not.toHaveBeenCalled();
     });
 
-    it('returns undefined when preferred conversionRate is missing', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: { ETH: { usdConversionRate: 2200 } },
-        networkConfigs: ethChainConfig,
-      });
-
-      const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('100', '0x1');
-
-      expect(output).toBeUndefined();
-      expect(mockFormatter.format).not.toHaveBeenCalled();
-    });
-
-    it('returns undefined when chain has no EVM network config', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: eurUsdRates,
-        networkConfigs: {},
-      });
-
-      const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('100', '0x1');
-
-      expect(output).toBeUndefined();
-      expect(mockFormatter.format).not.toHaveBeenCalled();
-    });
-
-    it('formats zero even when rates or chain config are missing', () => {
-      buildState({
-        preferredCurrency: 'eur',
-        currencyRates: {},
-        networkConfigs: {},
-      });
-
-      const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format(0, undefined);
-
-      expect(output).toBe('formatted:0');
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith(
-        'en-US',
-        expect.objectContaining({ currency: 'USD' }),
-      );
-    });
-  });
-
-  describe('pay flow (USD forced, preferred is already USD)', () => {
-    it('does not re-scale (identity), so numeric value is unchanged', () => {
-      mockUseTransactionPayCurrency.mockReturnValue('USD');
-      buildState({
-        preferredCurrency: 'usd',
-        currencyRates: {
-          ETH: { conversionRate: 2200, usdConversionRate: 2200 },
-        },
-        networkConfigs: { '0x1': { nativeCurrency: 'ETH' } },
-      });
-
-      renderHook(() => useAssetFiatFormatter()).result.current.format(
-        '100',
-        '0x1',
-      );
-
-      expect(mockFormatter.format).toHaveBeenCalledWith('100');
-    });
-
-    it('still formats when currency rates are missing (no conversion needed)', () => {
-      mockUseTransactionPayCurrency.mockReturnValue('USD');
-      buildState({
-        preferredCurrency: 'usd',
-        currencyRates: {},
-        networkConfigs: {},
-      });
-
-      const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('100', '0x1');
-
-      expect(output).toBe('formatted:100');
-    });
-  });
-
-  describe('formatter error fallback', () => {
     it('falls back to `${value} ${currency}` when Intl throws', () => {
       buildState({ preferredCurrency: 'eur' });
       mockGetIntlNumberFormatter.mockImplementation(() => {
@@ -274,7 +137,7 @@ describe('useAssetFiatFormatter', () => {
       });
 
       const { result } = renderHook(() => useAssetFiatFormatter());
-      const output = result.current.format('42', '0x1');
+      const output = result.current.format('42');
 
       expect(output).toBe('42 eur');
     });

--- a/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.ts
@@ -1,36 +1,29 @@
 import { useSelector } from 'react-redux';
 import { useCallback } from 'react';
 import { BigNumber } from 'bignumber.js';
-import { Hex } from '@metamask/utils';
 
 import I18n from '../../../../../../locales/i18n';
 import Logger from '../../../../../util/Logger';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
-import {
-  selectCurrencyRates,
-  selectCurrentCurrency,
-} from '../../../../../selectors/currencyRateController';
-import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { useTransactionPayCurrency } from './useTransactionPayCurrency';
 
 export type AssetFiatFormatter = (
-  preferredBalance: BigNumber.Value | undefined,
-  chainId: string | undefined,
+  amount: BigNumber.Value | undefined,
 ) => string | undefined;
 
 /**
- * Returns a formatter that converts a preferred-currency fiat balance into a
- * localized currency string, honoring the pay-flow currency override.
+ * Returns a currency formatter whose target currency follows the pay-flow
+ * override: USD inside `PAY_TRANSACTION_TYPES` confirmations, otherwise the
+ * user's preferred currency.
  *
- * `asset.fiat.balance` from `@metamask/assets-controllers` is denominated in
- * the user's preferred currency. When the active confirmation forces a
- * different pay currency (currently only USD), the numeric value must be
- * re-scaled by `(native→pay) / (native→preferred)` — not just relabeled.
+ * This hook only formats — it does not derive rates or convert values.
+ * Callers must pass an `amount` already denominated in `fiatCurrency`. Rate
+ * derivation should go through `useTokenFiatRates`, which owns the
+ * stablecoin exception and the USD/preferred-currency rate selection.
  *
- * Returns `undefined` when the value cannot be safely rendered in the target
- * currency (missing conversion rate, missing chain config). Callers should
- * treat `undefined` as "hide fiat", matching the existing testnet-hidden
- * fallback in `useAccountTokens`.
+ * Returns `undefined` when the input amount is `undefined`, so callers can
+ * pass through a missing rate as "hide fiat".
  */
 export function useAssetFiatFormatter(): {
   format: AssetFiatFormatter;
@@ -38,64 +31,29 @@ export function useAssetFiatFormatter(): {
 } {
   const preferredCurrency = useSelector(selectCurrentCurrency);
   const payCurrency = useTransactionPayCurrency();
-  const currencyRates = useSelector(selectCurrencyRates);
-  const networkConfigurationsByChainId = useSelector(
-    selectEvmNetworkConfigurationsByChainId,
-  );
-
   const fiatCurrency = payCurrency ?? preferredCurrency;
 
-  const needsConversion =
-    payCurrency === 'USD' &&
-    preferredCurrency?.toLowerCase() !== payCurrency.toLowerCase();
-
   const format = useCallback<AssetFiatFormatter>(
-    (preferredBalance, chainId) => {
-      const preferredAmount = new BigNumber(preferredBalance ?? 0);
-
-      let payAmount: BigNumber | undefined = preferredAmount;
-      // Zero is currency-invariant, so we skip the rate lookup even when a
-      // pay-currency conversion would otherwise be required. Keeps the
-      // enrichment "$0" placeholder working when rates or chain config are
-      // missing.
-      if (needsConversion && !preferredAmount.isZero()) {
-        const nativeCurrency =
-          networkConfigurationsByChainId?.[chainId as Hex]?.nativeCurrency;
-        const rateEntry = nativeCurrency
-          ? currencyRates?.[nativeCurrency]
-          : undefined;
-        const preferredRate = rateEntry?.conversionRate;
-        const usdRate = rateEntry?.usdConversionRate;
-
-        payAmount =
-          preferredRate && usdRate
-            ? preferredAmount.multipliedBy(usdRate).dividedBy(preferredRate)
-            : undefined;
-      }
-
-      if (payAmount === undefined) {
+    (amount) => {
+      if (amount === undefined) {
         return undefined;
       }
 
-      const hasDecimals = !payAmount.isInteger();
+      const value = new BigNumber(amount);
+      const hasDecimals = !value.isInteger();
 
       try {
         return getIntlNumberFormatter(I18n.locale, {
           style: 'currency',
           currency: fiatCurrency,
           minimumFractionDigits: hasDecimals ? 2 : 0,
-        }).format(payAmount.toFixed() as unknown as number);
+        }).format(value.toFixed() as unknown as number);
       } catch (error) {
         Logger.error(error as Error);
-        return `${payAmount.toFixed()} ${fiatCurrency}`;
+        return `${value.toFixed()} ${fiatCurrency}`;
       }
     },
-    [
-      needsConversion,
-      networkConfigurationsByChainId,
-      currencyRates,
-      fiatCurrency,
-    ],
+    [fiatCurrency],
   );
 
   return { format, fiatCurrency };

--- a/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAssetFiatFormatter.ts
@@ -1,0 +1,102 @@
+import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { BigNumber } from 'bignumber.js';
+import { Hex } from '@metamask/utils';
+
+import I18n from '../../../../../../locales/i18n';
+import Logger from '../../../../../util/Logger';
+import { getIntlNumberFormatter } from '../../../../../util/intl';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../selectors/currencyRateController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import { useTransactionPayCurrency } from './useTransactionPayCurrency';
+
+export type AssetFiatFormatter = (
+  preferredBalance: BigNumber.Value | undefined,
+  chainId: string | undefined,
+) => string | undefined;
+
+/**
+ * Returns a formatter that converts a preferred-currency fiat balance into a
+ * localized currency string, honoring the pay-flow currency override.
+ *
+ * `asset.fiat.balance` from `@metamask/assets-controllers` is denominated in
+ * the user's preferred currency. When the active confirmation forces a
+ * different pay currency (currently only USD), the numeric value must be
+ * re-scaled by `(native→pay) / (native→preferred)` — not just relabeled.
+ *
+ * Returns `undefined` when the value cannot be safely rendered in the target
+ * currency (missing conversion rate, missing chain config). Callers should
+ * treat `undefined` as "hide fiat", matching the existing testnet-hidden
+ * fallback in `useAccountTokens`.
+ */
+export function useAssetFiatFormatter(): {
+  format: AssetFiatFormatter;
+  fiatCurrency: string;
+} {
+  const preferredCurrency = useSelector(selectCurrentCurrency);
+  const payCurrency = useTransactionPayCurrency();
+  const currencyRates = useSelector(selectCurrencyRates);
+  const networkConfigurationsByChainId = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+
+  const fiatCurrency = payCurrency ?? preferredCurrency;
+
+  const needsConversion =
+    payCurrency === 'USD' &&
+    preferredCurrency?.toLowerCase() !== payCurrency.toLowerCase();
+
+  const format = useCallback<AssetFiatFormatter>(
+    (preferredBalance, chainId) => {
+      const preferredAmount = new BigNumber(preferredBalance ?? 0);
+
+      let payAmount: BigNumber | undefined = preferredAmount;
+      // Zero is currency-invariant, so we skip the rate lookup even when a
+      // pay-currency conversion would otherwise be required. Keeps the
+      // enrichment "$0" placeholder working when rates or chain config are
+      // missing.
+      if (needsConversion && !preferredAmount.isZero()) {
+        const nativeCurrency =
+          networkConfigurationsByChainId?.[chainId as Hex]?.nativeCurrency;
+        const rateEntry = nativeCurrency
+          ? currencyRates?.[nativeCurrency]
+          : undefined;
+        const preferredRate = rateEntry?.conversionRate;
+        const usdRate = rateEntry?.usdConversionRate;
+
+        payAmount =
+          preferredRate && usdRate
+            ? preferredAmount.multipliedBy(usdRate).dividedBy(preferredRate)
+            : undefined;
+      }
+
+      if (payAmount === undefined) {
+        return undefined;
+      }
+
+      const hasDecimals = !payAmount.isInteger();
+
+      try {
+        return getIntlNumberFormatter(I18n.locale, {
+          style: 'currency',
+          currency: fiatCurrency,
+          minimumFractionDigits: hasDecimals ? 2 : 0,
+        }).format(payAmount.toFixed() as unknown as number);
+      } catch (error) {
+        Logger.error(error as Error);
+        return `${payAmount.toFixed()} ${fiatCurrency}`;
+      }
+    },
+    [
+      needsConversion,
+      networkConfigurationsByChainId,
+      currencyRates,
+      fiatCurrency,
+    ],
+  );
+
+  return { format, fiatCurrency };
+}

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 
 import { useAccountTokens } from './useAccountTokens';
 import { getNetworkBadgeSource } from '../../utils/network';
-import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { TokenStandard } from '../../types/token';
 import {
   selectAssetsBySelectedAccountGroup,
@@ -16,7 +15,7 @@ import { useTokensData } from '../../../../hooks/useTokensData/useTokensData';
 import { buildEvmCaip19AssetId } from '../../../../../util/multichain/buildEvmCaip19AssetId';
 import { Hex } from '@metamask/utils';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
-import { useTransactionPayCurrency } from '../pay/useTransactionPayCurrency';
+import { useAssetFiatFormatter } from '../pay/useAssetFiatFormatter';
 import { selectInternalAccountsById } from '../../../../../selectors/accountsController';
 import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
 
@@ -28,17 +27,8 @@ jest.mock('../../utils/network', () => ({
   getNetworkBadgeSource: jest.fn(),
 }));
 
-jest.mock('../../../../../util/intl', () => ({
-  getIntlNumberFormatter: jest.fn(),
-}));
-
 jest.mock('../../../../../util/networks', () => ({
   isTestNet: jest.fn(),
-}));
-
-jest.mock('../../../../../../locales/i18n', () => ({
-  locale: 'en-US',
-  strings: jest.fn((key: string) => key),
 }));
 
 jest.mock('../transactions/useTransactionAccountOverride', () => ({
@@ -48,10 +38,10 @@ const useTransactionAccountOverrideMock = jest.mocked(
   useTransactionAccountOverride,
 );
 
-jest.mock('../pay/useTransactionPayCurrency', () => ({
-  useTransactionPayCurrency: jest.fn(),
+jest.mock('../pay/useAssetFiatFormatter', () => ({
+  useAssetFiatFormatter: jest.fn(),
 }));
-const useTransactionPayCurrencyMock = jest.mocked(useTransactionPayCurrency);
+const useAssetFiatFormatterMock = jest.mocked(useAssetFiatFormatter);
 
 jest.mock('../../../../../selectors/accountsController', () => ({
   selectInternalAccountsById: jest.fn(),
@@ -82,7 +72,6 @@ jest.mock('../../../../../util/multichain/buildEvmCaip19AssetId');
 
 const mockUseSelector = jest.mocked(useSelector);
 const mockGetNetworkBadgeSource = jest.mocked(getNetworkBadgeSource);
-const mockGetIntlNumberFormatter = jest.mocked(getIntlNumberFormatter);
 const mockSelectAssetsBySelectedAccountGroup = jest.mocked(
   selectAssetsBySelectedAccountGroup,
 );
@@ -90,6 +79,8 @@ const mockSelectCurrentCurrency = jest.mocked(selectCurrentCurrency);
 const mockIsTestNet = jest.mocked(isTestNet);
 const mockUseTokensData = jest.mocked(useTokensData);
 const mockBuildEvmCaip19AssetId = jest.mocked(buildEvmCaip19AssetId);
+
+const mockFormatFiat = jest.fn();
 
 const mockAssets = {
   '0x1': [
@@ -119,16 +110,11 @@ const mockAssets = {
   ],
 };
 
-const mockFormatter = {
-  format: jest.fn(),
-};
-
 describe('useAccountTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
     useTransactionAccountOverrideMock.mockReturnValue(undefined);
-    useTransactionPayCurrencyMock.mockReturnValue(undefined);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockSelectAssetsBySelectedAccountGroup.mockReturnValue(mockAssets as any);
@@ -150,10 +136,13 @@ describe('useAccountTokens', () => {
       return undefined;
     });
 
+    mockFormatFiat.mockReturnValue('$100.50');
+    useAssetFiatFormatterMock.mockReturnValue({
+      format: mockFormatFiat,
+      fiatCurrency: 'USD',
+    });
+
     mockGetNetworkBadgeSource.mockReturnValue('network-badge-source');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockGetIntlNumberFormatter.mockReturnValue(mockFormatter as any);
-    mockFormatter.format.mockReturnValue('$100.50');
     mockIsTestNet.mockReturnValue(false);
     mockUseTokensData.mockReturnValue({});
     mockBuildEvmCaip19AssetId.mockImplementation(
@@ -211,8 +200,8 @@ describe('useAccountTokens', () => {
       });
     });
 
-    it('handles integer amounts without decimals', () => {
-      const integerAssets = {
+    it('passes each asset balance to the fiat formatter', () => {
+      const balanceAssets = {
         '0x1': [
           {
             chainId: '0x1',
@@ -221,66 +210,31 @@ describe('useAccountTokens', () => {
             rawBalance: '0x1234',
             symbol: 'TOKEN1',
           },
-        ],
-      };
-
-      mockSelectAssetsBySelectedAccountGroup.mockReturnValue(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        integerAssets as any,
-      );
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
-          return integerAssets;
-        }
-        if (selector === selectCurrentCurrency) {
-          return 'USD';
-        }
-        return undefined;
-      });
-
-      renderHook(() => useAccountTokens());
-
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 0,
-      });
-    });
-
-    it('handles decimal amounts with fraction digits', () => {
-      const decimalAssets = {
-        '0x1': [
           {
             chainId: '0x1',
-            accountType: 'eip155:1/erc20:0xtoken1',
+            accountType: 'eip155:1/erc20:0xtoken2',
             fiat: { balance: '100.50' },
-            rawBalance: '0x1234',
-            symbol: 'TOKEN1',
+            rawBalance: '0x5678',
+            symbol: 'TOKEN2',
           },
         ],
       };
 
       mockSelectAssetsBySelectedAccountGroup.mockReturnValue(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        decimalAssets as any,
+        balanceAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectAssetsBySelectedAccountGroup) {
-          return decimalAssets;
-        }
-        if (selector === selectCurrentCurrency) {
-          return 'USD';
+          return balanceAssets;
         }
         return undefined;
       });
 
       renderHook(() => useAccountTokens());
 
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 2,
-      });
+      expect(mockFormatFiat).toHaveBeenCalledWith('100', '0x1');
+      expect(mockFormatFiat).toHaveBeenCalledWith('100.50', '0x1');
     });
   });
 
@@ -987,47 +941,54 @@ describe('useAccountTokens', () => {
     });
   });
 
-  describe('pay currency', () => {
-    it('uses preferred currency when useTransactionPayCurrency returns undefined', () => {
-      useTransactionPayCurrencyMock.mockReturnValue(undefined);
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
-          return mockAssets;
-        }
-        if (selector === selectCurrentCurrency) {
-          return 'eur';
-        }
-        return undefined;
-      });
+  describe('fiat formatter delegation', () => {
+    it('sets balanceInSelectedCurrency to the formatter output', () => {
+      mockFormatFiat.mockReturnValue('$110.00');
 
-      renderHook(() => useAccountTokens());
+      const { result } = renderHook(() => useAccountTokens());
 
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith('en-US', {
-        style: 'currency',
-        currency: 'eur',
-        minimumFractionDigits: 2,
+      result.current.forEach((asset) => {
+        expect(asset.balanceInSelectedCurrency).toBe('$110.00');
       });
     });
 
-    it('uses USD from useTransactionPayCurrency over preferred currency', () => {
-      useTransactionPayCurrencyMock.mockReturnValue('USD');
+    it('propagates undefined from the formatter as a hidden fiat value', () => {
+      mockFormatFiat.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useAccountTokens());
+
+      result.current.forEach((asset) => {
+        expect(asset.balanceInSelectedCurrency).toBeUndefined();
+      });
+    });
+
+    it('does not call the formatter for testnet assets when fiat is hidden', () => {
+      const testnetOnlyAssets = {
+        '0x5': [
+          {
+            chainId: '0x5',
+            accountType: 'eip155:5/erc20:0xtoken1',
+            fiat: { balance: '100.50' },
+            rawBalance: '0x1234',
+            symbol: 'TOKEN1',
+          },
+        ],
+      };
+
+      mockIsTestNet.mockReturnValue(true);
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectAssetsBySelectedAccountGroup) {
-          return mockAssets;
+          return testnetOnlyAssets;
         }
-        if (selector === selectCurrentCurrency) {
-          return 'eur';
+        if (selector === selectShowFiatInTestnets) {
+          return false;
         }
         return undefined;
       });
 
       renderHook(() => useAccountTokens());
 
-      expect(mockGetIntlNumberFormatter).toHaveBeenCalledWith('en-US', {
-        style: 'currency',
-        currency: 'USD',
-        minimumFractionDigits: 2,
-      });
+      expect(mockFormatFiat).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -16,6 +16,7 @@ import { buildEvmCaip19AssetId } from '../../../../../util/multichain/buildEvmCa
 import { Hex } from '@metamask/utils';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useAssetFiatFormatter } from '../pay/useAssetFiatFormatter';
+import { useTokenFiatRates } from '../tokens/useTokenFiatRates';
 import { selectInternalAccountsById } from '../../../../../selectors/accountsController';
 import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
 
@@ -42,6 +43,15 @@ jest.mock('../pay/useAssetFiatFormatter', () => ({
   useAssetFiatFormatter: jest.fn(),
 }));
 const useAssetFiatFormatterMock = jest.mocked(useAssetFiatFormatter);
+
+jest.mock('../tokens/useTokenFiatRates', () => ({
+  useTokenFiatRates: jest.fn(),
+}));
+const useTokenFiatRatesMock = jest.mocked(useTokenFiatRates);
+
+jest.mock('../../../../../core/Multichain/utils', () => ({
+  isNonEvmChainId: jest.fn((chainId: string) => !chainId?.startsWith('0x')),
+}));
 
 jest.mock('../../../../../selectors/accountsController', () => ({
   selectInternalAccountsById: jest.fn(),
@@ -86,14 +96,18 @@ const mockAssets = {
   '0x1': [
     {
       chainId: '0x1',
+      address: '0xtoken1',
       accountType: 'eip155:1/erc20:0xtoken1',
+      balance: '100.50',
       fiat: { balance: '100.50' },
       rawBalance: '0x1234',
       symbol: 'TOKEN1',
     },
     {
       chainId: '0x1',
+      address: '0xtoken2',
       accountType: 'eip155:1/erc20:0xtoken2',
+      balance: '0',
       fiat: { balance: '0' },
       rawBalance: '0x0',
       symbol: 'TOKEN2',
@@ -102,7 +116,9 @@ const mockAssets = {
   'solana:mainnet': [
     {
       chainId: 'solana:mainnet',
+      address: 'SolTokenPubkey1',
       accountType: 'solana:mainnet/spl:0xsoltoken1',
+      balance: '50.25',
       fiat: { balance: '50.25' },
       rawBalance: '0x5678',
       symbol: 'SOLTOKEN1',
@@ -141,6 +157,10 @@ describe('useAccountTokens', () => {
       format: mockFormatFiat,
       fiatCurrency: 'USD',
     });
+
+    useTokenFiatRatesMock.mockImplementation((requests) =>
+      requests.map(() => 1),
+    );
 
     mockGetNetworkBadgeSource.mockReturnValue('network-badge-source');
     mockIsTestNet.mockReturnValue(false);
@@ -192,27 +212,35 @@ describe('useAccountTokens', () => {
       });
     });
 
-    it('formats balance in selected currency', () => {
+    it('formats balance in selected currency for EVM assets', () => {
       const { result } = renderHook(() => useAccountTokens());
 
-      result.current.forEach((asset) => {
+      const evmRows = result.current.filter((a) =>
+        (a.chainId as string).startsWith('0x'),
+      );
+      expect(evmRows.length).toBeGreaterThan(0);
+      evmRows.forEach((asset) => {
         expect(asset.balanceInSelectedCurrency).toBe('$100.50');
       });
     });
 
-    it('passes each asset balance to the fiat formatter', () => {
+    it('passes each asset balance * fiat rate to the formatter', () => {
       const balanceAssets = {
         '0x1': [
           {
             chainId: '0x1',
+            address: '0xtoken1',
             accountType: 'eip155:1/erc20:0xtoken1',
+            balance: '100',
             fiat: { balance: '100' },
             rawBalance: '0x1234',
             symbol: 'TOKEN1',
           },
           {
             chainId: '0x1',
+            address: '0xtoken2',
             accountType: 'eip155:1/erc20:0xtoken2',
+            balance: '50',
             fiat: { balance: '100.50' },
             rawBalance: '0x5678',
             symbol: 'TOKEN2',
@@ -230,11 +258,15 @@ describe('useAccountTokens', () => {
         }
         return undefined;
       });
+      useTokenFiatRatesMock.mockReturnValue([2, 3]);
 
       renderHook(() => useAccountTokens());
 
-      expect(mockFormatFiat).toHaveBeenCalledWith('100', '0x1');
-      expect(mockFormatFiat).toHaveBeenCalledWith('100.50', '0x1');
+      const calls = mockFormatFiat.mock.calls.map((args) =>
+        args[0]?.toString(),
+      );
+      expect(calls).toContain('200');
+      expect(calls).toContain('150');
     });
   });
 
@@ -293,7 +325,9 @@ describe('useAccountTokens', () => {
       '0x1': [
         {
           chainId: '0x1',
+          address: '0xtoken1',
           accountType: 'eip155:1/erc20:0xtoken1',
+          balance: '10',
           fiat: { balance: '10' },
           rawBalance: '0x1234',
           symbol: 'MAINNET_TOKEN',
@@ -302,7 +336,9 @@ describe('useAccountTokens', () => {
       '0xaa36a7': [
         {
           chainId: '0xaa36a7',
+          address: '0xnative',
           accountType: 'eip155:11155111/slip44:60',
+          balance: '1000',
           fiat: { balance: '1000' },
           rawBalance: '0x5678',
           symbol: 'SepoliaETH',
@@ -942,14 +978,41 @@ describe('useAccountTokens', () => {
   });
 
   describe('fiat formatter delegation', () => {
-    it('sets balanceInSelectedCurrency to the formatter output', () => {
+    it('sets balanceInSelectedCurrency to the formatter output for EVM assets', () => {
       mockFormatFiat.mockReturnValue('$110.00');
 
       const { result } = renderHook(() => useAccountTokens());
 
-      result.current.forEach((asset) => {
+      const evmRows = result.current.filter((a) =>
+        (a.chainId as string).startsWith('0x'),
+      );
+      expect(evmRows.length).toBeGreaterThan(0);
+      evmRows.forEach((asset) => {
         expect(asset.balanceInSelectedCurrency).toBe('$110.00');
       });
+    });
+
+    it('formats non-EVM assets using their preferred-currency fiat balance', () => {
+      mockFormatFiat.mockImplementation((v) =>
+        v === undefined ? undefined : `formatted:${String(v)}`,
+      );
+
+      const { result } = renderHook(() => useAccountTokens());
+
+      const nonEvm = result.current.find((a) => a.chainId === 'solana:mainnet');
+      expect(nonEvm?.balanceInSelectedCurrency).toBe('formatted:50.25');
+    });
+
+    it('does not use useTokenFiatRates output for non-EVM assets', () => {
+      useTokenFiatRatesMock.mockReturnValue([999]);
+      mockFormatFiat.mockImplementation((v) =>
+        v === undefined ? undefined : `formatted:${String(v)}`,
+      );
+
+      const { result } = renderHook(() => useAccountTokens());
+
+      const nonEvm = result.current.find((a) => a.chainId === 'solana:mainnet');
+      expect(nonEvm?.balanceInSelectedCurrency).toBe('formatted:50.25');
     });
 
     it('propagates undefined from the formatter as a hidden fiat value', () => {
@@ -967,7 +1030,9 @@ describe('useAccountTokens', () => {
         '0x5': [
           {
             chainId: '0x5',
+            address: '0xtoken1',
             accountType: 'eip155:5/erc20:0xtoken1',
+            balance: '100.50',
             fiat: { balance: '100.50' },
             rawBalance: '0x1234',
             symbol: 'TOKEN1',

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -1056,4 +1056,128 @@ describe('useAccountTokens', () => {
       expect(mockFormatFiat).not.toHaveBeenCalled();
     });
   });
+
+  describe('sort key follows displayed fiat', () => {
+    it('sorts by derived fiat (balance * rate), not asset.fiat.balance', () => {
+      const stablecoinLikeAssets = {
+        '0x1': [
+          {
+            chainId: '0x1',
+            address: '0xstable',
+            accountType: 'eip155:1/erc20:0xstable',
+            balance: '1000',
+            fiat: { balance: '998' },
+            rawBalance: '0x1234',
+            symbol: 'USDC',
+          },
+          {
+            chainId: '0x1',
+            address: '0xvolatile',
+            accountType: 'eip155:1/erc20:0xvolatile',
+            balance: '10',
+            fiat: { balance: '999' },
+            rawBalance: '0x5678',
+            symbol: 'VOL',
+          },
+        ],
+      };
+
+      mockSelectAssetsBySelectedAccountGroup.mockReturnValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stablecoinLikeAssets as any,
+      );
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectAssetsBySelectedAccountGroup) {
+          return stablecoinLikeAssets;
+        }
+        return undefined;
+      });
+      // USDC rate = 1 (stablecoin bypass shape), VOL rate = 99.9.
+      // Derived fiat: USDC=1000*1=1000, VOL=10*99.9=999.
+      // asset.fiat.balance would sort VOL(999) above USDC(998).
+      // Correct sort by derived fiat puts USDC(1000) first.
+      useTokenFiatRatesMock.mockReturnValue([1, 99.9]);
+
+      const { result } = renderHook(() => useAccountTokens());
+
+      expect(result.current[0].symbol).toBe('USDC');
+      expect(result.current[1].symbol).toBe('VOL');
+    });
+  });
+
+  describe('zero balance with missing rate', () => {
+    it('renders $0 for an EVM zero-balance token even when useTokenFiatRates returns undefined', () => {
+      const zeroBalanceAssets = {
+        '0x1': [
+          {
+            chainId: '0x1',
+            address: '0xtoken1',
+            accountType: 'eip155:1/erc20:0xtoken1',
+            balance: '0',
+            fiat: { balance: '0' },
+            rawBalance: '0x0',
+            symbol: 'TOKEN1',
+          },
+        ],
+      };
+
+      mockSelectAssetsBySelectedAccountGroup.mockReturnValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        zeroBalanceAssets as any,
+      );
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectAssetsBySelectedAccountGroup) {
+          return zeroBalanceAssets;
+        }
+        return undefined;
+      });
+      useTokenFiatRatesMock.mockReturnValue([undefined]);
+      mockFormatFiat.mockImplementation((v) =>
+        v === undefined ? undefined : `formatted:${String(v)}`,
+      );
+
+      const { result } = renderHook(() =>
+        useAccountTokens({ includeNoBalance: true }),
+      );
+
+      const token = result.current.find((a) => a.symbol === 'TOKEN1');
+      expect(token?.balanceInSelectedCurrency).toBe('formatted:0');
+    });
+
+    it('still hides fiat for a non-zero EVM balance when rate is missing', () => {
+      const nonZeroAssets = {
+        '0x1': [
+          {
+            chainId: '0x1',
+            address: '0xtoken1',
+            accountType: 'eip155:1/erc20:0xtoken1',
+            balance: '10',
+            fiat: { balance: '10' },
+            rawBalance: '0x1234',
+            symbol: 'TOKEN1',
+          },
+        ],
+      };
+
+      mockSelectAssetsBySelectedAccountGroup.mockReturnValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        nonZeroAssets as any,
+      );
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectAssetsBySelectedAccountGroup) {
+          return nonZeroAssets;
+        }
+        return undefined;
+      });
+      useTokenFiatRatesMock.mockReturnValue([undefined]);
+      mockFormatFiat.mockImplementation((v) =>
+        v === undefined ? undefined : `formatted:${String(v)}`,
+      );
+
+      const { result } = renderHook(() => useAccountTokens());
+
+      const token = result.current.find((a) => a.symbol === 'TOKEN1');
+      expect(token?.balanceInSelectedCurrency).toBeUndefined();
+    });
+  });
 });

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -18,6 +18,11 @@ import { buildEvmCaip19AssetId } from '../../../../../util/multichain/buildEvmCa
 import type { RootState } from '../../../../../reducers';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useAssetFiatFormatter } from '../pay/useAssetFiatFormatter';
+import {
+  TokenFiatRateRequest,
+  useTokenFiatRates,
+} from '../tokens/useTokenFiatRates';
+import { isNonEvmChainId } from '../../../../../core/Multichain/utils';
 import { isNetworkTestnet } from './useNetworkFilter';
 
 export interface EnrichTokenRequest {
@@ -72,22 +77,11 @@ export function useAccountTokens({
   );
 
   const showFiatOnTestnets = useSelector(selectShowFiatInTestnets);
-  const { format: formatFiat } = useAssetFiatFormatter();
+  const { format: formatFiat, fiatCurrency } = useAssetFiatFormatter();
 
-  const assetIds = useMemo(
-    () =>
-      enrichTokenRequests.map((req) =>
-        buildEvmCaip19AssetId(req.address, req.chainId),
-      ),
-    [enrichTokenRequests],
-  );
-
-  const tokensByAssetId = useTokensData(assetIds);
-
-  return useMemo(() => {
+  const assetsWithBalance = useMemo(() => {
     const flatAssets = Object.values(assets).flat();
-
-    const assetsWithBalance = flatAssets.filter((asset) => {
+    return flatAssets.filter((asset) => {
       if (tokenFilter) {
         const address = asset.assetId;
         if (
@@ -115,7 +109,36 @@ export function useAccountTokens({
 
       return haveBalance || isTestNetAsset;
     });
+  }, [assets, includeNoBalance, tokenFilter]);
 
+  // useTokenFiatRates crashes on non-hex addresses (Solana etc.), so we
+  // build requests for EVM assets only. Non-EVM assets are handled below in
+  // the render memo by falling back to `asset.fiat.balance`.
+  const fiatRateRequests = useMemo<TokenFiatRateRequest[]>(
+    () =>
+      assetsWithBalance
+        .filter((asset) => asset.chainId && !isNonEvmChainId(asset.chainId))
+        .map((asset) => ({
+          address: asset.address as Hex,
+          chainId: asset.chainId as Hex,
+          currency: fiatCurrency.toLowerCase(),
+        })),
+    [assetsWithBalance, fiatCurrency],
+  );
+
+  const fiatRates = useTokenFiatRates(fiatRateRequests);
+
+  const assetIds = useMemo(
+    () =>
+      enrichTokenRequests.map((req) =>
+        buildEvmCaip19AssetId(req.address, req.chainId),
+      ),
+    [enrichTokenRequests],
+  );
+
+  const tokensByAssetId = useTokensData(assetIds);
+
+  return useMemo(() => {
     // "Show conversion on test networks" setting: when disabled, testnet
     // assets must not display fiat values nor be ranked by them.
     const isFiatHidden = (chainId?: string) =>
@@ -123,10 +146,31 @@ export function useAccountTokens({
       Boolean(chainId) &&
       isNetworkTestnet(chainId as string);
 
+    // EVM assets use the useTokenFiatRates-derived rate (picks up stablecoin
+    // bypass, and lets us convert to USD in pay flow). Non-EVM assets fall
+    // back to the assets-controller's preferred-currency `fiat.balance`,
+    // which is the pre-existing behavior for Solana/Bitcoin/etc.
+    // EVM assets and rates are in lockstep — both arrays derived from the
+    // same predicate over the same list, so a single index walk pairs them.
+    let evmIndex = 0;
     const processedAssets = assetsWithBalance.map((asset) => {
-      const balanceInSelectedCurrency = isFiatHidden(asset.chainId)
-        ? undefined
-        : formatFiat(asset.fiat?.balance, asset.chainId);
+      const isEvm = asset.chainId && !isNonEvmChainId(asset.chainId);
+      const rate = isEvm ? fiatRates[evmIndex++] : undefined;
+
+      let fiatAmount: BigNumber.Value | undefined;
+      if (isFiatHidden(asset.chainId)) {
+        fiatAmount = undefined;
+      } else if (isEvm) {
+        fiatAmount =
+          rate !== undefined && asset.balance
+            ? new BigNumber(asset.balance).multipliedBy(rate)
+            : undefined;
+      } else {
+        fiatAmount = asset.fiat?.balance;
+      }
+
+      const balanceInSelectedCurrency =
+        fiatAmount !== undefined ? formatFiat(fiatAmount) : undefined;
 
       return {
         ...asset,
@@ -137,7 +181,7 @@ export function useAccountTokens({
     });
 
     if (enrichTokenRequests.length > 0) {
-      const zeroFiat = formatFiat(0, undefined) ?? '';
+      const zeroFiat = formatFiat(0) ?? '';
 
       const existingKeys = new Set(
         processedAssets.map(
@@ -183,13 +227,12 @@ export function useAccountTokens({
       (a, b) => sortableFiatBalance(b).comparedTo(sortableFiatBalance(a)) || 0,
     );
   }, [
-    assets,
-    includeNoBalance,
+    assetsWithBalance,
     showFiatOnTestnets,
-    tokenFilter,
     enrichTokenRequests,
     assetIds,
     tokensByAssetId,
     formatFiat,
+    fiatRates,
   ]) as unknown as AssetType[];
 }

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -1,3 +1,4 @@
+import type { Asset } from '@metamask/assets-controllers';
 import { useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
@@ -31,30 +32,6 @@ export interface EnrichTokenRequest {
 }
 
 const EMPTY_REQUESTS: EnrichTokenRequest[] = [];
-
-function useAccountGroupAssets(accountAddress?: string | null) {
-  const internalAccountsById = useSelector(selectInternalAccountsById);
-  const accountToGroupMap = useSelector(selectAccountToGroupMap);
-
-  const accountGroupId = useMemo(() => {
-    if (!accountAddress) return undefined;
-    const internalAccountId = Object.keys(internalAccountsById).find(
-      (id) =>
-        internalAccountsById[id].address.toLowerCase() ===
-        accountAddress.toLowerCase(),
-    );
-    if (!internalAccountId) return undefined;
-    return accountToGroupMap[internalAccountId]?.id;
-  }, [accountAddress, internalAccountsById, accountToGroupMap]);
-
-  const selectOverrideAssets = useCallback(
-    (state: RootState) => selectAssetsByAccountGroupId(state, accountGroupId),
-    [accountGroupId],
-  );
-
-  const overrideAssets = useSelector(selectOverrideAssets);
-  return accountGroupId ? overrideAssets : undefined;
-}
 
 export function useAccountTokens({
   includeNoBalance = false,
@@ -111,18 +88,11 @@ export function useAccountTokens({
     });
   }, [assets, includeNoBalance, tokenFilter]);
 
-  // useTokenFiatRates crashes on non-hex addresses (Solana etc.), so we
-  // build requests for EVM assets only. Non-EVM assets are handled below in
-  // the render memo by falling back to `asset.fiat.balance`.
   const fiatRateRequests = useMemo<TokenFiatRateRequest[]>(
     () =>
       assetsWithBalance
-        .filter((asset) => asset.chainId && !isNonEvmChainId(asset.chainId))
-        .map((asset) => ({
-          address: asset.address as Hex,
-          chainId: asset.chainId as Hex,
-          currency: fiatCurrency.toLowerCase(),
-        })),
+        .filter(isEvmRateEligible)
+        .map((asset) => buildFiatRateRequest(asset, fiatCurrency)),
     [assetsWithBalance, fiatCurrency],
   );
 
@@ -146,38 +116,30 @@ export function useAccountTokens({
       Boolean(chainId) &&
       isNetworkTestnet(chainId as string);
 
-    // EVM assets use the useTokenFiatRates-derived rate (picks up stablecoin
-    // bypass, and lets us convert to USD in pay flow). Non-EVM assets fall
-    // back to the assets-controller's preferred-currency `fiat.balance`,
-    // which is the pre-existing behavior for Solana/Bitcoin/etc.
-    // EVM assets and rates are in lockstep — both arrays derived from the
-    // same predicate over the same list, so a single index walk pairs them.
+    const sortableFiatByAsset = new WeakMap<AssetType, BigNumber>();
     let evmIndex = 0;
     const processedAssets = assetsWithBalance.map((asset) => {
-      const isEvm = asset.chainId && !isNonEvmChainId(asset.chainId);
-      const rate = isEvm ? fiatRates[evmIndex++] : undefined;
-
-      let fiatAmount: BigNumber.Value | undefined;
-      if (isFiatHidden(asset.chainId)) {
-        fiatAmount = undefined;
-      } else if (isEvm) {
-        fiatAmount =
-          rate !== undefined && asset.balance
-            ? new BigNumber(asset.balance).multipliedBy(rate)
-            : undefined;
-      } else {
-        fiatAmount = asset.fiat?.balance;
-      }
+      const rate = isEvmRateEligible(asset) ? fiatRates[evmIndex++] : undefined;
+      const fiatAmount = deriveAssetFiat(
+        asset,
+        rate,
+        isFiatHidden(asset.chainId),
+      );
 
       const balanceInSelectedCurrency =
         fiatAmount !== undefined ? formatFiat(fiatAmount) : undefined;
 
-      return {
+      const processed = {
         ...asset,
         networkBadgeSource: getNetworkBadgeSource(asset.chainId as Hex),
         balanceInSelectedCurrency,
         standard: TokenStandard.ERC20 as const,
       } as AssetType;
+
+      if (fiatAmount !== undefined) {
+        sortableFiatByAsset.set(processed, fiatAmount);
+      }
+      return processed;
     });
 
     if (enrichTokenRequests.length > 0) {
@@ -218,10 +180,16 @@ export function useAccountTokens({
       }
     }
 
-    const sortableFiatBalance = (asset: AssetType) =>
-      isFiatHidden(asset.chainId)
-        ? new BigNumber(0)
-        : new BigNumber(asset.fiat?.balance || 0);
+    // Sort by the same fiat we display. Falls back to the assets-controller
+    // preferred-currency balance for tokens that have no derived fiat (e.g.
+    // enrichment placeholders added below with `zeroFiat`), so unknown
+    // tokens sink to the bottom.
+    const sortableFiatBalance = (asset: AssetType) => {
+      if (isFiatHidden(asset.chainId)) return new BigNumber(0);
+      const derived = sortableFiatByAsset.get(asset);
+      if (derived !== undefined) return derived;
+      return new BigNumber(asset.fiat?.balance || 0);
+    };
 
     return processedAssets.sort(
       (a, b) => sortableFiatBalance(b).comparedTo(sortableFiatBalance(a)) || 0,
@@ -235,4 +203,84 @@ export function useAccountTokens({
     formatFiat,
     fiatRates,
   ]) as unknown as AssetType[];
+}
+
+function useAccountGroupAssets(accountAddress?: string | null) {
+  const internalAccountsById = useSelector(selectInternalAccountsById);
+  const accountToGroupMap = useSelector(selectAccountToGroupMap);
+
+  const accountGroupId = useMemo(() => {
+    if (!accountAddress) return undefined;
+    const internalAccountId = Object.keys(internalAccountsById).find(
+      (id) =>
+        internalAccountsById[id].address.toLowerCase() ===
+        accountAddress.toLowerCase(),
+    );
+    if (!internalAccountId) return undefined;
+    return accountToGroupMap[internalAccountId]?.id;
+  }, [accountAddress, internalAccountsById, accountToGroupMap]);
+
+  const selectOverrideAssets = useCallback(
+    (state: RootState) => selectAssetsByAccountGroupId(state, accountGroupId),
+    [accountGroupId],
+  );
+
+  const overrideAssets = useSelector(selectOverrideAssets);
+  return accountGroupId ? overrideAssets : undefined;
+}
+
+/**
+ * Whether the asset is EVM-scoped with a hex address, i.e. eligible for
+ * `useTokenFiatRates` (which crashes on non-hex addresses like Solana).
+ * Non-EVM assets fall back to `asset.fiat.balance` in the render loop.
+ *
+ * This predicate is the single source of truth for the paired walks over
+ * `assetsWithBalance` — request build and rate consumption — so they cannot
+ * drift out of lockstep.
+ */
+function isEvmRateEligible(asset: Asset): boolean {
+  return (
+    Boolean(asset.chainId) &&
+    !isNonEvmChainId(asset.chainId) &&
+    'address' in asset &&
+    Boolean(asset.address)
+  );
+}
+
+function buildFiatRateRequest(
+  asset: Asset,
+  currency: string,
+): TokenFiatRateRequest {
+  return {
+    address: (asset as { address: Hex }).address,
+    chainId: asset.chainId as Hex,
+    currency: currency.toLowerCase(),
+  };
+}
+
+/**
+ * Fiat amount to display for a single asset, or `undefined` to hide.
+ *
+ * - Testnet-hidden → undefined.
+ * - EVM with rate → `balance * rate` (picks up stablecoin bypass).
+ * - EVM zero balance without rate → `0` (currency-invariant, avoids
+ * hiding `$0` rows when market data hasn't loaded).
+ * - EVM non-zero without rate → undefined (can't safely render).
+ * - Non-EVM → the assets-controller's preferred-currency `fiat.balance`.
+ */
+function deriveAssetFiat(
+  asset: Asset,
+  rate: number | undefined,
+  isFiatHidden: boolean,
+): BigNumber | undefined {
+  if (isFiatHidden) return undefined;
+
+  if (isEvmRateEligible(asset)) {
+    const balance = asset.balance ? new BigNumber(asset.balance) : undefined;
+    if (rate !== undefined && balance) return balance.multipliedBy(rate);
+    if (balance?.isZero()) return new BigNumber(0);
+    return undefined;
+  }
+
+  return asset.fiat?.balance ? new BigNumber(asset.fiat.balance) : undefined;
 }

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -10,18 +10,14 @@ import {
 import { selectInternalAccountsById } from '../../../../../selectors/accountsController';
 import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { isTestNet } from '../../../../../util/networks';
-import Logger from '../../../../../util/Logger';
-import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { selectShowFiatInTestnets } from '../../../../../selectors/settings';
-import I18n from '../../../../../../locales/i18n';
-import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { AssetType, TokenStandard } from '../../types/token';
 import { useTokensData } from '../../../../hooks/useTokensData/useTokensData';
 import { buildEvmCaip19AssetId } from '../../../../../util/multichain/buildEvmCaip19AssetId';
 import type { RootState } from '../../../../../reducers';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
-import { useTransactionPayCurrency } from '../pay/useTransactionPayCurrency';
+import { useAssetFiatFormatter } from '../pay/useAssetFiatFormatter';
 import { isNetworkTestnet } from './useNetworkFilter';
 
 export interface EnrichTokenRequest {
@@ -75,10 +71,8 @@ export function useAccountTokens({
     [accountOverride, accountAssets, globalAssets],
   );
 
-  const preferredCurrency = useSelector(selectCurrentCurrency);
-  const payCurrency = useTransactionPayCurrency();
-  const fiatCurrency = payCurrency ?? preferredCurrency;
   const showFiatOnTestnets = useSelector(selectShowFiatInTestnets);
+  const { format: formatFiat } = useAssetFiatFormatter();
 
   const assetIds = useMemo(
     () =>
@@ -130,24 +124,9 @@ export function useAccountTokens({
       isNetworkTestnet(chainId as string);
 
     const processedAssets = assetsWithBalance.map((asset) => {
-      const fiatAmount = new BigNumber(asset.fiat?.balance || 0);
-      const hasDecimals = !fiatAmount.isInteger();
-
-      let balanceInSelectedCurrency: string | undefined;
-      if (isFiatHidden(asset.chainId)) {
-        balanceInSelectedCurrency = undefined;
-      } else {
-        try {
-          balanceInSelectedCurrency = getIntlNumberFormatter(I18n.locale, {
-            style: 'currency',
-            currency: fiatCurrency,
-            minimumFractionDigits: hasDecimals ? 2 : 0,
-          }).format(fiatAmount.toFixed() as unknown as number);
-        } catch (error) {
-          Logger.error(error as Error);
-          balanceInSelectedCurrency = `${fiatAmount.toFixed()} ${fiatCurrency}`;
-        }
-      }
+      const balanceInSelectedCurrency = isFiatHidden(asset.chainId)
+        ? undefined
+        : formatFiat(asset.fiat?.balance, asset.chainId);
 
       return {
         ...asset,
@@ -158,16 +137,7 @@ export function useAccountTokens({
     });
 
     if (enrichTokenRequests.length > 0) {
-      let zeroFiat: string;
-      try {
-        zeroFiat = getIntlNumberFormatter(I18n.locale, {
-          style: 'currency',
-          currency: fiatCurrency,
-          minimumFractionDigits: 0,
-        }).format(0);
-      } catch {
-        zeroFiat = `0 ${fiatCurrency}`;
-      }
+      const zeroFiat = formatFiat(0, undefined) ?? '';
 
       const existingKeys = new Set(
         processedAssets.map(
@@ -215,11 +185,11 @@ export function useAccountTokens({
   }, [
     assets,
     includeNoBalance,
-    fiatCurrency,
     showFiatOnTestnets,
     tokenFilter,
     enrichTokenRequests,
     assetIds,
     tokensByAssetId,
+    formatFiat,
   ]) as unknown as AssetType[];
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Follow-up to #32631.

That PR fixed the *label* on pay-flow token amounts. It didn't fix the *value*: `asset.fiat.balance` comes from the assets-controller in the user's preferred currency (e.g. EUR), and `Intl.NumberFormat({ currency: 'USD' })` only changes the symbol — it doesn't convert. Result: EUR-preferred users saw their EUR magnitude next to a `$` symbol.

This PR converts the value instead of relabeling it, and encapsulates the pay-currency policy in a new hook.

**Changes**

- New `useAssetFiatFormatter` hook in [`hooks/pay/`](/app/components/Views/confirmations/hooks/pay/). Owns: reading pay currency, reading currency rates, re-scaling by `(native→USD) / (native→preferred)`, Intl formatting. Returns `undefined` when the target currency can't be safely computed (missing rate, missing chain config).
- `useAccountTokens` becomes currency-agnostic. Drops all pay-flow imports; calls `useAssetFiatFormatter` and forwards its output to `balanceInSelectedCurrency`. Public API and all 9 consumers unchanged.
- Zero balances short-circuit the conversion (0 is currency-invariant) so the enrichment `$0` placeholder always renders.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug that caused pay-flow token amounts (Perps, Predict, Money Account, mUSD) to be shown with a USD symbol but the user's preferred-currency numeric value, when the user's preferred currency was not USD.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A (follow-up to #32631)
Refs: #32631

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pay-flow confirmations convert token amounts to USD, not just relabel

  Background:
    Given the user has set their preferred fiat currency to EUR

  Scenario: Pay With modal shows USD-converted numeric values
    Given the user opens a Perps / Predict / Money / mUSD conversion confirmation
    When the user opens the "Pay with" modal
    Then every row shows a "$" prefix
    And the number is the USD equivalent (not the EUR magnitude)

  Scenario: musdClaim keeps the user's preferred currency
    Given the user opens an mUSD claim confirmation
    Then token amounts render in EUR

  Scenario: Regular Send flow is unaffected
    Given the user opens the regular Send flow
    Then token amounts render in EUR

  Scenario: Preferred currency already USD
    Given the user has set their preferred currency to USD
    When the user opens any pay-flow confirmation
    Then amounts render exactly as before this PR

  Scenario: Missing USD rate for a chain
    Given a token on a chain whose usdConversionRate has not loaded
    When the user opens a pay-flow confirmation
    Then that row shows no fiat value (rather than a wrong-currency value)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — visible symptom is the `$` prefix on a preferred-currency numeric value. Device recording will be attached with QA build.

### **After**


https://github.com/user-attachments/assets/7913f4e7-5e91-4e07-ba78-965a26836482



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how fiat amounts are computed and sorted in send/pay token lists; wrong rates or eligibility bugs could show incorrect USD values or hide balances, though missing-rate cases are explicitly guarded.
> 
> **Overview**
> Fixes pay-flow token rows showing a **USD symbol** while still using the **preferred-currency magnitude** from `asset.fiat.balance` by **computing EVM fiat as `balance × rate`** (via `useTokenFiatRates` with the active display currency) instead of formatting the assets-controller fiat field directly.
> 
> Adds **`useAssetFiatFormatter`**, which picks **pay-flow USD** vs **user preferred currency** (through `useTransactionPayCurrency`) and handles **Intl currency formatting** only; rate selection stays in `useTokenFiatRates`.
> 
> **`useAccountTokens`** delegates display formatting to that hook, builds rate requests only for **EVM hex-address** assets (non-EVM still uses `fiat.balance`), sorts by the **same derived fiat** shown in the UI, and keeps **$0** visible for zero balances when rates are missing while **hiding** non-zero rows without a rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad7b830e2af4bbbd1eacadbbe28711482a95e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->