### PR TITLE
fix(money): show USD amounts in Money toasts (MUSD-1174) cp-8.3.0

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -20,6 +20,7 @@ import {
 } from './useMoneyAccount';
 import { shouldShowMoneyFirstTimeDepositAnimation } from '../utils/firstTimeDeposit';
 import { getMemoizedInternalAccountByAddress } from '../../../../selectors/accountsController';
+import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import { selectAccountToGroupMap } from '../../../../selectors/multichainAccounts/accountTreeController';
 import Routes from '../../../../constants/navigation/Routes';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
@@ -683,7 +684,7 @@ describe('useMoneyTransactionStatus', () => {
       });
     });
 
-    it('confirmed → success toast with decoded fiat amount', () => {
+    it('confirmed → success toast with decoded dollar amount', () => {
       const { confirmedHandler } = renderAndGetHandlers();
 
       confirmedHandler(
@@ -699,8 +700,7 @@ describe('useMoneyTransactionStatus', () => {
 
       expect(depositSuccessFn).toHaveBeenCalledTimes(1);
       const params = depositSuccessFn.mock.calls[0][0];
-      expect(params.amountFiat).toContain('mUSD');
-      expect(params.amountFiat).toContain('12.34');
+      expect(params.amountFiat).toBe('$12.34');
     });
 
     it('failed → deposit failed toast', () => {
@@ -1508,37 +1508,82 @@ describe('useMoneyTransactionStatus', () => {
   });
 
   describe('formatMusdAmountForToast', () => {
-    it('falls back to mUSD format when no fiat rate is available', () => {
-      expect(formatMusdAmountForToast(BigInt(1_000_000))).toBe('1.00 mUSD');
-      expect(formatMusdAmountForToast(BigInt(123_456))).toBe('0.12 mUSD');
+    it('formats the decoded mUSD amount as US dollars', () => {
+      expect(formatMusdAmountForToast(BigInt(1_000_000))).toBe('$1.00');
+      expect(formatMusdAmountForToast(BigInt(123_456))).toBe('$0.12');
+      expect(formatMusdAmountForToast(BigInt(5_000_000))).toBe('$5.00');
+    });
+  });
+
+  describe('USD formatting regardless of preferred currency', () => {
+    beforeEach(() => {
+      jest.mocked(selectCurrentCurrency).mockReturnValue('EUR');
     });
 
-    it('formats as fiat when token market data, currency rates and network config resolve', () => {
-      const tokenRatesMock = jest.requireMock(
-        '../../../../selectors/tokenRatesController',
-      );
-      const currencyRatesMock = jest.requireMock(
-        '../../../../selectors/currencyRateController',
-      );
-      const networkConfigMock = jest.requireMock(
-        '../../../../selectors/networkController',
-      );
-      tokenRatesMock.selectTokenMarketData.mockReturnValueOnce({
-        '0x1': {
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': { price: 1 },
-        },
-      });
-      currencyRatesMock.selectCurrencyRates.mockReturnValueOnce({
-        ETH: { conversionRate: 2 },
-      });
-      networkConfigMock.selectNetworkConfigurations.mockReturnValueOnce({
-        '0x1': { nativeCurrency: 'ETH' },
-      });
-      currencyRatesMock.selectCurrentCurrency.mockReturnValueOnce('usd');
+    afterEach(() => {
+      jest.mocked(selectCurrentCurrency).mockReturnValue('usd');
+    });
 
-      const formatted = formatMusdAmountForToast(BigInt(5_000_000));
-      expect(formatted).not.toContain('mUSD');
-      expect(formatted).toMatch(/10/);
+    it('confirmed deposit → success amount is dollar-formatted when the preferred currency is EUR', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            data: encodeDepositData(BigInt(12_340_000)),
+          },
+        }),
+      );
+
+      expect(depositSuccessFn).toHaveBeenCalledTimes(1);
+      const amountFiat = depositSuccessFn.mock.calls[0][0].amountFiat;
+      expect(amountFiat).toMatch(/^\$/);
+      expect(amountFiat).not.toContain('€');
+    });
+
+    it('confirmed withdraw → success amount is dollar-formatted when the preferred currency is EUR', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            data: encodeWithdrawData(BigInt(50_000_000)),
+          },
+        }),
+      );
+
+      expect(withdrawSuccessFn).toHaveBeenCalledTimes(1);
+      const amountFiat = withdrawSuccessFn.mock.calls[0][0].amountFiat;
+      expect(amountFiat).toMatch(/^\$/);
+      expect(amountFiat).not.toContain('€');
+    });
+
+    it('confirmed perps send → success amount is dollar-formatted when the preferred currency is EUR', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          id: 'eur-send-tx',
+          type: TransactionType.perpsDeposit,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: MUSD_ADDRESS,
+            chainId: CHAIN_IDS.MONAD,
+            targetFiat: '100',
+          },
+        } as unknown as Partial<TransactionMeta>),
+      );
+
+      expect(sendSuccessFn).toHaveBeenCalledTimes(1);
+      const amountFiat = sendSuccessFn.mock.calls[0][0].amountFiat;
+      expect(amountFiat).toMatch(/^\$/);
+      expect(amountFiat).not.toContain('€');
     });
   });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -1,5 +1,4 @@
 import {
-  CHAIN_IDS,
   TransactionMeta,
   TransactionStatus,
   TransactionType,
@@ -15,24 +14,14 @@ import Logger from '../../../../util/Logger';
 import { fromTokenMinimalUnitString } from '../../../../util/number/bigint';
 import { strings } from '../../../../../locales/i18n';
 import { store } from '../../../../store';
-import {
-  selectCurrencyRates,
-  selectCurrentCurrency,
-} from '../../../../selectors/currencyRateController';
-import { selectNetworkConfigurations } from '../../../../selectors/networkController';
 import { getMemoizedInternalAccountByAddress } from '../../../../selectors/accountsController';
 import { selectAccountToGroupMap } from '../../../../selectors/multichainAccounts/accountTreeController';
-import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
-import {
-  renderShortAddress,
-  toChecksumAddress,
-} from '../../../../util/address';
+import { renderShortAddress } from '../../../../util/address';
 import {
   MUSD_DECIMALS,
-  MUSD_TOKEN_ADDRESS_BY_CHAIN,
   TOAST_TRACKING_CLEANUP_DELAY_MS,
 } from '../../Earn/constants/musd';
-import { moneyFormatFiat } from '../utils/moneyFormatFiat';
+import { moneyFormatUsd } from '../utils/moneyFormatFiat';
 import { TELLER_ABI } from '../utils/moneyAccountTransactions';
 import {
   isMoneyAccountTx,
@@ -117,50 +106,17 @@ function decodeTellerAmount(
   return undefined;
 }
 
-function getMusdFiatRate(): BigNumber | undefined {
-  const state = store.getState();
-  const tokenMarketData = selectTokenMarketData(state);
-  const currencyRates = selectCurrencyRates(state);
-  const networkConfigurations = selectNetworkConfigurations(state);
-
-  const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
-  if (!musdAddress) return undefined;
-
-  const checksumAddress = toChecksumAddress(musdAddress);
-  const chainConfig = networkConfigurations?.[CHAIN_IDS.MAINNET];
-  const nativeCurrency = chainConfig?.nativeCurrency;
-  const conversionRate = nativeCurrency
-    ? currencyRates?.[nativeCurrency]?.conversionRate
-    : undefined;
-
-  const priceInNativeCurrency =
-    tokenMarketData?.[CHAIN_IDS.MAINNET]?.[checksumAddress]?.price ??
-    tokenMarketData?.[CHAIN_IDS.MAINNET]?.[musdAddress]?.price;
-
-  if (!conversionRate || priceInNativeCurrency === undefined) return undefined;
-  return new BigNumber(priceInNativeCurrency).times(conversionRate);
-}
-
 export function formatMusdAmountForToast(amountWei: bigint): string {
   const musdDecimal = new BigNumber(
     fromTokenMinimalUnitString(amountWei.toString(), MUSD_DECIMALS),
   );
-  const rate = getMusdFiatRate();
-  const currentCurrency = selectCurrentCurrency(store.getState());
-
-  if (!rate || !currentCurrency) {
-    return `${musdDecimal.toFixed(2)} mUSD`;
-  }
-  return moneyFormatFiat(musdDecimal.times(rate), currentCurrency);
+  return moneyFormatUsd(musdDecimal);
 }
 
 function formatMetamaskPayFiat(value: unknown): string | undefined {
   const fiat = Number(value);
   if (Number.isNaN(fiat) || fiat <= 0) return undefined;
-  return moneyFormatFiat(
-    new BigNumber(fiat),
-    selectCurrentCurrency(store.getState()),
-  );
+  return moneyFormatUsd(new BigNumber(fiat));
 }
 
 function navigateToMoneyTransactionDetails(transactionId: string) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Money deposit and withdrawal toasts now always display amounts in USD with the `$` symbol, matching every other Money account surface.

Bug: with a non-USD preferred display currency selected (e.g. EUR), the toasts showed the amount converted into that currency (`12,34 €`) instead of the fixed USD value.

Fix: the toast formatters in `useMoneyTransactionStatus` previously converted the decoded mUSD amount via market rate × conversion rate into the selected currency, and formatted `metamaskPay.targetFiat` with the selected currency as well. Since mUSD is USD-pegged 1:1, both paths now format through `moneyFormatUsd` (en-US, USD) — the same pattern `useMoneyTransactionDisplayInfo` already uses for activity rows. The now-dead market-rate lookup (`getMusdFiatRate`) and its `X.XX mUSD` fallback are removed, so toast amounts are always `$X.XX` regardless of rate availability or the user's currency preference.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Money deposit and withdrawal toasts to always display amounts in USD ($) instead of the user's preferred fiat currency

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1174

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money toasts display USD amounts

  Scenario: user deposits into the Money account with a non-USD preferred currency
    Given the user's preferred fiat currency is set to EUR
    And the user has a Money account

    When user completes a Money deposit
    Then the success toast displays the amount in USD (e.g. "$12.34"), not in EUR

  Scenario: user withdraws from the Money account with a non-USD preferred currency
    Given the user's preferred fiat currency is set to EUR
    And the user has a Money account with a balance

    When user completes a Money withdrawal
    Then the success toast displays the amount in USD (e.g. "$50.00"), not in EUR
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-format change in Money toast copy with no auth, payment execution, or data-model changes; behavior is covered by updated unit tests.
> 
> **Overview**
> Money deposit, withdraw, and perps/predict success toasts were formatting amounts in the user’s **preferred fiat** (via mUSD market rates and `moneyFormatFiat`), which could show values like `12,34 €` instead of the **USD ($)** used elsewhere in Money.
> 
> **`useMoneyTransactionStatus`** now routes decoded mUSD amounts and `metamaskPay.targetFiat` through **`moneyFormatUsd`**, matching activity-row display. The **`getMusdFiatRate`** lookup and **`X.XX mUSD`** fallback are removed, so toast amounts are always **`$X.XX`** regardless of currency preference or rate availability.
> 
> Tests assert dollar formatting for deposits, withdraws, and perps sends even when **`selectCurrentCurrency`** is EUR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1320d8431aba39bdbea364e091ea01052eba53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
