### PR TITLE
feat(metamask-pay): track quote errors in transaction events

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -25,6 +25,7 @@ import {
   useIsTransactionPayQuoteLoading,
   useTransactionPayQuoteError,
   useTransactionPayQuotes,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
   useTransactionPayFiatPayment,
 } from './useTransactionPayData';
@@ -79,6 +80,10 @@ const QUOTE_MOCK = {
   strategy: TransactionPayStrategy.Relay,
 } as TransactionPayQuote<Json>;
 
+const NOOP_QUOTE_MOCK = {
+  strategy: TransactionPayStrategy.None,
+} as TransactionPayQuote<Json>;
+
 function runHook({ type }: { type?: TransactionType } = {}) {
   const state = merge(
     {},
@@ -99,6 +104,9 @@ describe('useTransactionPayMetrics', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useTransactionPayQuotesRawMock = jest.mocked(
+    useTransactionPayQuotesRaw,
+  );
 
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -161,6 +169,7 @@ describe('useTransactionPayMetrics', () => {
     } as never);
 
     useTransactionPayQuotesMock.mockReturnValue([]);
+    useTransactionPayQuotesRawMock.mockReturnValue([]);
     useAccountTokensMock.mockReturnValue([]);
     mockSelectConfirmationMetricsById.mockReturnValue(undefined);
 
@@ -1593,6 +1602,35 @@ describe('useTransactionPayMetrics', () => {
 
       useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
       useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
+      useTransactionPayQuotesRawMock.mockReturnValue([QUOTE_MOCK]);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      expect(lastProps()).not.toHaveProperty('mm_pay_quote_errors');
+    });
+
+    it('does NOT append when a cycle ends with only a no-op quote', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPayQuotesRawMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      // A completed same-token / no-conversion route: the raw quotes list
+      // holds a single no-op quote while the filtered list is empty. This is
+      // a success, not a quote error.
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+      useTransactionPayQuotesRawMock.mockReturnValue([NOOP_QUOTE_MOCK]);
 
       rerender({});
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -138,6 +138,10 @@ describe('useTransactionPayMetrics', () => {
     useTransactionPayQuoteError,
   );
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     jest.resetAllMocks();
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -1568,6 +1568,8 @@ describe('useTransactionPayMetrics', () => {
           amount: Number(TOKEN_AMOUNT_MOCK),
           amount_input_type: null,
           error_message: 'unknown',
+          error_reason: null,
+          error_detail: null,
         },
       ]);
     });
@@ -1761,7 +1763,7 @@ describe('useTransactionPayMetrics', () => {
       });
     });
 
-    it('uses quoteError.message as error_message when available', async () => {
+    it('records quoteError message, reason and joined detail when available', async () => {
       useTransactionPayQuoteErrorMock.mockReturnValue({
         message: 'Insufficient balance',
         reason: 'insufficient-source-balance',
@@ -1778,10 +1780,46 @@ describe('useTransactionPayMetrics', () => {
       await act(async () => noop());
 
       const errors = lastProps()?.mm_pay_quote_errors as
-        | { error_message: string }[]
+        | {
+            error_message: string;
+            error_reason: string | null;
+            error_detail: string | null;
+          }[]
         | undefined;
       expect(errors).toHaveLength(1);
       expect(errors?.[0].error_message).toBe('Insufficient balance');
+      expect(errors?.[0].error_reason).toBe('insufficient-source-balance');
+      expect(errors?.[0].error_detail).toBe(
+        'Required: 1.5 USDC | Current: 1 USDC',
+      );
+    });
+
+    it('does not append an entry when the amount is zero', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          amountHuman: '0',
+        } as TransactionPayRequiredToken,
+      ]);
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      expect(lastProps()).not.toHaveProperty('mm_pay_quote_errors');
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -134,7 +134,9 @@ describe('useTransactionPayMetrics', () => {
   const useIsTransactionPayQuoteLoadingMock = jest.mocked(
     useIsTransactionPayQuoteLoading,
   );
-  const useTransactionPayQuoteErrorMock = jest.mocked(useTransactionPayQuoteError);
+  const useTransactionPayQuoteErrorMock = jest.mocked(
+    useTransactionPayQuoteError,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -1616,7 +1618,10 @@ describe('useTransactionPayMetrics', () => {
 
       await act(async () => noop());
 
-      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      const errors = lastProps()?.mm_pay_quote_errors as Record<
+        string,
+        unknown
+      >[];
       expect(errors?.[0]).toMatchObject({
         amount_input_type: '50%',
       });
@@ -1643,7 +1648,10 @@ describe('useTransactionPayMetrics', () => {
 
       await act(async () => noop());
 
-      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      const errors = lastProps()?.mm_pay_quote_errors as Record<
+        string,
+        unknown
+      >[];
       expect(errors?.[0]).toMatchObject({
         amount_input_type: null,
       });
@@ -1739,7 +1747,10 @@ describe('useTransactionPayMetrics', () => {
       rerender({});
       await act(async () => noop());
 
-      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      const errors = lastProps()?.mm_pay_quote_errors as Record<
+        string,
+        unknown
+      >[];
       expect(errors).toHaveLength(1);
       expect(errors?.[0]).toMatchObject({
         pay_token: {
@@ -1766,7 +1777,9 @@ describe('useTransactionPayMetrics', () => {
       rerender({});
       await act(async () => noop());
 
-      const errors = lastProps()?.mm_pay_quote_errors as { error_message: string }[] | undefined;
+      const errors = lastProps()?.mm_pay_quote_errors as
+        | { error_message: string }[]
+        | undefined;
       expect(errors).toHaveLength(1);
       expect(errors?.[0].error_message).toBe('Insufficient balance');
     });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -22,6 +22,8 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { Json } from '@metamask/utils';
 import {
+  useIsTransactionPayQuoteLoading,
+  useTransactionPayQuoteError,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
   useTransactionPayFiatPayment,
@@ -129,6 +131,10 @@ describe('useTransactionPayMetrics', () => {
   const useTransactionAccountOverrideMock = jest.mocked(
     useTransactionAccountOverride,
   );
+  const useIsTransactionPayQuoteLoadingMock = jest.mocked(
+    useIsTransactionPayQuoteLoading,
+  );
+  const useTransactionPayQuoteErrorMock = jest.mocked(useTransactionPayQuoteError);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -168,6 +174,8 @@ describe('useTransactionPayMetrics', () => {
     useFiatPaymentHighlightedActionsMock.mockReturnValue([]);
     useTransactionPaySelectedFiatPaymentMethodMock.mockReturnValue(undefined);
     useTransactionAccountOverrideMock.mockReturnValue(undefined);
+    useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+    useTransactionPayQuoteErrorMock.mockReturnValue(undefined);
   });
 
   it('includes available crypto method even before a pay token is selected', async () => {
@@ -1510,6 +1518,257 @@ describe('useTransactionPayMetrics', () => {
       await act(async () => noop());
 
       expect(timingDispatches('mm_pay_time_to_load_quote_ms')).toHaveLength(0);
+    });
+  });
+
+  describe('mm_pay_quote_errors', () => {
+    const lastProps = () =>
+      (
+        updateConfirmationMetricMock.mock.calls.at(-1)?.[0] as {
+          params: { properties: Record<string, unknown> };
+        }
+      )?.params?.properties;
+
+    it('is omitted when no quote errors have occurred', async () => {
+      runHook();
+
+      await act(async () => noop());
+
+      expect(lastProps()).not.toHaveProperty('mm_pay_quote_errors');
+    });
+
+    it('appends one entry when a loading cycle ends with no quotes', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      expect(lastProps()?.mm_pay_quote_errors).toEqual([
+        {
+          pay_token: {
+            symbol: PAY_TOKEN_MOCK.symbol,
+            chainId: PAY_TOKEN_MOCK.chainId,
+            address: PAY_TOKEN_MOCK.address,
+          },
+          amount: Number(TOKEN_AMOUNT_MOCK),
+          amount_input_type: null,
+          error_message: 'unknown',
+        },
+      ]);
+    });
+
+    it('does NOT append when a cycle ends WITH quotes', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      useTransactionPayQuotesMock.mockReturnValue([QUOTE_MOCK]);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      expect(lastProps()).not.toHaveProperty('mm_pay_quote_errors');
+    });
+
+    it('records amount_input_type from stored metric', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      mockSelectConfirmationMetricsById.mockReturnValue({
+        properties: { mm_pay_amount_input_type: '50%' },
+      });
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      expect(errors?.[0]).toMatchObject({
+        amount_input_type: '50%',
+      });
+    });
+
+    it('records amount_input_type as null when no amount input has been made', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      mockSelectConfirmationMetricsById.mockReturnValue({});
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+
+      rerender({});
+
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      expect(errors?.[0]).toMatchObject({
+        amount_input_type: null,
+      });
+    });
+
+    it('accumulates multiple failed cycles oldest-first', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      // Cycle 1: loading true
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      rerender({});
+      await act(async () => noop());
+
+      // Cycle 1: loading false (no quotes)
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      rerender({});
+      await act(async () => noop());
+
+      // Cycle 2: loading true
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      rerender({});
+      await act(async () => noop());
+
+      // Cycle 2: loading false (no quotes)
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      rerender({});
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as unknown[];
+      expect(errors).toHaveLength(2);
+    });
+
+    it('does not duplicate entries on subsequent non-loading re-renders', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: PAY_TOKEN_MOCK,
+        setPayToken: noop,
+      } as ReturnType<typeof useTransactionPayToken>);
+
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      // Drive a single failed cycle: loading true → false
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      rerender({});
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      rerender({});
+      await act(async () => noop());
+
+      // Re-render 3 more times while still non-loading (quotes still [])
+      rerender({});
+      await act(async () => noop());
+      rerender({});
+      await act(async () => noop());
+      rerender({});
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as unknown[];
+      expect(errors).toHaveLength(1);
+    });
+
+    it('records null pay_token fields when no payToken is selected', async () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: undefined,
+        setPayToken: noop as never,
+      });
+
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+
+      await act(async () => noop());
+
+      // Drive a failed cycle: loading true → false with no quotes
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      rerender({});
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      rerender({});
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as Record<string, unknown>[];
+      expect(errors).toHaveLength(1);
+      expect(errors?.[0]).toMatchObject({
+        pay_token: {
+          symbol: null,
+          chainId: null,
+          address: null,
+        },
+      });
+    });
+
+    it('uses quoteError.message as error_message when available', async () => {
+      useTransactionPayQuoteErrorMock.mockReturnValue({
+        message: 'Insufficient balance',
+        reason: 'insufficient-source-balance',
+        detail: ['Required: 1.5 USDC', 'Current: 1 USDC'],
+      });
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(true);
+      useTransactionPayQuotesMock.mockReturnValue([]);
+
+      const { rerender } = runHook();
+      await act(async () => noop());
+
+      useIsTransactionPayQuoteLoadingMock.mockReturnValue(false);
+      rerender({});
+      await act(async () => noop());
+
+      const errors = lastProps()?.mm_pay_quote_errors as { error_message: string }[] | undefined;
+      expect(errors).toHaveLength(1);
+      expect(errors?.[0].error_message).toBe('Insufficient balance');
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -19,6 +19,7 @@ import {
   useIsTransactionPayQuoteLoading,
   useTransactionPayQuoteError,
   useTransactionPayQuotes,
+  useTransactionPayQuotesRaw,
   useTransactionPayRequiredTokens,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
@@ -50,6 +51,7 @@ export function useTransactionPayMetrics() {
   const quoteErrorsRef = useRef<Json[]>([]);
   const wasQuoteLoadingRef = useRef(false);
   const quotes = useTransactionPayQuotes();
+  const rawQuotes = useTransactionPayQuotesRaw();
   const isQuoteLoading = useIsTransactionPayQuoteLoading();
   const quoteError = useTransactionPayQuoteError();
   const { availableTokens: tokens, hasTokens } =
@@ -81,6 +83,12 @@ export function useTransactionPayMetrics() {
   }, [isQuoteRequested]);
 
   const hasQuotes = (quotes?.length ?? 0) > 0;
+
+  // Includes no-op (TransactionPayStrategy.None) quotes, which the filtered
+  // `quotes` list drops. A completed same-token / no-conversion route stores
+  // only a no-op quote, so it must count as a successful cycle here — not a
+  // quote error. Mirrors useNoPayTokenQuotesAlert, which uses raw quotes too.
+  const hasRawQuotes = (rawQuotes?.length ?? 0) > 0;
 
   if (hasQuotes && !hasLoadedQuoteRef.current) {
     hasLoadedQuoteRef.current = true;
@@ -131,7 +139,7 @@ export function useTransactionPayMetrics() {
   if (
     wasQuoteLoadingRef.current &&
     !isQuoteLoading &&
-    !hasQuotes &&
+    !hasRawQuotes &&
     sendingValue > 0
   ) {
     const inputType = storedMetrics?.properties?.mm_pay_amount_input_type as

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -16,6 +16,8 @@ import {
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { BridgeToken } from '../../../../UI/Bridge/types';
 import {
+  useIsTransactionPayQuoteLoading,
+  useTransactionPayQuoteError,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
 } from './useTransactionPayData';
@@ -45,7 +47,11 @@ export function useTransactionPayMetrics() {
   const highestBalanceChainId = useHighestBalanceCaipChainId();
   const automaticPayToken = useRef<BridgeToken | undefined>(undefined);
   const hasLoadedQuoteRef = useRef(false);
+  const quoteErrorsRef = useRef<Json[]>([]);
+  const wasQuoteLoadingRef = useRef(false);
   const quotes = useTransactionPayQuotes();
+  const isQuoteLoading = useIsTransactionPayQuoteLoading();
+  const quoteError = useTransactionPayQuoteError();
   const { availableTokens: tokens, hasTokens } =
     useTransactionPayAvailableTokens();
 
@@ -118,6 +124,28 @@ export function useTransactionPayMetrics() {
     (t) => !t.skipIfBalance,
   );
   const sendingValue = Number(primaryRequiredToken?.amountHuman ?? '0');
+
+  // Detect a failed quote-loading cycle: isLoading transitioned true -> false
+  // AND ended with no quotes. One entry appended per failed cycle, oldest-first.
+  if (wasQuoteLoadingRef.current && !isQuoteLoading && !hasQuotes) {
+    const inputType = storedMetrics?.properties?.mm_pay_amount_input_type as
+      | string
+      | undefined;
+    quoteErrorsRef.current = [
+      ...quoteErrorsRef.current,
+      {
+        pay_token: {
+          symbol: payToken?.symbol ?? null,
+          chainId: payToken?.chainId ?? null,
+          address: payToken?.address ?? null,
+        },
+        amount: sendingValue,
+        amount_input_type: inputType ?? null,
+        error_message: quoteError?.message ?? 'unknown',
+      },
+    ];
+  }
+  wasQuoteLoadingRef.current = isQuoteLoading;
 
   if (!automaticPayToken.current && payToken) {
     automaticPayToken.current = payToken;
@@ -235,6 +263,10 @@ export function useTransactionPayMetrics() {
   if (presentedPaymentMethodRef.current) {
     properties.mm_pay_payment_method_presented =
       presentedPaymentMethodRef.current;
+  }
+
+  if (quoteErrorsRef.current.length > 0) {
+    properties.mm_pay_quote_errors = quoteErrorsRef.current;
   }
 
   if (

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -127,7 +127,13 @@ export function useTransactionPayMetrics() {
 
   // Detect a failed quote-loading cycle: isLoading transitioned true -> false
   // AND ended with no quotes. One entry appended per failed cycle, oldest-first.
-  if (wasQuoteLoadingRef.current && !isQuoteLoading && !hasQuotes) {
+  // Ignore cycles where the amount is zero (nothing to quote for).
+  if (
+    wasQuoteLoadingRef.current &&
+    !isQuoteLoading &&
+    !hasQuotes &&
+    sendingValue > 0
+  ) {
     const inputType = storedMetrics?.properties?.mm_pay_amount_input_type as
       | string
       | undefined;
@@ -142,6 +148,8 @@ export function useTransactionPayMetrics() {
         amount: sendingValue,
         amount_input_type: inputType ?? null,
         error_message: quoteError?.message ?? 'unknown',
+        error_reason: quoteError?.reason ?? null,
+        error_detail: quoteError?.detail?.join(' | ') ?? null,
       },
     ];
   }


### PR DESCRIPTION
## **Description**

Adds `mm_pay_quote_errors` to the MetaMask Pay transaction metrics events — an array of objects accumulated throughout the confirmation lifecycle, one per failed quote-loading cycle, oldest-first.

A failed cycle is detected when the quote-loading flag transitions `true → false` while the quotes list is empty and the amount being sent is greater than zero (cycles with a zero amount are ignored). Each entry captures the state at the moment the failure occurred:

- `pay_token`: `{ symbol, chainId, address }` of the active payment token (fields null-coalesced when no token is selected)
- `amount`: required token amount in human-readable units (`amountHuman`)
- `amount_input_type`: verbatim copy of the existing `mm_pay_amount_input_type` metric (`'manual'`, `'50%'`, `'100%'`, or `null`)
- `error_message`: the structured error message from `TransactionPayController`'s `quoteError` field
- `error_reason`: the `quoteError.reason` code, or `null` when absent
- `error_detail`: the `quoteError.detail` string array joined with ` | `, or `null` when absent

The property is omitted entirely when no errors have occurred. All changes are UI-hook-side and flow through the existing `updateConfirmationMetric` → `confirmationMetrics.metricsById[id]` → finalized event pipeline — no controller or builder changes required.

Stacks on #32932 (which introduces `quoteError` on controller state and the `useTransactionPayQuoteError` hook).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only hook changes with no payment or controller logic; behavior is covered by new unit tests.
> 
> **Overview**
> Adds **`mm_pay_quote_errors`** to MetaMask Pay confirmation metrics so failed quote loads surface on **Transaction Finalized** analytics.
> 
> `useTransactionPayMetrics` watches quote loading (`true → false`), treats **raw** quotes (including no-op `TransactionPayStrategy.None` same-token routes) as success, and appends one object per failed cycle when there are no raw quotes and the send amount is &gt; 0. Each entry includes pay token, amount, `amount_input_type`, and structured `quoteError` fields (`message`, `reason`, joined `detail`); the property is omitted when empty.
> 
> Tests cover accumulation, deduplication, zero-amount skip, no-op quote exclusion, and missing pay token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1523fd47bcf88b3d0f0a1458b9790f2d5079c665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->