### PR TITLE
feat(perps): make market detail header identity a tight tap target

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1544,12 +1544,15 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       edges={['bottom', 'left', 'right']}
       testID={PerpsMarketDetailsViewSelectorsIDs.CONTAINER}
     >
+      {/* Only the market identity (icon + name + ticker + leverage) is a tap
+          target that opens the market list; it renders as a content-hugging
+          box inside the header. */}
       <PerpsMarketInlineHeader
         market={market}
         currentPrice={syncedChartCurrentPrice}
         onBackPress={handleBackPress}
         onFavoritePress={handleWatchlistPress}
-        onMarketListPress={handleMarketListPress}
+        onIdentityPress={handleMarketListPress}
         isFavorite={isWatchlist}
         useDetailLayout
         testID={PerpsMarketDetailsViewSelectorsIDs.HEADER}

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -7,7 +7,6 @@ interface PerpsMarketHeaderProps {
   onBackPress?: () => void;
   onMorePress?: () => void;
   onFavoritePress?: () => void;
-  onMarketListPress?: () => void;
   isFavorite?: boolean;
   testID?: string;
   /** Current price from candle stream - syncs header with chart */

--- a/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.test.tsx
@@ -138,13 +138,13 @@ describe('PerpsMarketInlineHeader', () => {
       expect(getByText('BTC')).toBeTruthy();
     });
 
-    it('handles the market list button press', () => {
-      const onMarketListPress = jest.fn();
+    it('opens the market list when the identity box is pressed', () => {
+      const onIdentityPress = jest.fn();
       const { getByTestId } = renderWithProvider(
         <PerpsMarketInlineHeader
           market={mockMarket}
           useDetailLayout
-          onMarketListPress={onMarketListPress}
+          onIdentityPress={onIdentityPress}
           testID={PerpsMarketHeaderSelectorsIDs.CONTAINER}
           currentPrice={45000}
         />,
@@ -155,38 +155,24 @@ describe('PerpsMarketInlineHeader', () => {
         getByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON),
       );
 
-      expect(onMarketListPress).toHaveBeenCalled();
+      expect(onIdentityPress).toHaveBeenCalled();
     });
 
-    it('expands the market list button touch target with hitSlop', () => {
-      const { getByTestId } = renderWithProvider(
+    it('does not make the identity a button without an onIdentityPress handler', () => {
+      const { queryByTestId, getByTestId } = renderWithProvider(
         <PerpsMarketInlineHeader
           market={mockMarket}
           useDetailLayout
-          onMarketListPress={jest.fn()}
           testID={PerpsMarketHeaderSelectorsIDs.CONTAINER}
           currentPrice={45000}
         />,
         { state: initialState },
       );
 
+      // Identity content still renders, but not as an interactive button.
       expect(
-        getByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON).props
-          .hitSlop,
-      ).toEqual({ top: 10, bottom: 10, left: 10, right: 10 });
-    });
-
-    it('does not render the market list button without a handler', () => {
-      const { queryByTestId } = renderWithProvider(
-        <PerpsMarketInlineHeader
-          market={mockMarket}
-          useDetailLayout
-          testID={PerpsMarketHeaderSelectorsIDs.CONTAINER}
-          currentPrice={45000}
-        />,
-        { state: initialState },
-      );
-
+        getByTestId(PerpsMarketHeaderSelectorsIDs.ASSET_NAME),
+      ).toBeTruthy();
       expect(
         queryByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON),
       ).toBeNull();

--- a/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.tsx
@@ -1,12 +1,17 @@
 import React, { type ReactNode, useMemo } from 'react';
+import { Pressable } from 'react-native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   ButtonIcon,
   ButtonIconSize,
+  FontWeight,
   HeaderSubpage,
   IconName,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import {
   getPerpsDisplaySymbol,
@@ -26,20 +31,25 @@ export interface PerpsMarketInlineHeaderProps {
   onBackPress?: () => void;
   onMorePress?: () => void;
   onFavoritePress?: () => void;
-  /** Opens the market list from the arrow next to the market name. */
-  onMarketListPress?: () => void;
   isFavorite?: boolean;
   testID?: string;
   endAccessory?: ReactNode;
   /**
    * When true, renders the redesigned market-detail layout instead of the
-   * compact one: title becomes the full asset name, a leverage pill +
-   * market-list arrow are added on the first row, the description becomes the
-   * static `[Ticker]-[collateral] perp` pair on the second row, and the live
+   * compact one: title becomes the full asset name, a leverage pill is added
+   * on the first row, the description becomes the static
+   * `[Ticker]-[collateral] perp` pair on the second row, and the live
    * price/24h change are removed from the header (relocated below by the
    * parent). When false, the compact layout (pair title + live price) renders.
    */
   useDetailLayout?: boolean;
+  /**
+   * Detail layout only. When provided, the market identity (icon + name +
+   * ticker + leverage) becomes a tightly-bounded pressable box that hugs its
+   * content — pressing it fires this callback and shows a button-like pressed
+   * background. The surrounding header row stays non-interactive.
+   */
+  onIdentityPress?: () => void;
 }
 
 export const PerpsMarketInlineHeader = ({
@@ -48,11 +58,11 @@ export const PerpsMarketInlineHeader = ({
   onBackPress,
   onMorePress,
   onFavoritePress,
-  onMarketListPress,
   isFavorite = false,
   testID,
   endAccessory,
   useDetailLayout = false,
+  onIdentityPress,
 }: PerpsMarketInlineHeaderProps) => {
   const displaySymbol = getPerpsDisplaySymbol(market.symbol);
 
@@ -60,60 +70,102 @@ export const PerpsMarketInlineHeader = ({
     ? market.name || displaySymbol
     : `${displaySymbol}-${PERPS_COLLATERAL_SYMBOL}`;
 
-  const titleEndAccessory = useMemo(() => {
-    const hasLeverage = Boolean(market.maxLeverage);
+  const leverageBadge = useMemo(
+    () =>
+      market.maxLeverage ? (
+        <PerpsLeverage maxLeverage={market.maxLeverage} />
+      ) : null,
+    [market.maxLeverage],
+  );
 
-    // The market-list arrow is only relevant in the redesigned layout.
-    const showMarketListButton = useDetailLayout && Boolean(onMarketListPress);
-
-    if (!hasLeverage && !showMarketListButton) {
-      return undefined;
+  // Detail layout: the icon + name + ticker + leverage are rendered together
+  // inside a single content-hugging box so they can act as one tap target
+  // without the empty row space becoming clickable.
+  const detailIdentity = useMemo(() => {
+    if (!useDetailLayout) {
+      return null;
     }
 
-    return (
+    const subtitle = strings('perps.market_details.perp_pair', {
+      ticker: displaySymbol,
+      collateral: PERPS_COLLATERAL_SYMBOL,
+    });
+
+    const renderContent = (pressed: boolean) => (
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        gap={1}
+        gap={3}
+        twClassName={`rounded-lg p-1 ${pressed ? 'bg-pressed' : ''}`}
       >
-        {hasLeverage ? (
-          <PerpsLeverage maxLeverage={market.maxLeverage} />
-        ) : null}
-        {showMarketListButton ? (
-          <ButtonIcon
-            iconName={IconName.ArrowDown}
-            size={ButtonIconSize.Sm}
-            onPress={onMarketListPress}
-            // Keep the chevron visually small but expand the touch target to
-            // ~44dp so it stays reliably tappable (accessibility).
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            testID={PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON}
-            accessibilityLabel={strings('perps.market_details.market_list')}
-          />
-        ) : null}
+        <PerpsTokenLogo
+          symbol={market.symbol}
+          size={40}
+          testID={PerpsMarketHeaderSelectorsIDs.ASSET_ICON}
+        />
+        <Box flexDirection={BoxFlexDirection.Column}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              numberOfLines={1}
+              testID={PerpsMarketHeaderSelectorsIDs.ASSET_NAME}
+            >
+              {displayTitle}
+            </Text>
+            {leverageBadge}
+          </Box>
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+            numberOfLines={1}
+            testID={PerpsMarketHeaderSelectorsIDs.SUBTITLE}
+          >
+            {subtitle}
+          </Text>
+        </Box>
       </Box>
     );
-  }, [market.maxLeverage, useDetailLayout, onMarketListPress]);
 
-  const description = useMemo(() => {
-    // Redesigned layout shows the market pair as a static subtitle. Price and
-    // 24h change move below the header (rendered by the parent view).
-    if (useDetailLayout) {
-      return strings('perps.market_details.perp_pair', {
-        ticker: displaySymbol,
-        collateral: PERPS_COLLATERAL_SYMBOL,
-      });
+    if (!onIdentityPress) {
+      return renderContent(false);
     }
 
     return (
+      <Pressable
+        onPress={onIdentityPress}
+        accessibilityRole="button"
+        accessibilityLabel={strings('perps.market_details.market_list')}
+        testID={PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON}
+      >
+        {({ pressed }) => renderContent(pressed)}
+      </Pressable>
+    );
+  }, [
+    useDetailLayout,
+    displaySymbol,
+    displayTitle,
+    leverageBadge,
+    market.symbol,
+    onIdentityPress,
+  ]);
+
+  const compactDescription = useMemo(
+    () => (
       <LivePriceHeader
         symbol={market.symbol}
         testIDPrice={PerpsMarketHeaderSelectorsIDs.PRICE}
         testIDChange={PerpsMarketHeaderSelectorsIDs.PRICE_CHANGE}
         currentPrice={currentPrice}
       />
-    );
-  }, [useDetailLayout, displaySymbol, market.symbol, currentPrice]);
+    ),
+    [market.symbol, currentPrice],
+  );
 
   const endButtonIconProps = useMemo(() => {
     const buttons = [];
@@ -153,21 +205,24 @@ export const PerpsMarketInlineHeader = ({
       endAccessory={endAccessory}
       endButtonIconProps={endAccessory ? undefined : endButtonIconProps}
       avatar={
-        <PerpsTokenLogo
-          symbol={market.symbol}
-          size={40}
-          testID={PerpsMarketHeaderSelectorsIDs.ASSET_ICON}
-        />
+        useDetailLayout ? (
+          detailIdentity
+        ) : (
+          <PerpsTokenLogo
+            symbol={market.symbol}
+            size={40}
+            testID={PerpsMarketHeaderSelectorsIDs.ASSET_ICON}
+          />
+        )
       }
-      title={displayTitle}
-      titleProps={{ testID: PerpsMarketHeaderSelectorsIDs.ASSET_NAME }}
-      titleEndAccessory={titleEndAccessory}
-      description={description}
-      descriptionProps={
+      title={useDetailLayout ? undefined : displayTitle}
+      titleProps={
         useDetailLayout
-          ? { testID: PerpsMarketHeaderSelectorsIDs.SUBTITLE }
-          : undefined
+          ? undefined
+          : { testID: PerpsMarketHeaderSelectorsIDs.ASSET_NAME }
       }
+      titleEndAccessory={useDetailLayout ? undefined : leverageBadge}
+      description={useDetailLayout ? undefined : compactDescription}
     />
   );
 };


### PR DESCRIPTION
## **Description**

The Perps market detail header previously showed a small chevron-down button next to the market name that navigated to the market list (assets) screen. The tap target was tiny.

This PR removes the chevron and instead groups the market identity — token icon, asset name, ticker subtitle and leverage pill — into a single content-hugging pressable box. Pressing anywhere on that box opens the market list.

Key details:

- The pressable box hugs its content only. The surrounding header row, the price / 24h-change row, and the status-bar safe-area inset are **not** part of the tap target.
- Button-like pressed feedback (a dimmed `background.pressed` background) is scoped to the identity box, so the dim no longer bleeds onto the price row or the area above the header.
- The back and favorite buttons remain independent, non-interfering tap targets.
- `PerpsMarketInlineHeader` now takes an `onIdentityPress` callback (replacing the old chevron/market-list button wiring); the market detail view passes its existing market-list navigation handler.

## **Changelog**

CHANGELOG entry: Changed the Perps market detail header so tapping the asset icon, name and ticker opens the markets list, replacing the chevron button.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps market detail header identity opens the market list

  Scenario: user opens the market list from the header identity
    Given the user is on a Perps market detail screen
    And the header no longer shows a chevron next to the market name

    When the user taps the market identity box (icon, name, ticker or leverage)
    Then the market list (assets) screen opens

  Scenario: pressed feedback stays scoped to the identity box
    Given the user is on a Perps market detail screen

    When the user presses and holds the market identity box
    Then only the identity box shows a dimmed background
    And the price, 24h change, and the area above the header are not dimmed

  Scenario: surrounding areas are not clickable
    Given the user is on a Perps market detail screen

    When the user taps the price, the empty space in the header row, or the fullscreen chart button
    Then the market list does not open
    And the fullscreen chart button still opens the fullscreen chart
```

## **Screenshots/Recordings**

### **Before**

<!-- Chevron button next to the market name; large full-row/price tap + dim area -->

N/A — pending device capture.

### **After**

<!-- No chevron; tight pressable box around icon + name + ticker + leverage with scoped pressed dim -->

https://github.com/user-attachments/assets/ef4fbb17-7b17-4820-8557-bc357510bb1f



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Perps header UI and navigation wiring only; behavior is unchanged aside from tap target and visual feedback scope.
> 
> **Overview**
> Replaces the small chevron next to the market name on **Perps market detail** with a single **content-hugging** tap target: icon, asset name, perp pair subtitle, and leverage pill. Tapping that box still opens the market list via the existing navigation handler, now wired through **`onIdentityPress`** instead of **`onMarketListPress`**.
> 
> In **`useDetailLayout`**, the identity block is built in the header avatar area (not `HeaderSubpage` title/description), wrapped in a **`Pressable`** when a handler is provided, with **`bg-pressed`** feedback limited to that box. Back and favorite stay separate controls; price/24h row and empty header space are no longer part of the market-list tap target. **`PerpsMarketHeader`** drops the old prop; unit tests cover identity press and non-interactive identity when no callback is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7a50cfffc42542f9cede099f0f8bb3380b9d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->