### PR TITLE
fix(networking): install WHATWG fetch globals unconditionally

### DIFF
--- a/app/core/NitroFetchSetup.test.ts
+++ b/app/core/NitroFetchSetup.test.ts
@@ -1,6 +1,9 @@
 import {
   fetch as nitroFetch,
   prefetchOnAppStart,
+  Headers as NitroHeaders,
+  Request as NitroRequest,
+  Response as NitroResponse,
 } from 'react-native-nitro-fetch';
 import {
   C2_DOMAIN_BLOCKLIST_URL,
@@ -89,6 +92,17 @@ describe('NitroFetchSetup', () => {
       });
 
       expect(localPrefetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('installFetchGlobals — WHATWG constructor globals', () => {
+    it('installs Headers, Request, and Response onto the global object', () => {
+      // NitroFetchSetup is imported at the top of this file, so the constructor
+      // globals must already be present as functional constructors.
+      expect(global.Headers).toBe(NitroHeaders);
+      expect(global.Request).toBe(NitroRequest);
+      expect(global.Response).toBe(NitroResponse);
+      expect(typeof global.Headers).toBe('function');
     });
   });
 

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -99,6 +99,33 @@ function withPrefetchKey(
   return { ...init, headers };
 }
 
+/**
+ * Installs the WHATWG constructor globals (`Headers`, `Request`, `Response`)
+ * using nitro-fetch's implementations, which are the app's canonical WHATWG
+ * classes once `global.fetch` is routed through nitro-fetch.
+ *
+ * Neither `@react-native/js-polyfills` nor Expo's winter runtime provide these
+ * constructors, so without this the identifiers are undefined at runtime. That
+ * makes any `headers instanceof Headers` check (nitro-fetch's request builder
+ * does exactly this) throw `ReferenceError: Can't find variable: Headers`
+ * before a request can be sent, and any `new Headers()` in app/dependency code
+ * throw as well.
+ *
+ * This runs unconditionally — including under test overrides — because the
+ * constructors are an environment invariant, independent of whether the
+ * production fetch swap and startup prefetching are installed.
+ */
+function installFetchGlobals(): void {
+  const _g = globalThis as unknown as {
+    Headers: typeof Headers;
+    Request: typeof Request;
+    Response: typeof Response;
+  };
+  _g.Headers = Headers;
+  _g.Request = Request;
+  _g.Response = Response;
+}
+
 function installProductionNitroFetch(): void {
   // NOTE: nitro-fetch uses a buffered transport by default — the full response
   // body is downloaded natively before the Promise resolves. `response.body.getReader()`
@@ -108,14 +135,6 @@ function installProductionNitroFetch(): void {
   //   - import `fetch` from 'expo/fetch' directly (see bridge-controller-init.ts)
   global.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
     nitroFetch(input, withPrefetchKey(input, init));
-  const _g = globalThis as unknown as {
-    Headers: typeof Headers;
-    Request: typeof Request;
-    Response: typeof Response;
-  };
-  _g.Headers = Headers;
-  _g.Request = Request;
-  _g.Response = Response;
 
   for (const { url, key } of STARTUP_PREFETCHES) {
     // Non-fatal: a registration failure means the cache is cold on next launch,
@@ -123,6 +142,10 @@ function installProductionNitroFetch(): void {
     prefetchOnAppStart(url, { prefetchKey: key }).catch(() => undefined);
   }
 }
+
+// Constructor globals are always required — they must exist even in builds
+// where the production fetch swap is skipped (e.g. test overrides).
+installFetchGlobals();
 
 if (!hasTestOverrides) {
   installProductionNitroFetch();


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

React Native's networking globals (`Headers`, `Request`, `Response`) are not provided by this app's runtime: `@react-native/js-polyfills` (see `metro.config.js`) does not install them, and the Expo "winter" runtime forced in `shim.js` installs `URL`, `TextDecoder`, `structuredClone`, etc. — but **not** the fetch constructors. Since the app replaced its entire networking stack with `react-native-nitro-fetch`, these globals were only assigned inside `installProductionNitroFetch()`, which is gated behind `if (!hasTestOverrides)` and runs late in startup.

The problem this causes: `react-native-nitro-fetch`'s request builder evaluates `headers instanceof Headers`. When the global `Headers` constructor is undefined, that expression throws `ReferenceError: Can't find variable: Headers` instead of returning `false` — crashing the request **before** it reaches the native network client. Because virtually every request carries headers, this manifests as *all* network requests failing (not flow-specific), and any app/dependency code doing `new Headers()` throws as well.

**Solution:** decouple the WHATWG constructor globals from the production-only fetch path. This PR extracts a dedicated `installFetchGlobals()` that installs `Headers`/`Request`/`Response` from nitro-fetch's implementations, and calls it **unconditionally** on module load — before the `hasTestOverrides` gate. `installProductionNitroFetch()` now owns only the `global.fetch` swap and startup prefetch registration (clearer single responsibility).

This makes the constructor globals an environment invariant that always exists, regardless of build type or startup ordering — so `new Headers()` / `instanceof Headers` are safe app-wide for every consumer, addressing the root cause rather than a single symptom.

1. **Reason for the change:** an environment gap (missing WHATWG fetch globals) surfaced as a hard `ReferenceError` crash in the networking layer, causing requests to fail.
2. **Improvement/solution:** the constructors are installed once, early, and unconditionally, eliminating the `!hasTestOverrides` gap and the startup-ordering fragility.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a crash that could cause network requests to fail when the global \`Headers\` constructor was unavailable.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Nitro Fetch "Can't find variable: Headers" network failures reported internally (all requests failing / Infura requests hanging). No public tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

\`\`\`gherkin
Feature: Network requests work when WHATWG fetch globals are relied upon

  Scenario: App boots and performs network requests
    Given a fresh app launch
    When the app makes network requests that pass plain-object or Headers-instance headers (e.g. Perps, Infura RPC, feature flags)
    Then requests reach the native client and complete without a "Can't find variable: Headers" ReferenceError

  Scenario: Constructor globals are always present
    Given the app has finished bootstrapping (including test-override builds)
    When any code evaluates \`new Headers()\`, \`new Request(...)\`, \`new Response(...)\`, or \`headers instanceof Headers\`
    Then the constructors are defined and behave as expected
\`\`\`

N/A for dedicated UI steps — this is a runtime bootstrap change with no UI. Covered by unit tests in \`app/core/NitroFetchSetup.test.ts\` (\`yarn jest app/core/NitroFetchSetup.test.ts\` → 20 passed).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no visual behavior changed.

### **Before**

N/A — non-visual failure. Requests could throw \`ReferenceError: Can't find variable: Headers\` before reaching the native client when the global \`Headers\` constructor was unavailable.

### **After**

N/A — constructor globals are installed unconditionally at bootstrap; requests reach the native client without throwing.

<img width="1690" height="959" alt="Screenshot 2026-07-16 at 16 32 23" src="https://github.com/user-attachments/assets/df3d643f-c4a8-46ed-9841-598ee498fe58" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [\`trace()\`](/app/util/trace.ts) for usage and [\`addToken\`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)