### PR TITLE
fix(money): update transaction data when pay token changes on deposit

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -295,11 +295,14 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const hasAutoSubmittedPrefill = useRef(false);
     useEffect(() => {
-      if (
-        !hasAutoSubmittedPrefill.current &&
-        isDepositPrefilled &&
-        amountFiat !== '0'
-      ) {
+      // Reset when prefill drops (e.g. pay token changed) so handleDone
+      // re-fires once the new prefill amount is ready.
+      if (!isDepositPrefilled) {
+        hasAutoSubmittedPrefill.current = false;
+        return;
+      }
+
+      if (!hasAutoSubmittedPrefill.current && amountFiat !== '0') {
         hasAutoSubmittedPrefill.current = true;
         handleDone();
       }

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
@@ -148,6 +148,7 @@ function syncMoneyAccountDepositRequiredAssets(
     updateTransaction(
       {
         ...transactionMeta,
+        txParams: { ...transactionMeta.txParams },
         requiredAssets: [{ ...existing[0], amount }, ...existing.slice(1)],
       },
       'Money Account deposit: sync requiredAssets amount',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

The deposit total stayed stale after changing the pay token because handleDone (which syncs requiredAssets and atomic-batch calldata) only fired on the first prefill. Reset the one-shot latch when the prefill drops so the full update re-runs for the new token/amount.

Also shallow-spread txParams in syncMoneyAccountDepositRequiredAssets to avoid mutating frozen controller state (read-only 'type' error).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1695

## **Manual testing steps**
NA

## **Screenshots/Recordings**
<img width="394" height="844" alt="Screenshot 2026-07-16 at 11 12 19 AM" src="https://github.com/user-attachments/assets/408b7a3a-d416-44d3-ad02-96e8cd0cdbbc" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes money deposit confirmation auto-submit and transaction metadata updates; scoped bugfix but affects payment amount sync on the confirmation path.
> 
> **Overview**
> Fixes **stale deposit totals** after switching the pay token on money account deposit confirmation. The auto-prefill path only called **`handleDone`** once because a one-shot ref never cleared; it now **resets when prefill drops** (e.g. token change) so **`handleDone`** runs again once the new prefill amount is ready, re-syncing **`requiredAssets`** and batch calldata.
> 
> Also **shallow-copies `txParams`** in **`syncMoneyAccountDepositRequiredAssets`** before **`updateTransaction`**, avoiding mutation of frozen transaction metadata that could throw a read-only **`type`** error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c5cb25d51c7018f6c11baae24af03fee02279c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->