### PR TITLE
fix(predict): route Popular Today to Trending cp-8.3.0

### DIFF
--- a/app/components/UI/Predict/constants/feedConfig.test.ts
+++ b/app/components/UI/Predict/constants/feedConfig.test.ts
@@ -29,9 +29,9 @@ describe('feedConfig', () => {
       'crypto',
       'live',
       'trending',
-      'popular-today',
     ]);
     expect(isPredictFeedId('world-cup')).toBe(false);
+    expect(isPredictFeedId('popular-today')).toBe(false);
   });
 
   it.each(PREDICT_FEED_IDS)('resolves known feed id %s', (feedId) => {
@@ -95,9 +95,7 @@ describe('feedConfig', () => {
   });
 
   it('represents hidden-tab feeds with exactly one tab', () => {
-    (
-      ['politics', 'crypto', 'live', 'trending', 'popular-today'] as const
-    ).forEach((feedId) => {
+    (['politics', 'crypto', 'live', 'trending'] as const).forEach((feedId) => {
       expect(PREDICT_FEED_REGISTRY[feedId].tabs).toHaveLength(1);
     });
   });
@@ -128,9 +126,6 @@ describe('feedConfig', () => {
   });
 
   it('resolves the dynamic filter config for a feed from the registry', () => {
-    expect(resolvePredictFeedDynamicFilterConfig('popular-today')).toBe(
-      PREDICT_FEED_REGISTRY['popular-today'].tabs[0].filters.dynamic,
-    );
     expect(resolvePredictFeedDynamicFilterConfig('trending')).toBe(
       PREDICT_FEED_REGISTRY.trending.tabs[0].filters.dynamic,
     );

--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -9,7 +9,6 @@ export const PREDICT_FEED_IDS = [
   'crypto',
   'live',
   'trending',
-  'popular-today',
 ] as const;
 
 export type PredictFeedId = (typeof PREDICT_FEED_IDS)[number];
@@ -240,39 +239,6 @@ export const PREDICT_FEED_REGISTRY: Record<PredictFeedId, PredictFeedConfig> = {
               status: 'open',
               order: 'volume24hr',
               limit: 10,
-            },
-          },
-        },
-      },
-    ],
-  },
-  'popular-today': {
-    id: 'popular-today',
-    titleKey: 'predict.feed.popular_today',
-    header: {
-      showBackButton: true,
-      showSearchButton: true,
-    },
-    tabs: [
-      {
-        id: 'all',
-        titleKey: 'predict.feed.popular_today',
-        defaultFilterId: 'all',
-        filters: {
-          static: [
-            createAllFilter({
-              status: 'open',
-              order: 'volume24hr',
-              limit: 12,
-            }),
-          ],
-          dynamic: {
-            source: 'related-tags',
-            baseTagSlug: 'all',
-            baseParams: {
-              status: 'open',
-              order: 'volume24hr',
-              limit: 12,
             },
           },
         },

--- a/app/components/UI/Predict/hooks/usePredictFeedConfig.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictFeedConfig.test.ts
@@ -187,7 +187,6 @@ describe('usePredictFeedConfig', () => {
       ['crypto', 'crypto'],
       ['sports', 'sports'],
       ['trending', 'all'],
-      ['popular-today', 'all'],
     ])(
       'passes baseTagSlug "%s" -> "%s" to usePredictFilterOptions',
       (feedId, expectedSlug) => {

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -59,7 +59,7 @@ export interface PredictMarketListRouteParams {
  * Generic Predict feed route parameters.
  *
  * Consumed by the config-driven `PredictFeedView` (powers Sports / Politics /
- * Crypto / Live / Trending / Popular Today). Carries stable IDs only — the
+ * Crypto / Live / Trending). Carries stable IDs only — the
  * view resolves them into a render-ready config via `usePredictFeedConfig`.
  * The route registration + deeplink parsing that populates these params lands
  * separately (route + deeplinks ticket); the view reads them via `useRoute`.

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.test.tsx
@@ -593,10 +593,10 @@ describe('PredictFeedView', () => {
     });
 
     it('delays trackFeedViewed until a dynamic initialFilterId resolves', () => {
-      // Simulate entry from a Popular-Today home chip: initialFilterId targets a
+      // Simulate entry from a Popular Today home chip: initialFilterId targets a
       // dynamic filter that hasn't loaded yet.
       mockRouteParams = {
-        feedId: 'popular-today',
+        feedId: 'trending',
         initialFilterId: 'soccer',
         entryPoint: 'home_chip',
       };
@@ -605,7 +605,7 @@ describe('PredictFeedView', () => {
       // default ('all') because the dynamic option hasn't resolved yet.
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'loading' },
           activeFilterId: 'all',
         }),
@@ -619,7 +619,7 @@ describe('PredictFeedView', () => {
       // Dynamic filters resolve; the pending filter is now applied.
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'ready' },
           activeFilterId: 'soccer',
           filters: [
@@ -649,7 +649,7 @@ describe('PredictFeedView', () => {
 
       expect(mockTrackFeedViewed).toHaveBeenCalledTimes(1);
       expect(mockTrackFeedViewed).toHaveBeenCalledWith({
-        feedId: 'popular-today',
+        feedId: 'trending',
         tabId: 'basketball',
         filterId: 'soccer',
         trackingMode: 'focus',
@@ -659,7 +659,7 @@ describe('PredictFeedView', () => {
 
     it('fires trackFeedViewed with fallback filter when dynamic loading fails (unavailable)', () => {
       mockRouteParams = {
-        feedId: 'popular-today',
+        feedId: 'trending',
         initialFilterId: 'soccer',
         entryPoint: 'home_chip',
       };
@@ -667,7 +667,7 @@ describe('PredictFeedView', () => {
       // Initially loading.
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'loading' },
           activeFilterId: 'all',
         }),
@@ -679,7 +679,7 @@ describe('PredictFeedView', () => {
       // Dynamic filters fail — status becomes unavailable, filter stays 'all'.
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'unavailable' },
           activeFilterId: 'all',
         }),
@@ -698,14 +698,14 @@ describe('PredictFeedView', () => {
       // response. The previous condition only fell back on 'unavailable', so
       // isFilterSettled stayed false permanently.
       mockRouteParams = {
-        feedId: 'popular-today',
+        feedId: 'trending',
         initialFilterId: 'soccer',
         entryPoint: 'home_chip',
       };
 
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'loading' },
           activeFilterId: 'all',
         }),
@@ -717,7 +717,7 @@ describe('PredictFeedView', () => {
       // Dynamic filters loaded successfully but 'soccer' is not in the list.
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
-          feedId: 'popular-today',
+          feedId: 'trending',
           dynamicFilters: { status: 'ready' },
           activeFilterId: 'all',
           // Only 'trending' is in the response — 'soccer' is absent.

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
@@ -46,8 +46,8 @@ const INITIAL_SKELETON_COUNT = 4;
 /**
  * Generic, config-driven Predict feed screen.
  *
- * Powers every configured feed (Sports / Politics / Crypto / Live / Trending /
- * Popular Today) from one component. Presentational: it consumes
+ * Powers every configured feed (Sports / Politics / Crypto / Live / Trending)
+ * from one component. Presentational: it consumes
  * `usePredictFeedConfig` for the render-ready config + tab/filter selection
  * state and `usePredictMarketList` for the active tab/filter's market data —
  * it owns no hydration/dedup/fallback logic itself.

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
@@ -193,7 +193,7 @@ describe('PredictPopularTodaySection', () => {
     ).toBeNull();
   });
 
-  it('navigates to the Popular Today feed when the header is pressed', () => {
+  it('navigates to the Trending feed when the header is pressed', () => {
     setFilterOptions({
       filterOptions: [createFilterOption('elections', 'Elections')],
     });
@@ -205,7 +205,7 @@ describe('PredictPopularTodaySection', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.FEED,
       params: {
-        feedId: 'popular-today',
+        feedId: 'trending',
         entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
       },
     });
@@ -216,7 +216,7 @@ describe('PredictPopularTodaySection', () => {
     });
   });
 
-  it('navigates to the Popular Today feed with the selected filter when a chip is pressed', () => {
+  it('navigates to the Trending feed with the selected filter when a chip is pressed', () => {
     setFilterOptions({
       filterOptions: [createFilterOption('elections', 'Elections')],
     });
@@ -232,7 +232,7 @@ describe('PredictPopularTodaySection', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.FEED,
       params: {
-        feedId: 'popular-today',
+        feedId: 'trending',
         initialFilterId: 'elections',
         entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
       },

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -28,17 +28,16 @@ import type {
 import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
 
 /**
- * Max number of filter chips rendered on the home section. The full
- * `popular-today` feed shows the complete list; the home rail shows a compact
- * prefix of the same ordered list.
+ * Max number of filter chips rendered on the home section. The home rail shows
+ * a compact prefix of the same ordered list as the Trending feed.
  */
 const POPULAR_TODAY_FILTER_LIMIT = 10;
 const SKELETON_COUNT = 8;
 const DEFAULT_CHIP_ROW_COUNT = 2;
 
 /**
- * Derive the section's filter-options params from the canonical `popular-today`
- * feed registry so there is a single source of truth. Crucially, we do NOT pass
+ * Derive the section's filter-options params from the canonical `trending` feed
+ * registry so there is a single source of truth. Crucially, we do NOT pass
  * a top-level `limit` here: that keeps the React Query cache key identical to
  * the full feed's `usePredictFilterOptions` call (which omits `limit`), so the
  * home section and the feed share the same cached related-tags request instead
@@ -46,7 +45,7 @@ const DEFAULT_CHIP_ROW_COUNT = 2;
  * `POPULAR_TODAY_FILTER_LIMIT` when slicing the returned options.
  */
 const POPULAR_TODAY_FILTER_PARAMS: PredictFilterOptionsParams = (() => {
-  const dynamicConfig = resolvePredictFeedDynamicFilterConfig('popular-today');
+  const dynamicConfig = resolvePredictFeedDynamicFilterConfig('trending');
 
   return {
     source: dynamicConfig?.source ?? 'related-tags',
@@ -100,9 +99,9 @@ interface PredictPopularTodaySectionProps {
 /**
  * Predict home "Popular today" tag rail (PRED-917).
  *
- * Uses the same related-tag source as the full `popular-today` feed. The header
- * opens the all-up Popular Today feed, while each chip opens that feed with the
- * selected related-tag filter preselected.
+ * Uses the same related-tag source as the Trending feed. The header opens the
+ * all-up Trending feed, while each chip opens that feed with the selected
+ * related-tag filter preselected.
  */
 const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
   testID = PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SECTION,
@@ -137,10 +136,10 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
     [rowCount],
   );
 
-  const navigateToPopularToday = useCallback(
+  const navigateToTrending = useCallback(
     (initialFilterId?: string) => {
       const params: PredictFeedRouteParams = {
-        feedId: 'popular-today',
+        feedId: 'trending',
         entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
         ...(initialFilterId ? { initialFilterId } : {}),
       };
@@ -159,8 +158,8 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
       actionType: PredictEventValues.ACTION_TYPE.SEE_ALL,
       entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
     });
-    navigateToPopularToday();
-  }, [navigateToPopularToday]);
+    navigateToTrending();
+  }, [navigateToTrending]);
 
   const handleChipPress = useCallback(
     (option: PredictFilterOption) => {
@@ -173,9 +172,9 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
         isDynamicFilter: true,
         entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
       });
-      navigateToPopularToday(option.id);
+      navigateToTrending(option.id);
     },
-    [navigateToPopularToday],
+    [navigateToTrending],
   );
 
   if (!isLoading && chips.length === 0) {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handlePredictUrl.test.ts
@@ -428,7 +428,7 @@ describe('handlePredictUrl', () => {
       });
     });
 
-    it('parses filter separately from tab', async () => {
+    it('redirects Popular Today links to the selected Trending filter', async () => {
       await handlePredictUrl({
         predictPath: '?feed=popular-today&filter=elections',
       });
@@ -436,7 +436,7 @@ describe('handlePredictUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
         screen: Routes.PREDICT.FEED,
         params: {
-          feedId: 'popular-today',
+          feedId: 'trending',
           initialFilterId: 'elections',
           entryPoint: 'deeplink',
         },
@@ -497,6 +497,21 @@ describe('handlePredictUrl', () => {
       jest.mocked(selectPredictHomeRedesignEnabledFlag).mockReturnValue(false);
 
       await handlePredictUrl({ predictPath: '?feed=sports&tab=all' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+        params: {
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('keeps the Popular Today redirect behind the home redesign flag', async () => {
+      jest.mocked(selectPredictHomeRedesignEnabledFlag).mockReturnValue(false);
+
+      await handlePredictUrl({
+        predictPath: '?feed=popular-today&filter=elections',
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
         screen: Routes.PREDICT.MARKET_LIST,

--- a/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handlePredictUrl.ts
@@ -236,7 +236,7 @@ const marketTarget = (
  * - https://link.metamask.io/predict?feed=world-cup&tab=live
  * - https://link.metamask.io/predict?feed=sports
  * - https://link.metamask.io/predict?feed=sports&tab=all&filter=live
- * - https://link.metamask.io/predict?feed=popular-today&filter=elections
+ * - https://link.metamask.io/predict?feed=popular-today&filter=elections (redirects to Trending)
  * - https://link.metamask.io/predict?feed=trending&q=bitcoin
  *
  * Origin/EntryPoint handling:
@@ -248,7 +248,8 @@ const marketTarget = (
  * - No market param: Navigate to market list
  * - market=X or marketId=X: Navigate directly to market details for market X
  * - feed=world-cup: Navigate to the dedicated World Cup feed when enabled
- * - feed=<known generic id> (sports/politics/crypto/live/trending/popular-today): Navigate to the generic PredictFeedView when the predictHomeRedesign flag is enabled (tab -> initialTabId, filter -> initialFilterId)
+ * - feed=<known generic id> (sports/politics/crypto/live/trending): Navigate to the generic PredictFeedView when the predictHomeRedesign flag is enabled (tab -> initialTabId, filter -> initialFilterId)
+ * - feed=popular-today: Redirect to the Trending feed while preserving its filter
  * - Unknown feed (or flag disabled): Fall back to the Predict market list
  * - Optional tab param when no market: Open feed on a specific tab
  * - query=X or q=X: Open feed with search overlay showing results for X
@@ -260,6 +261,8 @@ const resolvePredictTarget = ({
   // Parse navigation parameters from URL
   const navParams = parsePredictNavigationParams(predictPath);
   DevLogger.log('[handlePredictUrl] Parsed navigation parameters:', navParams);
+  const genericFeed =
+    navParams.feed === 'popular-today' ? 'trending' : navParams.feed;
 
   // Determine entry point:
   // - Base is origin if provided, otherwise 'deeplink'
@@ -281,12 +284,9 @@ const resolvePredictTarget = ({
       requestedTab: navParams.worldCupTab,
       entryPoint,
     });
-  } else if (
-    isPredictFeedId(navParams.feed) &&
-    getPredictHomeRedesignEnabled()
-  ) {
+  } else if (isPredictFeedId(genericFeed) && getPredictHomeRedesignEnabled()) {
     return genericFeedTarget({
-      feedId: navParams.feed,
+      feedId: genericFeed,
       // worldCupTab holds the raw (unvalidated) tab value; the generic feed's
       // sub-tab ids (e.g. basketball/all/live) are resolved by the view.
       initialTabId: navParams.worldCupTab,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Popular Today and Trending exposed overlapping prediction-market content through separate pages in the feature-flagged Predict homepage redesign. This removes the standalone Popular Today feed and routes its header and topic tags to Trending. Topic selections are passed as the initial Trending filter so the chosen topic remains selected after dynamic filters load. Existing `feed=popular-today` deeplinks also redirect to Trending while the redesign flag is enabled and retain the legacy market-list fallback while it is disabled.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Opened Popular Today topics in Trending and removed the duplicate Popular Today page

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1087

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Popular Today navigation on the redesigned Predict homepage

  Background:
    Given the Predict home redesign feature flag is enabled
    And the user is on the redesigned Predict homepage
    And Popular Today topics have loaded

  Scenario: Open a Popular Today topic in Trending
    When the user taps a topic in Popular Today
    Then the Trending page is displayed
    And the selected topic filter is active
    And the market list matches the selected topic

  Scenario: Open Trending from the Popular Today header
    When the user taps the Popular Today section header
    Then the Trending page is displayed
    And the All filter is active

  Scenario: Preserve the existing experience when the redesign is disabled
    Given the Predict home redesign feature flag is disabled
    When the user opens Predict
    Then the legacy Predict market list is displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - No recording was captured; this change only updates navigation between existing Predict screens.

### **After**

N/A - No recording was captured; this change introduces no visual UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: This is a navigation-only change; no manual Android test was performed.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: The behavior does not depend on account, token, or activity volume.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: This change adds no new operation or performance-sensitive code path.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and feed-registry consolidation only; no auth, payments, or new data paths. Deeplink behavior is gated on the existing home redesign flag.
> 
> **Overview**
> Removes the duplicate **`popular-today`** feed from `PREDICT_FEED_IDS` and `PREDICT_FEED_REGISTRY` so Predict only exposes Sports, Politics, Crypto, Live, and Trending as config-driven feeds.
> 
> The home **Popular today** rail is unchanged visually but now opens **Trending** (`feedId: 'trending'`), passing `initialFilterId` when a chip is tapped so the topic stays selected after dynamic filters load. Filter options are sourced from the **trending** registry entry (shared React Query cache with the full Trending feed).
> 
> **`feed=popular-today`** deeplinks map to Trending with the same `filter` param when the home redesign flag is on; with the flag off they still fall back to the legacy market list. Tests and docs/comments are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f380479250a9dc8e22c54baf3c053f3331632ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->