### PR TITLE
release: 8.2.1 (OTA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.1]
+
+### Fixed
+
+- Fixed live prediction market prices not updating for dynamically subscribed markets (#33289)
+
 ## [8.2.0]
 
 ### Added
@@ -12635,7 +12641,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.1...HEAD
+[8.2.1]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.0...v8.2.1
 [8.2.0]: https://github.com/MetaMask/metamask-mobile/compare/v8.1.1...v8.2.0
 [8.1.1]: https://github.com/MetaMask/metamask-mobile/compare/v8.1.0...v8.1.1
 [8.1.0]: https://github.com/MetaMask/metamask-mobile/compare/v8.0.4...v8.1.0

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -549,6 +549,23 @@ describe('WebSocketManager', () => {
       );
     });
 
+    it('sends dynamic subscription message for tokens added to an open connection', () => {
+      const manager = WebSocketManager.getInstance();
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      const market = mockWebSocketInstances[0];
+      market.simulateOpen();
+      market.send.mockClear();
+
+      manager.subscribeToMarketPrices(['token2'], jest.fn());
+
+      expect(market.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          operation: 'subscribe',
+          assets_ids: ['token2'],
+        }),
+      );
+    });
+
     it('calls callback with price updates for subscribed tokens', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn();
@@ -799,6 +816,23 @@ describe('WebSocketManager', () => {
         JSON.stringify({
           type: 'market',
           assets_ids: ['token1'],
+        }),
+      );
+    });
+
+    it('sends dynamic subscription message for an orderbook added to an open connection', () => {
+      const manager = WebSocketManager.getInstance();
+      manager.subscribeToMarketPrices(['token1'], jest.fn());
+      const market = getMarketInstance();
+      market.simulateOpen();
+      market.send.mockClear();
+
+      manager.subscribeToOrderbook('token2', jest.fn());
+
+      expect(market.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          operation: 'subscribe',
+          assets_ids: ['token2'],
         }),
       );
     });

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -788,7 +788,7 @@ export class WebSocketManager {
 
   private ensureMarketConnection(tokenIds: string[]): void {
     if (this.marketWs?.readyState === WebSocket.OPEN) {
-      this.sendMarketSubscribe(tokenIds);
+      this.sendMarketSubscriptionUpdate(tokenIds);
       return;
     }
     if (this.marketWs?.readyState === WebSocket.CONNECTING) {
@@ -961,7 +961,7 @@ export class WebSocketManager {
     this.scheduleOrderbookEmit(data.asset_id);
   }
 
-  private sendMarketSubscribe(tokenIds: string[]): void {
+  private sendInitialMarketSubscription(tokenIds: string[]): void {
     if (this.marketWs?.readyState !== WebSocket.OPEN) {
       return;
     }
@@ -969,6 +969,19 @@ export class WebSocketManager {
     this.marketWs.send(
       JSON.stringify({
         type: 'market',
+        assets_ids: tokenIds,
+      }),
+    );
+  }
+
+  private sendMarketSubscriptionUpdate(tokenIds: string[]): void {
+    if (this.marketWs?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.marketWs.send(
+      JSON.stringify({
+        operation: 'subscribe',
         assets_ids: tokenIds,
       }),
     );
@@ -1008,7 +1021,7 @@ export class WebSocketManager {
     });
 
     if (allTokenIds.size > 0) {
-      this.sendMarketSubscribe(Array.from(allTokenIds));
+      this.sendInitialMarketSubscription(Array.from(allTokenIds));
     }
   }
 

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -12,7 +12,7 @@ import otaConfig from '../../ota.config.js';
  * Reset when releasing a new native build as appropriate for that line.
  * Kept here (not only in ota.config.js) so changes there do not alter the Expo fingerprint and break CI.
  */
-export const OTA_VERSION: string = 'vX.XX.X';
+export const OTA_VERSION: string = 'v8.2.1';
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
OTA hotfix: branch `release/8.2.1-ota`.

- Native semver and build version are **not** bumped.
- `OTA_VERSION` in `app/constants/ota.ts` is `v8.2.1`.
- CHANGELOG.md header and production git tag both use bare `8.2.1` / `v8.2.1`; the `-ota` suffix is branch-only.

Made with [Cursor](https://cursor.com)