### PR TITLE
ci: run Linux CI on Namespace shadow behind NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH

### DIFF
--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -8,9 +8,13 @@ name: CI (Namespace shadow)
 # token-exchange, and dispatch steps use continue-on-error so this job's own
 # check always concludes success even when the dispatch cannot run.
 #
-# Shadow runs are iOS-only: ci.yml skips Android and Linux-only jobs when
-# runner_provider is namespace (see the BITRISE/NAMESPACE-SHADOW markers there),
-# mirroring the Bitrise shadow benchmark scope.
+# A shadow run is composed of two independently-flagged pipelines inside ci.yml
+# (see the BITRISE/NAMESPACE-SHADOW markers there); Android jobs never run:
+#   - iOS pipeline (build + E2E smoke): runs when NAMESPACE_SHADOW_AUTO_DISPATCH=true
+#   - Linux pipeline (lint/unit/scripts/etc. on namespace-profile-metamask-ci-linux):
+#     runs when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+# With both flags false, a manual dispatch yields a near-empty ci.yml run (only
+# provider-agnostic scaffolding like get_requirements / fingerprint / timings).
 #
 # Authentication: Token Exchange Service (same pattern as triage-forwarder.yml —
 # OIDC → POST /api/exchange/token). Prerequisites:
@@ -18,8 +22,9 @@ name: CI (Namespace shadow)
 #   - Rego policy mm-metamask-mobile-namespace-shadow-ci-token-exchange in
 #     token-exchange-service (matches the OIDC `workflow_ref` claim).
 #
-# Auto-dispatch gate: set repo Actions variable NAMESPACE_SHADOW_AUTO_DISPATCH=true
-# to dispatch on PR/push. Default (unset/false) = manual workflow_dispatch only.
+# Auto-dispatch gate: PR/push dispatch happens when NAMESPACE_SHADOW_AUTO_DISPATCH=true
+# or NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true (repo Actions variables). Default
+# (both unset/false) = manual workflow_dispatch only.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -44,10 +49,11 @@ jobs:
     name: "[shadow] Dispatch"
     runs-on: ubuntu-latest
     # Fork PRs use head.repo != github.repository — skip (no shadow, no token exchange).
-    # PR/push auto-dispatch requires NAMESPACE_SHADOW_AUTO_DISPATCH=true; workflow_dispatch always runs.
+    # PR/push auto-dispatch requires NAMESPACE_SHADOW_AUTO_DISPATCH=true (iOS pipeline)
+    # or NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true (Linux pipeline); workflow_dispatch always runs.
     if: >-
       ${{
-        (github.event_name == 'workflow_dispatch' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') &&
+        (github.event_name == 'workflow_dispatch' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') &&
         (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       }}
     steps:

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -9,10 +9,13 @@ name: CI (Namespace shadow)
 # check always concludes success even when the dispatch cannot run.
 #
 # A shadow run is composed of two independently-flagged pipelines inside ci.yml
-# (see the BITRISE/NAMESPACE-SHADOW markers there); Android jobs never run:
-#   - iOS pipeline (build + E2E smoke): runs when NAMESPACE_SHADOW_AUTO_DISPATCH=true
-#   - Linux pipeline (lint/unit/scripts/etc. on namespace-profile-metamask-ci-linux):
+# (see the BITRISE/NAMESPACE-SHADOW markers there):
+#   - iOS pipeline (build + E2E smoke on macOS runners): runs when
+#     NAMESPACE_SHADOW_AUTO_DISPATCH=true
+#   - Linux pipeline (lint/unit/scripts/etc. on namespace-profile-metamask-ci-linux,
+#     plus Android build + E2E smoke on namespace-profile-metamask-android-build):
 #     runs when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+# Appium Android stays skipped on shadow runs (pinned to Cirrus until Namespace parity).
 # With both flags false, a manual dispatch yields a near-empty ci.yml run (only
 # provider-agnostic scaffolding like get_requirements / fingerprint / timings).
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1251,11 +1251,11 @@ jobs:
 
   build-android-apks:
     name: 'Build Android APKs'
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux-runner job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
-        inputs.runner_provider != 'namespace' &&
+        (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') &&
         !cancelled() &&
         needs.get_requirements.outputs.android_e2e_needed == 'true' &&
         !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
@@ -1329,11 +1329,11 @@ jobs:
 
   e2e-smoke-tests-android:
     name: 'Android E2E Smoke Tests'
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux-runner job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&
-        inputs.runner_provider != 'namespace' &&
+        (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') &&
         !cancelled() &&
         needs.build-android-apks.result == 'success' &&
         (needs.prepare-e2e-timings.result == 'success' || needs.prepare-e2e-timings.result == 'failure' || needs.prepare-e2e-timings.result == 'skipped')
@@ -1412,7 +1412,9 @@ jobs:
 
   appium-smoke-tests-android:
     name: 'Appium Smoke Tests (Android)'
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
+    # BITRISE/NAMESPACE-SHADOW: always skipped on shadow runs. Appium Android is pinned to
+    # runner_provider=current (Cirrus) below until Namespace parity is ready, and it cannot
+    # download namespace-built APKs (they live in Namespace's artifact store, not GitHub's).
     if: >-
       ${{
         inputs.runner_provider != 'bitrise' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
   check-diff:
     name: Check diff
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-build' || 'macos-latest' }}
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
+    # NAMESPACE-SHADOW: macOS job — runs on Namespace shadow only when NAMESPACE_SHADOW_AUTO_DISPATCH=true (iOS pipeline)
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     steps:
@@ -170,8 +171,8 @@ jobs:
   dedupe:
     name: Dedupe
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     steps:
@@ -219,8 +220,8 @@ jobs:
   git-safe-dependencies:
     name: Run `@lavamoat/git-safe-dependencies`
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     steps:
@@ -261,8 +262,8 @@ jobs:
   scripts:
     name: Run `${{ matrix.scripts }}`
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     strategy:
@@ -321,8 +322,8 @@ jobs:
   js-bundle-size-check:
     name: JS bundle size check
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     permissions:
@@ -634,8 +635,8 @@ jobs:
   check-workflows:
     name: Check workflows
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     steps:
@@ -656,8 +657,8 @@ jobs:
   prepare-ci-js-deps:
     name: Prepare CI JS dependencies
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
     steps:
@@ -683,8 +684,8 @@ jobs:
   unit-tests:
     name: Unit tests (${{ matrix.shard }})
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
       - prepare-ci-js-deps
@@ -764,7 +765,8 @@ jobs:
       - integration-tests
     # Wait for integration shards so coverage can merge into Sonar, but still run
     # when integration fails — missing integration artifacts are tolerated below.
-    if: ${{ always() && github.event_name != 'merge_group' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && !cancelled() && needs.prepare-ci-js-deps.result == 'success' && needs.unit-tests.result == 'success' && needs.component-view-tests.result == 'success' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ always() && github.event_name != 'merge_group' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') && !cancelled() && needs.prepare-ci-js-deps.result == 'success' && needs.unit-tests.result == 'success' && needs.component-view-tests.result == 'success' }}
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -1032,8 +1034,8 @@ jobs:
   component-view-tests:
     name: Component view tests
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
       - prepare-ci-js-deps
@@ -1099,7 +1101,8 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' }}
+    # BITRISE/NAMESPACE-SHADOW: skipped on Bitrise shadow (iOS-only, INFRA-3679); Namespace shadow runs this Linux job only when NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true
+    if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' && inputs.runner_provider != 'bitrise' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true') }}
     needs:
       - get_requirements
       - prepare-ci-js-deps
@@ -1352,9 +1355,12 @@ jobs:
 
   build-ios-apps:
     name: 'Build iOS Apps'
+    # NAMESPACE-SHADOW: iOS pipeline runs on Namespace shadow only when NAMESPACE_SHADOW_AUTO_DISPATCH=true
+    # (downstream iOS jobs cascade-skip via needs when this is skipped)
     if: >-
       ${{
         !cancelled() &&
+        (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') &&
         needs.get_requirements.outputs.ios_e2e_needed == 'true' &&
         !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
       }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Extends the Namespace shadow CI (introduced in #32893) so we can also benchmark **Linux CI jobs on Namespace runners**, controlled by a second repo Actions variable.

**What is the reason for the change?**

The Namespace shadow currently runs iOS-only (gated by `NAMESPACE_SHADOW_AUTO_DISPATCH`, enabled since Jul 13). The next step of the Namespace evaluation is getting **Linux CI runs** (lint/dedupe/scripts/unit/component/integration tests) on `namespace-profile-metamask-ci-linux` runners, toggleable independently from the iOS pipeline.

**What is the improvement/solution?**

A namespace shadow run is now composed of two independently-flagged pipelines:

| `NAMESPACE_SHADOW_AUTO_DISPATCH` (existing) | `NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH` (new) | Shadow behavior |
|---|---|---|
| `true` | `false`/unset | Auto-dispatch on PR/push; iOS pipeline only (current behavior) |
| `false`/unset | `true` | Auto-dispatch on PR/push; Linux pipeline only (no macOS runners used) |
| `true` | `true` | Auto-dispatch on PR/push; iOS + Linux pipelines |
| `false`/unset | `false`/unset | No auto-dispatch; manual `workflow_dispatch` yields a near-empty scaffolding run |

The **Linux pipeline** covers everything that runs on Linux runners — the quality jobs on `namespace-profile-metamask-ci-linux` **and Android build + Android E2E smoke** on `namespace-profile-metamask-android-build` — matching what the Phase 5 benchmark exercised (verified against Phase 5 shadow run [27025678155](https://github.com/MetaMask/metamask-mobile/actions/runs/27025678155), where all Android jobs ran on Namespace runners).

1. **`ci-namespace-shadow.yml`** — the dispatch gate now ORs the two flags: PR/push auto-dispatch happens when either variable is `true` (manual `workflow_dispatch` always works; fork-PR guard unchanged).
2. **`ci.yml`** —
   - **Linux pipeline (12 jobs)**: `dedupe`, `git-safe-dependencies`, `scripts`, `js-bundle-size-check`, `check-workflows`, `prepare-ci-js-deps`, `unit-tests`, `component-view-tests`, `integration-tests`, `merge-unit-and-component-view-tests`, `build-android-apks`, `e2e-smoke-tests-android` now use `(inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH == 'true')` instead of a hard namespace skip. All of them already had namespace runner ternaries and nscloud checkout/cache/artifact steps from the Phase 5 benchmark — no step changes needed.
     - `prepare-ci-js-deps` is included because `merge-unit-and-component-view-tests` explicitly requires it to have succeeded.
     - `integration-tests` (added to `ci.yml` after #32893) previously had **no** shadow gate at all; it now follows the same BITRISE/NAMESPACE-SHADOW pattern (skipped on Bitrise shadow, flag-gated on Namespace shadow).
   - **iOS pipeline**: `check-diff` and `build-ios-apps` (the macOS entry jobs) are now gated on `NAMESPACE_SHADOW_AUTO_DISPATCH == 'true'` for namespace runs, so a Linux-only shadow uses no macOS runners. Downstream iOS jobs cascade-skip via `needs`.
   - **Unchanged (never run in namespace shadows)**: `appium-smoke-tests-android` (pinned to `runner_provider: current`/Cirrus until Namespace parity is ready, and it cannot download namespace-built APKs — they live in Namespace's artifact store, not GitHub's), performance tests, `report-fixture-validation` (PR comments), SonarCloud analysis + quality gate (would collide with the real run's analysis of the same commit), `cleanup-ci-js-deps`, `check-all-jobs-pass`, `log-merge-group-failure`.

Normal CI runs (`runner_provider` empty/`current`) and Bitrise shadow runs are unaffected — every new clause short-circuits to the previous behavior when the provider is not `namespace`.

**Rollout:**

1. Create the new variable (can be prepared in advance — merging this PR alone changes nothing for Linux):

   ```bash
   gh variable set NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH --body false --repo MetaMask/metamask-mobile
   ```

2. Greenlight Linux auto-dispatch: set the variable to `true`.
3. Kill switch (either pipeline, no code PR needed): set the respective variable back to `false`.

**Pre-merge verification (done):** with `NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true` and `NAMESPACE_SHADOW_AUTO_DISPATCH=false`, "CI (Namespace shadow)" was dispatched on this branch — [shadow ci.yml run](https://github.com/MetaMask/metamask-mobile/actions/runs/29453403464) (auto-dispatched by the `ready_for_review` event, superseding the [initial manual run](https://github.com/MetaMask/metamask-mobile/actions/runs/29452848246) via the ci.yml concurrency group — the auto-dispatch gate itself verified in the process) — in parallel with the [normal pull_request run](https://github.com/MetaMask/metamask-mobile/actions/runs/29452206023):

- Linux quality jobs (dedupe, lint, scripts, unit/integration/component tests…) ran on `namespace-profile-metamask-ci-linux` ✅
- `Build Android E2E APKs` + Android E2E smoke ran on `namespace-profile-metamask-android-build` ✅
- `Check diff` and `Build iOS Apps` (and all downstream iOS jobs) **skipped** — the iOS flag gate works ✅
- Smart E2E selection / Sonar / PR-comment / Appium jobs skipped — nothing touches the PR ✅
- The parallel normal run was unaffected (regular runners, regular behavior) ✅
- The dispatcher's auto-runs on earlier pushes were correctly `skipped` while both flags were `false` ✅

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — no Jira ticket yet (number can be added to the PR title later). Related prior work: #32893 (`NAMESPACE_SHADOW_AUTO_DISPATCH`, iOS-only namespace shadow), INFRA-3631 / INFRA-3678 (Namespace evaluation), INFRA-3679 (Bitrise shadow pattern).

## **Manual testing steps**

```gherkin
Feature: Namespace shadow CI with independent iOS and Linux pipeline flags

  Scenario: Linux pipeline disabled (default)
    Given NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH is unset or "false"
    And NAMESPACE_SHADOW_AUTO_DISPATCH is "true"
    When the shadow dispatches ci.yml with runner_provider=namespace
    Then only the iOS pipeline runs (current behavior)
    And dedupe, scripts, unit/component/integration tests are skipped

  Scenario: Linux-only shadow run
    Given NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH is "true"
    And NAMESPACE_SHADOW_AUTO_DISPATCH is "false"
    When the shadow dispatches ci.yml with runner_provider=namespace
    Then the quality jobs run on namespace-profile-metamask-ci-linux runners
    And the Android APK build and Android E2E smoke shards run on namespace-profile-metamask-android-build runners
    And Appium Android stays skipped
    And check-diff and build-ios-apps (and all downstream iOS jobs) are skipped
    And no macOS runner is used

  Scenario: both pipelines enabled
    Given both variables are "true"
    When the shadow dispatches ci.yml
    Then the Linux jobs and the iOS build + E2E smoke pipeline both run

  Scenario: auto-dispatch gate
    Given at least one of the two variables is "true"
    When a same-repo pull request is opened or synchronized, or a commit is pushed to main
    Then the shadow dispatcher fires (fork PRs never dispatch)
    And with both variables "false" only manual workflow_dispatch runs

  Scenario: no interference with normal CI
    Given a regular pull_request ci.yml run (runner_provider is empty)
    Then all conditions short-circuit to the previous behavior
    And Bitrise shadow runs remain iOS-only

  Scenario: validation
    Given the two modified workflow files
    When actionlint runs against them
    Then no errors are reported (verified locally)
```

## **Screenshots/Recordings**

CI workflow change — evidence is the verification runs:

### **Before**

Namespace shadow runs were iOS-only: [example run](https://github.com/MetaMask/metamask-mobile/actions/runs/28873341480) (Linux/Android jobs hard-skipped for `runner_provider=namespace`).

### **After**

Linux-pipeline shadow run with `NAMESPACE_SHADOW_LINUX_AUTO_DISPATCH=true`, iOS flag off: [shadow run 29453403464](https://github.com/MetaMask/metamask-mobile/actions/runs/29453403464) — Linux + Android jobs on Namespace runners, iOS jobs skipped, [parallel normal PR run](https://github.com/MetaMask/metamask-mobile/actions/runs/29452206023) unaffected.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
