### PR TITLE
feat(onboarding): trace social login pre-provider latency

### DIFF
--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -79,7 +79,7 @@ import { AccountType } from '../../../constants/onboarding';
 import { FeatureFlagNames } from '../../../constants/featureFlags';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { ATTRIBUTION_DEFAULT_TTL_MS } from '../../../core/redux/slices/attribution';
-import { endTrace, TraceName } from '../../../util/trace';
+import { endTrace, trace, TraceName } from '../../../util/trace';
 
 // Mock netinfo - using existing mock
 jest.mock('@react-native-community/netinfo');
@@ -976,6 +976,68 @@ describe('Onboarding', () => {
       );
     });
 
+    it('emits backdated pre-provider trace spans and closes the parent at OAuth provider launch', async () => {
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockResolvedValue({
+        type: 'success',
+        existingUser: false,
+        accountName: 'test@example.com',
+      });
+
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+      const googleOAuthFunction = navCall[1].params.onPressContinueWithGoogle;
+
+      await act(async () => {
+        await googleOAuthFunction(true);
+      });
+
+      expect(trace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.OnboardingSocialLoginPreProvider,
+          startTime: expect.any(Number),
+          tags: expect.objectContaining({ provider: 'google', flow: 'create' }),
+        }),
+      );
+      const childTraceNames = [
+        TraceName.OnboardingSocialLoginNetworkCheck,
+        TraceName.OnboardingSocialLoginMetricsEnable,
+        TraceName.OnboardingSocialLoginSentrySetup,
+      ];
+      childTraceNames.forEach((name) => {
+        expect(trace).toHaveBeenCalledWith(
+          expect.objectContaining({ name, startTime: expect.any(Number) }),
+        );
+        expect(endTrace).toHaveBeenCalledWith(
+          expect.objectContaining({ name, timestamp: expect.any(Number) }),
+        );
+      });
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.OnboardingSocialLoginPreProvider,
+          data: expect.objectContaining({ reached_oauth: true }),
+        }),
+      );
+    });
+
     it('calls Google OAuth login for create wallet flow on Android and navigates directly to ChoosePassword', async () => {
       Platform.OS = 'android'; // Set platform to Android
       mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
@@ -1791,6 +1853,15 @@ describe('Onboarding', () => {
             is_rehydration: 'false',
             failure_type: 'error',
             error_category: 'provider_login',
+          }),
+        }),
+      );
+      expect(endTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.OnboardingSocialLoginPreProvider,
+          data: expect.objectContaining({
+            reached_oauth: false,
+            reason: 'ios_google_login_unsupported',
           }),
         }),
       );

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -95,6 +95,12 @@ import { AuthConnection } from '../../../core/OAuthService/OAuthInterface';
 import { selectWalletSetupCompletedAttributionAnalyticsProps } from '../../../selectors/attribution';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { setupSentry } from '../../../util/sentry/utils';
+import {
+  emitSocialLoginPreProviderTrace,
+  endSocialLoginPreProviderTrace,
+  measureSocialLoginPreProviderStep,
+  startSocialLoginPreProviderTimings,
+} from './socialLoginPreProviderTrace';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import ErrorBoundary from '../ErrorBoundary';
 import FastOnboarding from './FastOnboarding';
@@ -763,9 +769,18 @@ const Onboarding = () => {
 
   const onPressContinueWithSocialLogin = useCallback(
     async (createWallet: boolean, provider: AuthConnection): Promise<void> => {
+      // TO-917: capture timestamps around the pre-provider awaits; spans are
+      // emitted after setupSentry() so they survive discardBufferedTraces().
+      const preProviderTimings = startSocialLoginPreProviderTimings();
+      let iosGoogleWarningShown = false;
+
       // check for internet connection
       try {
-        const netState = await netInfoFetch();
+        const netState = await measureSocialLoginPreProviderStep(
+          preProviderTimings,
+          'networkCheck',
+          () => netInfoFetch(),
+        );
         if (!netState.isConnected || netState.isInternetReachable === false) {
           navigation.dispatch(
             StackActions.replace(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -794,9 +809,25 @@ const Onboarding = () => {
       navigation.navigate('Onboarding');
 
       // Enable metrics for OAuth users
-      await metrics.enable(true);
+      await measureSocialLoginPreProviderStep(
+        preProviderTimings,
+        'metricsEnable',
+        () => metrics.enable(true),
+      );
       discardBufferedTraces();
-      await setupSentry();
+      await measureSocialLoginPreProviderStep(
+        preProviderTimings,
+        'sentrySetup',
+        () => setupSentry(),
+      );
+
+      // Sentry and consent are ready: emit the backdated pre-provider spans.
+      // The parent stays open until the OAuth provider launch (or an early
+      // exit) and is closed via endSocialLoginPreProviderTrace.
+      emitSocialLoginPreProviderTrace(preProviderTimings, {
+        provider,
+        flow: createWallet ? 'create' : 'rehydrate',
+      });
 
       const accountType = getSocialAccountType(provider, !createWallet);
       metrics.trackEvent(
@@ -854,9 +885,14 @@ const Onboarding = () => {
                 OAuthErrorType.UnsupportedPlatform,
               ),
             });
+            endSocialLoginPreProviderTrace({
+              reachedOAuth: false,
+              reason: 'ios_google_login_unsupported',
+            });
             return;
           }
 
+          iosGoogleWarningShown = true;
           await presentIosGoogleLoginVersionWarningSheet(navigation);
           track(MetaMetricsEvents.WALLET_GOOGLE_IOS_WARNING_VIEWED, {
             account_type: accountType,
@@ -875,6 +911,10 @@ const Onboarding = () => {
             provider,
             createWallet,
           );
+          endSocialLoginPreProviderTrace({
+            reachedOAuth: false,
+            reason: 'telegram_login_unavailable',
+          });
           return;
         }
 
@@ -894,6 +934,12 @@ const Onboarding = () => {
             op: TraceOperation.OnboardingUserJourney,
             tags: { ...getTraceTags(store.getState()), provider },
             parentContext: onboardingTraceCtx.current,
+          });
+
+          // OAuth provider launch: close the tap-to-launch parent span.
+          endSocialLoginPreProviderTrace({
+            reachedOAuth: true,
+            iosGoogleWarningShown,
           });
 
           try {
@@ -921,6 +967,10 @@ const Onboarding = () => {
           }
         } catch (error) {
           unsetLoading();
+          endSocialLoginPreProviderTrace({
+            reachedOAuth: false,
+            reason: 'login_handler_error',
+          });
           if (!(error instanceof OAuthError)) {
             trackSocialLoginFailed({
               authConnection: provider,
@@ -932,6 +982,15 @@ const Onboarding = () => {
           await handleLoginError(error as Error, provider, createWallet);
         }
       };
+      if (state.existingUser) {
+        // The existing-user alert blocks on user interaction; close the span
+        // here so its duration only covers automated work. The end call
+        // inside `action` becomes a no-op if the user proceeds.
+        endSocialLoginPreProviderTrace({
+          reachedOAuth: false,
+          reason: 'existing_user_alert',
+        });
+      }
       handleExistingUser(action);
     },
     [
@@ -946,6 +1005,7 @@ const Onboarding = () => {
       handleExistingUser,
       isGoogleLoginIosUnsupportedBlockingEnabled,
       isTelegramLoginEnabled,
+      state.existingUser,
     ],
   );
 

--- a/app/components/Views/Onboarding/socialLoginPreProviderTrace.test.ts
+++ b/app/components/Views/Onboarding/socialLoginPreProviderTrace.test.ts
@@ -1,0 +1,185 @@
+import { endTrace, trace, TraceName, TraceOperation } from '../../../util/trace';
+import {
+  emitSocialLoginPreProviderTrace,
+  endSocialLoginPreProviderTrace,
+  measureSocialLoginPreProviderStep,
+  startSocialLoginPreProviderTimings,
+  SocialLoginPreProviderTimings,
+} from './socialLoginPreProviderTrace';
+
+jest.mock('../../../util/trace', () => ({
+  ...jest.requireActual('../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+const mockTrace = trace as jest.MockedFunction<typeof trace>;
+const mockEndTrace = endTrace as jest.MockedFunction<typeof endTrace>;
+
+describe('socialLoginPreProviderTrace', () => {
+  let dateNowSpy: jest.SpyInstance;
+
+  const mockDateNowSequence = (...values: number[]) => {
+    values.forEach((value) => dateNowSpy.mockReturnValueOnce(value));
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dateNowSpy = jest.spyOn(Date, 'now');
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
+  describe('startSocialLoginPreProviderTimings', () => {
+    it('captures the tap time and starts with no recorded steps', () => {
+      mockDateNowSequence(1000);
+
+      const timings = startSocialLoginPreProviderTimings();
+
+      expect(timings).toEqual({ tapTime: 1000, steps: {} });
+    });
+  });
+
+  describe('measureSocialLoginPreProviderStep', () => {
+    it('returns the operation result and records the step boundaries', async () => {
+      mockDateNowSequence(1000, 1100, 1250);
+      const timings = startSocialLoginPreProviderTimings();
+
+      const result = await measureSocialLoginPreProviderStep(
+        timings,
+        'networkCheck',
+        async () => 'net-state',
+      );
+
+      expect(result).toBe('net-state');
+      expect(timings.steps.networkCheck).toEqual({ start: 1100, end: 1250 });
+    });
+
+    it('records the step boundaries when the operation rejects', async () => {
+      mockDateNowSequence(1000, 1100, 1250);
+      const timings = startSocialLoginPreProviderTimings();
+
+      await expect(
+        measureSocialLoginPreProviderStep(timings, 'sentrySetup', async () => {
+          throw new Error('sentry failed');
+        }),
+      ).rejects.toThrow('sentry failed');
+
+      expect(timings.steps.sentrySetup).toEqual({ start: 1100, end: 1250 });
+    });
+  });
+
+  describe('emitSocialLoginPreProviderTrace', () => {
+    const buildTimings = (): SocialLoginPreProviderTimings => ({
+      tapTime: 1000,
+      steps: {
+        networkCheck: { start: 1010, end: 1150 },
+        metricsEnable: { start: 1160, end: 1400 },
+        sentrySetup: { start: 1410, end: 1900 },
+      },
+    });
+
+    it('starts the parent span backdated to the tap time with the provided tags', () => {
+      const parentContext = { _name: 'parent' };
+      mockTrace.mockReturnValue(parentContext as never);
+
+      const result = emitSocialLoginPreProviderTrace(buildTimings(), {
+        provider: 'google',
+        flow: 'create',
+      });
+
+      expect(result).toBe(parentContext);
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginPreProvider,
+        op: TraceOperation.OnboardingUserJourney,
+        startTime: 1000,
+        tags: { provider: 'google', flow: 'create' },
+      });
+    });
+
+    it('emits one backdated child span per recorded step under the parent', () => {
+      const parentContext = { _name: 'parent' };
+      mockTrace.mockReturnValue(parentContext as never);
+
+      emitSocialLoginPreProviderTrace(buildTimings(), { provider: 'apple' });
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginNetworkCheck,
+        op: TraceOperation.OnboardingUserJourney,
+        startTime: 1010,
+        parentContext,
+      });
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginNetworkCheck,
+        timestamp: 1150,
+      });
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginMetricsEnable,
+        op: TraceOperation.OnboardingUserJourney,
+        startTime: 1160,
+        parentContext,
+      });
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginMetricsEnable,
+        timestamp: 1400,
+      });
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginSentrySetup,
+        op: TraceOperation.OnboardingUserJourney,
+        startTime: 1410,
+        parentContext,
+      });
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginSentrySetup,
+        timestamp: 1900,
+      });
+    });
+
+    it('skips steps without recorded timings', () => {
+      mockTrace.mockReturnValue(undefined as never);
+      const timings: SocialLoginPreProviderTimings = {
+        tapTime: 1000,
+        steps: { metricsEnable: { start: 1160, end: 1400 } },
+      };
+
+      emitSocialLoginPreProviderTrace(timings, { provider: 'google' });
+
+      const tracedNames = mockTrace.mock.calls.map(([request]) => request.name);
+      expect(tracedNames).toEqual([
+        TraceName.OnboardingSocialLoginPreProvider,
+        TraceName.OnboardingSocialLoginMetricsEnable,
+      ]);
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('endSocialLoginPreProviderTrace', () => {
+    it('ends the parent trace with the outcome data', () => {
+      endSocialLoginPreProviderTrace({
+        reachedOAuth: false,
+        reason: 'ios_google_login_unsupported',
+        iosGoogleWarningShown: false,
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginPreProvider,
+        data: {
+          reached_oauth: false,
+          reason: 'ios_google_login_unsupported',
+          ios_google_warning_shown: false,
+        },
+      });
+    });
+
+    it('omits optional outcome fields that are not provided', () => {
+      endSocialLoginPreProviderTrace({ reachedOAuth: true });
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.OnboardingSocialLoginPreProvider,
+        data: { reached_oauth: true },
+      });
+    });
+  });
+});

--- a/app/components/Views/Onboarding/socialLoginPreProviderTrace.ts
+++ b/app/components/Views/Onboarding/socialLoginPreProviderTrace.ts
@@ -1,0 +1,130 @@
+import {
+  endTrace,
+  trace,
+  TraceContext,
+  TraceName,
+  TraceOperation,
+  TraceValue,
+} from '../../../util/trace';
+
+/**
+ * Timing capture for the awaited operations that run between the social
+ * provider CTA tap and the OAuth provider launch (TO-917).
+ *
+ * Timestamps are captured locally while the awaits run, and only emitted as
+ * backdated Sentry spans once setupSentry() has resolved. Spans started
+ * before metrics opt-in would otherwise be dropped by discardBufferedTraces()
+ * or buffered without a parent link.
+ */
+
+export type SocialLoginPreProviderStep =
+  | 'networkCheck'
+  | 'metricsEnable'
+  | 'sentrySetup';
+
+interface StepTiming {
+  start: number;
+  end: number;
+}
+
+export interface SocialLoginPreProviderTimings {
+  tapTime: number;
+  steps: Partial<Record<SocialLoginPreProviderStep, StepTiming>>;
+}
+
+const STEP_TRACE_NAMES: Record<SocialLoginPreProviderStep, TraceName> = {
+  networkCheck: TraceName.OnboardingSocialLoginNetworkCheck,
+  metricsEnable: TraceName.OnboardingSocialLoginMetricsEnable,
+  sentrySetup: TraceName.OnboardingSocialLoginSentrySetup,
+};
+
+const STEP_ORDER: SocialLoginPreProviderStep[] = [
+  'networkCheck',
+  'metricsEnable',
+  'sentrySetup',
+];
+
+export const startSocialLoginPreProviderTimings =
+  (): SocialLoginPreProviderTimings => ({
+    tapTime: Date.now(),
+    steps: {},
+  });
+
+/**
+ * Run one of the pre-provider awaits while recording its wall-clock
+ * boundaries. Boundaries are recorded even when the operation throws so the
+ * failed step still appears in the emitted spans.
+ */
+export async function measureSocialLoginPreProviderStep<T>(
+  timings: SocialLoginPreProviderTimings,
+  step: SocialLoginPreProviderStep,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const start = Date.now();
+  try {
+    return await operation();
+  } finally {
+    timings.steps[step] = { start, end: Date.now() };
+  }
+}
+
+/**
+ * Emit the backdated parent span (CTA tap -> open until
+ * endSocialLoginPreProviderTrace) plus one child span per recorded step.
+ * Must only be called after setupSentry() has resolved.
+ */
+export function emitSocialLoginPreProviderTrace(
+  timings: SocialLoginPreProviderTimings,
+  tags: Record<string, TraceValue>,
+): TraceContext {
+  const parentContext = trace({
+    name: TraceName.OnboardingSocialLoginPreProvider,
+    op: TraceOperation.OnboardingUserJourney,
+    startTime: timings.tapTime,
+    tags,
+  });
+
+  for (const step of STEP_ORDER) {
+    const timing = timings.steps[step];
+    if (!timing) {
+      continue;
+    }
+    trace({
+      name: STEP_TRACE_NAMES[step],
+      op: TraceOperation.OnboardingUserJourney,
+      startTime: timing.start,
+      parentContext,
+    });
+    endTrace({
+      name: STEP_TRACE_NAMES[step],
+      timestamp: timing.end,
+    });
+  }
+
+  return parentContext;
+}
+
+export interface SocialLoginPreProviderOutcome {
+  reachedOAuth: boolean;
+  reason?: string;
+  iosGoogleWarningShown?: boolean;
+}
+
+/**
+ * Close the parent span. Safe to call more than once — endTrace() is a no-op
+ * when the trace has already been ended.
+ */
+export function endSocialLoginPreProviderTrace(
+  outcome: SocialLoginPreProviderOutcome,
+): void {
+  endTrace({
+    name: TraceName.OnboardingSocialLoginPreProvider,
+    data: {
+      reached_oauth: outcome.reachedOAuth,
+      ...(outcome.reason !== undefined ? { reason: outcome.reason } : {}),
+      ...(outcome.iosGoogleWarningShown !== undefined
+        ? { ios_google_warning_shown: outcome.iosGoogleWarningShown }
+        : {}),
+    },
+  });
+}

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -87,6 +87,11 @@ export enum TraceName {
   OnboardingExistingSrpImport = 'Onboarding - Existing SRP Import',
   OnboardingJourneyOverall = 'Onboarding - Overall Journey',
   OnboardingSocialLoginAttempt = 'Onboarding - Social Login Attempt',
+  /** Social provider CTA tap -> OAuth provider launch (TO-917). */
+  OnboardingSocialLoginPreProvider = 'Onboarding - Social Login Pre Provider',
+  OnboardingSocialLoginNetworkCheck = 'Onboarding - Social Login Network Check',
+  OnboardingSocialLoginMetricsEnable = 'Onboarding - Social Login Metrics Enable',
+  OnboardingSocialLoginSentrySetup = 'Onboarding - Social Login Sentry Setup',
   OnboardingPasswordSetupAttempt = 'Onboarding - Password Setup Attempt',
   OnboardingPasswordLoginAttempt = 'Onboarding - Password Login Attempt',
   OnboardingResetPassword = 'Onboarding - Reset Password',


### PR DESCRIPTION
## **TL;DR**

Social login runs three sequential awaits between the provider tap and the OAuth launch, and none of that time is measured today. This PR adds a backdated parent span (tap → OAuth launch) with a child span per await — instrumentation only, no behavior change.

## **Description**

When a user taps a social login provider on the Onboarding screen, three operations run one after another before the OAuth provider even starts:

```ts
await netInfoFetch();        // network connectivity check
await metrics.enable(true);  // metrics opt-in for OAuth users
await setupSentry();         // Sentry initialization
// ...only now does the OAuth provider launch
```

Today this time is invisible in Sentry. The existing `Onboarding - Overall Journey` and `Onboarding - Social Login Attempt` traces both start **after** these awaits finish, so we can see how long OAuth takes but not how long the user waited to get there (TO-917).

This PR adds measurement only — nothing about the execution order changes:

- **New parent span** `Onboarding - Social Login Pre Provider`: covers CTA tap → OAuth provider launch.
- **Three child spans**, one per await: `Network Check`, `Metrics Enable`, `Sentry Setup`.
- **Backdated emission**: timestamps are captured locally with `Date.now()` while the awaits run, and the spans are only emitted after `setupSentry()` resolves. Emitting earlier would lose them — `discardBufferedTraces()` runs mid-flow, and consent isn't cached yet.
- **Reliable closure on every exit path**: the parent span always ends with `reached_oauth` plus a `reason` when the flow bails early (`ios_google_login_unsupported`, `telegram_login_unavailable`, `login_handler_error`, `existing_user_alert`). It closes *before* the existing-user alert so user think-time never skews the numbers.
- **Bounded attributes only**: `provider`, `flow` (`create`/`rehydrate`), `ios_google_warning_shown`. No tokens or URLs.

Once released, baseline p50/p95 by provider and platform can be queried in Sentry with `transaction:"Onboarding - Social Login Pre Provider"`. Any optimization of these awaits should come after that data, not before.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-917

## **Manual testing steps**

```gherkin
Feature: Social login pre-provider latency tracing

  Scenario: Successful social login emits pre-provider spans
    Given a dev build with MM_SENTRY_DSN configured and Sentry debug logging enabled
    And the user is on the Onboarding screen

    When the user taps Continue with Google and completes the provider flow
    Then a "Onboarding - Social Login Pre Provider" transaction is logged with reached_oauth true
    And it contains "Network Check", "Metrics Enable" and "Sentry Setup" child spans backdated to the tap time

  Scenario: Blocked login closes the parent span with a reason
    Given an iOS device below version 17.4 with googleLoginIosUnsupportedBlockingEnabled on

    When the user taps Continue with Google
    Then the pre-provider span ends with reached_oauth false and reason ios_google_login_unsupported
```

## **Screenshots/Recordings**

### **Before**

N/A (no UI changes — instrumentation only)

### **After**

N/A (no UI changes — instrumentation only)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.