### PR TITLE
ci: request workflows:write for release changelog token exchange cp-8.3.0 

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -109,7 +109,11 @@ jobs:
       # - contents: write       → push the release / version-bump / changelog branches
       # - pull_requests: write  → open the release PRs
       # - members: read         → auto-changelog --autoCategorize resolves PR author teams (read:org)
-      # - workflows: write      → avoids a GitHub push-protection timeout on the changelog push
+      # - workflows: write      → this job cuts the release branch/PR itself from main, which can
+      #                           genuinely carry .github/workflows/* differences relative to the
+      #                           previous release branch (workflow files evolve on main between
+      #                           release cuts). This is a real need, not just a timeout workaround
+      #                           (contrast with update-release-changelog.yml).
       # OIDC works on every trigger, so no workflow_dispatch vs workflow_call token split is needed.
       - name: Get token
         id: get-token

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -109,6 +109,7 @@ jobs:
       # - contents: write       → push the release / version-bump / changelog branches
       # - pull_requests: write  → open the release PRs
       # - members: read         → auto-changelog --autoCategorize resolves PR author teams (read:org)
+      # - workflows: write      → avoids a GitHub push-protection timeout on the changelog push
       # OIDC works on every trigger, so no workflow_dispatch vs workflow_call token split is needed.
       - name: Get token
         id: get-token
@@ -119,6 +120,7 @@ jobs:
             contents: write
             pull_requests: write
             members: read
+            workflows: write
 
       - name: Create Release PR (semver / native version bump)
         if: needs.resolve-bases.outputs.is_ota != 'true'

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -109,11 +109,8 @@ jobs:
       # - contents: write       → push the release / version-bump / changelog branches
       # - pull_requests: write  → open the release PRs
       # - members: read         → auto-changelog --autoCategorize resolves PR author teams (read:org)
-      # - workflows: write      → this job cuts the release branch/PR itself from main, which can
-      #                           genuinely carry .github/workflows/* differences relative to the
-      #                           previous release branch (workflow files evolve on main between
-      #                           release cuts). This is a real need, not just a timeout workaround
-      #                           (contrast with update-release-changelog.yml).
+      # - workflows: write      → the release branch cut here comes from main and can genuinely
+      #                           differ in .github/workflows/* from the previous release branch
       # OIDC works on every trigger, so no workflow_dispatch vs workflow_call token split is needed.
       - name: Get token
         id: get-token

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -54,6 +54,16 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Mint a short-lived token via the token-exchange service (OIDC). It needs:
+      # - contents: write       → push the changelog branch
+      # - pull_requests: write  → open/update the changelog PR
+      # - workflows: write      → this step only ever pushes CHANGELOG.md, so no real workflow
+      #                           file diff is expected here. We only need this permission due
+      #                           to a GitHub API timeout bug: GitHub's push-protection check
+      #                           still has to determine on every push whether workflow files
+      #                           changed, and that check has been timing out and rejecting the
+      #                           push outright (same bug class as actions/checkout#2287).
+      #                           Holding the scope up front avoids the check entirely.
       - name: Get token
         id: get-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -62,6 +62,7 @@ jobs:
           permissions: |
             contents: write
             pull_requests: write
+            workflows: write
 
       - name: Checkout release branch
         uses: actions/checkout@v4

--- a/.github/workflows/update-release-changelog.yml
+++ b/.github/workflows/update-release-changelog.yml
@@ -57,13 +57,9 @@ jobs:
       # Mint a short-lived token via the token-exchange service (OIDC). It needs:
       # - contents: write       → push the changelog branch
       # - pull_requests: write  → open/update the changelog PR
-      # - workflows: write      → this step only ever pushes CHANGELOG.md, so no real workflow
-      #                           file diff is expected here. We only need this permission due
-      #                           to a GitHub API timeout bug: GitHub's push-protection check
-      #                           still has to determine on every push whether workflow files
-      #                           changed, and that check has been timing out and rejecting the
-      #                           push outright (same bug class as actions/checkout#2287).
-      #                           Holding the scope up front avoids the check entirely.
+      # - workflows: write      → workaround for a GitHub push-protection timeout bug on new
+      #                           branch pushes (see actions/checkout#2287); this step never
+      #                           actually touches workflow files.
       - name: Get token
         id: get-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1


### PR DESCRIPTION
## **Description**

`create-release-pr.yml` (OTA hotfix changelog path) and `update-release-changelog.yml` (native release changelog path) mint a short-lived token via the token-exchange service but never requested `workflows: write`, unlike `stable-branch-sync.yml` / `release-branch-sync.yml`, which already request and receive it for the same kind of push.

Without that scope already held by the token, GitHub's git server has to determine on every push whether the pushed commits touch `.github/workflows/*` — and that check has been timing out and rejecting the (unrelated) changelog push, even though the commit only ever touches `CHANGELOG.md`:

```
! [remote rejected]       release-changelog/8.2.1 -> release-changelog/8.2.1 (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

This reproduced 3 times in a row on `release/8.2.1-ota` ([run 29407614429](https://github.com/MetaMask/metamask-mobile/actions/runs/29407614429)) and is not a real permissions gap — in the same job, using the same token, an earlier push (the `OTA_VERSION` bump) succeeded fine. Holding `workflows: write` up front avoids GitHub needing to run that check at all, matching the pattern already used by `stable-branch-sync.yml` / `release-branch-sync.yml`.

**This PR alone is not sufficient** — the corresponding token-exchange-service policies (`mm-metamask-mobile-create-release-pr-token-exchange` and `mm-metamask-mobile-update-release-changelog-token-exchange`) also need `workflows: write` added to `grant_permissions`, otherwise the token exchange won't include the requested scope. That policy update is being made separately.


Token exchange service PR: https://github.com/consensys-vertical-apps/token-exchange-service/pull/141

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Release changelog token exchange

  Scenario: Changelog push after a release branch update
    Given the token-exchange-service policy grants workflows: write for this workflow
    When create-release-pr.yml or update-release-changelog.yml requests a token
    Then the exchanged token includes workflows: write
    And the subsequent changelog branch push succeeds without the
      "Unable to determine if workflow can be created or updated due to timeout" rejection
```

N/A for automated tests — this only affects CI token permissions on release branches, which isn't covered by unit/e2e suites. Validated by re-running the affected workflow once the token-exchange policy is updated.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only token permission changes with no app runtime impact; full effect depends on matching token-exchange policy updates.
> 
> **Overview**
> Adds **`workflows: write`** to the OIDC token-exchange permission list in **`create-release-pr.yml`** and **`update-release-changelog.yml`**, matching **`stable-branch-sync.yml`** / **`release-branch-sync.yml`**.
> 
> Without that scope, GitHub can time out while deciding whether a push touches `.github/workflows/*`, which has been rejecting changelog-only pushes (e.g. `release-changelog/*` updating `CHANGELOG.md`). **`create-release-pr`** documents the need when release branches diverge in workflow files from main; **`update-release-changelog`** documents it as a workaround for push-protection timeouts on new branch pushes.
> 
> Comments were added at the **Get token** step explaining each scope. **Token-exchange-service policies** must also grant `workflows: write` or the exchanged token will not include it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123bfc54fa207daacb46ebdf1b98572e0b8c78a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->