### PR TITLE
fix(predict): hide empty related-tag sub-tabs via activeEventsCount

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -1758,6 +1758,43 @@ describe('polymarket utils', () => {
         normalizeRelatedTagsToFilterOptions([], { source: 'hot-tags' }),
       ).toEqual([]);
     });
+
+    it('skips tags with activeEventsCount of 0 (empty chips like "Other")', () => {
+      const result = normalizeRelatedTagsToFilterOptions(
+        [
+          { id: '1', label: 'Other', slug: 'other', activeEventsCount: 0 },
+          { id: '2', label: 'NBA', slug: 'nba', activeEventsCount: 4 },
+        ],
+        { source: 'hot-tags' },
+      );
+
+      expect(result.map((o) => o.id)).toEqual(['nba']);
+    });
+
+    it('keeps tags with a missing activeEventsCount (fail-open)', () => {
+      const result = normalizeRelatedTagsToFilterOptions(
+        [
+          { id: '1', label: 'NBA', slug: 'nba' },
+          { id: '2', label: 'NFL', slug: 'nfl', activeEventsCount: 2 },
+        ],
+        { source: 'hot-tags' },
+      );
+
+      expect(result.map((o) => o.id)).toEqual(['nba', 'nfl']);
+    });
+
+    it('does not let empty tags consume a limit slot', () => {
+      const result = normalizeRelatedTagsToFilterOptions(
+        [
+          { id: '1', label: 'Other', slug: 'other', activeEventsCount: 0 },
+          { id: '2', label: 'NBA', slug: 'nba', activeEventsCount: 4 },
+          { id: '3', label: 'NFL', slug: 'nfl', activeEventsCount: 3 },
+        ],
+        { source: 'hot-tags', limit: 2 },
+      );
+
+      expect(result.map((o) => o.id)).toEqual(['nba', 'nfl']);
+    });
   });
 
   it('searches events via public-search endpoint', async () => {

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -1443,6 +1443,12 @@ export interface PolymarketRelatedTag {
   id: string | number;
   label?: string;
   slug: string;
+  /**
+   * Active event count for the tag. `omit_empty=true` only drops globally-empty
+   * tags, so a tag can still surface here with zero markets under the applied
+   * params; we skip those (see `normalizeRelatedTagsToFilterOptions`).
+   */
+  activeEventsCount?: number;
 }
 
 /**
@@ -1509,6 +1515,13 @@ export const normalizeRelatedTagsToFilterOptions = (
     // Check the cap before adding so `limit: 0` yields an empty list.
     if (limit !== undefined && options.length >= limit) {
       break;
+    }
+
+    // Skip tags with no active events so empty chips (e.g. "Other") never render.
+    // Fail-open: a missing count is kept (best-effort, matches prior behavior).
+    // Placed before the limit accounting so empty tags don't consume a slot.
+    if (tag?.activeEventsCount === 0) {
+      continue;
     }
 
     const slug = tag?.slug?.trim();


### PR DESCRIPTION
## **Description**

Empty dynamic sub-tabs/chips (e.g. "Other") rendered under a feed's related-tags even though they resolve to zero markets. The Polymarket related-tags endpoint's `omit_empty=true` only drops *globally*-empty tags, so a tag can still surface with no markets under the applied params.

This fix skips related tags whose `activeEventsCount` is `0` inside `normalizeRelatedTagsToFilterOptions` — the single point every dynamic chip (crypto, politics, sports tabs, trending, popular-today) flows through. The skip happens before the `limit` accounting so empty tags don't consume a chip slot, and it fails open (a missing/undefined count keeps the chip, preserving prior best-effort behavior). No extra API calls are introduced.

## **Changelog**

CHANGELOG entry: Fixed empty prediction market sub-tabs (e.g. "Other") showing zero markets by hiding related-tag chips with no active events.

## **Related issues**

Fixes: PRED-1085

## **Manual testing steps**

```gherkin
Feature: Hide empty related-tag sub-tabs

  Scenario: user opens a feed with a globally-non-empty but locally-empty related tag
    Given a Predict feed whose related-tags API returns a tag with activeEventsCount of 0
    When the user views the feed's filter chips
    Then the empty chip (e.g. "Other") is not rendered
    And chips with active events still render up to the configured limit
```

## **Screenshots/Recordings**

### **Before**

<!-- "Other" chip rendered with zero markets -->

### **After**

<!-- Empty chips no longer render -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
