### PR TITLE
fix(ci): reuse main BrowserStack apps on manual performance dispatch

### DIFF
--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -34,6 +34,8 @@ The native build fingerprint for test-only PRs is computed from **`main` HEAD** 
 
 If `main` has new native-changing commits but its CI build has not finished yet, reuse lookup may miss — CI logs a warning and **falls back to a fresh native build** instead of failing the workflow. Performance E2E on test-only PRs resolves BrowserStack apps via stable main `custom_id`s (`MetaMask-Android-*-main`) first, then legacy `…-main-<run_id>` IDs; if none are found it **falls back to a fresh dual Android upload** instead of failing.
 
+Manual `workflow_dispatch` of **Build Apps and Run Performance E2E Tests** uses the same test-only detection against `main`: test-only branches reuse main BrowserStack apps; otherwise a fresh Android dual upload runs. Explicit Android `bs://` URL inputs still skip build/upload. Scheduled and `main` push runs always build.
+
 This applies when all changed files match `e2e_test_files` or `e2e_ignorable` filters in `.github/rules/filter-rules.yml`, with at least one E2E test file changed, and no E2E-relevant workflow files were modified.
 
 Use the `force-builds` label or `[force-builds]` commit tag to override reuse and compile fresh builds — including on test-only PRs that would otherwise require main-branch artifacts.

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -286,11 +286,107 @@ jobs:
             echo "   Reasoning: $REASONING"
           fi
 
+  # Manual workflow_dispatch: mirror CI test-only reuse (compare branch vs main).
+  # workflow_call already passes reuse_main_builds from get-requirements / ci.yml.
+  detect-reuse-main-builds:
+    name: Detect reuse main builds (manual)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      !inputs.browserstack_app_url_android_onboarding &&
+      !inputs.browserstack_app_url_android_imported_wallet &&
+      inputs.reuse_main_builds != true
+    outputs:
+      reuse_main_builds: ${{ steps.set.outputs.reuse_main_builds }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main for change detection
+        run: git fetch --depth=1 origin main
+
+      - name: Filter changed files vs main
+        id: filter
+        uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
+        with:
+          base: main
+          filters: .github/rules/filter-rules.yml
+          list-files: shell
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Compute native build need (same flags as CI)
+        id: flags
+        env:
+          # Use pull_request so test-only / platform logic matches get-requirements CI path
+          # (schedule/push short-circuit to always native-build).
+          GITHUB_EVENT_NAME: pull_request
+          IS_FORK: 'false'
+          SHOULD_SKIP_E2E: 'false'
+          ALL_CHANGES_COUNT: ${{ steps.filter.outputs.all_changes_count }}
+          ALL_CHANGES_FILES: ${{ steps.filter.outputs.all_changes_files }}
+          IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_ignorable_count }}
+          E2E_TEST_FILES_COUNT: ${{ steps.filter.outputs.e2e_test_files_count }}
+          E2E_TEST_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_test_or_ignorable_count }}
+          E2E_WORKFLOWS_COUNT: ${{ steps.filter.outputs.e2e_relevant_workflows_count }}
+          ANDROID_COUNT: ${{ steps.filter.outputs.android_count }}
+          IOS_COUNT: ${{ steps.filter.outputs.ios_count }}
+          ANDROID_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.android_or_ignorable_count }}
+          IOS_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.ios_or_ignorable_count }}
+        run: node .github/scripts/run-compute-e2e-platform-flags.cjs
+
+      - name: Set reuse_main_builds
+        id: set
+        env:
+          NATIVE_BUILD_NEEDED: ${{ steps.flags.outputs.native_build_needed }}
+        run: |
+          if [ "$NATIVE_BUILD_NEEDED" = "false" ]; then
+            echo "reuse_main_builds=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Test-only changes vs main — reuse main BrowserStack apps (same as CI)"
+          else
+            echo "reuse_main_builds=false" >> "$GITHUB_OUTPUT"
+            echo "🔨 Native-relevant changes (or empty/non-test-only diff) — build Android apps"
+          fi
+
+  effective-reuse-main-builds:
+    name: Effective reuse main builds
+    runs-on: ubuntu-latest
+    needs: [detect-reuse-main-builds]
+    if: >-
+      always() &&
+      !cancelled() &&
+      (needs.detect-reuse-main-builds.result == 'success' || needs.detect-reuse-main-builds.result == 'skipped')
+    outputs:
+      reuse_main_builds: ${{ steps.set.outputs.reuse_main_builds }}
+    steps:
+      - name: Consolidate reuse_main_builds
+        id: set
+        env:
+          INPUT_REUSE: ${{ inputs.reuse_main_builds }}
+          DETECTED_REUSE: ${{ needs.detect-reuse-main-builds.outputs.reuse_main_builds }}
+        run: |
+          if [ "$INPUT_REUSE" = "true" ] || [ "$DETECTED_REUSE" = "true" ]; then
+            echo "reuse_main_builds=true" >> "$GITHUB_OUTPUT"
+            echo "Effective reuse_main_builds=true (input=${INPUT_REUSE:-false}, detected=${DETECTED_REUSE:-false})"
+          else
+            echo "reuse_main_builds=false" >> "$GITHUB_OUTPUT"
+            echo "Effective reuse_main_builds=false (input=${INPUT_REUSE:-false}, detected=${DETECTED_REUSE:-false})"
+          fi
+
   resolve-main-browserstack-urls:
     name: Resolve main-branch BrowserStack Android apps
     runs-on: ubuntu-latest
+    needs: [effective-reuse-main-builds]
     if: >-
-      inputs.reuse_main_builds &&
+      always() &&
+      !cancelled() &&
+      needs.effective-reuse-main-builds.result == 'success' &&
+      needs.effective-reuse-main-builds.outputs.reuse_main_builds == 'true' &&
       !inputs.browserstack_app_url_android_onboarding &&
       !inputs.browserstack_app_url_android_imported_wallet
     outputs:
@@ -318,15 +414,21 @@ jobs:
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-android-upload-to-browserstack.yml
-    needs: [determine-branch-name, resolve-main-browserstack-urls]
+    needs:
+      [
+        determine-branch-name,
+        resolve-main-browserstack-urls,
+        effective-reuse-main-builds,
+      ]
     # Build/upload when not reusing main, or when main reuse lookup found nothing.
     if: >-
       always() &&
       !cancelled() &&
+      (needs.effective-reuse-main-builds.result == 'success' || needs.effective-reuse-main-builds.result == 'skipped') &&
       (needs.resolve-main-browserstack-urls.result == 'skipped' || needs.resolve-main-browserstack-urls.result == 'success') &&
       (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet) &&
       (
-        !inputs.reuse_main_builds ||
+        needs.effective-reuse-main-builds.outputs.reuse_main_builds != 'true' ||
         needs.resolve-main-browserstack-urls.outputs.found != 'true'
       )
     with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Manual `workflow_dispatch` of **Build Apps and Run Performance E2E Tests** previously always built Android apps when BrowserStack URLs were omitted — even on test-only branches. CI already reuses `main` artifacts when `native_build_needed == false`.

This PR aligns manual runs with that CI behavior:

1. On `workflow_dispatch` (no Android `bs://` inputs, and `reuse_main_builds` not already true), compare the branch to `main` with the same `filter-rules.yml` + `compute-e2e-platform-flags` path as `get-requirements`.
2. If changes are test-only → resolve/reuse main BrowserStack apps (existing soft-fail fallback to dual upload if not found).
3. Otherwise → build and upload as before.
4. `workflow_call` from CI still uses the explicit `reuse_main_builds` input; schedule/`main` push still always build.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-1667

## **Manual testing steps**

```gherkin
Feature: Manual performance dispatch reuses main on test-only branches

  Scenario: test-only branch dispatch without bs:// URLs
    Given a branch with only E2E/performance test (or ignorable) changes vs main
    When I run "Build Apps and Run Performance E2E Tests" via workflow_dispatch with empty Android BrowserStack URL inputs
    Then "Detect reuse main builds (manual)" sets reuse_main_builds=true
    And "Resolve main-branch BrowserStack Android apps" runs
    And "Trigger Android Dual Versions" is skipped when apps are found

  Scenario: app-change branch still builds
    Given a branch with non-test app/native-relevant changes vs main
    When I dispatch the same workflow without BrowserStack URL inputs
    Then reuse_main_builds is false
    And Android dual upload builds run
```

## **Screenshots/Recordings**

N/A — CI workflow-only change; verify via Actions job logs on a test-only vs app-change branch.

## **Pre-merge checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my changes clearly and comprehensively
- [ ] I’ve not skipped any automated checks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3598b715-73d3-4e36-9d45-e8c014354b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3598b715-73d3-4e36-9d45-e8c014354b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

