### PR TITLE
fix: remove whole redux state pass through for bridge selectors

### DIFF
--- a/app/selectors/bridge.test.ts
+++ b/app/selectors/bridge.test.ts
@@ -4,14 +4,26 @@ jest.mock('./smartTransactionsController', () => ({
   getGaslessBridgeWith7702EnabledForChain: jest.fn().mockReturnValue(false),
 }));
 
-import { initialState } from '../core/redux/slices/bridge';
+import { initialState as bridgeInitialState } from '../core/redux/slices/bridge';
 import {
+  selectBatchSellSourceWalletAddress,
   selectGasIncludedQuoteParams,
   selectIsGasIncluded7702BridgeEnabled,
+  selectSourceWalletAddress,
+  selectValidDestInternalAccountIds,
 } from './bridge';
 import { BridgeToken } from '../components/UI/Bridge/types';
 import { Hex } from '@metamask/utils';
 import { RootState } from '../reducers';
+import {
+  evmAccountAddress,
+  evmAccountId,
+  initialState as bridgeSelectorInitialState,
+  solanaAccountAddress,
+  solanaAccountId,
+  solanaNativeTokenAddress,
+} from '../components/UI/Bridge/_mocks_/initialState';
+import { SolScope } from '@metamask/keyring-api';
 
 const mockToken: BridgeToken = {
   address: '0x123',
@@ -35,7 +47,218 @@ const mockDestToken: BridgeToken = {
   balanceFiat: '100',
 };
 
+const mockSolanaToken: BridgeToken = {
+  ...mockToken,
+  address: solanaNativeTokenAddress,
+  symbol: 'SOL',
+  chainId: SolScope.Mainnet,
+  name: 'Solana',
+};
+
+const selectorInitialState = bridgeSelectorInitialState as unknown as RootState;
+
+function createSelectorState(
+  bridgeOverrides: Partial<RootState['bridge']> = {},
+): RootState {
+  return {
+    ...selectorInitialState,
+    bridge: {
+      ...selectorInitialState.bridge,
+      ...bridgeOverrides,
+    },
+  };
+}
+
 describe('bridge selectors', () => {
+  describe('selectSourceWalletAddress', () => {
+    beforeEach(() => {
+      selectSourceWalletAddress.clearCache();
+      selectSourceWalletAddress.memoizedResultFunc.clearCache();
+      selectSourceWalletAddress.resetRecomputations();
+    });
+
+    it('returns undefined when the source token is missing', () => {
+      expect(selectSourceWalletAddress(createSelectorState())).toBeUndefined();
+    });
+
+    it.each([
+      ['EVM', mockToken, evmAccountAddress],
+      ['non-EVM', mockSolanaToken, solanaAccountAddress],
+    ])(
+      'returns the selected account group address for the %s source token',
+      (_label, sourceToken, expectedAddress) => {
+        const state = createSelectorState({ sourceToken });
+
+        expect(selectSourceWalletAddress(state)).toBe(expectedAddress);
+      },
+    );
+
+    it('does not recompute for unrelated state changes but does for a source token change', () => {
+      const state = createSelectorState({
+        sourceToken: mockToken,
+        sourceAmount: '1',
+      });
+      const firstResult = selectSourceWalletAddress(state);
+      const recomputations = selectSourceWalletAddress.recomputations();
+      const unrelatedState = {
+        ...state,
+        bridge: {
+          ...state.bridge,
+          sourceAmount: '2',
+        },
+      };
+
+      const secondResult = selectSourceWalletAddress(unrelatedState);
+
+      expect(secondResult).toBe(firstResult);
+      expect(selectSourceWalletAddress.recomputations()).toBe(recomputations);
+
+      const changedTokenState = {
+        ...unrelatedState,
+        bridge: {
+          ...unrelatedState.bridge,
+          sourceToken: mockSolanaToken,
+        },
+      };
+
+      expect(selectSourceWalletAddress(changedTokenState)).toBe(
+        solanaAccountAddress,
+      );
+      expect(selectSourceWalletAddress.recomputations()).toBe(
+        recomputations + 1,
+      );
+    });
+  });
+
+  describe('selectBatchSellSourceWalletAddress', () => {
+    beforeEach(() => {
+      selectBatchSellSourceWalletAddress.clearCache();
+      selectBatchSellSourceWalletAddress.memoizedResultFunc.clearCache();
+      selectBatchSellSourceWalletAddress.resetRecomputations();
+    });
+
+    it('returns undefined when the batch has no source tokens', () => {
+      expect(
+        selectBatchSellSourceWalletAddress(createSelectorState()),
+      ).toBeUndefined();
+    });
+
+    it('returns the account address for the first batch source token', () => {
+      const state = createSelectorState({
+        batchSellSourceTokens: [mockSolanaToken, mockToken],
+      });
+
+      expect(selectBatchSellSourceWalletAddress(state)).toBe(
+        solanaAccountAddress,
+      );
+    });
+
+    it('does not recompute for unrelated state changes but does for a batch token change', () => {
+      const state = createSelectorState({
+        batchSellSourceTokens: [mockToken],
+        sourceAmount: '1',
+      });
+      const firstResult = selectBatchSellSourceWalletAddress(state);
+      const recomputations =
+        selectBatchSellSourceWalletAddress.recomputations();
+      const unrelatedState = {
+        ...state,
+        bridge: {
+          ...state.bridge,
+          sourceAmount: '2',
+        },
+      };
+
+      const secondResult = selectBatchSellSourceWalletAddress(unrelatedState);
+
+      expect(secondResult).toBe(firstResult);
+      expect(selectBatchSellSourceWalletAddress.recomputations()).toBe(
+        recomputations,
+      );
+
+      const changedTokenState = {
+        ...unrelatedState,
+        bridge: {
+          ...unrelatedState.bridge,
+          batchSellSourceTokens: [mockSolanaToken],
+        },
+      };
+
+      expect(selectBatchSellSourceWalletAddress(changedTokenState)).toBe(
+        solanaAccountAddress,
+      );
+      expect(selectBatchSellSourceWalletAddress.recomputations()).toBe(
+        recomputations + 1,
+      );
+    });
+  });
+
+  describe('selectValidDestInternalAccountIds', () => {
+    beforeEach(() => {
+      selectValidDestInternalAccountIds.clearCache();
+      selectValidDestInternalAccountIds.memoizedResultFunc.clearCache();
+      selectValidDestInternalAccountIds.resetRecomputations();
+    });
+
+    it('returns an empty Set when the destination token is missing', () => {
+      expect(selectValidDestInternalAccountIds(createSelectorState())).toEqual(
+        new Set(),
+      );
+    });
+
+    it.each([
+      ['EVM', mockDestToken, [evmAccountId]],
+      ['non-EVM', mockSolanaToken, [solanaAccountId]],
+    ])(
+      'returns valid internal account IDs for the %s destination',
+      (_label, destToken, expectedAccountIds) => {
+        const state = createSelectorState({ destToken });
+
+        expect(selectValidDestInternalAccountIds(state)).toEqual(
+          new Set(expectedAccountIds),
+        );
+      },
+    );
+
+    it('keeps the Set reference stable for unrelated state changes and recomputes for a destination token change', () => {
+      const state = createSelectorState({
+        destToken: mockDestToken,
+        sourceAmount: '1',
+      });
+      const firstResult = selectValidDestInternalAccountIds(state);
+      const recomputations = selectValidDestInternalAccountIds.recomputations();
+      const unrelatedState = {
+        ...state,
+        bridge: {
+          ...state.bridge,
+          sourceAmount: '2',
+        },
+      };
+
+      const secondResult = selectValidDestInternalAccountIds(unrelatedState);
+
+      expect(secondResult).toBe(firstResult);
+      expect(selectValidDestInternalAccountIds.recomputations()).toBe(
+        recomputations,
+      );
+
+      const changedTokenState = {
+        ...unrelatedState,
+        bridge: {
+          ...unrelatedState.bridge,
+          destToken: mockSolanaToken,
+        },
+      };
+
+      expect(selectValidDestInternalAccountIds(changedTokenState)).toEqual(
+        new Set([solanaAccountId]),
+      );
+      expect(selectValidDestInternalAccountIds.recomputations()).toBe(
+        recomputations + 1,
+      );
+    });
+  });
+
   describe('selectIsGasIncluded7702BridgeEnabled', () => {
     beforeEach(() => {
       jest
@@ -45,7 +268,7 @@ describe('bridge selectors', () => {
 
     it('returns false when sourceToken is undefined', () => {
       const mockState = {
-        bridge: { ...initialState, sourceToken: undefined },
+        bridge: { ...bridgeInitialState, sourceToken: undefined },
       } as RootState;
 
       expect(selectIsGasIncluded7702BridgeEnabled(mockState)).toBe(false);
@@ -54,7 +277,7 @@ describe('bridge selectors', () => {
     it('returns false when sourceToken has no chainId', () => {
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: { ...mockToken, chainId: undefined },
         },
       } as unknown as RootState;
@@ -68,7 +291,7 @@ describe('bridge selectors', () => {
         .mockReturnValue(true);
 
       const mockState = {
-        bridge: { ...initialState, sourceToken: mockToken },
+        bridge: { ...bridgeInitialState, sourceToken: mockToken },
       } as RootState;
 
       expect(selectIsGasIncluded7702BridgeEnabled(mockState)).toBe(true);
@@ -90,7 +313,7 @@ describe('bridge selectors', () => {
     it('returns gasIncluded true with 7702 false when STX send bundle is supported', () => {
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           isGasIncludedSTXSendBundleSupported: true,
           isGasIncluded7702Supported: true,
         },
@@ -104,7 +327,7 @@ describe('bridge selectors', () => {
     it('returns gasIncluded true with 7702 true for swap when 7702 is supported', () => {
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: { ...mockDestToken, chainId: mockToken.chainId },
           isGasIncludedSTXSendBundleSupported: false,
@@ -120,7 +343,7 @@ describe('bridge selectors', () => {
     it('returns gasIncluded false with 7702 false for swap without 7702 support', () => {
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: { ...mockDestToken, chainId: mockToken.chainId },
           isGasIncludedSTXSendBundleSupported: false,
@@ -136,7 +359,7 @@ describe('bridge selectors', () => {
     it('returns gasIncluded false with 7702 false for bridge mode if disabled via flag', () => {
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: mockDestToken,
           isGasIncludedSTXSendBundleSupported: false,
@@ -156,7 +379,7 @@ describe('bridge selectors', () => {
 
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: mockDestToken,
           isGasIncludedSTXSendBundleSupported: false,
@@ -176,7 +399,7 @@ describe('bridge selectors', () => {
 
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: mockDestToken,
           isGasIncludedSTXSendBundleSupported: false,
@@ -196,7 +419,7 @@ describe('bridge selectors', () => {
 
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: mockDestToken,
           isGasIncludedSTXSendBundleSupported: false,
@@ -217,7 +440,7 @@ describe('bridge selectors', () => {
       };
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: solanaToken,
           isGasIncludedSTXSendBundleSupported: false,
           isGasIncluded7702Supported: false,
@@ -237,7 +460,7 @@ describe('bridge selectors', () => {
       };
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: solanaToken,
           isGasIncludedSTXSendBundleSupported: true,
           isGasIncluded7702Supported: true,
@@ -256,7 +479,7 @@ describe('bridge selectors', () => {
 
       const mockState = {
         bridge: {
-          ...initialState,
+          ...bridgeInitialState,
           sourceToken: mockToken,
           destToken: mockDestToken,
           isGasIncludedSTXSendBundleSupported: true,

--- a/app/selectors/bridge.ts
+++ b/app/selectors/bridge.ts
@@ -15,27 +15,24 @@ import {
   selectIsGasIncludedSTXSendBundleSupported,
   selectIsGasIncluded7702Supported,
 } from '../core/redux/slices/bridge';
-import { selectInternalAccountsByScope } from '../selectors/accountsController';
+import { selectInternalAccountsById } from '../selectors/accountsController';
 import type { AccountId } from '@metamask/accounts-controller';
 import { EthScope } from '@metamask/keyring-api';
-import { createDeepEqualSelector } from './util';
 import { KnownCaipNamespace } from '@metamask/utils';
 import { getGaslessBridgeWith7702EnabledForChain } from './smartTransactionsController';
+import { anyScopesMatch } from '../components/hooks/useAccountGroupsForPermissions/utils';
 
 /**
  * Gets the wallet address for a given source token by finding the selected account
  * that matches the token's chain scope
  */
 export const selectSourceWalletAddress = createSelector(
-  [(state: RootState) => state, selectSourceToken],
-  (state, sourceToken) => {
+  [selectSourceToken, selectSelectedInternalAccountByScope],
+  (sourceToken, getAccountByScope) => {
     if (!sourceToken) return undefined;
 
     const chainId = formatChainIdToCaip(sourceToken.chainId);
-    const internalAccount =
-      selectSelectedInternalAccountByScope(state)(chainId);
-
-    return internalAccount ? internalAccount.address : undefined;
+    return getAccountByScope(chainId)?.address;
   },
 );
 
@@ -44,16 +41,13 @@ export const selectSourceWalletAddress = createSelector(
  * selected account that matches the token's chain scope.
  */
 export const selectBatchSellSourceWalletAddress = createSelector(
-  [(state: RootState) => state, selectBatchSellSourceTokens],
-  (state, sourceTokens) => {
+  [selectBatchSellSourceTokens, selectSelectedInternalAccountByScope],
+  (sourceTokens, getAccountByScope) => {
     const [sourceToken] = sourceTokens;
     if (!sourceToken) return undefined;
 
     const chainId = formatChainIdToCaip(sourceToken.chainId);
-    const internalAccount =
-      selectSelectedInternalAccountByScope(state)(chainId);
-
-    return internalAccount ? internalAccount.address : undefined;
+    return getAccountByScope(chainId)?.address;
   },
 );
 
@@ -62,21 +56,22 @@ export const selectBatchSellSourceWalletAddress = createSelector(
  * for the currently selected destination token. For EVM destinations, includes
  * both the specific EVM chain and the EVM wildcard scope (eip155:0).
  */
-export const selectValidDestInternalAccountIds = createDeepEqualSelector(
-  [(state: RootState) => state, selectDestToken],
-  (state, destToken): Set<AccountId> => {
+export const selectValidDestInternalAccountIds = createSelector(
+  [selectDestToken, selectInternalAccountsById],
+  (destToken, internalAccountsById): Set<AccountId> => {
     if (!destToken) return new Set<AccountId>();
 
     const destScope = formatChainIdToCaip(destToken.chainId);
     const isEvm = destScope.startsWith(KnownCaipNamespace.Eip155);
 
-    const byDestScope = selectInternalAccountsByScope(state, destScope);
-    const evmWildcard = isEvm
-      ? selectInternalAccountsByScope(state, EthScope.Eoa)
-      : [];
-
     return new Set<AccountId>(
-      [...byDestScope, ...evmWildcard].map((a) => a.id),
+      Object.values(internalAccountsById)
+        .filter(
+          (account) =>
+            anyScopesMatch(account.scopes, destScope) ||
+            (isEvm && anyScopesMatch(account.scopes, EthScope.Eoa)),
+        )
+        .map((account) => account.id),
     );
   },
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR removes whole Redux-state passthrough inputs from three Bridge account selectors. The selectors now compose granular token and account inputs, preventing result recomputation on unrelated dispatches while preserving selected account-group lookup, destination scope matching, and the existing `Set<AccountId>` API.

It also adds EVM and non-EVM value coverage plus recomputation and reference-stability tests.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #31269

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — this is an internal selector memoization change with no UI behavior change.

Automated verification: run `yarn jest app/selectors/bridge.test.ts` and confirm all 24 tests pass, including the unrelated-state recomputation and stable Set-reference cases.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI changes.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destination account eligibility logic was rewritten (different data source and `anyScopesMatch` vs per-scope queries); behavior should match but account picking for bridge is user-facing if wrong.
> 
> **Overview**
> **Refactors three Bridge account selectors** so they no longer depend on the entire `RootState`, which was forcing recomputation on every unrelated dispatch.
> 
> `selectSourceWalletAddress` and `selectBatchSellSourceWalletAddress` now compose `selectSourceToken` / `selectBatchSellSourceTokens` with `selectSelectedInternalAccountByScope` instead of calling scope lookup inside a `(state) => state` input. **`selectValidDestInternalAccountIds`** drops `createDeepEqualSelector` and `selectInternalAccountsByScope` in favor of `selectInternalAccountsById` plus `anyScopesMatch` for destination scope and EVM wildcard (`eip155:0`) filtering, while still returning a `Set<AccountId>`.
> 
> **Tests** add shared bridge selector mock state, EVM/Solana coverage, and assertions that unrelated bridge fields (e.g. `sourceAmount`) do not trigger recomputation or new `Set` references until the relevant token changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f604031c139e1bf5273f9c698dcc40a777eee5a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->