### PR TITLE
refactor: make ImportFromSecretRecoveryPhrase React Compiler compatible

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -111,6 +111,60 @@ import { importNewSecretRecoveryPhrase } from '../../../actions/multiSrp';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
+function handleWalletImportFailure({
+  importError,
+  track,
+  navigation,
+  isMetricsEnabled,
+  onboardingTraceCtx,
+}) {
+  track(MetaMetricsEvents.WALLET_SETUP_FAILURE, {
+    wallet_setup_type: 'import',
+    error_type: importError.toString(),
+  });
+
+  if (onboardingTraceCtx) {
+    trace({
+      name: TraceName.OnboardingPasswordSetupError,
+      op: TraceOperation.OnboardingUserJourney,
+      parentContext: onboardingTraceCtx,
+      tags: { errorMessage: importError.toString() },
+    });
+    endTrace({ name: TraceName.OnboardingPasswordSetupError });
+  }
+
+  if (importError.toString() === PASSCODE_NOT_SET_ERROR) {
+    Alert.alert(
+      'Security Alert',
+      'In order to proceed, you need to turn Passcode on or any biometrics authentication method supported in your device (FaceID, TouchID or Fingerprint)',
+    );
+    return;
+  }
+
+  const metricsEnabled = isMetricsEnabled();
+
+  if (metricsEnabled) {
+    captureException(importError, {
+      tags: {
+        view: 'ImportFromSecretRecoveryPhrase',
+        context: 'Wallet import failed - auto reported',
+      },
+    });
+  }
+
+  navigation.reset({
+    routes: [
+      {
+        name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
+        params: {
+          metricsEnabled,
+          error: importError,
+        },
+      },
+    ],
+  });
+}
+
 /**
  * View where users can set restore their account
  * using a secret recovery phrase (SRP)
@@ -153,7 +207,7 @@ const ImportFromSecretRecoveryPhrase = ({
   const [isPasswordFieldFocused, setIsPasswordFieldFocused] = useState(false);
 
   const srpInputGridRef = useRef(null);
-  const slideAnim = useRef(new Animated.Value(0)).current;
+  const [slideAnim] = useState(() => new Animated.Value(0));
   const [currentInputWord, setCurrentInputWord] = useState('');
 
   const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
@@ -172,10 +226,7 @@ const ImportFromSecretRecoveryPhrase = ({
   }, [seedPhrase]);
 
   useEffect(() => {
-    if (error) {
-      setError('');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setError('');
   }, [seedPhrase]);
 
   useEffect(() => {
@@ -187,11 +238,14 @@ const ImportFromSecretRecoveryPhrase = ({
 
   const { isEnabled: isMetricsEnabled } = useAnalytics();
 
-  const track = (event, properties) => {
-    const eventBuilder = AnalyticsEventBuilder.createEventBuilder(event);
-    eventBuilder.addProperties(properties);
-    trackOnboarding(eventBuilder.build(), saveOnboardingEvent);
-  };
+  const track = useCallback(
+    (event, properties) => {
+      const eventBuilder = AnalyticsEventBuilder.createEventBuilder(event);
+      eventBuilder.addProperties(properties);
+      trackOnboarding(eventBuilder.build(), saveOnboardingEvent);
+    },
+    [saveOnboardingEvent],
+  );
 
   const onQrCodePress = useCallback(() => {
     let shouldHideSRP = true;
@@ -214,7 +268,7 @@ const ImportFromSecretRecoveryPhrase = ({
         }
         setHideSeedPhraseInput(shouldHideSRP);
       },
-      onScanError: (error) => {
+      onScanError: () => {
         setHideSeedPhraseInput(shouldHideSRP);
       },
     });
@@ -260,14 +314,22 @@ const ImportFromSecretRecoveryPhrase = ({
   };
 
   // The header is rendered in-screen via HeaderStandard, so hide the native one.
-  const updateNavBar = () => {
+  const updateNavBar = useCallback(() => {
     navigation.setOptions({ headerShown: false });
-  };
+  }, [navigation]);
 
   useEffect(() => {
     updateNavBar();
+  }, [updateNavBar, currentStep]);
+
+  useEffect(() => {
+    let cancelled = false;
+
     const setBiometricsOption = async () => {
       const authData = await Authentication.getType();
+      if (cancelled || !authData) {
+        return;
+      }
       if (authData.currentAuthType === AUTHENTICATION_TYPE.PASSCODE) {
         setBiometryType(passcodeType(authData.currentAuthType));
       } else if (authData.availableBiometryType) {
@@ -277,7 +339,9 @@ const ImportFromSecretRecoveryPhrase = ({
 
     setBiometricsOption();
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+    };
   }, [currentStep]);
 
   useEffect(
@@ -387,154 +451,113 @@ const ImportFromSecretRecoveryPhrase = ({
 
     if (loading) return;
     track(MetaMetricsEvents.WALLET_IMPORT_ATTEMPTED);
-    let error = null;
+    let setupError = null;
     if (!passwordRequirementsMet(password)) {
-      error = strings('import_from_seed.password_length_error');
+      setupError = strings('import_from_seed.password_length_error');
     } else if (password !== confirmPassword) {
-      error = strings('import_from_seed.password_dont_match');
+      setupError = strings('import_from_seed.password_dont_match');
     }
 
     if (failedSeedPhraseRequirements(parsedSeed)) {
-      error = strings('import_from_seed.seed_phrase_requirements');
+      setupError = strings('import_from_seed.seed_phrase_requirements');
     } else if (!isValidMnemonic(parsedSeed)) {
-      error = strings('import_from_seed.invalid_seed_phrase');
+      setupError = strings('import_from_seed.invalid_seed_phrase');
     }
 
-    if (error) {
+    if (setupError) {
       track(MetaMetricsEvents.WALLET_SETUP_FAILURE, {
         wallet_setup_type: 'import',
-        error_type: error,
+        error_type: setupError,
       });
-    } else {
-      try {
-        setLoading(true);
-        const onboardingTraceCtx = route?.params?.onboardingTraceCtx;
-        const oauthLoginSuccess = route?.params?.oauthLoginSuccess || false;
-        trace({
-          name: TraceName.OnboardingSRPAccountImportTime,
-          op: TraceOperation.OnboardingUserJourney,
-          parentContext: onboardingTraceCtx,
-          tags: {
-            is_social_login: oauthLoginSuccess,
-            account_type: oauthLoginSuccess ? 'social_import' : 'srp_import',
-            biometrics_enabled: Boolean(biometryType),
-          },
-        });
+      return;
+    }
 
-        // latest ux changes - we are forcing user to enable biometric by default
-        const authData = await Authentication.componentAuthenticationType(
-          true,
-          false,
-        );
+    setLoading(true);
+    const onboardingTraceCtx = route?.params?.onboardingTraceCtx;
+    const oauthLoginSuccess = route?.params?.oauthLoginSuccess || false;
 
-        // Ask user to allow biometrics access control
-        authData.currentAuthType =
-          await Authentication.requestBiometricsAccessControlForIOS(
-            authData.currentAuthType,
-          );
-
-        await Authentication.newWalletAndRestore(
-          password,
-          authData,
-          parsedSeed,
-          true,
-          isQrSyncImport,
-        );
-
-        setBiometryType(authData.availableBiometryType);
-        setLoading(false);
-        passwordSet();
-        setLockTime(AppConstants.DEFAULT_LOCK_TIMEOUT);
-        seedphraseBackedUp();
-        track(MetaMetricsEvents.WALLET_IMPORTED, {
+    let authData;
+    try {
+      trace({
+        name: TraceName.OnboardingSRPAccountImportTime,
+        op: TraceOperation.OnboardingUserJourney,
+        parentContext: onboardingTraceCtx,
+        tags: {
+          is_social_login: oauthLoginSuccess,
+          account_type: oauthLoginSuccess ? 'social_import' : 'srp_import',
           biometrics_enabled: Boolean(biometryType),
-        });
-        track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
-          wallet_setup_type: 'import',
-          new_wallet: false,
-          account_type: AccountType.Imported,
-          ...walletSetupCompletedAttributionProps,
-        });
+        },
+      });
 
-        fetchAccountsWithActivity();
-        const resetAction = CommonActions.reset({
-          index: 1,
-          routes: [
-            {
-              name: Routes.ONBOARDING.SUCCESS_FLOW,
-              params: {
-                screen: Routes.ONBOARDING.SUCCESS,
-                params: {
-                  successFlow: ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
-                },
-              },
+      // latest ux changes - we are forcing user to enable biometric by default
+      authData = await Authentication.componentAuthenticationType(true, false);
+
+      // Ask user to allow biometrics access control
+      authData.currentAuthType =
+        await Authentication.requestBiometricsAccessControlForIOS(
+          authData.currentAuthType,
+        );
+
+      await Authentication.newWalletAndRestore(
+        password,
+        authData,
+        parsedSeed,
+        true,
+        isQrSyncImport,
+      );
+    } catch (importError) {
+      setLoading(false);
+      handleWalletImportFailure({
+        importError,
+        track,
+        navigation,
+        isMetricsEnabled,
+        onboardingTraceCtx,
+      });
+      return;
+    }
+
+    setBiometryType(authData.availableBiometryType);
+    setLoading(false);
+    passwordSet();
+    setLockTime(AppConstants.DEFAULT_LOCK_TIMEOUT);
+    seedphraseBackedUp();
+    track(MetaMetricsEvents.WALLET_IMPORTED, {
+      biometrics_enabled: Boolean(biometryType),
+    });
+    track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
+      wallet_setup_type: 'import',
+      new_wallet: false,
+      account_type: AccountType.Imported,
+      ...walletSetupCompletedAttributionProps,
+    });
+
+    fetchAccountsWithActivity();
+    const resetAction = CommonActions.reset({
+      index: 1,
+      routes: [
+        {
+          name: Routes.ONBOARDING.SUCCESS_FLOW,
+          params: {
+            screen: Routes.ONBOARDING.SUCCESS,
+            params: {
+              successFlow: ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
             },
-          ],
-        });
-        endTrace({ name: TraceName.OnboardingSRPAccountImportTime });
-        endTrace({ name: TraceName.OnboardingExistingSrpImport });
-        endTrace({ name: TraceName.OnboardingJourneyOverall });
+          },
+        },
+      ],
+    });
+    endTrace({ name: TraceName.OnboardingSRPAccountImportTime });
+    endTrace({ name: TraceName.OnboardingExistingSrpImport });
+    endTrace({ name: TraceName.OnboardingJourneyOverall });
 
-        if (isMetricsEnabled()) {
-          navigation.dispatch(resetAction);
-        } else {
-          navigation.navigate('OptinMetrics', {
-            accountType: AccountType.Imported,
-            successFlow: ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
-          });
-        }
-      } catch (error) {
-        setLoading(false);
-
-        track(MetaMetricsEvents.WALLET_SETUP_FAILURE, {
-          wallet_setup_type: 'import',
-          error_type: error.toString(),
-        });
-
-        const onboardingTraceCtx = route?.params?.onboardingTraceCtx;
-        if (onboardingTraceCtx) {
-          trace({
-            name: TraceName.OnboardingPasswordSetupError,
-            op: TraceOperation.OnboardingUserJourney,
-            parentContext: onboardingTraceCtx,
-            tags: { errorMessage: error.toString() },
-          });
-          endTrace({ name: TraceName.OnboardingPasswordSetupError });
-        }
-
-        if (error.toString() === PASSCODE_NOT_SET_ERROR) {
-          Alert.alert(
-            'Security Alert',
-            'In order to proceed, you need to turn Passcode on or any biometrics authentication method supported in your device (FaceID, TouchID or Fingerprint)',
-          );
-          return;
-        }
-
-        // For errors, report to Sentry if metrics enabled and navigate to error screen
-        const metricsEnabled = isMetricsEnabled();
-
-        if (metricsEnabled) {
-          captureException(error, {
-            tags: {
-              view: 'ImportFromSecretRecoveryPhrase',
-              context: 'Wallet import failed - auto reported',
-            },
-          });
-        }
-
-        // Navigate to error screen based on metrics consent
-        navigation.reset({
-          routes: [
-            {
-              name: Routes.ONBOARDING.WALLET_CREATION_ERROR,
-              params: {
-                metricsEnabled,
-                error,
-              },
-            },
-          ],
-        });
-      }
+    if (isMetricsEnabled()) {
+      navigation.dispatch(resetAction);
+    } else {
+      navigation.navigate('OptinMetrics', {
+        accountType: AccountType.Imported,
+        successFlow: ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
+      });
     }
   };
 

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -1157,6 +1157,31 @@ describe('ImportFromSecretRecoveryPhrase', () => {
 
         mockAlert.mockRestore();
       });
+
+      it('restores seed phrase visibility when onScanError is called', async () => {
+        const { getByTestId } = customRender(
+          <ImportFromSecretRecoveryPhrase />,
+        );
+
+        const qrButton = getByTestId(
+          ImportFromSeedSelectorsIDs.QR_CODE_BUTTON_ID,
+        );
+        await act(async () => {
+          fireEvent.press(qrButton);
+        });
+
+        const [, params] = navigationSpy.mock.calls[0];
+        const { onScanError } = params;
+
+        await act(async () => {
+          onScanError(new Error('scan failed'));
+        });
+
+        // Screen remains mounted and interactive after scan error handling.
+        expect(
+          getByTestId(ImportFromSeedSelectorsIDs.QR_CODE_BUTTON_ID),
+        ).toBeOnTheScreen();
+      });
     });
 
     it('handles backspace key press when input is empty and index > 0', async () => {
@@ -1692,6 +1717,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
     });
 
     it('error message is shown when passcode is not set', async () => {
+      const mockAlert = jest.spyOn(Alert, 'alert');
       const { getByTestId } = await renderCreatePasswordUI();
 
       const passwordInput = getByTestId(
@@ -1701,32 +1727,157 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
       );
 
-      // Enter valid passwords
       await act(async () => {
         fireEvent.changeText(passwordInput, 'StrongPass123!');
         fireEvent.changeText(confirmPasswordInput, 'StrongPass123!');
       });
 
-      // Check learn more checkbox
       const learnMoreCheckbox = getByTestId(
         ImportFromSeedSelectorsIDs.CHECKBOX_TEXT_ID,
       );
       fireEvent.press(learnMoreCheckbox);
 
-      // Mock Authentication.newWalletAndRestore to throw passcode error
+      jest
+        .spyOn(Authentication, 'componentAuthenticationType')
+        .mockResolvedValueOnce({
+          currentAuthType: AUTHENTICATION_TYPE.BIOMETRIC,
+          availableBiometryType: BIOMETRY_TYPE.FACE_ID,
+        });
+      // Error.message "Passcode not set." → toString() matches PASSCODE_NOT_SET_ERROR
       jest
         .spyOn(Authentication, 'newWalletAndRestore')
-        .mockRejectedValueOnce(new Error('Error: Passcode not set.'));
+        .mockRejectedValueOnce(new Error('Passcode not set.'));
 
-      // Try to import
-      const confirmButton = getByTestId(
-        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith(
+          'Security Alert',
+          'In order to proceed, you need to turn Passcode on or any biometrics authentication method supported in your device (FaceID, TouchID or Fingerprint)',
+        );
+      });
+
+      mockAlert.mockRestore();
+    });
+
+    it('tracks setup failure when password does not meet requirements', async () => {
+      const passwordUtils = jest.requireActual('../../../util/password') as {
+        passwordRequirementsMet: (password: string) => boolean;
+      };
+      const passwordRequirementsMetSpy = jest
+        .spyOn(passwordUtils, 'passwordRequirementsMet')
+        .mockReturnValue(false);
+
+      const { getByTestId } = await renderCreatePasswordUI();
+
+      await act(async () => {
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+      });
+      fireEvent.press(getByTestId(ImportFromSeedSelectorsIDs.CHECKBOX_TEXT_ID));
+
+      const newWalletAndRestoreSpy = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
       );
-      fireEvent.press(confirmButton);
 
-      // await waitFor(() => {
-      //   expect(getByText('Unlock with Face ID?')).toBeOnTheScreen();
-      // });
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+        );
+      });
+
+      expect(newWalletAndRestoreSpy).not.toHaveBeenCalled();
+      passwordRequirementsMetSpy.mockRestore();
+    });
+
+    it('tracks setup failure when imported seed phrase is invalid', async () => {
+      const { getByTestId } = await renderCreatePasswordUI();
+
+      await act(async () => {
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+      });
+      fireEvent.press(getByTestId(ImportFromSeedSelectorsIDs.CHECKBOX_TEXT_ID));
+
+      const validators = jest.requireActual('../../../util/validators') as {
+        failedSeedPhraseRequirements: (seed: string) => boolean;
+        isValidMnemonic: (seed: string) => boolean;
+      };
+      const failedSeedSpy = jest
+        .spyOn(validators, 'failedSeedPhraseRequirements')
+        .mockReturnValue(false);
+      const invalidMnemonicSpy = jest
+        .spyOn(validators, 'isValidMnemonic')
+        .mockReturnValue(false);
+
+      const newWalletAndRestoreSpy = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
+      );
+
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+        );
+      });
+
+      expect(newWalletAndRestoreSpy).not.toHaveBeenCalled();
+      failedSeedSpy.mockRestore();
+      invalidMnemonicSpy.mockRestore();
+    });
+
+    it('tracks setup failure when seed phrase requirements fail', async () => {
+      const { getByTestId } = await renderCreatePasswordUI();
+
+      await act(async () => {
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+        fireEvent.changeText(
+          getByTestId(ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID),
+          'StrongPass123!',
+        );
+      });
+      fireEvent.press(getByTestId(ImportFromSeedSelectorsIDs.CHECKBOX_TEXT_ID));
+
+      const validators = jest.requireActual('../../../util/validators') as {
+        failedSeedPhraseRequirements: (seed: string) => boolean;
+      };
+      const failedSeedSpy = jest
+        .spyOn(validators, 'failedSeedPhraseRequirements')
+        .mockReturnValue(true);
+
+      const newWalletAndRestoreSpy = jest.spyOn(
+        Authentication,
+        'newWalletAndRestore',
+      );
+
+      await act(async () => {
+        fireEvent.press(
+          getByTestId(ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID),
+        );
+      });
+
+      expect(newWalletAndRestoreSpy).not.toHaveBeenCalled();
+      failedSeedSpy.mockRestore();
     });
 
     it('Import seed phrase with optin metrics flow', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Makes the first-time onboarding **Import From Secret Recovery Phrase** screen React Compiler compatible without changing user-facing behavior.

**Why:** Two `eslint-disable-next-line react-hooks/exhaustive-deps` directives caused React Compiler to skip optimizing this component. Unstable Animated values via `useRef(...).current` and conditionals inside `try/catch` are also known bailout patterns.

**What changed:**

- Removed both `exhaustive-deps` disables: clear SRP validation errors with `setError('')` on `seedPhrase` change; split navbar vs biometrics effects with proper dependencies and async cancellation.
- Replaced `useRef(new Animated.Value(0)).current` with `useState(() => new Animated.Value(0))`.
- Extracted `handleWalletImportFailure` outside the component and moved post-import success navigation out of `try/catch`.
- Wrapped `track` in `useCallback`; cleaned shadowed `error` names in QR / import paths.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-925

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Import From Secret Recovery Phrase (onboarding)

  Scenario: new user imports a wallet with a valid SRP
    Given the app is on a fresh install with no existing wallet
    And the user is on the Import From Secret Recovery Phrase screen
    When the user pastes a valid 12-word Secret Recovery Phrase
    And taps Continue
    And creates a password that meets requirements
    And accepts the acknowledgment checkbox
    And taps Import
    Then the wallet is imported successfully
    And the user proceeds to the onboarding success or OptinMetrics flow

  Scenario: user sees validation when passwords do not match
    Given the user is on the create password step after entering a valid SRP
    When the user enters mismatched new and confirm passwords
    Then a password mismatch error is shown
    And Import remains disabled until passwords match

  Scenario: validation error clears when the phrase is edited
    Given the user has a validation error on the SRP step
    When the user edits or clears the seed phrase
    Then the validation error is cleared

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-time wallet import (auth, restore, navigation, and error reporting); behavior is intended to be unchanged but regressions would block onboarding.
> 
> **Overview**
> Refactors **Import From Secret Recovery Phrase** so React Compiler can optimize the screen without changing onboarding behavior.
> 
> **Hooks and effects:** Removes `exhaustive-deps` suppressions by clearing SRP errors whenever `seedPhrase` changes, memoizing `track` and `updateNavBar`, and splitting navbar vs biometrics setup into effects with correct dependencies and async **cancel-on-unmount** for biometrics.
> 
> **Animation:** Replaces `useRef(new Animated.Value(0)).current` with lazy `useState` so the slide animation value is stable for the compiler.
> 
> **Import flow:** Pulls wallet-import failure handling (metrics, traces, passcode alert, Sentry, error navigation) into module-level `handleWalletImportFailure`. `onPressImport` now returns early on validation failures, limits `try/catch` to authentication/restore, and runs success navigation and Redux updates **after** a successful restore. Renames shadowed `error` variables in the import and QR paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd967e41c8bd1d525fe4c3173f0733741715628. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->