### PR TITLE
revert: remove watchlist star filter from Trending Tokens

### DIFF
--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -41,8 +41,6 @@ export enum TokenDetailsSource {
   WatchlistHomepage = 'watchlist_homepage',
   /** Full-screen watchlist view */
   WatchlistFullscreen = 'watchlist_fullscreen',
-  /** Explore Trending Tokens — watchlist filter pill active */
-  ExploreWatchlistFilter = 'explore_watchlist_filter',
   /** Fallback when source cannot be determined */
   Unknown = 'unknown',
 }
@@ -54,7 +52,6 @@ const EXPLORE_TOKEN_DETAILS_SOURCES = new Set<TokenDetailsSource>([
   TokenDetailsSource.ExploreRwasStocks,
   TokenDetailsSource.ExploreSearch,
   TokenDetailsSource.Trending,
-  TokenDetailsSource.ExploreWatchlistFilter,
 ]);
 
 /**

--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -20,7 +20,6 @@ import {
   PriceChangeOption,
 } from '../../components/TrendingTokensBottomSheet';
 import { TrendingFilterContext } from '../../components/TrendingTokensList/TrendingTokensList';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { mockTheme } from '../../../../../util/theme';
 
 import { useTrendingRequest } from '../../hooks/useTrendingRequest/useTrendingRequest';
@@ -31,43 +30,9 @@ const TEST_IDS = {
   skeleton: 'trending-tokens-skeleton',
   emptySearchResult: 'empty-search-result-state',
   emptyErrorState: 'empty-error-trending-state',
-  watchlistEmptyState: 'trending-watchlist-empty-state',
   tokensList: 'trending-tokens-list',
   retryButton: 'empty-error-trending-state--retry-button',
-  watchlistFilter: 'trending-watchlist-filter-watchlist',
 } as const;
-
-let mockIsWatchlistEnabled = false;
-const mockRefetchWatchlist = jest.fn();
-const mockUseTokenWatchlistQuery = jest.fn();
-
-jest.mock('../../../Assets/selectors/featureFlags', () => ({
-  selectTokenWatchlistEnabled: jest.fn(),
-}));
-
-jest.mock('../../../Assets/watchlist/hooks/useTokenWatchlistQuery', () => ({
-  useTokenWatchlistQuery: () => mockUseTokenWatchlistQuery(),
-}));
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: (selector: (state: unknown) => unknown) => {
-    const { selectTokenWatchlistEnabled } = jest.requireMock(
-      '../../../Assets/selectors/featureFlags',
-    );
-    if (selector === selectTokenWatchlistEnabled) return mockIsWatchlistEnabled;
-    return jest.requireActual('react-redux').useSelector(selector);
-  },
-}));
-
-jest.mock(
-  '../../../../../images/watchlist-empty-dark.svg',
-  () => 'WatchlistEmptyDark',
-);
-jest.mock(
-  '../../../../../images/watchlist-empty-light.svg',
-  () => 'WatchlistEmptyLight',
-);
 
 const initialMetrics: Metrics = {
   frame: { x: 0, y: 0, width: 320, height: 640 },
@@ -100,19 +65,8 @@ jest.mock(
   '../../components/TrendingTokensList/TrendingTokensList',
   (): typeof TrendingTokensList => {
     const { View, Text, ScrollView } = jest.requireActual('react-native');
-    return ({
-      trendingTokens,
-      refreshControl,
-      tokenDetailsSource,
-    }: {
-      trendingTokens: TrendingAsset[];
-      refreshControl?: React.ReactElement;
-      tokenDetailsSource?: string;
-    }) => (
+    return ({ trendingTokens, refreshControl }) => (
       <ScrollView testID="trending-tokens-list" refreshControl={refreshControl}>
-        {tokenDetailsSource ? (
-          <Text testID="token-details-source">{tokenDetailsSource}</Text>
-        ) : null}
         {trendingTokens.map((token, index) => (
           <View key={token.assetId || index} testID={`token-${index}`}>
             <Text>{token.name}</Text>
@@ -194,12 +148,6 @@ describe('TrendingTokensData', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsWatchlistEnabled = false;
-    mockUseTokenWatchlistQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-      refetch: mockRefetchWatchlist,
-    });
   });
 
   // Test table for different states
@@ -233,30 +181,6 @@ describe('TrendingTokensData', () => {
         search: { searchResults: [], searchQuery: 'nonexistent' },
       },
       elemsRendered: [TEST_IDS.emptySearchResult],
-    },
-    {
-      testName:
-        'watchlist empty state when watchlist filter is active and empty',
-      overrideProps: {
-        trendingTokens: [],
-        isWatchlistFilterActive: true,
-        search: { searchResults: [], searchQuery: '' },
-      },
-      elemsRendered: [TEST_IDS.watchlistEmptyState],
-    },
-    {
-      testName:
-        'watchlist tokens when watchlist filter is active and trending results are empty',
-      overrideProps: {
-        isWatchlistFilterActive: true,
-        search: { searchResults: [], searchQuery: '' },
-      },
-      elemsRendered: [TEST_IDS.tokensList],
-      actAssert: async (testUtils) => {
-        const { getByText, queryByTestId } = testUtils;
-        expect(getByText('Token 1')).toBeOnTheScreen();
-        expect(queryByTestId(TEST_IDS.emptyErrorState)).not.toBeOnTheScreen();
-      },
     },
     {
       testName: 'empty error state when there is an error on main token view',
@@ -327,12 +251,6 @@ describe('TrendingTokensFullView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRoute.mockReturnValue({ params: undefined });
-    mockIsWatchlistEnabled = false;
-    mockUseTokenWatchlistQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-      refetch: mockRefetchWatchlist,
-    });
     const mocks = arrangeMocks();
     mocks.setTrendingRequestMock({ results: [createMockToken()] });
     mocks.setTrendingSearchMock({ data: [createMockToken()] });
@@ -452,7 +370,7 @@ describe('TrendingTokensFullView', () => {
     });
   });
 
-  it('calls refetch when pull-to-refresh is triggered', async () => {
+  it('calls refetch when pull-to-refresh is triggered', () => {
     const mockTokens = [
       createMockToken({ name: 'Token 1', assetId: 'eip155:1/erc20:0x123' }),
     ];
@@ -466,9 +384,7 @@ describe('TrendingTokensFullView', () => {
     expect(getByTestId('trending-tokens-list')).toBeOnTheScreen();
     const { RefreshControl } = jest.requireActual('react-native');
     const refreshControl = UNSAFE_getByType(RefreshControl);
-    await act(async () => {
-      fireEvent(refreshControl, 'refresh');
-    });
+    fireEvent(refreshControl, 'refresh');
 
     expect(mocks.mockRefetch).toHaveBeenCalledTimes(1);
   });
@@ -743,190 +659,6 @@ describe('TrendingTokensFullView', () => {
       expect(getByText('Token X')).toBeOnTheScreen();
       expect(getByText('Token Y')).toBeOnTheScreen();
       expect(queryByTestId('empty-search-result-state')).not.toBeOnTheScreen();
-    });
-  });
-
-  describe('watchlist filter', () => {
-    it('does not render watchlist filter when feature flag is off', () => {
-      mockIsWatchlistEnabled = false;
-      const { queryByTestId } = renderTrendingFullView();
-
-      expect(queryByTestId(TEST_IDS.watchlistFilter)).not.toBeOnTheScreen();
-    });
-
-    it('renders watchlist star filter when feature flag is on', () => {
-      mockIsWatchlistEnabled = true;
-      const { getByTestId } = renderTrendingFullView();
-
-      expect(getByTestId(TEST_IDS.watchlistFilter)).toBeOnTheScreen();
-    });
-
-    it('toggles watchlist filter off when star is pressed again', async () => {
-      mockIsWatchlistEnabled = true;
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId, queryByTestId } = renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-      expect(getByTestId(TEST_IDS.watchlistEmptyState)).toBeOnTheScreen();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-      expect(queryByTestId(TEST_IDS.watchlistEmptyState)).not.toBeOnTheScreen();
-    });
-
-    it('shows watchlist empty state when watchlist filter is active and empty', async () => {
-      mockIsWatchlistEnabled = true;
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId, getByText } = renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-
-      expect(getByTestId(TEST_IDS.watchlistEmptyState)).toBeOnTheScreen();
-      expect(
-        getByText(strings('token_watchlist.home_empty_title')),
-      ).toBeOnTheScreen();
-      expect(
-        getByText(strings('token_watchlist.home_empty_subtitle')),
-      ).toBeOnTheScreen();
-    });
-
-    it('shows watchlist tokens when watchlist filter is active', async () => {
-      mockIsWatchlistEnabled = true;
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [
-          {
-            assetId: 'eip155:1/slip44:60',
-            name: 'Ethereum',
-            symbol: 'ETH',
-            decimals: 18,
-            marketData: {
-              price: 2170.28,
-              marketCap: 260_000_000_000,
-              totalVolume: 15_000_000_000,
-              pricePercentChange24h: 0.2,
-            },
-          },
-        ],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId, getByText } = renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-
-      expect(getByTestId('trending-tokens-list')).toBeOnTheScreen();
-      expect(getByText('Ethereum')).toBeOnTheScreen();
-    });
-
-    it('shows watchlist tokens and enables price filter when trending results are empty', async () => {
-      mockIsWatchlistEnabled = true;
-      const mocks = arrangeMocks();
-      mocks.setTrendingSearchMock({ data: [] });
-      mocks.setTrendingRequestMock({ results: [] });
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [
-          {
-            assetId: 'eip155:1/slip44:60',
-            name: 'Ethereum',
-            symbol: 'ETH',
-            decimals: 18,
-            marketData: {
-              price: 2170.28,
-              marketCap: 260_000_000_000,
-              totalVolume: 15_000_000_000,
-              pricePercentChange24h: 0.2,
-            },
-          },
-        ],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId, getByText, queryByTestId } =
-        renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-
-      expect(getByTestId('trending-tokens-list')).toBeOnTheScreen();
-      expect(getByText('Ethereum')).toBeOnTheScreen();
-      expect(queryByTestId(TEST_IDS.emptyErrorState)).not.toBeOnTheScreen();
-      expect(
-        getByTestId('price-change-button').props.accessibilityState?.disabled,
-      ).toBe(false);
-    });
-
-    it('passes explore_watchlist_filter source when watchlist filter is active', async () => {
-      mockIsWatchlistEnabled = true;
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [
-          {
-            assetId: 'eip155:1/slip44:60',
-            name: 'Ethereum',
-            symbol: 'ETH',
-            decimals: 18,
-            marketData: {
-              price: 2170.28,
-              marketCap: 260_000_000_000,
-              totalVolume: 15_000_000_000,
-              pricePercentChange24h: 0.2,
-            },
-          },
-        ],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId } = renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-
-      expect(getByTestId('token-details-source')).toHaveTextContent(
-        TokenDetailsSource.ExploreWatchlistFilter,
-      );
-    });
-
-    it('refetches watchlist data on pull-to-refresh in watchlist mode', async () => {
-      mockIsWatchlistEnabled = true;
-      mockUseTokenWatchlistQuery.mockReturnValue({
-        data: [
-          {
-            assetId: 'eip155:1/slip44:60',
-            name: 'Ethereum',
-            symbol: 'ETH',
-            decimals: 18,
-            marketData: {
-              price: 2170.28,
-              marketCap: 260_000_000_000,
-              totalVolume: 15_000_000_000,
-              pricePercentChange24h: 0.2,
-            },
-          },
-        ],
-        isLoading: false,
-        refetch: mockRefetchWatchlist,
-      });
-
-      const { getByTestId, UNSAFE_getByType } = renderTrendingFullView();
-
-      await userEvent.press(getByTestId(TEST_IDS.watchlistFilter));
-
-      const { RefreshControl } = jest.requireActual('react-native');
-      const refreshControl = UNSAFE_getByType(RefreshControl);
-      await act(async () => {
-        fireEvent(refreshControl, 'refresh');
-      });
-
-      expect(mockRefetchWatchlist).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import TrendingQuickBuy from '../../components/TrendingQuickBuy/TrendingQuickBuy';
 import { View, RefreshControl } from 'react-native';
 import { useRoute, type RouteProp } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import TrendingTokensList, {
@@ -24,7 +23,6 @@ import { useTrendingSearch } from '../../hooks/useTrendingSearch/useTrendingSear
 import { useTokenListFilters } from '../../hooks/useTokenListFilters/useTokenListFilters';
 import EmptyErrorTrendingState from '../../../../Views/TrendingView/components/EmptyErrorState/EmptyErrorTrendingState';
 import EmptySearchResultState from '../../../../Views/TrendingView/components/EmptyErrorState/EmptySearchResultState';
-import WatchlistEmptyState from '../../../../Views/Homepage/Sections/Watchlist/components/WatchlistEmptyState';
 import TrendingFeedSessionManager from '../../services/TrendingFeedSessionManager';
 import { useSearchTracking } from '../../hooks/useSearchTracking/useSearchTracking';
 import { FilterButton } from '../../components/FilterBar/FilterBar';
@@ -39,11 +37,6 @@ import {
 } from '../../../../Views/TrendingView/search/abTestConfig';
 import type { QuickBuySheetSource } from '../../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/analytics';
 import { useQuickBuySearchKeyboard } from '../../hooks/useQuickBuySearchKeyboard/useQuickBuySearchKeyboard';
-import { selectTokenWatchlistEnabled } from '../../../Assets/selectors/featureFlags';
-import { useTokenWatchlistQuery } from '../../../Assets/watchlist/hooks/useTokenWatchlistQuery';
-import { mapWatchlistTokenToTrendingAsset } from '../../../../Views/Homepage/Sections/Watchlist/utils/mapWatchlistTokenToTrendingAsset';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
-import { getCaipChainIdFromAssetId } from '../../components/TrendingTokenRowItem/utils';
 
 export type TrendingTokensFullViewEntryPoint =
   | 'crypto_movers'
@@ -68,10 +61,6 @@ export interface TrendingTokensDataProps {
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
   onQuickTrade?: (token: TrendingAsset) => void;
-  /** When true, an empty list shows the watchlist empty illustration instead of the error state. */
-  isWatchlistFilterActive?: boolean;
-  /** Token Details analytics source for row navigation. */
-  tokenDetailsSource?: TokenDetailsSource;
 
   search: {
     searchResults: TrendingAsset[];
@@ -92,8 +81,6 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
     onLoadMore,
     isLoadingMore,
     onQuickTrade,
-    isWatchlistFilterActive = false,
-    tokenDetailsSource = TokenDetailsSource.Trending,
   } = props;
 
   const tw = useTailwind();
@@ -115,20 +102,7 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
     return <EmptySearchResultState />;
   }
 
-  if (
-    !isLoading &&
-    isWatchlistFilterActive &&
-    !isSearching &&
-    trendingTokens.length === 0
-  ) {
-    return (
-      <View style={tw`pt-40`} testID="trending-watchlist-empty-state">
-        <WatchlistEmptyState />
-      </View>
-    );
-  }
-
-  if (!isSearching && trendingTokens.length === 0) {
+  if (!isSearching && !hasSearchResults) {
     return <EmptyErrorTrendingState onRetry={handleRefresh} />;
   }
 
@@ -141,7 +115,6 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
         onLoadMore={onLoadMore}
         isLoadingMore={isLoadingMore}
         onQuickTrade={onQuickTrade}
-        tokenDetailsSource={tokenDetailsSource}
         refreshControl={
           <RefreshControl
             colors={[theme.colors.primary.default]}
@@ -157,9 +130,6 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
 
 const TrendingTokensFullView = () => {
   const sessionManager = TrendingFeedSessionManager.getInstance();
-  const isWatchlistEnabled = useSelector(selectTokenWatchlistEnabled);
-  const [showWatchlistOnly, setShowWatchlistOnly] = useState(false);
-  const isWatchlistFilterActive = isWatchlistEnabled && showWatchlistOnly;
   const [quickTradeToken, setQuickTradeToken] = useState<TrendingAsset | null>(
     null,
   );
@@ -180,11 +150,6 @@ const TrendingTokensFullView = () => {
       : strings('trending.trending_tokens');
   const filters = useTokenListFilters({ timeOption: initialTimeOption });
 
-  const isSearchActive =
-    filters.isSearchVisible || Boolean(filters.searchQuery?.trim());
-  /** Watchlist list mode: star selected and user is not searching trending tokens. */
-  const isWatchlistListMode = isWatchlistFilterActive && !isSearchActive;
-
   const [sortBy, setSortBy] = useState<SortTrendingBy | undefined>(
     initialTimeOption ? mapTimeOptionToSortBy(initialTimeOption) : undefined,
   );
@@ -192,7 +157,7 @@ const TrendingTokensFullView = () => {
 
   const {
     data: searchResults,
-    isLoading: isTrendingLoading,
+    isLoading,
     refetch: refetchTokensSection,
     loadMore,
     isLoadingMore,
@@ -203,50 +168,7 @@ const TrendingTokensFullView = () => {
     filterLowQuality: true,
   });
 
-  const {
-    data: watchlistData,
-    isLoading: isWatchlistLoading,
-    refetch: refetchWatchlist,
-  } = useTokenWatchlistQuery();
-
-  const watchlistTokens = useMemo(() => {
-    if (!isWatchlistListMode) {
-      return [];
-    }
-
-    let tokens = (watchlistData ?? []).map(mapWatchlistTokenToTrendingAsset);
-
-    if (filters.selectedNetwork && filters.selectedNetwork.length > 0) {
-      const selectedChainId = filters.selectedNetwork[0];
-      tokens = tokens.filter(
-        (token) => getCaipChainIdFromAssetId(token.assetId) === selectedChainId,
-      );
-    }
-
-    if (filters.selectedPriceChangeOption) {
-      tokens = sortTrendingTokens(
-        tokens,
-        filters.selectedPriceChangeOption,
-        filters.priceChangeSortDirection,
-        filters.selectedTimeOption,
-      );
-    }
-
-    return tokens;
-  }, [
-    isWatchlistListMode,
-    watchlistData,
-    filters.selectedNetwork,
-    filters.selectedPriceChangeOption,
-    filters.priceChangeSortDirection,
-    filters.selectedTimeOption,
-  ]);
-
   const trendingTokens = useMemo(() => {
-    if (isWatchlistListMode) {
-      return watchlistTokens;
-    }
-
     if (searchResults.length === 0) {
       return [];
     }
@@ -266,18 +188,12 @@ const TrendingTokensFullView = () => {
       filters.selectedTimeOption,
     );
   }, [
-    isWatchlistListMode,
-    watchlistTokens,
     searchResults,
     filters.searchQuery,
     filters.selectedPriceChangeOption,
     filters.priceChangeSortDirection,
     filters.selectedTimeOption,
   ]);
-
-  const isLoading = isWatchlistListMode
-    ? isWatchlistLoading
-    : isTrendingLoading;
 
   useSearchTracking({
     searchQuery: filters.searchQuery,
@@ -338,22 +254,13 @@ const TrendingTokensFullView = () => {
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      if (isWatchlistListMode) {
-        await refetchWatchlist();
-      } else {
-        refetchTokensSection?.();
-      }
+      refetchTokensSection?.();
     } catch (error) {
       console.warn('Failed to refresh trending tokens:', error);
     } finally {
       setRefreshing(false);
     }
-  }, [
-    isWatchlistListMode,
-    refetchWatchlist,
-    refetchTokensSection,
-    setRefreshing,
-  ]);
+  }, [refetchTokensSection, setRefreshing]);
 
   const closeQuickBuy = useCallback(() => {
     setQuickTradeToken(null);
@@ -373,14 +280,6 @@ const TrendingTokensFullView = () => {
     />
   );
 
-  const handleWatchlistFilterPress = useCallback(() => {
-    setShowWatchlistOnly((prev) => !prev);
-  }, []);
-
-  const tokenDetailsSource = isWatchlistListMode
-    ? TokenDetailsSource.ExploreWatchlistFilter
-    : TokenDetailsSource.Trending;
-
   return (
     <TokenListPageLayout
       title={pageTitle}
@@ -391,14 +290,9 @@ const TrendingTokensFullView = () => {
       isLoading={isLoading}
       onRefresh={handleRefresh}
       allowedNetworks={TRENDING_NETWORKS_LIST}
-      showWatchlistFilter={isWatchlistEnabled}
-      onWatchlistFilterPress={handleWatchlistFilterPress}
       extraFilters={timeFilterButton}
-      isWatchlistFilterActive={isWatchlistFilterActive}
-      isWatchlistListMode={isWatchlistListMode}
-      tokenDetailsSource={tokenDetailsSource}
-      onLoadMore={isWatchlistListMode ? undefined : loadMore}
-      isLoadingMore={isWatchlistListMode ? false : isLoadingMore}
+      onLoadMore={loadMore}
+      isLoadingMore={isLoadingMore}
       extraBottomSheets={
         <TrendingTokenTimeBottomSheet
           isVisible={showTimeBottomSheet}

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.test.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.test.tsx
@@ -151,39 +151,4 @@ describe('FilterBar', () => {
     );
     expect(queryByTestId('extra-filter')).toBeNull();
   });
-
-  it('renders watchlist star filter when showWatchlistFilter is true', () => {
-    const { getByTestId } = renderWithProvider(
-      <FilterBar
-        {...defaultProps}
-        showWatchlistFilter
-        onWatchlistFilterPress={jest.fn()}
-      />,
-    );
-    expect(
-      getByTestId('trending-watchlist-filter-watchlist'),
-    ).toBeOnTheScreen();
-  });
-
-  it('does not render watchlist star filter by default', () => {
-    const { queryByTestId } = renderWithProvider(
-      <FilterBar {...defaultProps} />,
-    );
-    expect(
-      queryByTestId('trending-watchlist-filter-watchlist'),
-    ).not.toBeOnTheScreen();
-  });
-
-  it('calls onWatchlistFilterPress when star filter is pressed', () => {
-    const onWatchlistFilterPress = jest.fn();
-    const { getByTestId } = renderWithProvider(
-      <FilterBar
-        {...defaultProps}
-        showWatchlistFilter
-        onWatchlistFilterPress={onWatchlistFilterPress}
-      />,
-    );
-    fireEvent.press(getByTestId('trending-watchlist-filter-watchlist'));
-    expect(onWatchlistFilterPress).toHaveBeenCalledTimes(1);
-  });
 });

--- a/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
+++ b/app/components/UI/Trending/components/FilterBar/FilterBar.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { ScrollView } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
-  FilterButton as FilterPillButton,
   IconName,
   SelectButton,
   SelectButtonVariant,
 } from '@metamask/design-system-react-native';
-import { strings } from '../../../../../../locales/i18n';
 
 export interface FilterButtonProps {
   testID: string;
@@ -58,12 +56,6 @@ export interface FilterBarProps {
   networkName: string;
   onNetworkPress: () => void;
 
-  /** When true, renders the watchlist star filter before other pills. */
-  showWatchlistFilter?: boolean;
-  /** Whether the watchlist filter is currently active. */
-  isWatchlistFilterActive?: boolean;
-  /** Called when the watchlist star filter is pressed (toggle). */
-  onWatchlistFilterPress?: () => void;
   /** Optional extra filter buttons rendered after the network button */
   extraFilters?: React.ReactNode;
   /** Optional testID override for the price-change button */
@@ -84,9 +76,6 @@ const FilterBar: React.FC<FilterBarProps> = ({
   priceChangeIconName,
   networkName,
   onNetworkPress,
-  showWatchlistFilter = false,
-  isWatchlistFilterActive = false,
-  onWatchlistFilterPress,
   extraFilters,
   priceChangeTestID = 'price-change-button',
   networkTestID = 'all-networks-button',
@@ -103,21 +92,6 @@ const FilterBar: React.FC<FilterBarProps> = ({
         'flex-grow-0 flex-row items-center gap-2 px-4 pb-4',
       )}
     >
-      {showWatchlistFilter && onWatchlistFilterPress ? (
-        <FilterPillButton
-          isSelected={isWatchlistFilterActive}
-          startIconName={IconName.StarFilled}
-          onPress={onWatchlistFilterPress}
-          testID="trending-watchlist-filter-watchlist"
-          accessibilityLabel={strings('perps.watchlist.filter_badge_label')}
-          contentWrapperProps={{ gap: 0 }}
-          twClassName={
-            isWatchlistFilterActive ? undefined : 'bg-background-muted'
-          }
-        >
-          {null}
-        </FilterPillButton>
-      ) : null}
       <FilterButton
         testID={priceChangeTestID}
         label={priceChangeButtonText}

--- a/app/components/UI/Trending/components/TokenListPageLayout/TokenListPageLayout.tsx
+++ b/app/components/UI/Trending/components/TokenListPageLayout/TokenListPageLayout.tsx
@@ -16,7 +16,6 @@ import { TrendingTokensData } from '../../Views/TrendingTokensFullView/TrendingT
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { ProcessedNetwork } from '../../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import type { TokenListFilters } from '../../hooks/useTokenListFilters/useTokenListFilters';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 
 export interface TokenListPageLayoutProps {
   /** Page title displayed in the header */
@@ -37,16 +36,6 @@ export interface TokenListPageLayoutProps {
   allowedNetworks: ProcessedNetwork[];
   /** Optional extra filter buttons (e.g., time filter) */
   extraFilters?: React.ReactNode;
-  /** When true, shows the watchlist star filter in the filter bar. */
-  showWatchlistFilter?: boolean;
-  /** Whether the watchlist filter is currently active (star pill selected). */
-  isWatchlistFilterActive?: boolean;
-  /** When true, list data comes from watchlist (not trending search). */
-  isWatchlistListMode?: boolean;
-  /** Called when the watchlist star filter is toggled. */
-  onWatchlistFilterPress?: () => void;
-  /** Token Details analytics source passed through to list rows. */
-  tokenDetailsSource?: TokenDetailsSource;
   /** Optional extra bottom sheets rendered at the end */
   extraBottomSheets?: React.ReactNode;
   /** Called when the user scrolls near the end of the list to fetch the next page. */
@@ -77,11 +66,6 @@ const TokenListPageLayout: React.FC<TokenListPageLayoutProps> = ({
   onRefresh,
   allowedNetworks,
   extraFilters,
-  showWatchlistFilter,
-  isWatchlistFilterActive,
-  isWatchlistListMode = false,
-  onWatchlistFilterPress,
-  tokenDetailsSource,
   extraBottomSheets,
   onLoadMore,
   isLoadingMore,
@@ -115,13 +99,10 @@ const TokenListPageLayout: React.FC<TokenListPageLayoutProps> = ({
         <FilterBar
           priceChangeButtonText={filters.priceChangeButtonText}
           onPriceChangePress={filters.handlePriceChangePress}
-          isPriceChangeDisabled={tokens.length === 0}
+          isPriceChangeDisabled={searchResults.length === 0}
           priceChangeIconName={filters.priceChangeSortDirectionIcon}
           networkName={filters.selectedNetworkName}
           onNetworkPress={filters.handleAllNetworksPress}
-          showWatchlistFilter={showWatchlistFilter}
-          isWatchlistFilterActive={isWatchlistFilterActive}
-          onWatchlistFilterPress={onWatchlistFilterPress}
           extraFilters={extraFilters}
         />
       ) : null}
@@ -138,8 +119,6 @@ const TokenListPageLayout: React.FC<TokenListPageLayoutProps> = ({
         onLoadMore={onLoadMore}
         isLoadingMore={isLoadingMore}
         onQuickTrade={onQuickTrade}
-        isWatchlistFilterActive={isWatchlistListMode}
-        tokenDetailsSource={tokenDetailsSource}
       />
 
       <TrendingTokenNetworkBottomSheet

--- a/app/components/UI/Trending/components/TrendingTokensList/TrendingTokensList.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensList/TrendingTokensList.tsx
@@ -4,7 +4,6 @@ import { FlashList } from '@shopify/flash-list';
 import { TrendingAsset } from '@metamask/assets-controllers';
 import TrendingTokenRowItem from '../TrendingTokenRowItem/TrendingTokenRowItem';
 import { TimeOption, PriceChangeOption } from '../TrendingTokensBottomSheet';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 
 /**
  * Filter context for analytics tracking
@@ -49,11 +48,6 @@ export interface TrendingTokensListProps {
    * When provided, shows a Quick Trade flash button on each row.
    */
   onQuickTrade?: (token: TrendingAsset) => void;
-  /**
-   * Token Details `source` for MetaMetrics when navigating from a row.
-   * @default TokenDetailsSource.Trending
-   */
-  tokenDetailsSource?: TokenDetailsSource;
 }
 
 /**
@@ -71,7 +65,6 @@ const TrendingTokensList: React.FC<TrendingTokensListProps> = React.memo(
     onLoadMore,
     isLoadingMore,
     onQuickTrade,
-    tokenDetailsSource = TokenDetailsSource.Trending,
   }) => {
     const renderItem = useCallback(
       ({ item, index }: { item: TrendingAsset; index: number }) => (
@@ -81,10 +74,9 @@ const TrendingTokensList: React.FC<TrendingTokensListProps> = React.memo(
           position={index}
           filterContext={filterContext}
           onQuickTrade={onQuickTrade}
-          tokenDetailsSource={tokenDetailsSource}
         />
       ),
-      [selectedTimeOption, filterContext, onQuickTrade, tokenDetailsSource],
+      [selectedTimeOption, filterContext, onQuickTrade],
     );
 
     const keyExtractor = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Reverts #33421 to remove the watchlist star filter from **Explore → Trending Tokens**.

This reverts watchlist-filter mode in `TrendingTokensFullView`, `FilterBar`, `TokenListPageLayout`, and `TrendingTokensList`, including related tests and `TokenDetailsSource.ExploreWatchlistFilter` analytics attribution. Later watchlist work on `main` (e.g. full-screen watchlist from #33492) is preserved.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Removed the watchlist filter from the Trending Tokens explore screen.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [ASSETS-3708](https://consensyssoftware.atlassian.net/browse/ASSETS-3708)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trending Tokens watchlist filter removal
  Scenario: Star filter no longer shown on Trending Tokens
    Given assetsGlobalWatchlistV1 is enabled
    When the user opens Explore → Trending Tokens
    Then the star filter pill is not shown
    And the list shows trending tokens as before
  Scenario: Existing trending filters still work
    Given the user is on Explore → Trending Tokens
    When the user applies network and price-change filters
    Then the trending token list updates as expected
  Scenario: Other watchlist flows unaffected
    Given the user has watchlisted tokens
    When the user opens the homepage watchlist or full-screen watchlist
    Then watchlist content still loads and behaves as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[ASSETS-3708]: https://consensyssoftware.atlassian.net/browse/ASSETS-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and analytics revert on the trending explore screen; no auth, payments, or shared watchlist homepage flows are removed in this diff.
> 
> **Overview**
> Removes the **watchlist star filter** from Explore → Trending Tokens so the screen only loads and displays **trending search** results again.
> 
> **TrendingTokensFullView** drops watchlist feature-flag wiring, `useTokenWatchlistQuery`, watchlist-to-trending mapping, the watchlist empty illustration, and watchlist-specific pull-to-refresh; pagination and refresh always target trending search. **FilterBar** and **TokenListPageLayout** no longer expose watchlist filter props, and **TrendingTokensList** stops passing a custom `tokenDetailsSource` into rows (defaults apply).
> 
> **Analytics:** `TokenDetailsSource.ExploreWatchlistFilter` is removed from the explore attribution set in `isExploreTokenDetailsSource`. Empty/error UI now keys off **search results** (e.g. price-change filter disabled when `searchResults` is empty).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3c596d04c12d8bfe4e526d4321b06c711320bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->