### PR TITLE
fix(perps): show readable minimum order size error on reverse

### DIFF
--- a/app/components/UI/Perps/utils/translatePerpsError.test.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.test.ts
@@ -18,6 +18,7 @@ jest.mock('@metamask/perps-controller', () => {
       MARKETS_FAILED: 'MARKETS_FAILED',
       UNKNOWN_ERROR: 'UNKNOWN_ERROR',
       ORDER_LEVERAGE_REDUCTION_FAILED: 'ORDER_LEVERAGE_REDUCTION_FAILED',
+      ORDER_SIZE_MIN: 'ORDER_SIZE_MIN',
       IOC_CANCEL: 'IOC_CANCEL',
       CONNECTION_TIMEOUT: 'CONNECTION_TIMEOUT',
       WITHDRAW_INSUFFICIENT_BALANCE: 'WITHDRAW_INSUFFICIENT_BALANCE',
@@ -395,6 +396,51 @@ describe('handlePerpsError', () => {
         'perps.errors.providerNotAvailable',
         {
           providerId: 'Unknown',
+        },
+      );
+    });
+  });
+
+  describe('with ORDER_SIZE_MIN error', () => {
+    it('uses amount from context', () => {
+      const result = handlePerpsError({
+        error: PERPS_ERROR_CODES.ORDER_SIZE_MIN,
+        context: { amount: '25' },
+      });
+
+      expect(result).toBe('perps.order.validation.minimum_amount [amount:25]');
+      expect(strings).toHaveBeenCalledWith(
+        'perps.order.validation.minimum_amount',
+        {
+          amount: '25',
+        },
+      );
+    });
+
+    it('falls back to the default minimum order size when amount is not provided', () => {
+      const result = handlePerpsError({
+        error: PERPS_ERROR_CODES.ORDER_SIZE_MIN,
+      });
+
+      // Should never leak the raw `{{amount}}` placeholder to users
+      expect(result).toBe('perps.order.validation.minimum_amount [amount:10]');
+      expect(strings).toHaveBeenCalledWith(
+        'perps.order.validation.minimum_amount',
+        {
+          amount: '10',
+        },
+      );
+    });
+
+    it('falls back to the default minimum order size for Error object without amount', () => {
+      const error = new Error(PERPS_ERROR_CODES.ORDER_SIZE_MIN);
+      const result = handlePerpsError({ error });
+
+      expect(result).toBe('perps.order.validation.minimum_amount [amount:10]');
+      expect(strings).toHaveBeenCalledWith(
+        'perps.order.validation.minimum_amount',
+        {
+          amount: '10',
         },
       );
     });

--- a/app/components/UI/Perps/utils/translatePerpsError.ts
+++ b/app/components/UI/Perps/utils/translatePerpsError.ts
@@ -1,6 +1,7 @@
 import { strings } from '../../../../../locales/i18n';
 import {
   PERPS_ERROR_CODES,
+  TRADING_DEFAULTS,
   type PerpsErrorCode,
   type PerpsDebugLogger,
 } from '@metamask/perps-controller';
@@ -368,6 +369,14 @@ export function handlePerpsError(params: HandlePerpsErrorParams): string {
         break;
       case PERPS_ERROR_CODES.PROVIDER_NOT_AVAILABLE:
         errorParams.providerId = context?.providerId || 'Unknown';
+        break;
+      case PERPS_ERROR_CODES.ORDER_SIZE_MIN:
+        // The minimum order size message requires an `amount` for interpolation.
+        // Fall back to the default minimum order size when no amount is provided
+        // (e.g. flip/reverse position errors surfaced via toast) so we never leak
+        // the raw `{{amount}}` placeholder to users.
+        errorParams.amount =
+          context?.amount || TRADING_DEFAULTS.amount.mainnet.toString();
         break;
       // Add other error codes that need parameters as they arise
       default:


### PR DESCRIPTION
## **Description**

When reversing (flipping) a perps position with an amount below the minimum order size, the bottom sheet / toast displayed the raw i18n placeholder text `Minimum order size is $[missing {{amount}} value]` instead of a readable message.

**Reason for the change:** The controller rejects the order with the `ORDER_SIZE_MIN` error code. That error is surfaced through a toast via `PerpsToastOptions.orderManagement.market.creationFailed(error)`, which calls `handlePerpsError`. `handlePerpsError` correctly maps `ORDER_SIZE_MIN` to the i18n key `perps.order.validation.minimum_amount` (`"Minimum order size is ${{amount}}"`), but never supplied the `{{amount}}` interpolation value, so i18n rendered the literal placeholder. The regular order form flow (`usePerpsOrderValidation`) already passes `amount`, which is why this only reproduced on the toast-driven paths such as reversing a position.

**Solution:** Added an `ORDER_SIZE_MIN` case in `handlePerpsError` that always provides an `amount` for interpolation — using `context.amount` when available and falling back to the default minimum order size (`TRADING_DEFAULTS.amount.mainnet`, i.e. `$10`). This centrally guarantees the placeholder is never leaked to users from any caller. Added test coverage for the new case (including the `Error` object variant) and registered `ORDER_SIZE_MIN` in the test's `PERPS_ERROR_CODES` mock.

## **Changelog**

CHANGELOG entry: Fixed a bug where reversing a perps position below the minimum order size showed a raw text placeholder instead of a readable error message.

## **Related issues**

Fixes: #33493

## **Manual testing steps**

```gherkin
Feature: Perps reverse position minimum order size error

  Scenario: user reverses a position below the minimum order size
    Given the user has an open perps position smaller than the minimum order size
    And the user opens the "Reverse Position" bottom sheet

    When the user taps "Reverse"
    Then an "Order failed" message is shown
    And the message reads "Minimum order size is $10" with a readable amount
    And no raw "{{amount}}" placeholder text is displayed
```

## **Screenshots/Recordings**

### **Before**

The reverse position sheet showed: `Minimum order size is $[missing {{amount}} value]`.

### **After**

The message now renders a readable value, e.g. `Minimum order size is $10`.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
