### PR TITLE
perf(predict): memoize market feed items

### DIFF
--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx
@@ -262,6 +262,14 @@ function setupPredictMarketTest(
 }
 
 describe('PredictMarket', () => {
+  it('does not re-render the market card when props are unchanged', () => {
+    const { rerender } = setupPredictMarketTest(mockSingleMarket);
+
+    rerender(<PredictMarket market={mockSingleMarket} />);
+
+    expect(PredictMarketSingle).toHaveBeenCalledTimes(1);
+  });
+
   it('renders PredictMarketSingle for markets with one outcome', () => {
     const { getByTestId } = setupPredictMarketTest(mockSingleMarket);
 

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -113,4 +113,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
   );
 };
 
-export default PredictMarket;
+const MemoizedPredictMarket: React.FC<PredictMarketProps> =
+  React.memo(PredictMarket);
+
+export default MemoizedPredictMarket;

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -724,6 +724,15 @@ describe('PredictFeed', () => {
   });
 
   describe('market list rendering', () => {
+    it('does not re-render market list items when feed props are unchanged', () => {
+      const { rerender } = render(<PredictFeed />);
+      const initialRenderCount = mockPredictMarket.mock.calls.length;
+
+      rerender(<PredictFeed />);
+
+      expect(mockPredictMarket).toHaveBeenCalledTimes(initialRenderCount);
+    });
+
     it('renders market cards with correct testIDs using 1-based indexing', () => {
       const { getByTestId } = render(<PredictFeed />);
 

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -242,20 +242,22 @@ interface PredictMarketListItemProps {
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
 }
 
-const PredictMarketListItem: React.FC<PredictMarketListItemProps> = ({
-  market,
-  entryPoint,
-  testID,
-  predictFeedTab,
-  transactionActiveAbTests,
-}) => (
-  <PredictMarket
-    market={market}
-    entryPoint={entryPoint}
-    testID={testID}
-    predictFeedTab={predictFeedTab}
-    transactionActiveAbTests={transactionActiveAbTests}
-  />
+const PredictMarketListItem: React.FC<PredictMarketListItemProps> = React.memo(
+  ({
+    market,
+    entryPoint,
+    testID,
+    predictFeedTab,
+    transactionActiveAbTests,
+  }) => (
+    <PredictMarket
+      market={market}
+      entryPoint={entryPoint}
+      testID={testID}
+      predictFeedTab={predictFeedTab}
+      transactionActiveAbTests={transactionActiveAbTests}
+    />
+  ),
 );
 
 interface PredictTabContentProps {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Predict feed parent updates could re-render every visible FlashList market item even when its props were unchanged. This adds `React.memo` at both the shared `PredictMarket` component and the feed-local `PredictMarketListItem` boundary so unchanged rows are skipped while prop and Redux selector updates still render normally.

Regression tests verify that unchanged market card and list item props retain their render count across parent re-renders.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #31323

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict feed market rendering

  Scenario: Feed parent re-renders without market changes
    Given the Predict feed displays market cards

    When the feed parent re-renders with unchanged market props
    Then unchanged market cards do not re-render
```

Automated coverage: `yarn jest app/components/UI/Predict/components/PredictMarket/PredictMarket.test.tsx app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - Internal performance change with no visual output.

### **After**

N/A - Internal performance change with no visual output.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: No platform-specific behavior; automated regression coverage validates the change.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: This render optimization does not depend on account or token scale.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: No new operation or production trace boundary is introduced.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-only optimization with automated regression tests; no API or data-flow changes, though memo still re-renders when props or internal Redux selector values change.
> 
> **Overview**
> Reduces unnecessary work when the Predict feed parent re-renders by wrapping **`PredictMarket`** (default export) and feed-local **`PredictMarketListItem`** in **`React.memo`**, so FlashList rows skip rendering when their props are unchanged.
> 
> Adds regression tests that **`rerender`** with the same props and assert child/card render counts do not increase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9e1a32bd5d38913b80c9884a98346d2325f273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->