### PR TITLE
fix(predict): Design QA feedback to the redesigned Predict home and feed cp-8.3.0

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -22,7 +22,7 @@ import { useChipScrollList } from './useChipScrollList';
 
 export { calculateChipScrollX } from './calculateChipScrollX';
 
-const DEFAULT_CONTAINER_CLASS = 'pt-3 pb-4';
+const DEFAULT_CONTAINER_CLASS = 'pt-3 pb-3';
 const DEFAULT_CHIP_CLASS = 'rounded-xl px-4 py-2';
 
 const PredictChipList: React.FC<PredictChipListProps> = ({

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -123,9 +123,8 @@ const CHART_REQUEST_DURATION_BY_RECURRENCE_MS: Record<string, number> = {
 };
 const PROGRESS_RING_SIZE = 54;
 const PROGRESS_RING_STROKE_WIDTH = 4;
-const PROGRESS_RING_RADIUS =
-  (PROGRESS_RING_SIZE - PROGRESS_RING_STROKE_WIDTH) / 2;
-const PROGRESS_RING_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RING_RADIUS;
+const COMPACT_PROGRESS_RING_SIZE = 40;
+const COMPACT_PROGRESS_RING_STROKE_WIDTH = 2;
 const CRYPTO_ACCENT_DEFAULT = 'rgb(245, 158, 11)';
 const CRYPTO_ACCENT_BY_SYMBOL: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
@@ -814,49 +813,62 @@ const ProgressLogo = React.memo(
     progress,
     color,
     trackColor,
+    compact,
   }: {
     imageUrl?: string;
     progress: number;
     color: string;
     trackColor: string;
+    compact?: boolean;
   }) => {
     const tw = useTailwind();
-    const strokeDashoffset = PROGRESS_RING_CIRCUMFERENCE * (1 - progress);
+    const ringSize = compact ? COMPACT_PROGRESS_RING_SIZE : PROGRESS_RING_SIZE;
+    const strokeWidth = compact
+      ? COMPACT_PROGRESS_RING_STROKE_WIDTH
+      : PROGRESS_RING_STROKE_WIDTH;
+    const radius = (ringSize - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const strokeDashoffset = circumference * (1 - progress);
 
     return (
-      <Box twClassName="h-[54px] w-[54px] items-center justify-center">
+      <Box
+        twClassName="items-center justify-center"
+        style={tw.style({ width: ringSize, height: ringSize })}
+      >
         <Box twClassName="absolute inset-0">
           <Svg
-            width={PROGRESS_RING_SIZE}
-            height={PROGRESS_RING_SIZE}
-            viewBox={`0 0 ${PROGRESS_RING_SIZE} ${PROGRESS_RING_SIZE}`}
+            width={ringSize}
+            height={ringSize}
+            viewBox={`0 0 ${ringSize} ${ringSize}`}
           >
             <Circle
-              cx={PROGRESS_RING_SIZE / 2}
-              cy={PROGRESS_RING_SIZE / 2}
-              r={PROGRESS_RING_RADIUS}
+              cx={ringSize / 2}
+              cy={ringSize / 2}
+              r={radius}
               stroke={trackColor}
               strokeOpacity={0.7}
-              strokeWidth={PROGRESS_RING_STROKE_WIDTH}
+              strokeWidth={strokeWidth}
               fill="transparent"
             />
             <Circle
-              cx={PROGRESS_RING_SIZE / 2}
-              cy={PROGRESS_RING_SIZE / 2}
-              r={PROGRESS_RING_RADIUS}
+              cx={ringSize / 2}
+              cy={ringSize / 2}
+              r={radius}
               stroke={color}
-              strokeWidth={PROGRESS_RING_STROKE_WIDTH}
-              strokeDasharray={`${PROGRESS_RING_CIRCUMFERENCE} ${PROGRESS_RING_CIRCUMFERENCE}`}
+              strokeWidth={strokeWidth}
+              strokeDasharray={`${circumference} ${circumference}`}
               strokeDashoffset={strokeDashoffset}
               strokeLinecap="round"
               fill="transparent"
-              transform={`rotate(-90 ${PROGRESS_RING_SIZE / 2} ${
-                PROGRESS_RING_SIZE / 2
-              })`}
+              transform={`rotate(-90 ${ringSize / 2} ${ringSize / 2})`}
             />
           </Svg>
         </Box>
-        <Box twClassName="h-10 w-10 overflow-hidden rounded-full bg-default">
+        <Box
+          twClassName={`${
+            compact ? 'h-8 w-8' : 'h-10 w-10'
+          } overflow-hidden rounded-full bg-default`}
+        >
           {imageUrl ? (
             <Image
               source={{ uri: imageUrl }}
@@ -905,6 +917,7 @@ const LiveStatus = React.memo(
         progress={progressRemaining}
         color={accentColor}
         trackColor={trackColor}
+        compact={compact}
       />
     );
 
@@ -1354,9 +1367,15 @@ const PredictCryptoUpDownMarketCard: React.FC<
             >
               {cardTitle}
             </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              Resets every {resetDuration}
+            </Text>
           </Box>
 
-          <Box twClassName="w-full items-center gap-2">
+          <Box twClassName="w-full">
             <OutcomeButtons
               compact
               upToken={upToken}
@@ -1366,12 +1385,6 @@ const PredictCryptoUpDownMarketCard: React.FC<
               marketStatus={selectedMarket.status as PredictMarketStatus}
               onBuyPress={handleBuyPress}
             />
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              Resets every {resetDuration}
-            </Text>
           </Box>
         </Box>
       </Pressable>

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -416,7 +416,7 @@ describe('PredictMarketSportCard', () => {
       { state: initialState },
     );
 
-    expect(getByText('Live')).toBeOnTheScreen();
+    expect(getByText('LIVE')).toBeOnTheScreen();
     expect(getByText('75’')).toBeOnTheScreen();
     expect(getByText('0')).toBeOnTheScreen();
     expect(getByText('1')).toBeOnTheScreen();

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -285,7 +285,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
 
   return (
     <TouchableOpacity
-      style={tw.style(isCarousel ? '' : 'my-[8px]')}
+      style={tw.style(isCarousel ? 'h-full' : 'my-[8px]')}
       testID={testID}
       onPress={handleCardPress}
       activeOpacity={0.9}
@@ -306,9 +306,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
           </Box>
         )}
 
-        <Box
-          twClassName={isCompact ? 'flex-1 p-3 justify-between' : 'p-4 gap-4'}
-        >
+        <Box twClassName={isCompact ? 'flex-1 p-3' : 'p-4 gap-4'}>
           <Text
             variant={TextVariant.HeadingSm}
             color={TextColor.TextDefault}
@@ -319,16 +317,18 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
             {market.title}
           </Text>
 
-          <PredictSportScoreboard
-            game={game}
-            compact={isCompact}
-            testID={testID ? `${testID}-scoreboard` : undefined}
-          />
+          <Box twClassName={isCompact ? 'flex-1 mt-3 justify-center' : ''}>
+            <PredictSportScoreboard
+              game={game}
+              compact={isCompact}
+              testID={testID ? `${testID}-scoreboard` : undefined}
+            />
+          </Box>
 
           {showBuyButtons && (
             <Box
               flexDirection={BoxFlexDirection.Row}
-              twClassName="w-full gap-2"
+              twClassName={`w-full gap-2 ${isCompact ? 'mt-1' : ''}`}
             >
               {buttonItems.map((item) => (
                 <Box key={item.key} twClassName="flex-1">

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx
@@ -170,7 +170,7 @@ describe('PredictSportScoreboard', () => {
         />,
       );
 
-      expect(getByText('Live')).toBeOnTheScreen();
+      expect(getByText('LIVE')).toBeOnTheScreen();
       expect(getByText('25’')).toBeOnTheScreen();
     });
 

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -202,7 +202,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
                   fontWeight={FontWeight.Medium}
                   color={TextColor.SuccessDefault}
                 >
-                  Live
+                  LIVE
                 </Text>
                 <Box twClassName="w-3" />
               </Box>

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
@@ -251,6 +251,7 @@ const PredictFeedView: React.FC = () => {
       })),
     [filters],
   );
+  const showFilterList = chips.length >= 2;
 
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
@@ -251,7 +251,6 @@ const PredictFeedView: React.FC = () => {
       })),
     [filters],
   );
-  const showFilterList = chips.length >= 2;
 
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
@@ -160,7 +160,7 @@ const PredictHome: React.FC = () => {
           >
             <Text
               testID={PredictHomeSelectorsIDs.TITLE}
-              variant={TextVariant.DisplayMd}
+              variant={TextVariant.HeadingMd}
             >
               {strings('wallet.predict')}
             </Text>

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
@@ -129,7 +129,7 @@ const PredictHome: React.FC = () => {
 
   return (
     <SafeAreaView
-      edges={{ bottom: 'additive' }}
+      edges={{ bottom: 'off' }}
       style={tw.style('flex-1 bg-default')}
     >
       <Box

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
@@ -166,34 +166,38 @@ const PredictHome: React.FC = () => {
             </Text>
           </Box>
 
-          <PredictPortfolioModule
-            onDepositWalletWithdrawPress={handleDepositWalletWithdrawPress}
-          />
-          <Box
-            testID={PredictHomeSelectorsIDs.LIVE_NOW_IMPRESSION}
-            onLayout={registerSection(PredictEventValues.SECTION_ID.LIVE_NOW)}
-          >
-            <PredictLiveNowSection />
-          </Box>
-          <Box
-            testID={PredictHomeSelectorsIDs.CATEGORIES_IMPRESSION}
-            onLayout={registerSection(PredictEventValues.SECTION_ID.CATEGORIES)}
-          >
-            <PredictCategoriesSection />
-          </Box>
-          <Box
-            testID={PredictHomeSelectorsIDs.POPULAR_TODAY_IMPRESSION}
-            onLayout={registerSection(
-              PredictEventValues.SECTION_ID.POPULAR_TODAY,
-            )}
-          >
-            <PredictPopularTodaySection />
-          </Box>
-          <Box
-            testID={PredictHomeSelectorsIDs.TRENDING_IMPRESSION}
-            onLayout={registerSection(PredictEventValues.SECTION_ID.TRENDING)}
-          >
-            <PredictTrendingSection />
+          <Box twClassName="gap-6">
+            <PredictPortfolioModule
+              onDepositWalletWithdrawPress={handleDepositWalletWithdrawPress}
+            />
+            <Box
+              testID={PredictHomeSelectorsIDs.LIVE_NOW_IMPRESSION}
+              onLayout={registerSection(PredictEventValues.SECTION_ID.LIVE_NOW)}
+            >
+              <PredictLiveNowSection />
+            </Box>
+            <Box
+              testID={PredictHomeSelectorsIDs.CATEGORIES_IMPRESSION}
+              onLayout={registerSection(
+                PredictEventValues.SECTION_ID.CATEGORIES,
+              )}
+            >
+              <PredictCategoriesSection />
+            </Box>
+            <Box
+              testID={PredictHomeSelectorsIDs.POPULAR_TODAY_IMPRESSION}
+              onLayout={registerSection(
+                PredictEventValues.SECTION_ID.POPULAR_TODAY,
+              )}
+            >
+              <PredictPopularTodaySection />
+            </Box>
+            <Box
+              testID={PredictHomeSelectorsIDs.TRENDING_IMPRESSION}
+              onLayout={registerSection(PredictEventValues.SECTION_ID.TRENDING)}
+            >
+              <PredictTrendingSection />
+            </Box>
           </Box>
         </Animated.ScrollView>
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
@@ -74,7 +74,7 @@ const PredictCategoriesSection: React.FC<PredictCategoriesSectionProps> = ({
   );
 
   return (
-    <Box testID={testID} twClassName="my-2">
+    <Box testID={testID}>
       <SectionHeader
         testID={PREDICT_CATEGORIES_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.categories_title')}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -147,7 +147,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
   }
 
   return (
-    <Box testID={testID} twClassName="my-2">
+    <Box testID={testID}>
       {/* "See all" navigates to the generic PredictFeedView (feedId 'live'). */}
       <SectionHeader
         testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.HEADER}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -154,6 +154,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
         title={strings('predict.home.live_now_title')}
         isInteractive
         onPress={handleSeeAll}
+        twClassName="p-0 mb-2"
       />
 
       <Box twClassName="-mx-4">

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -183,7 +183,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
   }
 
   return (
-    <Box testID={testID} twClassName="my-2">
+    <Box testID={testID}>
       <SectionHeader
         testID={PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.HEADER}
         title={strings('predict.feed.popular_today')}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -243,7 +243,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
                   >
                     <Text
                       variant={TextVariant.BodySm}
-                      color={TextColor.TextAlternative}
+                      color={TextColor.TextDefault}
                       fontWeight={FontWeight.Medium}
                     >
                       {label}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -90,7 +90,7 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
           </Text>
         </Box>
       ) : (
-        <Box twClassName="gap-3">
+        <Box twClassName="gap-1">
           {markets.map((market) => (
             <PredictMarket
               key={market.id}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -57,7 +57,7 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
   }, [navigation]);
 
   return (
-    <Box testID={testID} twClassName="my-2">
+    <Box testID={testID}>
       {/* "See all" navigates to the generic PredictFeedView (feedId 'trending').
           Passing `onPress` is what renders the chevron + touchable. */}
       <SectionHeader


### PR DESCRIPTION
<!-- Suggested PR title: fix(predict): apply Design QA styling polish -->

## **Description**

<!-- mms-check: type=text required=true -->

Applies the PRED-1089 Design QA feedback to the redesigned Predict home and feed:

- Aligns the Predict home title, section spacing, headers, chip colors, card spacing, and bottom safe-area treatment with the approved designs.
- Hides the feed filter list when fewer than two filter options are available, avoiding a redundant single chip on the Live feed.
- Refines compact Live carousel cards, including the BTC progress icon, reset-label placement, sports scoreboard spacing, button alignment, and uppercase `LIVE` status.
- Reduces the shared filter-chip container bottom padding for consistent feed spacing.

### Automated validation

- `npx jest -c jest.config.view.js app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx --runInBand --silent --coverage=false`
- `npx jest app/components/UI/Predict/views/PredictFeedView/PredictFeedView.test.tsx --runInBand --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx --runInBand --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx --runInBand --coverage=false`
- `npx jest app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.test.tsx --runInBand --coverage=false`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed spacing and styling inconsistencies on the Predict home and live market views

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1089

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict Design QA polish

  Scenario: View the redesigned Predict home
    Given the Predict home redesign is enabled
    And the user opens Predict
    When the Predict home finishes loading
    Then the title size matches the Perps home title
    And the portfolio and market sections have 24px spacing
    And the screen has no black bottom safe-area bar
    And Popular Today and Trending use the updated text and card spacing

  Scenario: View live market cards
    Given the Predict home contains live crypto and sports markets
    When the user views the Live Now carousel
    Then the compact BTC icon and progress ring match the approved dimensions
    And the BTC reset label appears directly below the title
    And the crypto and sports action buttons align at the bottom of their cards
    And the sports status displays as "LIVE"

  Scenario: Open a feed with filter options
    Given the user opens a Predict feed
    When the feed has fewer than two filter options
    Then the filter list is hidden
    When the feed has two or more filter options
    Then the filter list is displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — Design QA evidence is tracked in PRED-1089; attach the final simulator screenshots when opening the PR.

### **Before**

N/A — see PRED-1089.

### **After**

https://github.com/user-attachments/assets/cf2911e3-5971-4ee0-81a4-5766f46990f0

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — presentation-only changes with no performance-sensitive operations.
- [x] I've tested with a power user scenario
  - N/A — the changes do not depend on account or asset volume.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no new key operations or asynchronous workflows were introduced.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only spacing, typography, and layout changes in Predict UI with no auth, data, or trading logic touched.
> 
> **Overview**
> Applies **PRED-1089** styling polish across Predict home and live market UI.
> 
> **Predict home** uses a smaller title (`HeadingMd`), turns off the bottom safe-area inset to remove the black bar, and groups portfolio + sections in a **`gap-6`** stack while dropping per-section vertical margins. Section headers and list spacing are tightened (e.g. Trending card **`gap-1`**, Popular Today chips use default text color).
> 
> **Live carousel cards**: compact crypto cards get a smaller progress ring/logo via a **`compact`** `ProgressLogo`, with **“Resets every …”** moved directly under the title; compact sports cards use full-height carousel layout and centered scoreboard with bottom-aligned buy buttons.
> 
> **Shared tweaks**: sport scoreboard live label is **`LIVE`** (tests updated); filter chip list default container padding is **`pb-3`** instead of **`pb-4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc53474d2304210ecd762b2a9a146021ce1427bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->