### PR TITLE
fix(ramps): fix Transak checkout background color mismatch — aggregator flow (TMCU-1087)

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/Checkout.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/Checkout.styles.ts
@@ -1,14 +1,19 @@
 import { StyleSheet } from 'react-native';
-import { Theme } from '../../../../../../util/theme/models';
+import { Theme, AppThemeKey } from '../../../../../../util/theme/models';
+import { colors } from '../../../../../../styles/common';
 
-const styleSheet = (params: { theme: Theme }) =>
-  StyleSheet.create({
+const styleSheet = (params: { theme: Theme }) => {
+  const isDark = params.theme.themeAppearance === AppThemeKey.dark;
+  return StyleSheet.create({
     headerWithoutPadding: {
       paddingVertical: 0,
     },
     webview: {
-      backgroundColor: params.theme.colors.background.default,
+      backgroundColor: isDark
+        ? colors.transakBackgroundDark
+        : colors.transakBackgroundLight,
     },
   });
+};
 
 export default styleSheet;

--- a/app/components/UI/Ramp/Aggregator/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Checkout/Checkout.tsx
@@ -38,6 +38,9 @@ import {
 } from '../../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './Checkout.styles';
+import { useTheme } from '../../../../../../util/theme';
+import { AppThemeKey } from '../../../../../../util/theme/models';
+import { colors } from '../../../../../../styles/common';
 import Device from '../../../../../../util/device';
 import { shouldStartLoadWithRequest } from '../../../../../../util/browser';
 import { CHECKOUT_TEST_IDS } from './Checkout.testIds';
@@ -67,6 +70,16 @@ const CheckoutWebView = () => {
   const handleSuccessfulOrder = useHandleSuccessfulOrder();
 
   const { styles } = useStyles(styleSheet, {});
+  const { themeAppearance } = useTheme();
+  // Intentionally overrides the design-system BottomSheet background to match
+  // Transak's iframe, which we cannot style. Keeps the native chrome seamless
+  // with the embedded checkout flow. See colors.transak* in app/styles/common.ts.
+  const transakBgStyle = {
+    backgroundColor:
+      themeAppearance === AppThemeKey.dark
+        ? colors.transakBackgroundDark
+        : colors.transakBackgroundLight,
+  };
 
   const { url: uri, customOrderId, provider } = params;
 
@@ -252,6 +265,7 @@ const CheckoutWebView = () => {
         isFullscreen
         isInteractable={!Device.isAndroid()}
         keyboardAvoidingViewEnabled={false}
+        style={transakBgStyle}
       >
         <BottomSheetHeader
           endAccessory={

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -28,7 +28,6 @@ const createStyles = (
       flex: options?.asScreen ? 1 : undefined,
       justifyContent: 'center',
       alignItems: 'center',
-      backgroundColor: colors.background.default,
     },
     content: {
       width: '100%',

--- a/app/styles/common.ts
+++ b/app/styles/common.ts
@@ -27,6 +27,11 @@ export const colors = {
   gettingStartedPageBackgroundColor: '#EAC2FF',
   gettingStartedTextColor: '#3D065F',
   gettingStartedPageBackgroundColorLightMode: '#FFF2EB',
+  // Transak's iframe renders these background colors — values are set by Transak
+  // and outside our control. Used to match the BottomSheet surface so the
+  // checkout feels seamless. Update only if Transak changes their theme colors.
+  transakBackgroundDark: '#1a1a1a',
+  transakBackgroundLight: '#ffffff',
 };
 
 export const onboardingCarouselColors: Record<


### PR DESCRIPTION
## **Description**

Follow-up to #33310 — applies the same Transak checkout background fix to the **legacy aggregator flow** (`app/components/UI/Ramp/Aggregator/Views/Checkout/`).

The component-library `BottomSheet` (used in the aggregator) does not have a `twClassName` prop like the MMDS version. Instead, the `style` prop is spread last into the sheet surface after `getElevatedSurfaceColor(theme)`, so passing `style={{ backgroundColor }}` correctly overrides it.

Changes:
- Adds `transakBackgroundDark` / `transakBackgroundLight` to `app/styles/common.ts` (same constants as #33310 — will resolve trivially on merge)
- Updates `Checkout.styles.ts` to use Transak colors for the WebView `backgroundColor` (prevents load flash)
- Applies `style={transakBgStyle}` to the WebView `BottomSheet` only — error states keep the default design-system surface
- Removes `backgroundColor: colors.background.default` from `ErrorView` so the container owns the surface color

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1087](https://consensyssoftware.atlassian.net/browse/TMCU-1087)

## **Manual testing steps**

```gherkin
Feature: Transak checkout background color — aggregator flow

  Scenario: user opens Transak checkout in dark mode (aggregator)
    Given the app is in dark mode
    And the user is on the legacy aggregator Buy flow
    And the user has selected a Transak quote

    When the user proceeds to the checkout screen
    Then the BottomSheet background matches the Transak iframe with no visible color mismatch

  Scenario: user opens Transak checkout in light mode (aggregator)
    Given the app is in light mode

    When the user proceeds to the checkout screen
    Then the BottomSheet background is white matching the Transak iframe
```

## **Screenshots/Recordings**

<!-- Add before/after recordings here -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-1087]: https://consensyssoftware.atlassian.net/browse/TMCU-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI background overrides for the ramp checkout WebView; no payment, auth, or order-handling logic changes.
> 
> **Overview**
> Aligns the legacy aggregator **Transak checkout** BottomSheet and WebView surfaces with Transak’s fixed iframe colors so dark/light mode no longer shows a visible seam around the embedded flow.
> 
> Adds **`transakBackgroundDark`** / **`transakBackgroundLight`** in `app/styles/common.ts`, applies them to the WebView style (load flash) and **`style={transakBgStyle}`** on the checkout BottomSheet only. Error paths keep the default design-system sheet; **`ErrorView`** no longer sets its own `backgroundColor` so the parent owns the surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35277d612705358eb83d75e50049d2c6bcb560c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->