### PR TITLE
chore: bump @react-native-masked-view/masked-view to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-firebase/app": "^20.5.0",
     "@react-native-firebase/messaging": "^20.5.0",
-    "@react-native-masked-view/masked-view": "^0.3.1",
+    "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-native/babel-preset": "0.83.0",
     "@react-native/eslint-config": "0.83.0",
     "@react-native/typescript-config": "0.83.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13122,7 +13122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-masked-view/masked-view@npm:^0.3.1":
+"@react-native-masked-view/masked-view@npm:^0.3.2":
   version: 0.3.2
   resolution: "@react-native-masked-view/masked-view@npm:0.3.2"
   peerDependencies:
@@ -36120,7 +36120,7 @@ __metadata:
     "@react-native-cookies/cookies": "npm:^6.2.1"
     "@react-native-firebase/app": "npm:^20.5.0"
     "@react-native-firebase/messaging": "npm:^20.5.0"
-    "@react-native-masked-view/masked-view": "npm:^0.3.1"
+    "@react-native-masked-view/masked-view": "npm:^0.3.2"
     "@react-native/babel-preset": "npm:0.83.0"
     "@react-native/eslint-config": "npm:0.83.0"
     "@react-native/jest-preset": "npm:0.85.3"


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (safe-chores wave). 0.3.2 is the version validated against RN 0.85 / New Architecture; landing it now on 0.83 lets it soak on main and keeps the eventual RN core bump a version-only diff. Note: the previous `^0.3.1` range was already resolving 0.3.2 in the lockfile, so this raises the declared floor without changing the installed version — `ios/Podfile.lock` already lists `RNCMaskedView (0.3.2)` and is untouched.

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `@react-native-masked-view/masked-view` from `^0.3.1` to `^0.3.2` as part of the incremental pre-upgrade dependency work for React Native 0.85. The caret range was already resolving 0.3.2, so the installed package and native pod are unchanged; this pins the minimum to the RN 0.85-validated version so future installs can't drift below it.

Verified locally: `yarn lint:tsc` green, single lockfile resolution at 0.3.2, no `ios/Podfile.lock` diff (pod already at 0.3.2).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — declared-range-only bump, installed version unchanged; covered by build + smoke CI.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only semver floor change with no application or native code diffs; installed version stays 0.3.2.
> 
> **Overview**
> Raises the declared minimum for **`@react-native-masked-view/masked-view`** from **`^0.3.1`** to **`^0.3.2`** in `package.json` and aligns the matching **`yarn.lock`** descriptor. This is incremental prep for the React Native 0.85 migration so the dependency floor matches the version validated on RN 0.85 / New Architecture.
> 
> The caret range was already resolving to **0.3.2**, so there is no change to the installed JS package or native pods in this diff—only the declared floor so fresh installs cannot resolve below 0.3.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662e438228e304e5b7ffd86056ff6ef7b46e5a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->