### PR TITLE
fix(money): fund Add mUSD via MM Pay fiat deposit instead of standalone Ramps (MUSD-1164)

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -163,9 +163,6 @@ jest.mock('../../../../../selectors/tokenBalancesController', () => ({
 jest.mock('../../hooks/useMoneyAnalytics', () => ({
   useMoneyAnalytics: jest.fn(),
 }));
-jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
-  useRampNavigation: () => ({ goToBuy: jest.fn(() => Promise.resolve()) }),
-}));
 jest.mock('../../../../../selectors/preferencesController', () => ({
   ...jest.requireActual('../../../../../selectors/preferencesController'),
   selectPrivacyMode: jest.fn(() => false),

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -33,11 +33,6 @@ const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockInitiateDeposit = jest.fn(() => Promise.resolve());
-const mockGoToBuy = jest.fn(() => Promise.resolve());
-
-jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
-  useRampNavigation: () => ({ goToBuy: mockGoToBuy }),
-}));
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -207,7 +202,7 @@ describe('MoneyAddMoneySheet', () => {
     expect(getByText('mUSD')).toBeOnTheScreen();
   });
 
-  it('shows the move-mUSD row with the "Add mUSD" label and routes to the Ramps buy flow when the selected EVM account has no mUSD tokens or fiat balance', () => {
+  it('shows the move-mUSD row with the "Add mUSD" label and starts the MM Pay fiat deposit when the selected EVM account has no mUSD tokens or fiat balance', () => {
     (useMusdBalance as jest.Mock).mockReturnValue({
       fiatBalanceAggregated: undefined,
       fiatBalanceAggregatedFormatted: '$0.00',
@@ -228,13 +223,13 @@ describe('MoneyAddMoneySheet', () => {
     fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      autoSelectFiatPayment: true,
+      intent: 'card',
     });
-    expect(mockInitiateDeposit).not.toHaveBeenCalled();
   });
 
-  it('shows the move-mUSD row with the "Add mUSD" label and routes to the Ramps buy flow when the selected EVM account mUSD fiat balance is zero', () => {
+  it('shows the move-mUSD row with the "Add mUSD" label and starts the MM Pay fiat deposit when the selected EVM account mUSD fiat balance is zero', () => {
     (useMusdBalance as jest.Mock).mockReturnValue({
       fiatBalanceAggregated: '0',
       fiatBalanceAggregatedFormatted: '$0.00',
@@ -255,9 +250,27 @@ describe('MoneyAddMoneySheet', () => {
     fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      autoSelectFiatPayment: true,
+      intent: 'card',
     });
+  });
+
+  it('disables the "Add mUSD" row when there is no mUSD and the fiat deposit flow is unavailable', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '0',
+      fiatBalanceAggregatedFormatted: '$0.00',
+      hasMusdBalanceOnAnyChain: false,
+      tokenBalanceAggregated: '0',
+      tokenBalanceByChain: {},
+    });
+    (useRegionHasFiatProvider as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
     expect(mockInitiateDeposit).not.toHaveBeenCalled();
   });
 
@@ -602,7 +615,7 @@ describe('MoneyAddMoneySheet', () => {
       });
     });
 
-    it('calls trackSurfaceClicked with the RAMPS_BUY redirect target when "Add mUSD" is pressed with no mUSD balance', () => {
+    it('calls trackSurfaceClicked with the MONEY_DEPOSIT redirect target when "Add mUSD" is pressed with no mUSD balance', () => {
       (useMusdBalance as jest.Mock).mockReturnValue({
         fiatBalanceAggregated: '0',
         fiatBalanceAggregatedFormatted: '$0.00',
@@ -617,7 +630,7 @@ describe('MoneyAddMoneySheet', () => {
 
       expect(mockTrackSurfaceClicked).toHaveBeenCalledWith({
         component_name: COMPONENT_NAMES.MONEY_ADD_MONEY_SHEET_MOVE_MUSD,
-        redirect_target: SCREEN_NAMES.RAMPS_BUY,
+        redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
       });
     });
   });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -29,10 +29,7 @@ import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN,
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../Earn/constants/musd';
-import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
-import Logger from '../../../../../util/Logger';
 import {
   useMoneyAccountDeposit,
   type InitiateDepositOptions,
@@ -71,7 +68,6 @@ const MoneyAddMoneySheet: React.FC = () => {
     tokenBalanceByChain,
   } = useMusdBalance();
   const { initiateDeposit } = useMoneyAccountDeposit();
-  const { goToBuy } = useRampNavigation();
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
   const transactions = useSelector(selectTransactions);
@@ -83,6 +79,7 @@ const MoneyAddMoneySheet: React.FC = () => {
     () => enabledTransactionTypes.includes(TransactionType.moneyAccountDeposit),
     [enabledTransactionTypes],
   );
+  const canDepositFiat = isFiatDepositEnabled && regionHasFiatProvider;
 
   const { trackBottomSheetViewed, trackSurfaceClicked } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_ADD_MONEY_SHEET,
@@ -174,25 +171,17 @@ const MoneyAddMoneySheet: React.FC = () => {
   const hasMusdBalance = hasMusdBalanceOnAnyChain || hasParsedFiatBalance;
 
   const handleMoveMusd = useCallback(() => {
-    // With no mUSD anywhere there is nothing to move, so the row routes to
-    // Ramps to buy mUSD instead.
+    // With no mUSD anywhere there is nothing to move, so the row funds the
+    // money account through the MM Pay fiat deposit (debit card / Apple Pay)
+    // instead — the money account is only ever funded via MM Pay, never the
+    // standalone Ramps flow.
     if (!hasMusdBalance) {
       trackSurfaceClicked({
         component_name: COMPONENT_NAMES.MONEY_ADD_MONEY_SHEET_MOVE_MUSD,
-        redirect_target: SCREEN_NAMES.RAMPS_BUY,
+        redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
       });
 
-      sheetRef.current?.onCloseBottomSheet(() => {
-        goToBuy({
-          assetId:
-            MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
-        }).catch((error) => {
-          Logger.error(
-            error as Error,
-            '[MoneyAddMoneySheet] Failed to open the Ramps buy flow for mUSD',
-          );
-        });
-      });
+      startDeposit({ autoSelectFiatPayment: true, intent: 'card' });
       return;
     }
 
@@ -220,13 +209,7 @@ const MoneyAddMoneySheet: React.FC = () => {
         chainId: sourceChainId,
       },
     });
-  }, [
-    goToBuy,
-    hasMusdBalance,
-    startDeposit,
-    tokenBalanceByChain,
-    trackSurfaceClicked,
-  ]);
+  }, [hasMusdBalance, startDeposit, tokenBalanceByChain, trackSurfaceClicked]);
 
   const moveMusdAmount = useMemo(
     () => moneyFormatUsd(new BigNumber(tokenBalanceAggregated)),
@@ -245,7 +228,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       testID: MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       disabled: !hasAnyCryptoBalance,
     },
-    ...(isFiatDepositEnabled && regionHasFiatProvider
+    ...(canDepositFiat
       ? [
           {
             label: strings(
@@ -268,6 +251,9 @@ const MoneyAddMoneySheet: React.FC = () => {
       icon: IconName.Add,
       onPress: handleMoveMusd,
       testID: MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      // Without mUSD the row falls back to the MM Pay fiat deposit, so it is
+      // only actionable when that flow is available.
+      disabled: !hasMusdBalance && !canDepositFiat,
     },
     {
       label: strings('money.add_money_sheet.bank_account'),

--- a/app/components/UI/Money/constants/moneyEvents.ts
+++ b/app/components/UI/Money/constants/moneyEvents.ts
@@ -17,7 +17,6 @@ export enum SCREEN_NAMES {
   MONEY_ACTIVITY_DETAILS = 'money_activity_details',
   MONEY_POTENTIAL_EARNINGS = 'money_potential_earnings',
   MONEY_FIRST_TIME_DEPOSIT = 'money_first_time_deposit',
-  RAMPS_BUY = 'ramps_buy',
 }
 
 export enum BOTTOM_SHEET_NAMES {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Pressing "Add mUSD" in the Money add funds sheet when the account has no mUSD now starts the MM Pay fiat deposit (debit card / Apple Pay) — the same flow as the "Debit card or Apple Pay" row — so the money account is funded through MM Pay.

Bug: after #33250 the row opened the standalone Ramps aggregator buy flow, which funds the wallet outside MM Pay. The money account must only ever be funded via MM Pay, so routing to standard Ramps was incorrect.

When the MM Pay fiat deposit is unavailable (fiat deposits disabled remotely or no fiat provider for the region) and there is no mUSD to move, the row is disabled again, matching its pre-#33250 behavior. The now-unused `RAMPS_BUY` analytics screen name is removed; the press event reports `redirect_target: money_deposit`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the "Add mUSD" option in the Money add funds sheet opening the standalone Ramps buy flow when the user has no mUSD; it now opens the MM Pay debit card / Apple Pay deposit

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1164

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add mUSD routes to the MM Pay fiat deposit

  Scenario: user without mUSD presses Add mUSD
    Given the selected account holds no mUSD on any chain
    And the Money add funds sheet is open

    When user presses the "Add mUSD" row
    Then the sheet closes and the MM Pay deposit confirmation opens with the debit card / Apple Pay payment method preselected

  Scenario: user without mUSD presses Add mUSD in a region without a fiat provider
    Given the selected account holds no mUSD on any chain
    And fiat deposits are unavailable (disabled remotely or no fiat provider for the region)

    When user views the Money add funds sheet
    Then the "Add mUSD" row is disabled

  Scenario: user with mUSD presses the move-mUSD row
    Given the selected account holds mUSD

    When user presses the "$X mUSD" row
    Then the MM Pay deposit confirmation opens with mUSD preselected as the payment token
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/e6115eb1-0c02-449f-85df-96a7fdbc01dd

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/615ebe1b-8a7f-4c95-89d4-a9605c087aeb


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user funding path and deposit gating in Money add-funds UI; incorrect routing could block funding or send users to the wrong flow, but scope is limited to one sheet with updated tests.
> 
> **Overview**
> **Add mUSD** in `MoneyAddMoneySheet` no longer opens standalone Ramps buy when the user has no mUSD. It now uses the same **MM Pay fiat deposit** path as **Debit card / Apple Pay** (`startDeposit` with `autoSelectFiatPayment: true`, `intent: 'card'`), and analytics report `redirect_target: money_deposit` instead of `ramps_buy`.
> 
> The move-mUSD row is **disabled** when there is no mUSD and fiat deposit is unavailable (`canDepositFiat` = enabled deposit type + regional provider). `useRampNavigation` / `goToBuy` and the unused `SCREEN_NAMES.RAMPS_BUY` constant are removed.
> 
> Tests are updated for the new deposit behavior, analytics target, and the disabled-row case; Ramps navigation mocks are dropped from related test files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca2af7c71349140a755f3f682b17bdf6599009b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->