### PR TITLE
chore: bump @walletconnect/core to 2.23.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -418,7 +418,7 @@
     "@types/readable-stream": "^2.3.9",
     "@veriff/react-native-sdk": "^11.2.0",
     "@viem/anvil": "^0.0.10",
-    "@walletconnect/core": "^2.23.0",
+    "@walletconnect/core": "^2.23.10",
     "@walletconnect/react-native-compat": "^2.23.0",
     "@walletconnect/utils": "^2.23.0",
     "@xmldom/xmldom": "^0.8.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20868,9 +20868,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:^2.23.0":
-  version: 2.23.4
-  resolution: "@walletconnect/core@npm:2.23.4"
+"@walletconnect/core@npm:^2.23.10":
+  version: 2.23.10
+  resolution: "@walletconnect/core@npm:2.23.10"
   dependencies:
     "@walletconnect/heartbeat": "npm:1.2.2"
     "@walletconnect/jsonrpc-provider": "npm:1.0.14"
@@ -20883,13 +20883,13 @@ __metadata:
     "@walletconnect/relay-auth": "npm:1.1.0"
     "@walletconnect/safe-json": "npm:1.0.2"
     "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.23.4"
-    "@walletconnect/utils": "npm:2.23.4"
+    "@walletconnect/types": "npm:2.23.10"
+    "@walletconnect/utils": "npm:2.23.10"
     "@walletconnect/window-getters": "npm:1.0.1"
-    es-toolkit: "npm:1.44.0"
+    es-toolkit: "npm:1.45.1"
     events: "npm:3.3.0"
     uint8arrays: "npm:3.1.1"
-  checksum: 10/cb2291eacefbf6dda518eda124e4f7ba1dbc66aae38647976e68e08e771795684187f9724adb14eb7565df857882902d205480954d6a931e4c5d71ef94f77957
+  checksum: 10/d271dfd350c05bdb98098728a5658c526d840f513f8ac33dcbe90bba37dcf511a653b098cea39ebeaf5e118a31369d29cd86f3ed9b20dac1564412826096c9f3
   languageName: node
   linkType: hard
 
@@ -21193,6 +21193,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@walletconnect/types@npm:2.23.10":
+  version: 2.23.10
+  resolution: "@walletconnect/types@npm:2.23.10"
+  dependencies:
+    "@walletconnect/events": "npm:1.0.1"
+    "@walletconnect/heartbeat": "npm:1.2.2"
+    "@walletconnect/jsonrpc-types": "npm:1.0.4"
+    "@walletconnect/keyvaluestorage": "npm:1.1.1"
+    "@walletconnect/logger": "npm:3.0.2"
+    events: "npm:3.3.0"
+  checksum: 10/74627d8ebb7525a72a682a15f3084a45074392b4cd876c9056e340d18b6acdc020c53e8cc7a0e7d7c550133e82f0cf537468c3d4adabbf367d0bb68910a4ee81
+  languageName: node
+  linkType: hard
+
 "@walletconnect/types@npm:2.23.4, @walletconnect/types@npm:^2.23.0":
   version: 2.23.4
   resolution: "@walletconnect/types@npm:2.23.4"
@@ -21326,7 +21340,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.23.4, @walletconnect/utils@npm:^2.23.0":
+"@walletconnect/utils@npm:2.23.10":
+  version: 2.23.10
+  resolution: "@walletconnect/utils@npm:2.23.10"
+  dependencies:
+    "@msgpack/msgpack": "npm:3.1.3"
+    "@noble/ciphers": "npm:1.3.0"
+    "@noble/curves": "npm:1.9.7"
+    "@noble/hashes": "npm:1.8.0"
+    "@scure/base": "npm:1.2.6"
+    "@walletconnect/jsonrpc-utils": "npm:1.0.8"
+    "@walletconnect/keyvaluestorage": "npm:1.1.1"
+    "@walletconnect/logger": "npm:3.0.2"
+    "@walletconnect/relay-api": "npm:1.0.11"
+    "@walletconnect/relay-auth": "npm:1.1.0"
+    "@walletconnect/safe-json": "npm:1.0.2"
+    "@walletconnect/time": "npm:1.0.2"
+    "@walletconnect/types": "npm:2.23.10"
+    "@walletconnect/window-getters": "npm:1.0.1"
+    "@walletconnect/window-metadata": "npm:1.0.1"
+    blakejs: "npm:1.2.1"
+    detect-browser: "npm:5.3.0"
+    ox: "npm:0.9.3"
+    uint8arrays: "npm:3.1.1"
+  checksum: 10/81cad31af968029e554aac312d2458852288f800eaeed63edcff81c3f8450629c5228f0e45c404b0776bab1e5d2eecd8c8907539ba76ac3ad7348a9ea2b288e4
+  languageName: node
+  linkType: hard
+
+"@walletconnect/utils@npm:^2.23.0":
   version: 2.23.4
   resolution: "@walletconnect/utils@npm:2.23.4"
   dependencies:
@@ -28086,15 +28127,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:1.44.0":
-  version: 1.44.0
-  resolution: "es-toolkit@npm:1.44.0"
+"es-toolkit@npm:1.45.1":
+  version: 1.45.1
+  resolution: "es-toolkit@npm:1.45.1"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
-  checksum: 10/72a74c8688dec99743b3170e1e78822b983519b795643c2f04c4a8e6b49e2d6f554013e2266850de7929718b4113768912e9b8394eb6e3d6c9e28a38fb8f5317
+  checksum: 10/e092803bd0ba473db04798311e39bfc1e27e7bb958309f2e49c1be59931c7d88d5d84fc12483b32e0e73c2dec42739b73b4dfe6322a37c2a158b552456b24134
   languageName: node
   linkType: hard
 
@@ -36184,7 +36225,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.1.0"
     "@veriff/react-native-sdk": "npm:^11.2.0"
     "@viem/anvil": "npm:^0.0.10"
-    "@walletconnect/core": "npm:^2.23.0"
+    "@walletconnect/core": "npm:^2.23.10"
     "@walletconnect/react-native-compat": "npm:^2.23.0"
     "@walletconnect/types": "npm:^2.23.0"
     "@walletconnect/utils": "npm:^2.23.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21193,7 +21193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.23.10":
+"@walletconnect/types@npm:2.23.10, @walletconnect/types@npm:^2.23.0":
   version: 2.23.10
   resolution: "@walletconnect/types@npm:2.23.10"
   dependencies:
@@ -21204,20 +21204,6 @@ __metadata:
     "@walletconnect/logger": "npm:3.0.2"
     events: "npm:3.3.0"
   checksum: 10/74627d8ebb7525a72a682a15f3084a45074392b4cd876c9056e340d18b6acdc020c53e8cc7a0e7d7c550133e82f0cf537468c3d4adabbf367d0bb68910a4ee81
-  languageName: node
-  linkType: hard
-
-"@walletconnect/types@npm:2.23.4, @walletconnect/types@npm:^2.23.0":
-  version: 2.23.4
-  resolution: "@walletconnect/types@npm:2.23.4"
-  dependencies:
-    "@walletconnect/events": "npm:1.0.1"
-    "@walletconnect/heartbeat": "npm:1.2.2"
-    "@walletconnect/jsonrpc-types": "npm:1.0.4"
-    "@walletconnect/keyvaluestorage": "npm:1.1.1"
-    "@walletconnect/logger": "npm:3.0.2"
-    events: "npm:3.3.0"
-  checksum: 10/aeecf95d6fccd9880cdf67860d94399d7055714f77001c347275e8cf1d63a87bdf53403b6a1c5acdfd32d9d77792d00ff9333c3c2aa8d7d0e410643dddee4523
   languageName: node
   linkType: hard
 
@@ -21340,7 +21326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.23.10":
+"@walletconnect/utils@npm:2.23.10, @walletconnect/utils@npm:^2.23.0":
   version: 2.23.10
   resolution: "@walletconnect/utils@npm:2.23.10"
   dependencies:
@@ -21364,34 +21350,6 @@ __metadata:
     ox: "npm:0.9.3"
     uint8arrays: "npm:3.1.1"
   checksum: 10/81cad31af968029e554aac312d2458852288f800eaeed63edcff81c3f8450629c5228f0e45c404b0776bab1e5d2eecd8c8907539ba76ac3ad7348a9ea2b288e4
-  languageName: node
-  linkType: hard
-
-"@walletconnect/utils@npm:^2.23.0":
-  version: 2.23.4
-  resolution: "@walletconnect/utils@npm:2.23.4"
-  dependencies:
-    "@msgpack/msgpack": "npm:3.1.3"
-    "@noble/ciphers": "npm:1.3.0"
-    "@noble/curves": "npm:1.9.7"
-    "@noble/hashes": "npm:1.8.0"
-    "@scure/base": "npm:1.2.6"
-    "@walletconnect/jsonrpc-utils": "npm:1.0.8"
-    "@walletconnect/keyvaluestorage": "npm:1.1.1"
-    "@walletconnect/logger": "npm:3.0.2"
-    "@walletconnect/relay-api": "npm:1.0.11"
-    "@walletconnect/relay-auth": "npm:1.1.0"
-    "@walletconnect/safe-json": "npm:1.0.2"
-    "@walletconnect/time": "npm:1.0.2"
-    "@walletconnect/types": "npm:2.23.4"
-    "@walletconnect/window-getters": "npm:1.0.1"
-    "@walletconnect/window-metadata": "npm:1.0.1"
-    blakejs: "npm:1.2.1"
-    bs58: "npm:6.0.0"
-    detect-browser: "npm:5.3.0"
-    ox: "npm:0.9.3"
-    uint8arrays: "npm:3.1.1"
-  checksum: 10/c3a7a2355b71c2aab5d63427f780f836010e3d1abc6cae0252c2b051965335379418ae1ae0dceab82caa9d87eb1e847ef36236b0d27030f96a5a4bf73b01ad68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (safe-chores wave). 2.23.10 is the version validated against RN 0.85 / New Architecture; landing it now on 0.83 lets it soak on main and keeps the eventual RN core bump a version-only diff. JS-only package (no native pod, no Podfile.lock change). The direct `@walletconnect/utils` / `@walletconnect/types` deps intentionally stay on `^2.23.0` per the upgrade plan scope — core 2.23.10 pins its own matching 2.23.10 internals, and no type conflicts surfaced.

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `@walletconnect/core` from `^2.23.0` (resolving 2.23.4) to `^2.23.10` as part of the incremental pre-upgrade dependency work for React Native 0.85. Landing it on 0.83 first isolates any regression to this single change and gives it soak time on `main`.

Verified locally: `yarn lint:tsc` green, all 8 WalletConnect unit test suites pass (206 tests in `app/core/WalletConnect`), no new duplicate lockfile entries beyond the exact-version pins that already existed on `main` (2.19.0 / 2.19.1 / 2.23.0 from transitive dependents).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Connect to a dApp via WalletConnect (QR / deeplink)
2. Approve a session, sign a message, and disconnect
3. Verify session proposal, request handling, and disconnect events behave normally

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> WalletConnect session/signing flows depend on core; it's a patch-minor dependency jump with no code changes, so regressions would show up only at runtime.
> 
> **Overview**
> Bumps the direct **`@walletconnect/core`** dependency from **`^2.23.0`** (lockfile had **2.23.4**) to **`^2.23.10`**, with **`yarn.lock`** aligned so resolved **`@walletconnect/core`**, **`types`**, and **`utils`** are **2.23.10** and **`es-toolkit`** moves **1.44.0 → 1.45.1** via core’s dependency tree.
> 
> There are **no app or native changes**—only **`package.json`** and the lockfile. **`@walletconnect/react-native-compat`**, **`@walletconnect/utils`**, and **`@walletconnect/types`** stay on **`^2.23.0`** in the manifest; this is framed as pre-RN **0.85** soak work on current **0.83**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60569dbfb0189865e3afd64ff61be61af8ee344f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->