### PR TITLE
fix: cp-8.3.0 Fix return undefined token fiat amount instead of locking 1

### DIFF
--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
@@ -97,7 +97,7 @@ describe('useTokenFiatRates', () => {
     ]);
   });
 
-  it('returns conversion rate only if token price not found', () => {
+  it('returns undefined if token price not found', () => {
     const result = runHook({
       requests: [
         {
@@ -107,7 +107,7 @@ describe('useTokenFiatRates', () => {
       ],
     });
 
-    expect(result).toEqual([CONVERSION_RATE_1_MOCK]);
+    expect(result).toEqual([undefined]);
   });
 
   it('returns fixed exchange rate for stablecoin when currency is USD', () => {

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -55,7 +55,11 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
           return undefined;
         }
 
-        return (token?.price ?? 1) * conversionRate;
+        if (!token?.price) {
+          return undefined;
+        }
+
+        return token.price * conversionRate;
       }),
     [
       currencyRates,

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
@@ -14,11 +14,25 @@ const useTransactionMetadataRequestMock = jest.mocked(
   useTransactionMetadataRequest,
 );
 
-function runHook(tokenAddress: Hex, chainId: Hex) {
+const marketDataMock = {
+  engine: {
+    backgroundState: {
+      TokenRatesController: {
+        marketData: {
+          '0x1': {
+            '0x1234567890AbcdEF1234567890aBcdef12345678': { price: 1 },
+          },
+        },
+      },
+    },
+  },
+};
+
+function runHook(tokenAddress: Hex, chainId: Hex, extraState = {}) {
   return renderHookWithProvider(
     () => useTokenWithBalance(tokenAddress, chainId),
     {
-      state: merge({}, otherControllersMock),
+      state: merge({}, otherControllersMock, marketDataMock, extraState),
     },
   );
 }

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -95,8 +95,7 @@ export function useTransactionCustomAmount({
     TransactionType.moneyAccountWithdraw,
   ]);
   const tokenAddress = getTokenAddress(transactionMeta);
-  const payTokenFiatRate =
-    useTokenFiatRate(tokenAddress, chainId, currency) ?? 1;
+  const payTokenFiatRate = useTokenFiatRate(tokenAddress, chainId, currency);
   const musdFiatRate =
     useTokenFiatRate(
       MUSD_TOKEN_ADDRESS,
@@ -166,7 +165,9 @@ export function useTransactionCustomAmount({
 
   const amountHuman = useMemo(
     () =>
-      new BigNumber(amountFiat || '0').dividedBy(tokenFiatRate).toString(10),
+      tokenFiatRate
+        ? new BigNumber(amountFiat || '0').dividedBy(tokenFiatRate).toString(10)
+        : '0',
     [amountFiat, tokenFiatRate],
   );
 
@@ -360,7 +361,7 @@ export function useTransactionCustomAmount({
   };
 }
 
-function useTokenBalance(tokenUsdRate: number) {
+function useTokenBalance(tokenUsdRate: number | undefined) {
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
   const transactionId = transactionMeta?.id ?? '';
 
@@ -372,9 +373,11 @@ function useTokenBalance(tokenUsdRate: number) {
 
   const { data: predictBalanceHuman = 0 } = usePredictBalance();
 
-  const predictBalanceUsd = new BigNumber(predictBalanceHuman ?? '0')
-    .multipliedBy(tokenUsdRate)
-    .toNumber();
+  const predictBalanceUsd = tokenUsdRate
+    ? new BigNumber(predictBalanceHuman ?? '0')
+        .multipliedBy(tokenUsdRate)
+        .toNumber()
+    : 0;
 
   const { withdrawableMusd, withdrawableFiatRaw } = useMoneyAccountBalance();
 
@@ -396,7 +399,9 @@ function useTokenBalance(tokenUsdRate: number) {
     if (withdrawableMusd === undefined) {
       return 0;
     }
-    return withdrawableMusd.multipliedBy(tokenUsdRate).toNumber();
+    return tokenUsdRate
+      ? withdrawableMusd.multipliedBy(tokenUsdRate).toNumber()
+      : 0;
   }
 
   if (hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])) {


### PR DESCRIPTION
## **Description**

In `useTokenFiatRates`, when a token's price was not found, the code was falling back to `token?.price ?? 1`, which incorrectly used `1` as a default price multiplier. This caused the fiat amount to silently return `conversionRate` instead of indicating no price is available — making it look like the token was worth 1 unit of the base currency.

This fix changes the behavior to return `undefined` when `token.price` is falsy, so callers can distinguish between "price not found" and a real fiat value. The test expectation is updated accordingly.

## **Changelog**

CHANGELOG entry: Fixed `useTokenFiatRates` returning an incorrect fiat amount (using conversion rate × 1) when a token price is unavailable — now returns `undefined` instead.

## **Related issues**

Fixes: cherry-pick of #33447 (cp-8.3.0)

## **Manual testing steps**

1. Open MetaMask Mobile and navigate to a confirmation screen that displays token fiat amounts (e.g. a token approval or transfer).
2. Use a token whose price is **not** available in the price feed.
3. Verify the fiat amount for that token shows as unavailable/empty rather than an incorrect non-zero value.
4. Verify tokens **with** known prices still display the correct fiat amount.

## **Screenshots/Recordings**

Before:
<img width="530" height="1008" alt="rc - before - send" src="https://github.com/user-attachments/assets/fb3e58b9-0ae5-43b6-bcca-c39710c4c056" />

<img width="530" height="1008" alt="rc - before - mmpay" src="https://github.com/user-attachments/assets/7778b8bd-fdd1-4203-b6d5-cfcc859b2eb0" />

After: 
<img width="530" height="1008" alt="rc - after - send" src="https://github.com/user-attachments/assets/f11099b7-014f-4a1a-a9ef-c64701172712" />

<img width="530" height="1008" alt="rc - after - mmpay" src="https://github.com/user-attachments/assets/bcf9adce-9b26-4fe2-b56e-9165bc9f8a3c" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MM Pay / confirmation amount and balance USD math when price feeds are missing; behavior is safer but users may see zero/empty conversions until prices load.
> 
> **Overview**
> Stops **confirmation pay flows** from treating a missing token price as **1** and showing a bogus fiat value (effectively `conversionRate` alone).
> 
> **`useTokenFiatRates`** now returns **`undefined`** when `token.price` is absent instead of multiplying by a default `1`. The unit test expectation is updated from the conversion rate to **`undefined`**.
> 
> **`useTransactionCustomAmount`** no longer falls back with `?? 1` on the pay-token fiat rate. Fiat→token conversion and USD balance helpers (`amountHuman`, `useTokenBalance` for predict / money-account withdraw) guard on a defined rate and use **`'0'`** or **`0`** when the rate is missing, while mUSD still keeps its `?? 1` fallback for money-account withdraw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb43200c9600780a77fd86516daed40d1442e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->