### PR TITLE
fix(money): skip first-deposit celebration for funded restored accounts (MUSD-903)

### DIFF
--- a/app/components/UI/Money/utils/firstTimeDeposit.test.ts
+++ b/app/components/UI/Money/utils/firstTimeDeposit.test.ts
@@ -4,11 +4,15 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import {
+  hasExistingMoneyBalance,
   hasPriorMoneyDeposit,
   shouldShowMoneyFirstTimeDepositAnimation,
 } from './firstTimeDeposit';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
 import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
+import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
+import ReactQueryService from '../../../../core/ReactQueryService';
+import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 
 jest.mock('../../../../selectors/transactionController', () => ({
   selectNonReplacedTransactions: jest.fn(),
@@ -16,6 +20,19 @@ jest.mock('../../../../selectors/transactionController', () => ({
 
 jest.mock('../selectors/featureFlags', () => ({
   selectMoneyFirstTimeDepositAnimationEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/moneyAccountController', () => ({
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
+
+jest.mock('../../../../core/ReactQueryService', () => ({
+  __esModule: true,
+  default: {
+    queryClient: {
+      getQueryData: jest.fn(),
+    },
+  },
 }));
 
 const mockedSelectNonReplacedTransactions =
@@ -27,6 +44,17 @@ const mockedFlagSelector =
   selectMoneyFirstTimeDepositAnimationEnabledFlag as unknown as jest.MockedFunction<
     (state: unknown) => boolean
   >;
+
+const mockedSelectPrimaryMoneyAccount =
+  selectPrimaryMoneyAccount as unknown as jest.MockedFunction<
+    (state: unknown) => { address: string } | undefined
+  >;
+
+const mockedGetQueryData = ReactQueryService.queryClient
+  .getQueryData as jest.Mock;
+
+const MOCK_MONEY_ACCOUNT_ADDRESS = '0xMoneyAccount';
+const mockPrimaryMoneyAccount = { address: MOCK_MONEY_ACCOUNT_ADDRESS };
 
 const baseTx = {
   status: TransactionStatus.confirmed,
@@ -109,11 +137,66 @@ describe('hasPriorMoneyDeposit', () => {
   });
 });
 
+describe('hasExistingMoneyBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSelectPrimaryMoneyAccount.mockReturnValue(mockPrimaryMoneyAccount);
+    mockedGetQueryData.mockReturnValue(undefined);
+  });
+
+  it('returns false when there is no primary money account', () => {
+    mockedSelectPrimaryMoneyAccount.mockReturnValue(undefined);
+
+    const result = hasExistingMoneyBalance(mockState);
+
+    expect(result).toBe(false);
+    expect(mockedGetQueryData).not.toHaveBeenCalled();
+  });
+
+  it('returns false when there is no cached balance entry', () => {
+    mockedGetQueryData.mockReturnValue(undefined);
+
+    const result = hasExistingMoneyBalance(mockState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the cached total balance is zero', () => {
+    mockedGetQueryData.mockReturnValue({ totalBalance: '0' });
+
+    const result = hasExistingMoneyBalance(mockState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the cached total balance is invalid', () => {
+    mockedGetQueryData.mockReturnValue({ totalBalance: 'not-a-number' });
+
+    const result = hasExistingMoneyBalance(mockState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when the cached total balance is positive', () => {
+    mockedGetQueryData.mockReturnValue({ totalBalance: '5000000' });
+
+    const result = hasExistingMoneyBalance(mockState);
+
+    expect(result).toBe(true);
+    expect(mockedGetQueryData).toHaveBeenCalledWith([
+      MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
+      MOCK_MONEY_ACCOUNT_ADDRESS,
+    ]);
+  });
+});
+
 describe('shouldShowMoneyFirstTimeDepositAnimation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedFlagSelector.mockReturnValue(true);
     mockedSelectNonReplacedTransactions.mockReturnValue([]);
+    mockedSelectPrimaryMoneyAccount.mockReturnValue(mockPrimaryMoneyAccount);
+    mockedGetQueryData.mockReturnValue(undefined);
   });
 
   it('returns true for a first money deposit with the feature enabled', () => {
@@ -163,5 +246,25 @@ describe('shouldShowMoneyFirstTimeDepositAnimation', () => {
     const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
 
     expect(result).toBe(false);
+  });
+
+  it('returns false when the money account already has a balance despite no prior local deposits', () => {
+    const tx = makeTx('current-tx', TransactionType.moneyAccountDeposit);
+    mockedSelectNonReplacedTransactions.mockReturnValue([tx]);
+    mockedGetQueryData.mockReturnValue({ totalBalance: '5000000' });
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when the cached money account balance is zero', () => {
+    const tx = makeTx('current-tx', TransactionType.moneyAccountDeposit);
+    mockedSelectNonReplacedTransactions.mockReturnValue([tx]);
+    mockedGetQueryData.mockReturnValue({ totalBalance: '0' });
+
+    const result = shouldShowMoneyFirstTimeDepositAnimation(mockState, tx);
+
+    expect(result).toBe(true);
   });
 });

--- a/app/components/UI/Money/utils/firstTimeDeposit.ts
+++ b/app/components/UI/Money/utils/firstTimeDeposit.ts
@@ -2,8 +2,13 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
+import { type MoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
+import BigNumber from 'bignumber.js';
 import { RootState } from '../../../../reducers';
 import { selectNonReplacedTransactions } from '../../../../selectors/transactionController';
+import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
+import ReactQueryService from '../../../../core/ReactQueryService';
+import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 import { selectMoneyFirstTimeDepositAnimationEnabledFlag } from '../selectors/featureFlags';
 import { isMoneyDepositTx } from './moneyTransactionGuards';
 
@@ -26,6 +31,31 @@ export function hasPriorMoneyDeposit(
 }
 
 /**
+ * Returns true if the primary money account's last-fetched balance is greater
+ * than zero. Reads the cached balance, which at deposit-confirmation time
+ * predates the deposit — so a restored, already-funded wallet counts as
+ * having an existing balance.
+ */
+export function hasExistingMoneyBalance(state: RootState): boolean {
+  const primaryMoneyAccount = selectPrimaryMoneyAccount(state);
+  if (!primaryMoneyAccount) {
+    return false;
+  }
+
+  const balance =
+    ReactQueryService.queryClient.getQueryData<MoneyAccountBalanceResponse>([
+      MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
+      primaryMoneyAccount.address,
+    ]);
+  if (!balance?.totalBalance) {
+    return false;
+  }
+
+  const totalBalance = new BigNumber(balance.totalBalance);
+  return !totalBalance.isNaN() && totalBalance.isGreaterThan(0);
+}
+
+/**
  * Returns true if confirming `tx` should trigger the first-time deposit full-page
  * animation takeover. We use this both to decide whether to show the first
  * deposit animation, and to whether to hide the successful deposit toast.
@@ -37,6 +67,7 @@ export function shouldShowMoneyFirstTimeDepositAnimation(
   return (
     isMoneyDepositTx(tx) &&
     selectMoneyFirstTimeDepositAnimationEnabledFlag(state) &&
-    !hasPriorMoneyDeposit(state, tx.id)
+    !hasPriorMoneyDeposit(state, tx.id) &&
+    !hasExistingMoneyBalance(state)
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

First-time Money deposit detection now also considers the money account's balance: a user whose account already holds funds is treated as an existing depositor, so they get the regular success toast instead of the first-deposit full-page animation takeover.

Bug: the "is this the user's first deposit" check (`hasPriorMoneyDeposit`) only scanned local TransactionController history. A wallet restored from SRP has no local history, so a restored user with an already-funded money account was treated as brand-new on their next deposit — the Money Home showed the first-time celebration takeover and suppressed the normal success toast, an inconsistent state for an established account.

Fix: `shouldShowMoneyFirstTimeDepositAnimation` additionally requires `hasExistingMoneyBalance` to be false. The new predicate resolves the primary money account and synchronously reads the last-fetched balance from the `MoneyAccountBalanceService` react-query cache (the same `getQueryData` pattern as `useRefreshMoneyBalanceOnTxConfirm`); at deposit-confirmation time that cached value predates the deposit. Both consumers of the guard (the animation navigation in `useMoneyFirstTimeDepositTracker` and the toast suppression in `useMoneyTransactionStatus`) stay consistent automatically.

Known limitation (accepted in the ticket): a restored user who previously spent their balance to zero still looks like a new account — there is no on-chain history signal available today.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed restored wallets with a funded Money account being shown the first-time deposit celebration instead of the regular deposit confirmation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-903

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: First-time deposit detection for restored accounts

  Scenario: restored user with a funded money account makes a deposit
    Given a wallet with a funded Money account is restored from SRP on a fresh install
    And the user opens the Money Home so the balance has loaded

    When user completes another Money deposit
    Then the regular deposit success toast is shown
    And the first-time deposit full-page animation is not shown

  Scenario: new user makes their first deposit
    Given a fresh wallet with a Money account holding zero balance

    When user completes their first Money deposit
    Then the first-time deposit full-page animation is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX guard change in Money deposit confirmation with synchronous cache reads only; no auth, payments, or persistence changes.
> 
> **Overview**
> Restored wallets with **no local deposit history** but an **already-funded Money account** no longer get the first-time deposit full-page animation or suppressed success toast on the next deposit.
> 
> `shouldShowMoneyFirstTimeDepositAnimation` now also requires **`hasExistingMoneyBalance`** to be false. That helper reads the primary money account’s **cached** balance from React Query (`getQueryData` on the money account balance query) and treats any valid **positive** `totalBalance` as an existing balance—at confirmation time that cache still reflects the pre-deposit balance, so restored funded accounts are classified correctly.
> 
> Unit tests cover `hasExistingMoneyBalance` (missing account, missing cache, zero, invalid, positive) and guard behavior when balance is positive vs zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b29dc57339de91477e971f1a6a84d99c2e34f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->