### PR TITLE
test(onboarding): add fresh SRP wallet performance coverage

### DIFF
--- a/tests/page-objects/Notifications/PushNotificationOnboardingView.ts
+++ b/tests/page-objects/Notifications/PushNotificationOnboardingView.ts
@@ -1,0 +1,40 @@
+import { NewUserSheetSelectorsIDs } from '../../../app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.testIds';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+  Matchers,
+  PlaywrightMatchers,
+  UnifiedGestures,
+} from '../../framework';
+
+class PushNotificationOnboardingView {
+  get title(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(NewUserSheetSelectorsIDs.TITLE),
+      appium: () =>
+        PlaywrightMatchers.getElementById(NewUserSheetSelectorsIDs.TITLE, {
+          exact: true,
+        }),
+    });
+  }
+
+  get notNowButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(NewUserSheetSelectorsIDs.BUTTON_NOT_NOW),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          NewUserSheetSelectorsIDs.BUTTON_NOT_NOW,
+          { exact: true },
+        ),
+    });
+  }
+
+  async tapNotNowButton(): Promise<void> {
+    await UnifiedGestures.waitAndTap(this.notNowButton, {
+      description: 'Push Notification Onboarding Not Now Button',
+    });
+  }
+}
+
+export default new PushNotificationOnboardingView();

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -29,11 +29,17 @@ import {
   System,
 } from '../../tags.performance.js';
 
-type PostOnboardingDestination =
-  | 'interest-questionnaire'
-  | 'push-notification'
-  | 'predict-modal'
-  | 'wallet';
+// Single source of truth for post-onboarding destinations. The count is used
+// as the loop safety cap so adding a new destination automatically extends
+// the cap.
+const POST_ONBOARDING_DESTINATIONS = [
+  'interest-questionnaire',
+  'push-notification',
+  'predict-modal',
+  'wallet',
+] as const;
+
+type PostOnboardingDestination = (typeof POST_ONBOARDING_DESTINATIONS)[number];
 
 type PostOnboardingSource =
   | 'metametrics'
@@ -229,6 +235,12 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         );
       });
 
+      // Note: `IMPORT_SEED_BUTTON` is the testID name, but the underlying
+      // component (app/components/Views/OnboardingSheet/index.tsx) toggles
+      // its behavior on the `createWallet` prop. Because we entered via
+      // "Create a new wallet", tapping this button fires `onPressCreate` and
+      // navigates to ChoosePassword — i.e. it starts a fresh SRP creation,
+      // not an import. The Page Object method name mirrors the testID.
       await OnboardingSheet.tapImportSeedButton();
       await passwordScreenTimer.measure(async () => {
         await CreatePasswordView.isVisible();
@@ -272,17 +284,23 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       const postOnboardingTimers: TimerHelper[] = [];
       let source: PostOnboardingSource = 'metametrics';
       const dismissedDestinations = new Set<PostOnboardingDestination>();
-      let step = 1;
+      let destination: PostOnboardingDestination | undefined;
 
       await MetaMetricsOptInView.tapAgreeButton();
 
-      while (step <= 4) {
+      // Safety cap derived from POST_ONBOARDING_DESTINATIONS so adding a
+      // new destination extends the cap automatically.
+      for (
+        let hop = 1;
+        hop <= POST_ONBOARDING_DESTINATIONS.length && destination !== 'wallet';
+        hop += 1
+      ) {
         const transitionTimer = new TimerHelper(
-          `Fresh SRP post-onboarding transition ${step}`,
+          `Fresh SRP post-onboarding transition ${hop}`,
           POST_ONBOARDING_THRESHOLD,
           currentDeviceDetails.platform,
         );
-        const destination = await measurePostOnboardingDestination(
+        destination = await measurePostOnboardingDestination(
           appDriver,
           transitionTimer,
           dismissedDestinations,
@@ -300,14 +318,15 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await dismissPostOnboardingDestination(destination);
         dismissedDestinations.add(destination);
         source = destination;
-        step += 1;
       }
 
-      if (postOnboardingTimers.length === 4) {
-        const lastTimer = postOnboardingTimers.at(-1);
-        if (!lastTimer?.id.includes('usable wallet')) {
-          throw new Error('Usable wallet was not reached after onboarding');
-        }
+      // Assert on the resolved destination, not on the timer count or label
+      // string — the loop must reach the usable wallet regardless of how many
+      // post-onboarding prompts appeared along the way.
+      if (destination !== 'wallet') {
+        throw new Error(
+          `Fresh SRP onboarding did not reach the usable wallet after ${postOnboardingTimers.length} post-onboarding transition(s)`,
+        );
       }
 
       performanceTracker.addTimers(...postOnboardingTimers);

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -1,0 +1,311 @@
+import { test as perfTest } from '../../framework/fixtures/playwright';
+import {
+  addOverhead,
+  asPlaywrightElement,
+  isOverheadTrackingActive,
+  PlaywrightAssertions,
+  PlaywrightGestures,
+  PlaywrightMatchers,
+} from '../../framework';
+import { OnboardingInterestQuestionnaireTestIds } from '../../../app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds';
+import { NewUserSheetSelectorsIDs } from '../../../app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.testIds';
+import { PREDICT_GTM_MODAL_TEST_IDS } from '../../../app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.testIds';
+import { WalletViewSelectorsIDs } from '../../../app/components/Views/Wallet/WalletView.testIds';
+import TimerHelper, {
+  type PlatformThreshold,
+} from '../../framework/TimerHelper';
+import { getPasswordForScenario } from '../../framework/utils/TestConstants.js';
+import OnboardingView from '../../page-objects/Onboarding/OnboardingView';
+import OnboardingSheet from '../../page-objects/Onboarding/OnboardingSheet';
+import CreatePasswordView from '../../page-objects/Onboarding/CreatePasswordView';
+import ProtectYourWalletView from '../../page-objects/Onboarding/ProtectYourWalletView';
+import MetaMetricsOptInView from '../../page-objects/Onboarding/MetaMetricsOptInView';
+import OnboardingInterestQuestionnaireView from '../../page-objects/Onboarding/OnboardingInterestQuestionnaireView';
+import PushNotificationOnboardingView from '../../page-objects/Notifications/PushNotificationOnboardingView';
+import PredictModalView from '../../page-objects/Predict/PredictModalView';
+import {
+  Performance,
+  PerformanceOnboarding,
+  System,
+} from '../../tags.performance.js';
+
+type PostOnboardingDestination =
+  | 'interest-questionnaire'
+  | 'push-notification'
+  | 'predict-modal'
+  | 'wallet';
+
+type PostOnboardingSource =
+  | 'metametrics'
+  | Exclude<PostOnboardingDestination, 'wallet'>;
+
+const POST_ONBOARDING_THRESHOLD: PlatformThreshold = {
+  ios: 5_000,
+  android: 5_000,
+};
+
+const POST_ONBOARDING_DESTINATION_LABELS: Record<
+  PostOnboardingDestination,
+  string
+> = {
+  'interest-questionnaire': 'onboarding interest questionnaire',
+  'push-notification': 'push notification sheet',
+  'predict-modal': 'Predict onboarding sheet',
+  wallet: 'usable wallet',
+};
+
+const POST_ONBOARDING_SOURCE_LABELS: Record<PostOnboardingSource, string> = {
+  metametrics: '"Agree" on MetaMetrics',
+  'interest-questionnaire': '"Skip" on the onboarding interest questionnaire',
+  'push-notification': '"Not now" on the push notification sheet',
+  'predict-modal': '"Not now" on the Predict onboarding sheet',
+};
+
+const waitForPostOnboardingDestination = async (
+  appDriver: WebdriverIO.Browser,
+  dismissedDestinations: ReadonlySet<PostOnboardingDestination>,
+): Promise<PostOnboardingDestination> => {
+  const candidates: {
+    destination: PostOnboardingDestination;
+    marker: string;
+    getElement: () => ReturnType<typeof asPlaywrightElement>;
+  }[] = [
+    {
+      destination: 'interest-questionnaire',
+      marker: OnboardingInterestQuestionnaireTestIds.SKIP_BUTTON,
+      getElement: () =>
+        asPlaywrightElement(OnboardingInterestQuestionnaireView.skipButton),
+    },
+    {
+      destination: 'push-notification',
+      marker: NewUserSheetSelectorsIDs.TITLE,
+      getElement: () =>
+        asPlaywrightElement(PushNotificationOnboardingView.title),
+    },
+    {
+      destination: 'predict-modal',
+      marker: PREDICT_GTM_MODAL_TEST_IDS.NOT_NOW_BUTTON,
+      getElement: () => asPlaywrightElement(PredictModalView.notNowButton),
+    },
+    {
+      destination: 'wallet',
+      marker: WalletViewSelectorsIDs.WALLET_CONTAINER,
+      getElement: () =>
+        PlaywrightMatchers.getElementById(
+          WalletViewSelectorsIDs.WALLET_CONTAINER,
+          { exact: true },
+        ),
+    },
+  ];
+
+  let visibleCandidate: (typeof candidates)[number] | undefined;
+
+  await appDriver.waitUntil(
+    async () => {
+      const probeStartedAt = Date.now();
+      const pageSource = await appDriver.getPageSource();
+      visibleCandidate = candidates.find(
+        (candidate) =>
+          !dismissedDestinations.has(candidate.destination) &&
+          pageSource.includes(candidate.marker),
+      );
+
+      if (visibleCandidate) {
+        if (isOverheadTrackingActive()) {
+          addOverhead(Date.now() - probeStartedAt);
+        }
+        return true;
+      }
+
+      return false;
+    },
+    {
+      timeout: 30_000,
+      interval: 250,
+      timeoutMsg: 'No post-onboarding destination became visible',
+    },
+  );
+
+  const resolvedCandidate = visibleCandidate;
+  if (!resolvedCandidate) {
+    throw new Error('Post-onboarding destination was not resolved');
+  }
+
+  await PlaywrightAssertions.expectElementToBeVisible(
+    resolvedCandidate.getElement(),
+    {
+      description: `${POST_ONBOARDING_DESTINATION_LABELS[resolvedCandidate.destination]} should be visible`,
+    },
+  );
+
+  return resolvedCandidate.destination;
+};
+
+const measurePostOnboardingDestination = async (
+  appDriver: WebdriverIO.Browser,
+  timer: TimerHelper,
+  dismissedDestinations: ReadonlySet<PostOnboardingDestination>,
+): Promise<PostOnboardingDestination> => {
+  let destination: PostOnboardingDestination | undefined;
+
+  await timer.measure(async () => {
+    destination = await waitForPostOnboardingDestination(
+      appDriver,
+      dismissedDestinations,
+    );
+  });
+
+  if (!destination) {
+    throw new Error('Post-onboarding destination was not resolved');
+  }
+
+  return destination;
+};
+
+const dismissPostOnboardingDestination = async (
+  destination: Exclude<PostOnboardingDestination, 'wallet'>,
+): Promise<void> => {
+  switch (destination) {
+    case 'interest-questionnaire':
+      await OnboardingInterestQuestionnaireView.tapSkipButton();
+      break;
+    case 'push-notification':
+      await PushNotificationOnboardingView.tapNotNowButton();
+      break;
+    case 'predict-modal':
+      await PredictModalView.tapNotNowButton();
+      break;
+  }
+};
+
+/* TO-915: Fresh SRP wallet creation from onboarding to a usable wallet. */
+perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
+  perfTest(
+    'Fresh SRP wallet creation performance',
+    { tag: '@metamask-onboarding-team' },
+    async ({ currentDeviceDetails, driver: appDriver, performanceTracker }) => {
+      perfTest.setTimeout(10 * 60 * 1_000);
+
+      // These are conservative initial guardrails to calibrate against CI
+      // performance baselines once this coverage is running consistently.
+      const onboardingSheetTimer = new TimerHelper(
+        'Time since the user taps "Create a new wallet" until the onboarding sheet is visible',
+        { ios: 1_500, android: 1_800 },
+        currentDeviceDetails.platform,
+      );
+      const passwordScreenTimer = new TimerHelper(
+        'Time since the user selects SRP wallet creation until the password fields are visible',
+        { ios: 1_500, android: 2_000 },
+        currentDeviceDetails.platform,
+      );
+      const walletCreationTimer = new TimerHelper(
+        'Time since the user taps "Create Password" until the wallet backup screen is visible',
+        { ios: 5_000, android: 7_000 },
+        currentDeviceDetails.platform,
+      );
+      const backupSkipTimer = new TimerHelper(
+        'Time since the user taps "Remind me later" until the MetaMetrics screen is visible',
+        { ios: 2_000, android: 2_500 },
+        currentDeviceDetails.platform,
+      );
+
+      await PlaywrightAssertions.expectElementToBeVisible(
+        asPlaywrightElement(OnboardingView.newWalletButton),
+        {
+          timeout: 60_000,
+          description: 'Fresh-install onboarding screen should be ready',
+        },
+      );
+
+      await OnboardingView.tapCreateNewWalletButton();
+      await onboardingSheetTimer.measure(async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(OnboardingSheet.importSeedButton),
+        );
+      });
+
+      await OnboardingSheet.tapImportSeedButton();
+      await passwordScreenTimer.measure(async () => {
+        await CreatePasswordView.isVisible();
+      });
+
+      const password = getPasswordForScenario('onboarding') ?? '';
+      await CreatePasswordView.enterPassword(password);
+      await CreatePasswordView.reEnterPassword(password);
+      await PlaywrightGestures.hideKeyboard();
+      await CreatePasswordView.tapIUnderstandCheckBox();
+
+      await CreatePasswordView.tapCreatePasswordButton();
+      await walletCreationTimer.measure(async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(ProtectYourWalletView.remindMeLaterButton),
+          {
+            timeout: 30_000,
+            description: 'Wallet backup screen should be visible',
+          },
+        );
+      });
+
+      await ProtectYourWalletView.tapRemindMeLater();
+      await backupSkipTimer.measure(async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(MetaMetricsOptInView.screenTitle),
+          {
+            timeout: 30_000,
+            description: 'MetaMetrics screen should be visible',
+          },
+        );
+      });
+
+      performanceTracker.addTimers(
+        onboardingSheetTimer,
+        passwordScreenTimer,
+        walletCreationTimer,
+        backupSkipTimer,
+      );
+
+      const postOnboardingTimers: TimerHelper[] = [];
+      let source: PostOnboardingSource = 'metametrics';
+      const dismissedDestinations = new Set<PostOnboardingDestination>();
+      let step = 1;
+
+      await MetaMetricsOptInView.tapAgreeButton();
+
+      while (step <= 4) {
+        const transitionTimer = new TimerHelper(
+          `Fresh SRP post-onboarding transition ${step}`,
+          POST_ONBOARDING_THRESHOLD,
+          currentDeviceDetails.platform,
+        );
+        const destination = await measurePostOnboardingDestination(
+          appDriver,
+          transitionTimer,
+          dismissedDestinations,
+        );
+
+        transitionTimer.changeName(
+          `Time since the user taps ${POST_ONBOARDING_SOURCE_LABELS[source]} until ${POST_ONBOARDING_DESTINATION_LABELS[destination]} is visible`,
+        );
+        postOnboardingTimers.push(transitionTimer);
+
+        if (destination === 'wallet') {
+          break;
+        }
+
+        await dismissPostOnboardingDestination(destination);
+        dismissedDestinations.add(destination);
+        source = destination;
+        step += 1;
+      }
+
+      if (postOnboardingTimers.length === 4) {
+        const lastTimer = postOnboardingTimers.at(-1);
+        if (!lastTimer?.id.includes('usable wallet')) {
+          throw new Error('Usable wallet was not reached after onboarding');
+        }
+      }
+
+      performanceTracker.addTimers(...postOnboardingTimers);
+    },
+  );
+});

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -5,12 +5,12 @@ import {
   isOverheadTrackingActive,
   PlaywrightAssertions,
   PlaywrightGestures,
-  PlaywrightMatchers,
 } from '../../framework';
 import { OnboardingInterestQuestionnaireTestIds } from '../../../app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds';
 import { NewUserSheetSelectorsIDs } from '../../../app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.testIds';
 import { PREDICT_GTM_MODAL_TEST_IDS } from '../../../app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.testIds';
-import { WalletViewSelectorsIDs } from '../../../app/components/Views/Wallet/WalletView.testIds';
+import { TabBarSelectorIDs } from '../../../app/components/Nav/Main/TabBar.testIds';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import TimerHelper, {
   type PlatformThreshold,
 } from '../../framework/TimerHelper';
@@ -88,13 +88,12 @@ const waitForPostOnboardingDestination = async (
       getElement: () => asPlaywrightElement(PredictModalView.notNowButton),
     },
     {
+      // Wait on the tab-bar Wallet button (matches import-wallet.spec.ts) so
+      // the timer stops when the home experience is actually usable, not
+      // just when the wallet shell mounts.
       destination: 'wallet',
-      marker: WalletViewSelectorsIDs.WALLET_CONTAINER,
-      getElement: () =>
-        PlaywrightMatchers.getElementById(
-          WalletViewSelectorsIDs.WALLET_CONTAINER,
-          { exact: true },
-        ),
+      marker: TabBarSelectorIDs.WALLET,
+      getElement: () => asPlaywrightElement(TabBarComponent.tabBarWalletButton),
     },
   ];
 
@@ -104,20 +103,19 @@ const waitForPostOnboardingDestination = async (
     async () => {
       const probeStartedAt = Date.now();
       const pageSource = await appDriver.getPageSource();
+      // Every getPageSource poll is Appium round-trip work, not app work —
+      // account for the full probe so cumulative polling latency doesn't
+      // inflate the measured transition duration. The `waitForDisplayed`
+      // check below adds its own bounded probe on top.
+      if (isOverheadTrackingActive()) {
+        addOverhead(Date.now() - probeStartedAt);
+      }
       visibleCandidate = candidates.find(
         (candidate) =>
           !dismissedDestinations.has(candidate.destination) &&
           pageSource.includes(candidate.marker),
       );
-
-      if (visibleCandidate) {
-        if (isOverheadTrackingActive()) {
-          addOverhead(Date.now() - probeStartedAt);
-        }
-        return true;
-      }
-
-      return false;
+      return Boolean(visibleCandidate);
     },
     {
       timeout: 30_000,
@@ -131,12 +129,20 @@ const waitForPostOnboardingDestination = async (
     throw new Error('Post-onboarding destination was not resolved');
   }
 
+  // `pageSource.includes(marker)` matches any occurrence in the hierarchy —
+  // a mounted-but-covered route (e.g. Wallet behind a sheet) can win before
+  // the topmost sheet is dismissed. Assert the specific candidate element is
+  // actually displayed to guard against selecting a covered screen.
+  const displayedProbeStartedAt = Date.now();
   await PlaywrightAssertions.expectElementToBeVisible(
     resolvedCandidate.getElement(),
     {
       description: `${POST_ONBOARDING_DESTINATION_LABELS[resolvedCandidate.destination]} should be visible`,
     },
   );
+  if (isOverheadTrackingActive()) {
+    addOverhead(Date.now() - displayedProbeStartedAt);
+  }
 
   return resolvedCandidate.destination;
 };

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -133,16 +133,15 @@ const waitForPostOnboardingDestination = async (
   // a mounted-but-covered route (e.g. Wallet behind a sheet) can win before
   // the topmost sheet is dismissed. Assert the specific candidate element is
   // actually displayed to guard against selecting a covered screen.
-  const displayedProbeStartedAt = Date.now();
+  // Note: expectElementToBeVisible internally accounts for probe overhead
+  // where appropriate; do not wrap it in addOverhead here — that would also
+  // subtract legitimate UI-wait time and under-report the transition.
   await PlaywrightAssertions.expectElementToBeVisible(
     resolvedCandidate.getElement(),
     {
       description: `${POST_ONBOARDING_DESTINATION_LABELS[resolvedCandidate.destination]} should be visible`,
     },
   );
-  if (isOverheadTrackingActive()) {
-    addOverhead(Date.now() - displayedProbeStartedAt);
-  }
 
   return resolvedCandidate.destination;
 };


### PR DESCRIPTION
# test(onboarding): add fresh SRP wallet performance coverage

## **Description**

Adds Android performance coverage for the fresh Secret Recovery Phrase wallet creation path requested in TO-915.

The Appium test measures the key transitions from fresh onboarding through password creation, wallet backup, MetaMetrics, optional post-onboarding prompts, and arrival at a usable wallet. It also adds a unified page object for the push-notification onboarding prompt so the flow can handle feature-dependent post-onboarding destinations.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TO-915

## **Manual testing steps**

```gherkin
Feature: Fresh SRP wallet creation performance coverage

  Scenario: create a fresh SRP wallet from onboarding
    Given MetaMask Mobile is freshly installed with no existing wallet

    When the performance test creates a new SRP wallet
    And the user creates a password
    And the user postpones wallet backup
    And the user accepts MetaMetrics
    And the user dismisses any optional post-onboarding prompts
    Then the Wallet screen should become usable
    And each measured transition should remain within its Android threshold
```

Local validation: passed on Android emulator `Medium_Phone_API_36.1` using `app-prod-debug.apk`. The authoritative performance measurements will run on BrowserStack through PR CI.

## **Screenshots/Recordings**

### **Before**

N/A — automated performance coverage only.

### **After**

N/A — automated performance coverage only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Not applicable to fresh-wallet onboarding coverage.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - The performance framework records and attaches each `TimerHelper` measurement.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions (page object + performance spec); no production app logic, auth, or data handling changes.
> 
> **Overview**
> Adds **TO-915** performance coverage for creating a fresh SRP wallet from first launch through a usable Wallet tab, using `TimerHelper` guardrails on each major step (onboarding sheet, password, backup skip, MetaMetrics).
> 
> After MetaMetrics opt-in, a **post-onboarding loop** measures transitions to whichever optional prompts appear (interest questionnaire, push notification sheet, Predict GTM modal) and dismisses them until the tab-bar Wallet control is visible—using page-source markers plus a visibility check so covered routes don’t false-positive. Appium `getPageSource` polling overhead is subtracted where the performance framework supports it.
> 
> Introduces **`PushNotificationOnboardingView`** as a unified Detox/Appium page object (title + “Not now”) so the push-notification step can be automated in this flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c60e12e34f4b2511b2069fd475542d3186221742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->