### PR TITLE
chore: QuickBuy update direction property as trade_type

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -320,7 +320,7 @@ describe('QuickBuyRoot', () => {
       expect.objectContaining({
         [QuickBuyEventProperties.ASSET_NAME]: 'PEPE',
         [QuickBuyEventProperties.SOURCE]: 'market_insights',
-        [QuickBuyEventProperties.TRADER_TRADE_TYPE]: 'buy',
+        [QuickBuyEventProperties.TRADE_TYPE]: 'buy',
       }),
     );
   });
@@ -342,7 +342,7 @@ describe('QuickBuyRoot', () => {
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
-  it('includes market_cap, original_entry_point and trader_trade_type from analyticsContext when provided', () => {
+  it('includes market_cap, original_entry_point and trade_type from analyticsContext when provided', () => {
     renderWithProvider(
       <QuickBuyRoot
         isVisible
@@ -369,7 +369,7 @@ describe('QuickBuyRoot', () => {
         [QuickBuyEventProperties.MARKET_CAP]: 1_500_000,
         [QuickBuyEventProperties.SOURCE]: 'profile_position',
         [QuickBuyEventProperties.ORIGINAL_ENTRY_POINT]: 'leaderboard',
-        [QuickBuyEventProperties.TRADER_TRADE_TYPE]: 'sell',
+        [QuickBuyEventProperties.TRADE_TYPE]: 'sell',
       },
     );
   });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -130,9 +130,8 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     track(MetaMetricsEvents.SOCIAL_QUICK_BUY_SHEET_VIEWED, {
       [QuickBuyEventProperties.ASSET_NAME]: target.tokenSymbol,
       ...buildQuickBuySharedAnalyticsProperties(analyticsContext),
-      [QuickBuyEventProperties.TRADER_TRADE_TYPE]:
-        analyticsContext.traderTradeType ??
-        QuickBuyEventValues.TRADER_TRADE_TYPE.BUY,
+      [QuickBuyEventProperties.TRADE_TYPE]:
+        analyticsContext.traderTradeType ?? QuickBuyEventValues.TRADE_TYPE.BUY,
     });
   }, [analyticsContext, target.tokenSymbol, track]);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/buildQuickBuySharedAnalyticsProperties.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/buildQuickBuySharedAnalyticsProperties.ts
@@ -9,7 +9,7 @@ import type { QuickBuyAnalyticsContext } from '../types';
 export function buildQuickBuySharedAnalyticsProperties(
   analyticsContext?: Pick<
     QuickBuyAnalyticsContext,
-    'source' | 'originalEntryPoint' | 'marketCap' | 'traderTradeType'
+    'source' | 'originalEntryPoint' | 'marketCap'
   >,
 ): Record<string, string | number | boolean> {
   const props: Record<string, string | number | boolean> = {};
@@ -23,10 +23,6 @@ export function buildQuickBuySharedAnalyticsProperties(
   }
   if (typeof analyticsContext?.marketCap === 'number') {
     props[QuickBuyEventProperties.MARKET_CAP] = analyticsContext.marketCap;
-  }
-  if (analyticsContext?.traderTradeType) {
-    props[QuickBuyEventProperties.TRADER_TRADE_TYPE] =
-      analyticsContext.traderTradeType;
   }
 
   return props;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics/quickBuyEvents.ts
@@ -32,7 +32,6 @@ export const QuickBuyEventProperties = {
   STATUS: 'status',
   TRADE_TYPE: 'trade_type',
   TRADER_ADDRESS: 'trader_address',
-  TRADER_TRADE_TYPE: 'trader_trade_type',
   TX_HASH: 'tx_hash',
 } as const;
 
@@ -58,7 +57,7 @@ export const QuickBuyEventValues = {
     SUCCESS: 'success',
     FAILED: 'failed',
   },
-  TRADER_TRADE_TYPE: {
+  TRADE_TYPE: {
     BUY: 'buy',
     SELL: 'sell',
   },

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.test.ts
@@ -53,6 +53,10 @@ jest.mock('../analytics', () => {
         RECEIVE_TOKEN_SELECTED: 'receive_token_selected',
         SLIPPAGE_CHANGED: 'slippage_changed',
       },
+      TRADE_TYPE: {
+        BUY: 'buy',
+        SELL: 'sell',
+      },
     },
   };
 });
@@ -294,6 +298,53 @@ describe('useQuickBuyAnalytics', () => {
           [QuickBuyEventProperties.PREVIOUS_SLIPPAGE]: '0.5',
         }),
       );
+    });
+
+    it('includes trade_type when tradeMode is provided', () => {
+      const { result } = renderHook(() =>
+        useQuickBuyAnalytics(TRADER, CAIP19, undefined, 'buy'),
+      );
+
+      act(() => {
+        result.current.trackQuoteSelected(0, 1);
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.SOCIAL_QUICK_BUY_INTERACTED,
+        expect.objectContaining({
+          [QuickBuyEventProperties.TRADE_TYPE]:
+            QuickBuyEventValues.TRADE_TYPE.BUY,
+        }),
+      );
+    });
+
+    it('includes trade_type as sell when tradeMode is sell', () => {
+      const { result } = renderHook(() =>
+        useQuickBuyAnalytics(TRADER, CAIP19, undefined, 'sell'),
+      );
+
+      act(() => {
+        result.current.trackPayWithSelected('USDC', 'ETH');
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.SOCIAL_QUICK_BUY_INTERACTED,
+        expect.objectContaining({
+          [QuickBuyEventProperties.TRADE_TYPE]:
+            QuickBuyEventValues.TRADE_TYPE.SELL,
+        }),
+      );
+    });
+
+    it('does not include trade_type when tradeMode is not provided', () => {
+      const { result } = renderHook(() => useQuickBuyAnalytics(TRADER, CAIP19));
+
+      act(() => {
+        result.current.trackQuoteSelected(0, 1);
+      });
+
+      const call = mockTrack.mock.calls[0][1];
+      expect(call).not.toHaveProperty(QuickBuyEventProperties.TRADE_TYPE);
     });
 
     it('is a no-op when traderAddress is empty', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyAnalytics.ts
@@ -9,7 +9,7 @@ import {
   QuickBuyEventProperties,
   QuickBuyEventValues,
 } from '../analytics';
-import type { QuickBuyAnalyticsContext } from '../types';
+import type { QuickBuyAnalyticsContext, QuickBuyTradeMode } from '../types';
 
 type QuickBuyDismissStage =
   (typeof QuickBuyEventValues.DISMISS_STAGE)[keyof typeof QuickBuyEventValues.DISMISS_STAGE];
@@ -29,6 +29,7 @@ export function useQuickBuyAnalytics(
   traderAddress: string,
   caip19: string,
   analyticsContext?: QuickBuyAnalyticsContext,
+  tradeMode?: QuickBuyTradeMode,
 ): {
   refs: QuickBuyAnalyticsRefs;
   trackAmountSelected: (
@@ -68,7 +69,6 @@ export function useQuickBuyAnalytics(
     source: analyticsSource,
     originalEntryPoint,
     marketCap,
-    traderTradeType,
   } = analyticsContext ?? {};
 
   const sharedAnalyticsProps = useMemo(
@@ -77,9 +77,8 @@ export function useQuickBuyAnalytics(
         source: analyticsSource,
         originalEntryPoint,
         marketCap,
-        traderTradeType,
       }),
-    [analyticsSource, originalEntryPoint, marketCap, traderTradeType],
+    [analyticsSource, originalEntryPoint, marketCap],
   );
 
   // Dismiss cleanup must run only on unmount. `sharedAnalyticsProps` updates when
@@ -167,10 +166,13 @@ export function useQuickBuyAnalytics(
         [QuickBuyEventProperties.TRADER_ADDRESS]: resolvedTraderAddress,
         [QuickBuyEventProperties.CAIP19]: caip19,
         [QuickBuyEventProperties.INTERACTION_TYPE]: interactionType,
+        ...(tradeMode !== undefined
+          ? { [QuickBuyEventProperties.TRADE_TYPE]: tradeMode }
+          : {}),
         ...props,
       });
     },
-    [resolvedTraderAddress, caip19, track, sharedAnalyticsProps],
+    [resolvedTraderAddress, caip19, track, sharedAnalyticsProps, tradeMode],
   );
 
   const trackQuoteSelected = useCallback(

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -255,6 +255,8 @@ export function useQuickBuyController(
     [target.chain, target.tokenAddress],
   );
 
+  const [tradeMode, setTradeMode] = useState<QuickBuyTradeMode>('buy');
+
   const {
     refs: { lastInputMethodRef, lastTrackedAmountRef, submitStartedAtRef },
     trackAmountSelected,
@@ -266,9 +268,7 @@ export function useQuickBuyController(
     trackTradeSubmitted,
     trackTradeCompleted,
     markTradeSubmitted,
-  } = useQuickBuyAnalytics(traderAddress, caip19, analyticsContext);
-
-  const [tradeMode, setTradeMode] = useState<QuickBuyTradeMode>('buy');
+  } = useQuickBuyAnalytics(traderAddress, caip19, analyticsContext, tradeMode);
   const [fiatAmount, setFiatAmount] = useState('');
   const [sourceAmountTokens, setSourceAmountTokens] = useState('');
   // True when the user has committed the slider to 100% ("sell all"). In this


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Replaces the two overlapping direction properties (trader_trade_type auto-spread via shared props, and trade_type already in submitted/completed tradeBaseProps) with a single trade_type key that carries the user's actual selected mode (buy | sell) at event time.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-900

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ea81d1379508806754c2f2c203c3d0cb297b3358. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->