### PR TITLE
fix(e2e): seed SOL into AssetsController for homepage network filter smoke

### DIFF
--- a/tests/smoke-appium/networks/homepage-sections-network-filter.spec.ts
+++ b/tests/smoke-appium/networks/homepage-sections-network-filter.spec.ts
@@ -16,11 +16,6 @@ import { NetworkToCaipChainId } from '../../../app/components/UI/NetworkMultiSel
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
 import { SolScope } from '@metamask/keyring-api';
 import type { AssetsControllerState } from '@metamask/assets-controller';
-import type {
-  MultichainAssetsControllerState,
-  MultichainAssetsRatesControllerState,
-  MultichainBalancesControllerState,
-} from '@metamask/assets-controllers';
 
 const ETH_TOKEN = {
   address: '0x0000000000000000000000000000000000000000',
@@ -182,58 +177,37 @@ function createHomepageTokensFilterFixture() {
     DEFAULT_SOLANA_FIXTURE_ACCOUNT
   ] = SOLANA_ACCOUNT_ID;
 
-  const existingMultichainAssetsController =
-    (backgroundState.MultichainAssetsController ??
-      {}) as Partial<MultichainAssetsControllerState>;
-  backgroundState.MultichainAssetsController = {
-    ...existingMultichainAssetsController,
-    accountsAssets: {
-      ...existingMultichainAssetsController.accountsAssets,
-      [SOLANA_ACCOUNT_ID]: [SOL_ASSET_ID],
-    },
-    assetsMetadata: {
-      ...existingMultichainAssetsController.assetsMetadata,
+  // Non-EVM assets are read from AssetsController when assetsUnifyState is on.
+  const existingAssetsController = (backgroundState.AssetsController ??
+    {}) as Partial<AssetsControllerState>;
+  const now = Date.now();
+  backgroundState.AssetsController = {
+    ...existingAssetsController,
+    assetsInfo: {
+      ...existingAssetsController.assetsInfo,
       [SOL_ASSET_ID]: {
-        fungible: true,
-        iconUrl: '',
-        units: [
-          {
-            decimals: 9,
-            symbol: 'SOL',
-            name: 'Solana',
-          },
-        ],
+        type: 'native' as const,
         symbol: 'SOL',
         name: 'Solana',
+        decimals: 9,
       },
     },
-  };
-
-  const existingMultichainBalancesController =
-    (backgroundState.MultichainBalancesController ??
-      {}) as Partial<MultichainBalancesControllerState>;
-  backgroundState.MultichainBalancesController = {
-    ...existingMultichainBalancesController,
-    balances: {
-      ...existingMultichainBalancesController.balances,
+    assetsBalance: {
+      ...existingAssetsController.assetsBalance,
       [SOLANA_ACCOUNT_ID]: {
+        ...existingAssetsController.assetsBalance?.[SOLANA_ACCOUNT_ID],
         [SOL_ASSET_ID]: {
           amount: '1',
-          unit: 'SOL',
         },
       },
     },
-  };
-
-  const existingMultichainAssetsRatesController =
-    (backgroundState.MultichainAssetsRatesController ??
-      {}) as Partial<MultichainAssetsRatesControllerState>;
-  backgroundState.MultichainAssetsRatesController = {
-    ...existingMultichainAssetsRatesController,
-    conversionRates: {
-      ...existingMultichainAssetsRatesController.conversionRates,
+    assetsPrice: {
+      ...existingAssetsController.assetsPrice,
       [SOL_ASSET_ID]: {
-        rate: '200',
+        assetPriceType: 'fungible' as const,
+        price: 200,
+        usdPrice: 200,
+        lastUpdated: now,
       },
     },
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes Appium smoke CI failure in `SmokeWalletPlatform: Homepage Tokens Section - Network Filter` — specifically `shows all tokens on homepage regardless of network filter set in tokens full view`.

With `assetsUnifyState` enabled, non-EVM assets are read from `AssetsController`, not `MultichainAssetsController` / `MultichainBalancesController`. The fixture only seeded SOL into the Multichain controllers, so `asset-SOL` never rendered on the homepage after returning from Tokens Full View.

This PR seeds SOL into `AssetsController` (`assetsInfo`, `assetsBalance`, `assetsPrice`) under the Solana account id and removes the unused Multichain-only SOL seeding.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — CI flake / Appium smoke fixture fix for assets unify

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage tokens section network filter Appium smoke

  Scenario: SOL and ETH remain visible on homepage after Linea filter in Tokens Full View
    Given an Appium main-e2e build with assetsUnifyState enabled
    And a fixture that seeds ETH/USDC via AssetsController and SOL via AssetsController for the Solana account
    When the user opens Tokens Full View and filters to Linea
    And ETH is not visible in the full view
    And the user navigates back to the homepage
    Then SOL is visible on the homepage Tokens section
    And ETH is visible on the homepage Tokens section
```

Local verification:

```bash
# iOS
yarn appium-smoke:ios -- tests/smoke-appium/networks/homepage-sections-network-filter.spec.ts

# Android
yarn appium-smoke:android -- tests/smoke-appium/networks/homepage-sections-network-filter.spec.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E fixture-only change; no UI code changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)