### PR TITLE
perf(predict): memoize merged chart data

### DIFF
--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -1053,6 +1053,30 @@ describe('useCryptoUpDownChartData', () => {
       expect(result.current.value).toBe(51500);
     });
 
+    it('reuses merged chart data when inputs are unchanged', async () => {
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+      const { result, rerender } = renderHook(
+        () => useCryptoUpDownChartData(market),
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current.data).toEqual(historicalData);
+      });
+      act(() => {
+        liveUpdateHandler?.({
+          symbol: 'btc/usd',
+          price: 51500,
+          timestamp: 210,
+        });
+      });
+      const mergedChartData = result.current.data;
+
+      rerender({});
+
+      expect(result.current.data).toBe(mergedChartData);
+    });
+
     it('falls back to the target price at event start when history is unavailable', () => {
       const { Wrapper } = createWrapper();
       const market = createMarket();

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -415,11 +415,22 @@ export const useCryptoUpDownChartData = (
     livePointOffsetFromEventStart <= 90;
   const shouldUseFallbackStartPoint =
     stableHistoricalData.length > 0 || firstLivePointIsNearEventStart;
-  const baseHistoricalData = mergeLivelinePoints(
-    shouldUseFallbackStartPoint ? stableFallbackStartPoint : EMPTY_DATA,
-    stableHistoricalData,
+  const chartData = useMemo(
+    () =>
+      mergeLivelinePoints(
+        mergeLivelinePoints(
+          shouldUseFallbackStartPoint ? stableFallbackStartPoint : EMPTY_DATA,
+          stableHistoricalData,
+        ),
+        livePoints,
+      ),
+    [
+      livePoints,
+      shouldUseFallbackStartPoint,
+      stableFallbackStartPoint,
+      stableHistoricalData,
+    ],
   );
-  const chartData = mergeLivelinePoints(baseHistoricalData, livePoints);
   const hasRenderableChartData = chartData.length >= 2;
   const newestLivePointTime = livePoints.at(-1)?.time;
   const liveWindowStartSecs =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`useCryptoUpDownChartData` merged fallback, historical, and live liveline points on every hook render, including renders where none of those inputs changed. This repeated array allocation and sorting on the live chart path.

The two merge passes now run inside `useMemo` and recompute only when fallback selection, fallback points, historical points, or live points change. A regression test verifies that unrelated re-renders reuse the merged chart data reference.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #31270

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Crypto Up/Down chart data memoization

  Scenario: Chart hook re-renders with unchanged point data
    Given fallback, historical, and live chart points are merged

    When the hook re-renders without changing those inputs
    Then the existing merged chart data is reused
```

Automated coverage: `yarn jest app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts --runInBand --coverage=false`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - Internal performance change with no visual output.

### **After**

N/A - Internal performance change with no visual output.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: No platform-specific behavior; automated regression coverage validates the change.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: This render optimization does not depend on account or token scale.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: No new operation or production trace boundary is introduced.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance change in chart data assembly; dependency list matches prior merge inputs and is covered by a reference-stability test.
> 
> **Overview**
> **`useCryptoUpDownChartData`** no longer rebuilds the live chart series on every hook render. Fallback, historical, and live liveline points are merged inside **`useMemo`**, so the double **`mergeLivelinePoints`** pass (allocate + sort) runs only when **`livePoints`**, **`stableHistoricalData`**, fallback selection, or **`stableFallbackStartPoint`** change.
> 
> A new test asserts that after historical + live data are merged, an unrelated **`rerender`** keeps the same **`result.current.data`** reference—guarding the intended render-path optimization for **`PredictCryptoUpDownChart`** / **`LivelineChart`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db112b6765dfd339cfc9e87c502437848d359bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->