### PR TITLE
feat(perps): show full asset names in top movers and related markets

### DIFF
--- a/app/components/UI/Perps/components/PerpsPillItem/PerpsPillItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsPillItem/PerpsPillItem.test.tsx
@@ -12,9 +12,36 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+jest.mock('../../selectors/featureFlags', () => ({
+  selectPerpsShowFullAssetNamesFlag: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const { selectPerpsShowFullAssetNamesFlag } = jest.requireMock(
+  '../../selectors/featureFlags',
+);
+const { useSelector } = jest.requireMock('react-redux');
+const mockUseSelector = useSelector as jest.MockedFunction<
+  (selector: unknown) => unknown
+>;
+
+// Returns the feature-flag value only for the full asset names selector,
+// and false for every other selector.
+const mockSelectors = (showFullAssetNames: boolean) => {
+  mockUseSelector.mockImplementation((selector) =>
+    selector === selectPerpsShowFullAssetNamesFlag ? showFullAssetNames : false,
+  );
+};
+
 describe('PerpsPillItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default to the production default (flag off) so tickers are shown.
+    mockSelectors(false);
   });
 
   const buildItem = (
@@ -131,5 +158,47 @@ describe('PerpsPillItem', () => {
 
     rerender(<PerpsPillItem item={buildItem('-0.5')} />);
     expect(getByText('-0.50%')).toBeTruthy();
+  });
+
+  describe('full asset name feature flag', () => {
+    const buildNamedItem = (): PerpsFeedItem =>
+      ({
+        market: {
+          symbol: 'ETH',
+          name: 'Ethereum',
+          change24hPercent: '1.5',
+        },
+        isWatchlisted: false,
+      }) as PerpsFeedItem;
+
+    it('shows the ticker symbol when the flag is off', () => {
+      mockSelectors(false);
+
+      const { getByText, queryByText } = render(
+        <PerpsPillItem item={buildNamedItem()} />,
+      );
+
+      expect(getByText('ETH')).toBeTruthy();
+      expect(queryByText('Ethereum')).toBeNull();
+    });
+
+    it('shows the full asset name when the flag is on', () => {
+      mockSelectors(true);
+
+      const { getByText, queryByText } = render(
+        <PerpsPillItem item={buildNamedItem()} />,
+      );
+
+      expect(getByText('Ethereum')).toBeTruthy();
+      expect(queryByText('ETH')).toBeNull();
+    });
+
+    it('falls back to the ticker symbol when the flag is on but no name exists', () => {
+      mockSelectors(true);
+
+      const { getByText } = render(<PerpsPillItem item={buildItem('1.5')} />);
+
+      expect(getByText('ETH')).toBeTruthy();
+    });
   });
 });

--- a/app/components/UI/Perps/components/PerpsPillItem/PerpsPillItem.tsx
+++ b/app/components/UI/Perps/components/PerpsPillItem/PerpsPillItem.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import {
   PERPS_EVENT_VALUE,
@@ -11,6 +12,7 @@ import { formatPercentChange } from '../../../Trending/utils/formatPercentChange
 import { ExplorePill } from '../../../Trending/components/ExplorePill';
 import type { PerpsFeedItem } from '../../types/perpsFeedTypes';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import { selectPerpsShowFullAssetNamesFlag } from '../../selectors/featureFlags';
 
 const LOGO_SIZE = 24;
 
@@ -49,10 +51,18 @@ const PerpsPillItem: React.FC<PerpsPillItemProps> = ({
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const { market } = item;
 
+  const showFullAssetNames = useSelector(selectPerpsShowFullAssetNamesFlag);
+
   const { changeLabel, changeTextColor } = useMemo(
     () => formatPercentChange(market.change24hPercent),
     [market.change24hPercent],
   );
+
+  const title = useMemo(() => {
+    const label =
+      showFullAssetNames && market.name ? market.name : market.symbol;
+    return getPerpsDisplaySymbol(label);
+  }, [showFullAssetNames, market.name, market.symbol]);
 
   const onPress = () => {
     onCardPress?.();
@@ -86,7 +96,7 @@ const PerpsPillItem: React.FC<PerpsPillItemProps> = ({
           recyclingKey={market.symbol}
         />
       }
-      title={getPerpsDisplaySymbol(market.symbol)}
+      title={title}
       changeLabel={changeLabel}
       changeTextColor={changeTextColor}
     />


### PR DESCRIPTION
## **Description**

The Perps **Top Movers** and **Related Markets** sections both render each market through the shared `PerpsPillItem` component, which previously always displayed the ticker symbol (e.g. `BTC`).

This PR makes those pill items display the full asset name (e.g. `Bitcoin`) instead, reusing the existing `perpsShowFullAssetNames` remote feature flag (`selectPerpsShowFullAssetNamesFlag`) that already drives the same behavior in `PerpsMarketRowItem` and `PerpsRecentlyAddedSection`. This keeps naming consistent across all Perps market surfaces.

Behavior:

- Flag **on** and a name is available → show the full asset name (`market.name`), run through `getPerpsDisplaySymbol` to strip any HIP-3 dex prefix.
- Flag **off**, or no name available → fall back to the ticker symbol (`market.symbol`), unchanged from today.

No section components needed changes since both sections share `PerpsPillItem`.

## **Changelog**

CHANGELOG entry: null

<!-- Gated behind the `perpsShowFullAssetNames` remote feature flag; not enabled for end users by default. -->

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Full asset names in Perps Top Movers and Related Markets

  Scenario: User views pills with the full asset names flag disabled
    Given the perpsShowFullAssetNames feature flag is off
    When the user opens the Perps home screen Top Movers section
    And the user opens a market's Related Markets section
    Then each pill displays the ticker symbol (e.g. "BTC")

  Scenario: User views pills with the full asset names flag enabled
    Given the perpsShowFullAssetNames feature flag is on
    When the user opens the Perps home screen Top Movers section
    And the user opens a market's Related Markets section
    Then each pill displays the full asset name (e.g. "Bitcoin")
    And pills without a resolved name fall back to the ticker symbol
```

## **Screenshots/Recordings**

### **Before**

N/A — pills show ticker symbols.

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-16 at 14 35 05" src="https://github.com/user-attachments/assets/9bc09cba-caee-4231-be7c-d479f3af90c8" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-07-16 at 14 35 01" src="https://github.com/user-attachments/assets/fe189337-9315-4aad-9a77-4bd324bd628f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gated behind an existing remote feature flag with symbol fallback; UI-only change in a shared Perps component with test coverage.
> 
> **Overview**
> **Perps pill labels** (Top Movers, Related Markets, and any surface using `PerpsPillItem`) now follow the existing `perpsShowFullAssetNames` remote flag instead of always showing the ticker.
> 
> When the flag is on and `market.name` is present, the pill title shows the full name (via `getPerpsDisplaySymbol`); otherwise it stays on `market.symbol`. Tests mock the flag selector and cover on/off and missing-name fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d232c575cb762d72298c963daaffa41ca6d4ff1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->