### PR TITLE
fix(predict): Trending too few markets & unstable count cp-8.3.0

### DIFF
--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -227,7 +227,10 @@ export const PREDICT_FEED_REGISTRY: Record<PredictFeedId, PredictFeedConfig> = {
             createAllFilter({
               status: 'open',
               order: 'volume24hr',
-              limit: 5,
+              // Fetch 10 (not the ~5 shown) so the home Trending section still
+              // fills its display cap after standalone/staleness filtering, and
+              // so the "See all" feed loads 10 per infinite-scroll page.
+              limit: 10,
             }),
           ],
           dynamic: {
@@ -236,7 +239,7 @@ export const PREDICT_FEED_REGISTRY: Record<PredictFeedId, PredictFeedConfig> = {
             baseParams: {
               status: 'open',
               order: 'volume24hr',
-              limit: 5,
+              limit: 10,
             },
           },
         },

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.test.ts
@@ -49,7 +49,10 @@ describe('usePredictTrendingSection', () => {
       expect.objectContaining({
         order: 'volume24hr',
         status: 'open',
-        limit: TRENDING_DISPLAY_LIMIT,
+        // Fetch limit is intentionally larger than the display cap so the
+        // section fills after filtering; keep it decoupled from
+        // TRENDING_DISPLAY_LIMIT.
+        limit: 10,
       }),
     );
   });

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/usePredictTrendingSection.ts
@@ -10,6 +10,13 @@ import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
 export const TRENDING_DISPLAY_LIMIT = 5;
 
 /**
+ * How many markets we fetch. Deliberately larger than {@link TRENDING_DISPLAY_LIMIT}
+ * so that after standalone/staleness filtering the home section still has enough
+ * survivors to fill its display cap. Mirrors the feed registry's trending limit.
+ */
+const TRENDING_FETCH_LIMIT = 10;
+
+/**
  * Query params derived from the feed registry so the home section and the
  * full "See all" feed share the same React Query cache key.
  * Falls back to hardcoded params if the registry entry is missing.
@@ -18,7 +25,7 @@ const TRENDING_PARAMS: PredictMarketListParams =
   resolvePredictFeedDefaultFilter('trending')?.params ?? {
     order: 'volume24hr',
     status: 'open',
-    limit: TRENDING_DISPLAY_LIMIT,
+    limit: TRENDING_FETCH_LIMIT,
   };
 
 export interface UsePredictTrendingSectionResult {


### PR DESCRIPTION
## **Description**

Trending was capped at `limit: 5` in `feedConfig.ts`. Two user-visible bugs resulted:

1. **Too few markets** — the home Trending section fetches 5, but `filterStandaloneMarkets` + `getVisiblePredictMarkets` (staleness/dead-outcome filtering) drop some, so the section often rendered only 2–3 cards.
2. **Unstable count (no user action)** — the home section and the "See all" Trending feed share the **same React Query cache key**. `usePredictMarketList` accumulates *all* cached pages, so when the feed's infinite-scroll `fetchNextPage` appended a page, the home section's `.slice(0, 5)` suddenly had a larger pool and jumped from 3 → 5 after the user navigated back.

**Fix:** bump the trending fetch limit from `5` → `10` (static + dynamic params). One config change drives both surfaces:
- Home fetches 10 → enough survivors after filtering to reliably fill its display cap of 5, and stays stable.
- The "See all" feed loads 10 per infinite-scroll page (pagination already wired via `onEndReached` → `fetchNextPage`).

The home display cap (`TRENDING_DISPLAY_LIMIT = 5`) is unchanged; the fetch limit is now a distinct concept from the display cap. No changes to shared `staleTime` or the staleness scorer.

## **Changelog**

CHANGELOG entry: Fixed the Predict Trending list showing too few markets and its count changing without user action.

## **Related issues**

Fixes: [PRED-1086](https://consensyssoftware.atlassian.net/browse/PRED-1086)

## **Manual testing steps**

```gherkin
Feature: Predict Trending list

  Scenario: Home Trending section shows a stable, full list
    Given I am on the Predict home screen
    When the Trending section finishes loading
    Then I see up to 5 trending markets (not 2-3)

  Scenario: Count stays stable after visiting the full feed
    Given I am on the Predict home screen with the Trending section loaded
    When I tap the "Trending" section title to open the "See all" feed
    And I scroll to load more markets
    And I navigate back to the home screen
    Then the Trending section count is unchanged (no 3 -> 5 jump)

  Scenario: See all feed paginates in pages of 10
    Given I open the Trending "See all" feed
    Then the first page shows up to 10 markets
    When I scroll to the end
    Then 10 more markets are lazy-loaded
```

## **Screenshots/Recordings**

### **Before**

N/A — behavioral/data-limit change; see manual testing steps.

### **After**

N/A — behavioral/data-limit change; see manual testing steps.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1086]: https://consensyssoftware.atlassian.net/browse/PRED-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and hook limit changes only; display cap and shared cache behavior are unchanged aside from fetching a larger first page.
> 
> **Overview**
> **Trending fetch limit is raised from 5 to 10** in the trending feed registry (`feedConfig`) for both static and dynamic filters, so the home section and "See all" feed request more markets per page (10 per infinite-scroll page on the full feed).
> 
> The home **Trending** hook now treats **fetch limit (10)** and **display cap (5)** as separate constants (`TRENDING_FETCH_LIMIT` vs `TRENDING_DISPLAY_LIMIT`), with registry-driven params and a fallback that uses the fetch limit—not the display cap. UI still shows at most 5 via `slice`.
> 
> This addresses markets dropping below 5 after standalone/staleness filtering when only 5 were fetched, and count jumping when the shared `usePredictMarketList` cache grew after scrolling the full Trending feed.
> 
> Tests are updated to expect `limit: 10` on the market list query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee81fb657f1821dd59278673b2f61a1426ee17a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->