### PR TITLE
feat: kick off money upgrade process in modal stack

### DIFF
--- a/app/components/UI/Money/routes/index.test.tsx
+++ b/app/components/UI/Money/routes/index.test.tsx
@@ -198,6 +198,18 @@ describe('MoneyConfirmationScreenStack', () => {
 });
 
 describe('MoneyModalStack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls useUpgradeMoneyAccountOnMount on mount', () => {
+    renderWithProvider(<MoneyModalStack />, {
+      theme: themeWithCustomBackground,
+    });
+
+    expect(mockUseUpgradeMoneyAccountOnMount).toHaveBeenCalledTimes(1);
+  });
+
   it('registers the Add money sheet as a modal screen', () => {
     const { getByTestId } = renderWithProvider(<MoneyModalStack />, {
       theme: themeWithCustomBackground,

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -86,59 +86,66 @@ const MoneyConfirmationScreenStack = () => {
   );
 };
 
-const MoneyModalStack = () => (
-  <ModalStack.Navigator
-    screenOptions={{
-      ...clearNativeStackNavigatorOptions,
-      ...transparentModalScreenOptions,
-    }}
-  >
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.ADD_MONEY_SHEET}
-      component={MoneyAddMoneySheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.MORE_SHEET}
-      component={MoneyMoreSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.TRANSFER_MONEY_SHEET}
-      component={MoneyTransferSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.APY_INFO_SHEET}
-      component={MoneyApyInfoSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.EARNINGS_INFO_SHEET}
-      component={MoneyEarningsInfoSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.MONEY_BALANCE_INFO_SHEET}
-      component={MoneyBalanceInfoSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.LINK_CARD_SHEET}
-      component={MoneyLinkCardSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.EARN_CRYPTO_INFO_SHEET}
-      component={MoneyEarnCryptoInfoSheet}
-      options={{ headerShown: false }}
-    />
-    <ModalStack.Screen
-      name={Routes.MONEY.MODALS.GEO_BLOCK_SHEET}
-      component={MoneyGeoBlockSheet}
-      options={{ headerShown: false }}
-    />
-  </ModalStack.Navigator>
-);
+// Money modals are reachable without the Money tab (e.g. Card Home's "Add
+// money" action), so this stack must also kick off the account upgrade —
+// opening any Money sheet is the user's signal of intent to use the feature.
+const MoneyModalStack = () => {
+  useUpgradeMoneyAccountOnMount();
+
+  return (
+    <ModalStack.Navigator
+      screenOptions={{
+        ...clearNativeStackNavigatorOptions,
+        ...transparentModalScreenOptions,
+      }}
+    >
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.ADD_MONEY_SHEET}
+        component={MoneyAddMoneySheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.MORE_SHEET}
+        component={MoneyMoreSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.TRANSFER_MONEY_SHEET}
+        component={MoneyTransferSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.APY_INFO_SHEET}
+        component={MoneyApyInfoSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.EARNINGS_INFO_SHEET}
+        component={MoneyEarningsInfoSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.MONEY_BALANCE_INFO_SHEET}
+        component={MoneyBalanceInfoSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.LINK_CARD_SHEET}
+        component={MoneyLinkCardSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.EARN_CRYPTO_INFO_SHEET}
+        component={MoneyEarnCryptoInfoSheet}
+        options={{ headerShown: false }}
+      />
+      <ModalStack.Screen
+        name={Routes.MONEY.MODALS.GEO_BLOCK_SHEET}
+        component={MoneyGeoBlockSheet}
+        options={{ headerShown: false }}
+      />
+    </ModalStack.Navigator>
+  );
+};
 
 export { MoneyConfirmationScreenStack, MoneyModalStack, MoneyTabScreenStack };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
We previously would only kick off the money account upgrade process when the user landed on a money account screen. Because we show an 'add' cta on the home screen even if the user hasn't been on the money account it was possible to add money without the upgrade process starting.

<img width="554" height="1041" alt="image" src="https://github.com/user-attachments/assets/428f2f7b-c138-41cb-8eba-a474772ffd12" />

This PR ensures that we also trigger the upgrade process when any money account modal is opened.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: upgrade money account when money account modal opens

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-layer change reusing an existing mount hook; behavior is covered by a new unit test and aligns with other Money stacks.
> 
> **Overview**
> **Money modal entry now starts the account upgrade flow**, matching tab and confirmation stacks so users who open Money sheets from outside the Money tab (e.g. Card Home “Add money”) still get `upgradeMoneyAccount` kicked off on mount.
> 
> `MoneyModalStack` is refactored from an inline component to a function that calls `useUpgradeMoneyAccountOnMount()` before rendering the same modal navigator. Tests add a `beforeEach` mock reset and assert the hook runs once when `MoneyModalStack` mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70179091d7c05637c1821491ce658d9023d94ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->