### PR TITLE
fix(predict): route withdrawals by wallet type

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -8715,6 +8715,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.signWithdraw?.mockResolvedValue({
         callData: '0xnewdata' as `0x${string}`,
         amount: 100,
+        walletType: 'safe',
       });
 
       await withController(async ({ controller }) => {
@@ -8748,6 +8749,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.signWithdraw?.mockResolvedValue({
         callData: '0xnewdata' as `0x${string}`,
         amount: 250.5,
+        walletType: 'safe',
       });
 
       await withController(async ({ controller }) => {
@@ -8777,6 +8779,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.signWithdraw?.mockResolvedValue({
         callData: '0xmodifieddata' as `0x${string}`,
         amount: 100,
+        walletType: 'safe',
       });
 
       await withController(async ({ controller }) => {
@@ -8828,6 +8831,60 @@ describe('PredictController', () => {
       });
     });
 
+    it('leaves deposit-wallet transaction data unchanged for external signing', async () => {
+      const estimateGas = jest.fn().mockResolvedValue({
+        gas: '0x5208',
+        simulationFails: undefined,
+      });
+      mockPolymarketProvider.signWithdraw?.mockResolvedValue({
+        callData: ERC20_TRANSFER_CALL_DATA,
+        amount: 0.07,
+        walletType: 'deposit-wallet',
+      });
+      mockPolymarketProvider.getAccountState.mockResolvedValue({
+        address: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+        isDeployed: true,
+        walletType: 'deposit-wallet',
+      });
+
+      await withController(
+        async ({ controller }) => {
+          controller.updateStateForTesting((state) => {
+            state.withdrawTransaction = {
+              chainId: 137,
+              status: PredictWithdrawStatus.IDLE,
+              providerId: POLYMARKET_PROVIDER_ID,
+              predictAddress:
+                '0x2222222222222222222222222222222222222222' as `0x${string}`,
+              transactionId: 'tx-1',
+              amount: 0,
+            };
+          });
+          const transaction = {
+            ...mockTransactionMeta,
+            txParams: { ...mockTransactionMeta.txParams },
+          } as unknown as TransactionMeta;
+
+          const result = await controller.beforeSign({
+            transactionMeta: transaction,
+          });
+          result?.updateTransaction?.(transaction);
+
+          expect(transaction.txParams).toEqual(mockTransactionMeta.txParams);
+          expect(transaction.assetsFiatValues).toEqual({ receiving: '0.07' });
+          expect(controller.state.withdrawTransaction).toEqual(
+            expect.objectContaining({
+              amount: 0.07,
+              status: PredictWithdrawStatus.PENDING,
+            }),
+          );
+          expect(mockInvalidateQueries).not.toHaveBeenCalled();
+          expect(estimateGas).not.toHaveBeenCalled();
+        },
+        { mocks: { estimateGas } },
+      );
+    });
+
     it('throw error when prepareWithdrawConfirmation fails', async () => {
       mockPolymarketProvider.signWithdraw?.mockRejectedValue(
         new Error('Confirmation preparation failed'),
@@ -8857,6 +8914,7 @@ describe('PredictController', () => {
       mockPolymarketProvider.signWithdraw?.mockResolvedValue({
         callData: '0xnewdata' as `0x${string}`,
         amount: 100,
+        walletType: 'safe',
       });
 
       await withController(

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -3994,13 +3994,6 @@ export class PredictController extends BaseController<
     }
 
     const signer = this.getSigner(request.transactionMeta.txParams.from);
-
-    const chainId = activeWithdrawTransaction.chainId;
-
-    const networkClientId = this.messenger.call(
-      'NetworkController:findNetworkClientIdByChainId',
-      numberToHex(chainId),
-    );
     const withdrawDataPrefix = withdrawTransaction.data?.slice(0, 10);
 
     if (
@@ -4011,13 +4004,43 @@ export class PredictController extends BaseController<
       return;
     }
 
-    // Invalidate query cache (to avoid nonce issues)
-    await this.invalidateQueryCache(chainId);
+    const accountState = await provider.getAccountState({
+      ownerAddress: signer.address,
+    });
+    const chainId = activeWithdrawTransaction.chainId;
 
-    const { callData, amount } = await provider.signWithdraw({
+    if (accountState.walletType === 'safe') {
+      // Invalidate query cache to avoid using a stale Safe nonce.
+      await this.invalidateQueryCache(chainId);
+    }
+
+    const { callData, amount, walletType } = await provider.signWithdraw({
       callData: withdrawTransaction?.data as Hex,
       signer,
     });
+
+    if (walletType === 'deposit-wallet') {
+      this.update((state) => {
+        if (state.withdrawTransaction) {
+          state.withdrawTransaction.amount = amount;
+          state.withdrawTransaction.status = PredictWithdrawStatus.PENDING;
+        }
+      });
+
+      return {
+        updateTransaction: (transaction: TransactionMeta) => {
+          transaction.assetsFiatValues = {
+            ...transaction.assetsFiatValues,
+            receiving: String(amount),
+          };
+        },
+      };
+    }
+
+    const networkClientId = this.messenger.call(
+      'NetworkController:findNetworkClientIdByChainId',
+      numberToHex(chainId),
+    );
 
     const newParams = {
       ...withdrawTransaction,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -994,6 +994,32 @@ describe('PolymarketProvider', () => {
     });
   });
 
+  it('keeps funded legacy Safe users when raw activity is empty', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+    mockGetRawBalance.mockImplementation(async ({ tokenAddress }) =>
+      tokenAddress === USDC_E_ADDRESS ? 100_000_000n : 0n,
+    );
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const accountState = await createProvider().getAccountState({
+      ownerAddress: signer.address,
+    });
+
+    expect(accountState).toEqual({
+      address: legacySafeAddress,
+      isDeployed: true,
+      walletType: 'safe',
+    });
+    expect(mockResolveDepositWalletAddress).toHaveBeenCalledWith({
+      ownerAddress: signer.address,
+    });
+  });
+
   it('fails closed when raw Activity API fails for a deployed legacy Safe', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
@@ -2005,7 +2031,31 @@ describe('PolymarketProvider', () => {
         protocol: expect.objectContaining({ key: 'v2' }),
       }),
     );
-    expect(result).toEqual({ callData: '0xsignedWithdraw', amount: 1 });
+    expect(result).toEqual({
+      callData: '0xsignedWithdraw',
+      amount: 1,
+      walletType: 'safe',
+    });
+  });
+
+  it('leaves deposit-wallet withdrawals for external signing', async () => {
+    mockIsSmartContractAddress
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const provider = createProvider();
+    await provider.prepareWithdraw({ signer });
+
+    const result = await provider.signWithdraw?.({
+      signer,
+      callData: '0xtransfer',
+    });
+
+    expect(mockBuildWithdrawTransaction).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      callData: '0xtransfer',
+      amount: 1,
+      walletType: 'deposit-wallet',
+    });
   });
 
   it('gets crypto price history from Chainlink candle closes', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -2806,6 +2806,31 @@ export class PolymarketProvider implements PredictProvider {
         depositWalletAddress,
         numberToHex(POLYGON_MAINNET_CHAIN_ID),
       );
+
+      if (legacySafeIsDeployed && !depositWalletIsDeployed) {
+        const protocol = this.#getProtocol();
+        const [legacyPusdBalance, legacyUsdceBalance] = await Promise.all([
+          getRawBalance({
+            address: legacySafeAddress,
+            tokenAddress: protocol.collateral.tradingToken,
+          }),
+          getRawBalance({
+            address: legacySafeAddress,
+            tokenAddress: protocol.collateral.legacyUsdceToken,
+          }),
+        ]);
+
+        if (legacyPusdBalance > 0n || legacyUsdceBalance > 0n) {
+          const accountState: AccountState = {
+            address: legacySafeAddress,
+            isDeployed: true,
+            walletType: 'safe',
+          };
+          this.#setCachedAccountState(normalizedOwnerAddress, accountState);
+          return accountState;
+        }
+      }
+
       const accountState: AccountState = {
         address: depositWalletAddress,
         isDeployed: depositWalletIsDeployed,
@@ -3273,20 +3298,28 @@ export class PolymarketProvider implements PredictProvider {
       throw new Error('Signer address is required');
     }
 
-    const safeAddress =
-      this.#getCachedAccountState(signer.address)?.address ??
-      computeProxyAddress(signer.address);
-
     const amount = getSafeTransferAmount(callData);
-    const requestedAmountRaw = getSafeTransferAmountRaw(callData);
+    const accountState =
+      this.#getCachedAccountState(signer.address) ??
+      (await this.getAccountState({ ownerAddress: signer.address }));
 
+    if (accountState.walletType === 'deposit-wallet') {
+      // Transaction Pay signs and publishes deposit-wallet batches externally.
+      return {
+        callData,
+        amount,
+        walletType: accountState.walletType,
+      };
+    }
+
+    const requestedAmountRaw = getSafeTransferAmountRaw(callData);
     const safeLegacyUsdceBalance = await this.#getLegacyUsdceBalance({
-      safeAddress,
+      safeAddress: accountState.address,
       protocol,
     });
     const signedWithdrawTransaction = await buildWithdrawTransaction({
       signer,
-      safeAddress,
+      safeAddress: accountState.address,
       requestedAmountRaw,
       protocol,
       safeLegacyUsdceBalance,
@@ -3295,6 +3328,7 @@ export class PolymarketProvider implements PredictProvider {
     return {
       callData: signedWithdrawTransaction.params.data,
       amount,
+      walletType: accountState.walletType,
     };
   }
 

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -162,6 +162,7 @@ export interface SignWithdrawParams {
 export interface SignWithdrawResponse {
   callData: Hex;
   amount: number;
+  walletType: AccountState['walletType'];
 }
 
 export interface PredictProvider {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Predict withdrawals were routing some accounts through the wrong contract execution model.

The reported account has a deployed legacy Gnosis Safe holding 100 USDC.e but no Polymarket activity. Its derived deposit wallet is undeployed and empty. The activity-only classifier therefore selected the undeployed deposit wallet, and MetaMask Pay failed with `Deposit wallet ... is not deployed`.

This change keeps a deployed legacy Safe when it contains pUSD or USDC.e and the derived deposit wallet is not deployed, even when the Activity API is empty. This lets funded pre-trade accounts use the existing Safe withdrawal path.

The change also fixes the complementary deposit-wallet path. `signWithdraw` no longer builds Gnosis Safe `execTransaction` calldata for accounts classified as `deposit-wallet`. The original transfer metadata remains untouched so Transaction Pay can execute the existing Polymarket EIP-712 `WALLET` batch flow. Safe accounts continue to invalidate the nonce cache, build signed Safe execution calldata, and estimate gas as before.

Existing UUPS and BeaconProxy address resolution remains unchanged and is covered by the existing deposit-wallet resolver tests.

Automated verification:

```bash
yarn jest app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts app/components/UI/Predict/controllers/PredictController.test.ts app/components/UI/Predict/providers/polymarket/depositWallet.test.ts app/components/UI/Predict/providers/polymarket/preflight/withdraw.test.ts app/core/Engine/controllers/transaction-pay-controller/polymarket-callbacks.test.ts app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts --runInBand --coverage=false
yarn lint:tsc
```

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Predict withdrawals for legacy Safe and deposit-wallet accounts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: PRED-1128

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict withdrawals use the correct wallet execution path

  Scenario: funded legacy Safe without trading activity withdraws through the Safe
    Given an account has a deployed legacy Predict Safe containing USDC.e or pUSD
    And the Safe has no Polymarket activity
    And the account's derived deposit wallet is not deployed

    When the user opens Predict and starts a withdrawal
    Then the Predict account resolves to the funded legacy Safe
    And the withdrawal does not fail with "Deposit wallet ... is not deployed"

  Scenario: deployed deposit wallet withdraws through Transaction Pay
    Given an account resolves to a deployed UUPS or BeaconProxy deposit wallet
    And the deposit wallet has a withdrawable Predict balance

    When the user confirms a withdrawal
    Then Predict does not build Safe execTransaction calldata
    And Transaction Pay submits the Polymarket WALLET batch
    And the withdrawal completes successfully

  Scenario: active legacy Safe retains existing behavior
    Given an account has a deployed legacy Safe with Polymarket activity

    When the user confirms a withdrawal
    Then Predict signs the existing Safe withdrawal transaction
    And the transaction continues through the existing Safe flow
```

Manual device validation remains pending while this PR is in draft.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - logic-only wallet classification and transaction-routing change with no visual UI difference.

### **After**

N/A - logic-only wallet classification and transaction-routing change with no visual UI difference.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Pending: manual Android validation will be completed before this draft is marked ready for review.
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - N/A: wallet routing depends on the Predict contract generation and balances, not wallet account/token scale.
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: this reuses existing account-state and withdrawal boundaries and adds no new long-running operation.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes withdrawal account classification and pre-sign transaction mutation paths for real funds on Polygon; scope is limited to Predict/Polymarket but incorrect routing could still block or mis-route withdrawals.
> 
> **Overview**
> Fixes Predict withdrawals for accounts that were misclassified or signed with the wrong execution model.
> 
> **Account resolution:** When a deployed legacy Safe holds pUSD or USDC.e and the derived deposit wallet is not deployed, `getAccountState` now returns that Safe even if Polymarket activity is empty—so funded pre-trade users are not sent to an undeployed deposit wallet.
> 
> **Signing and confirmation:** `signWithdraw` returns a `walletType` and skips Safe `execTransaction` building for `deposit-wallet` accounts (original ERC20 transfer calldata is preserved for Transaction Pay). In `beforeSign`, Safe nonce cache invalidation and gas estimation run only for Safe wallets; deposit-wallet flows only update amount/status and fiat display without rewriting `txParams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82196a6785d0bbfb85acb8792187166aa9105e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->