### PR TITLE
fix: use getPerpsDisplaySymbol on recently viewed rail

### DIFF
--- a/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.test.tsx
@@ -122,6 +122,21 @@ describe('PerpsRecentlyViewedRail', () => {
     expect(screen.getByText('+2.5%')).toBeOnTheScreen();
   });
 
+  it('strips the dex prefix from the displayed symbol and accessibility label', () => {
+    render(
+      <PerpsRecentlyViewedRail
+        markets={[createMarket('xyz:TSLA')]}
+        onMarketPress={mockOnMarketPress}
+      />,
+    );
+
+    expect(screen.getByText('TSLA')).toBeOnTheScreen();
+    expect(screen.queryByText('xyz:TSLA')).toBeNull();
+    expect(
+      screen.getByLabelText('TSLA recently viewed market'),
+    ).toBeOnTheScreen();
+  });
+
   it('preserves the newest-first order passed in via props', () => {
     render(
       <PerpsRecentlyViewedRail

--- a/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentlyViewedRail/PerpsRecentlyViewedRail.tsx
@@ -6,6 +6,7 @@ import {
   TextColor as DSTextColor,
 } from '@metamask/design-system-react-native';
 import {
+  getPerpsDisplaySymbol,
   PERPS_EVENT_PROPERTY,
   type PerpsMarketData,
 } from '@metamask/perps-controller';
@@ -54,6 +55,7 @@ const PerpsRecentlyViewedTile: React.FC<{
 
   const isPositiveChange = !market.change24h.startsWith('-');
   const changeColor = isPositiveChange ? TextColor.Success : TextColor.Error;
+  const displaySymbol = getPerpsDisplaySymbol(market.symbol);
 
   return (
     <TouchableOpacity
@@ -62,7 +64,7 @@ const PerpsRecentlyViewedTile: React.FC<{
       style={styles.tile}
       testID={`perps-recently-viewed-tile-${market.symbol}`}
       accessibilityRole="button"
-      accessibilityLabel={`${market.symbol} recently viewed market`}
+      accessibilityLabel={`${displaySymbol} recently viewed market`}
     >
       <PerpsTokenLogo symbol={market.symbol} size={32} />
 
@@ -72,7 +74,7 @@ const PerpsRecentlyViewedTile: React.FC<{
           color={TextColor.Default}
           numberOfLines={1}
         >
-          {market.symbol}
+          {displaySymbol}
         </Text>
         <PerpsLeverage maxLeverage={market.maxLeverage} />
       </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes bug where perp market prefix was not being stripped on recently viewed rail

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: strip market prefix from recently viewed rail markets

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="828" height="1792" alt="IMG_3256" src="https://github.com/user-attachments/assets/d122777b-8474-4a7a-b393-1de8b1297ed7" />

### **After**

<img width="416" height="187" alt="Screenshot 2026-07-16 at 11 14 03 AM" src="https://github.com/user-attachments/assets/7cf500c3-bbfe-4832-b427-6058cc98aced" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-only change in one rail component, aligned with existing perps UI patterns; no auth, data, or navigation logic changes.
> 
> **Overview**
> The **Recently searched** perps rail now shows user-facing symbols through `getPerpsDisplaySymbol` instead of the raw `market.symbol`, so prefixed markets (e.g. `xyz:TSLA`) render as **TSLA** in the tile text and accessibility label.
> 
> `testID`, analytics, and `PerpsTokenLogo` still use the full symbol; only display and a11y strings change. A unit test covers prefix stripping for `xyz:TSLA`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9486dda84fd65879feb34b3809799f9c4a298341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->