### PR TITLE
fix(money): memoize assets-controller getStateForTransactionPay (MUSD-1180)

### DIFF
--- a/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch
@@ -1,0 +1,134 @@
+diff --git a/dist/utils/formatStateForTransactionPay.cjs b/dist/utils/formatStateForTransactionPay.cjs
+index 441dd463f07040fc989af125262d226b2c7c4a0c..763f648bfbebeaec5669ca79b723d4f1c4ef92dd 100644
+--- a/dist/utils/formatStateForTransactionPay.cjs
++++ b/dist/utils/formatStateForTransactionPay.cjs
+@@ -30,7 +30,62 @@ function getAmountFromBalance(balance) {
+  * @param params.networkConfigurationsByChainId - Optional chain ID to network config (for native symbol).
+  * @returns Legacy-compatible state for transaction-pay-controller.
+  */
++function areAccountsEqual(a, b) {
++    if (a === b) {
++        return true;
++    }
++    if (a.length !== b.length) {
++        return false;
++    }
++    for (let i = 0; i < a.length; i++) {
++        if (a[i].id !== b[i].id || a[i].address !== b[i].address) {
++            return false;
++        }
++    }
++    return true;
++}
++function areRecordsShallowEqual(a, b) {
++    if (a === b) {
++        return true;
++    }
++    if (!a || !b) {
++        return false;
++    }
++    const aKeys = Object.keys(a);
++    const bKeys = Object.keys(b);
++    if (aKeys.length !== bKeys.length) {
++        return false;
++    }
++    for (const key of aKeys) {
++        if (a[key] !== b[key]) {
++            return false;
++        }
++    }
++    return true;
++}
++// This function is invoked (via AssetsController:getStateForTransactionPay) on
++// every TransactionController:stateChange, but its inputs only change when the
++// assets pipeline updates. Recomputing runs keccak256 (toChecksumAddress) per
++// asset per call, which dominates CPU profiles during transaction approval, so
++// the last result is memoized on input identity.
++let lastCall = null;
+ function formatStateForTransactionPay(params) {
++    if (lastCall &&
++        lastCall.params.assetsBalance === params.assetsBalance &&
++        lastCall.params.assetsInfo === params.assetsInfo &&
++        lastCall.params.assetsPrice === params.assetsPrice &&
++        lastCall.params.selectedCurrency === params.selectedCurrency &&
++        lastCall.params.networkConfigurationsByChainId ===
++            params.networkConfigurationsByChainId &&
++        areAccountsEqual(lastCall.params.accounts, params.accounts) &&
++        areRecordsShallowEqual(lastCall.params.nativeAssetIdentifiers, params.nativeAssetIdentifiers)) {
++        return lastCall.result;
++    }
++    const result = computeStateForTransactionPay(params);
++    lastCall = { params, result };
++    return result;
++}
++function computeStateForTransactionPay(params) {
+     var _a, _b;
+     const { assetsBalance, assetsInfo, assetsPrice, selectedCurrency, accounts, nativeAssetIdentifiers, networkConfigurationsByChainId = {}, } = params;
+     const tokenBalances = {};
+diff --git a/dist/utils/formatStateForTransactionPay.mjs b/dist/utils/formatStateForTransactionPay.mjs
+index ce8029dd048919468e1829e37c4897c7c6203d50..fbb1140f54a6a1eaef56804f85283841560c1dd0 100644
+--- a/dist/utils/formatStateForTransactionPay.mjs
++++ b/dist/utils/formatStateForTransactionPay.mjs
+@@ -27,7 +27,62 @@ function getAmountFromBalance(balance) {
+  * @param params.networkConfigurationsByChainId - Optional chain ID to network config (for native symbol).
+  * @returns Legacy-compatible state for transaction-pay-controller.
+  */
++function areAccountsEqual(a, b) {
++    if (a === b) {
++        return true;
++    }
++    if (a.length !== b.length) {
++        return false;
++    }
++    for (let i = 0; i < a.length; i++) {
++        if (a[i].id !== b[i].id || a[i].address !== b[i].address) {
++            return false;
++        }
++    }
++    return true;
++}
++function areRecordsShallowEqual(a, b) {
++    if (a === b) {
++        return true;
++    }
++    if (!a || !b) {
++        return false;
++    }
++    const aKeys = Object.keys(a);
++    const bKeys = Object.keys(b);
++    if (aKeys.length !== bKeys.length) {
++        return false;
++    }
++    for (const key of aKeys) {
++        if (a[key] !== b[key]) {
++            return false;
++        }
++    }
++    return true;
++}
++// This function is invoked (via AssetsController:getStateForTransactionPay) on
++// every TransactionController:stateChange, but its inputs only change when the
++// assets pipeline updates. Recomputing runs keccak256 (toChecksumAddress) per
++// asset per call, which dominates CPU profiles during transaction approval, so
++// the last result is memoized on input identity.
++let lastCall = null;
+ export function formatStateForTransactionPay(params) {
++    if (lastCall &&
++        lastCall.params.assetsBalance === params.assetsBalance &&
++        lastCall.params.assetsInfo === params.assetsInfo &&
++        lastCall.params.assetsPrice === params.assetsPrice &&
++        lastCall.params.selectedCurrency === params.selectedCurrency &&
++        lastCall.params.networkConfigurationsByChainId ===
++            params.networkConfigurationsByChainId &&
++        areAccountsEqual(lastCall.params.accounts, params.accounts) &&
++        areRecordsShallowEqual(lastCall.params.nativeAssetIdentifiers, params.nativeAssetIdentifiers)) {
++        return lastCall.result;
++    }
++    const result = computeStateForTransactionPay(params);
++    lastCall = { params, result };
++    return result;
++}
++function computeStateForTransactionPay(params) {
+     var _a, _b;
+     const { assetsBalance, assetsInfo, assetsPrice, selectedCurrency, accounts, nativeAssetIdentifiers, networkConfigurationsByChainId = {}, } = params;
+     const tokenBalances = {};

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^10.2.0",
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.2.0#~/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch",
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A109.4.0#~/.yarn/patches/@metamask-assets-controllers-npm-109.4.0-25a362106e.patch",
     "@metamask/authenticated-user-storage": "^3.0.1",
     "@metamask/base-controller": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8013,7 +8013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^10.2.0":
+"@metamask/assets-controller@npm:10.2.0":
   version: 10.2.0
   resolution: "@metamask/assets-controller@npm:10.2.0"
   dependencies:
@@ -8084,6 +8084,43 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
   checksum: 10/5a78033fe14262c938857bcc40bdafe40435f86983634515bc51f2613f2df5e27885b7d504c2d3bb8c02079a34917a46db62ad2da629a90fb9cdc2a48c926419
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.2.0#~/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch":
+  version: 10.2.0
+  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A10.2.0#~/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch::version=10.2.0&hash=af4cfb"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/account-tree-controller": "npm:^7.5.4"
+    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/assets-controllers": "npm:^109.4.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/client-controller": "npm:^1.0.1"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/core-backend": "npm:^6.5.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.4.1"
+    "@metamask/permission-controller": "npm:^13.1.1"
+    "@metamask/phishing-controller": "npm:^17.2.0"
+    "@metamask/polling-controller": "npm:^16.0.8"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/transaction-controller": "npm:^68.3.0"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/3bae85167bda8aecc82d837e1f28f39abf1606e0db5b74a6f73c2d7fe21e130a0812a7b04d6b2776cf252d6a703d720f3596c6d437de92b4db4fcf046acd0784
   languageName: node
   linkType: hard
 
@@ -35945,7 +35982,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^10.2.0"
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A10.2.0#~/.yarn/patches/@metamask-assets-controller-npm-10.2.0-df253abe04.patch"
     "@metamask/assets-controllers": "patch:@metamask/assets-controllers@npm%3A109.4.0#~/.yarn/patches/@metamask-assets-controllers-npm-109.4.0-25a362106e.patch"
     "@metamask/authenticated-user-storage": "npm:^3.0.1"
     "@metamask/auto-changelog": "npm:^5.3.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`formatStateForTransactionPay` in `@metamask/assets-controller` now memoizes its last result on input identity (Yarn patch on 10.2.0, the version instantiated by the Engine).

This function converts the full AssetsController state into the legacy five-controller shape for transaction-pay-controller, checksumming (keccak256) every asset address on every call. It is invoked via the `AssetsController:getStateForTransactionPay` messenger action on every `TransactionController:stateChange` — which fires many times during a single transaction approval, and twice per event through messenger delegation — while its inputs (`assetsBalance`/`assetsInfo`/`assetsPrice` state slices, selected currency, selected accounts, network configurations) only change on assets-pipeline updates.

A CPU profile of the Money account Buy flow on iPhone Pro Max (MUSD-1180) showed keccak via `toChecksumAddress` as the primary bottleneck at 10.4% of all samples (~23% of active CPU), with GC pauses (4.1%) as a symptom of the resulting object churn.

The memoization compares the controller state slices and network configurations by reference (BaseController state updates are immutable, so unchanged slices keep their identity), the currency by value, and the per-call-rebuilt `accounts` array and `nativeAssetIdentifiers` record element-wise. Any real input change recomputes; verified by direct invocation that equal inputs return the cached object, changed balance/account/currency inputs recompute, and the recomputed output is byte-identical to the unpatched function.

Bug: every transaction state event re-ran keccak256 over the full asset list (50+ hashes per event on a multi-chain portfolio), dominating JS-thread CPU during transaction approval and contributing to the sluggish Buy flow.

The proper fix belongs upstream in MetaMask/core; this patch is the mobile-side mitigation and is removable once a fixed package version ships. Companion render-path fixes: #33465.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved transaction approval responsiveness by removing redundant per-event asset state recomputation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1180

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account deposit approval performance

  Scenario: user initiates a Buy/deposit from the Money account
    Given the user has a multi-chain portfolio with many tokens

    When the user opens Add money > Deposit funds and proceeds through the amount screen
    Then the screen responds without multi-second JS-thread stalls

  Scenario: balances still update after approval
    Given the user completes a deposit

    When the assets pipeline refreshes balances
    Then MetaMask Pay token balances and rates reflect the new state (cache invalidates on state change)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no visual change; performance-only. CPU profile evidence in MUSD-1180.

### **After**

N/A — no visual change; performance-only.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path pay/approval state shaping; stale cache would only occur if inputs changed without reference or shallow equality detecting it, which the PR argues is unlikely given immutable controller updates.
> 
> **Overview**
> Adds a **Yarn patch** on `@metamask/assets-controller@10.2.0` so `formatStateForTransactionPay` no longer rebuilds transaction-pay state on every `TransactionController:stateChange`.
> 
> The wrapper **memoizes the last result** when inputs are unchanged: controller state slices and network config by reference, currency by value, and `accounts` / `nativeAssetIdentifiers` via shallow helpers. Otherwise it runs the existing logic under `computeStateForTransactionPay`. **package.json** and **yarn.lock** point the dependency at the patch instead of the plain npm release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521bd42a3025c943131a42c8498e652ea8e52d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->