### PR TITLE
fix(perps): make market detail price/change row scroll instead of sticky

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1555,35 +1555,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         testID={PerpsMarketDetailsViewSelectorsIDs.HEADER}
       />
 
-      {/* Below header: live price + 24h change and fullscreen chart button */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
-        gap={2}
-        twClassName="px-4 pb-2"
-        testID={PerpsMarketDetailsViewSelectorsIDs.MARKET_SUMMARY}
-      >
-        {/* Flexible wrapper lets the price shrink; the button stays fixed. */}
-        <Box twClassName="flex-1">
-          <LivePriceHeader
-            symbol={market.symbol}
-            testIDPrice={PerpsMarketHeaderSelectorsIDs.PRICE}
-            testIDChange={PerpsMarketHeaderSelectorsIDs.PRICE_CHANGE}
-            currentPrice={syncedChartCurrentPrice}
-            size="large"
-          />
-        </Box>
-        <ButtonIcon
-          iconName={IconName.Expand}
-          size={ButtonIconSize.Md}
-          onPress={handleFullscreenChartOpen}
-          style={styles.marketSummaryFullscreenButton}
-          testID={PerpsMarketDetailsViewSelectorsIDs.FULLSCREEN_CHART_BUTTON}
-          accessibilityLabel={strings('perps.market_details.fullscreen_chart')}
-        />
-      </Box>
-
       <View style={styles.scrollableContentContainer}>
         <ScrollView
           ref={scrollViewRef}
@@ -1595,6 +1566,41 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
           }
         >
+          {/* Below header: live price + 24h change and fullscreen chart button.
+              Rendered inside the ScrollView (not the header) so it scrolls with
+              the content instead of staying sticky. */}
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            gap={2}
+            twClassName="px-4 pb-2"
+            testID={PerpsMarketDetailsViewSelectorsIDs.MARKET_SUMMARY}
+          >
+            {/* Flexible wrapper lets the price shrink; the button stays fixed. */}
+            <Box twClassName="flex-1">
+              <LivePriceHeader
+                symbol={market.symbol}
+                testIDPrice={PerpsMarketHeaderSelectorsIDs.PRICE}
+                testIDChange={PerpsMarketHeaderSelectorsIDs.PRICE_CHANGE}
+                currentPrice={syncedChartCurrentPrice}
+                size="large"
+              />
+            </Box>
+            <ButtonIcon
+              iconName={IconName.Expand}
+              size={ButtonIconSize.Md}
+              onPress={handleFullscreenChartOpen}
+              style={styles.marketSummaryFullscreenButton}
+              testID={
+                PerpsMarketDetailsViewSelectorsIDs.FULLSCREEN_CHART_BUTTON
+              }
+              accessibilityLabel={strings(
+                'perps.market_details.fullscreen_chart',
+              )}
+            />
+          </Box>
+
           {/* TradingView Chart Section */}
           <View style={[styles.section, styles.chartSection]}>
             <ComponentErrorBoundary


### PR DESCRIPTION
## **Description**

On the Perps market detail screen, the live price and 24h price-change row (together with the fullscreen chart button) was rendered in the fixed area between the header and the `ScrollView`, which made it "sticky" — it stayed pinned below the header while the rest of the content scrolled, effectively behaving like part of the header.

This PR moves that summary row into the `ScrollView` as its first child so it is no longer part of/pinned to the header and now scrolls together with the page content. There is no visual change at rest (initial scroll position): the row keeps its `px-4 pb-2` spacing and the chart section keeps its `marginTop`, so ordering and spacing are identical — only the stickiness behavior changes.

1. **Reason for the change:** The price/change row should not be sticky and should not be treated as part of the header.
2. **Improvement/solution:** Relocate the market summary row (`MARKET_SUMMARY`) from outside the `ScrollView` to inside it, above the chart section, so it scrolls with the content.

## **Changelog**

CHANGELOG entry: Fixed the Perps market detail screen so the live price and 24h change row scrolls with the page instead of staying stuck below the header.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3348
 
## **Manual testing steps**

```gherkin
Feature: Perps market detail price row is not sticky

  Scenario: user scrolls the market detail screen
    Given the user is on a Perps market detail screen
    And the live price and 24h change row is shown below the header

    When the user scrolls down the content
    Then the price and 24h change row scrolls away with the content
    And it does not remain pinned below the header
    And at the top of the screen the layout looks unchanged from before
```

## **Screenshots/Recordings**

### **Before**

<!-- Price/change row stayed pinned below the header while content scrolled. -->

### **After**

<!-- Price/change row scrolls away with the content; no visual change at rest. -->

https://github.com/user-attachments/assets/617a92c4-cdf1-4c26-b283-b3affd8e6a20



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout-tree move in one Perps screen with no logic, API, or test ID changes—low regression risk beyond scroll UX.
> 
> **Overview**
> On **Perps market details**, the row with **live price**, **24h change**, and the **fullscreen chart** control was sitting in the fixed gap between `PerpsMarketInlineHeader` and the `ScrollView`, so it stayed pinned under the header while the chart and rest of the page scrolled.
> 
> This change **relocates** that `MARKET_SUMMARY` block to the **first child inside** `ScrollView` (still above the chart section). Layout, spacing (`px-4 pb-2`), and test IDs are unchanged; only scroll behavior changes so the price row moves with the content instead of acting like part of the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c1b4b6bf32fe6b3f8e96a97a5c3bcaa27b15c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->