### PR TITLE
ci: request workflows:write for crowdin translation token exchange 

### DIFF
--- a/.github/workflows/crowdin-rc-download-translations.yml
+++ b/.github/workflows/crowdin-rc-download-translations.yml
@@ -58,6 +58,12 @@ jobs:
           }}
 
     steps:
+      # Mint a short-lived token via the token-exchange service (OIDC). It needs:
+      # - contents: write       → push the l10n translations branch
+      # - pull_requests: write  → open the translations PR
+      # - workflows: write      → workaround for a GitHub push-protection timeout bug on new
+      #                           branch pushes (see actions/checkout#2287); this step never
+      #                           actually touches workflow files.
       - name: Get token
         id: get-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1
@@ -66,6 +72,7 @@ jobs:
           permissions: |
             contents: write
             pull_requests: write
+            workflows: write
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/crowdin_download_translations.yml
+++ b/.github/workflows/crowdin_download_translations.yml
@@ -13,6 +13,12 @@ jobs:
       id-token: write
 
     steps:
+      # Mint a short-lived token via the token-exchange service (OIDC). It needs:
+      # - contents: write       → push the l10n translations branch
+      # - pull_requests: write  → open the translations PR
+      # - workflows: write      → workaround for a GitHub push-protection timeout bug on new
+      #                           branch pushes (see actions/checkout#2287); this step never
+      #                           actually touches workflow files.
       - name: Get token
         id: get-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1
@@ -21,6 +27,7 @@ jobs:
           permissions: |
             contents: write
             pull_requests: write
+            workflows: write
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary

Extends the fix from #33352 to the two Crowdin translation workflows that share the same new-branch-push pattern:

- `crowdin_download_translations.yml`
- `crowdin-rc-download-translations.yml`

Both mint an installation token via the token-exchange service and push a brand-new l10n branch (`l10n_crowdin_translations_*`) to open a translations PR. This is the exact pattern that caused `create-release-pr.yml` and `update-release-changelog.yml` to intermittently fail with:

```
! [remote rejected] ... (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)
```

GitHub performs a slow, dynamic push-protection check on new-branch pushes when the pushing token lacks the `workflows` scope, and that check occasionally times out on this monorepo. Pre-granting `workflows: write` on the minted token avoids the slow path entirely, even though these steps never touch `.github/workflows/*`.

## Dependency

⚠️ This only updates what the workflows **request**. The token-exchange service's OPA policy also needs to **grant** `workflows: write` for these two workflows, the same way it was updated for `create-release-pr.yml` / `update-release-changelog.yml`. A policy-update prompt is included below for whoever owns that repo.

https://github.com/consensys-vertical-apps/token-exchange-service/pull/143

## Test plan

- [ ] Confirm YAML is valid (`ruby -ryaml -e "YAML.load_file(...)"` passed locally for both files)
- [ ] Confirm token-exchange OPA policy is updated to grant `workflows: write` to these two workflows
- [ ] Trigger `crowdin_download_translations.yml` and `crowdin-rc-download-translations.yml` manually (`workflow_dispatch`) and confirm the translations PR/branch push succeeds without the timeout error

Made with [Cursor](https://cursor.com)