### PR TITLE
fix(money): show projected 1-year balance in USD (MUSD-1173) cp-8.3.0

### DIFF
--- a/app/components/UI/Money/components/BalanceProjection/BalanceProjection.test.tsx
+++ b/app/components/UI/Money/components/BalanceProjection/BalanceProjection.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
-import BigNumber from 'bignumber.js';
 import { BalanceProjection } from './BalanceProjection';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
-import useFiatFormatter from '../../../SimulationDetails/FiatDisplay/useFiatFormatter';
 import { strings } from '../../../../../../locales/i18n';
 import {
   MONEY_TOOLTIP_NAMES,
@@ -12,7 +10,6 @@ import {
 import Routes from '../../../../../constants/navigation/Routes';
 
 jest.mock('../../hooks/useMoneyAccountBalance');
-jest.mock('../../../SimulationDetails/FiatDisplay/useFiatFormatter');
 
 const mockTrackTooltipClicked = jest.fn();
 
@@ -35,7 +32,6 @@ jest.mock('@react-navigation/native', () => {
 });
 
 const useMoneyAccountBalanceMock = jest.mocked(useMoneyAccountBalance);
-const useFiatFormatterMock = jest.mocked(useFiatFormatter);
 
 const ONE_YEAR_LABEL = strings('confirm.custom_amount.projected_balance', {
   projectedYears: 1,
@@ -58,13 +54,8 @@ function mockBalance({
 }
 
 describe('BalanceProjection', () => {
-  const formatFiat = jest.fn(
-    (value: BigNumber) => `$${value.toFixed(2, BigNumber.ROUND_HALF_UP)}`,
-  );
-
   beforeEach(() => {
     jest.clearAllMocks();
-    useFiatFormatterMock.mockReturnValue(formatFiat);
   });
 
   it('renders label and projected balance for $1,000 at apyDecimal 0.04 over 1 year (~$1,040.00)', () => {
@@ -76,7 +67,7 @@ describe('BalanceProjection', () => {
 
     expect(getByTestId('balance-projection')).toBeOnTheScreen();
     expect(getByText(ONE_YEAR_LABEL, { exact: false })).toBeOnTheScreen();
-    expect(getByText('$1040.00')).toBeOnTheScreen();
+    expect(getByText('$1,040.00')).toBeOnTheScreen();
   });
 
   it('compounds the projection over multiple years', () => {
@@ -86,7 +77,7 @@ describe('BalanceProjection', () => {
       <BalanceProjection amountFiat="1000" projectedYears={5} />,
     );
 
-    expect(getByText('$1216.65')).toBeOnTheScreen();
+    expect(getByText('$1,216.65')).toBeOnTheScreen();
   });
 
   it('renders the APY pitch when amountFiat is "0"', () => {
@@ -303,14 +294,14 @@ describe('BalanceProjection', () => {
     expect(queryByTestId('balance-projection-apy-pitch')).toBeNull();
   });
 
-  it('passes a BigNumber to the fiat formatter when projecting', () => {
-    mockBalance({ apyDecimal: 0.04, apyPercent: 4 });
+  it('renders the projected balance in dollars regardless of the preferred currency', () => {
+    mockBalance({ apyDecimal: 0.05, apyPercent: 5 });
 
-    render(<BalanceProjection amountFiat="1000" projectedYears={1} />);
+    const { getByText, queryByText } = render(
+      <BalanceProjection amountFiat="100" projectedYears={1} />,
+    );
 
-    expect(formatFiat).toHaveBeenCalledTimes(1);
-    const passed = formatFiat.mock.calls[0][0];
-    expect(BigNumber.isBigNumber(passed)).toBe(true);
-    expect(passed.toFixed(2)).toBe('1040.00');
+    expect(getByText('$105.00')).toBeOnTheScreen();
+    expect(queryByText(/€/)).toBeNull();
   });
 });

--- a/app/components/UI/Money/components/BalanceProjection/BalanceProjection.tsx
+++ b/app/components/UI/Money/components/BalanceProjection/BalanceProjection.tsx
@@ -16,10 +16,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
-import useFiatFormatter from '../../../SimulationDetails/FiatDisplay/useFiatFormatter';
 import { strings } from '../../../../../../locales/i18n';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { isPositiveNumberOrZero } from '../../utils/number';
+import { moneyFormatUsd } from '../../utils/moneyFormatFiat';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import {
   MONEY_TOOLTIP_NAMES,
@@ -39,7 +39,6 @@ export function BalanceProjection({
 }: BalanceProjectionProps) {
   const navigation = useNavigation();
   const { vaultApyQuery, apyDecimal, apyPercent } = useMoneyAccountBalance();
-  const formatFiat = useFiatFormatter();
   const { trackTooltipClicked } = useMoneyAnalytics({
     screen_name: SCREEN_NAMES.MONEY_DEPOSIT,
   });
@@ -112,7 +111,7 @@ export function BalanceProjection({
               projectedYears,
             })}{' '}
             <Text variant={TextVariant.BodyMd} color={TextColor.SuccessDefault}>
-              {formatFiat(projected)}
+              {moneyFormatUsd(projected)}
             </Text>
           </Text>
           <ButtonIcon


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Projected 1-year balance" text on the Money crypto deposit screen now always displays the amount in USD with the `$` symbol, matching every other Money account surface.

Bug: with a non-USD preferred display currency selected (e.g. EUR), the projection rendered with that currency's symbol (`1.040,00 €`) even though the underlying value is USD-denominated — the deposit amount on this screen is a dollar input (the same value feeds `ReceiveRow` as `inputAmountUsd`), so the number was correct but mislabelled.

Fix: `BalanceProjection` no longer formats via `useFiatFormatter` (which stamps the user's selected currency onto the raw number); it renders through `moneyFormatUsd` (en-US, USD) — the same pattern used by Money activity rows and the Money toasts (#33330). This also removes the component's only Redux currency dependency, so it is structurally incapable of rendering a non-USD symbol.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the projected 1-year balance on the Money deposit screen to always display in USD ($) instead of the user's preferred fiat currency

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1173

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Projected 1-year balance displays USD

  Scenario: user views the balance projection with a non-USD preferred currency
    Given the user's preferred fiat currency is set to EUR
    And the user has a Money account

    When user opens the Money crypto deposit screen and enters an amount
    Then the "Projected 1-year balance" text displays the amount in USD (e.g. "$1,040.00"), not in EUR
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-only change in one Money component with updated unit tests; no payment, auth, or balance calculation logic changes.
> 
> **Overview**
> **BalanceProjection** on the Money crypto deposit screen now formats the projected balance with **`moneyFormatUsd`** instead of **`useFiatFormatter`**, so the label always shows **USD with `$`** (e.g. `$1,040.00`) even when the user’s preferred display currency is something else.
> 
> Tests drop the fiat-formatter mock, update expected strings for en-US grouping, and add coverage that euro symbols are not shown for the projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05613a5dfe405a876de5be6a2a6db6aaa135e965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->