### PR TITLE
fix: allow isAuthenticating updates on frozen SecureKeychain

### DIFF
--- a/app/core/SecureKeychain.test.ts
+++ b/app/core/SecureKeychain.test.ts
@@ -190,6 +190,19 @@ describe('SecureKeychain - Secure Item Methods', () => {
   });
 
   describe('getSecureItem', () => {
+    it('toggles isAuthenticating on the frozen singleton instance', async () => {
+      const instance = SecureKeychain.getInstance();
+      const scopeOptions = { service: 'test-service' };
+
+      (Keychain.getGenericPassword as jest.Mock).mockResolvedValue(false);
+
+      expect(instance.isAuthenticating).toBe(false);
+
+      await SecureKeychain.getSecureItem(scopeOptions);
+
+      expect(instance.isAuthenticating).toBe(false);
+    });
+
     it('retrieves and decrypts item successfully', async () => {
       const key = 'test-key';
       const originalValue = 'plain-text-value';

--- a/app/core/SecureKeychain.ts
+++ b/app/core/SecureKeychain.ts
@@ -8,9 +8,14 @@ import { AnalyticsEventBuilder } from '../util/analytics/AnalyticsEventBuilder';
 import Device from '../util/device';
 import AUTHENTICATION_TYPE from '../constants/userProperties';
 import { UserProfileProperty } from '../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
+interface SecureKeychainPrivateState {
+  code: string;
+  isAuthenticating: boolean;
+}
+
 const privates = new WeakMap<
   SecureKeychainEncryptor,
-  { code: string; isAuthenticating: boolean }
+  SecureKeychainPrivateState
 >();
 const encryptor = new Encryptor({
   keyDerivationOptions: LEGACY_DERIVATION_OPTIONS,
@@ -42,14 +47,11 @@ class SecureKeychainEncryptor {
   }
 
   get isAuthenticating(): boolean {
-    return privates.get(this)?.isAuthenticating ?? false;
+    return this.#getPrivateState().isAuthenticating;
   }
 
   set isAuthenticating(value: boolean) {
-    const state = privates.get(this);
-    if (state) {
-      state.isAuthenticating = value;
-    }
+    this.#getPrivateState().isAuthenticating = value;
   }
 
   static getInstance(code: string): SecureKeychainEncryptor {
@@ -58,15 +60,23 @@ class SecureKeychainEncryptor {
   }
 
   encryptPassword(password: string) {
-    return encryptor.encrypt(privates.get(this).code, { password });
+    return encryptor.encrypt(this.#getPrivateState().code, { password });
   }
 
   decryptPassword(data: string): Promise<{
     password: string;
   }> {
-    return encryptor.decrypt(privates.get(this).code, data) as Promise<{
+    return encryptor.decrypt(this.#getPrivateState().code, data) as Promise<{
       password: string;
     }>;
+  }
+
+  #getPrivateState(): SecureKeychainPrivateState {
+    const state = privates.get(this);
+    if (!state) {
+      throw new Error('SecureKeychainEncryptor private state is missing');
+    }
+    return state;
   }
 }
 

--- a/app/core/SecureKeychain.ts
+++ b/app/core/SecureKeychain.ts
@@ -8,7 +8,10 @@ import { AnalyticsEventBuilder } from '../util/analytics/AnalyticsEventBuilder';
 import Device from '../util/device';
 import AUTHENTICATION_TYPE from '../constants/userProperties';
 import { UserProfileProperty } from '../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
-const privates = new WeakMap();
+const privates = new WeakMap<
+  SecureKeychainEncryptor,
+  { code: string; isAuthenticating: boolean }
+>();
 const encryptor = new Encryptor({
   keyDerivationOptions: LEGACY_DERIVATION_OPTIONS,
 });
@@ -32,11 +35,21 @@ enum SecureKeychainTypes {
  * the phone's keychain
  */
 class SecureKeychainEncryptor {
-  isAuthenticating = false;
   private static instance: SecureKeychainEncryptor | null = null;
 
   private constructor(code: string) {
-    privates.set(this, { code });
+    privates.set(this, { code, isAuthenticating: false });
+  }
+
+  get isAuthenticating(): boolean {
+    return privates.get(this)?.isAuthenticating ?? false;
+  }
+
+  set isAuthenticating(value: boolean) {
+    const state = privates.get(this);
+    if (state) {
+      state.isAuthenticating = value;
+    }
   }
 
   static getInstance(code: string): SecureKeychainEncryptor {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Biometric / fingerprint unlock fails on the Login screen with:

TypeError: Cannot assign to read-only property 'isAuthenticating'

Root cause: SecureKeychain.init() calls Object.freeze(instance) on the singleton. During unlock, getGenericPassword() / getSecureItem() set instance.isAuthenticating = true|false so LockManagerService does not auto-lock mid-auth. That write mutates a frozen object. After the React Native 0.81 → 0.83 / Hermes upgrade (shipped with the 8.4 line), this assignment throws instead of failing silently, so Login surfaces the error and unlock cannot complete.

Solution: Keep Object.freeze(instance) (salt / instance integrity), but move isAuthenticating into the existing WeakMap-backed private state and expose it via getter/setter. Callers keep the same API; the flag can change without mutating frozen own-data properties. 
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: ixed fingerprint and biometric unlock failing with a read-only isAuthenticating error after the React Native 0.83 upgrade


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: 

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: biometric unlock after SecureKeychain freeze fix

  Scenario: user unlocks wallet with fingerprint after app lock
    Given the app is installed with biometrics / fingerprint enabled for MetaMask
    And the wallet is locked and the Login screen is visible

    When the user authenticates with fingerprint / biometrics
    Then the wallet unlocks successfully
    And the Login screen does not show "Cannot assign to read-only property 'isAuthenticating'"

  Scenario: user can still unlock with password if biometrics is cancelled
    Given the app is locked and biometrics are enabled
    When the user cancels the biometric prompt
    And the user enters their password and taps Unlock
    Then the wallet unlocks successfully
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b8910696-a0f5-49db-9706-0238de471222


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/195152fc-0365-48df-bcae-f4aeebc4839a


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches login/unlock and auto-lock coordination during keychain auth; behavior is intended to be unchanged but failures would block wallet access.
> 
> **Overview**
> Fixes **biometric/fingerprint unlock** failing on Login with `Cannot assign to read-only property 'isAuthenticating'` after the RN 0.83 / Hermes upgrade, where writes to frozen objects now throw.
> 
> `SecureKeychain.init()` still **`Object.freeze`s** the singleton, but **`isAuthenticating` is no longer an own property** on `SecureKeychainEncryptor`. It lives in the existing **`WeakMap` private state** (alongside `code`) and is exposed through a **getter/setter**, so `getGenericPassword` / `getSecureItem` can flip the flag during auth without mutating the frozen instance. **`LockManagerService`** and other callers keep the same **`instance.isAuthenticating`** API.
> 
> Adds a unit test that **`getSecureItem` resets `isAuthenticating` to false** on the frozen singleton after a mocked keychain read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c67f54a2d050638e221016d46d69d3c1c110fe1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->