### PR TITLE
fix: skip calldata encoding for initial deposit batch creation

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -283,6 +283,7 @@ describe('useMoneyAccountDeposit', () => {
         amount: BigInt(0),
         chainId: MOCK_VAULT_CONFIG.chainId,
         boringVault: MOCK_VAULT_CONFIG.boringVault,
+        initialiseWithoutData: true,
       }),
     );
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -167,9 +167,8 @@ export function useMoneyAccountDeposit() {
       });
 
       try {
-        // Commented out to improve the performance of the deposit batch creation.
         // Allows confirmation skeleton to render immediately before setup work for immediate navigation.
-        // await waitForNextFrame();
+        await waitForNextFrame();
 
         const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
           amount: BigInt(0),

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -167,8 +167,9 @@ export function useMoneyAccountDeposit() {
       });
 
       try {
+        // Commented out to improve the performance of the deposit batch creation.
         // Allows confirmation skeleton to render immediately before setup work for immediate navigation.
-        await waitForNextFrame();
+        // await waitForNextFrame();
 
         const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
           amount: BigInt(0),
@@ -178,6 +179,7 @@ export function useMoneyAccountDeposit() {
           accountantAddress: depositSetup.accountantAddress,
           lensAddress: depositSetup.lensAddress,
           provider: depositSetup.provider,
+          initialiseWithoutData: true,
         });
 
         // We only set the transaction from the money account perspective.

--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -307,7 +307,7 @@ describe('moneyAccountTransactions', () => {
 
       expect(result.approveTx.params.data).toBeDefined();
       expect(typeof result.approveTx.params.data).toBe('string');
-      expect(result.approveTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.approveTx.params.data?.startsWith('0x')).toBe(true);
     });
 
     it('calls previewDeposit with correct arguments', async () => {
@@ -384,9 +384,9 @@ describe('moneyAccountTransactions', () => {
       });
 
       expect(result.approveTx.params.data).toBeDefined();
-      expect(result.approveTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.approveTx.params.data?.startsWith('0x')).toBe(true);
       expect(result.depositTx.params.data).toBeDefined();
-      expect(result.depositTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.depositTx.params.data?.startsWith('0x')).toBe(true);
     });
   });
 
@@ -674,10 +674,10 @@ describe('moneyAccountTransactions', () => {
       });
 
       expect(result.withdrawTx.params.data).toBeDefined();
-      expect(result.withdrawTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.withdrawTx.params.data?.startsWith('0x')).toBe(true);
 
       expect(result.transferTx.params.data).toBeDefined();
-      expect(result.transferTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.transferTx.params.data?.startsWith('0x')).toBe(true);
     });
 
     it('calls getRate on the accountant contract', async () => {
@@ -708,8 +708,8 @@ describe('moneyAccountTransactions', () => {
       });
 
       expect(mockGetRate).not.toHaveBeenCalled();
-      expect(result.withdrawTx.params.data.startsWith('0x')).toBe(true);
-      expect(result.transferTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.withdrawTx.params.data?.startsWith('0x')).toBe(true);
+      expect(result.transferTx.params.data?.startsWith('0x')).toBe(true);
     });
 
     it('encodes the recipient address in the transfer calldata', async () => {
@@ -726,7 +726,7 @@ describe('moneyAccountTransactions', () => {
       });
 
       // The recipient address (lowercased, without 0x prefix) should appear in the calldata
-      expect(result.transferTx.params.data.toLowerCase()).toContain(
+      expect(result.transferTx.params.data?.toLowerCase()).toContain(
         MOCK_RECIPIENT_ADDRESS.toLowerCase().slice(2),
       );
     });
@@ -749,10 +749,9 @@ describe('moneyAccountTransactions', () => {
       const iface = new ethers.utils.Interface([
         'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
       ]);
-      const decoded = iface.decodeFunctionData(
-        'withdraw',
-        result.withdrawTx.params.data,
-      );
+      const withdrawData = result.withdrawTx.params.data;
+      if (!withdrawData) throw new Error('Expected withdraw data');
+      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
       const encodedMinimumAssets = BigInt(decoded.minimumAssets.toString());
       expect(encodedMinimumAssets).toBe(amount - 1n);
     });
@@ -771,10 +770,9 @@ describe('moneyAccountTransactions', () => {
       const iface = new ethers.utils.Interface([
         'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
       ]);
-      const decoded = iface.decodeFunctionData(
-        'withdraw',
-        result.withdrawTx.params.data,
-      );
+      const withdrawData = result.withdrawTx.params.data;
+      if (!withdrawData) throw new Error('Expected withdraw data');
+      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
       expect(BigInt(decoded.minimumAssets.toString())).toBe(0n);
     });
 
@@ -796,10 +794,9 @@ describe('moneyAccountTransactions', () => {
       const iface = new ethers.utils.Interface([
         'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
       ]);
-      const decoded = iface.decodeFunctionData(
-        'withdraw',
-        result.withdrawTx.params.data,
-      );
+      const withdrawData = result.withdrawTx.params.data;
+      if (!withdrawData) throw new Error('Expected withdraw data');
+      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
       const shareAmount = BigInt(decoded.shareAmount.toString());
 
       // With ceiling division: (1_960_000 * 1_000_000 + 1_000_094 - 1) / 1_000_094 = 1_959_816
@@ -938,7 +935,7 @@ describe('moneyAccountTransactions', () => {
         MOCK_RECIPIENT,
       );
 
-      expect(result[1].data.toLowerCase()).toContain(
+      expect(result[1].data?.toLowerCase()).toContain(
         MOCK_RECIPIENT.toLowerCase().slice(2),
       );
     });

--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -330,6 +330,64 @@ describe('moneyAccountTransactions', () => {
         MOCK_ACCOUNTANT,
       );
     });
+
+    it('returns undefined data fields when initialiseWithoutData is true', async () => {
+      const result = await buildMoneyAccountDepositBatch({
+        amount: BigInt(0),
+        chainId: MOCK_CHAIN_ID,
+        boringVault: MOCK_BORING_VAULT,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        lensAddress: MOCK_LENS,
+        provider: MOCK_PROVIDER,
+        initialiseWithoutData: true,
+      });
+
+      expect(result.approveTx.params.data).toBeUndefined();
+      expect(result.depositTx.params.data).toBeUndefined();
+      expect(result.approveTx.type).toBe(TransactionType.tokenMethodApprove);
+      expect(result.depositTx.type).toBe(TransactionType.moneyAccountDeposit);
+      expect(result.approveTx.params.to).toBe(MOCK_MUSD_ADDRESS);
+      expect(result.depositTx.params.to).toBe(MOCK_TELLER);
+    });
+
+    it('skips calldata encoding but still resolves minimumMint for non-zero amounts when initialiseWithoutData is true', async () => {
+      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
+
+      const result = await buildMoneyAccountDepositBatch({
+        amount: BigInt(1_000_000),
+        chainId: MOCK_CHAIN_ID,
+        boringVault: MOCK_BORING_VAULT,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        lensAddress: MOCK_LENS,
+        provider: MOCK_PROVIDER,
+        initialiseWithoutData: true,
+      });
+
+      expect(result.approveTx.params.data).toBeUndefined();
+      expect(result.depositTx.params.data).toBeUndefined();
+    });
+
+    it('builds calldata normally when initialiseWithoutData is false', async () => {
+      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
+
+      const result = await buildMoneyAccountDepositBatch({
+        amount: BigInt(1_000_000),
+        chainId: MOCK_CHAIN_ID,
+        boringVault: MOCK_BORING_VAULT,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        lensAddress: MOCK_LENS,
+        provider: MOCK_PROVIDER,
+        initialiseWithoutData: false,
+      });
+
+      expect(result.approveTx.params.data).toBeDefined();
+      expect(result.approveTx.params.data.startsWith('0x')).toBe(true);
+      expect(result.depositTx.params.data).toBeDefined();
+      expect(result.depositTx.params.data.startsWith('0x')).toBe(true);
+    });
   });
 
   describe('updateMoneyAccountDepositTokenAmount', () => {

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -271,9 +271,13 @@ export async function updateMoneyAccountDepositTokenAmount(
     provider,
   });
 
+  const approveData = approveTx.params.data;
+  const depositData = depositTx.params.data;
+  if (!approveData || !depositData) return [];
+
   return [
-    { nestedTransactionIndex: 0, transactionData: approveTx.params.data },
-    { nestedTransactionIndex: 1, transactionData: depositTx.params.data },
+    { nestedTransactionIndex: 0, transactionData: approveData },
+    { nestedTransactionIndex: 1, transactionData: depositData },
   ];
 }
 
@@ -315,9 +319,13 @@ export async function updateMoneyAccountWithdrawTokenAmount(
     provider,
   });
 
+  const withdrawData = withdrawTx.params.data;
+  const transferData = transferTx.params.data;
+  if (!withdrawData || !transferData) return [];
+
   return [
-    { nestedTransactionIndex: 0, transactionData: withdrawTx.params.data },
-    { nestedTransactionIndex: 1, transactionData: transferTx.params.data },
+    { nestedTransactionIndex: 0, transactionData: withdrawData },
+    { nestedTransactionIndex: 1, transactionData: transferData },
   ];
 }
 

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -55,7 +55,7 @@ export function applySlippage(value: bigint): bigint {
 export interface MoneyAccountTxParams {
   params: {
     to: Hex;
-    data: Hex;
+    data?: Hex;
     value: Hex;
   };
   type: TransactionType;
@@ -204,10 +204,10 @@ export async function buildMoneyAccountDepositBatch({
         );
 
   const approveData = initialiseWithoutData
-    ? (undefined as Hex)
+    ? undefined
     : buildApproveData(boringVault, amount);
   const depositData = initialiseWithoutData
-    ? (undefined as Hex)
+    ? undefined
     : buildDepositData(musdAddress, amount, minimumMint);
 
   return {

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -175,6 +175,7 @@ export async function buildMoneyAccountDepositBatch({
   accountantAddress,
   lensAddress,
   provider,
+  initialiseWithoutData = false,
 }: {
   amount: bigint;
   chainId: Hex;
@@ -183,6 +184,7 @@ export async function buildMoneyAccountDepositBatch({
   accountantAddress: string;
   lensAddress: string;
   provider: ethers.providers.Provider;
+  initialiseWithoutData?: boolean;
 }): Promise<MoneyAccountDepositBatchResult> {
   const musdAddress = getMoneyAccountDepositAssetAddress(chainId);
 
@@ -201,8 +203,12 @@ export async function buildMoneyAccountDepositBatch({
           }),
         );
 
-  const approveData = buildApproveData(boringVault, amount);
-  const depositData = buildDepositData(musdAddress, amount, minimumMint);
+  const approveData = initialiseWithoutData
+    ? (undefined as Hex)
+    : buildApproveData(boringVault, amount);
+  const depositData = initialiseWithoutData
+    ? (undefined as Hex)
+    : buildDepositData(musdAddress, amount, minimumMint);
 
   return {
     approveTx: {

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
@@ -74,10 +74,16 @@ export async function getAmountData(
       throw prefixError(error, MONEY_ACCOUNT_DEPOSIT_ERROR_PREFIX);
     }
 
+    const approveData = buildResult.approveTx.params.data;
+    const depositData = buildResult.depositTx.params.data;
+    if (!approveData || !depositData) {
+      throw new Error('Missing calldata in deposit batch result');
+    }
+
     return {
       updates: [
-        { nestedTransactionIndex: 0, data: buildResult.approveTx.params.data },
-        { nestedTransactionIndex: 1, data: buildResult.depositTx.params.data },
+        { nestedTransactionIndex: 0, data: approveData },
+        { nestedTransactionIndex: 1, data: depositData },
       ],
     };
   } catch (error) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Add initialiseWithoutData option to buildMoneyAccountDepositBatch to defer calldata encoding until the user selects an amount. This avoids unnecessary ABI encoding and the waitForNextFrame delay during the initial deposit setup, improving perceived navigation speed.

- Add initialiseWithoutData param (default false) that returns undefined data fields when true
- Pass initialiseWithoutData: true from useMoneyAccountDeposit
- Remove waitForNextFrame await before deposit batch creation
- Add test coverage for initialiseWithoutData behavior

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1707

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how deposit batches are first registered (no calldata until MM Pay re-encodes on amount change); guards limit blast radius but deposit flow correctness depends on the existing amount-update path still running.
> 
> **Overview**
> **Initial money-account deposit setup** now creates the zero-amount transaction batch **without encoding approve/deposit calldata**, so navigation to the confirmation screen does less work up front. `buildMoneyAccountDepositBatch` accepts **`initialiseWithoutData`** (default `false`); when true it still sets `to`, types, and amounts logic but leaves **`params.data` undefined**. `useMoneyAccountDeposit` passes **`initialiseWithoutData: true`** for that placeholder batch.
> 
> Transaction param types treat **`data` as optional**, and paths that **must** have calldata (deposit amount updates, pay-controller amount callback, withdraw data helpers) **guard** and return empty updates or throw if data is missing. Tests cover the new flag and use optional chaining where `data` may be absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28360c48c586595a7453ecb919628255b641e9f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->