### PR TITLE
fix(predict): remove redundant Live filter chip

### DIFF
--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -44,6 +44,8 @@ export interface PredictFeedTabConfig {
 export interface PredictFeedConfig {
   id: PredictFeedId;
   titleKey: string;
+  /** Whether the feed exposes user-selectable filter chips. Defaults to true. */
+  showFilterBar?: boolean;
   header: {
     showBackButton: boolean;
     showSearchButton: boolean;
@@ -189,6 +191,7 @@ export const PREDICT_FEED_REGISTRY: Record<PredictFeedId, PredictFeedConfig> = {
   live: {
     id: 'live',
     titleKey: 'predict.feed.live',
+    showFilterBar: false,
     header: {
       showBackButton: true,
       showSearchButton: true,

--- a/app/components/UI/Predict/hooks/usePredictFeedConfig.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictFeedConfig.test.ts
@@ -90,11 +90,23 @@ describe('usePredictFeedConfig', () => {
   });
 
   describe('static-only feeds', () => {
+    it('hides the filter bar for the Live feed', () => {
+      const { result } = renderHook(() => usePredictFeedConfig('live'));
+
+      expect(result.current.showFilterBar).toBe(false);
+    });
+
     it('exposes static filters and disables dynamic fetching', () => {
       const { result } = renderHook(() => usePredictFeedConfig('live'));
 
       expect(ids(result.current.filters)).toEqual(['live']);
       expect(result.current.filters[0].isDynamic).toBe(false);
+      expect(result.current.activeFilter?.params).toEqual({
+        status: 'open',
+        order: 'volume24hr',
+        limit: 10,
+        live: true,
+      });
       expect(result.current.dynamicFilters.status).toBe('idle');
       expect(mockUsePredictFilterOptions).toHaveBeenCalledWith(
         { source: 'related-tags' },

--- a/app/components/UI/Predict/hooks/usePredictFeedConfig.ts
+++ b/app/components/UI/Predict/hooks/usePredictFeedConfig.ts
@@ -55,6 +55,8 @@ export interface PredictFeedConfigResult {
   tabs: PredictFeedTabSummary[];
   /** Hidden for single-tab feeds; filters still render for that one tab. */
   showTabBar: boolean;
+  /** Hidden when the active feed has no user-selectable filters. */
+  showFilterBar: boolean;
   activeTabId?: string;
   setActiveTabId: (id: string) => void;
   /** Static + deduped dynamic filters for the active tab. */
@@ -356,6 +358,7 @@ export const usePredictFeedConfig = (
     header: config?.header,
     tabs,
     showTabBar: tabs.length > 1,
+    showFilterBar: config?.showFilterBar ?? true,
     activeTabId: resolvedActiveTabId,
     setActiveTabId,
     filters,

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.test.tsx
@@ -170,6 +170,7 @@ const feedConfigResult = (
     { id: 'tennis', titleKey: 'predict.feed.tabs.tennis' },
   ],
   showTabBar: true,
+  showFilterBar: true,
   activeTabId: 'basketball',
   setActiveTabId: mockSetActiveTabId,
   filters: [
@@ -295,13 +296,14 @@ describe('PredictFeedView', () => {
       expect(screen.getAllByText('Tennis').length).toBeGreaterThan(0);
     });
 
-    it('hides the tab bar for a single-tab feed but still renders filters', () => {
+    it('hides the tab and filter bars for the Live feed', () => {
       mockUsePredictFeedConfig.mockReturnValue(
         feedConfigResult({
           feedId: 'live',
           titleKey: 'predict.feed.live',
           tabs: [{ id: 'live', titleKey: 'predict.feed.live' }],
           showTabBar: false,
+          showFilterBar: false,
           activeTabId: 'live',
           filters: [
             {
@@ -321,8 +323,8 @@ describe('PredictFeedView', () => {
         screen.queryByTestId(PredictFeedViewSelectorsIDs.TABS),
       ).not.toBeOnTheScreen();
       expect(
-        screen.getByTestId(PredictFeedViewSelectorsIDs.FILTERS),
-      ).toBeOnTheScreen();
+        screen.queryByTestId(PredictFeedViewSelectorsIDs.FILTERS),
+      ).not.toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
@@ -67,6 +67,7 @@ const PredictFeedView: React.FC = () => {
     header,
     tabs,
     showTabBar,
+    showFilterBar,
     activeTabId,
     setActiveTabId,
     filters,
@@ -391,12 +392,14 @@ const PredictFeedView: React.FC = () => {
           />
         )}
 
-        <PredictChipList
-          chips={chips}
-          activeChipKey={activeFilterId ?? ''}
-          onChipSelect={handleFilterSelect}
-          testID={PredictFeedViewSelectorsIDs.FILTERS}
-        />
+        {showFilterBar && (
+          <PredictChipList
+            chips={chips}
+            activeChipKey={activeFilterId ?? ''}
+            onChipSelect={handleFilterSelect}
+            testID={PredictFeedViewSelectorsIDs.FILTERS}
+          />
+        )}
 
         {renderContent()}
       </Box>

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.view.test.tsx
@@ -101,4 +101,23 @@ describe('PredictFeedView (component view)', () => {
       ),
     ).toBeOnTheScreen();
   });
+
+  it('hides Live filter chips while requesting only live markets', async () => {
+    const { findByTestId, queryByTestId } = renderPredictFeedView({
+      initialParams: { feedId: 'live' },
+    });
+
+    await findByTestId(
+      PredictFeedViewSelectorsIDs.EMPTY_STATE,
+      {},
+      { timeout: 10000 },
+    );
+
+    expect(
+      queryByTestId(PredictFeedViewSelectorsIDs.FILTERS),
+    ).not.toBeOnTheScreen();
+    expect(Engine.context.PredictController.listMarkets).toHaveBeenCalledWith(
+      expect.objectContaining({ live: true }),
+    );
+  });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The feature-flagged Predict Live page displayed a preselected Live filter chip even though the entire page is already scoped to live markets. This adds a feed-level filter-bar display setting and disables the bar for the Live feed. The internal Live filter remains active, so market requests continue to include `live: true`, while filter chips on other feeds remain unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the redundant Live filter chip from the Live prediction markets page

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1082

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Live prediction markets page

  Background:
    Given the Predict home redesign feature flag is enabled
    And the user is on the redesigned Predict homepage

  Scenario: Open the Live page without a redundant filter
    When the user opens the Live page
    Then the Live page is displayed
    And no filter chip row is displayed
    And only live prediction markets are requested

  Scenario: Preserve filter chips on other feeds
    When the user opens the Sports page
    Then the Sports filter chip row is displayed
    And the All and Live filter chips are available

  Scenario: Preserve the existing experience when the redesign is disabled
    Given the Predict home redesign feature flag is disabled
    When the user opens Predict
    Then the legacy Predict market list is displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - No screenshot or recording was captured for the redundant Live filter chip.

### **After**

N/A - No screenshot or recording was captured; the change only removes an existing redundant chip.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: This is a filter visibility change; no manual Android test was performed.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: The behavior does not depend on account, token, or activity volume.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: This change adds no new operation or performance-sensitive code path.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility change in Predict feeds with tests; no auth, payments, or API contract changes beyond existing live filter params.
> 
> **Overview**
> Removes the redundant **Live** filter chip on the Live prediction markets screen by adding an optional feed-level **`showFilterBar`** flag (default **true**) and setting **`showFilterBar: false`** on the Live feed in **`feedConfig`**.
> 
> **`usePredictFeedConfig`** exposes **`showFilterBar`**, and **`PredictFeedView`** only renders **`PredictChipList`** when it is true. The Live feed still uses its internal live filter, so **`usePredictMarketList`** continues to request markets with **`live: true`**; Sports and other feeds are unchanged.
> 
> Tests cover hook behavior, unit view expectations, and a component-view check that the filter row is absent and **`listMarkets`** includes **`live: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b364ef15b15a72cb36e968d63ae5a8de45420c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->