### PR TITLE
feat(ramps): prepare Transak native order Pusher client

### DIFF
--- a/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
+++ b/app/core/Engine/controllers/ramps-controller/ramps-controller-init.ts
@@ -72,6 +72,9 @@ export const rampsControllerInit: MessengerClientInitFunction<
     controller
       .init()
       .then(() => {
+        // Starts HTTP polling for all pending V2 orders, and (from
+        // @metamask/ramps-controller >= 17.1.0) subscribes pending Transak
+        // Native orders to Transak Pusher channels for real-time wake-ups.
         controller.startOrderPolling();
       })
       .catch(() => {

--- a/package.json
+++ b/package.json
@@ -485,6 +485,7 @@
     "psl": "^1.15.0",
     "pump": "3.0.0",
     "punycode": "^2.1.1",
+    "pusher-js": "^8.4.0",
     "qs": "6.15.2",
     "query-string": "^6.12.1",
     "randomfill": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36226,6 +36226,7 @@ __metadata:
     psl: "npm:^1.15.0"
     pump: "npm:3.0.0"
     punycode: "npm:^2.1.1"
+    pusher-js: "npm:^8.4.0"
     qs: "npm:6.15.2"
     query-string: "npm:^6.12.1"
     randomfill: "npm:^1.0.4"
@@ -39879,6 +39880,15 @@ __metadata:
   dependencies:
     bitcoin-ops: "npm:^1.3.0"
   checksum: 10/963fb0b61258e7654d6e3e34e68c8672bc3fdbd154da0a9af0482d2b7b9e9227b11bc17a39f42003f92e996cb552395e903d369347c840381a356964cf553967
+  languageName: node
+  linkType: hard
+
+"pusher-js@npm:^8.4.0":
+  version: 8.5.0
+  resolution: "pusher-js@npm:8.5.0"
+  dependencies:
+    tweetnacl: "npm:^1.0.3"
+  checksum: 10/99e6c102aa0d35c7cdd4341770c69b9b63f3bf3552f2238b105745a164630c94c84caa485758a7c147d1c9523e5e372678080e1caad6b8c2b05af8bd42a7414e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add direct `pusher-js` dependency so Metro can resolve the Transak order-updates client shipped in `@metamask/ramps-controller` 17.1.0
- Document that `startOrderPolling()` also starts Transak Native Pusher subscriptions (core behavior; no mobile API changes required)
- Depends on [MetaMask/core#9541](https://github.com/MetaMask/core/pull/9541) publishing `@metamask/ramps-controller@17.1.0` — after publish, bump the dependency / lockfile to `^17.1.0` (tracked as follow-up in this PR)

## Test plan
- [x] `yarn install` succeeds with `pusher-js` added
- [ ] After core#9541 publishes 17.1.0: `yarn up @metamask/ramps-controller@^17.1.0` and confirm a pending Transak Native order updates via Pusher wake-up (faster than the 30s poll)
- [ ] Confirm aggregator orders still update via HTTP polling
- [ ] Confirm toasts / analytics still fire on `RampsController:orderStatusChanged`


Made with [Cursor](https://cursor.com)