### PR TITLE
chore: update navigation for final step

### DIFF
--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.test.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.test.tsx
@@ -190,9 +190,17 @@ const fireTrigger = async (path: string) => {
 // Advance to the terminal Notify step the way the Rive would: Trade -> Follow
 // (`next`) -> Notify (`followTopTraders`). Completion triggers are gated on this
 // step, so tests must reach it before firing `gotIt`/`allowNotifications`.
+//
+// Entering the Notify slide pulses the visible button's completion trigger as it
+// animates in (same as the maybe-later transition), which the component swallows
+// exactly once. We reproduce that spurious pulse here so the helper leaves the
+// component in the same state as the real runtime — latch consumed — and the
+// caller's own `gotIt`/`allowNotifications` acts as the user's real tap.
 const advanceToNotifyStep = async () => {
   await fireTrigger(RIVE_TRIGGERS.NEXT);
   await fireTrigger(RIVE_TRIGGERS.FOLLOW_TOP_TRADERS);
+  // Spurious entry pulse from the follow-path Notify transition (swallowed).
+  await fireTrigger(RIVE_TRIGGERS.GOT_IT);
 };
 
 const getLastStringValue = (path: string) =>
@@ -667,6 +675,9 @@ describe('SocialLeaderboardOnboarding', () => {
 
     await fireTrigger(RIVE_TRIGGERS.NEXT);
     await fireTrigger(RIVE_TRIGGERS.FOLLOW_TOP_TRADERS);
+    // Spurious entry pulse from the follow-path Notify transition (swallowed).
+    await fireTrigger(RIVE_TRIGGERS.GOT_IT);
+    // The user's real "Got it" tap on the Notify step completes the flow.
     await fireTrigger(RIVE_TRIGGERS.GOT_IT);
 
     expect(mockTrack).toHaveBeenCalledWith(
@@ -684,6 +695,56 @@ describe('SocialLeaderboardOnboarding', () => {
         nux_step: 'step_3',
         traders_followed_count: 2,
         traders_pre_selected_count: 3,
+      }),
+    );
+  });
+
+  it('swallows the follow-path completion pulse, then completes on the real tap', async () => {
+    // "Follow the top three" advances to the Notify slide, whose transition
+    // pulses the visible button's completion trigger as it animates in (observed
+    // on Android; iOS timing hides it). That first pulse must be ignored so the
+    // user is not ejected straight to the leaderboard the moment they follow —
+    // the user's real tap afterwards must still complete the flow.
+    renderComponent();
+
+    await fireTrigger(RIVE_TRIGGERS.NEXT);
+    await fireTrigger(RIVE_TRIGGERS.FOLLOW_TOP_TRADERS);
+
+    // Spurious entry pulse of the visible completion trigger is swallowed.
+    await fireTrigger(RIVE_TRIGGERS.GOT_IT);
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      MetaMetricsEvents.SOCIAL_FOLLOW_TRADING_ONBOARDING_COMPLETED,
+      expect.anything(),
+    );
+
+    // The user's real tap afterwards completes the flow.
+    await fireTrigger(RIVE_TRIGGERS.GOT_IT);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.SOCIAL_LEADERBOARD.VIEW, { source: 'nux' }),
+    );
+  });
+
+  it('swallows an allowNotifications entry pulse on the follow-path Notify step', async () => {
+    // The follow-path Notify slide shows the two-button ("Allow notifications")
+    // layout while prompting, so its entry pulse can arrive on that trigger too.
+    // It must be swallowed without requesting permission or navigating.
+    renderComponent();
+
+    await fireTrigger(RIVE_TRIGGERS.NEXT);
+    await fireTrigger(RIVE_TRIGGERS.FOLLOW_TOP_TRADERS);
+
+    await fireTrigger(RIVE_TRIGGERS.ALLOW_NOTIFICATIONS);
+    expect(mockRequestPushPermission).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    // The real "Allow notifications" tap afterwards still enables and completes.
+    await fireTrigger(RIVE_TRIGGERS.ALLOW_NOTIFICATIONS);
+    expect(mockRequestPushPermission).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.SOCIAL_LEADERBOARD.VIEW, {
+        source: 'nux',
+        showNotificationsBanner: false,
       }),
     );
   });

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
@@ -600,6 +600,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
     const toFollow = topTraders.filter((trader) => !trader.isFollowing);
     tradersFollowedCountRef.current = toFollow.length;
     setStep(2);
+    swallowNextCompletionRef.current = true;
     await Promise.all(
       toFollow.map((trader) =>
         toggleFollow(trader.id, {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Small onboarding polish. On the "Follow the best" step, tapping "Follow the top three" advances to the final **"Never miss a move"** (Notify) step. In android it skipped to the leaderboard.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: null

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small onboarding navigation guard in an existing latch pattern; scope is limited to the social leaderboard NUX follow path and covered by new tests.
> 
> **Overview**
> Fixes Android skipping straight to the leaderboard after **Follow the top three** instead of staying on the final **Never miss a move** Notify step.
> 
> When the user follows the top traders, `handleFollowTopThree` now arms the same **swallow-next-completion** latch already used on the maybe-later path. The Rive transition into the follow-path Notify slide can fire a spurious `gotIt` or `allowNotifications` pulse as the button animates in; that first pulse is ignored so navigation and completion analytics only run on the user’s real tap.
> 
> Tests were updated so `advanceToNotifyStep` and completion scenarios reproduce the entry pulse, and new cases assert swallow-then-complete behavior for both completion triggers on the follow-path Notify step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4402dbda494255c76f129f3ce8520ad9d967532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->