### PR TITLE
fix: react compiler issues on ChoosePassword and ManualBackupStep1

### DIFF
--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -768,10 +768,10 @@ describe('ChoosePassword', () => {
   });
 
   describe('Authentication Type Detection', () => {
-    it('reads passcode storage flags when auth type is DEVICE_AUTHENTICATION', async () => {
+    it('reads passcode storage flags when auth type is legacy PASSCODE', async () => {
       const mockGetType = jest.spyOn(Authentication, 'getType');
       mockGetType.mockResolvedValueOnce({
-        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+        currentAuthType: 'device_passcode' as AUTHENTICATION_TYPE,
         availableBiometryType: undefined,
       });
       const mockStorageWrapper = jest.mocked(StorageWrapper);

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -142,11 +142,11 @@ jest.mock('../../../store/storage-wrapper', () => ({
 
 jest.mock('../../../core/Authentication', () => ({
   getType: jest.fn().mockResolvedValue({
-    currentAuthType: 'passcode',
+    currentAuthType: 'device_passcode',
     availableBiometryType: 'faceID',
   }),
   componentAuthenticationType: jest.fn().mockResolvedValue({
-    currentAuthType: 'passcode',
+    currentAuthType: 'device_passcode',
     availableBiometryType: 'faceID',
   }),
   requestBiometricsAccessControlForIOS: jest.fn((authType) =>
@@ -356,6 +356,15 @@ const fillAndSubmitForm = async (
 };
 
 describe('ChoosePassword', () => {
+  const defaultKeyringControllerState = {
+    keyrings: [
+      {
+        type: 'HD Key Tree',
+        accounts: ['0xhd1'],
+      },
+    ],
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrackOnboarding.mockClear();
@@ -363,9 +372,20 @@ describe('ChoosePassword', () => {
     ReduxService.store = store as unknown as ReduxStore;
     mockRefreshGeolocation.mockResolvedValue('GB');
     (Authentication.getType as jest.Mock).mockResolvedValue({
-      currentAuthType: 'passcode',
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- getType still returns PASSCODE
+      currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
       availableBiometryType: 'faceID',
     });
+    (
+      Engine.context.KeyringController as unknown as {
+        state: typeof defaultKeyringControllerState;
+      }
+    ).state = {
+      keyrings: defaultKeyringControllerState.keyrings.map((keyring) => ({
+        ...keyring,
+        accounts: [...keyring.accounts],
+      })),
+    };
     mockRoute.params = {
       [ONBOARDING]: true,
       [PROTECT]: true,
@@ -428,7 +448,10 @@ describe('ChoosePassword', () => {
 
       await act(async () => {
         resolveWalletCreation();
-        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      await waitFor(() => {
+        expect(mockNavigation.replace).toHaveBeenCalled();
       });
 
       mockNewWalletAndKeychain.mockRestore();
@@ -470,7 +493,10 @@ describe('ChoosePassword', () => {
 
       await act(async () => {
         resolveWalletCreation();
-        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      await waitFor(() => {
+        expect(mockNavigation.replace).toHaveBeenCalled();
       });
 
       mockNewWalletAndKeychain.mockRestore();
@@ -984,10 +1010,11 @@ describe('ChoosePassword', () => {
   });
 
   describe('Authentication Type Detection', () => {
-    it('reads passcode storage flags when auth type is legacy PASSCODE', async () => {
+    it('sets passcode biometry type when auth type is PASSCODE', async () => {
       const mockGetType = jest.spyOn(Authentication, 'getType');
-      mockGetType.mockResolvedValueOnce({
-        currentAuthType: 'device_passcode' as AUTHENTICATION_TYPE,
+      mockGetType.mockResolvedValue({
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- getType still returns PASSCODE
+        currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
         availableBiometryType: undefined,
       });
       const mockStorageWrapper = jest.mocked(StorageWrapper);
@@ -1000,8 +1027,12 @@ describe('ChoosePassword', () => {
           return Promise.resolve('true');
         return Promise.resolve(null);
       });
+      jest
+        .spyOn(Authentication, 'newWalletAndKeychain')
+        .mockResolvedValue(undefined);
+      mockTrackOnboarding.mockClear();
 
-      renderWithProviders(<ChoosePassword />);
+      const component = renderWithProviders(<ChoosePassword />);
       await waitForInit();
 
       expect(mockGetType).toHaveBeenCalled();
@@ -1011,20 +1042,21 @@ describe('ChoosePassword', () => {
       expect(mockStorageWrapper.getItem).toHaveBeenCalledWith(
         '@MetaMask:passcodeDisabled',
       );
-      mockGetType.mockRestore();
-    });
 
-    it('treats DEVICE_AUTHENTICATION as device passcode auth type', async () => {
-      const mockGetType = jest.spyOn(Authentication, 'getType');
-      mockGetType.mockResolvedValueOnce({
-        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
-        availableBiometryType: undefined,
+      await fillAndSubmitForm(component, 'StrongPassword123!@#');
+
+      await waitFor(() => {
+        expect(mockTrackOnboarding).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: EVENT_NAME.WALLET_CREATED,
+            properties: expect.objectContaining({
+              biometrics_enabled: true,
+            }),
+          }),
+          expect.any(Function),
+        );
       });
 
-      renderWithProviders(<ChoosePassword />);
-      await waitForInit();
-
-      expect(mockGetType).toHaveBeenCalled();
       mockGetType.mockRestore();
     });
 

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -49,6 +49,12 @@ jest.mock('../../../util/mnemonic', () => ({
   ),
 }));
 
+jest.mock('../../../util/Logger', () => ({
+  error: jest.fn(),
+  log: jest.fn(),
+  warn: jest.fn(),
+}));
+
 jest.mock('@metamask/key-tree', () => ({
   mnemonicPhraseToBytes: jest.fn((_phrase) => new Uint8Array([1, 2, 3])),
 }));
@@ -69,6 +75,7 @@ import type { Span } from '@sentry/core';
 import OAuthLoginService from '../../../core/OAuthService/OAuthService';
 import { captureException } from '@sentry/react-native';
 import Engine from '../../../core/Engine';
+import Logger from '../../../util/Logger';
 
 const mockTrackOnboarding = trackOnboarding as jest.MockedFunction<
   typeof trackOnboarding
@@ -99,6 +106,16 @@ jest.mock('../../../core/Engine', () => ({
         },
       ]),
       importAccountWithStrategy: jest.fn().mockResolvedValue('0x123'),
+      exportAccount: jest.fn().mockResolvedValue('0xprivatekey'),
+      addNewAccount: jest.fn().mockResolvedValue(undefined),
+      state: {
+        keyrings: [
+          {
+            type: 'HD Key Tree',
+            accounts: ['0xhd1'],
+          },
+        ],
+      },
     },
     PreferencesController: {
       setSelectedAddress: jest.fn(),
@@ -345,6 +362,10 @@ describe('ChoosePassword', () => {
     store = mockStore(createInitialState());
     ReduxService.store = store as unknown as ReduxStore;
     mockRefreshGeolocation.mockResolvedValue('GB');
+    (Authentication.getType as jest.Mock).mockResolvedValue({
+      currentAuthType: 'passcode',
+      availableBiometryType: 'faceID',
+    });
     mockRoute.params = {
       [ONBOARDING]: true,
       [PROTECT]: true,
@@ -376,6 +397,41 @@ describe('ChoosePassword', () => {
       expect(() =>
         component.getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
       ).toThrow();
+      expect(
+        component.queryByTestId(ChoosePasswordSelectorsIDs.BACK_BUTTON_ID),
+      ).toBeNull();
+    });
+
+    it('shows back button when not loading and hides it while creating wallet', async () => {
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      let resolveWalletCreation: () => void;
+      const walletCreationPromise = new Promise<void>((resolve) => {
+        resolveWalletCreation = resolve;
+      });
+      mockNewWalletAndKeychain.mockReturnValue(walletCreationPromise);
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+
+      expect(
+        component.getByTestId(ChoosePasswordSelectorsIDs.BACK_BUTTON_ID),
+      ).toBeOnTheScreen();
+
+      await fillAndSubmitForm(component);
+
+      expect(
+        component.queryByTestId(ChoosePasswordSelectorsIDs.BACK_BUTTON_ID),
+      ).toBeNull();
+
+      await act(async () => {
+        resolveWalletCreation();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      mockNewWalletAndKeychain.mockRestore();
     });
 
     it('toggles between form and loading state when wallet creation is in progress', async () => {
@@ -643,6 +699,166 @@ describe('ChoosePassword', () => {
       mockNewWalletAndKeychain.mockRestore();
     });
 
+    it('recreates vault and reimports simple-key accounts for non-onboarding previous screen', async () => {
+      const keyringController = Engine.context.KeyringController as unknown as {
+        state: {
+          keyrings: { type: string; accounts: string[] }[];
+        };
+        exportAccount: jest.Mock;
+        addNewAccount: jest.Mock;
+        importAccountWithStrategy: jest.Mock;
+        exportSeedPhrase: jest.Mock;
+      };
+
+      keyringController.state = {
+        keyrings: [
+          { type: 'HD Key Tree', accounts: ['0xhd1', '0xhd2'] },
+          { type: 'Simple Key Pair', accounts: ['0ximported'] },
+        ],
+      };
+      keyringController.exportAccount = jest
+        .fn()
+        .mockResolvedValue('0xprivatekey');
+      keyringController.addNewAccount = jest.fn().mockResolvedValue(undefined);
+      keyringController.importAccountWithStrategy = jest
+        .fn()
+        .mockResolvedValue('0ximported');
+
+      const mockNewWalletAndRestore = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
+      );
+      mockNewWalletAndRestore.mockResolvedValue(undefined);
+
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: PROTECT,
+      };
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+
+      await fillAndSubmitForm(component, 'StrongPassword123!@#');
+
+      await waitFor(() => {
+        expect(mockNewWalletAndRestore).toHaveBeenCalled();
+      });
+
+      expect(keyringController.exportAccount).toHaveBeenCalledWith(
+        { password: '' },
+        '0ximported',
+      );
+      expect(keyringController.addNewAccount).toHaveBeenCalledTimes(1);
+      expect(keyringController.importAccountWithStrategy).toHaveBeenCalled();
+
+      mockNewWalletAndRestore.mockRestore();
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+      };
+    });
+
+    it('logs and continues when exporting simple-key accounts fails during vault recreate', async () => {
+      const keyringController = Engine.context.KeyringController as unknown as {
+        state: {
+          keyrings: { type: string; accounts: string[] }[];
+        };
+        exportAccount: jest.Mock;
+      };
+
+      keyringController.state = {
+        keyrings: [
+          { type: 'HD Key Tree', accounts: ['0xhd1'] },
+          { type: 'Simple Key Pair', accounts: ['0ximported'] },
+        ],
+      };
+      keyringController.exportAccount = jest
+        .fn()
+        .mockRejectedValue(new Error('export failed'));
+
+      const mockNewWalletAndRestore = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
+      );
+      mockNewWalletAndRestore.mockResolvedValue(undefined);
+
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: PROTECT,
+      };
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+      await fillAndSubmitForm(component, 'StrongPassword123!@#');
+
+      await waitFor(() => {
+        expect(Logger.error).toHaveBeenCalledWith(
+          expect.any(Error),
+          'error while trying to get imported accounts on recreate vault',
+        );
+        expect(mockNewWalletAndRestore).toHaveBeenCalled();
+      });
+
+      mockNewWalletAndRestore.mockRestore();
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+      };
+    });
+
+    it('logs when reimporting private-key accounts fails during vault recreate', async () => {
+      const keyringController = Engine.context.KeyringController as unknown as {
+        state: {
+          keyrings: { type: string; accounts: string[] }[];
+        };
+        exportAccount: jest.Mock;
+        addNewAccount: jest.Mock;
+        importAccountWithStrategy: jest.Mock;
+      };
+
+      keyringController.state = {
+        keyrings: [
+          { type: 'HD Key Tree', accounts: ['0xhd1'] },
+          { type: 'Simple Key Pair', accounts: ['0ximported'] },
+        ],
+      };
+      keyringController.exportAccount = jest
+        .fn()
+        .mockResolvedValue('0xprivatekey');
+      keyringController.addNewAccount = jest.fn().mockResolvedValue(undefined);
+      keyringController.importAccountWithStrategy = jest
+        .fn()
+        .mockRejectedValue(new Error('import failed'));
+
+      const mockNewWalletAndRestore = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
+      );
+      mockNewWalletAndRestore.mockResolvedValue(undefined);
+
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: PROTECT,
+      };
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+      await fillAndSubmitForm(component, 'StrongPassword123!@#');
+
+      await waitFor(() => {
+        expect(Logger.error).toHaveBeenCalledWith(
+          expect.any(Error),
+          'error while trying to import accounts on recreate vault',
+        );
+      });
+
+      mockNewWalletAndRestore.mockRestore();
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+      };
+    });
+
     it('calls exportSeedPhrase after SRP wallet creation', async () => {
       const mockExportSeedPhrase = Engine.context.KeyringController
         .exportSeedPhrase as jest.Mock;
@@ -795,6 +1011,21 @@ describe('ChoosePassword', () => {
       expect(mockStorageWrapper.getItem).toHaveBeenCalledWith(
         '@MetaMask:passcodeDisabled',
       );
+      mockGetType.mockRestore();
+    });
+
+    it('treats DEVICE_AUTHENTICATION as device passcode auth type', async () => {
+      const mockGetType = jest.spyOn(Authentication, 'getType');
+      mockGetType.mockResolvedValueOnce({
+        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+        availableBiometryType: undefined,
+      });
+
+      renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+
+      expect(mockGetType).toHaveBeenCalled();
+      mockGetType.mockRestore();
     });
 
     it('reads biometry storage flags when face ID is available', async () => {
@@ -823,6 +1054,7 @@ describe('ChoosePassword', () => {
       expect(mockStorageWrapper.getItem).toHaveBeenCalledWith(
         '@MetaMask:passcodeDisabled',
       );
+      mockGetType.mockRestore();
     });
 
     it('uses PASSWORD auth type for wallet creation when biometrics are declined on iOS', async () => {

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -768,10 +768,10 @@ describe('ChoosePassword', () => {
   });
 
   describe('Authentication Type Detection', () => {
-    it('reads passcode storage flags when auth type is PASSCODE', async () => {
+    it('reads passcode storage flags when auth type is DEVICE_AUTHENTICATION', async () => {
       const mockGetType = jest.spyOn(Authentication, 'getType');
       mockGetType.mockResolvedValueOnce({
-        currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
+        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
         availableBiometryType: undefined,
       });
       const mockStorageWrapper = jest.mocked(StorageWrapper);
@@ -1366,7 +1366,7 @@ describe('ChoosePassword', () => {
 
       mockComponentAuthenticationType.mockReset();
       mockComponentAuthenticationType.mockResolvedValue({
-        currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
+        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
         availableBiometryType: BIOMETRY_TYPE.FACE_ID,
       });
     });
@@ -1414,7 +1414,7 @@ describe('ChoosePassword', () => {
 
       mockComponentAuthenticationType.mockReset();
       mockComponentAuthenticationType.mockResolvedValue({
-        currentAuthType: AUTHENTICATION_TYPE.PASSCODE,
+        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
         availableBiometryType: BIOMETRY_TYPE.FACE_ID,
       });
     });

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -129,6 +129,40 @@ interface ExtendedKeyringController {
   ) => Promise<string>;
 }
 
+async function exportSimpleKeyPairAccounts(
+  keyringController: ExtendedKeyringController,
+  keychainPassword: string,
+): Promise<string[]> {
+  const simpleKeyrings = keyringController.state.keyrings.filter(
+    (keyring) => keyring.type === 'Simple Key Pair',
+  );
+  const importedAccounts: string[] = [];
+  for (const simpleKeyring of simpleKeyrings) {
+    const simpleKeyringAccounts = await Promise.all(
+      simpleKeyring.accounts.map((account) =>
+        keyringController.exportAccount(
+          { password: keychainPassword },
+          account,
+        ),
+      ),
+    );
+    importedAccounts.push(...simpleKeyringAccounts);
+  }
+  return importedAccounts;
+}
+
+async function reimportPrivateKeyAccounts(
+  keyringController: ExtendedKeyringController,
+  importedAccounts: string[],
+): Promise<void> {
+  for (const importedAccount of importedAccounts) {
+    await keyringController.importAccountWithStrategy(
+      AccountImportStrategy.privateKey,
+      [importedAccount],
+    );
+  }
+}
+
 const ChoosePassword = () => {
   const { themeAppearance } = useContext(ThemeContext);
   const tw = useTailwind();
@@ -158,7 +192,6 @@ const ChoosePassword = () => {
   const [biometryType, setBiometryType] = useState<string | null>(null);
   const [isPasswordFieldFocused, setIsPasswordFieldFocused] = useState(false);
 
-  const mounted = useRef(true);
   const passwordSetupAttemptTraceCtx = useRef<TraceContext | null>(null);
   const confirmPasswordInputRef = useRef<TextInput | null>(null);
   // Flag to know if password in keyring was set or not
@@ -275,23 +308,13 @@ const ChoosePassword = () => {
         password: keychainPassword,
       });
       const seedPhrase = uint8ArrayToMnemonic(seedPhraseUint8, wordlist);
+
       let importedAccounts: string[] = [];
-      // Get imported accounts
       try {
-        const simpleKeyrings = keyringController.state.keyrings.filter(
-          (keyring) => keyring.type === 'Simple Key Pair',
+        importedAccounts = await exportSimpleKeyPairAccounts(
+          keyringController,
+          keychainPassword,
         );
-        for (const simpleKeyring of simpleKeyrings) {
-          const simpleKeyringAccounts = await Promise.all(
-            simpleKeyring.accounts.map((account) =>
-              keyringController.exportAccount(
-                { password: keychainPassword },
-                account,
-              ),
-            ),
-          );
-          importedAccounts = [...importedAccounts, ...simpleKeyringAccounts];
-        }
       } catch (e) {
         Logger.error(
           e as Error,
@@ -320,12 +343,7 @@ const ChoosePassword = () => {
 
       // Import imported accounts again
       try {
-        for (const importedAccount of importedAccounts) {
-          await context.KeyringController.importAccountWithStrategy(
-            AccountImportStrategy.privateKey,
-            [importedAccount],
-          );
-        }
+        await reimportPrivateKeyAccounts(keyringController, importedAccounts);
       } catch (e) {
         Logger.error(
           e as Error,
@@ -421,7 +439,7 @@ const ChoosePassword = () => {
   }, [navigation]);
 
   const handlePostWalletCreation = useCallback(
-    async (authType: AuthData, marketingOptInChecked: boolean) => {
+    async (authType: AuthData, isMarketingOptedIn: boolean) => {
       dispatch(passwordSetAction());
       dispatch(setLockTimeAction(AppConstants.DEFAULT_LOCK_TIMEOUT));
 
@@ -442,8 +460,8 @@ const ChoosePassword = () => {
       endTrace({ name: TraceName.OnboardingNewSocialCreateWallet });
       endTrace({ name: TraceName.OnboardingJourneyOverall });
 
-      dispatch(setDataCollectionForMarketing(marketingOptInChecked));
-      OAuthLoginService.updateMarketingOptInStatus(marketingOptInChecked).catch(
+      dispatch(setDataCollectionForMarketing(isMarketingOptedIn));
+      OAuthLoginService.updateMarketingOptInStatus(isMarketingOptedIn).catch(
         (err) => {
           Logger.error(err);
         },
@@ -455,26 +473,28 @@ const ChoosePassword = () => {
           ? getSocialAccountType(oauthProvider, false)
           : undefined;
 
+      const analyticsProperties = {
+        [UserProfileProperty.HAS_MARKETING_CONSENT]:
+          Boolean(isMarketingOptedIn),
+        is_metrics_opted_in: true,
+        location: 'onboarding_choosePassword',
+        updated_after_onboarding: false,
+        ...(socialAccountType && { account_type: socialAccountType }),
+      };
+      const identifyTraits = {
+        ...generateDeviceAnalyticsMetaData(),
+        ...generateUserSettingsAnalyticsMetaData(),
+      };
+
       try {
         metrics.trackEvent(
           metrics
             .createEventBuilder(MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED)
-            .addProperties({
-              [UserProfileProperty.HAS_MARKETING_CONSENT]: Boolean(
-                marketingOptInChecked,
-              ),
-              is_metrics_opted_in: true,
-              location: 'onboarding_choosePassword',
-              updated_after_onboarding: false,
-              ...(socialAccountType && { account_type: socialAccountType }),
-            })
+            .addProperties(analyticsProperties)
             .build(),
         );
 
-        await metrics.identify({
-          ...generateDeviceAnalyticsMetaData(),
-          ...generateUserSettingsAnalyticsMetaData(),
-        });
+        await metrics.identify(identifyTraits);
       } catch (analyticsError) {
         Logger.error(analyticsError as Error);
       }
@@ -564,21 +584,12 @@ const ChoosePassword = () => {
     [recreateVault, dispatch, track, route.params, navigation],
   );
 
-  const onPressCreate = useCallback(async () => {
-    const validation = validatePasswordSubmission();
-    if (!validation.valid) return;
-
-    const provider = route.params?.provider;
-    const accountType = provider
-      ? getSocialAccountType(provider, false)
-      : AccountType.Metamask;
-    const isSocialLogin = getOauth2LoginSuccess();
-
-    track(MetaMetricsEvents.WALLET_CREATION_ATTEMPTED, {
-      account_type: accountType,
-    });
-
-    try {
+  const runWalletCreation = useCallback(
+    async (
+      accountType: AccountType,
+      isSocialLogin: boolean | undefined,
+      provider: ChoosePasswordRouteParams['provider'],
+    ) => {
       setLoading(true);
       const previous_screen = route.params?.[PREVIOUS_SCREEN];
 
@@ -630,21 +641,45 @@ const ChoosePassword = () => {
       });
 
       endTrace({ name: TraceName.OnboardingSRPAccountCreationTime });
+    },
+    [
+      route.params,
+      biometryType,
+      handleWalletCreation,
+      handlePostWalletCreation,
+      track,
+      marketingOptInChecked,
+    ],
+  );
+
+  const onPressCreate = useCallback(async () => {
+    const validation = validatePasswordSubmission();
+    if (!validation.valid) return;
+
+    const provider = route.params?.provider;
+    const accountType = provider
+      ? getSocialAccountType(provider, false)
+      : AccountType.Metamask;
+    const isSocialLogin = getOauth2LoginSuccess();
+
+    track(MetaMetricsEvents.WALLET_CREATION_ATTEMPTED, {
+      account_type: accountType,
+    });
+
+    try {
+      await runWalletCreation(accountType, isSocialLogin, provider);
     } catch (err) {
       const metricsEnabled = metrics.isEnabled();
       await handleWalletCreationError(err as Error, metricsEnabled);
     }
   }, [
     validatePasswordSubmission,
-    route.params,
+    route.params?.provider,
     track,
     getOauth2LoginSuccess,
-    biometryType,
-    handleWalletCreation,
-    handlePostWalletCreation,
+    runWalletCreation,
     handleWalletCreationError,
     metrics,
-    marketingOptInChecked,
   ]);
 
   const onPasswordChange = useCallback(
@@ -710,7 +745,9 @@ const ChoosePassword = () => {
       await StorageWrapper.getItem(BIOMETRY_CHOICE_DISABLED);
       await StorageWrapper.getItem(PASSCODE_DISABLED);
 
-      if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSCODE) {
+      if (
+        authData.currentAuthType === AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION
+      ) {
         setBiometryType(passcodeType(authData.currentAuthType));
       } else if (authData.availableBiometryType) {
         setBiometryType(authData.availableBiometryType);
@@ -720,10 +757,9 @@ const ChoosePassword = () => {
     initBiometrics();
   }, [route.params?.onboardingTraceCtx]);
 
-  //Reset mounted flag and end trace on unmount
+  // End password-setup trace on unmount
   useEffect(
     () => () => {
-      mounted.current = false;
       if (passwordSetupAttemptTraceCtx.current) {
         endTrace({ name: TraceName.OnboardingPasswordSetupAttempt });
         passwordSetupAttemptTraceCtx.current = null;
@@ -757,9 +793,11 @@ const ChoosePassword = () => {
         <HeaderStandard
           includesTopInset
           onBack={loading ? undefined : () => navigation.goBack()}
-          backButtonProps={{
-            testID: ChoosePasswordSelectorsIDs.BACK_BUTTON_ID,
-          }}
+          backButtonProps={
+            loading
+              ? undefined
+              : { testID: ChoosePasswordSelectorsIDs.BACK_BUTTON_ID }
+          }
         />
         {loading ? (
           <Box

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -746,12 +746,12 @@ const ChoosePassword = () => {
       await StorageWrapper.getItem(PASSCODE_DISABLED);
 
       const isDevicePasscodeAuth =
-        authData.currentAuthType ===
-          AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION ||
-        authData.currentAuthType === ('device_passcode' as AUTHENTICATION_TYPE);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- still returned by Authentication.getType()
+        authData.currentAuthType === AUTHENTICATION_TYPE.PASSCODE;
 
       if (isDevicePasscodeAuth) {
-        setBiometryType(passcodeType(authData.currentAuthType));
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- passcodeType expects PASSCODE
+        setBiometryType(passcodeType(AUTHENTICATION_TYPE.PASSCODE));
       } else if (authData.availableBiometryType) {
         setBiometryType(authData.availableBiometryType);
       }

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -745,9 +745,12 @@ const ChoosePassword = () => {
       await StorageWrapper.getItem(BIOMETRY_CHOICE_DISABLED);
       await StorageWrapper.getItem(PASSCODE_DISABLED);
 
-      if (
-        authData.currentAuthType === AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION
-      ) {
+      const isDevicePasscodeAuth =
+        authData.currentAuthType ===
+          AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION ||
+        authData.currentAuthType === ('device_passcode' as AUTHENTICATION_TYPE);
+
+      if (isDevicePasscodeAuth) {
         setBiometryType(passcodeType(authData.currentAuthType));
       } else if (authData.availableBiometryType) {
         setBiometryType(authData.availableBiometryType);

--- a/app/components/Views/ManualBackupStep1/ManualBackupStep1.types.ts
+++ b/app/components/Views/ManualBackupStep1/ManualBackupStep1.types.ts
@@ -11,11 +11,6 @@ export interface ManualBackupStep1Params {
    * Takes precedence over fetching from keyring.
    */
   seedPhrase?: string[];
-  /**
-   * @deprecated Use seedPhrase instead. Kept for backwards compatibility.
-   * Words passed from previous screen as fallback.
-   */
-  words?: string[];
 }
 
 /**

--- a/app/components/Views/ManualBackupStep1/index.test.tsx
+++ b/app/components/Views/ManualBackupStep1/index.test.tsx
@@ -140,7 +140,6 @@ const createMockNavigation = () => ({
 
 interface SetupOptions {
   seedPhrase?: string[];
-  words?: string[];
   backupFlow?: boolean;
   settingsBackup?: boolean;
 }
@@ -186,7 +185,6 @@ const renderPasswordView = async () => {
 
   const result = renderComponent({
     seedPhrase: undefined,
-    words: undefined,
     backupFlow: false,
     settingsBackup: false,
   });
@@ -530,7 +528,6 @@ describe('ManualBackupStep1', () => {
 
       const { wrapper } = renderComponent({
         seedPhrase: undefined,
-        words: undefined,
         backupFlow: false,
         settingsBackup: false,
       });
@@ -552,7 +549,6 @@ describe('ManualBackupStep1', () => {
 
       renderComponent({
         seedPhrase: undefined,
-        words: [],
         backupFlow: false,
         settingsBackup: false,
       });

--- a/app/components/Views/ManualBackupStep1/index.test.tsx
+++ b/app/components/Views/ManualBackupStep1/index.test.tsx
@@ -86,6 +86,13 @@ jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
+jest.mock('../../../util/mnemonic', () => ({
+  uint8ArrayToMnemonic: jest.fn(
+    () =>
+      'abstract accident acoustic announce apple april argue artistic atmosphere aunt around awesome',
+  ),
+}));
+
 jest.mock('../../../core/Engine', () => {
   const mockHasFundsFn = jest.fn().mockReturnValue(true);
   const mockExportSeedPhraseFn = jest.fn().mockResolvedValue(new Uint8Array());
@@ -547,7 +554,7 @@ describe('ManualBackupStep1', () => {
       mockGetPassword.mockResolvedValue({ password: 'test-password' });
       mockExportSeedPhrase.mockResolvedValue(new Uint8Array([0]));
 
-      renderComponent({
+      const { wrapper } = renderComponent({
         seedPhrase: undefined,
         backupFlow: false,
         settingsBackup: false,
@@ -555,7 +562,55 @@ describe('ManualBackupStep1', () => {
 
       await waitFor(() => {
         expect(mockGetPassword).toHaveBeenCalled();
+        expect(mockExportSeedPhrase).toHaveBeenCalledWith({
+          password: 'test-password',
+        });
       });
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByTestId(ManualBackUpStepsSelectorsIDs.BLUR_BUTTON),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('shows password view when getPassword returns false', async () => {
+      mockGetPassword.mockResolvedValue(false);
+
+      const { wrapper } = renderComponent({
+        seedPhrase: undefined,
+        backupFlow: false,
+        settingsBackup: false,
+      });
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByTestId(
+            ManualBackUpStepsSelectorsIDs.CONFIRM_PASSWORD_INPUT,
+          ),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('shows password view when seed phrase export fails after credentials resolve', async () => {
+      mockGetPassword.mockResolvedValue({ password: 'test-password' });
+      mockExportSeedPhrase.mockRejectedValue(new Error('export failed'));
+
+      const { wrapper } = renderComponent({
+        seedPhrase: undefined,
+        backupFlow: false,
+        settingsBackup: false,
+      });
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByTestId(
+            ManualBackUpStepsSelectorsIDs.CONFIRM_PASSWORD_INPUT,
+          ),
+        ).toBeOnTheScreen();
+      });
+
+      expect(Logger.error).toHaveBeenCalled();
     });
   });
 
@@ -583,6 +638,12 @@ describe('ManualBackupStep1', () => {
         expect(mockExportSeedPhrase).toHaveBeenCalledWith({
           password: 'correct-password',
         });
+      });
+
+      await waitFor(() => {
+        expect(
+          wrapper.getByTestId(ManualBackUpStepsSelectorsIDs.BLUR_BUTTON),
+        ).toBeOnTheScreen();
       });
     });
 

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -102,13 +96,16 @@ const ManualBackupStep1 = () => {
     [saveOnboardingEvent],
   );
 
-  const tryExportSeedPhrase = async (pwd: string): Promise<string[]> => {
-    const { KeyringController } = Engine.context;
-    const uint8ArrayMnemonic = await KeyringController.exportSeedPhrase({
-      password: pwd,
-    });
-    return uint8ArrayToMnemonic(uint8ArrayMnemonic, wordlist).split(' ');
-  };
+  const tryExportSeedPhrase = useCallback(
+    async (pwd: string): Promise<string[]> => {
+      const { KeyringController } = Engine.context;
+      const uint8ArrayMnemonic = await KeyringController.exportSeedPhrase({
+        password: pwd,
+      });
+      return uint8ArrayToMnemonic(uint8ArrayMnemonic, wordlist).split(' ');
+    },
+    [],
+  );
 
   const showWhatIsSeedphrase = useCallback(() => {
     showSeedphraseDefinition({
@@ -130,39 +127,48 @@ const ManualBackupStep1 = () => {
         return;
       }
 
-      const wordsFromParams = route.params?.words;
-      if (wordsFromParams && wordsFromParams.length > 0) {
-        if (!cancelled) {
-          setWords(wordsFromParams);
-          setReady(true);
+      let credentials: Awaited<ReturnType<typeof Authentication.getPassword>>;
+      let exportError: unknown;
+      let exportedWords: string[] | undefined;
+
+      try {
+        credentials = await Authentication.getPassword();
+      } catch (e) {
+        exportError = e;
+      }
+
+      if (cancelled) return;
+
+      if (
+        !exportError &&
+        credentials &&
+        credentials !== false &&
+        typeof credentials.password === 'string'
+      ) {
+        try {
+          exportedWords = await tryExportSeedPhrase(credentials.password);
+        } catch (e) {
+          exportError = e;
         }
+      }
+
+      if (cancelled) return;
+
+      if (exportedWords) {
+        setWords(exportedWords);
+        setReady(true);
         return;
       }
 
-      try {
-        const credentials = await Authentication.getPassword();
-        if (cancelled) return;
-
-        if (credentials && !cancelled) {
-          const exportedWords = await tryExportSeedPhrase(credentials.password);
-          if (!cancelled) {
-            setWords(exportedWords);
-            setReady(true);
-          }
-        } else if (!cancelled) {
-          setView(CONFIRM_PASSWORD);
-          setReady(true);
-        }
-      } catch (e) {
+      if (exportError) {
         const srpRecoveryError = new Error(
           'Error trying to recover SRP from keyring-controller',
         );
         Logger.error(srpRecoveryError);
-        if (!cancelled) {
-          setView(CONFIRM_PASSWORD);
-          setReady(true);
-        }
       }
+
+      setView(CONFIRM_PASSWORD);
+      setReady(true);
     };
 
     initializeSeedPhrase();
@@ -170,8 +176,7 @@ const ManualBackupStep1 = () => {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [seedPhrase, tryExportSeedPhrase]);
 
   useEffect(() => {
     // Check if user has funds
@@ -215,39 +220,41 @@ const ManualBackupStep1 = () => {
     track(MetaMetricsEvents.WALLET_SECURITY_PHRASE_REVEALED, {});
   };
 
-  const isMountedRef = useRef(true);
+  const tryUnlockWithPassword = useCallback(
+    async (pwd: string) => {
+      setReady(false);
+      let unlockError: unknown;
+      let exportedSeedPhrase: string[] | undefined;
 
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
+      try {
+        exportedSeedPhrase = await tryExportSeedPhrase(pwd);
+      } catch (e) {
+        unlockError = e;
+      }
+
+      if (exportedSeedPhrase) {
+        setWords(exportedSeedPhrase);
+        setView(SEED_PHRASE);
+      } else if (unlockError) {
+        let msg = strings('reveal_credential.warning_incorrect_password');
+        if (
+          String(unlockError).toLowerCase() !==
+          WRONG_PASSWORD_ERROR.toLowerCase()
+        ) {
+          msg = strings('reveal_credential.unknown_error');
+        }
+        setWarningIncorrectPassword(msg);
+      }
+      setReady(true);
     },
-    [],
+    [tryExportSeedPhrase],
   );
 
-  const tryUnlockWithPassword = async (pwd: string) => {
-    setReady(false);
-    try {
-      const exportedSeedPhrase = await tryExportSeedPhrase(pwd);
-      if (!isMountedRef.current) return;
-      setWords(exportedSeedPhrase);
-      setView(SEED_PHRASE);
-      setReady(true);
-    } catch (e) {
-      if (!isMountedRef.current) return;
-      let msg = strings('reveal_credential.warning_incorrect_password');
-      if (String(e).toLowerCase() !== WRONG_PASSWORD_ERROR.toLowerCase()) {
-        msg = strings('reveal_credential.unknown_error');
-      }
-      setWarningIncorrectPassword(msg);
-      setReady(true);
-    }
-  };
-
-  const tryUnlock = () => {
+  const tryUnlock = useCallback(() => {
     if (password) {
       tryUnlockWithPassword(password);
     }
-  };
+  }, [password, tryUnlockWithPassword]);
 
   const renderSeedPhraseConcealer = () => (
     <SeedPhraseConcealer

--- a/app/components/Views/ManualBackupStep1/index.tsx
+++ b/app/components/Views/ManualBackupStep1/index.tsx
@@ -127,7 +127,8 @@ const ManualBackupStep1 = () => {
         return;
       }
 
-      let credentials: Awaited<ReturnType<typeof Authentication.getPassword>>;
+      let credentials: Awaited<ReturnType<typeof Authentication.getPassword>> =
+        null;
       let exportError: unknown;
       let exportedWords: string[] | undefined;
 
@@ -142,7 +143,6 @@ const ManualBackupStep1 = () => {
       if (
         !exportError &&
         credentials &&
-        credentials !== false &&
         typeof credentials.password === 'string'
       ) {
         try {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Make ChoosePassword and ManualBackupStep1 for React Compiler optimization.

Why: The compiler skipped these screens due to Rules-of-React / BuildHIR limits — exhaustive-deps suppressions, value blocks inside try/catch, and catch-path state updates. ChoosePassword also kept showing the header back control on the Fox loading screen because HeaderStandard renders back whenever backButtonProps is set, even if onBack is undefined.

What changed:

* ChoosePassword: extract vault helpers; hoist analytics out of try/catch; split runWalletCreation; remove unused mounted ref; use DEVICE_AUTHENTICATION; hide back button while loading
* ManualBackupStep1: remove exhaustive-deps disable with real deps; move state updates out of catch; remove isMountedRef; drop deprecated words param (use seedPhrase only)

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-927. https://consensyssoftware.atlassian.net/browse/TO-928

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: ChoosePassword and ManualBackupStep1 React Compiler compatibility

  Scenario: Create password for a new SRP wallet
    Given a user is creating a new wallet with Secret Recovery Phrase
    When the user enters a valid password and confirmation and continues
    Then the Fox loading screen is shown without a header back button
    And onboarding continues to Manual Backup Step 1 with the seed phrase

  Scenario: Create password for a social login wallet
    Given a user completes social login and lands on Choose Password
    When the user enters a valid password and continues
    Then the Fox loading screen is shown without a header back button
    And onboarding continues to the success / questionnaire flow as before

  Scenario: Manual backup seed phrase reveal
    Given a user is on Manual Backup Step 1 with a seed phrase available
    When the user reveals the seed phrase and continues
    Then Manual Backup Step 2 opens with the same words

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/cf3d995d-a308-44b5-87ed-0be9c107d2b3


https://github.com/user-attachments/assets/a2d68433-2106-43ca-a837-79bc395bae67




<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding wallet creation, vault recreate/import, and SRP export flows; behavior should be equivalent but regressions would affect new-wallet and manual backup paths.
> 
> **Overview**
> Refactors **ChoosePassword** and **ManualBackupStep1** so React Compiler can optimize them: fewer Rules-of-React violations (state updates in `catch`, value blocks in `try/catch`, suppressed hook deps) and a small onboarding UX fix on the Fox loading screen.
> 
> On **ChoosePassword**, vault recreate logic moves into `exportSimpleKeyPairAccounts` / `reimportPrivateKeyAccounts`; wallet creation is split into `runWalletCreation` with analytics payloads built outside `try/catch`; biometry init checks `DEVICE_AUTHENTICATION` instead of `PASSCODE`; the unused `mounted` ref is removed. **While `loading` is true, `backButtonProps` is omitted** so the header back control does not show during wallet creation.
> 
> On **ManualBackupStep1**, seed recovery and password unlock use success/error variables instead of updating state inside `catch`; `isMountedRef` is removed; the init effect depends on `seedPhrase` and `tryExportSeedPhrase`. The deprecated route param **`words` is removed**—only `seedPhrase` is supported—and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc155531be6edd2ab200f875f23596d16b63ac79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->