### PR TITLE
fix(predict): hide empty dynamic feed filters

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -13,7 +13,14 @@ import {
   DEFAULT_WIMBLEDON_TAB_FLAG,
 } from '../../constants/flags';
 import type { OrderPreview } from '../types';
-import { Side, type PredictActivity, type PredictPosition } from '../../types';
+import {
+  PredictMarketStatus,
+  Recurrence,
+  Side,
+  type PredictActivity,
+  type PredictMarket,
+  type PredictPosition,
+} from '../../types';
 import type { PredictFeatureFlags } from '../../types/flags';
 import {
   ACCOUNT_STATE_CACHE_TTL_MS,
@@ -392,6 +399,41 @@ function createProvider(featureFlags?: Partial<PredictFeatureFlags>) {
   });
 }
 
+function createVisibleMarket(
+  id: string,
+  overrides: Partial<PredictMarket> = {},
+): PredictMarket {
+  return {
+    id,
+    providerId: POLYMARKET_PROVIDER_ID,
+    slug: id,
+    title: id,
+    description: id,
+    image: '',
+    status: PredictMarketStatus.OPEN,
+    recurrence: Recurrence.NONE,
+    category: 'trending',
+    tags: [],
+    outcomes: [
+      {
+        id: `${id}-outcome`,
+        providerId: POLYMARKET_PROVIDER_ID,
+        marketId: id,
+        title: id,
+        description: id,
+        image: '',
+        status: PredictMarketStatus.OPEN,
+        tokens: [{ id: `${id}-token`, title: id, price: 0.5 }],
+        volume: 1,
+        groupItemTitle: id,
+      },
+    ],
+    liquidity: 1,
+    volume: 1,
+    ...overrides,
+  };
+}
+
 describe('PolymarketProvider', () => {
   const originalBuilderCode = process.env.MM_PREDICT_BUILDER_CODE;
 
@@ -585,6 +627,10 @@ describe('PolymarketProvider', () => {
         { id: '1', label: 'NBA', slug: 'nba' },
         { id: '2', label: 'Politics', slug: 'politics' },
       ]);
+      jest.spyOn(provider, 'listMarkets').mockResolvedValue({
+        markets: [createVisibleMarket('market-1')],
+        nextCursor: null,
+      });
 
       await expect(
         provider.listFilterOptions({ source: 'hot-tags' }),
@@ -607,6 +653,68 @@ describe('PolymarketProvider', () => {
         },
       ]);
       expect(mockFetchRelatedTagsFromPolymarketApi).toHaveBeenCalledWith('all');
+    });
+
+    it('drops filter options whose applied params render zero markets', async () => {
+      const provider = createProvider();
+      mockFetchRelatedTagsFromPolymarketApi.mockResolvedValue([
+        { id: '1', label: 'NBA', slug: 'nba' },
+        { id: '2', label: 'Other', slug: 'other' },
+      ]);
+      const listMarketsSpy = jest
+        .spyOn(provider, 'listMarkets')
+        .mockImplementation(async ({ tagSlugs }) => ({
+          markets: tagSlugs?.includes('other')
+            ? [
+                createVisibleMarket('child-market', {
+                  parentMarketId: 'parent-market',
+                }),
+                createVisibleMarket('market-without-visible-outcomes', {
+                  outcomes: [],
+                }),
+              ]
+            : [createVisibleMarket('market-1')],
+          nextCursor: null,
+        }));
+
+      const result = await provider.listFilterOptions({
+        source: 'related-tags',
+        baseParams: { live: true, status: 'open' },
+      });
+
+      expect(result.map((option) => option.id)).toEqual(['nba']);
+      expect(listMarketsSpy).toHaveBeenCalledWith({
+        order: 'volume24hr',
+        status: 'open',
+        live: true,
+        tagSlugs: ['other'],
+      });
+    });
+
+    it('validates filter options with their configured market page size', async () => {
+      const provider = createProvider();
+      mockFetchRelatedTagsFromPolymarketApi.mockResolvedValue([
+        { id: '1', label: 'NBA', slug: 'nba' },
+      ]);
+      const listMarketsSpy = jest
+        .spyOn(provider, 'listMarkets')
+        .mockImplementation(async ({ limit }) => ({
+          markets: limit === 12 ? [createVisibleMarket('market-1')] : [],
+          nextCursor: null,
+        }));
+
+      const result = await provider.listFilterOptions({
+        source: 'related-tags',
+        baseParams: { status: 'open', limit: 12 },
+      });
+
+      expect(result.map((option) => option.id)).toEqual(['nba']);
+      expect(listMarketsSpy).toHaveBeenCalledWith({
+        order: 'volume24hr',
+        status: 'open',
+        tagSlugs: ['nba'],
+        limit: 12,
+      });
     });
 
     it('uses a feed-specific base tag slug when provided', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -27,6 +27,8 @@ import {
   type PredictTradeStatusValue,
 } from '../../constants/eventNames';
 import { filterSupportedLeagues } from '../../constants/sports';
+import { filterStandaloneMarkets } from '../../utils/feed';
+import { getVisiblePredictMarkets } from '../../utils/marketStaleness';
 import { getPrimarySportsCardOutcomes } from '../../utils/sports';
 import { resolveWorldCupFeedEvents } from './sportsUtils';
 import { PREDICT_ACTIVITY_PAGE_SIZE } from '../../constants/transactions';
@@ -1065,11 +1067,25 @@ export class PolymarketProvider implements PredictProvider {
     try {
       const tags = await fetchRelatedTagsFromPolymarketApi(slug);
 
-      return normalizeRelatedTagsToFilterOptions(tags, {
+      const filterOptions = normalizeRelatedTagsToFilterOptions(tags, {
         source: params.source,
         baseParams: params.baseParams,
         limit: params.limit,
       });
+
+      // `omit_empty` only excludes globally empty tags. Validate each option
+      // against the same params and visibility rules as the redesigned feed.
+      const marketAvailability = await Promise.all(
+        filterOptions.map(async (option) => {
+          const { markets } = await this.listMarkets(option.params);
+          return (
+            getVisiblePredictMarkets(filterStandaloneMarkets(markets)).length >
+            0
+          );
+        }),
+      );
+
+      return filterOptions.filter((_, index) => marketAvailability[index]);
     } catch (error) {
       // Dynamic filters are best-effort and non-blocking: on any failure return
       // an empty list so the UI can keep static filters and hide dynamic ones.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Polymarket's `omit_empty=true` related-tags response only removes globally empty tags. Dynamic filter chips in the feature-flagged Predict home redesign could therefore resolve to zero visible markets after applying the feed parameters and client visibility rules.

This change validates each normalized dynamic filter with its exact market-list parameters and the same standalone-market and staleness filtering used by the redesigned feed. Filters with no visible markets are omitted while valid filters remain available. Regression coverage verifies both hidden-market filtering and preservation of the configured market page size.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [PRED-1085](https://consensyssoftware.atlassian.net/browse/PRED-1085)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict dynamic feed filters

  Scenario: User opens a redesigned Predict feed with an empty related tag
    Given the predictHomeRedesign feature flag is enabled
    And the related-tags response includes the "Other" filter
    And "Other" has no standalone visible markets for the applied feed parameters

    When the user opens the redesigned Predict feed
    Then the "Other" filter chip is hidden
    And dynamic filters with visible markets remain available
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

N/A: This is a provider-level filtering change covered by automated tests; no screenshots or recordings were captured.

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
  - N/A: This provider-level filtering change was verified with unit tests rather than a device build.
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - N/A: The behavior does not depend on wallet size, account count, or token count.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
  - N/A: Existing `listFilterOptions` and `listMarkets` controller operations are already traced; this change adds no new operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1085]: https://consensyssoftware.atlassian.net/browse/PRED-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds one `listMarkets` call per dynamic filter at load time (parallel), which increases API load and could slow filter discovery, but changes are confined to feed filter chips with no auth or funds impact.
> 
> **Overview**
> Dynamic Polymarket related-tag filters can still appear in the redesigned Predict home even when **no markets would show** after feed params and client-side visibility rules—API `omit_empty` only drops globally empty tags.
> 
> **`PolymarketProvider.listFilterOptions`** now probes each normalized option with **`listMarkets(option.params)`**, then keeps the chip only if **`getVisiblePredictMarkets(filterStandaloneMarkets(markets))`** has at least one market (same pipeline as the feed/carousel hooks). Options that would render an empty list are dropped.
> 
> Tests add **`createVisibleMarket`**, stub **`listMarkets`** on existing filter-option cases, and cover hiding filters with only child/empty-outcome markets plus honoring **`baseParams.limit`** during validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36370b2382c6f4ef0b6f9c1300b90201dc0d351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->