### PR TITLE
feat(perps): show caret icon in market header clickable area cp-8.4.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketInlineHeader/PerpsMarketInlineHeader.tsx
@@ -8,7 +8,10 @@ import {
   ButtonIconSize,
   FontWeight,
   HeaderSubpage,
+  Icon,
+  IconColor,
   IconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -118,6 +121,13 @@ export const PerpsMarketInlineHeader = ({
               {displayTitle}
             </Text>
             {leverageBadge}
+            {onIdentityPress ? (
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Xs}
+                color={IconColor.IconAlternative}
+              />
+            ) : null}
           </Box>
           <Text
             variant={TextVariant.BodySm}


### PR DESCRIPTION
## **Description**

In the Perps market detail header, the tappable market identity area (token icon + asset name + leverage badge) opens the market list, but there was no visual affordance indicating it was interactive.

This PR adds a right-facing chevron (`>`) icon after the leverage badge inside the clickable identity area, matching the [Figma design](https://www.figma.com/design/RKxgK44BoVRyKtmjjP4SFc/PERPS---13-Jul---xx-Nov?node-id=10042-13211&m=dev). The icon is only rendered when the identity area is actually pressable (i.e. when `onIdentityPress` is provided), so non-interactive usages of the header remain unchanged. No other behavior was modified.

## **Changelog**

CHANGELOG entry: Added a caret icon to the Perps market header to indicate the asset name area is tappable and opens the market list.

## **Related issues**

Fixes: https://consensys.slack.com/archives/C092T3GPHQD/p1784540153926999

## **Manual testing steps**

```gherkin
Feature: Perps market header clickable affordance

  Scenario: user views the perps market detail header
    Given the user is on a Perps market detail screen
    Then a ">" caret icon is shown after the leverage badge next to the asset name

  Scenario: user taps the market identity area
    Given the user is on a Perps market detail screen
    When the user taps the asset icon/name/leverage area (showing the caret)
    Then the market list opens
```

## **Screenshots/Recordings**

### **Before**

<!-- No caret icon shown next to the asset name/leverage badge. -->

### **After**

<img width="1206" height="2622" alt="simulator_screenshot_D784FA67-8CF7-4444-B861-4184F097B892" src="https://github.com/user-attachments/assets/5343e736-f58f-4334-b4c5-fdb07f60dc04" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual affordance in Perps header UI with no logic, API, or data-handling changes.
> 
> **Overview**
> Adds a small **right-arrow icon** after the leverage badge in the Perps market detail header identity row so users can see the asset name area opens the market list, aligned with Figma.
> 
> The chevron is **only shown when `onIdentityPress` is set** (detail layout with a pressable identity); compact or non-interactive header usages are unchanged. No navigation or callback behavior was modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b01f77d9b9321edfe764e6a4f1fe64df2aacffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->