### PR TITLE
chore: memoize Swaps QuoteRow rendering

### DIFF
--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
@@ -5,16 +5,33 @@ import { QuoteRowProps, QuoteRowViewProps } from './QuoteRow';
 import { useSelector } from 'react-redux';
 import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 
-jest.mock('./QuoteRow', () => ({
-  QuoteRowView: ({ providerName, quoteRequestId }: QuoteRowViewProps) => {
+const mockQuoteRowRenderCounts = new Map<string, number>();
+
+jest.mock('./QuoteRow', () => {
+  const ReactActual = jest.requireActual('react');
+
+  function MockQuoteRowView({
+    providerName,
+    quoteRequestId,
+  }: QuoteRowViewProps) {
     const { Text } = jest.requireActual('react-native');
+
+    mockQuoteRowRenderCounts.set(
+      quoteRequestId,
+      (mockQuoteRowRenderCounts.get(quoteRequestId) ?? 0) + 1,
+    );
+
     return (
       <Text testID={`quote-row-${quoteRequestId}`}>
         {providerName} - {quoteRequestId}
       </Text>
     );
-  },
-}));
+  }
+
+  return {
+    QuoteRowView: ReactActual.memo(MockQuoteRowView),
+  };
+});
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -50,6 +67,7 @@ describe('QuoteList', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockQuoteRowRenderCounts.clear();
   });
 
   describe('rendering', () => {
@@ -123,6 +141,50 @@ describe('QuoteList', () => {
 
       const renderedRows = getAllByText(/Lifi - quote-/);
       expect(renderedRows).toHaveLength(5);
+    });
+  });
+
+  describe('memoization', () => {
+    it('does not re-render unchanged rows when one quote changes', () => {
+      // Arrange
+      const quotes = [
+        createMockQuote({
+          provider: { name: 'Lifi' },
+          quoteRequestId: 'quote-1',
+        }),
+        createMockQuote({
+          provider: { name: 'Socket' },
+          quoteRequestId: 'quote-2',
+        }),
+        createMockQuote({
+          provider: { name: 'Hop' },
+          quoteRequestId: 'quote-3',
+        }),
+      ];
+      const { rerender } = render(<QuoteList data={quotes} />);
+      const updatedQuotes = [
+        createMockQuote({
+          provider: { name: 'Lifi' },
+          quoteRequestId: 'quote-1',
+        }),
+        createMockQuote({
+          provider: { name: 'Socket' },
+          quoteRequestId: 'quote-2',
+          formattedTotalCost: '$101.00',
+        }),
+        createMockQuote({
+          provider: { name: 'Hop' },
+          quoteRequestId: 'quote-3',
+        }),
+      ];
+
+      // Act
+      rerender(<QuoteList data={updatedQuotes} />);
+
+      // Assert
+      expect(mockQuoteRowRenderCounts.get('quote-1')).toBe(1);
+      expect(mockQuoteRowRenderCounts.get('quote-2')).toBe(2);
+      expect(mockQuoteRowRenderCounts.get('quote-3')).toBe(1);
     });
   });
 

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { QuoteList } from './QuoteList';
-import { QuoteRowProps } from './QuoteRow';
+import { QuoteRowProps, QuoteRowViewProps } from './QuoteRow';
 import { useSelector } from 'react-redux';
 import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 
 jest.mock('./QuoteRow', () => ({
-  QuoteRowView: ({ provider, quoteRequestId }: QuoteRowProps) => {
+  QuoteRowView: ({ providerName, quoteRequestId }: QuoteRowViewProps) => {
     const { Text } = jest.requireActual('react-native');
     return (
       <Text testID={`quote-row-${quoteRequestId}`}>
-        {provider.name} - {quoteRequestId}
+        {providerName} - {quoteRequestId}
       </Text>
     );
   },

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { QuoteList } from './QuoteList';
 import { QuoteRowProps } from './QuoteRow';
+import { useSelector } from 'react-redux';
+import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 
 jest.mock('./QuoteRow', () => ({
-  QuoteRow: ({ provider, quoteRequestId }: QuoteRowProps) => {
+  QuoteRowView: ({ provider, quoteRequestId }: QuoteRowProps) => {
     const { Text } = jest.requireActual('react-native');
     return (
       <Text testID={`quote-row-${quoteRequestId}`}>
@@ -14,9 +16,24 @@ jest.mock('./QuoteRow', () => ({
   },
 }));
 
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => undefined),
+}));
+
+jest.mock('../../utils/exchange-rates', () => ({
+  getDisplayCurrencyValue: jest.fn(() => '$0.00'),
+}));
+
 jest.mock('../../hooks/useShouldRenderGasSponsoredBanner', () => ({
   useShouldRenderGasSponsoredBanner: jest.fn(),
 }));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockGetDisplayCurrencyValue =
+  getDisplayCurrencyValue as jest.MockedFunction<
+    typeof getDisplayCurrencyValue
+  >;
 
 describe('QuoteList', () => {
   const mockOnPress = jest.fn();
@@ -36,6 +53,19 @@ describe('QuoteList', () => {
   });
 
   describe('rendering', () => {
+    it('selects currency data once for multiple rows', () => {
+      const quotes = [
+        createMockQuote({ quoteRequestId: 'quote-1' }),
+        createMockQuote({ quoteRequestId: 'quote-2' }),
+        createMockQuote({ quoteRequestId: 'quote-3' }),
+      ];
+
+      render(<QuoteList data={quotes} />);
+
+      expect(mockUseSelector).toHaveBeenCalledTimes(6);
+      expect(mockGetDisplayCurrencyValue).toHaveBeenCalledTimes(3);
+    });
+
     it('renders empty list when data is empty array', () => {
       const { queryByTestId } = render(<QuoteList data={[]} />);
 

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
@@ -1,9 +1,50 @@
 import React from 'react';
-import { QuoteRow, QuoteRowProps } from './QuoteRow';
+import { useSelector } from 'react-redux';
+import { QuoteRowProps, QuoteRowView } from './QuoteRow';
+import { selectDestToken } from '../../../../../core/redux/slices/bridge';
+import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../selectors/currencyRateController';
+import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
+///: END:ONLY_INCLUDE_IF(keyring-snaps)
+import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 
 interface Props {
   data: QuoteRowProps[];
 }
 
-export const QuoteList = ({ data }: Props) =>
-  data.map((quote) => <QuoteRow key={quote.quoteRequestId} {...quote} />);
+export const QuoteList = ({ data }: Props) => {
+  const destToken = useSelector(selectDestToken);
+  const evmMultiChainMarketData = useSelector(selectTokenMarketData);
+  const evmMultiChainCurrencyRates = useSelector(selectCurrencyRates);
+  const networkConfigurationsByChainId = useSelector(
+    selectNetworkConfigurations,
+  );
+  const currentCurrency = useSelector(selectCurrentCurrency);
+
+  let nonEvmMultichainAssetRates = {};
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
+  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
+
+  return data.map((quote) => (
+    <QuoteRowView
+      key={quote.quoteRequestId}
+      {...quote}
+      formattedReceiveAmountFiat={getDisplayCurrencyValue({
+        token: destToken,
+        amount: quote.receiveAmount,
+        evmMultiChainMarketData,
+        networkConfigurationsByChainId,
+        evmMultiChainCurrencyRates,
+        currentCurrency,
+        nonEvmMultichainAssetRates,
+      })}
+      destTokenSymbol={destToken?.symbol}
+    />
+  ));
+};

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
@@ -31,10 +31,11 @@ export const QuoteList = ({ data }: Props) => {
   nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
   ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
-  return data.map((quote) => (
+  return data.map(({ provider, ...quote }) => (
     <QuoteRowView
       key={quote.quoteRequestId}
       {...quote}
+      providerName={provider.name}
       formattedReceiveAmountFiat={getDisplayCurrencyValue({
         token: destToken,
         amount: quote.receiveAmount,

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { QuoteRow, QuoteRowProps } from './QuoteRow';
+import { QuoteRow, QuoteRowProps, QuoteRowView } from './QuoteRow';
 import { strings } from '../../../../../../locales/i18n';
 import { BridgeToken } from '../../types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -74,6 +74,12 @@ describe('QuoteRow', () => {
       } catch {
         return null;
       }
+    });
+  });
+
+  describe('memoization', () => {
+    it('memoizes QuoteRowView', () => {
+      expect(QuoteRowView).toHaveProperty('$$typeof', Symbol.for('react.memo'));
     });
   });
 

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
@@ -43,108 +43,113 @@ export interface QuoteRowViewProps extends QuoteRowProps {
   destTokenSymbol?: string;
 }
 
-export const QuoteRowView = ({
-  selected,
-  provider,
-  isLowestCost,
-  formattedTotalCost,
-  formattedReceiveAmountFiat,
-  destTokenSymbol,
-  onPress,
-  quoteRequestId,
-  loading,
-  receiveAmount,
-}: QuoteRowViewProps) => {
-  const theme = useTheme();
-  const formattedReceiveAmount = useMemo(
-    () =>
-      receiveAmount && receiveAmount !== '0' && destTokenSymbol
-        ? formatAmountWithLocaleSeparators(
-            limitToMaximumDecimalPlaces(parseFloat(receiveAmount)),
-          )
-        : receiveAmount,
-    [receiveAmount, destTokenSymbol],
-  );
+export const QuoteRowView = React.memo(
+  ({
+    selected,
+    provider,
+    isLowestCost,
+    formattedTotalCost,
+    formattedReceiveAmountFiat,
+    destTokenSymbol,
+    onPress,
+    quoteRequestId,
+    loading,
+    receiveAmount,
+  }: QuoteRowViewProps) => {
+    const theme = useTheme();
+    const formattedReceiveAmount = useMemo(
+      () =>
+        receiveAmount && receiveAmount !== '0' && destTokenSymbol
+          ? formatAmountWithLocaleSeparators(
+              limitToMaximumDecimalPlaces(parseFloat(receiveAmount)),
+            )
+          : receiveAmount,
+      [receiveAmount, destTokenSymbol],
+    );
 
-  return (
-    <TouchableOpacity onPress={() => onPress(quoteRequestId)}>
-      <Box
-        paddingVertical={3}
-        paddingHorizontal={4}
-        backgroundColor={
-          selected
-            ? BoxBackgroundColor.BackgroundMuted
-            : BoxBackgroundColor.BackgroundDefault
-        }
-        gap={2}
-        flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.Between}
-        alignItems={BoxAlignItems.Center}
-      >
-        <Box gap={1}>
+    return (
+      <TouchableOpacity onPress={() => onPress(quoteRequestId)}>
+        <Box
+          paddingVertical={3}
+          paddingHorizontal={4}
+          backgroundColor={
+            selected
+              ? BoxBackgroundColor.BackgroundMuted
+              : BoxBackgroundColor.BackgroundDefault
+          }
+          gap={2}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Center}
+        >
+          <Box gap={1}>
+            <Box
+              gap={1}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Skeleton hideChildren={loading}>
+                <View>
+                  <Text
+                    fontWeight={FontWeight.Medium}
+                    variant={TextVariantDS.BodyMd}
+                  >
+                    {provider.name}
+                  </Text>
+                </View>
+              </Skeleton>
+              <View>
+                {isLowestCost && !loading && (
+                  <TagBase
+                    shape={TagShape.Rectangle}
+                    textProps={{
+                      variant: TextVariant.BodySM,
+                      style: { fontWeight: 500 },
+                      color: theme.colors.success.default,
+                    }}
+                    severity={TagSeverity.Success}
+                  >
+                    {strings('bridge.lowest_cost')}
+                  </TagBase>
+                )}
+              </View>
+            </Box>
+            <Skeleton hideChildren={loading}>
+              <Text
+                variant={TextVariantDS.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings('bridge.total_cost')}: {formattedTotalCost}
+              </Text>
+            </Skeleton>
+          </Box>
           <Box
+            justifyContent={BoxJustifyContent.Center}
+            alignItems={BoxAlignItems.End}
             gap={1}
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
           >
             <Skeleton hideChildren={loading}>
-              <View>
-                <Text
-                  fontWeight={FontWeight.Medium}
-                  variant={TextVariantDS.BodyMd}
-                >
-                  {provider.name}
-                </Text>
-              </View>
+              <Text
+                variant={TextVariantDS.BodyMd}
+                fontWeight={FontWeight.Medium}
+              >
+                ~ {formattedReceiveAmount} {destTokenSymbol}
+              </Text>
             </Skeleton>
-            <View>
-              {isLowestCost && !loading && (
-                <TagBase
-                  shape={TagShape.Rectangle}
-                  textProps={{
-                    variant: TextVariant.BodySM,
-                    style: { fontWeight: 500 },
-                    color: theme.colors.success.default,
-                  }}
-                  severity={TagSeverity.Success}
-                >
-                  {strings('bridge.lowest_cost')}
-                </TagBase>
-              )}
-            </View>
+            <Skeleton hideChildren={loading}>
+              <Text
+                variant={TextVariantDS.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                ~ {formattedReceiveAmountFiat}
+              </Text>
+            </Skeleton>
           </Box>
-          <Skeleton hideChildren={loading}>
-            <Text
-              variant={TextVariantDS.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              {strings('bridge.total_cost')}: {formattedTotalCost}
-            </Text>
-          </Skeleton>
         </Box>
-        <Box
-          justifyContent={BoxJustifyContent.Center}
-          alignItems={BoxAlignItems.End}
-          gap={1}
-        >
-          <Skeleton hideChildren={loading}>
-            <Text variant={TextVariantDS.BodyMd} fontWeight={FontWeight.Medium}>
-              ~ {formattedReceiveAmount} {destTokenSymbol}
-            </Text>
-          </Skeleton>
-          <Skeleton hideChildren={loading}>
-            <Text
-              variant={TextVariantDS.BodySm}
-              color={TextColor.TextAlternative}
-            >
-              ~ {formattedReceiveAmountFiat}
-            </Text>
-          </Skeleton>
-        </Box>
-      </Box>
-    </TouchableOpacity>
-  );
-};
+      </TouchableOpacity>
+    );
+  },
+);
 
 export const QuoteRow = (props: QuoteRowProps) => {
   const destToken = useSelector(selectDestToken);

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
@@ -38,7 +38,8 @@ export interface QuoteRowProps {
   receiveAmount?: string;
 }
 
-export interface QuoteRowViewProps extends QuoteRowProps {
+export interface QuoteRowViewProps extends Omit<QuoteRowProps, 'provider'> {
+  providerName: string;
   formattedReceiveAmountFiat: string;
   destTokenSymbol?: string;
 }
@@ -46,7 +47,7 @@ export interface QuoteRowViewProps extends QuoteRowProps {
 export const QuoteRowView = React.memo(
   ({
     selected,
-    provider,
+    providerName,
     isLowestCost,
     formattedTotalCost,
     formattedReceiveAmountFiat,
@@ -94,7 +95,7 @@ export const QuoteRowView = React.memo(
                     fontWeight={FontWeight.Medium}
                     variant={TextVariantDS.BodyMd}
                   >
-                    {provider.name}
+                    {providerName}
                   </Text>
                 </View>
               </Skeleton>
@@ -151,7 +152,7 @@ export const QuoteRowView = React.memo(
   },
 );
 
-export const QuoteRow = (props: QuoteRowProps) => {
+export const QuoteRow = ({ provider, ...props }: QuoteRowProps) => {
   const destToken = useSelector(selectDestToken);
   const formattedReceiveAmountFiat = useDisplayCurrencyValue(
     props.receiveAmount,
@@ -161,6 +162,7 @@ export const QuoteRow = (props: QuoteRowProps) => {
   return (
     <QuoteRowView
       {...props}
+      providerName={provider.name}
       formattedReceiveAmountFiat={formattedReceiveAmountFiat}
       destTokenSymbol={destToken?.symbol}
     />

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx
@@ -38,30 +38,32 @@ export interface QuoteRowProps {
   receiveAmount?: string;
 }
 
-export const QuoteRow = ({
+export interface QuoteRowViewProps extends QuoteRowProps {
+  formattedReceiveAmountFiat: string;
+  destTokenSymbol?: string;
+}
+
+export const QuoteRowView = ({
   selected,
   provider,
   isLowestCost,
   formattedTotalCost,
+  formattedReceiveAmountFiat,
+  destTokenSymbol,
   onPress,
   quoteRequestId,
   loading,
   receiveAmount,
-}: QuoteRowProps) => {
+}: QuoteRowViewProps) => {
   const theme = useTheme();
-  const destToken = useSelector(selectDestToken);
-  const formattedReceiveAmountFiat = useDisplayCurrencyValue(
-    receiveAmount,
-    destToken,
-  );
   const formattedReceiveAmount = useMemo(
     () =>
-      receiveAmount && receiveAmount !== '0' && destToken
+      receiveAmount && receiveAmount !== '0' && destTokenSymbol
         ? formatAmountWithLocaleSeparators(
             limitToMaximumDecimalPlaces(parseFloat(receiveAmount)),
           )
         : receiveAmount,
-    [receiveAmount, destToken],
+    [receiveAmount, destTokenSymbol],
   );
 
   return (
@@ -127,7 +129,7 @@ export const QuoteRow = ({
         >
           <Skeleton hideChildren={loading}>
             <Text variant={TextVariantDS.BodyMd} fontWeight={FontWeight.Medium}>
-              ~ {formattedReceiveAmount} {destToken?.symbol}
+              ~ {formattedReceiveAmount} {destTokenSymbol}
             </Text>
           </Skeleton>
           <Skeleton hideChildren={loading}>
@@ -141,5 +143,21 @@ export const QuoteRow = ({
         </Box>
       </Box>
     </TouchableOpacity>
+  );
+};
+
+export const QuoteRow = (props: QuoteRowProps) => {
+  const destToken = useSelector(selectDestToken);
+  const formattedReceiveAmountFiat = useDisplayCurrencyValue(
+    props.receiveAmount,
+    destToken,
+  );
+
+  return (
+    <QuoteRowView
+      {...props}
+      formattedReceiveAmountFiat={formattedReceiveAmountFiat}
+      destTokenSymbol={destToken?.symbol}
+    />
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Reduces unnecessary Bridge quote-row work during quote updates. Currency and destination-token selectors now run once in `QuoteList` instead of once per row, while a memoized presentational row receives primitive display props and skips rendering when its quote values are unchanged.

Automated validation:
- `yarn jest app/components/UI/Bridge/components/QuoteSelectorView/` — 70 tests passed.
- `yarn lint:tsc` — passed.
- Targeted ESLint — no errors; one pre-existing deprecated number-utility warning remains in `QuoteRow.tsx`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31367

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge quote row render isolation

  Scenario: refresh quotes while the quote selector is open
    Given the Bridge quote selector displays at least three quotes
    And React Native DevTools Profiler is recording component renders

    When a quote refresh updates one quote
    Then the updated quote row re-renders
    And unchanged quote rows do not re-render
    And the displayed providers, costs, and receive amounts remain correct
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — internal performance change with no visual impact.

### **After**

<!-- [screenshots/recordings] -->

N/A — internal performance change with no visual impact.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance refactor in the Bridge quote list; display values now come from `getDisplayCurrencyValue` in the list path instead of per-row hooks, with tests guarding render isolation and existing row behavior.
> 
> **Overview**
> **Reduces Bridge quote-selector re-renders** by splitting each row into a memoized `QuoteRowView` and moving Redux/currency work up to `QuoteList`.
> 
> `QuoteList` now runs destination-token, market, currency, and network selectors once per list render, computes per-row fiat receive amounts with `getDisplayCurrencyValue`, and passes primitive props (`providerName`, `formattedReceiveAmountFiat`, `destTokenSymbol`) into `QuoteRowView`. Unchanged rows are intended to skip re-rendering when only one quote updates.
> 
> `QuoteRow` remains as a thin wrapper (still using `useDisplayCurrencyValue`) for callers outside the list. Tests assert centralized selector usage, memo on `QuoteRowView`, and that only the changed row re-renders on partial quote updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7bb4696fe6858cc6daf1050c32e4588e13fab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->