### PR TITLE
fix: show preparation state for Money Account deposits cp-8.4.0

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -858,7 +858,7 @@ describe('CustomAmountInfo', () => {
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
 
-    it('shows amount-update loading state for non-Money transactions', async () => {
+    it('immediately closes keyboard and disables amount editing for non-Money transactions', async () => {
       const deferred = createDeferredPromise();
       useTransactionCustomAmountMock.mockReturnValue({
         ...useTransactionCustomAmountMock(),
@@ -869,6 +869,7 @@ describe('CustomAmountInfo', () => {
       fireEvent.press(getByTestId('deposit-keyboard-done-button'));
 
       expect(queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
+      expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
       expect(getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
 
       await act(async () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -30,6 +30,7 @@ import {
   useTransactionPayRequiredTokens,
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { strings } from '../../../../../../../locales/i18n';
@@ -289,6 +290,9 @@ describe('CustomAmountInfo', () => {
   );
 
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useTransactionPayQuotesLastUpdatedMock = jest.mocked(
+    useTransactionPayQuotesLastUpdated,
+  );
 
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
@@ -416,6 +420,7 @@ describe('CustomAmountInfo', () => {
     });
     useIsTransactionPayLoadingMock.mockReturnValue(false);
     useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesLastUpdatedMock.mockReturnValue(undefined);
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
     useTokenFiatRatesMock.mockReturnValue([1, 1]);
     useTransactionMetadataRequestMock.mockReturnValue({
@@ -755,18 +760,29 @@ describe('CustomAmountInfo', () => {
       ).toBeUndefined();
     });
 
-    it('clears local preparation when the amount update resolves', async () => {
+    it('keeps the loading review through the handoff to controller loading', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
 
-      useIsTransactionPayLoadingMock.mockReturnValue(true);
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
       });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
 
       expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
 
@@ -781,6 +797,67 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).not.toBeDisabled();
+    });
+
+    it('releases the loading review when a fast quote completes between renders', async () => {
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(123);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
+    it('ignores stale quote updates while the amount is still committing', async () => {
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(1);
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(2);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(3);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
     });
 
     it('keeps preparation active while the amount update is pending', async () => {
@@ -925,14 +1002,21 @@ describe('CustomAmountInfo', () => {
       onReject: jest.fn(),
     });
 
-    const { getByText } = render();
+    const view = render();
 
     await act(async () => {
-      fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+      fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
     });
 
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+    view.rerender(createCustomAmountInfo());
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+    view.rerender(createCustomAmountInfo());
+
     await act(async () => {
-      fireEvent.press(getByText(strings('confirm.deposit_edit_amount_done')));
+      fireEvent.press(
+        view.getByText(strings('confirm.deposit_edit_amount_done')),
+      );
     });
 
     expect(setIsConfirmationSubmittingMock).toHaveBeenCalledWith(true);
@@ -1425,22 +1509,25 @@ describe('CustomAmountInfo', () => {
   });
 
   describe('showPaymentDetails', () => {
-    async function pressDone(
-      getByText: ReturnType<typeof render>['getByText'],
-    ) {
+    async function pressDone(view: ReturnType<typeof render>) {
       await act(async () => {
-        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+        fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
       });
+
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(createCustomAmountInfo());
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+      view.rerender(createCustomAmountInfo());
     }
 
     it('shows fee rows for same-chain payment without quotes', async () => {
       useTransactionPayHasSourceAmountMock.mockReturnValue(false);
       useTransactionPayQuotesMock.mockReturnValue([]);
 
-      const { getByText, getByTestId } = render();
-      await pressDone(getByText);
+      const view = render();
+      await pressDone(view);
 
-      expect(getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
     });
 
     it('hides fee rows when no-quotes alert is present', async () => {
@@ -1458,20 +1545,20 @@ describe('CustomAmountInfo', () => {
         fieldAlerts: [] as Alert[],
       } as AlertsContextParams);
 
-      const { getByText, queryByTestId } = render();
-      await pressDone(getByText);
+      const view = render();
+      await pressDone(view);
 
-      expect(queryByTestId('bridge-fee-row')).toBeNull();
+      expect(view.queryByTestId('bridge-fee-row')).toBeNull();
     });
 
     it('shows fee rows when quotes exist regardless of source amount', async () => {
       useTransactionPayHasSourceAmountMock.mockReturnValue(true);
       useTransactionPayQuotesMock.mockReturnValue([{} as never]);
 
-      const { getByText, getByTestId } = render();
-      await pressDone(getByText);
+      const view = render();
+      await pressDone(view);
 
-      expect(getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -41,6 +41,7 @@ import { Platform } from 'react-native';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
 import { CustomAmountInfoTestIds } from './custom-amount-info.testIds';
+import { ConfirmationFooterSelectorIDs } from '../../../ConfirmationView.testIds';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { useTokenFiatRates } from '../../../hooks/tokens/useTokenFiatRates';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
@@ -208,37 +209,59 @@ const mockToastRef = {
   current: { showToast: mockShowToast, closeToast: jest.fn() },
 };
 
+interface DeferredPromise {
+  promise: Promise<void>;
+  reject: (reason?: unknown) => void;
+  resolve: () => void;
+}
+
+function createDeferredPromise(): DeferredPromise {
+  let reject: DeferredPromise['reject'] = noop;
+  let resolve: DeferredPromise['resolve'] = noop;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createCustomAmountInfo(
+  props: CustomAmountInfoProps & { transactionType?: TransactionType } = {},
+) {
+  return (
+    <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
+      <CustomAmountInfo {...props} />
+    </ToastContext.Provider>
+  );
+}
+
 function render(
   props: CustomAmountInfoProps & { transactionType?: TransactionType } = {},
 ) {
-  return renderWithProvider(
-    <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-      <CustomAmountInfo {...props} />
-    </ToastContext.Provider>,
-    {
-      state: merge(
-        {},
-        simpleSendTransactionControllerMock,
-        transactionApprovalControllerMock,
-        otherControllersMock,
-        {
-          engine: {
-            backgroundState: {
-              TransactionController: {
-                transactions: [
-                  {
-                    type:
-                      props.transactionType ||
-                      TransactionType.contractInteraction,
-                  },
-                ],
-              },
+  return renderWithProvider(createCustomAmountInfo(props), {
+    state: merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      otherControllersMock,
+      {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  type:
+                    props.transactionType ||
+                    TransactionType.contractInteraction,
+                },
+              ],
             },
           },
         },
-      ),
-    },
-  );
+      },
+    ),
+  });
 }
 
 describe('CustomAmountInfo', () => {
@@ -615,6 +638,160 @@ describe('CustomAmountInfo', () => {
     expect(
       queryByText(new RegExp(strings('confirm.label.pay_with'))),
     ).toBeOnTheScreen();
+  });
+
+  describe('Money Account quote preparation', () => {
+    function arrangePendingPreparation() {
+      const deferred = createDeferredPromise();
+      const updateTokenAmount = jest.fn(() => deferred.promise);
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: 'money-account-deposit-transaction',
+        type: TransactionType.moneyAccountDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+      useTransactionCustomAmountMock.mockReturnValue({
+        ...useTransactionCustomAmountMock(),
+        updateTokenAmount,
+      });
+
+      return { deferred, updateTokenAmount };
+    }
+
+    it('replaces the keypad with preparation feedback before the amount update resolves', () => {
+      arrangePendingPreparation();
+      const { getByTestId, getByText, queryByTestId } = render({
+        supportAccountSelection: true,
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      fireEvent.press(getByTestId('deposit-keyboard-done-button'));
+
+      expect(queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
+      expect(getByTestId('pay-account-selector')).toBeOnTheScreen();
+      expect(getByTestId('pay-with')).toBeOnTheScreen();
+      expect(
+        getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+      expect(getByText(strings('confirm.preparing_order'))).toBeOnTheScreen();
+      expect(getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(getByTestId('bridge-time-row-skeleton')).toBeOnTheScreen();
+      expect(getByTestId('total-row-skeleton')).toBeOnTheScreen();
+    });
+
+    it('blocks review rows, amount editing, and duplicate submission during preparation', () => {
+      const { updateTokenAmount } = arrangePendingPreparation();
+      const { getByTestId } = render({
+        supportAccountSelection: true,
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      const doneButton = getByTestId('deposit-keyboard-done-button');
+
+      act(() => {
+        fireEvent.press(doneButton);
+        fireEvent.press(doneButton);
+      });
+
+      expect(updateTokenAmount).toHaveBeenCalledTimes(1);
+      expect(
+        getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props.pointerEvents,
+      ).toBe('none');
+      expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
+    });
+
+    it('keeps preparation feedback between amount preparation and quote loading', async () => {
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(view.queryByTestId('bridge-fee-row')).not.toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+    });
+
+    it('shows the populated post-keypad state after quote loading settles', async () => {
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+      expect(view.queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
+    });
+
+    it('restores amount entry and the existing toast after preparation fails', async () => {
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      await act(async () => {
+        deferred.reject(new Error('update failed'));
+        await Promise.resolve();
+      });
+
+      expect(view.getByTestId('deposit-keyboard')).toBeOnTheScreen();
+      expect(view.getByTestId('custom-amount-input').props.onPress).toEqual(
+        expect.any(Function),
+      );
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('retains the existing pending amount UI for non-Money transactions', () => {
+      const deferred = createDeferredPromise();
+      useTransactionCustomAmountMock.mockReturnValue({
+        ...useTransactionCustomAmountMock(),
+        updateTokenAmount: jest.fn(() => deferred.promise),
+      });
+      const { getByTestId, queryByTestId } = render();
+
+      fireEvent.press(getByTestId('deposit-keyboard-done-button'));
+
+      expect(getByTestId('deposit-keyboard')).toBeOnTheScreen();
+      expect(queryByTestId('bridge-fee-row-skeleton')).not.toBeOnTheScreen();
+    });
   });
 
   it('calls onAmountSubmit when Done button is pressed', async () => {
@@ -1305,15 +1482,29 @@ describe('CustomAmountInfo', () => {
         onReject: jest.fn(),
       });
 
-      const { getByText } = render({
+      const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
 
       await act(async () => {
-        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+        fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
       });
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
       await act(async () => {
-        fireEvent.press(getByText(strings('confirm.deposit_edit_amount_done')));
+        fireEvent.press(
+          view.getByText(strings('confirm.deposit_edit_amount_done')),
+        );
       });
 
       // Mount-time screen-viewed + three reactive + two imperative CTA events,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -659,7 +659,7 @@ describe('CustomAmountInfo', () => {
 
     it('replaces the keypad with preparation feedback before the amount update resolves', () => {
       arrangePendingPreparation();
-      const { getByTestId, getByText, queryByTestId } = render({
+      const { getByTestId, getByText, queryByTestId, queryByText } = render({
         supportAccountSelection: true,
         transactionType: TransactionType.moneyAccountDeposit,
       });
@@ -672,7 +672,12 @@ describe('CustomAmountInfo', () => {
       expect(
         getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).toBeDisabled();
-      expect(getByText(strings('confirm.preparing_order'))).toBeOnTheScreen();
+      expect(
+        getByText(strings('confirm.deposit_edit_amount_done')),
+      ).toBeOnTheScreen();
+      expect(
+        queryByText(strings('confirm.preparing_order')),
+      ).not.toBeOnTheScreen();
       expect(getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
       expect(getByTestId('bridge-time-row-skeleton')).toBeOnTheScreen();
       expect(getByTestId('total-row-skeleton')).toBeOnTheScreen();
@@ -698,7 +703,7 @@ describe('CustomAmountInfo', () => {
       expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
     });
 
-    it('keeps preparation feedback throughout quote loading', async () => {
+    it('keeps the loading review throughout quote loading', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
@@ -728,8 +733,11 @@ describe('CustomAmountInfo', () => {
         view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).toBeDisabled();
       expect(
-        view.getByText(strings('confirm.preparing_order')),
+        view.getByText(strings('confirm.deposit_edit_amount_done')),
       ).toBeOnTheScreen();
+      expect(
+        view.queryByText(strings('confirm.preparing_order')),
+      ).not.toBeOnTheScreen();
       expect(
         view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
           .pointerEvents,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -51,6 +51,7 @@ import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePa
 import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
+import { mockTheme } from '../../../../../../util/theme';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 jest.mock('../../../hooks/ui/useMMPayNavigation');
@@ -701,6 +702,22 @@ describe('CustomAmountInfo', () => {
         getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props.pointerEvents,
       ).toBe('none');
       expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
+    });
+
+    it('keeps the amount visually enabled during preparation', () => {
+      arrangePendingPreparation();
+      const { getByTestId } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      fireEvent.press(getByTestId('deposit-keyboard-done-button'));
+
+      expect(getByTestId('custom-amount-input')).toHaveStyle({
+        color: mockTheme.colors.text.default,
+      });
+      expect(getByTestId('custom-amount-symbol')).toHaveStyle({
+        color: mockTheme.colors.text.default,
+      });
     });
 
     it('keeps the loading review throughout quote loading', async () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -697,6 +697,8 @@ describe('CustomAmountInfo', () => {
         fireEvent.press(doneButton);
       });
 
+      // Both presses occur before React rerenders, so the synchronous guard
+      // must prevent the second amount update.
       expect(updateTokenAmount).toHaveBeenCalledTimes(1);
       expect(
         getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props.pointerEvents,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -858,7 +858,7 @@ describe('CustomAmountInfo', () => {
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
 
-    it('retains the existing pending amount UI for non-Money transactions', () => {
+    it('shows amount-update loading state for non-Money transactions', async () => {
       const deferred = createDeferredPromise();
       useTransactionCustomAmountMock.mockReturnValue({
         ...useTransactionCustomAmountMock(),
@@ -868,8 +868,13 @@ describe('CustomAmountInfo', () => {
 
       fireEvent.press(getByTestId('deposit-keyboard-done-button'));
 
-      expect(getByTestId('deposit-keyboard')).toBeOnTheScreen();
-      expect(queryByTestId('bridge-fee-row-skeleton')).not.toBeOnTheScreen();
+      expect(queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
+      expect(getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
     });
   });
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -95,9 +95,19 @@ jest.mock('../../rows/predict-account-picker-row', () => ({
 }));
 jest.mock('../../../../../../util/transaction-controller', () => ({}));
 
+const mockTransactionPayControllerState = {
+  transactionData: {} as Record<
+    string,
+    { isLoading?: boolean; quotesLastUpdated?: number }
+  >,
+};
+
 jest.mock('../../../../../../core/Engine', () => ({
   context: {
     TransactionPayController: {
+      get state() {
+        return mockTransactionPayControllerState;
+      },
       updateFiatPayment: jest.fn(),
     },
     TransactionController: {
@@ -330,6 +340,7 @@ describe('CustomAmountInfo', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockShowToast.mockReset();
+    mockTransactionPayControllerState.transactionData = {};
 
     mockUseRampsUserRegion.mockReturnValue({
       userRegion: { regionCode: 'us-ca' },
@@ -647,11 +658,26 @@ describe('CustomAmountInfo', () => {
   });
 
   describe('Money Account quote preparation', () => {
+    const transactionId = 'money-account-deposit-transaction';
+
+    function setControllerTransactionData({
+      isLoading,
+      quotesLastUpdated,
+    }: {
+      isLoading: boolean;
+      quotesLastUpdated?: number;
+    }) {
+      mockTransactionPayControllerState.transactionData[transactionId] = {
+        isLoading,
+        quotesLastUpdated,
+      };
+    }
+
     function arrangePendingPreparation() {
       const deferred = createDeferredPromise();
       const updateTokenAmount = jest.fn(() => deferred.promise);
       useTransactionMetadataRequestMock.mockReturnValue({
-        id: 'money-account-deposit-transaction',
+        id: transactionId,
         type: TransactionType.moneyAccountDeposit,
         txParams: { from: '0x123' },
       } as never);
@@ -734,6 +760,7 @@ describe('CustomAmountInfo', () => {
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
 
+      setControllerTransactionData({ isLoading: true });
       useIsTransactionPayLoadingMock.mockReturnValue(true);
       await act(async () => {
         deferred.resolve();
@@ -760,12 +787,13 @@ describe('CustomAmountInfo', () => {
       ).toBeUndefined();
     });
 
-    it('keeps the loading review through the handoff to controller loading', async () => {
+    it('keeps the loading review until Redux observes controller loading', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      setControllerTransactionData({ isLoading: true });
 
       await act(async () => {
         deferred.resolve();
@@ -799,12 +827,16 @@ describe('CustomAmountInfo', () => {
       ).not.toBeDisabled();
     });
 
-    it('releases the loading review when a fast quote completes between renders', async () => {
+    it('keeps the loading review until Redux observes a fast completed quote', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      setControllerTransactionData({
+        isLoading: false,
+        quotesLastUpdated: 123,
+      });
 
       await act(async () => {
         deferred.resolve();
@@ -843,6 +875,10 @@ describe('CustomAmountInfo', () => {
 
       expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
 
+      setControllerTransactionData({
+        isLoading: true,
+        quotesLastUpdated: 2,
+      });
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
@@ -891,6 +927,7 @@ describe('CustomAmountInfo', () => {
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      setControllerTransactionData({ isLoading: true });
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
@@ -935,24 +972,46 @@ describe('CustomAmountInfo', () => {
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
 
-    it('immediately closes keyboard and disables amount editing for non-Money transactions', async () => {
+    it('keeps the universal loading review until Redux observes controller loading', async () => {
       const deferred = createDeferredPromise();
+      const nonMoneyTransactionId = 'non-money-transaction';
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: nonMoneyTransactionId,
+        type: TransactionType.contractInteraction,
+        txParams: { from: '0x123' },
+      } as never);
       useTransactionCustomAmountMock.mockReturnValue({
         ...useTransactionCustomAmountMock(),
         updateTokenAmount: jest.fn(() => deferred.promise),
       });
-      const { getByTestId, queryByTestId } = render();
+      const view = render();
 
-      fireEvent.press(getByTestId('deposit-keyboard-done-button'));
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
 
-      expect(queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
-      expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
-      expect(getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(view.queryByTestId('deposit-keyboard')).not.toBeOnTheScreen();
+      expect(
+        view.getByTestId('custom-amount-input').props.onPress,
+      ).toBeUndefined();
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
 
+      mockTransactionPayControllerState.transactionData[nonMoneyTransactionId] =
+        { isLoading: true };
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
       });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      view.rerender(createCustomAmountInfo());
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
+      view.rerender(createCustomAmountInfo());
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
     });
   });
 
@@ -1520,14 +1579,11 @@ describe('CustomAmountInfo', () => {
       view.rerender(createCustomAmountInfo());
     }
 
-    it('clears the handoff for synchronous updates without quote signals', async () => {
+    it('clears the handoff immediately for synchronous updates without quote signals', async () => {
       const view = render();
 
       await act(async () => {
         fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
-      });
-      await act(async () => {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
       });
 
       expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -29,9 +29,7 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayRequiredTokens,
   useIsTransactionPayLoading,
-  useIsTransactionPayQuoteLoading,
   useTransactionPayQuotes,
-  useTransactionPayQuotesLastUpdated,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { strings } from '../../../../../../../locales/i18n';
@@ -290,14 +288,7 @@ describe('CustomAmountInfo', () => {
     useIsTransactionPayLoading,
   );
 
-  const useIsTransactionPayQuoteLoadingMock = jest.mocked(
-    useIsTransactionPayQuoteLoading,
-  );
-
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
-  const useTransactionPayQuotesLastUpdatedMock = jest.mocked(
-    useTransactionPayQuotesLastUpdated,
-  );
 
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
@@ -424,9 +415,7 @@ describe('CustomAmountInfo', () => {
       onReject: jest.fn(),
     });
     useIsTransactionPayLoadingMock.mockReturnValue(false);
-    useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
     useTransactionPayQuotesMock.mockReturnValue([]);
-    useTransactionPayQuotesLastUpdatedMock.mockReturnValue(undefined);
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
     useTokenFiatRatesMock.mockReturnValue([1, 1]);
     useTransactionMetadataRequestMock.mockReturnValue({
@@ -738,6 +727,7 @@ describe('CustomAmountInfo', () => {
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
 
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
@@ -745,19 +735,6 @@ describe('CustomAmountInfo', () => {
 
       expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
       expect(view.queryByTestId('bridge-fee-row')).not.toBeOnTheScreen();
-      expect(
-        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
-      ).toBeDisabled();
-
-      useIsTransactionPayLoadingMock.mockReturnValue(true);
-      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
-      view.rerender(
-        createCustomAmountInfo({
-          transactionType: TransactionType.moneyAccountDeposit,
-        }),
-      );
-
-      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
       expect(
         view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).toBeDisabled();
@@ -776,18 +753,22 @@ describe('CustomAmountInfo', () => {
       ).toBeUndefined();
     });
 
-    it('releases the loading review when quote loading completes between renders', async () => {
+    it('clears local preparation when the amount update resolves', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
       await act(async () => {
         deferred.resolve();
         await deferred.promise;
       });
 
-      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(123);
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      useIsTransactionPayLoadingMock.mockReturnValue(false);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -800,15 +781,14 @@ describe('CustomAmountInfo', () => {
       ).not.toBeDisabled();
     });
 
-    it('ignores a stale quote update while the amount is still being committed', async () => {
-      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(1);
+    it('keeps preparation active while the amount update is pending', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
       });
       fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
 
-      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(2);
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -824,20 +804,6 @@ describe('CustomAmountInfo', () => {
         deferred.resolve();
         await deferred.promise;
       });
-
-      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
-
-      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(3);
-      view.rerender(
-        createCustomAmountInfo({
-          transactionType: TransactionType.moneyAccountDeposit,
-        }),
-      );
-
-      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
-      expect(
-        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
-      ).not.toBeDisabled();
     });
 
     it('shows the populated post-keypad state after quote loading settles', async () => {
@@ -851,7 +817,6 @@ describe('CustomAmountInfo', () => {
         await deferred.promise;
       });
       useIsTransactionPayLoadingMock.mockReturnValue(true);
-      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -859,7 +824,6 @@ describe('CustomAmountInfo', () => {
       );
 
       useIsTransactionPayLoadingMock.mockReturnValue(false);
-      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -1603,14 +1567,12 @@ describe('CustomAmountInfo', () => {
         fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
       });
       useIsTransactionPayLoadingMock.mockReturnValue(true);
-      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
         }),
       );
       useIsTransactionPayLoadingMock.mockReturnValue(false);
-      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -681,6 +681,7 @@ describe('CustomAmountInfo', () => {
         type: TransactionType.moneyAccountDeposit,
         txParams: { from: '0x123' },
       } as never);
+      setControllerTransactions([{ id: transactionId }]);
       useTransactionCustomAmountMock.mockReturnValue({
         ...useTransactionCustomAmountMock(),
         updateTokenAmount,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -800,6 +800,46 @@ describe('CustomAmountInfo', () => {
       ).not.toBeDisabled();
     });
 
+    it('ignores a stale quote update while the amount is still being committed', async () => {
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(1);
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(2);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(3);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
     it('shows the populated post-keypad state after quote loading settles', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -965,7 +965,7 @@ describe('CustomAmountInfo', () => {
       updateTokenAmount: updateTokenAmountMock,
     });
 
-    const { getByText, queryByText } = render({
+    const { getByText, queryByText, getByTestId } = render({
       onAmountSubmit: mockOnAmountSubmit,
     });
 
@@ -981,8 +981,11 @@ describe('CustomAmountInfo', () => {
     expect(mockShowToast).toHaveBeenCalledWith(
       expect.objectContaining({ labelOptions: expect.any(Array) }),
     );
-    // Keyboard stays open: Done button still present
+    // Keyboard stays open: Done button and amount editing remain available.
     expect(queryByText(strings('confirm.edit_amount_done'))).toBeOnTheScreen();
+    expect(getByTestId('custom-amount-input').props.onPress).toEqual(
+      expect.any(Function),
+    );
   });
 
   it('does not show toast when the transaction was removed before updateTokenAmount rejects', async () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -828,6 +828,38 @@ describe('CustomAmountInfo', () => {
       ).not.toBeDisabled();
     });
 
+    it('ignores a stale Redux quote timestamp during controller loading handoff', async () => {
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(100);
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      setControllerTransactionData({ isLoading: true });
+
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).toBeDisabled();
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(101);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
     it('keeps the loading review until Redux observes a fast completed quote', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -698,7 +698,7 @@ describe('CustomAmountInfo', () => {
       expect(getByTestId('custom-amount-input').props.onPress).toBeUndefined();
     });
 
-    it('keeps preparation feedback between amount preparation and quote loading', async () => {
+    it('keeps preparation feedback throughout quote loading', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
@@ -727,6 +727,16 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).toBeDisabled();
+      expect(
+        view.getByText(strings('confirm.preparing_order')),
+      ).toBeOnTheScreen();
+      expect(
+        view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
+          .pointerEvents,
+      ).toBe('none');
+      expect(
+        view.getByTestId('custom-amount-input').props.onPress,
+      ).toBeUndefined();
     });
 
     it('shows the populated post-keypad state after quote loading settles', async () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -1520,6 +1520,22 @@ describe('CustomAmountInfo', () => {
       view.rerender(createCustomAmountInfo());
     }
 
+    it('clears the handoff for synchronous updates without quote signals', async () => {
+      const view = render();
+
+      await act(async () => {
+        fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
+      });
+      await act(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
     it('shows fee rows for same-chain payment without quotes', async () => {
       useTransactionPayHasSourceAmountMock.mockReturnValue(false);
       useTransactionPayQuotesMock.mockReturnValue([]);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -29,7 +29,9 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayRequiredTokens,
   useIsTransactionPayLoading,
+  useIsTransactionPayQuoteLoading,
   useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { strings } from '../../../../../../../locales/i18n';
@@ -288,7 +290,14 @@ describe('CustomAmountInfo', () => {
     useIsTransactionPayLoading,
   );
 
+  const useIsTransactionPayQuoteLoadingMock = jest.mocked(
+    useIsTransactionPayQuoteLoading,
+  );
+
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useTransactionPayQuotesLastUpdatedMock = jest.mocked(
+    useTransactionPayQuotesLastUpdated,
+  );
 
   const useTransactionPayHasSourceAmountMock = jest.mocked(
     useTransactionPayHasSourceAmount,
@@ -415,7 +424,9 @@ describe('CustomAmountInfo', () => {
       onReject: jest.fn(),
     });
     useIsTransactionPayLoadingMock.mockReturnValue(false);
+    useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
     useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesLastUpdatedMock.mockReturnValue(undefined);
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
     useTokenFiatRatesMock.mockReturnValue([1, 1]);
     useTransactionMetadataRequestMock.mockReturnValue({
@@ -739,6 +750,7 @@ describe('CustomAmountInfo', () => {
       ).toBeDisabled();
 
       useIsTransactionPayLoadingMock.mockReturnValue(true);
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -764,6 +776,30 @@ describe('CustomAmountInfo', () => {
       ).toBeUndefined();
     });
 
+    it('releases the loading review when quote loading completes between renders', async () => {
+      const { deferred } = arrangePendingPreparation();
+      const view = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+      fireEvent.press(view.getByTestId('deposit-keyboard-done-button'));
+      await act(async () => {
+        deferred.resolve();
+        await deferred.promise;
+      });
+
+      useTransactionPayQuotesLastUpdatedMock.mockReturnValue(123);
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
+
+      expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
+      expect(
+        view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
+      ).not.toBeDisabled();
+    });
+
     it('shows the populated post-keypad state after quote loading settles', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
@@ -775,6 +811,7 @@ describe('CustomAmountInfo', () => {
         await deferred.promise;
       });
       useIsTransactionPayLoadingMock.mockReturnValue(true);
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -782,6 +819,7 @@ describe('CustomAmountInfo', () => {
       );
 
       useIsTransactionPayLoadingMock.mockReturnValue(false);
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
@@ -1525,12 +1563,14 @@ describe('CustomAmountInfo', () => {
         fireEvent.press(view.getByText(strings('confirm.edit_amount_done')));
       });
       useIsTransactionPayLoadingMock.mockReturnValue(true);
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,
         }),
       );
       useIsTransactionPayLoadingMock.mockReturnValue(false);
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
       view.rerender(
         createCustomAmountInfo({
           transactionType: TransactionType.moneyAccountDeposit,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.testIds.ts
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.testIds.ts
@@ -1,3 +1,4 @@
 export const CustomAmountInfoTestIds = {
   BOTTOM_BLOCK: 'custom-amount-info-bottom-block',
+  REVIEW_ROWS: 'custom-amount-info-review-rows',
 } as const;

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -192,6 +192,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     );
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
+    const [isPreparingQuote, setIsPreparingQuote] = useState(false);
+    const isPreparingQuoteRef = useRef(false);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -221,11 +223,14 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const { toastRef } = useContext(ToastContext);
 
+    const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const isResultReady =
-      useIsResultReady({ isKeyboardVisible }) ||
+      isPreparingQuote ||
+      isTransactionResultReady ||
       (isAddMusdIntent && !isKeyboardVisible);
     const quotes = useTransactionPayQuotes();
     const isQuotesLoading = useIsTransactionPayLoading();
+    const showLoadingReview = isPreparingQuote || isQuotesLoading;
     const hasSourceAmount = useTransactionPayHasSourceAmount();
     const { alerts } = useAlerts();
     const accountNoFundsAlert = useAccountNoFundsAlert();
@@ -234,7 +239,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       (a) => a.key === AlertKeys.NoPayTokenQuotes,
     );
     const showPaymentDetails =
-      isQuotesLoading ||
+      showLoadingReview ||
       Boolean(quotes?.length) ||
       (!isAddMusdIntent && !hasSourceAmount && !hasNoQuotesAlert);
 
@@ -254,6 +259,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const handleDone = useCallback(async () => {
       const keyboardVisibleAtStart = isKeyboardVisibleRef.current;
+      if (isPreparingQuoteRef.current) {
+        return;
+      }
+
+      if (isMoneyAccountDeposit) {
+        isPreparingQuoteRef.current = true;
+        setIsPreparingQuote(true);
+        setIsKeyboardVisible(false);
+      }
       try {
         await updateTokenAmount();
         if (selectedFiatPaymentMethodId && transactionId) {
@@ -281,6 +295,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             toastRef?.current?.closeToast(),
           ),
         );
+        if (isMoneyAccountDeposit) {
+          isPreparingQuoteRef.current = false;
+          setIsPreparingQuote(false);
+          setIsKeyboardVisible(true);
+        }
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
       }
@@ -295,6 +314,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       onAmountSubmit?.();
     }, [
       amountFiat,
+      isMoneyAccountDeposit,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
       toastRef,
@@ -302,6 +322,14 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       transactionId,
       updateTokenAmount,
     ]);
+
+    useEffect(() => {
+      // Keep the local loading review mounted until controller loading takes over.
+      if (isPreparingQuote && isQuotesLoading) {
+        isPreparingQuoteRef.current = false;
+        setIsPreparingQuote(false);
+      }
+    }, [isPreparingQuote, isQuotesLoading]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {
@@ -378,8 +406,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               (isPrefillPending || isDepositPrefillLoading)
             }
             onPress={handleAmountPress}
-            disabled={!hasPaymentOption}
-            showCursor={isKeyboardVisible}
+            disabled={!hasPaymentOption || isPreparingQuote}
+            showCursor={isKeyboardVisible && !isPreparingQuote}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -413,7 +441,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             </>
           )}
           {isResultReady && (
-            <Box>
+            <Box
+              pointerEvents={isPreparingQuote ? 'none' : 'auto'}
+              testID={CustomAmountInfoTestIds.REVIEW_ROWS}
+            >
               {supportAccountSelection &&
                 !selectedFiatPaymentMethodId &&
                 !shouldHideAccountSelector && <PayAccountSelector />}
@@ -423,7 +454,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 <PayWithRow isResultReady />
               )}
               {!hasAccountNoFunds &&
-                (showPaymentDetails && !isAwaitingPrefillResult ? (
+                (isPreparingQuote ? (
+                  <PaymentDetailsSkeleton />
+                ) : showPaymentDetails && !isAwaitingPrefillResult ? (
                   <>
                     <BridgeFeeRow />
                     <BridgeTimeRow />
@@ -435,11 +468,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                   </>
                 ) : (
                   (isAddMusdIntent || isAwaitingPrefillResult) && (
-                    <>
-                      <InfoRowSkeleton />
-                      <InfoRowSkeleton />
-                      <InfoRowSkeleton />
-                    </>
+                    <PaymentDetailsSkeleton />
                   )
                 ))}
               <PercentageRow />
@@ -454,28 +483,30 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {footerText}
             </Text>
           )}
-          {isKeyboardVisible && (hasPaymentOption || hasAccountNoFunds) && (
-            <DepositKeyboard
-              hidePercentageButtons={
-                Boolean(selectedFiatPaymentMethodId) ||
-                shouldHideAccountSelector
-              }
-              alertMessage={alertTitle}
-              value={amountFiat}
-              onChange={updatePendingAmount}
-              onDonePress={handleDone}
-              onPercentagePress={handlePercentagePress}
-              hasInput={hasInput}
-              hasMax={
-                (hasMax || isMoneyDepositNoFee) &&
-                (isWithdraw || !isNativePayToken)
-              }
-            />
-          )}
+          {isKeyboardVisible &&
+            !isPreparingQuote &&
+            (hasPaymentOption || hasAccountNoFunds) && (
+              <DepositKeyboard
+                hidePercentageButtons={
+                  Boolean(selectedFiatPaymentMethodId) ||
+                  shouldHideAccountSelector
+                }
+                alertMessage={alertTitle}
+                value={amountFiat}
+                onChange={updatePendingAmount}
+                onDonePress={handleDone}
+                onPercentagePress={handlePercentagePress}
+                hasInput={hasInput}
+                hasMax={
+                  (hasMax || isMoneyDepositNoFee) &&
+                  (isWithdraw || !isNativePayToken)
+                }
+              />
+            )}
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {!isKeyboardVisible && (
+          {(!isKeyboardVisible || isPreparingQuote) && (
             <ConfirmButton
               alertTitle={alertTitle}
               disableConfirm={
@@ -484,6 +515,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 isPrefillPending ||
                 isAwaitingPrefillResult
               }
+              isPreparingQuote={isPreparingQuote}
               onContinue={trackContinue}
             />
           )}
@@ -597,13 +629,25 @@ function BuySection() {
   );
 }
 
+function PaymentDetailsSkeleton() {
+  return (
+    <>
+      <InfoRowSkeleton testId="bridge-fee-row-skeleton" />
+      <InfoRowSkeleton testId="bridge-time-row-skeleton" />
+      <InfoRowSkeleton testId="total-row-skeleton" />
+    </>
+  );
+}
+
 function ConfirmButton({
   alertTitle,
   disableConfirm,
+  isPreparingQuote,
   onContinue,
 }: Readonly<{
   alertTitle: string | undefined;
   disableConfirm?: boolean;
+  isPreparingQuote?: boolean;
   onContinue?: () => void;
 }>) {
   const { styles } = useStyles(styleSheet, {});
@@ -616,6 +660,7 @@ function ConfirmButton({
     hasBlockingAlerts ||
     isLoading ||
     Boolean(disableConfirm) ||
+    isPreparingQuote ||
     isHeadlessBuyInProgress;
   const buttonLabel = useButtonLabel();
 
@@ -638,7 +683,7 @@ function ConfirmButton({
       variant={ButtonVariant.Primary}
       isFullWidth
       isDisabled={disabled}
-      isLoading={isHeadlessBuyInProgress}
+      isLoading={isPreparingQuote || isHeadlessBuyInProgress}
       loadingText={strings('confirm.preparing_order')}
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -346,7 +346,19 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       ) {
         setIsAmountUpdateComplete(false);
         setIsAmountUpdating(false);
+        return;
       }
+
+      if (!isAmountUpdateComplete) {
+        return;
+      }
+
+      const handoffTimeout = setTimeout(() => {
+        setIsAmountUpdateComplete(false);
+        setIsAmountUpdating(false);
+      }, 0);
+
+      return () => clearTimeout(handoffTimeout);
     }, [isAmountUpdateComplete, isQuotesLoading, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -517,7 +517,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 isPrefillPending ||
                 isAwaitingPrefillResult
               }
-              showPreparingOrder={showMoneyAccountLoadingReview}
+              isLoadingReview={showMoneyAccountLoadingReview}
               onContinue={trackContinue}
             />
           )}
@@ -644,12 +644,12 @@ function PaymentDetailsSkeleton() {
 function ConfirmButton({
   alertTitle,
   disableConfirm,
-  showPreparingOrder,
+  isLoadingReview,
   onContinue,
 }: Readonly<{
   alertTitle: string | undefined;
   disableConfirm?: boolean;
-  showPreparingOrder?: boolean;
+  isLoadingReview?: boolean;
   onContinue?: () => void;
 }>) {
   const { styles } = useStyles(styleSheet, {});
@@ -662,7 +662,7 @@ function ConfirmButton({
     hasBlockingAlerts ||
     isLoading ||
     Boolean(disableConfirm) ||
-    showPreparingOrder ||
+    isLoadingReview ||
     isHeadlessBuyInProgress;
   const buttonLabel = useButtonLabel();
 
@@ -685,12 +685,12 @@ function ConfirmButton({
       variant={ButtonVariant.Primary}
       isFullWidth
       isDisabled={disabled}
-      isLoading={showPreparingOrder || isHeadlessBuyInProgress}
+      isLoading={isHeadlessBuyInProgress}
       loadingText={strings('confirm.preparing_order')}
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     >
-      {alertTitle ?? buttonLabel}
+      {isLoadingReview ? buttonLabel : (alertTitle ?? buttonLabel)}
     </Button>
   );
 }

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -305,11 +305,18 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             ]
           : undefined;
         const controllerQuotesLastUpdated = transactionData?.quotesLastUpdated;
+        const reduxQuotesLastUpdated = quotesLastUpdatedRef.current;
+        const latestQuotesLastUpdated =
+          controllerQuotesLastUpdated === undefined
+            ? reduxQuotesLastUpdated
+            : reduxQuotesLastUpdated === undefined
+              ? controllerQuotesLastUpdated
+              : Math.max(controllerQuotesLastUpdated, reduxQuotesLastUpdated);
 
         if (transactionData?.isLoading) {
           setQuoteHandoff({
             kind: 'loading',
-            quotesLastUpdated: controllerQuotesLastUpdated,
+            quotesLastUpdated: latestQuotesLastUpdated,
           });
         } else if (
           controllerQuotesLastUpdated !== undefined &&

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -43,8 +43,10 @@ import {
 } from '../../transactions/custom-amount';
 import {
   useIsTransactionPayLoading,
+  useIsTransactionPayQuoteLoading,
   useTransactionPayFiatPayment,
   useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
@@ -194,6 +196,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isPreparingQuote, setIsPreparingQuote] = useState(false);
     const isPreparingQuoteRef = useRef(false);
+    const quotesLastUpdatedBeforePreparationRef = useRef<number | undefined>(
+      undefined,
+    );
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -225,6 +230,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();
+    const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
+    const isQuoteLoading = useIsTransactionPayQuoteLoading();
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isPreparingQuote || isQuotesLoading;
     const showMoneyAccountLoadingReview =
@@ -267,6 +274,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
       if (isMoneyAccountDeposit) {
         isPreparingQuoteRef.current = true;
+        quotesLastUpdatedBeforePreparationRef.current = quotesLastUpdated;
         setIsPreparingQuote(true);
         setIsKeyboardVisible(false);
       }
@@ -318,6 +326,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       amountFiat,
       isMoneyAccountDeposit,
       onAmountSubmit,
+      quotesLastUpdated,
       selectedFiatPaymentMethodId,
       toastRef,
       trackAmountCommitted,
@@ -326,12 +335,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     ]);
 
     useEffect(() => {
-      // Keep the local loading review mounted until controller loading takes over.
-      if (isPreparingQuote && isQuotesLoading) {
+      const hasCompletedQuoteRequest =
+        quotesLastUpdated !== undefined &&
+        quotesLastUpdated !== quotesLastUpdatedBeforePreparationRef.current;
+
+      if (isPreparingQuote && (isQuoteLoading || hasCompletedQuoteRequest)) {
         isPreparingQuoteRef.current = false;
         setIsPreparingQuote(false);
       }
-    }, [isPreparingQuote, isQuotesLoading]);
+    }, [isPreparingQuote, isQuoteLoading, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -193,7 +193,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isPreparingQuote, setIsPreparingQuote] = useState(false);
-    const isPreparingQuoteRef = useRef(false);
+    // React batches rapid presses before the state update rerenders, so keep a
+    // synchronous guard separate from the render state.
+    const isAmountUpdateInProgressRef = useRef(false);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -261,12 +263,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const handleDone = useCallback(async () => {
       const keyboardVisibleAtStart = isKeyboardVisibleRef.current;
-      if (isPreparingQuoteRef.current) {
+      if (isAmountUpdateInProgressRef.current) {
         return;
       }
 
       if (isMoneyAccountDeposit) {
-        isPreparingQuoteRef.current = true;
+        isAmountUpdateInProgressRef.current = true;
         setIsPreparingQuote(true);
         setIsKeyboardVisible(false);
       }
@@ -304,7 +306,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         return;
       } finally {
         if (isMoneyAccountDeposit) {
-          isPreparingQuoteRef.current = false;
+          isAmountUpdateInProgressRef.current = false;
           setIsPreparingQuote(false);
         }
       }

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -195,10 +195,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isPreparingQuote, setIsPreparingQuote] = useState(false);
+    const [isAmountUpdateComplete, setIsAmountUpdateComplete] = useState(false);
     const isPreparingQuoteRef = useRef(false);
     const quotesLastUpdatedBeforePreparationRef = useRef<number | undefined>(
       undefined,
     );
+    const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -231,6 +233,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();
     const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
+    quotesLastUpdatedRef.current = quotesLastUpdated;
     const isQuoteLoading = useIsTransactionPayQuoteLoading();
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isPreparingQuote || isQuotesLoading;
@@ -275,6 +278,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       if (isMoneyAccountDeposit) {
         isPreparingQuoteRef.current = true;
         quotesLastUpdatedBeforePreparationRef.current = quotesLastUpdated;
+        setIsAmountUpdateComplete(false);
         setIsPreparingQuote(true);
         setIsKeyboardVisible(false);
       }
@@ -307,11 +311,17 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         );
         if (isMoneyAccountDeposit) {
           isPreparingQuoteRef.current = false;
+          setIsAmountUpdateComplete(false);
           setIsPreparingQuote(false);
           setIsKeyboardVisible(true);
         }
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
+      }
+      if (isMoneyAccountDeposit) {
+        quotesLastUpdatedBeforePreparationRef.current =
+          quotesLastUpdatedRef.current;
+        setIsAmountUpdateComplete(true);
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -339,11 +349,20 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         quotesLastUpdated !== undefined &&
         quotesLastUpdated !== quotesLastUpdatedBeforePreparationRef.current;
 
-      if (isPreparingQuote && (isQuoteLoading || hasCompletedQuoteRequest)) {
+      if (
+        isPreparingQuote &&
+        isAmountUpdateComplete &&
+        (isQuoteLoading || hasCompletedQuoteRequest)
+      ) {
         isPreparingQuoteRef.current = false;
         setIsPreparingQuote(false);
       }
-    }, [isPreparingQuote, isQuoteLoading, quotesLastUpdated]);
+    }, [
+      isAmountUpdateComplete,
+      isPreparingQuote,
+      isQuoteLoading,
+      quotesLastUpdated,
+    ]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -495,7 +495,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {(!isKeyboardVisible || showLoadingReview) && (
+          {!isKeyboardVisible && (
             <ConfirmButton
               alertTitle={alertTitle}
               disableConfirm={

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -407,8 +407,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               !hasAccountNoFunds &&
               (isPrefillPending || isDepositPrefillLoading)
             }
-            onPress={handleAmountPress}
-            disabled={!hasPaymentOption || showMoneyAccountLoadingReview}
+            onPress={
+              showMoneyAccountLoadingReview ? undefined : handleAmountPress
+            }
+            disabled={!hasPaymentOption}
             showCursor={isKeyboardVisible && !showMoneyAccountLoadingReview}
           />
           {!hidePayTokenAmount &&

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -43,10 +43,8 @@ import {
 } from '../../transactions/custom-amount';
 import {
   useIsTransactionPayLoading,
-  useIsTransactionPayQuoteLoading,
   useTransactionPayFiatPayment,
   useTransactionPayQuotes,
-  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
@@ -195,12 +193,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isPreparingQuote, setIsPreparingQuote] = useState(false);
-    const [isAmountUpdateComplete, setIsAmountUpdateComplete] = useState(false);
     const isPreparingQuoteRef = useRef(false);
-    const quotesLastUpdatedBeforePreparationRef = useRef<number | undefined>(
-      undefined,
-    );
-    const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -232,9 +225,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();
-    const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
-    quotesLastUpdatedRef.current = quotesLastUpdated;
-    const isQuoteLoading = useIsTransactionPayQuoteLoading();
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isPreparingQuote || isQuotesLoading;
     const showMoneyAccountLoadingReview =
@@ -277,8 +267,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
       if (isMoneyAccountDeposit) {
         isPreparingQuoteRef.current = true;
-        quotesLastUpdatedBeforePreparationRef.current = quotesLastUpdated;
-        setIsAmountUpdateComplete(false);
         setIsPreparingQuote(true);
         setIsKeyboardVisible(false);
       }
@@ -310,18 +298,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           ),
         );
         if (isMoneyAccountDeposit) {
-          isPreparingQuoteRef.current = false;
-          setIsAmountUpdateComplete(false);
-          setIsPreparingQuote(false);
           setIsKeyboardVisible(true);
         }
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
-      }
-      if (isMoneyAccountDeposit) {
-        quotesLastUpdatedBeforePreparationRef.current =
-          quotesLastUpdatedRef.current;
-        setIsAmountUpdateComplete(true);
+      } finally {
+        if (isMoneyAccountDeposit) {
+          isPreparingQuoteRef.current = false;
+          setIsPreparingQuote(false);
+        }
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -336,32 +321,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       amountFiat,
       isMoneyAccountDeposit,
       onAmountSubmit,
-      quotesLastUpdated,
       selectedFiatPaymentMethodId,
       toastRef,
       trackAmountCommitted,
       transactionId,
       updateTokenAmount,
-    ]);
-
-    useEffect(() => {
-      const hasCompletedQuoteRequest =
-        quotesLastUpdated !== undefined &&
-        quotesLastUpdated !== quotesLastUpdatedBeforePreparationRef.current;
-
-      if (
-        isPreparingQuote &&
-        isAmountUpdateComplete &&
-        (isQuoteLoading || hasCompletedQuoteRequest)
-      ) {
-        isPreparingQuoteRef.current = false;
-        setIsPreparingQuote(false);
-      }
-    }, [
-      isAmountUpdateComplete,
-      isPreparingQuote,
-      isQuoteLoading,
-      quotesLastUpdated,
     ]);
 
     const wasPrefillPending = useRef(isPrefillPending);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -444,24 +444,16 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {disablePay !== true && hasPaymentOption && (
                 <PayWithRow isResultReady />
               )}
-              {!hasAccountNoFunds &&
-                (showLoadingReview ? (
-                  <PaymentDetailsSkeleton />
-                ) : showPaymentDetails && !isAwaitingPrefillResult ? (
-                  <>
-                    <BridgeFeeRow />
-                    <BridgeTimeRow />
-                    {canSelectWithdrawToken ? (
-                      <ReceiveRow inputAmountUsd={amountFiat} />
-                    ) : (
-                      <TotalRow />
-                    )}
-                  </>
-                ) : (
-                  (isAddMusdIntent || isAwaitingPrefillResult) && (
-                    <PaymentDetailsSkeleton />
-                  )
-                ))}
+              {!hasAccountNoFunds && (
+                <Quote
+                  amountFiat={amountFiat}
+                  canSelectWithdrawToken={canSelectWithdrawToken}
+                  isAddMusdIntent={isAddMusdIntent}
+                  isAwaitingPrefillResult={isAwaitingPrefillResult}
+                  isLoading={showLoadingReview}
+                  showPaymentDetails={showPaymentDetails}
+                />
+              )}
               <PercentageRow />
             </Box>
           )}
@@ -616,6 +608,46 @@ function BuySection() {
       </Button>
     </Box>
   );
+}
+
+function Quote({
+  amountFiat,
+  canSelectWithdrawToken,
+  isAddMusdIntent,
+  isAwaitingPrefillResult,
+  isLoading,
+  showPaymentDetails,
+}: Readonly<{
+  amountFiat: string;
+  canSelectWithdrawToken: boolean;
+  isAddMusdIntent: boolean;
+  isAwaitingPrefillResult: boolean;
+  isLoading: boolean;
+  showPaymentDetails: boolean;
+}>) {
+  if (isLoading) {
+    return <PaymentDetailsSkeleton />;
+  }
+
+  if (showPaymentDetails && !isAwaitingPrefillResult) {
+    return (
+      <>
+        <BridgeFeeRow />
+        <BridgeTimeRow />
+        {canSelectWithdrawToken ? (
+          <ReceiveRow inputAmountUsd={amountFiat} />
+        ) : (
+          <TotalRow />
+        )}
+      </>
+    );
+  }
+
+  if (isAddMusdIntent || isAwaitingPrefillResult) {
+    return <PaymentDetailsSkeleton />;
+  }
+
+  return null;
 }
 
 function PaymentDetailsSkeleton() {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -474,26 +474,24 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {footerText}
             </Text>
           )}
-          {isKeyboardVisible &&
-            !showLoadingReview &&
-            (hasPaymentOption || hasAccountNoFunds) && (
-              <DepositKeyboard
-                hidePercentageButtons={
-                  Boolean(selectedFiatPaymentMethodId) ||
-                  shouldHideAccountSelector
-                }
-                alertMessage={alertTitle}
-                value={amountFiat}
-                onChange={updatePendingAmount}
-                onDonePress={handleDone}
-                onPercentagePress={handlePercentagePress}
-                hasInput={hasInput}
-                hasMax={
-                  (hasMax || isMoneyDepositNoFee) &&
-                  (isWithdraw || !isNativePayToken)
-                }
-              />
-            )}
+          {isKeyboardVisible && (hasPaymentOption || hasAccountNoFunds) && (
+            <DepositKeyboard
+              hidePercentageButtons={
+                Boolean(selectedFiatPaymentMethodId) ||
+                shouldHideAccountSelector
+              }
+              alertMessage={alertTitle}
+              value={amountFiat}
+              onChange={updatePendingAmount}
+              onDonePress={handleDone}
+              onPercentagePress={handlePercentagePress}
+              hasInput={hasInput}
+              hasMax={
+                (hasMax || isMoneyDepositNoFee) &&
+                (isWithdraw || !isNativePayToken)
+              }
+            />
+          )}
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -229,10 +229,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const quotes = useTransactionPayQuotes();
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isAmountUpdating || isQuotesLoading;
-    const showMoneyAccountLoadingReview =
-      isMoneyAccountDeposit && showLoadingReview;
     const isResultReady =
-      showMoneyAccountLoadingReview ||
+      showLoadingReview ||
       isTransactionResultReady ||
       (isAddMusdIntent && !isKeyboardVisible);
     const hasSourceAmount = useTransactionPayHasSourceAmount();
@@ -267,11 +265,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         return;
       }
 
-      if (isMoneyAccountDeposit) {
-        isAmountUpdateInProgressRef.current = true;
-        setIsAmountUpdating(true);
-        setIsKeyboardVisible(false);
-      }
+      isAmountUpdateInProgressRef.current = true;
+      setIsAmountUpdating(true);
+      setIsKeyboardVisible(false);
+
       try {
         await updateTokenAmount();
         if (selectedFiatPaymentMethodId && transactionId) {
@@ -299,16 +296,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             toastRef?.current?.closeToast(),
           ),
         );
-        if (isMoneyAccountDeposit) {
-          setIsKeyboardVisible(true);
-        }
+        setIsKeyboardVisible(true);
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
       } finally {
-        if (isMoneyAccountDeposit) {
-          isAmountUpdateInProgressRef.current = false;
-          setIsAmountUpdating(false);
-        }
+        isAmountUpdateInProgressRef.current = false;
+        setIsAmountUpdating(false);
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -321,7 +314,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       onAmountSubmit?.();
     }, [
       amountFiat,
-      isMoneyAccountDeposit,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
       toastRef,
@@ -404,11 +396,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               !hasAccountNoFunds &&
               (isPrefillPending || isDepositPrefillLoading)
             }
-            onPress={
-              showMoneyAccountLoadingReview ? undefined : handleAmountPress
-            }
+            onPress={showLoadingReview ? undefined : handleAmountPress}
             disabled={!hasPaymentOption}
-            showCursor={isKeyboardVisible && !showMoneyAccountLoadingReview}
+            showCursor={isKeyboardVisible && !showLoadingReview}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -443,7 +433,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           )}
           {isResultReady && (
             <Box
-              pointerEvents={showMoneyAccountLoadingReview ? 'none' : 'auto'}
+              pointerEvents={showLoadingReview ? 'none' : 'auto'}
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
               {supportAccountSelection &&
@@ -455,7 +445,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 <PayWithRow isResultReady />
               )}
               {!hasAccountNoFunds &&
-                (showMoneyAccountLoadingReview ? (
+                (showLoadingReview ? (
                   <PaymentDetailsSkeleton />
                 ) : showPaymentDetails && !isAwaitingPrefillResult ? (
                   <>
@@ -485,7 +475,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             </Text>
           )}
           {isKeyboardVisible &&
-            !showMoneyAccountLoadingReview &&
+            !showLoadingReview &&
             (hasPaymentOption || hasAccountNoFunds) && (
               <DepositKeyboard
                 hidePercentageButtons={
@@ -507,7 +497,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {(!isKeyboardVisible || showMoneyAccountLoadingReview) && (
+          {(!isKeyboardVisible || showLoadingReview) && (
             <ConfirmButton
               alertTitle={alertTitle}
               disableConfirm={
@@ -516,7 +506,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 isPrefillPending ||
                 isAwaitingPrefillResult
               }
-              isLoadingReview={showMoneyAccountLoadingReview}
+              isLoadingReview={showLoadingReview}
               onContinue={trackContinue}
             />
           )}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -224,13 +224,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const { toastRef } = useContext(ToastContext);
 
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
-    const isResultReady =
-      isPreparingQuote ||
-      isTransactionResultReady ||
-      (isAddMusdIntent && !isKeyboardVisible);
     const quotes = useTransactionPayQuotes();
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isPreparingQuote || isQuotesLoading;
+    const showMoneyAccountLoadingReview =
+      isMoneyAccountDeposit && showLoadingReview;
+    const isResultReady =
+      showMoneyAccountLoadingReview ||
+      isTransactionResultReady ||
+      (isAddMusdIntent && !isKeyboardVisible);
     const hasSourceAmount = useTransactionPayHasSourceAmount();
     const { alerts } = useAlerts();
     const accountNoFundsAlert = useAccountNoFundsAlert();
@@ -406,8 +408,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               (isPrefillPending || isDepositPrefillLoading)
             }
             onPress={handleAmountPress}
-            disabled={!hasPaymentOption || isPreparingQuote}
-            showCursor={isKeyboardVisible && !isPreparingQuote}
+            disabled={!hasPaymentOption || showMoneyAccountLoadingReview}
+            showCursor={isKeyboardVisible && !showMoneyAccountLoadingReview}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -442,7 +444,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           )}
           {isResultReady && (
             <Box
-              pointerEvents={isPreparingQuote ? 'none' : 'auto'}
+              pointerEvents={showMoneyAccountLoadingReview ? 'none' : 'auto'}
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
               {supportAccountSelection &&
@@ -454,7 +456,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 <PayWithRow isResultReady />
               )}
               {!hasAccountNoFunds &&
-                (isPreparingQuote ? (
+                (showMoneyAccountLoadingReview ? (
                   <PaymentDetailsSkeleton />
                 ) : showPaymentDetails && !isAwaitingPrefillResult ? (
                   <>
@@ -484,7 +486,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             </Text>
           )}
           {isKeyboardVisible &&
-            !isPreparingQuote &&
+            !showMoneyAccountLoadingReview &&
             (hasPaymentOption || hasAccountNoFunds) && (
               <DepositKeyboard
                 hidePercentageButtons={
@@ -506,7 +508,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           {(!hasPaymentOption || hasAccountNoFunds) &&
             !hideBuyForNoFunds &&
             !isDepositPrefillEnabled && <BuySection />}
-          {(!isKeyboardVisible || isPreparingQuote) && (
+          {(!isKeyboardVisible || showMoneyAccountLoadingReview) && (
             <ConfirmButton
               alertTitle={alertTitle}
               disableConfirm={
@@ -515,7 +517,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 isPrefillPending ||
                 isAwaitingPrefillResult
               }
-              isPreparingQuote={isPreparingQuote}
+              showPreparingOrder={showMoneyAccountLoadingReview}
               onContinue={trackContinue}
             />
           )}
@@ -642,12 +644,12 @@ function PaymentDetailsSkeleton() {
 function ConfirmButton({
   alertTitle,
   disableConfirm,
-  isPreparingQuote,
+  showPreparingOrder,
   onContinue,
 }: Readonly<{
   alertTitle: string | undefined;
   disableConfirm?: boolean;
-  isPreparingQuote?: boolean;
+  showPreparingOrder?: boolean;
   onContinue?: () => void;
 }>) {
   const { styles } = useStyles(styleSheet, {});
@@ -660,7 +662,7 @@ function ConfirmButton({
     hasBlockingAlerts ||
     isLoading ||
     Boolean(disableConfirm) ||
-    isPreparingQuote ||
+    showPreparingOrder ||
     isHeadlessBuyInProgress;
   const buttonLabel = useButtonLabel();
 
@@ -683,7 +685,7 @@ function ConfirmButton({
       variant={ButtonVariant.Primary}
       isFullWidth
       isDisabled={disabled}
-      isLoading={isPreparingQuote || isHeadlessBuyInProgress}
+      isLoading={showPreparingOrder || isHeadlessBuyInProgress}
       loadingText={strings('confirm.preparing_order')}
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -192,7 +192,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     );
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
-    const [isPreparingQuote, setIsPreparingQuote] = useState(false);
+    const [isAmountUpdating, setIsAmountUpdating] = useState(false);
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
@@ -228,7 +228,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();
     const isQuotesLoading = useIsTransactionPayLoading();
-    const showLoadingReview = isPreparingQuote || isQuotesLoading;
+    const showLoadingReview = isAmountUpdating || isQuotesLoading;
     const showMoneyAccountLoadingReview =
       isMoneyAccountDeposit && showLoadingReview;
     const isResultReady =
@@ -269,7 +269,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
       if (isMoneyAccountDeposit) {
         isAmountUpdateInProgressRef.current = true;
-        setIsPreparingQuote(true);
+        setIsAmountUpdating(true);
         setIsKeyboardVisible(false);
       }
       try {
@@ -307,7 +307,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       } finally {
         if (isMoneyAccountDeposit) {
           isAmountUpdateInProgressRef.current = false;
-          setIsPreparingQuote(false);
+          setIsAmountUpdating(false);
         }
       }
       EngineService.flushState();

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -45,6 +45,7 @@ import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
   useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
@@ -193,9 +194,14 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isAmountUpdating, setIsAmountUpdating] = useState(false);
+    const [isAmountUpdateComplete, setIsAmountUpdateComplete] = useState(false);
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
+    const quotesLastUpdatedBeforeAmountUpdateRef = useRef<number | undefined>(
+      undefined,
+    );
+    const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
       wasKeyboardEverVisible.current = true;
@@ -227,6 +233,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const isTransactionResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();
+    const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
+    quotesLastUpdatedRef.current = quotesLastUpdated;
     const isQuotesLoading = useIsTransactionPayLoading();
     const showLoadingReview = isAmountUpdating || isQuotesLoading;
     const isResultReady =
@@ -266,6 +274,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       }
 
       isAmountUpdateInProgressRef.current = true;
+      setIsAmountUpdateComplete(false);
       setIsAmountUpdating(true);
       setIsKeyboardVisible(false);
 
@@ -282,6 +291,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         // Amount committed (pre-quote) funnel event; only fires once the amount
         // has been successfully applied above (no-op for non-money flows).
         trackAmountCommitted();
+        quotesLastUpdatedBeforeAmountUpdateRef.current =
+          quotesLastUpdatedRef.current;
+        setIsAmountUpdateComplete(true);
       } catch (error) {
         const isConfirmationDismissed =
           !Engine.context.TransactionController.state.transactions.some(
@@ -297,11 +309,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           ),
         );
         setIsKeyboardVisible(true);
+        setIsAmountUpdateComplete(false);
+        setIsAmountUpdating(false);
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
       } finally {
         isAmountUpdateInProgressRef.current = false;
-        setIsAmountUpdating(false);
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -321,6 +334,20 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       transactionId,
       updateTokenAmount,
     ]);
+
+    useEffect(() => {
+      const hasCompletedQuoteRequest =
+        quotesLastUpdated !== undefined &&
+        quotesLastUpdated !== quotesLastUpdatedBeforeAmountUpdateRef.current;
+
+      if (
+        isAmountUpdateComplete &&
+        (isQuotesLoading || hasCompletedQuoteRequest)
+      ) {
+        setIsAmountUpdateComplete(false);
+        setIsAmountUpdating(false);
+      }
+    }, [isAmountUpdateComplete, isQuotesLoading, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -101,6 +101,16 @@ import { InfoRowSkeleton } from '../../UI/info-row/info-row';
 
 const AMOUNT_UPDATE_ERROR_PREFIX = 'MetaMask Pay: Amount Update: ';
 
+type QuoteHandoff =
+  | {
+      kind: 'loading';
+      quotesLastUpdated: number | undefined;
+    }
+  | {
+      kind: 'completed';
+      quotesLastUpdated: number;
+    };
+
 export interface CustomAmountInfoProps {
   autoSelectFiatPayment?: boolean;
   children?: ReactNode;
@@ -194,13 +204,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isAmountUpdating, setIsAmountUpdating] = useState(false);
-    const [isAmountUpdateComplete, setIsAmountUpdateComplete] = useState(false);
+    const [quoteHandoff, setQuoteHandoff] = useState<QuoteHandoff>();
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
-    const quotesLastUpdatedBeforeAmountUpdateRef = useRef<number | undefined>(
-      undefined,
-    );
     const quotesLastUpdatedRef = useRef<number | undefined>(undefined);
     const wasKeyboardEverVisible = useRef(isKeyboardVisible);
     if (isKeyboardVisible) {
@@ -274,7 +281,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       }
 
       isAmountUpdateInProgressRef.current = true;
-      setIsAmountUpdateComplete(false);
+      setQuoteHandoff(undefined);
       setIsAmountUpdating(true);
       setIsKeyboardVisible(false);
 
@@ -291,9 +298,31 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         // Amount committed (pre-quote) funnel event; only fires once the amount
         // has been successfully applied above (no-op for non-money flows).
         trackAmountCommitted();
-        quotesLastUpdatedBeforeAmountUpdateRef.current =
-          quotesLastUpdatedRef.current;
-        setIsAmountUpdateComplete(true);
+
+        const transactionData = transactionId
+          ? Engine.context.TransactionPayController.state.transactionData[
+              transactionId
+            ]
+          : undefined;
+        const controllerQuotesLastUpdated = transactionData?.quotesLastUpdated;
+
+        if (transactionData?.isLoading) {
+          setQuoteHandoff({
+            kind: 'loading',
+            quotesLastUpdated: controllerQuotesLastUpdated,
+          });
+        } else if (
+          controllerQuotesLastUpdated !== undefined &&
+          controllerQuotesLastUpdated !== quotesLastUpdatedRef.current
+        ) {
+          setQuoteHandoff({
+            kind: 'completed',
+            quotesLastUpdated: controllerQuotesLastUpdated,
+          });
+        } else {
+          setQuoteHandoff(undefined);
+          setIsAmountUpdating(false);
+        }
       } catch (error) {
         const isConfirmationDismissed =
           !Engine.context.TransactionController.state.transactions.some(
@@ -309,7 +338,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           ),
         );
         setIsKeyboardVisible(true);
-        setIsAmountUpdateComplete(false);
+        setQuoteHandoff(undefined);
         setIsAmountUpdating(false);
         // Keep keyboard visible so the user can retry; do not advance the flow.
         return;
@@ -336,30 +365,24 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     ]);
 
     useEffect(() => {
-      const hasCompletedQuoteRequest =
+      if (!quoteHandoff) {
+        return;
+      }
+
+      const hasObservedLoading =
+        quoteHandoff.kind === 'loading' && isQuotesLoading;
+      const hasObservedCompletedQuote =
         quotesLastUpdated !== undefined &&
-        quotesLastUpdated !== quotesLastUpdatedBeforeAmountUpdateRef.current;
+        (quoteHandoff.kind === 'completed'
+          ? quotesLastUpdated >= quoteHandoff.quotesLastUpdated
+          : quoteHandoff.quotesLastUpdated === undefined ||
+            quotesLastUpdated > quoteHandoff.quotesLastUpdated);
 
-      if (
-        isAmountUpdateComplete &&
-        (isQuotesLoading || hasCompletedQuoteRequest)
-      ) {
-        setIsAmountUpdateComplete(false);
+      if (hasObservedLoading || hasObservedCompletedQuote) {
+        setQuoteHandoff(undefined);
         setIsAmountUpdating(false);
-        return;
       }
-
-      if (!isAmountUpdateComplete) {
-        return;
-      }
-
-      const handoffTimeout = setTimeout(() => {
-        setIsAmountUpdateComplete(false);
-        setIsAmountUpdating(false);
-      }, 0);
-
-      return () => clearTimeout(handoffTimeout);
-    }, [isAmountUpdateComplete, isQuotesLoading, quotesLastUpdated]);
+    }, [isQuotesLoading, quoteHandoff, quotesLastUpdated]);
 
     const wasPrefillPending = useRef(isPrefillPending);
     useEffect(() => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -506,7 +506,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 isPrefillPending ||
                 isAwaitingPrefillResult
               }
-              isLoadingReview={showLoadingReview}
+              isAmountUpdating={isAmountUpdating}
               onContinue={trackContinue}
             />
           )}
@@ -633,12 +633,12 @@ function PaymentDetailsSkeleton() {
 function ConfirmButton({
   alertTitle,
   disableConfirm,
-  isLoadingReview,
+  isAmountUpdating,
   onContinue,
 }: Readonly<{
   alertTitle: string | undefined;
   disableConfirm?: boolean;
-  isLoadingReview?: boolean;
+  isAmountUpdating?: boolean;
   onContinue?: () => void;
 }>) {
   const { styles } = useStyles(styleSheet, {});
@@ -651,7 +651,7 @@ function ConfirmButton({
     hasBlockingAlerts ||
     isLoading ||
     Boolean(disableConfirm) ||
-    isLoadingReview ||
+    isAmountUpdating ||
     isHeadlessBuyInProgress;
   const buttonLabel = useButtonLabel();
 
@@ -679,7 +679,7 @@ function ConfirmButton({
       onPress={handleConfirm}
       testID={ConfirmationFooterSelectorIDs.CONFIRM_BUTTON}
     >
-      {isLoadingReview ? buttonLabel : (alertTitle ?? buttonLabel)}
+      {isAmountUpdating ? buttonLabel : (alertTitle ?? buttonLabel)}
     </Button>
   );
 }

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
@@ -11,6 +11,7 @@ import {
   useIsTransactionPayLoading,
   useIsTransactionPayQuoteLoading,
   useTransactionPayQuotes,
+  useTransactionPayQuotesLastUpdated,
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
@@ -46,6 +47,8 @@ const TOTALS_MOCK = {
   total: { usd: '1000', fiat: '1234' },
 } as TransactionPayTotals;
 
+const QUOTES_LAST_UPDATED_MOCK = 123;
+
 const FIAT_PAYMENT_MOCK: TransactionFiatPayment = {
   selectedPaymentMethodId: 'pm-123',
   amountFiat: '50.00',
@@ -65,6 +68,7 @@ const state = merge(
               isMaxAmount: true,
               isPostQuote: true,
               quotes: [QUOTE_MOCK],
+              quotesLastUpdated: QUOTES_LAST_UPDATED_MOCK,
               sourceAmounts: [SOURCE_AMOUNT_MOCK],
               tokens: [REQUIRED_TOKEN_MOCK],
               totals: TOTALS_MOCK,
@@ -92,6 +96,13 @@ describe('useTransactionPayData', () => {
     expect(
       renderHookWithProvider(useTransactionPayQuotes, { state }).result.current,
     ).toStrictEqual([QUOTE_MOCK]);
+  });
+
+  it('returns the quote update timestamp', () => {
+    expect(
+      renderHookWithProvider(useTransactionPayQuotesLastUpdated, { state })
+        .result.current,
+    ).toBe(QUOTES_LAST_UPDATED_MOCK);
   });
 
   it('returns required tokens', () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -6,6 +6,7 @@ import {
   selectTransactionPayIsMaxAmountByTransactionId,
   selectTransactionPayIsPostQuoteByTransactionId,
   selectTransactionPayQuotesByTransactionId,
+  selectTransactionPayQuotesLastUpdatedByTransactionId,
   selectTransactionPaySourceAmountsByTransactionId,
   selectTransactionPayTokensByTransactionId,
   selectTransactionPayTotalsByTransactionId,
@@ -15,6 +16,12 @@ import { useConfirmationContext } from '../../context/confirmation-context';
 
 export function useTransactionPayQuotes() {
   return useTransactionPayData(selectTransactionPayQuotesByTransactionId);
+}
+
+export function useTransactionPayQuotesLastUpdated() {
+  return useTransactionPayData(
+    selectTransactionPayQuotesLastUpdatedByTransactionId,
+  );
 }
 
 export function useTransactionPayRequiredTokens() {

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
@@ -166,15 +166,39 @@ describe('useUpdateTransactionPayAmount', () => {
     expect(updateTokenAmountMock).not.toHaveBeenCalled();
   });
 
-  it('delegates to updateTokenAmount for transactions that are neither money account deposit nor withdraw', () => {
+  it('delegates to updateTokenAmount for transactions that are neither money account deposit nor withdraw', async () => {
     const { result } = runHook();
 
-    result.current.updateTransactionPayAmount('1.23');
+    await result.current.updateTransactionPayAmount('1.23');
 
     expect(updateTokenAmountMock).toHaveBeenCalledWith('1.23');
     expect(updateMoneyAccountDepositTokenAmountMock).not.toHaveBeenCalled();
     expect(updateMoneyAccountWithdrawTokenAmountMock).not.toHaveBeenCalled();
     expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+  });
+
+  it('waits for delegated nested amount updates', async () => {
+    let resolveUpdate: () => void = () => undefined;
+    updateTokenAmountMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    const { result } = runHook();
+
+    const updatePromise = result.current.updateTransactionPayAmount('1.23');
+    let isSettled = false;
+    updatePromise.then(() => {
+      isSettled = true;
+    });
+    await flushPromises();
+
+    expect(isSettled).toBe(false);
+
+    resolveUpdate();
+    await updatePromise;
+
+    expect(isSettled).toBe(true);
   });
 
   it('rejects and logs when updateAtomicBatchData rejects', async () => {

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
@@ -201,6 +201,15 @@ describe('useUpdateTransactionPayAmount', () => {
     expect(isSettled).toBe(true);
   });
 
+  it('rejects when a delegated nested amount update fails', async () => {
+    updateTokenAmountMock.mockRejectedValue(new Error('update failed'));
+    const { result } = runHook();
+
+    await expect(
+      result.current.updateTransactionPayAmount('1.23'),
+    ).rejects.toThrow('update failed');
+  });
+
   it('rejects and logs when updateAtomicBatchData rejects', async () => {
     const error = new Error('boom');
     updateAtomicBatchDataMock.mockRejectedValue(error);

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
@@ -114,7 +114,7 @@ export function useUpdateTransactionPayAmount() {
         return;
       }
 
-      updateTokenAmount(amountHuman);
+      await updateTokenAmount(amountHuman);
     },
     [
       transactionMeta,

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -1,3 +1,4 @@
+import { act } from 'react';
 import { merge } from 'lodash';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
@@ -12,7 +13,9 @@ import {
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import { toHex } from 'viem';
+import Logger from '../../../../../util/Logger';
 
 jest.mock('../../../../../util/transaction-controller');
 
@@ -111,6 +114,74 @@ describe('useUpdateTokenAmount', () => {
           TOKEN_TRANSFER_DATA_MOCK.length - 4,
         ) + toHex(15000).substring(2),
     });
+  });
+
+  it('returns the nested update promise', async () => {
+    let resolveUpdate: () => void = () => undefined;
+    const updatePromise = new Promise<Hex>((resolve) => {
+      resolveUpdate = () => resolve('0x0');
+    });
+    updateAtomicBatchDataMock.mockReturnValue(updatePromise);
+    const { result } = runHook({
+      transactionMeta: {
+        nestedTransactions: [
+          {
+            data: '0x1234',
+          },
+          {
+            data: TOKEN_TRANSFER_DATA_MOCK,
+            to: tokenAddress1Mock,
+          },
+        ],
+      },
+    });
+
+    let resultPromise: Promise<unknown> = Promise.resolve();
+    act(() => {
+      resultPromise = Promise.resolve(result.current.updateTokenAmount('1.5'));
+    });
+    let isSettled = false;
+    resultPromise.then(() => {
+      isSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(isSettled).toBe(false);
+
+    resolveUpdate();
+    await resultPromise;
+
+    expect(isSettled).toBe(true);
+  });
+
+  it('logs nested update failures without rejecting', async () => {
+    const error = new Error('update failed');
+    const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
+    updateAtomicBatchDataMock.mockRejectedValue(error);
+    const { result } = runHook({
+      transactionMeta: {
+        nestedTransactions: [
+          {
+            data: '0x1234',
+          },
+          {
+            data: TOKEN_TRANSFER_DATA_MOCK,
+            to: tokenAddress1Mock,
+          },
+        ],
+      },
+    });
+
+    let updatePromise: Promise<unknown> = Promise.resolve();
+    act(() => {
+      updatePromise = Promise.resolve(result.current.updateTokenAmount('1.5'));
+    });
+
+    await expect(updatePromise).resolves.toBeUndefined();
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      error,
+      'Failed to update token amount in nested transaction',
+    );
   });
 
   it('does not update amount if new amount is equal to current amount', () => {

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -16,8 +16,10 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { toHex } from 'viem';
 import Logger from '../../../../../util/Logger';
+import { useConfirmationContext } from '../../context/confirmation-context';
 
 jest.mock('../../../../../util/transaction-controller');
+jest.mock('../../context/confirmation-context');
 
 jest.mock('../../../../../core/redux/slices/confirmationMetrics', () => ({
   ...(jest.requireActual(
@@ -58,11 +60,16 @@ function runHook({
 describe('useUpdateTokenAmount', () => {
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
   const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
+  const useConfirmationContextMock = jest.mocked(useConfirmationContext);
+  const setIsTransactionDataUpdatingMock = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     updateAtomicBatchDataMock.mockResolvedValue('0x0');
+    useConfirmationContextMock.mockReturnValue({
+      setIsTransactionDataUpdating: setIsTransactionDataUpdatingMock,
+    } as unknown as ReturnType<typeof useConfirmationContext>);
   });
 
   it('updates all transaction data with new amount', () => {
@@ -173,15 +180,16 @@ describe('useUpdateTokenAmount', () => {
     });
 
     let updatePromise: Promise<unknown> = Promise.resolve();
-    act(() => {
+    await act(async () => {
       updatePromise = Promise.resolve(result.current.updateTokenAmount('1.5'));
+      await expect(updatePromise).rejects.toThrow('update failed');
     });
 
-    await expect(updatePromise).rejects.toThrow('update failed');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       error,
       'Failed to update token amount in nested transaction',
     );
+    expect(setIsTransactionDataUpdatingMock).toHaveBeenLastCalledWith(false);
   });
 
   it('does not update amount if new amount is equal to current amount', () => {

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -154,7 +154,7 @@ describe('useUpdateTokenAmount', () => {
     expect(isSettled).toBe(true);
   });
 
-  it('logs nested update failures without rejecting', async () => {
+  it('logs and rejects nested update failures', async () => {
     const error = new Error('update failed');
     const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
     updateAtomicBatchDataMock.mockRejectedValue(error);
@@ -177,7 +177,7 @@ describe('useUpdateTokenAmount', () => {
       updatePromise = Promise.resolve(result.current.updateTokenAmount('1.5'));
     });
 
-    await expect(updatePromise).resolves.toBeUndefined();
+    await expect(updatePromise).rejects.toThrow('update failed');
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       error,
       'Failed to update token amount in nested transaction',

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -80,7 +80,7 @@ export function useUpdateTokenAmount() {
       setPreviousAmountRaw(amountRaw);
 
       if (nestedCallIndex !== undefined) {
-        updateAtomicBatchData({
+        return updateAtomicBatchData({
           transactionId,
           transactionIndex: nestedCallIndex,
           transactionData: newData,
@@ -90,8 +90,6 @@ export function useUpdateTokenAmount() {
             'Failed to update token amount in nested transaction',
           );
         });
-
-        return;
       }
 
       updateEditableParams(transactionId as string, {

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -89,6 +89,7 @@ export function useUpdateTokenAmount() {
             error,
             'Failed to update token amount in nested transaction',
           );
+          throw error;
         });
       }
 

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -85,6 +85,7 @@ export function useUpdateTokenAmount() {
           transactionIndex: nestedCallIndex,
           transactionData: newData,
         }).catch((error) => {
+          setPreviousAmountRaw(undefined);
           Logger.error(
             error,
             'Failed to update token amount in nested transaction',

--- a/app/selectors/transactionPayController.test.ts
+++ b/app/selectors/transactionPayController.test.ts
@@ -4,6 +4,7 @@ import {
   selectTransactionPayTotalsByTransactionId,
   selectIsTransactionPayLoadingByTransactionId,
   selectTransactionPayQuotesByTransactionId,
+  selectTransactionPayQuotesLastUpdatedByTransactionId,
   selectTransactionPayTokensByTransactionId,
   selectTransactionPaymentTokenByTransactionId,
   selectTransactionPaySourceAmountsByTransactionId,
@@ -137,6 +138,22 @@ describe('transactionPayController selectors', () => {
       );
 
       expect(result).toStrictEqual(quotes);
+    });
+  });
+
+  describe('selectTransactionPayQuotesLastUpdatedByTransactionId', () => {
+    it('returns the quote update timestamp from transaction data', () => {
+      const quotesLastUpdated = 123;
+      const state = createMockRootState({
+        [TRANSACTION_ID_MOCK]: { quotesLastUpdated },
+      });
+
+      const result = selectTransactionPayQuotesLastUpdatedByTransactionId(
+        state,
+        TRANSACTION_ID_MOCK,
+      );
+
+      expect(result).toBe(quotesLastUpdated);
     });
   });
 

--- a/app/selectors/transactionPayController.ts
+++ b/app/selectors/transactionPayController.ts
@@ -48,6 +48,12 @@ export const selectTransactionPayQuotesByTransactionId = createSelector(
     transactionData.quotes.filter((quote) => !isNoOpQuote(quote)),
 );
 
+export const selectTransactionPayQuotesLastUpdatedByTransactionId =
+  createSelector(
+    selectTransactionDataByTransactionId,
+    (transactionData) => transactionData?.quotesLastUpdated,
+  );
+
 export const selectTransactionPayTokensByTransactionId = createSelector(
   selectTransactionDataByTransactionId,
   (transactionData) => transactionData?.tokens ?? [],


### PR DESCRIPTION
## **Description**

Money Account deposits could appear unresponsive for several seconds after the user pressed **Continue** because the amount-entry keypad remained visible while transaction calldata and quote prerequisites were prepared.

This change adds a local preparation state for Money Account deposits. It immediately replaces the keypad with the existing review-loading presentation, keeps the **From** and **Pay with** rows visible but non-interactive, disables amount editing and duplicate submission, and displays fee/time/total skeletons with a disabled **Add funds** button. The amount retains its normal visual emphasis while its edit action is unavailable. The same UI remains visible while TransactionPayController fetches quotes, and the amount, account, and payment token stay locked until quote loading settles. This avoids a perceived loading restart, stale review details, or an enabled-button flicker between the two phases.

The amount-update-to-quote transition uses TransactionPayController's authoritative state rather than a timer. Local loading remains active until Redux observes controller loading or a quote timestamp newer than the latest value visible from either the controller or Redux. Synchronous flows that produce no quote signal clear immediately, nested transaction amount updates are awaited before inspecting controller state, and the behavior remains shared across Money and non-Money confirmation flows. Nested update failures are logged and propagated to the existing error path, and their pending transaction-data marker is cleared so loading cannot remain latched after recovery.

If preparation fails, the amount-entry keypad is restored and the existing error toast is retained. Relay quote latency and quote failures remain separate from this local preparation state.

## **Changelog**

CHANGELOG entry: Fixed missing loading feedback while Money Account deposits were being prepared

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/issues/33317

## **Manual testing steps**

```gherkin
Feature: Money Account deposit preparation feedback

  Scenario: user continues from Money Account deposit amount entry
    Given a user is entering an Add funds amount for a Money Account deposit

    When the user presses Continue
    Then the keypad is immediately replaced by a loading review
    And the From and Pay with rows remain visible but cannot be changed
    And the Add funds button remains disabled until quote loading settles

  Scenario: Money Account deposit preparation fails
    Given a user pressed Continue from Money Account deposit amount entry

    When transaction preparation fails
    Then the amount-entry keypad is restored
    And the existing amount-update error toast is displayed
```

Automated verification:

- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx --runInBand` — 87 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts --runInBand` — 6 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts --runInBand` — 20 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts --runInBand` — 72 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts --runInBand` — 14 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --no-watchman app/selectors/transactionPayController.test.ts --runInBand` — 25 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn lint:tsc`
- Commit-time Prettier and ESLint hooks

## **Screenshots/Recordings**

### **Before**

N/A — no simulator recording was captured for this code-only change.

### **After**

N/A — the preparation transition is covered by targeted component unit tests.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android — N/A; manual device testing was not performed in this session.
- [x] I've tested with a power user scenario — N/A; this change targets immediate visual feedback and has focused unit coverage.
- [x] I've instrumented key operations with Sentry traces for production performance metrics — N/A; instrumentation and underlying controller optimization are separate follow-up work.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation submit flow and Money Account deposit timing/race handling; changes are localized and heavily unit-tested but affect when users can edit amounts or confirm.
> 
> **Overview**
> Money Account deposit amount entry no longer sits on the keypad while calldata and quotes are prepared. Pressing **Continue** now drives a shared **preparation / quote-loading** review: the keypad is replaced immediately with fee/time/total skeletons, **From** / **Pay with** stay visible but non-interactive, amount editing and double **Done** taps are blocked, and the primary CTA stays disabled until loading settles.
> 
> **`CustomAmountInfo`** adds local `isAmountUpdating` plus a **`quoteHandoff`** that bridges `TransactionPayController` state (`isLoading`, `quotesLastUpdated`) with Redux via new **`useTransactionPayQuotesLastUpdated`**, so stale quote timestamps do not flash real fee rows or re-enable the button between amount commit and quote fetch. Failures restore the keypad and keep the existing amount-update toast.
> 
> Amount updates are **`await`**ed end-to-end (`useUpdateTransactionPayAmount` → `useUpdateTokenAmount`), including nested batch updates that now **reject** and reset pending state on failure. Review UI is refactored into **`Quote`** / **`PaymentDetailsSkeleton`** with a **`REVIEW_ROWS`** test id; coverage adds a large **Money Account quote preparation** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051b59638db4f7af35b2591fabfdb0f2fb028784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


