### PR TITLE
fix(money): prevent large balances overlapping Add button on Money card (MUSD-1183)

### DIFF
--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -431,12 +431,20 @@ describe('MoneyBalanceCard', () => {
       );
     });
 
-    it('renders the mUSD currency suffix next to the APY value', () => {
+    it('renders the mUSD currency suffix next to the balance label', () => {
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-      expect(getByTestId(MoneyBalanceCardTestIds.APY_TAG)).toHaveTextContent(
-        /• mUSD/,
-      );
+      expect(
+        getByTestId(MoneyBalanceCardTestIds.CURRENCY_SUFFIX),
+      ).toHaveTextContent(/• mUSD/);
+    });
+
+    it('does not render the mUSD currency suffix inside the APY tag', () => {
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+      expect(
+        getByTestId(MoneyBalanceCardTestIds.APY_TAG),
+      ).not.toHaveTextContent(/• mUSD/);
     });
   });
 

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
@@ -4,6 +4,7 @@ export const MoneyBalanceCardTestIds = {
   ERROR_CONTAINER: 'money-balance-card-error-container',
   UNAVAILABLE_CONTAINER: 'money-balance-card-unavailable-container',
   LABEL: 'money-balance-card-label',
+  CURRENCY_SUFFIX: 'money-balance-card-currency-suffix',
   INFO_BUTTON: 'money-balance-card-info-button',
   BALANCE: 'money-balance-card-balance',
   BALANCE_SKELETON: 'money-balance-card-balance-skeleton',

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -291,7 +291,7 @@ const MoneyBalanceCard = () => {
         ),
       ]}
     >
-      <Box twClassName="flex-1 gap-1 pr-3">
+      <Box twClassName="min-w-0 flex-1 gap-1 pr-3">
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -270,6 +270,8 @@ const MoneyBalanceCard = () => {
         color={TextColor.TextDefault}
         isHidden={privacyMode}
         length={SensitiveTextLength.Medium}
+        numberOfLines={1}
+        twClassName="shrink"
         testID={MoneyBalanceCardTestIds.BALANCE}
       >
         {balanceText}
@@ -302,6 +304,14 @@ const MoneyBalanceCard = () => {
           >
             {strings('money.balance_card.label')}
           </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+            testID={MoneyBalanceCardTestIds.CURRENCY_SUFFIX}
+          >
+            {strings('money.balance_card.currency_suffix')}
+          </Text>
           <ButtonIcon
             iconName={IconName.Info}
             iconProps={{ color: IconColor.IconAlternative, size: IconSize.Sm }}
@@ -321,6 +331,7 @@ const MoneyBalanceCard = () => {
             <Skeleton
               height={20}
               width={60}
+              twClassName="shrink-0"
               testID={MoneyBalanceCardTestIds.APY_TAG_SKELETON}
             />
           ) : (
@@ -328,16 +339,10 @@ const MoneyBalanceCard = () => {
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
               color={TextColor.SuccessDefault}
+              twClassName="shrink-0"
               testID={MoneyBalanceCardTestIds.APY_TAG}
             >
               {strings('money.apy_label', { percentage: apyPercent ?? 0 })}
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                {strings('money.apy_currency_suffix')}
-              </Text>
             </Text>
           )}
         </Box>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7425,6 +7425,7 @@
     },
     "balance_card": {
       "label": "Money balance",
+      "currency_suffix": " • mUSD",
       "add": "Add",
       "info_sheet_title": "Money balance",
       "info_sheet_body": "Your dollar-backed mUSD balance that's always available to spend, send, or trade anytime. We don't calculate this into your total account balance.\n\nWithdrawals process immediately, subject to standard network confirmation times on the relevant blockchain. If liquidity is tight, there may be temporary delays."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Large Money account balances crowded the Money card on the Home screen: the balance and the `4% APY • mUSD` label shared a single row, so with big values (e.g. `$888,888,888.88`) the APY and `mUSD` label were pushed under, or overlapped with, the fixed **Add** button.

This reworks the card layout to match the Figma designs:

- The `• mUSD` label now sits on the first row next to `Money balance` (with the info icon): `Money balance • mUSD ⓘ`.
- The second row shows the balance followed by just the `4% APY` value.
- The balance now shrinks and truncates (single line) while the APY stays fixed and visible, so the balance area uses the available horizontal space without ever overlapping the **Add** button, across screen sizes and balances up to at least `$888,888,888.88`.

Existing interactions with the card, the information icon, and the **Add** button are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money card on the Home screen so large balances no longer overlap the Add button and the mUSD label and APY stay visible.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1183

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money card large balance layout on Home

  Scenario: user with a large Money account balance views the Home screen
    Given the user has a Money account with a balance of $888,888,888.88

    When the user opens the Home screen
    Then the first row shows "Money balance • mUSD" with the information icon
    And the second row shows the balance followed by the APY
    And the balance does not overlap the Add button
    And the mUSD label and the APY remain fully visible
    And tapping the card, the information icon, and the Add button behave as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/40bc900f-8c76-4543-a168-a32274b838a4" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and layout-only changes on the Money home card with updated unit tests; no auth, payments, or data-flow changes.
> 
> **Overview**
> Fixes Home **Money balance** card layout when balances are very large so content no longer crowds or overlaps the **Add** button.
> 
> **`• mUSD`** moves from the APY line to the top row beside **Money balance** (new `money.balance_card.currency_suffix` string and `CURRENCY_SUFFIX` test ID). The second row shows only the **APY** percentage.
> 
> The left column uses **`min-w-0`** flex constraints; the balance **`SensitiveText`** is single-line with **`shrink`**, while APY and its skeleton use **`shrink-0`** so the balance truncates instead of pushing APY under the button. Tests now assert mUSD on the label row and not inside the APY tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd64bb84af849d2831d3ab438f5639c73d18217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->