### PR TITLE
fix(money): keep activity filter tabs stationary on selection (MUSD-1194)

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import { fireEvent } from '@testing-library/react-native';
+import type { ReactTestInstance } from 'react-test-renderer';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
@@ -404,6 +406,55 @@ describe('MoneyActivityView', () => {
 
     expect(getByTestId('activity-mock-tx-money-tx-sent')).toBeOnTheScreen();
     expect(queryByTestId('activity-mock-tx-money-tx-converted')).toBeNull();
+  });
+
+  describe('filter tab active state', () => {
+    const backgroundColorOf = (chip: ReactTestInstance) =>
+      StyleSheet.flatten(chip.props.style as StyleProp<ViewStyle>)
+        ?.backgroundColor;
+
+    it('marks the All tab active and the other tabs inactive on first render', () => {
+      const { getByTestId } = renderWithProvider(<MoneyActivityView />);
+
+      const allBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_ALL),
+      );
+      const depositsBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_DEPOSITS),
+      );
+      const transfersBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_TRANSFERS),
+      );
+      const purchasesBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_PURCHASES),
+      );
+
+      expect(allBackground).toBeDefined();
+      expect(allBackground).not.toEqual(depositsBackground);
+      expect(transfersBackground).toEqual(depositsBackground);
+      expect(purchasesBackground).toEqual(depositsBackground);
+    });
+
+    it('moves the active background to the Deposits tab when it is pressed', () => {
+      const { getByTestId } = renderWithProvider(<MoneyActivityView />);
+      const activeBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_ALL),
+      );
+      const inactiveBackground = backgroundColorOf(
+        getByTestId(MoneyActivityViewTestIds.FILTER_DEPOSITS),
+      );
+
+      fireEvent.press(getByTestId(MoneyActivityViewTestIds.FILTER_DEPOSITS));
+
+      expect(
+        backgroundColorOf(
+          getByTestId(MoneyActivityViewTestIds.FILTER_DEPOSITS),
+        ),
+      ).toEqual(activeBackground);
+      expect(
+        backgroundColorOf(getByTestId(MoneyActivityViewTestIds.FILTER_ALL)),
+      ).toEqual(inactiveBackground);
+    });
   });
 
   it('renders empty state when there are no transactions', () => {

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -15,6 +15,8 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   Button,
+  ButtonBaseSize,
+  ButtonFilter,
   ButtonIconSize,
   ButtonIcon,
   ButtonSize,
@@ -314,14 +316,9 @@ const MoneyActivityView = () => {
         style={styles.filterScroll}
         contentContainerStyle={styles.filterRow}
       >
-        <Button
-          variant={
-            isActive(MoneyActivityFilter.All)
-              ? ButtonVariant.Primary
-              : ButtonVariant.Secondary
-          }
-          size={ButtonSize.Md}
-          twClassName="px-3"
+        <ButtonFilter
+          isActive={isActive(MoneyActivityFilter.All)}
+          size={ButtonBaseSize.Md}
           onPress={() =>
             handleFilterPress(
               MoneyActivityFilter.All,
@@ -332,15 +329,10 @@ const MoneyActivityView = () => {
           testID={MoneyActivityViewTestIds.FILTER_ALL}
         >
           {strings(FILTER_LABEL_KEYS.all)}
-        </Button>
-        <Button
-          variant={
-            isActive(MoneyActivityFilter.Deposits)
-              ? ButtonVariant.Primary
-              : ButtonVariant.Secondary
-          }
-          size={ButtonSize.Md}
-          twClassName="px-3"
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={isActive(MoneyActivityFilter.Deposits)}
+          size={ButtonBaseSize.Md}
           onPress={() =>
             handleFilterPress(
               MoneyActivityFilter.Deposits,
@@ -351,15 +343,10 @@ const MoneyActivityView = () => {
           testID={MoneyActivityViewTestIds.FILTER_DEPOSITS}
         >
           {strings(FILTER_LABEL_KEYS.deposits)}
-        </Button>
-        <Button
-          variant={
-            isActive(MoneyActivityFilter.Transfers)
-              ? ButtonVariant.Primary
-              : ButtonVariant.Secondary
-          }
-          size={ButtonSize.Md}
-          twClassName="px-3"
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={isActive(MoneyActivityFilter.Transfers)}
+          size={ButtonBaseSize.Md}
           onPress={() =>
             handleFilterPress(
               MoneyActivityFilter.Transfers,
@@ -370,15 +357,10 @@ const MoneyActivityView = () => {
           testID={MoneyActivityViewTestIds.FILTER_TRANSFERS}
         >
           {strings(FILTER_LABEL_KEYS.transfers)}
-        </Button>
-        <Button
-          variant={
-            isActive(MoneyActivityFilter.Purchases)
-              ? ButtonVariant.Primary
-              : ButtonVariant.Secondary
-          }
-          size={ButtonSize.Md}
-          twClassName="px-3"
+        </ButtonFilter>
+        <ButtonFilter
+          isActive={isActive(MoneyActivityFilter.Purchases)}
+          size={ButtonBaseSize.Md}
           onPress={() =>
             handleFilterPress(
               MoneyActivityFilter.Purchases,
@@ -389,7 +371,7 @@ const MoneyActivityView = () => {
           testID={MoneyActivityViewTestIds.FILTER_PURCHASES}
         >
           {strings(FILTER_LABEL_KEYS.purchases)}
-        </Button>
+        </ButtonFilter>
       </ScrollView>
 
       {isSettling ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money activity list filter tabs (All / Deposits / Sends / Purchases) now stay fully stationary when a tab is selected — only the background and text colour change.

Bug: selecting a tab caused the whole tab row to shift slightly. The chips toggled between `Button` `ButtonVariant.Primary` (active) and `ButtonVariant.Secondary` (inactive); the Secondary variant renders a 1px border (transparent) that the Primary variant does not, so the selected chip shrank by 2px in width and height and nudged every chip after it.

The chips are now rendered with the design system's `ButtonFilter`, whose `isActive` prop changes only background/text colour and never touches the box model. This is the same component the Ramp `OrdersList` and `PerpsTransactionsView` filter bars already use. The change is pure styling with no platform branches, so behaviour is identical on iOS and Android. `onPress` handlers, analytics wiring, and testIDs are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that caused the activity list filter tabs to shift position when a tab was selected

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1194

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Activity list filter tabs stay stationary on selection

  Scenario: user selects a filter tab in the Money activity list
    Given the user is on the Money activity screen with the filter tabs visible

    When user taps the "Deposits" tab (or any other inactive tab)
    Then the tapped tab changes to the active background/text colour
    And no tab shifts, resizes, or moves — the tab row layout is unchanged
    And the behaviour is identical on iOS and Android
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Selecting a tab caused a slight positional shift of the tab row (see ticket recording).

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/59bbab2c-a0c3-4ed8-86b1-241b16e393df



Tabs remain fully stationary on selection; only colours change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only swap to an existing design-system component with no logic or data changes.
> 
> **Overview**
> **Money activity filter chips** no longer jump when you select a tab. The row used to swap `Button` between Primary and Secondary variants; Secondary’s border changed chip size, so the whole strip shifted.
> 
> All four filters (All, Deposits, Sends, Purchases) now use design-system **`ButtonFilter`** with `isActive` and `ButtonBaseSize.Md`, so only colors change and layout stays fixed. Press handlers, analytics, and testIDs are unchanged.
> 
> **Tests** add a `filter tab active state` block that asserts default active styling on All, inactive styling on the other tabs, and that the active background moves to Deposits after a press.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842b20d35e556b32847b3b0a46a09ad9616ae4a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->