### PR TITLE
chore: bump react-native-inappbrowser-reborn to 3.7.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4021,7 +4021,7 @@ PODS:
     - Yoga
   - RNI18n (2.0.15):
     - React
-  - RNInAppBrowser (3.7.0):
+  - RNInAppBrowser (3.7.1):
     - React-Core
   - RNKeychain (9.2.3):
     - boost
@@ -5251,7 +5251,7 @@ SPEC CHECKSUMS:
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: b407c25a3f51d22dd7430e6b530f753f112b7e77
   RNI18n: 11ec5086508673ef71b5b567da3e8bcca8a926e1
-  RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
+  RNInAppBrowser: 904d24dc75e8e6c6c98a3160329192608946f9df
   RNKeychain: 483402cf2b90647eb0cf569cebbc069d32addea4
   RNNotifee: 5165d37aaf980031837be3caece2eae5a6d73ae8
   RNOS: d07e5090b5060c6f2b83116d740a32cfdb33afe3

--- a/package.json
+++ b/package.json
@@ -513,7 +513,7 @@
     "react-native-gzip": "patch:react-native-gzip@npm%3A1.1.0#~/.yarn/patches/react-native-gzip-npm-1.1.0.patch",
     "react-native-i18n": "patch:react-native-i18n@npm%3A2.0.15#~/.yarn/patches/react-native-i18n-npm-2.0.15-7f3cf7cee6.patch",
     "react-native-in-app-review": "^4.3.3",
-    "react-native-inappbrowser-reborn": "^3.7.0",
+    "react-native-inappbrowser-reborn": "^3.7.1",
     "react-native-jazzicon": "^0.1.2",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-keyboard-controller": "1.20.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36343,7 +36343,7 @@ __metadata:
     react-native-gzip: "patch:react-native-gzip@npm%3A1.1.0#~/.yarn/patches/react-native-gzip-npm-1.1.0.patch"
     react-native-i18n: "patch:react-native-i18n@npm%3A2.0.15#~/.yarn/patches/react-native-i18n-npm-2.0.15-7f3cf7cee6.patch"
     react-native-in-app-review: "npm:^4.3.3"
-    react-native-inappbrowser-reborn: "npm:^3.7.0"
+    react-native-inappbrowser-reborn: "npm:^3.7.1"
     react-native-jazzicon: "npm:^0.1.2"
     react-native-keyboard-aware-scroll-view: "npm:^0.9.5"
     react-native-keyboard-controller: "npm:1.20.7"
@@ -40699,15 +40699,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-inappbrowser-reborn@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "react-native-inappbrowser-reborn@npm:3.7.0"
+"react-native-inappbrowser-reborn@npm:^3.7.1":
+  version: 3.7.1
+  resolution: "react-native-inappbrowser-reborn@npm:3.7.1"
   dependencies:
     invariant: "npm:^2.2.4"
     opencollective-postinstall: "npm:^2.0.3"
   peerDependencies:
     react-native: ">=0.56"
-  checksum: 10/f7ecb7a2474d19aeb453958b334c5fb5e06bb27a45b42596bfe48f61c66518c91c186c3c1805011ae28bc247caf41ac5a004befa581acd13ef4066d436085aaf
+  checksum: 10/c1f8e149000779208c82385ffee80ffdd415aeacc25556eef25d9bcdaa4c12ea9b679d22b95210add645a68ddc296bacd14f22366f1757d528391ddc9e1f974e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (safe-chores wave). 3.7.1 is the version validated against RN 0.85 / New Architecture; landing it now on 0.83 lets it soak on main and keeps the eventual RN core bump a version-only diff. Patch-level bump, no patch file involved, single lockfile resolution, `ios/Podfile.lock` regenerated via local `pod install` (`RNInAppBrowser` 3.7.0 → 3.7.1).

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `react-native-inappbrowser-reborn` from `3.7.0` to `3.7.1` as part of the incremental pre-upgrade dependency work for React Native 0.85. Landing it on 0.83 first isolates any regression to this single change and gives it soak time on `main`.

Verified locally: `yarn lint:tsc` green, single lockfile resolution at 3.7.1, `ios/Podfile.lock` updated via `yarn pod:install`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Open the in-app browser from a flow that uses `InAppBrowser` (e.g. external link opening in-app)
2. Verify pages load and the browser sheet opens/dismisses normally on iOS and Android

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump with no application code changes; manual smoke of in-app browser open/dismiss is the main regression surface.
> 
> **Overview**
> Bumps **`react-native-inappbrowser-reborn`** from **3.7.0** to **3.7.1** as a pre-RN 0.85 dependency step, with no app or patch changes.
> 
> **`package.json`** and **`yarn.lock`** pin the new version; **`ios/Podfile.lock`** updates **`RNInAppBrowser`** to 3.7.1 after `pod install`. Existing **`InAppBrowser`** call sites (e.g. in-app links from charts) stay on the same API—only the native dependency revision changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106fd314cb4528d7c2175f30dc0eb23c390f3a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->