### PR TITLE
feat(stellar): Stellar preparation - add `Stellar` send flow support

### DIFF
--- a/app/components/Views/confirmations/components/send/send.non-evm.view.test.tsx
+++ b/app/components/Views/confirmations/components/send/send.non-evm.view.test.tsx
@@ -6,6 +6,7 @@ import {
   buildAddressBookOverridesWithEvmContact,
   buildNonEvmSendAccountsOverrides,
   buildTronSendFixture,
+  buildStellarSendFixture,
   NON_EVM_BTC_ACCOUNT_ID,
   NON_EVM_SOLANA_ACCOUNT_ID,
   sendViewOverrides,
@@ -31,6 +32,8 @@ const SOLANA_MAINNET_CHAIN_ID =
   'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as const;
 
 const TRON_MAINNET_CHAIN_ID = 'tron:728126428' as const;
+
+const STELLAR_MAINNET_CHAIN_ID = 'stellar:pubnet' as const;
 
 const NON_EVM_NETWORK_OVERRIDE = {
   engine: {
@@ -89,6 +92,16 @@ const TRON_NATIVE_ASSET_SEND_FIVE = {
   balance: '10',
   rawBalance: '0x989680', // 10 TRX in sun
   accountId: 'tron-acc-1',
+};
+
+const STELLAR_NATIVE_ASSET_SEND_FIVE = {
+  address: `${STELLAR_MAINNET_CHAIN_ID}/slip44:148`,
+  chainId: STELLAR_MAINNET_CHAIN_ID,
+  symbol: 'XLM',
+  decimals: 7,
+  balance: '10',
+  rawBalance: '100000000', // 10 XLM in stroops
+  accountId: 'stellar-acc-1',
 };
 
 const VALID_SOLANA_RECIPIENT = '11111111111111111111111111111111';
@@ -434,6 +447,63 @@ describeForPlatforms('Send (Non-EVM)', () => {
         {
           screen: Routes.SEND.AMOUNT,
           params: { asset: TRON_NATIVE_ASSET_SEND_FIVE },
+        },
+      );
+
+    expect(
+      getByTestId(RedesignedSendViewSelectorsIDs.SEND_AMOUNT),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(getByText('5'));
+
+    const continueButton = getByRole('button', { name: 'Continue' });
+    await waitFor(() => expect(continueButton).toBeEnabled(), {
+      timeout: 5000,
+    });
+    fireEvent.press(continueButton);
+
+    const recipientInput = await findByTestId(
+      RedesignedSendViewSelectorsIDs.RECIPIENT_ADDRESS_INPUT,
+      {},
+      { timeout: 5000 },
+    );
+    fireEvent.changeText(recipientInput, recipientAddresses[0]);
+
+    const reviewButton = await findByTestId(
+      RedesignedSendViewSelectorsIDs.REVIEW_BUTTON,
+      {},
+      { timeout: 5000 },
+    );
+    await waitFor(() => expect(reviewButton).toBeEnabled(), {
+      timeout: 5000,
+    });
+    fireEvent.press(reviewButton);
+
+    await waitFor(() => {
+      expect(snapHandleRequestSpy).toHaveBeenCalledWith(
+        'SnapController:handleRequest',
+        expect.objectContaining({
+          request: expect.objectContaining({ method: 'confirmSend' }),
+        }),
+      );
+    });
+
+    expect(await findByTestId('route-TransactionsView')).toBeOnTheScreen();
+  }, 20000);
+
+  it('STELLAR native: digit 5 submits and opens transfer confirmation route', async () => {
+    const { stellarOverrides, recipientAddresses } = buildStellarSendFixture();
+    const state = initialStateWallet().withOverrides(stellarOverrides).build();
+
+    const { getByTestId, getByText, getByRole, findByTestId } =
+      renderScreenWithRoutes(
+        SendFlowWithHardwareWalletProvider as unknown as React.ComponentType,
+        { name: Routes.SEND.DEFAULT },
+        [{ name: Routes.TRANSACTIONS_VIEW }],
+        { state },
+        {
+          screen: Routes.SEND.AMOUNT,
+          params: { asset: STELLAR_NATIVE_ASSET_SEND_FIVE },
         },
       );
 

--- a/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
@@ -8,6 +8,7 @@ import {
   isSolanaAccount,
   isBtcAccount,
   isTronAccount,
+  isStellarAccount,
 } from '../../../../../core/Multichain/utils';
 import { useSendContext } from '../../context/send-context';
 import { useSendType } from './useSendType';
@@ -29,6 +30,7 @@ jest.mock('../../../../../core/Multichain/utils', () => ({
   isSolanaAccount: jest.fn(),
   isBtcAccount: jest.fn(),
   isTronAccount: jest.fn(),
+  isStellarAccount: jest.fn(),
 }));
 
 jest.mock('../../../../../selectors/multichainAccounts/wallets', () => ({
@@ -56,6 +58,9 @@ const mockIsBtcAccount = isBtcAccount as jest.MockedFunction<
 >;
 const mockIsTronAccount = isTronAccount as jest.MockedFunction<
   typeof isTronAccount
+>;
+const mockIsStellarAccount = isStellarAccount as jest.MockedFunction<
+  typeof isStellarAccount
 >;
 const mockUseSendContext = useSendContext as jest.MockedFunction<
   typeof useSendContext
@@ -118,6 +123,18 @@ describe('useAccounts', () => {
     },
   };
 
+  const mockStellarAccount = {
+    id: 'stellar-account-1',
+    address: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI',
+    type: 'stellar:account',
+    metadata: {
+      name: 'Stellar Account 1',
+      keyring: {
+        type: 'Stellar Keyring',
+      },
+    },
+  };
+
   const mockWallet = {
     id: 'wallet-1',
     metadata: {
@@ -152,6 +169,13 @@ describe('useAccounts', () => {
           name: 'Group 4',
         },
       },
+      'group-5': {
+        id: 'group-5',
+        accounts: ['stellar-account-1'],
+        metadata: {
+          name: 'Group 5',
+        },
+      },
     },
   };
 
@@ -160,6 +184,7 @@ describe('useAccounts', () => {
     'solana-account-1': mockSolanaAccount,
     'bitcoin-account-1': mockBitcoinAccount,
     'tron-account-1': mockTronAccount,
+    'stellar-account-1': mockStellarAccount,
   };
 
   beforeEach(() => {
@@ -191,6 +216,7 @@ describe('useAccounts', () => {
     mockIsSolanaAccount.mockReturnValue(false);
     mockIsBtcAccount.mockReturnValue(false);
     mockIsTronAccount.mockReturnValue(false);
+    mockIsStellarAccount.mockReturnValue(false);
   });
 
   describe('when isEvmSendType is true', () => {
@@ -203,10 +229,12 @@ describe('useAccounts', () => {
         isNonEvmNativeSendType: false,
         isBitcoinSendType: false,
         isTronSendType: false,
+        isStellarSendType: false,
         isPredefinedEvm: true,
         isPredefinedSolana: false,
         isPredefinedBitcoin: false,
         isPredefinedTron: false,
+        isPredefinedStellar: false,
       });
       mockIsEvmAccountType.mockImplementation(
         (accountType) => accountType === 'eip155:eoa',
@@ -399,6 +427,62 @@ describe('useAccounts', () => {
     it('filters out account when from address matches Tron account address', () => {
       mockUseSendContext.mockReturnValue({
         from: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        maxValueMode: false,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+      });
+
+      const { result } = renderHook(() => useAccounts());
+
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  describe('when isStellarSendType is true', () => {
+    beforeEach(() => {
+      createMockUseSendType({
+        isStellarSendType: true,
+        isPredefinedStellar: true,
+      });
+      mockIsEvmAccountType.mockReturnValue(false);
+      mockIsSolanaAccount.mockReturnValue(false);
+      mockIsBtcAccount.mockReturnValue(false);
+      mockIsTronAccount.mockReturnValue(false);
+      mockIsStellarAccount.mockImplementation(
+        (account) => account.type === 'stellar:account',
+      );
+    });
+
+    it('returns Stellar compatible accounts', () => {
+      const { result } = renderHook(() => useAccounts());
+
+      expect(result.current).toEqual([
+        {
+          accountGroupId: 'group-5',
+          accountGroupName: 'Group 5',
+          accountName: 'Stellar Account 1',
+          accountType: 'stellar:account',
+          address: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI',
+          walletName: 'Wallet 1',
+        },
+      ]);
+    });
+
+    it('filters out non-Stellar accounts', () => {
+      const { result } = renderHook(() => useAccounts());
+
+      expect(result.current).toHaveLength(1);
+      expect(mockIsStellarAccount).toHaveBeenCalledWith(mockEvmAccount);
+      expect(mockIsStellarAccount).toHaveBeenCalledWith(mockSolanaAccount);
+      expect(mockIsStellarAccount).toHaveBeenCalledWith(mockBitcoinAccount);
+      expect(mockIsStellarAccount).toHaveBeenCalledWith(mockTronAccount);
+      expect(mockIsStellarAccount).toHaveBeenCalledWith(mockStellarAccount);
+    });
+
+    it('filters out account when from address matches Stellar account address', () => {
+      mockUseSendContext.mockReturnValue({
+        from: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI',
         maxValueMode: false,
         updateAsset: jest.fn(),
         updateTo: jest.fn(),

--- a/app/components/Views/confirmations/hooks/send/useAccounts.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.ts
@@ -14,6 +14,7 @@ import {
   /// BEGIN:ONLY_INCLUDE_IF(tron)
   isTronAccount,
   /// END:ONLY_INCLUDE_IF
+  isStellarAccount,
 } from '../../../../../core/Multichain/utils';
 import { type RecipientType } from '../../components/UI/recipient';
 import { useSendContext } from '../../context/send-context';
@@ -32,6 +33,7 @@ export const useAccounts = (): RecipientType[] => {
     /// BEGIN:ONLY_INCLUDE_IF(tron)
     isTronSendType,
     /// END:ONLY_INCLUDE_IF
+    isStellarSendType,
   } = useSendType();
 
   const isAccountCompatible = useMemo(
@@ -60,6 +62,9 @@ export const useAccounts = (): RecipientType[] => {
         return isTronAccount(account);
       }
       /// END:ONLY_INCLUDE_IF
+      if (isStellarSendType) {
+        return isStellarAccount(account);
+      }
       return false;
     },
     [
@@ -72,6 +77,7 @@ export const useAccounts = (): RecipientType[] => {
       /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
       /// END:ONLY_INCLUDE_IF
+      isStellarSendType,
       from,
     ],
   );

--- a/app/components/Views/confirmations/hooks/send/useContacts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useContacts.test.ts
@@ -120,6 +120,8 @@ describe('useContacts', () => {
         isPredefinedSolana: false,
         isPredefinedBitcoin: false,
         isPredefinedTron: false,
+        isStellarSendType: false,
+        isPredefinedStellar: false,
       });
     });
 

--- a/app/components/Views/confirmations/hooks/send/useSendActions.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendActions.test.ts
@@ -168,6 +168,8 @@ describe('useSendActions', () => {
         isPredefinedBitcoin: false,
         isTronSendType: false,
         isPredefinedTron: false,
+        isStellarSendType: false,
+        isPredefinedStellar: false,
       });
 
       mockUseSendContext.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
@@ -92,6 +92,26 @@ const mockBitcoinToken: AssetType = {
   rawBalance: '0xdef0',
 } as unknown as AssetType;
 
+const mockStellarToken: AssetType = {
+  address: 'stellar:pubnet/slip44:148',
+  chainId: 'stellar:pubnet',
+  symbol: 'XLM',
+  ticker: 'XLM',
+  decimals: 7,
+  balance: '50',
+  balanceFiat: '$6.00',
+  image: 'https://example.com/xlm.png',
+  aggregators: [],
+  logo: 'https://example.com/xlm.png',
+  isNative: true,
+  accountType: 'stellar:pubnet/slip44:148',
+  networkBadgeSource: 'network-badge-source',
+  balanceInSelectedCurrency: '$6.00',
+  standard: TokenStandard.ERC20,
+  fiat: { balance: '6' },
+  rawBalance: '0xabcd',
+} as unknown as AssetType;
+
 describe('useSendTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -104,10 +124,12 @@ describe('useSendTokens', () => {
       isSolanaSendType: undefined,
       isBitcoinSendType: undefined,
       isTronSendType: undefined,
+      isStellarSendType: undefined,
       isPredefinedEvm: false,
       isPredefinedSolana: false,
       isPredefinedBitcoin: false,
       isPredefinedTron: false,
+      isPredefinedStellar: false,
     });
   });
 
@@ -235,6 +257,28 @@ describe('useSendTokens', () => {
     });
     expect(result.current).toHaveLength(1);
     expect(result.current[0]).toEqual(mockBitcoinToken);
+  });
+
+  it('filters to Stellar tokens when isPredefinedStellar is true', () => {
+    createMockUseSendType({
+      isPredefinedEvm: false,
+      isPredefinedSolana: false,
+      isPredefinedTron: false,
+      isPredefinedBitcoin: false,
+      isPredefinedStellar: true,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+      mockStellarToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockStellarToken);
   });
 
   it('passes includeNoBalance option to useAccountTokens', () => {

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.ts
@@ -17,6 +17,7 @@ export function useSendTokens({
     isPredefinedBitcoin,
     isPredefinedSolana,
     isPredefinedEvm,
+    isPredefinedStellar,
   } = useSendType();
   const allTokens = useAccountTokens({
     includeNoBalance,
@@ -30,6 +31,7 @@ export function useSendTokens({
       solana: !!isPredefinedSolana,
       tron: !!isPredefinedTron,
       bip122: !!isPredefinedBitcoin,
+      stellar: !!isPredefinedStellar,
     };
 
     const matchedAccountType = Object.entries(accountTypeMap).find(
@@ -49,5 +51,6 @@ export function useSendTokens({
     isPredefinedSolana,
     isPredefinedTron,
     isPredefinedBitcoin,
+    isPredefinedStellar,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -54,10 +54,12 @@ describe('useSendType', () => {
         isSolanaSendType: undefined,
         isBitcoinSendType: undefined,
         isTronSendType: undefined,
+        isStellarSendType: undefined,
         isPredefinedEvm: false,
         isPredefinedSolana: false,
         isPredefinedBitcoin: false,
         isPredefinedTron: false,
+        isPredefinedStellar: false,
       });
     });
   });

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -4,6 +4,7 @@ import {
   isBitcoinChainId,
   /// END:ONLY_INCLUDE_IF
   isSolanaChainId,
+  isStellarChainId,
 } from '@metamask/bridge-controller';
 import { useCallback, useMemo } from 'react';
 
@@ -28,6 +29,7 @@ export const useSendType = () => {
   const isPredefinedBitcoin = predefinedRecipient?.chainType === 'bitcoin';
   const isPredefinedSolana = predefinedRecipient?.chainType === 'solana';
   const isPredefinedTron = predefinedRecipient?.chainType === 'tron';
+  const isPredefinedStellar = predefinedRecipient?.chainType === 'stellar';
 
   const isPredefinedNonEvm =
     predefinedRecipient?.chainType && predefinedRecipient.chainType !== 'evm';
@@ -75,6 +77,11 @@ export const useSendType = () => {
   );
   /// END:ONLY_INCLUDE_IF
 
+  const isStellarSendType = useMemo(
+    () => createChainTypeCheck(isPredefinedStellar, isStellarChainId),
+    [createChainTypeCheck, isPredefinedStellar],
+  );
+
   const assetIsNative =
     asset && 'isNative' in asset ? Boolean(asset.isNative) : undefined;
 
@@ -95,6 +102,8 @@ export const useSendType = () => {
       isTronSendType,
       isPredefinedTron,
       /// END:ONLY_INCLUDE_IF
+      isStellarSendType,
+      isPredefinedStellar,
     }),
     [
       isEvmSendType,
@@ -111,6 +120,8 @@ export const useSendType = () => {
       isTronSendType,
       isPredefinedTron,
       /// END:ONLY_INCLUDE_IF
+      isStellarSendType,
+      isPredefinedStellar,
     ],
   );
 };

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
@@ -117,6 +117,34 @@ describe('useToAddressValidation', () => {
     });
   });
 
+  it('validate stellar address correctly', async () => {
+    mockUseSendContext.mockReturnValue({
+      asset: {
+        name: 'Stellar',
+        address: 'stellar:pubnet/slip44:148',
+        isNative: true,
+        chainId: 'stellar:pubnet',
+        symbol: 'XLM',
+        decimals: 7,
+      },
+      to: 'dummy',
+      chainId: 'stellar:pubnet',
+    } as unknown as ReturnType<typeof useSendContext>);
+    const { result } = renderHookWithProvider(
+      () => useToAddressValidation(),
+      mockState,
+    );
+    await waitFor(() => {
+      expect(result.current).toStrictEqual({
+        loading: false,
+        resolvedAddress: undefined,
+        toAddressError: 'Invalid address',
+        toAddressValidated: 'dummy',
+        toAddressWarning: undefined,
+      });
+    });
+  });
+
   it('validate tron address correctly', async () => {
     mockUseSendContext.mockReturnValue({
       asset: {

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
@@ -10,6 +10,7 @@ import {
   validateSolanaAddress,
   validateBitcoinAddress,
   validateTronAddress,
+  validateStellarAddress,
 } from '../../utils/send-address-validations';
 import { useSendContext } from '../../context/send-context';
 import { useSendType } from './useSendType';
@@ -24,8 +25,13 @@ interface ValidationResult {
 
 export const useToAddressValidation = () => {
   const { asset, chainId, to } = useSendContext();
-  const { isEvmSendType, isSolanaSendType, isBitcoinSendType, isTronSendType } =
-    useSendType();
+  const {
+    isEvmSendType,
+    isSolanaSendType,
+    isBitcoinSendType,
+    isTronSendType,
+    isStellarSendType,
+  } = useSendType();
   const { validateName } = useNameValidation();
   const [result, setResult] = useState<ValidationResult>({});
   const [loading, setLoading] = useState(false);
@@ -67,6 +73,10 @@ export const useToAddressValidation = () => {
         return validateTronAddress(toAddress);
       }
 
+      if (isStellarSendType) {
+        return validateStellarAddress(toAddress);
+      }
+
       if (isENS(toAddress)) {
         return await validateName(chainId, toAddress);
       }
@@ -82,6 +92,7 @@ export const useToAddressValidation = () => {
       isSolanaSendType,
       isBitcoinSendType,
       isTronSendType,
+      isStellarSendType,
       validateName,
     ],
   );

--- a/app/components/Views/confirmations/utils/address.test.ts
+++ b/app/components/Views/confirmations/utils/address.test.ts
@@ -76,6 +76,20 @@ describe('derivePredefinedRecipientParams', () => {
     });
   });
 
+  describe('Stellar addresses', () => {
+    it('returns Stellar chain type for valid Stellar address', () => {
+      const address =
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.STELLAR,
+      });
+    });
+  });
+
   describe('Invalid addresses', () => {
     it('returns undefined for invalid address', () => {
       const address = 'invalid-address';
@@ -121,10 +135,17 @@ describe('derivePredefinedRecipientParams', () => {
       expect(result?.chainType).toBe(ChainType.BITCOIN);
     });
 
-    it('checks Tron address last', () => {
+    it('checks Tron address before Stellar', () => {
       const tronAddress = 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7';
       const result = derivePredefinedRecipientParams(tronAddress);
       expect(result?.chainType).toBe(ChainType.TRON);
+    });
+
+    it('checks Stellar address last', () => {
+      const stellarAddress =
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+      const result = derivePredefinedRecipientParams(stellarAddress);
+      expect(result?.chainType).toBe(ChainType.STELLAR);
     });
   });
 });

--- a/app/components/Views/confirmations/utils/address.ts
+++ b/app/components/Views/confirmations/utils/address.ts
@@ -3,6 +3,7 @@ import { isAddress as isSolanaAddress } from '@solana/addresses';
 import { isAddress as isEvmAddress } from 'ethers/lib/utils';
 import {
   isBtcMainnetAddress,
+  isStellarAddress,
   isTronAddress,
 } from '../../../../core/Multichain/utils';
 
@@ -32,6 +33,13 @@ export const derivePredefinedRecipientParams = (address: string) => {
     return {
       address,
       chainType: ChainType.TRON,
+    };
+  }
+
+  if (isStellarAddress(address)) {
+    return {
+      address,
+      chainType: ChainType.STELLAR,
     };
   }
 

--- a/app/components/Views/confirmations/utils/send-address-validations.test.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.test.ts
@@ -5,6 +5,7 @@ import {
   validateBitcoinAddress,
   validateHexAddress,
   validateSolanaAddress,
+  validateStellarAddress,
   validateTronAddress,
 } from './send-address-validations';
 jest.mock('./token', () => ({
@@ -97,6 +98,24 @@ describe('validateSolanaAddress', () => {
   it('does not returns error if address is solana address', () => {
     expect(
       validateSolanaAddress('14grJpemFaf88c8tiVb77W7TYg2W3ir6pfkKz3YjhhZ5'),
+    ).toStrictEqual({});
+  });
+});
+
+describe('validateStellarAddress', () => {
+  it('returns error if address is not stellar address', () => {
+    expect(
+      validateStellarAddress('0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477'),
+    ).toStrictEqual({
+      error: 'Invalid address',
+    });
+  });
+
+  it('does not return error if address is stellar address', () => {
+    expect(
+      validateStellarAddress(
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI',
+      ),
     ).toStrictEqual({});
   });
 });

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -10,6 +10,7 @@ import {
 import {
   isBtcMainnetAddress,
   isTronAddress,
+  isStellarAddress,
 } from '../../../../core/Multichain/utils';
 import { LOWER_CASED_BURN_ADDRESSES } from '../../../../constants/address';
 
@@ -109,6 +110,20 @@ export const validateTronAddress = (
   warning?: string;
 } => {
   if (!isTronAddress(toAddress)) {
+    return {
+      error: strings('send.invalid_address'),
+    };
+  }
+  return {};
+};
+
+export const validateStellarAddress = (
+  toAddress: string,
+): {
+  error?: string;
+  warning?: string;
+} => {
+  if (!isStellarAddress(toAddress)) {
     return {
       error: strings('send.invalid_address'),
     };

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -37,6 +37,7 @@ export enum ChainType {
   SOLANA = 'solana',
   BITCOIN = 'bitcoin',
   TRON = 'tron',
+  STELLAR = 'stellar',
 }
 
 export interface PredefinedRecipient {
@@ -84,7 +85,7 @@ export function isValidPositiveNumericString(str: string) {
  * @param params.asset - Optional preselected asset (token or NFT) to send. When provided, skips the asset selection screen.
  * @param params.predefinedRecipient - Optional recipient with chain information. Should be an object containing:
  * - `address`: The recipient's address string
- * - `chainType`: One of 'evm', 'solana', 'bitcoin', or 'tron'
+ * - `chainType`: One of 'evm', 'solana', 'bitcoin', or 'tron' or 'stellar'
  *
  * @remarks
  * The predefinedRecipient is passed through navigation params and can be used by downstream screens

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -5,6 +5,7 @@ import {
   BtcAccountType,
   TrxAccountType,
   TrxScope,
+  XlmAccountType,
 } from '@metamask/keyring-api';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 import Engine from '../Engine';
@@ -199,6 +200,27 @@ export function isTronAddress(address: string): boolean {
     Logger.error(new Error('Error decoding Tron address'), { error });
     return false;
   }
+}
+
+/**
+ * Returns whether an account is a Stellar account.
+ *
+ * @param account - The internal account to check.
+ * @returns `true` if the account is of type Eoa, false otherwise.
+ */
+export function isStellarAccount(account: InternalAccount): boolean {
+  const { Account } = XlmAccountType;
+  return Boolean(account && account.type === Account);
+}
+
+/**
+ * Stellar account address (StrKey, starts with G).
+ *
+ * @param address - The address to check.
+ * @returns `true` if the string matches the Stellar account key format.
+ */
+export function isStellarAddress(address: string): boolean {
+  return /^G[A-Z2-7]{55}$/u.test(address);
 }
 
 /**

--- a/app/util/address/index.test.ts
+++ b/app/util/address/index.test.ts
@@ -339,6 +339,25 @@ describe('isValidAddressInputViaQRCode', () => {
     });
   });
 
+  describe('Stellar addresses', () => {
+    it('should be valid for Stellar mainnet address', () => {
+      const mockInput =
+        'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(true);
+    });
+
+    it('should be invalid for invalid Stellar address (wrong length)', () => {
+      const mockInput = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQ';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(false);
+    });
+
+    it('should be invalid for invalid Stellar address (does not start with G)', () => {
+      const mockInput =
+        'HBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+      expect(isValidAddressInputViaQRCode(mockInput)).toBe(false);
+    });
+  });
+
   describe('Tron addresses', () => {
     it('should be valid for Tron mainnet address', () => {
       const mockInput = 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7';

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -8,6 +8,7 @@ import { isAddress as isSolanaAddress } from '@solana/addresses';
 import {
   isBtcMainnetAddress,
   isTronAddress,
+  isStellarAddress,
 } from '../../core/Multichain/utils';
 import {
   getChecksumAddress,
@@ -807,7 +808,7 @@ export async function validateAddressOrENS(
     confusableCollection,
   };
 }
-/** Method to evaluate if an input is a valid ethereum, solana, bitcoin, or tron address
+/** Method to evaluate if an input is a valid ethereum, solana, bitcoin, stellar or tron address
  * via QR code scanning.
  *
  * @param {string} input - a random string.
@@ -823,6 +824,10 @@ export function isValidAddressInputViaQRCode(input: string) {
   }
 
   if (isTronAddress(input)) {
+    return true;
+  }
+
+  if (isStellarAddress(input)) {
     return true;
   }
 

--- a/tests/component-view/presets/send.ts
+++ b/tests/component-view/presets/send.ts
@@ -54,6 +54,16 @@ export interface TronSendFixture {
   recipientAddresses: [string, string];
 }
 
+export interface StellarSendFixtureOptions {
+  senderAddress?: string;
+  recipientAddresses?: [string, string];
+}
+
+export interface StellarSendFixture {
+  stellarOverrides: DeepPartial<RootState>;
+  recipientAddresses: [string, string];
+}
+
 export const NON_EVM_SOLANA_ACCOUNT_ID = 'solana-acc-1';
 export const NON_EVM_BTC_ACCOUNT_ID = 'btc-acc-1';
 
@@ -173,6 +183,130 @@ export function buildTronSendFixture(
   } as unknown as DeepPartial<RootState>;
 
   return { tronOverrides, recipientAddresses };
+}
+
+const STELLAR_SEND_GROUP_ID = 'entropy:wallet1/0';
+const STELLAR_SEND_WALLETS_KEY = 'entropy:wallet1';
+const STELLAR_SEND_ACCOUNT_IDS = [
+  'stellar-acc-1',
+  'stellar-acc-2',
+  'stellar-acc-3',
+];
+
+/**
+ * Builds state overrides and recipient addresses for Stellar send view tests.
+ * Use with initialStateWallet().withOverrides(stellarOverrides).build().
+ */
+export function buildStellarSendFixture(
+  options: StellarSendFixtureOptions = {},
+): StellarSendFixture {
+  const senderAddress =
+    options.senderAddress ??
+    'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+  const recipientAddresses =
+    options.recipientAddresses ??
+    ([
+      'GCEZWKCA5VLDNRLD3HRGYFMXLE3ZPZF6NPSQ2GDBZKTYISBDMZCFLPTB',
+      'GCQTGZO5X3UK6YOLYUKJ5FRQGG4OHUTYPTEZ7MY3LY5KVWE5U7ATFIQX',
+    ] as [string, string]);
+
+  const STELLAR_MAINNET_SCOPE = 'stellar:pubnet';
+
+  const stellarAccountEntries = Object.fromEntries([
+    [
+      STELLAR_SEND_ACCOUNT_IDS[0],
+      {
+        id: STELLAR_SEND_ACCOUNT_IDS[0],
+        address: senderAddress,
+        metadata: { name: 'Stellar Account 1', importTime: Date.now() },
+        options: {},
+        methods: [],
+        type: 'stellar:account',
+        scopes: [STELLAR_MAINNET_SCOPE],
+      },
+    ],
+    [
+      STELLAR_SEND_ACCOUNT_IDS[1],
+      {
+        id: STELLAR_SEND_ACCOUNT_IDS[1],
+        address: recipientAddresses[0],
+        metadata: { name: 'Stellar Account 2', importTime: Date.now() },
+        options: {},
+        methods: [],
+        type: 'stellar:account',
+        scopes: [STELLAR_MAINNET_SCOPE],
+      },
+    ],
+    [
+      STELLAR_SEND_ACCOUNT_IDS[2],
+      {
+        id: STELLAR_SEND_ACCOUNT_IDS[2],
+        address: recipientAddresses[1],
+        metadata: { name: 'Stellar Account 3', importTime: Date.now() },
+        options: {},
+        methods: [],
+        type: 'stellar:account',
+        scopes: [STELLAR_MAINNET_SCOPE],
+      },
+    ],
+  ]);
+
+  const baseEngine = (sendViewOverrides as Record<string, unknown>).engine as
+    | { backgroundState?: Record<string, unknown> }
+    | undefined;
+  const stellarOverrides = {
+    ...sendViewOverrides,
+    engine: {
+      backgroundState: {
+        ...baseEngine?.backgroundState,
+        MultichainNetworkController: {
+          isEvmSelected: false,
+        },
+        AccountsController: {
+          internalAccounts: {
+            accounts: stellarAccountEntries,
+            selectedAccount: STELLAR_SEND_ACCOUNT_IDS[0],
+          },
+        },
+        AccountTreeController: {
+          accountTree: {
+            wallets: {
+              [STELLAR_SEND_WALLETS_KEY]: {
+                id: STELLAR_SEND_WALLETS_KEY,
+                type: 'Entropy',
+                metadata: { name: 'Wallet 1', entropy: { id: 'wallet1' } },
+                groups: {
+                  [STELLAR_SEND_GROUP_ID]: {
+                    id: STELLAR_SEND_GROUP_ID,
+                    type: 'MultipleAccount',
+                    metadata: {
+                      name: 'Group 1',
+                      pinned: false,
+                      hidden: false,
+                      lastSelected: 0,
+                    },
+                    accounts: STELLAR_SEND_ACCOUNT_IDS,
+                  },
+                },
+              },
+            },
+          },
+          selectedAccountGroup: STELLAR_SEND_GROUP_ID,
+        },
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {
+            enableMultichainAccounts: {
+              enabled: true,
+              featureVersion: '1',
+              minimumVersion: '0.0.0',
+            },
+          },
+        },
+      },
+    },
+  } as unknown as DeepPartial<RootState>;
+
+  return { stellarOverrides, recipientAddresses };
 }
 
 /**


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This PR is one of the prerequisite PR for stellar that extracted from this working Branch https://github.com/MetaMask/metamask-mobile/pull/32803

This PR adds Stellar send validation, account filtering, and related tests.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Stellar send flow support

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect send recipient validation and account selection for real transfers; risk is moderated by mirroring existing non-EVM chains and broad test coverage, but incorrect address rules could block or mis-route sends.
> 
> **Overview**
> **Adds Stellar (XLM) to the redesigned send flow** using the same multichain pattern as Solana, Bitcoin, and Tron.
> 
> Send type detection now exposes `isStellarSendType` / `isPredefinedStellar` (via `isStellarChainId` and `chainType: 'stellar'`). Recipient validation uses new `validateStellarAddress` and StrKey checks (`isStellarAddress`). Compatible Stellar accounts and XLM tokens are filtered in `useAccounts` and `useSendTokens`. QR scans and `derivePredefinedRecipientParams` recognize Stellar `G…` addresses and map them to `ChainType.STELLAR`.
> 
> `core/Multichain/utils` adds `isStellarAccount` (`stellar:account`) and address format helpers. Coverage includes unit tests, `buildStellarSendFixture`, and a non-EVM component test for native XLM send through `confirmSend` to the transactions view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8b8c334334d2e7103f0945b7ccb23640ff2333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->