### PR TITLE
fix(money): reduce per-keystroke overhead in deposit amount screen (MUSD-1180)

### DIFF
--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -209,6 +209,18 @@ describe('PayWithRow', () => {
     expect(getByTestId('pay-with-symbol')).toHaveTextContent('Select token');
   });
 
+  it('does not re-render on parent re-render with identical props', () => {
+    const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+    const { rerender } = render();
+    const initialRenderCallCount = useTransactionPayTokenMock.mock.calls.length;
+
+    rerender(<PayWithRow />);
+
+    expect(useTransactionPayTokenMock).toHaveBeenCalledTimes(
+      initialRenderCallCount,
+    );
+  });
+
   it('disables edit if hardware wallet', async () => {
     isHardwareAccountMock.mockReturnValue(true);
 

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { PaymentType } from '@consensys/on-ramp-sdk';
@@ -61,7 +61,7 @@ interface PayWithRouteParams {
   preferredPaymentToken?: SetPayTokenRequest;
 }
 
-export function PayWithRow({
+function PayWithRowComponent({
   isResultReady,
 }: { isResultReady?: boolean } = {}) {
   const transactionMeta = useTransactionMetadataRequest();
@@ -97,6 +97,8 @@ export function PayWithRow({
 
   return <PayWithRowInteractive />;
 }
+
+export const PayWithRow = memo(PayWithRowComponent);
 
 function PayWithRowLayout({
   label,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -542,6 +542,46 @@ describe('useTransactionCustomAmount', () => {
     });
   });
 
+  it('sets manual metric once across consecutive updatePendingAmount calls', async () => {
+    const { result } = runHook();
+
+    await act(async () => {
+      result.current.updatePendingAmount('123.45');
+    });
+
+    await act(async () => {
+      result.current.updatePendingAmount('123.46');
+    });
+
+    const manualMetricCalls = setConfirmationMetricMock.mock.calls.filter(
+      ([metric]) => metric.properties?.mm_pay_amount_input_type === 'manual',
+    );
+
+    expect(manualMetricCalls).toHaveLength(1);
+  });
+
+  it('sets input type metric matching the last input source across manual and percentage updates', async () => {
+    const { result } = runHook();
+
+    await act(async () => {
+      result.current.updatePendingAmount('123.45');
+    });
+
+    await act(async () => {
+      result.current.updatePendingAmountPercentage(50);
+    });
+
+    await act(async () => {
+      result.current.updatePendingAmount('678.9');
+    });
+
+    const inputTypeMetrics = setConfirmationMetricMock.mock.calls
+      .map(([metric]) => metric.properties?.mm_pay_amount_input_type)
+      .filter(Boolean);
+
+    expect(inputTypeMetrics).toEqual(['manual', '50%', 'manual']);
+  });
+
   it('returns hasInput as true after amount changed and debounce', async () => {
     const { result } = runHook();
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -76,6 +76,9 @@ export function useTransactionCustomAmount({
   const [isPrefillPending, setIsPrefillPending] = useState(isAddMusdFlow);
   const hasPrefilled = useRef(false);
   const depositMaxHumanRef = useRef<string | null>(null);
+  // Dispatching the metric per keystroke triggers a store-wide selector sweep;
+  // only dispatch when the input type actually changes.
+  const lastAmountInputTypeRef = useRef<string | null>(null);
 
   const debounceSetAmountDelayed = useMemo(
     () =>
@@ -228,11 +231,15 @@ export function useTransactionCustomAmount({
 
       depositMaxHumanRef.current = null;
 
-      setConfirmationMetric({
-        properties: {
-          mm_pay_amount_input_type: 'manual',
-        },
-      });
+      if (lastAmountInputTypeRef.current !== 'manual') {
+        lastAmountInputTypeRef.current = 'manual';
+
+        setConfirmationMetric({
+          properties: {
+            mm_pay_amount_input_type: 'manual',
+          },
+        });
+      }
 
       setAmountFiat(newAmount);
     },
@@ -257,6 +264,8 @@ export function useTransactionCustomAmount({
           .multipliedBy(balanceUsd)
           .decimalPlaces(2, BigNumber.ROUND_DOWN),
       );
+
+      lastAmountInputTypeRef.current = `${percentage}%`;
 
       setConfirmationMetric({
         properties: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money account Buy/deposit amount screen (`CustomAmountInfo`) now avoids two sources of per-keystroke overhead, making keypad input more responsive on device:

1. `updatePendingAmount` dispatches the `mm_pay_amount_input_type` confirmation metric only when the input type actually changes, instead of on every keypad digit. Every dispatch triggers a store-wide `useSelector` sweep across the large confirmation tree, so the previous per-digit dispatch of an unchanged `'manual'` value was pure overhead. The percentage handler re-arms the guard, so the recorded metric still always reflects the last input type used.
2. `PayWithRow` is wrapped in `React.memo`. Its only prop is a stable boolean, but it was re-rendered by the parent on every keypad digit, re-invoking its full hook cluster (including the `useAccountTokens` portfolio scan). Internal Redux/query subscriptions still re-render it whenever its own data changes.

Bug: typing an amount in the Buy flow re-dispatched an unchanged metric and reconciled the payment row subtree on every digit, contributing to the sluggish input reported on iPhone Pro Max (MUSD-1180).

Remaining bottlenecks in this flow (out of scope here) are tracked in the ticket: the ~4 independent `useAccountTokens` instances re-computing on polling ticks, and quote pipeline latency addressed by #33433.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved keypad responsiveness when entering an amount in the Money account deposit flow

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1180

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account deposit amount entry

  Scenario: user types a deposit amount
    Given the user opens the Money account and taps Add money > Deposit funds

    When the user types digits on the amount keypad
    Then each digit appears without lag and the payment row does not flicker

  Scenario: user mixes manual and percentage input
    Given the user is on the deposit amount screen

    When the user types digits, taps a percentage button, then types digits again
    Then the amount updates correctly for each input
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no visual change; performance-only.

### **After**

N/A — no visual change; performance-only.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only UI changes with targeted metric deduplication; behavior is covered by new unit tests and does not alter amount calculation logic.
> 
> **Overview**
> Improves **Money deposit / custom amount** keypad responsiveness by cutting work that ran on every digit.
> 
> **`useTransactionCustomAmount`** now dispatches `mm_pay_amount_input_type` for manual typing only when the input type changes (tracked via `lastAmountInputTypeRef`), instead of re-dispatching `'manual'` on each keystroke. That avoids repeated confirmation metric updates that were triggering broad Redux selector churn. Percentage taps still update the ref and emit metrics; switching manual → percentage → manual again still records the correct sequence.
> 
> **`PayWithRow`** is exported as `React.memo(PayWithRowComponent)` so parent re-renders during amount entry do not re-run its hook tree when props are unchanged.
> 
> Tests cover memo behavior on `PayWithRow` and deduplicated / mixed manual–percentage metric emissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92966a5ad1ef1c79d1bacfa6055e1e83a277e08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->