### PR TITLE
refactor(perps): migrate market row to MMDS ListItem

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.styles.ts
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.styles.ts
@@ -5,9 +5,7 @@ const styleSheet = () =>
     container: {
       flex: 1,
     },
-    contentContainer: {
-      paddingHorizontal: 16,
-    },
+    contentContainer: {},
     emptyContainer: {
       flex: 1,
       justifyContent: 'center',

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -18,20 +18,6 @@ jest.mock('../PerpsTokenLogo', () => {
   };
 });
 
-jest.mock('../../../../../component-library/hooks', () => ({
-  useStyles: () => ({
-    styles: {
-      addButton: {
-        width: 32,
-        height: 32,
-        borderRadius: 16,
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
-    },
-  }),
-}));
-
 jest.mock('../../hooks/stream', () => ({
   usePerpsLivePrices: jest.fn(() => ({})), // Return empty object - no live prices in tests
 }));
@@ -230,9 +216,7 @@ describe('PerpsMarketRowItem', () => {
       expect(
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('Bitcoin');
-      expect(
-        screen.getByTestId(getPerpsMarketRowItemSelector.tickerSuffix('BTC')),
-      ).toHaveTextContent('BTC');
+      expect(screen.getByText('BTC · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('shows the ticker symbol when the flag is disabled', () => {
@@ -244,9 +228,8 @@ describe('PerpsMarketRowItem', () => {
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('BTC');
       expect(screen.queryByText('Bitcoin')).not.toBeOnTheScreen();
-      expect(
-        screen.queryByTestId(getPerpsMarketRowItemSelector.tickerSuffix('BTC')),
-      ).not.toBeOnTheScreen();
+      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
+      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
     });
 
     it('strips the provider prefix from the ticker when the flag is disabled', () => {
@@ -265,11 +248,7 @@ describe('PerpsMarketRowItem', () => {
       ).toHaveTextContent('TSLA');
       expect(screen.queryByText('xyz:TSLA')).not.toBeOnTheScreen();
       expect(screen.queryByText('Tesla')).not.toBeOnTheScreen();
-      expect(
-        screen.queryByTestId(
-          getPerpsMarketRowItemSelector.tickerSuffix('xyz:TSLA'),
-        ),
-      ).not.toBeOnTheScreen();
+      expect(screen.queryByText('TSLA · $2.5B Vol')).not.toBeOnTheScreen();
     });
 
     it('shows the full asset name for a provider-prefixed symbol when the flag is enabled', () => {
@@ -287,11 +266,7 @@ describe('PerpsMarketRowItem', () => {
         ),
       ).toHaveTextContent('Tesla');
       expect(screen.queryByText('xyz:TSLA')).not.toBeOnTheScreen();
-      expect(
-        screen.getByTestId(
-          getPerpsMarketRowItemSelector.tickerSuffix('xyz:TSLA'),
-        ),
-      ).toHaveTextContent('TSLA');
+      expect(screen.getByText('TSLA · $2.5B Vol')).toBeOnTheScreen();
     });
 
     it('does not show ticker suffix when the HIP-3 bare symbol equals the name', () => {
@@ -310,11 +285,8 @@ describe('PerpsMarketRowItem', () => {
         ),
       ).toHaveTextContent('AAPL');
       // No suffix — it would be a duplicate of the asset label
-      expect(
-        screen.queryByTestId(
-          getPerpsMarketRowItemSelector.tickerSuffix('xyz:AAPL'),
-        ),
-      ).not.toBeOnTheScreen();
+      expect(screen.queryByText('AAPL · $2.5B Vol')).not.toBeOnTheScreen();
+      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
     });
 
     it('falls back to the ticker when the flag is enabled but name is missing', () => {
@@ -325,9 +297,8 @@ describe('PerpsMarketRowItem', () => {
       expect(
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('BTC');
-      expect(
-        screen.queryByTestId(getPerpsMarketRowItemSelector.tickerSuffix('BTC')),
-      ).not.toBeOnTheScreen();
+      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
+      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
     });
 
     it('does not show a duplicate ticker when the name falls back to the symbol', () => {
@@ -342,9 +313,8 @@ describe('PerpsMarketRowItem', () => {
       expect(
         screen.getByTestId(getPerpsMarketRowItemSelector.assetLabel('BTC')),
       ).toHaveTextContent('BTC');
-      expect(
-        screen.queryByTestId(getPerpsMarketRowItemSelector.tickerSuffix('BTC')),
-      ).not.toBeOnTheScreen();
+      expect(screen.queryByText('BTC · $2.5B Vol')).not.toBeOnTheScreen();
+      expect(screen.getByText('$2.5B Vol')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -1,22 +1,14 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { getPerpsMarketRowItemSelector } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import {
-  Box,
-  BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
-  Card,
-  FontWeight,
-  Icon,
-  IconColor,
+  ButtonIcon,
+  ButtonIconSize,
+  ButtonIconVariant,
   IconName,
-  IconSize,
-  Text,
+  ListItem,
   TextColor,
-  TextVariant,
 } from '@metamask/design-system-react-native';
 import {
   PERPS_CONSTANTS,
@@ -38,24 +30,7 @@ import PerpsBadge from '../PerpsBadge';
 import PerpsLeverage from '../PerpsLeverage/PerpsLeverage';
 import PerpsTokenLogo from '../PerpsTokenLogo';
 import { PerpsMarketRowItemProps } from './PerpsMarketRowItem.types';
-import { useStyles } from '../../../../../component-library/hooks';
-import type { Theme } from '@metamask/design-tokens';
 import { selectPerpsShowFullAssetNamesFlag } from '../../selectors/featureFlags';
-
-const styleSheet = ({ theme }: { theme: Theme }) =>
-  StyleSheet.create({
-    addButton: {
-      width: 32,
-      height: 32,
-      borderRadius: 16,
-      backgroundColor: theme.colors.background.defaultPressed,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    name: {
-      flexShrink: 1,
-    },
-  });
 
 const PerpsMarketRowItem = ({
   market,
@@ -71,8 +46,6 @@ const PerpsMarketRowItem = ({
     symbols: [market.symbol],
     throttleMs: 3000, // 3 seconds for list view
   });
-
-  const { styles } = useStyles(styleSheet, {});
 
   const showFullAssetNames = useSelector(selectPerpsShowFullAssetNamesFlag);
 
@@ -202,153 +175,63 @@ const PerpsMarketRowItem = ({
     [showFullAssetNames, displayMarket.name, displayMarket.symbol],
   );
 
+  const description = showTickerSuffix
+    ? `${getPerpsDisplaySymbol(displayMarket.symbol)} \u00B7 ${displayText}`
+    : displayText;
+
   return (
-    <Card
+    <ListItem
+      isInteractive
       onPress={handlePress}
       testID={getPerpsMarketRowItemSelector.rowItem(market.symbol)}
-      touchableOpacityProps={{ activeOpacity: 0.7 }}
-      twClassName={`flex-row justify-between items-center border-0 rounded-none bg-transparent px-0 ${compact ? 'py-2' : 'py-3'}`}
-    >
-      {/* Left section: Icon + token info */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        twClassName="flex-1 mr-2"
-      >
-        <Box marginRight={4}>
-          <PerpsTokenLogo
-            symbol={displayMarket.symbol}
-            size={iconSize}
-            recyclingKey={displayMarket.symbol}
-            testID={getPerpsMarketRowItemSelector.tokenLogo(
-              displayMarket.symbol,
-            )}
+      avatar={
+        <PerpsTokenLogo
+          symbol={displayMarket.symbol}
+          size={iconSize}
+          recyclingKey={displayMarket.symbol}
+          testID={getPerpsMarketRowItemSelector.tokenLogo(displayMarket.symbol)}
+        />
+      }
+      title={assetLabel}
+      titleProps={{
+        testID: getPerpsMarketRowItemSelector.assetLabel(displayMarket.symbol),
+        numberOfLines: 1,
+      }}
+      titleEndAccessory={
+        <PerpsLeverage maxLeverage={displayMarket.maxLeverage} />
+      }
+      description={description}
+      descriptionEndAccessory={
+        showBadge && badgeType ? (
+          <PerpsBadge
+            type={badgeType}
+            testID={getPerpsMarketRowItemSelector.badge(displayMarket.symbol)}
           />
-        </Box>
-
-        <Box twClassName="flex-1">
-          {/* Asset label + leverage */}
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            gap={2}
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextDefault}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-              style={styles.name}
-              testID={getPerpsMarketRowItemSelector.assetLabel(
-                displayMarket.symbol,
-              )}
-            >
-              {assetLabel}
-            </Text>
-            <PerpsLeverage maxLeverage={displayMarket.maxLeverage} />
-          </Box>
-
-          {/* Metric row */}
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            gap={2}
-            twClassName="mt-0.5"
-          >
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              gap={1}
-            >
-              {showTickerSuffix && (
-                <>
-                  <Text
-                    variant={TextVariant.BodySm}
-                    color={TextColor.TextAlternative}
-                    numberOfLines={1}
-                    testID={getPerpsMarketRowItemSelector.tickerSuffix(
-                      market.symbol,
-                    )}
-                  >
-                    {getPerpsDisplaySymbol(displayMarket.symbol)}
-                  </Text>
-                  <Text
-                    variant={TextVariant.BodySm}
-                    color={TextColor.TextAlternative}
-                    numberOfLines={1}
-                  >
-                    {'\u00B7'}
-                  </Text>
-                </>
-              )}
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-                numberOfLines={1}
-              >
-                {displayText}
-              </Text>
-            </Box>
-            {showBadge && badgeType && (
-              <PerpsBadge
-                type={badgeType}
-                testID={getPerpsMarketRowItemSelector.badge(
-                  displayMarket.symbol,
-                )}
-              />
-            )}
-          </Box>
-        </Box>
-      </Box>
-
-      {/* Right section: Price + 24h change + optional add button */}
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.End}
-        gap={2}
-      >
-        <Box alignItems={BoxAlignItems.End} gap={1}>
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-          >
-            {displayMarket.price}
-          </Text>
-          <Text
-            variant={TextVariant.BodySm}
-            color={
-              isPositiveChange
-                ? TextColor.SuccessDefault
-                : TextColor.ErrorDefault
-            }
-          >
-            {displayMarket.change24hPercent}
-          </Text>
-        </Box>
-
-        {onAddPress && (
-          <TouchableOpacity
+        ) : undefined
+      }
+      value={displayMarket.price}
+      subvalue={displayMarket.change24hPercent}
+      subvalueProps={{
+        color: isPositiveChange
+          ? TextColor.SuccessDefault
+          : TextColor.ErrorDefault,
+      }}
+      endAccessory={
+        onAddPress ? (
+          <ButtonIcon
+            iconName={IconName.Add}
+            size={ButtonIconSize.Md}
+            variant={ButtonIconVariant.Filled}
             onPress={() => onAddPress(displayMarket)}
             testID={getPerpsMarketRowItemSelector.addButton(
               displayMarket.symbol,
             )}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            activeOpacity={0.6}
-          >
-            <View style={styles.addButton}>
-              <Icon
-                name={IconName.Add}
-                size={IconSize.Md}
-                color={IconColor.IconDefault}
-              />
-            </View>
-          </TouchableOpacity>
-        )}
-      </Box>
-    </Card>
+          />
+        ) : undefined
+      }
+      accessoryGap={onAddPress ? 3 : undefined}
+      twClassName={compact ? 'py-2 min-h-0' : undefined}
+    />
   );
 };
 

--- a/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.styles.ts
+++ b/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.styles.ts
@@ -45,6 +45,7 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     suggestedSubtitle: {
       marginBottom: 4,
+      paddingHorizontal: 16,
     },
     suggestedHeader: {
       marginBottom: 4,
@@ -54,7 +55,13 @@ const styleSheet = (params: { theme: Theme }) => {
       marginTop: 4,
       marginBottom: 8,
     },
-    showMoreButtonContainer: {},
+    showMoreButtonContainer: {
+      paddingHorizontal: 16,
+    },
+    // Skeleton loading (rows own horizontal inset via ListItem)
+    skeletonContainer: {
+      paddingHorizontal: 16,
+    },
   });
 };
 

--- a/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
+++ b/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
@@ -103,6 +103,7 @@ const PerpsWatchlistMarketsV1: React.FC<PerpsWatchlistMarketsProps> = ({
   showLeadingDivider = true,
 }) => {
   const navigation = useNavigation();
+  const { styles } = useStyles(styleSheet, {});
 
   const handleMarketPress = useCallback(
     (market: PerpsMarketData) => {
@@ -164,9 +165,11 @@ const PerpsWatchlistMarketsV1: React.FC<PerpsWatchlistMarketsProps> = ({
     <Box style={sectionStyle} testID={PerpsWatchlistSelectorsIDs.SECTION}>
       {showLeadingDivider ? <SectionDivider /> : null}
       <SectionHeader title={strings('perps.home.watchlist')} />
-      <Box paddingHorizontal={4} style={contentContainerStyle}>
+      <Box style={contentContainerStyle}>
         {isLoading ? (
-          <PerpsRowSkeleton count={3} />
+          <Box style={styles.skeletonContainer}>
+            <PerpsRowSkeleton count={3} />
+          </Box>
         ) : (
           <FlatList
             data={markets}
@@ -281,7 +284,7 @@ const PerpsWatchlistMarketsV2: React.FC<PerpsWatchlistMarketsProps> = ({
     return (
       <Box style={sectionStyle} testID={PerpsWatchlistSelectorsIDs.SECTION}>
         {watchlistHeader}
-        <Box paddingHorizontal={4} style={contentContainerStyle}>
+        <Box style={[styles.skeletonContainer, contentContainerStyle]}>
           <PerpsRowSkeleton count={3} />
         </Box>
       </Box>
@@ -322,7 +325,7 @@ const PerpsWatchlistMarketsV2: React.FC<PerpsWatchlistMarketsProps> = ({
   return (
     <Box style={sectionStyle} testID={PerpsWatchlistSelectorsIDs.SECTION}>
       {watchlistHeader}
-      <Box paddingHorizontal={4} style={contentContainerStyle}>
+      <Box style={contentContainerStyle}>
         <Animated.View layout={LinearTransition.duration(ANIMATION_DURATION)}>
           {hasWatchlist && (
             <>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Perps market rows were hand-rolled with `Card`/`Box` and `px-0`, while parents supplied horizontal padding. That drifted from MMDS `ListItem` defaults and made watchlist/suggested rows harder to keep consistent with the design system.

This migrates shared `PerpsMarketRowItem` to MMDS `ListItem` (avatar, title + leverage, description, value/subvalue, optional add `ButtonIcon` end accessory) and removes parent horizontal padding so rows use default `ListItem` `px-4` aligned with `SectionHeader`.

**What changed:**
- Replaced custom `Card`/`Box` market row layout with MMDS `ListItem` slots and typography defaults
- Replaced custom add-to-watchlist circle with MMDS `ButtonIcon` (`Filled`) + `accessoryGap` when present
- Removed horizontal padding from `PerpsWatchlistMarkets` content and `PerpsMarketList` so padding is owned by `ListItem`; kept inset on Show more / Suggested label / skeleton chrome
- Updated `PerpsMarketRowItem` unit tests for string descriptions and ListItem structure

Affects all `PerpsMarketRowItem` consumers: watchlist/suggested, market list, and home category sections (Explore crypto, Commodities, Stocks, Forex).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated Perps market list rows to use MetaMask Design System ListItem layout

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3590

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market rows use MMDS ListItem

  Scenario: user views watchlist and suggested markets on Perps home
    Given the user has Perps enabled and the watchlist redesign flag is on
    And the user has more than 3 markets on their watchlist
    And suggested markets are available

    When the user opens Perps home and scrolls to Watchlist
    Then watchlist rows show icon, name, leverage, volume, price, and 24h change with ListItem spacing
    And tapping "Show N more" expands the watchlist and "Show less" collapses it
    And suggested rows show a trailing + button with a gap before the price column
    And tapping + adds the market to the watchlist without navigating away
    And tapping a row opens market details

  Scenario: user views category market sections on Perps home
    Given markets are loaded for crypto, commodities, stocks, and forex

    When the user scrolls Perps home through Explore crypto, Commodities, Stocks, and Forex
    Then each section row matches the same ListItem layout as watchlist (no + button)
    And section headers and row content share the same horizontal inset

  Scenario: user browses the full market list
    Given the user opens Perps market list from search or a section header

    When the user scrolls the market list
    Then rows use ListItem padding (not double-padded)
    And pressing a row still opens market details
```

Unit tests:

```bash
yarn jest app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
yarn jest app/components/UI/Perps/components/PerpsWatchlistMarkets
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

https://github.com/user-attachments/assets/818e9609-82e5-4bcd-acae-dee03a43f79d

### **After**

https://github.com/user-attachments/assets/b24fc8e7-1891-4dd2-958b-bd3ca1a39950

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only design-system refactor across Perps list UIs; behavior and navigation are intended to stay the same with no security or data-path changes.
> 
> **Overview**
> **Perps market rows** now use MetaMask Design System **`ListItem`** instead of a hand-built **`Card`/`Box`** layout, so watchlist, market list, and home category sections share the same row chrome and default horizontal inset (`px-4`).
> 
> The row maps existing data into **`ListItem`** slots: logo as **avatar**, asset name + leverage on the title row, volume/metric (and optional ticker prefix) as a single **description** string, price and 24h change as **value/subvalue**, and watchlist **+** as a filled **`ButtonIcon`** with **`accessoryGap`** when **`onAddPress`** is set. Parent lists (**`PerpsMarketList`**, **`PerpsWatchlistMarkets`**) drop extra horizontal padding on row containers so padding isn’t doubled; skeleton loaders, “Show more”, and suggested subtitles keep their own **`paddingHorizontal: 16`**.
> 
> Unit tests were updated to assert combined description text (e.g. `BTC · $2.5B Vol`) instead of a separate ticker-suffix test id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06369cb15e568b4ea8e380f14ef6d6912b4690e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->