### PR TITLE
refactor: make ImportNewSecretRecoveryPhrase React Compiler compatible

### DIFF
--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
@@ -115,6 +115,11 @@ jest.mock('../../hooks/useAccountsWithNetworkActivitySync', () => ({
   }),
 }));
 
+jest.mock('../../../util/Logger', () => ({
+  error: jest.fn(),
+  log: jest.fn(),
+}));
+
 const valid12WordMnemonic =
   'lazy youth dentist air relief leave neither liquid belt aspect bone frame';
 
@@ -698,6 +703,46 @@ describe('ImportNewSecretRecoveryPhrase', () => {
       expect(mockImportNewSecretRecoveryPhrase).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
     });
+
+    it('shows error alert when seedless password check throws', async () => {
+      const mockAlert = jest.spyOn(Alert, 'alert');
+      mockCheckIsSeedlessPasswordOutdated.mockRejectedValueOnce(
+        new Error('seedless password check failed'),
+      );
+      mockGetString.mockResolvedValue(valid12WordMnemonic);
+
+      const { getByTestId, getByText } = renderScreen(
+        ImportNewSecretRecoveryPhrase,
+        { name: 'ImportNewSecretRecoveryPhrase' },
+        {
+          state: initialState,
+        },
+      );
+
+      const pasteButton = getByText(messages.import_from_seed.paste);
+
+      await act(async () => {
+        await fireEvent.press(pasteButton);
+      });
+
+      await waitFor(() => {
+        expect(getByTestId(ImportSRPIDs.IMPORT_BUTTON)).toBeEnabled();
+      });
+
+      await act(async () => {
+        await fireEvent.press(getByTestId(ImportSRPIDs.IMPORT_BUTTON));
+      });
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith(
+          messages.import_new_secret_recovery_phrase.error_title,
+          messages.import_new_secret_recovery_phrase.error_message,
+        );
+      });
+      expect(mockImportNewSecretRecoveryPhrase).not.toHaveBeenCalled();
+
+      mockAlert.mockRestore();
+    });
   });
 
   describe('QR scanner', () => {
@@ -1167,6 +1212,33 @@ describe('ImportNewSecretRecoveryPhrase', () => {
       );
 
       mockAlert.mockRestore();
+    });
+
+    it('logs error when QR scan fails', async () => {
+      const Logger = jest.requireMock('../../../util/Logger');
+      const { getByTestId } = renderScreen(
+        ImportNewSecretRecoveryPhrase,
+        { name: 'ImportNewSecretRecoveryPhrase' },
+        {
+          state: initialState,
+        },
+      );
+
+      await act(async () => {
+        await fireEvent.press(getByTestId('qr-code-button'));
+      });
+
+      const navigateCall = mockNavigate.mock.calls.find(
+        (call) => call[0] === 'QRTabSwitcher',
+      );
+      const onScanError = navigateCall[1].onScanError;
+      const scanError = new Error('camera permission denied');
+
+      await act(async () => {
+        onScanError(scanError);
+      });
+
+      expect(Logger.error).toHaveBeenCalledWith(scanError, 'QR scan error');
     });
   });
 

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
@@ -63,6 +63,34 @@ import {
   validateMnemonic,
 } from './validation';
 
+async function checkSeedlessPasswordOutdated(): Promise<boolean> {
+  return Authentication.checkIsSeedlessPasswordOutdated({
+    skipCache: true,
+    captureSentryError: true,
+  });
+}
+
+function showImportSrpErrorAlert(errorMessage: string): void {
+  switch (errorMessage) {
+    case DUPLICATE_MNEMONIC_ERROR_MESSAGES[0]:
+    case DUPLICATE_MNEMONIC_ERROR_MESSAGES[1]:
+      Alert.alert(
+        strings('import_new_secret_recovery_phrase.error_duplicate_srp'),
+      );
+      break;
+    case 'KeyringController - The account you are trying to import is a duplicate':
+      Alert.alert(
+        strings('import_new_secret_recovery_phrase.error_duplicate_account'),
+      );
+      break;
+    default:
+      Alert.alert(
+        strings('import_new_secret_recovery_phrase.error_title'),
+        strings('import_new_secret_recovery_phrase.error_message'),
+      );
+  }
+}
+
 /**
  * View that's displayed when the user is trying to import a new secret recovery phrase
  */
@@ -100,11 +128,10 @@ const ImportNewSecretRecoveryPhrase = () => {
     [seedPhrase],
   );
 
+  // Clear validation errors whenever the seed phrase changes.
+  // Always calling setError('') is safe — React bails out when value is unchanged.
   useEffect(() => {
-    if (error) {
-      setError('');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setError('');
   }, [seedPhrase]);
 
   const dismiss = useCallback(() => {
@@ -133,8 +160,8 @@ const ImportNewSecretRecoveryPhrase = () => {
           );
         }
       },
-      onScanError: (error: unknown) => {
-        Logger.error(error as Error, 'QR scan error');
+      onScanError: (scanError: unknown) => {
+        Logger.error(scanError as Error, 'QR scan error');
       },
     });
   }, [navigation]);
@@ -145,19 +172,22 @@ const ImportNewSecretRecoveryPhrase = () => {
     });
   }, [navigation]);
 
-  const trackDiscoveryEvent = (discoveredAccountsCount: number) => {
-    trackEvent(
-      createEventBuilder(
-        MetaMetricsEvents.IMPORT_SECRET_RECOVERY_PHRASE_COMPLETED,
-      )
-        .addProperties({
-          number_of_solana_accounts_discovered: discoveredAccountsCount,
-        })
-        .build(),
-    );
-  };
+  const trackDiscoveryEvent = useCallback(
+    (discoveredAccountsCount: number) => {
+      trackEvent(
+        createEventBuilder(
+          MetaMetricsEvents.IMPORT_SECRET_RECOVERY_PHRASE_COMPLETED,
+        )
+          .addProperties({
+            number_of_solana_accounts_discovered: discoveredAccountsCount,
+          })
+          .build(),
+      );
+    },
+    [trackEvent, createEventBuilder],
+  );
 
-  const onSubmit = async () => {
+  const onSubmit = useCallback(async () => {
     const phrase = seedPhrase
       .map((item) => item.trim())
       .filter((item) => item !== '')
@@ -178,19 +208,23 @@ const ImportNewSecretRecoveryPhrase = () => {
     }
 
     setLoading(true);
-    try {
-      // check if seedless pwd is outdated skip cache before importing SRP
-      const isSeedlessPwdOutdated =
-        await Authentication.checkIsSeedlessPasswordOutdated({
-          skipCache: true,
-          captureSentryError: true,
-        });
-      if (isSeedlessPwdOutdated) {
-        // no need to handle error here, password outdated state will trigger modal that force user to log out
-        setLoading(false);
-        return;
-      }
 
+    let isSeedlessPwdOutdated = false;
+    try {
+      isSeedlessPwdOutdated = await checkSeedlessPasswordOutdated();
+    } catch (e) {
+      showImportSrpErrorAlert((e as Error)?.message);
+      setLoading(false);
+      return;
+    }
+
+    if (isSeedlessPwdOutdated) {
+      // Password outdated state will trigger modal that force user to log out
+      setLoading(false);
+      return;
+    }
+
+    try {
       await importNewSecretRecoveryPhrase(
         phrase,
         undefined,
@@ -198,51 +232,39 @@ const ImportNewSecretRecoveryPhrase = () => {
           trackDiscoveryEvent(discoveredAccountsCount);
         },
       );
-
-      setLoading(false);
-      setSeedPhrase(['']);
-
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: `${strings('import_new_secret_recovery_phrase.success_1')} ${
-              hdKeyrings.length + 1
-            } ${strings('import_new_secret_recovery_phrase.success_2')}`,
-          },
-        ],
-        iconName: ComponentIconName.Check,
-        hasNoTimeout: false,
-      });
-
-      fetchAccountsWithActivity();
-
-      navigation.navigate('WalletView');
     } catch (e) {
-      const errorMessage = (e as Error)?.message;
-      switch (errorMessage) {
-        case DUPLICATE_MNEMONIC_ERROR_MESSAGES[0]:
-        case DUPLICATE_MNEMONIC_ERROR_MESSAGES[1]:
-          Alert.alert(
-            strings('import_new_secret_recovery_phrase.error_duplicate_srp'),
-          );
-          break;
-        case 'KeyringController - The account you are trying to import is a duplicate':
-          Alert.alert(
-            strings(
-              'import_new_secret_recovery_phrase.error_duplicate_account',
-            ),
-          );
-          break;
-        default:
-          Alert.alert(
-            strings('import_new_secret_recovery_phrase.error_title'),
-            strings('import_new_secret_recovery_phrase.error_message'),
-          );
-      }
+      showImportSrpErrorAlert((e as Error)?.message);
       setLoading(false);
+      return;
     }
-  };
+
+    setLoading(false);
+    setSeedPhrase(['']);
+
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      labelOptions: [
+        {
+          label: `${strings('import_new_secret_recovery_phrase.success_1')} ${
+            hdKeyrings.length + 1
+          } ${strings('import_new_secret_recovery_phrase.success_2')}`,
+        },
+      ],
+      iconName: ComponentIconName.Check,
+      hasNoTimeout: false,
+    });
+
+    fetchAccountsWithActivity();
+
+    navigation.navigate('WalletView');
+  }, [
+    seedPhrase,
+    trackDiscoveryEvent,
+    toastRef,
+    hdKeyrings.length,
+    fetchAccountsWithActivity,
+    navigation,
+  ]);
 
   return (
     <Box twClassName="flex-1 bg-default">


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Makes the multi-SRP **Import New Secret Recovery Phrase** screen (`Routes.MULTI_SRP.IMPORT` / `ImportSRPView`) React Compiler compatible without changing user-facing behavior.

**Why:** An `eslint-disable-next-line react-hooks/exhaustive-deps` caused React Compiler to skip optimizing this component. Conditionals and alert branching inside `try/catch` are also known bailout patterns.

**What changed:**
- Removed the `exhaustive-deps` disable by clearing validation errors with `setError('')` whenever `seedPhrase` changes.
- Extracted `checkSeedlessPasswordOutdated` and `showImportSrpErrorAlert` helpers outside the component; hoisted async results / conditionals out of `try/catch`.
- Wrapped `trackDiscoveryEvent` and `onSubmit` in `useCallback`; renamed shadowed QR `error` param to `scanError`.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-926

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Import New Secret Recovery Phrase

 Scenario: user imports an additional SRP from Add Wallet
    Given the user is unlocked with an existing wallet
    And the user opens Account selector then Add wallet actions
    When the user taps Import wallet
    And pastes a valid unused 12-word Secret Recovery Phrase
    And taps Continue
    Then the SRP is imported successfully
    And a success toast is shown
    And the user lands on WalletView

  Scenario: user sees an error for a duplicate SRP
    Given the user is on the Import New Secret Recovery Phrase screen
    When the user pastes an SRP that is already imported
    And taps Continue
    Then a duplicate SRP error alert is shown
    And the user remains on the import screen

   Scenario: validation error clears when the phrase is edited
    Given the user has a validation error on the import screen
    When the user edits or clears the seed phrase
    Then the validation error is cleared
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 467cb4babe8bbd009998beb5a3186868c921237f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->