### PR TITLE
release: release-changelog/8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.1]
+
+### Fixed
+
+- Fixed live prediction market prices not updating for dynamically subscribed markets. (#33289)
+
+
 ## [8.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed live prediction market prices not updating for dynamically subscribed markets. (#33289)
-
+- Fixed live prediction market prices not updating for dynamically subscribed markets (#33289)
 
 ## [8.2.0]
 
@@ -12642,7 +12641,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#957](https://github.com/MetaMask/metamask-mobile/pull/957): fix timeouts (#957)
 - [#954](https://github.com/MetaMask/metamask-mobile/pull/954): Bugfix: onboarding navigation (#954)
 
-[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.1...HEAD
+[8.2.1]: https://github.com/MetaMask/metamask-mobile/compare/v8.2.0...v8.2.1
 [8.2.0]: https://github.com/MetaMask/metamask-mobile/compare/v8.1.1...v8.2.0
 [8.1.1]: https://github.com/MetaMask/metamask-mobile/compare/v8.1.0...v8.1.1
 [8.1.0]: https://github.com/MetaMask/metamask-mobile/compare/v8.0.4...v8.1.0


### PR DESCRIPTION
This PR updates the change log for 8.2.1. (Hotfix - no test plan generated.)

Made with [Cursor](https://cursor.com)