### PR TITLE
fix(money): suppress amount-update error toast on dismissed confirmation (MUSD-1188)

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { merge, noop } from 'lodash';
 import { ToastContext } from '../../../../../../component-library/components/Toast';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import Engine from '../../../../../../core/Engine';
 import {
   CustomAmountInfo,
   CustomAmountInfoProps,
@@ -96,6 +97,9 @@ jest.mock('../../../../../../core/Engine', () => ({
     TransactionPayController: {
       updateFiatPayment: jest.fn(),
     },
+    TransactionController: {
+      state: { transactions: [] },
+    },
   },
 }));
 jest.mock('../../PayAccountSelector', () => {
@@ -189,6 +193,15 @@ jest.mock('../../../../../UI/Ramp/hooks/useRampsPaymentMethods', () => ({
 
 const TOKEN_ADDRESS_MOCK = '0x123' as Hex;
 const CHAIN_ID_MOCK = '0x1' as Hex;
+const TRANSACTION_ID_MOCK = 'tx-mock-id';
+
+function setControllerTransactions(transactions: { id: string }[]) {
+  (
+    Engine.context.TransactionController as unknown as {
+      state: { transactions: { id: string }[] };
+    }
+  ).state = { transactions };
+}
 
 const mockShowToast = jest.fn();
 const mockToastRef = {
@@ -389,6 +402,8 @@ describe('CustomAmountInfo', () => {
     useMoneyNoFeeTokensMock.mockReturnValue({ isMoneyNoFeeToken: false });
     usePayWithMoneyAccountSectionMock.mockReturnValue(null);
     useAccountNoFundsAlertMock.mockReturnValue([]);
+
+    setControllerTransactions([]);
   });
 
   it('renders amount', () => {
@@ -666,6 +681,12 @@ describe('CustomAmountInfo', () => {
     const error = new Error('update failed');
     const updateTokenAmountMock = jest.fn().mockRejectedValue(error);
     const mockOnAmountSubmit = jest.fn();
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      type: TransactionType.contractInteraction,
+      txParams: { from: '0x123' },
+    } as never);
+    setControllerTransactions([{ id: TRANSACTION_ID_MOCK }]);
     useTransactionCustomAmountMock.mockReturnValue({
       amountFiat: '123.45',
       amountHuman: '0',
@@ -700,6 +721,88 @@ describe('CustomAmountInfo', () => {
     );
     // Keyboard stays open: Done button still present
     expect(queryByText(strings('confirm.edit_amount_done'))).toBeOnTheScreen();
+  });
+
+  it('does not show toast when the transaction was removed before updateTokenAmount rejects', async () => {
+    const error = new Error(
+      `Cannot update transaction as ID not found - ${TRANSACTION_ID_MOCK}`,
+    );
+    const updateTokenAmountMock = jest.fn().mockRejectedValue(error);
+    const mockOnAmountSubmit = jest.fn();
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      type: TransactionType.contractInteraction,
+      txParams: { from: '0x123' },
+    } as never);
+    // Confirmation dismissed by back navigation: the transaction is gone.
+    setControllerTransactions([]);
+    useTransactionCustomAmountMock.mockReturnValue({
+      amountFiat: '123.45',
+      amountHuman: '0',
+      amountHumanDebounced: '0',
+      amountFiatDebounced: '0',
+      hasInput: true,
+      isDepositPrefillEnabled: false,
+      isDepositPrefilled: false,
+      isInputChanged: false,
+      isPrefillPending: false,
+      isDepositPrefillLoading: false,
+      updatePendingAmount: noop,
+      updatePendingAmountPercentage: noop,
+      updateTokenAmount: updateTokenAmountMock,
+    });
+
+    const { getByText } = render({
+      onAmountSubmit: mockOnAmountSubmit,
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+    });
+
+    expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockOnAmountSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not show toast when only unrelated transactions remain after the tracked one is removed', async () => {
+    const error = new Error('update failed');
+    const updateTokenAmountMock = jest.fn().mockRejectedValue(error);
+    const mockOnAmountSubmit = jest.fn();
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      type: TransactionType.contractInteraction,
+      txParams: { from: '0x123' },
+    } as never);
+    // Tracked transaction is gone; an unrelated one still lingers in state.
+    setControllerTransactions([{ id: 'unrelated-tx-id' }]);
+    useTransactionCustomAmountMock.mockReturnValue({
+      amountFiat: '123.45',
+      amountHuman: '0',
+      amountHumanDebounced: '0',
+      amountFiatDebounced: '0',
+      hasInput: true,
+      isDepositPrefillEnabled: false,
+      isDepositPrefilled: false,
+      isInputChanged: false,
+      isPrefillPending: false,
+      isDepositPrefillLoading: false,
+      updatePendingAmount: noop,
+      updatePendingAmountPercentage: noop,
+      updateTokenAmount: updateTokenAmountMock,
+    });
+
+    const { getByText } = render({
+      onAmountSubmit: mockOnAmountSubmit,
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+    });
+
+    expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockOnAmountSubmit).not.toHaveBeenCalled();
   });
 
   it('renders PayAccountSelector when supportAccountSelection is true', () => {
@@ -984,6 +1087,7 @@ describe('CustomAmountInfo', () => {
         type: TransactionType.moneyAccountDeposit,
         txParams: { from: '0x123' },
       } as never);
+      setControllerTransactions([{ id: 'tx-1' }]);
       useTransactionPayFiatPaymentMock.mockReturnValue({
         selectedPaymentMethodId: '/payments/debit-credit-card',
         amountFiat: '100',

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -263,6 +263,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         // has been successfully applied above (no-op for non-money flows).
         trackAmountCommitted();
       } catch (error) {
+        const isConfirmationDismissed =
+          !Engine.context.TransactionController.state.transactions.some(
+            (tx) => tx.id === transactionId,
+          );
+        if (isConfirmationDismissed) {
+          return;
+        }
         const prefixed = prefixError(error, AMOUNT_UPDATE_ERROR_PREFIX);
         toastRef?.current?.showToast(
           getAmountUpdateErrorToastOptions(prefixed, () =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Navigating back from the money account card (MM Pay) to token details briefly flashed an error toast: `MetaMask Pay: Amount Update: Money Account Deposit: Cannot update transaction as ID not found`.

Back navigation rejects the confirmation and removes its transaction from the `TransactionController`. A pending deposit prefill auto-submit can still run the amount update against the now-removed transaction id, which rejects with "Cannot update transaction as ID not found". `handleDone`'s catch then surfaced that failure as a toast.

The fix checks the live `TransactionController` state inside `handleDone`'s catch: if the confirmation's transaction no longer exists, the update failure is a benign teardown race and the toast is suppressed. Genuine update failures (transaction still present, e.g. a reverted `previewDeposit`) still surface the toast.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an error message that flashed when navigating back from the money account card to token details.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1188](https://consensyssoftware.atlassian.net/browse/MUSD-1188)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account card navigation

  Scenario: user navigates back from the money account card to token details
    Given user is on the token details screen

    When user selects the money account card to open MM Pay
    And user navigates back to token details
    Then no error message toast is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Error toast flashed on back navigation from the money account card to token details (see MUSD-1188).

### **After**

No error toast is shown on back navigation.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1188]: https://consensyssoftware.atlassian.net/browse/MUSD-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX fix in confirmation error handling; genuine update failures while the transaction still exists are unchanged.
> 
> **Overview**
> Fixes a **flash error toast** when leaving MM Pay (money account card) back to token details: a late `updateTokenAmount` failure after the confirmation transaction was already removed was treated like a real update error.
> 
> In **`handleDone`**’s `catch`, the flow now checks **`TransactionController`** for the current transaction id. If it’s gone (dismissed confirmation / back navigation), the handler **returns without showing the amount-update toast** or advancing the flow. **Real failures** while the transaction is still present still show the toast and keep the keyboard open for retry.
> 
> Tests extend the **Engine** mock with **`TransactionController.state.transactions`**, add **`setControllerTransactions`**, and cover: toast when the tx exists on reject; **no toast** when the tracked tx was removed (including when unrelated txs remain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a2431f9624b22b2c0cdb8147b3baa60e447920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->