### PR TITLE
fix: incorrect non-evm url in useActivityBlockExplorer

### DIFF
--- a/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { useActivityBlockExplorer } from './useActivityBlockExplorer';
+import { SolScope, TrxScope } from '@metamask/keyring-api';
 import {
   findBlockExplorerUrlForChain,
   getBlockExplorerTxUrl,
@@ -57,27 +58,18 @@ describe('useActivityBlockExplorer', () => {
     expect(resolve('eip155:1', '0x1')).toBeUndefined();
   });
 
-  it('builds a non-EVM templated explorer link', () => {
-    findBase.mockReturnValue('https://explorer.solana.com/tx/{txId}');
-    expect(resolve('solana:abc', '0xhash')).toEqual({
-      url: 'https://explorer.solana.com/tx/0xhash',
-      title: 'explorer.solana.com',
+  it.each([
+    [SolScope.Mainnet, 'https://solscan.io/tx/', 'solscan.io'],
+    [TrxScope.Mainnet, 'https://tronscan.org/#/transaction/', 'tronscan.org'],
+  ])('builds a non-EVM templated explorer link', (chainId, url, title) => {
+    expect(resolve(chainId, '0xhash')).toEqual({
+      url: `${url}0xhash`,
+      title: title,
     });
   });
 
-  it('builds a non-EVM /tx/ link and strips the trailing slash', () => {
-    findBase.mockReturnValue('https://solscan.io/');
-    expect(resolve('solana:abc', '0xhash')).toEqual({
-      url: 'https://solscan.io/tx/0xhash',
-      title: 'solscan.io',
-    });
-  });
-
-  it('falls back to the raw url for the title when it cannot be parsed', () => {
-    findBase.mockReturnValue('not-a-valid-base');
-    expect(resolve('solana:abc', '0xhash')).toEqual({
-      url: 'not-a-valid-base/tx/0xhash',
-      title: 'not-a-valid-base/tx/0xhash',
-    });
+  // it is a never case
+  it('return undefined for url and title when it cannot be parsed', () => {
+    expect(resolve('unknown-non-evm:abc', '0xhash')).toBeUndefined();
   });
 });

--- a/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
@@ -69,7 +69,7 @@ describe('useActivityBlockExplorer', () => {
   });
 
   // it is a never case
-  it('return undefined for url and title when it cannot be parsed', () => {
+  it('returns undefined for unsupported non-EVM chain ids', () => {
     expect(resolve('unknown-non-evm:abc', '0xhash')).toBeUndefined();
   });
 });

--- a/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.test.ts
@@ -64,7 +64,7 @@ describe('useActivityBlockExplorer', () => {
   ])('builds a non-EVM templated explorer link', (chainId, url, title) => {
     expect(resolve(chainId, '0xhash')).toEqual({
       url: `${url}0xhash`,
-      title: title,
+      title,
     });
   });
 

--- a/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.ts
@@ -1,3 +1,4 @@
+import { CaipChainId } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { RPC } from '../../../../constants/network';
 import {
@@ -48,6 +49,6 @@ export function useActivityBlockExplorer(
     return url ? { url, title } : undefined;
   }
 
-  const url = getNonEvmTransactionUrl(hash, chainId);
+  const url = getNonEvmTransactionUrl(hash, chainId as CaipChainId);
   return url ? { url, title: hostnameOf(url) } : undefined;
 }

--- a/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityBlockExplorer.ts
@@ -5,6 +5,7 @@ import {
   getBlockExplorerTxUrl,
 } from '../../../../util/networks';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
+import { getTransactionUrl as getNonEvmTransactionUrl } from '../../../../core/Multichain/utils';
 
 export interface ActivityExplorerLink {
   url: string;
@@ -13,14 +14,6 @@ export interface ActivityExplorerLink {
 
 function isEvmChainId(chainId: string): boolean {
   return chainId.startsWith('eip155:') || chainId.startsWith('0x');
-}
-
-/** Builds a non-EVM explorer tx url from its (possibly templated) base url. */
-function buildNonEvmTxUrl(base: string, hash: string): string {
-  if (/\{.*?\}/u.test(base)) {
-    return base.replace(/\{.*?\}/u, hash);
-  }
-  return `${base.replace(/\/$/u, '')}/tx/${hash}`;
 }
 
 function hostnameOf(url: string): string {
@@ -46,16 +39,15 @@ export function useActivityBlockExplorer(
     return undefined;
   }
 
-  const base = findBlockExplorerUrlForChain(chainId, networkConfigurations);
-  if (!base) {
-    return undefined;
-  }
-
   if (isEvmChainId(chainId)) {
+    const base = findBlockExplorerUrlForChain(chainId, networkConfigurations);
+    if (!base) {
+      return undefined;
+    }
     const { url, title } = getBlockExplorerTxUrl(RPC, hash, base);
     return url ? { url, title } : undefined;
   }
 
-  const url = buildNonEvmTxUrl(base, hash);
-  return { url, title: hostnameOf(url) };
+  const url = getNonEvmTransactionUrl(hash, chainId);
+  return url ? { url, title: hostnameOf(url) } : undefined;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

hook `useActivityBlockExplorer` is return a incorrect explorer url for non-evm, it assume every non-evm is using `${baseURl}/tx/${hash}` pattern

the fix using the predefine function getTransactionUrl from multichain urls, which already done in a better sharp

@vinnyhoward 
This useActivityBlockExplorer somehow is redundant from `useMultichainBlockExplorerTxUrl`, but the PR is not going to make change to replace `useActivityBlockExplorer`, but we should consider to consolidate it

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed useActivityBlockExplorer return incorrect URL for non-evm

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to activity explorer link resolution with existing multichain URL helpers; EVM path unchanged and tests cover the new behavior.
> 
> **Overview**
> **Activity details** non-EVM “view on explorer” links were built with a one-size-fits-all `${baseUrl}/tx/${hash}` (or simple template) rule, which produced wrong URLs for chains like Solana and Tron.
> 
> Non-EVM resolution now delegates to multichain **`getTransactionUrl`**, which uses the existing per-chain explorer URL formats. EVM behavior is unchanged: it still resolves the base URL from network configuration and **`getBlockExplorerTxUrl`**. Unsupported non-EVM chain IDs return no link when **`getTransactionUrl`** yields an empty URL.
> 
> Tests were aligned to assert Solana and Tron mainnet URLs and to expect **`undefined`** for unknown non-EVM chains instead of the old generic templating cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51676dcbfefac0b863c9861fd8161739c7beade3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->