### PR TITLE
chore: adds label for open feed rows with "Holding" / "Open"

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/FeedView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/FeedView.testIds.ts
@@ -19,5 +19,7 @@ export const getFeedTradeButtonTestId = (id: string) =>
 export const getFeedTradeCardTestId = (id: string) =>
   `${FeedViewSelectorsIDs.TRADE_CARD}-${id}`;
 export const getFeedTraderTestId = (id: string) => `feed-item-trader-${id}`;
+export const getFeedNewPositionTestId = (id: string) =>
+  `feed-item-new-position-${id}`;
 export const getFeedAudienceOptionTestId = (audience: string) =>
   `${FeedViewSelectorsIDs.AUDIENCE_TOGGLE}-${audience}`;

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.test.tsx
@@ -5,6 +5,7 @@ import FeedItemRow from './FeedItemRow';
 import type { FeedPerpItem, FeedSpotItem } from '../types';
 import {
   getFeedItemTestId,
+  getFeedNewPositionTestId,
   getFeedTradeButtonTestId,
   getFeedTradeCardTestId,
   getFeedTraderTestId,
@@ -218,5 +219,93 @@ describe('FeedItemRow', () => {
     expect(
       screen.queryByTestId('feed-item-perp-badges-perp-1-leverage'),
     ).toBeNull();
+  });
+
+  it('shows the "Just bought" label on an empty open spot row', () => {
+    const item: FeedSpotItem = {
+      ...spotItem,
+      action: 'bought',
+      valueLabel: '',
+      pnlLabel: '',
+      hasValueData: false,
+      hasPnlData: false,
+    };
+
+    renderWithProvider(
+      <FeedItemRow
+        item={item}
+        onTradePress={jest.fn()}
+        onPositionPress={jest.fn()}
+        onTraderPress={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId(getFeedNewPositionTestId('spot-1')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText('social_leaderboard.feed.new_position.bought'),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows the "Just opened" label on an empty open perp row', () => {
+    const item: FeedPerpItem = {
+      ...perpItem,
+      action: 'opened',
+      valueLabel: '',
+      pnlLabel: '',
+      hasValueData: false,
+      hasPnlData: false,
+    };
+
+    renderWithProvider(
+      <FeedItemRow
+        item={item}
+        onTradePress={jest.fn()}
+        onPositionPress={jest.fn()}
+        onTraderPress={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('social_leaderboard.feed.new_position.opened'),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not show a new-position label on an empty closed row', () => {
+    const item: FeedPerpItem = {
+      ...perpItem,
+      action: 'closed',
+      valueLabel: '',
+      pnlLabel: '',
+      hasValueData: false,
+      hasPnlData: false,
+    };
+
+    renderWithProvider(
+      <FeedItemRow
+        item={item}
+        onTradePress={jest.fn()}
+        onPositionPress={jest.fn()}
+        onTraderPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId(getFeedNewPositionTestId('perp-1'))).toBeNull();
+  });
+
+  it('shows value/PnL and no new-position label when an open row has data', () => {
+    renderWithProvider(
+      <FeedItemRow
+        item={spotItem}
+        onTradePress={jest.fn()}
+        onPositionPress={jest.fn()}
+        onTraderPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('$123,000.5')).toBeOnTheScreen();
+    expect(screen.getByText('+12%')).toBeOnTheScreen();
+    expect(screen.queryByTestId(getFeedNewPositionTestId('spot-1'))).toBeNull();
   });
 });

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.test.tsx
@@ -221,7 +221,7 @@ describe('FeedItemRow', () => {
     ).toBeNull();
   });
 
-  it('shows the "Just bought" label on an empty open spot row', () => {
+  it('shows the "Holding" label on an empty open spot row', () => {
     const item: FeedSpotItem = {
       ...spotItem,
       action: 'bought',
@@ -248,7 +248,7 @@ describe('FeedItemRow', () => {
     ).toBeOnTheScreen();
   });
 
-  it('shows the "Just opened" label on an empty open perp row', () => {
+  it('shows the "Open" label on an empty open perp row', () => {
     const item: FeedPerpItem = {
       ...perpItem,
       action: 'opened',

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
@@ -75,8 +75,10 @@ const FeedItemRow: React.FC<FeedItemRowProps> = ({
   const symbol = item.type === 'spot' ? item.tokenSymbol : item.marketSymbol;
 
   // For open rows whose value/P&L hasn't arrived yet, surface an intentional
-  // "Just bought"/"Just opened" label instead of a blank right column. Only open
-  // actions have a label; closed rows (`sold`/`closed`) stay blank when empty.
+  // state label ("Holding" for spot, "Open" for perps) instead of a blank right
+  // column. The row is an entry that hasn't been exited, so there's no realized
+  // P&L to show yet. Only open actions have a label; closed rows (`sold`/`closed`)
+  // stay blank when empty.
   const newPositionLabelKey =
     item.action === 'bought'
       ? 'social_leaderboard.feed.new_position.bought'

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
@@ -23,6 +23,7 @@ import type { FeedItem } from '../types';
 import { formatFeedTimestamp } from '../../utils/formatters';
 import {
   getFeedItemTestId,
+  getFeedNewPositionTestId,
   getFeedTradeButtonTestId,
   getFeedTradeCardTestId,
   getFeedTraderTestId,
@@ -72,6 +73,16 @@ const FeedItemRow: React.FC<FeedItemRowProps> = ({
   const actionLabel = strings(`social_leaderboard.feed.action.${item.action}`);
   const timeLabel = formatFeedTimestamp(item.timestamp);
   const symbol = item.type === 'spot' ? item.tokenSymbol : item.marketSymbol;
+
+  // For open rows whose value/P&L hasn't arrived yet, surface an intentional
+  // "Just bought"/"Just opened" label instead of a blank right column. Only open
+  // actions have a label; closed rows (`sold`/`closed`) stay blank when empty.
+  const newPositionLabelKey =
+    item.action === 'bought'
+      ? 'social_leaderboard.feed.new_position.bought'
+      : item.action === 'opened'
+        ? 'social_leaderboard.feed.new_position.opened'
+        : null;
 
   return (
     <Box twClassName="px-4 py-3 gap-4" testID={getFeedItemTestId(item.id)}>
@@ -181,7 +192,7 @@ const FeedItemRow: React.FC<FeedItemRowProps> = ({
             </Text>
           </Box>
 
-          {(item.hasValueData || item.hasPnlData) && (
+          {item.hasValueData || item.hasPnlData ? (
             <Box alignItems={BoxAlignItems.End}>
               {item.hasValueData ? (
                 <Text
@@ -207,7 +218,18 @@ const FeedItemRow: React.FC<FeedItemRowProps> = ({
                 </Text>
               ) : null}
             </Box>
-          )}
+          ) : newPositionLabelKey ? (
+            <Box alignItems={BoxAlignItems.End}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                numberOfLines={1}
+                testID={getFeedNewPositionTestId(item.id)}
+              >
+                {strings(newPositionLabelKey)}
+              </Text>
+            </Box>
+          ) : null}
         </Box>
       </Pressable>
     </Box>

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedItemRow.tsx
@@ -19,7 +19,7 @@ import { strings } from '../../../../../../locales/i18n';
 import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
 import PerpBadges from '../../components/PerpBadges';
 import PositionTokenAvatar from '../../components/PositionTokenAvatar';
-import type { FeedItem } from '../types';
+import type { FeedAction, FeedItem } from '../types';
 import { formatFeedTimestamp } from '../../utils/formatters';
 import {
   getFeedItemTestId,
@@ -30,6 +30,14 @@ import {
 } from '../FeedView.testIds';
 
 const AVATAR_SIZE = 24;
+
+// Open actions map to an intentional state label shown when the right column
+// would otherwise be blank. Closed actions (`sold`/`closed`) have no entry, so
+// their empty rows stay blank.
+const NEW_POSITION_LABEL_KEYS: Partial<Record<FeedAction, string>> = {
+  bought: 'social_leaderboard.feed.new_position.bought',
+  opened: 'social_leaderboard.feed.new_position.opened',
+};
 
 const styles = StyleSheet.create({
   // Keep the tappable trader identity flexible so the Trade button retains its
@@ -77,14 +85,8 @@ const FeedItemRow: React.FC<FeedItemRowProps> = ({
   // For open rows whose value/P&L hasn't arrived yet, surface an intentional
   // state label ("Holding" for spot, "Open" for perps) instead of a blank right
   // column. The row is an entry that hasn't been exited, so there's no realized
-  // P&L to show yet. Only open actions have a label; closed rows (`sold`/`closed`)
-  // stay blank when empty.
-  const newPositionLabelKey =
-    item.action === 'bought'
-      ? 'social_leaderboard.feed.new_position.bought'
-      : item.action === 'opened'
-        ? 'social_leaderboard.feed.new_position.opened'
-        : null;
+  // P&L to show yet.
+  const newPositionLabelKey = NEW_POSITION_LABEL_KEYS[item.action] ?? null;
 
   return (
     <Box twClassName="px-4 py-3 gap-4" testID={getFeedItemTestId(item.id)}>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1124,8 +1124,8 @@
         "closed": "closed"
       },
       "new_position": {
-        "bought": "Just bought",
-        "opened": "Just opened"
+        "bought": "Holding",
+        "opened": "Open"
       },
       "empty_following": {
         "title": "No activity yet",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1123,6 +1123,10 @@
         "opened": "opened",
         "closed": "closed"
       },
+      "new_position": {
+        "bought": "Just bought",
+        "opened": "Just opened"
+      },
       "empty_following": {
         "title": "No activity yet",
         "description": "Follow traders to see their trades show up here."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Open feed rows whose value/P&L data hasn't arrived yet, brand-new buy with no realized gain, rendered a blank right column, which read as broken. This adds an intentional empty-state label so the row looks deliberate:
- spot `bought` → "Holding"
- perp `opened` → "Open"

If a current value is present but only PnL is missing, the row still shows the value, so the label only appears on genuinely empty open rows.
Implements a suggestion from feed review to make the empty state read as intentional rather than missing data.

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-16 at 10 52 04" src="https://github.com/user-attachments/assets/4f6ce022-5be3-470b-963b-24c9b857bd69" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-16 at 10 51 37" src="https://github.com/user-attachments/assets/21561ca4-1949-412b-bad2-2710018bc5c1" />

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-894

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only empty-state copy in the social feed with no auth, data, or trading logic changes.
> 
> **Overview**
> Open social leaderboard feed rows that still have no value or P&L used to leave the trade card’s right column empty, which looked like missing data. **`FeedItemRow`** now shows an intentional fallback when both `hasValueData` and `hasPnlData` are false: spot **`bought`** → **“Holding”**, perp **`opened`** → **“Open”**. **`sold`** / **`closed`** rows with no metrics stay blank.
> 
> Copy lives under `social_leaderboard.feed.new_position` in **`en.json`**, with a **`getFeedNewPositionTestId`** helper and **`FeedItemRow`** tests covering open vs closed and rows that already have value/P&L.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a171fb527544d326069e0574046578881b6e434d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->