### PR TITLE
docs(qa): Performance E2E failure autofix Cursor Automation

### DIFF
--- a/.agents/skills/performance-failure-autofix/AUTOMATION.md
+++ b/.agents/skills/performance-failure-autofix/AUTOMATION.md
@@ -1,0 +1,127 @@
+# Cursor Automation setup — Performance failure autofix
+
+Cursor Automations are configured in the Cursor product UI
+([cursor.com/automations](https://cursor.com/automations)), not committed as
+YAML. This document is the paste-ready configuration for the agent defined by
+[`SKILL.md`](./SKILL.md).
+
+## Create the automation
+
+1. Open [Cursor Automations](https://cursor.com/automations) → **Create**.
+2. Name: `Performance E2E failure triage + fix`
+3. Repository: `MetaMask/metamask-mobile`
+4. Copy the **Agent prompt** below into the automation prompt field.
+5. Configure triggers, tools, and secrets as listed.
+6. Enable the automation.
+
+## Trigger
+
+| Field | Value |
+| ----- | ----- |
+| Type | **GitHub** → **Workflow run completed** (or **failed**, if that option exists) |
+| Repository | `MetaMask/metamask-mobile` |
+| Workflow filter | Prefer matching names that contain `Performance` (see workflow list below). If the UI only supports “any workflow”, rely on the prompt’s early-exit gate. |
+| Branch filter | Optional: `main`, `MMQA-performance-improvements`, release branches — or leave open and let the agent decide |
+
+### Workflows in scope
+
+- `Build Apps and Run Performance E2E Tests` (`.github/workflows/run-performance-e2e.yml`)
+- `Performance E2E Tests for Release Builds` (`.github/workflows/run-performance-e2e-release.yml`)
+- `Performance E2E Tests for Experimental Builds` (`.github/workflows/run-performance-e2e-experimental.yml`)
+
+If the completed workflow is **not** one of these, exit immediately with no Slack message and no PR.
+
+## Tools to enable
+
+| Tool | Why |
+| ---- | --- |
+| **GitHub** (read Actions, download artifacts, open PRs) | Required — logs, artifacts, PR creation |
+| **Slack** (send DM / message) | Required — notify Javier Vera |
+| **Browser / web fetch** (if available) | Optional — open BrowserStack session pages |
+| **Shell / code edit** | Required — download video, inspect recordings, implement fix |
+
+Do **not** enable tools that post to public channels unless you intentionally change the Slack destination.
+
+## Runtime secrets
+
+Add these as Automation / Cloud Agent secrets (never commit them):
+
+| Secret | Purpose |
+| ------ | ------- |
+| `BROWSERSTACK_USERNAME` | Download App Automate session video + metadata |
+| `BROWSERSTACK_ACCESS_KEY` | Same |
+| `GH_TOKEN` or GitHub App auth | Already provided by Cursor GitHub integration in most setups |
+| Slack auth | Already provided by Cursor Slack integration when the Slack tool is enabled |
+
+## Agent prompt (paste this)
+
+```text
+You are the Performance Failure Autofix agent for MetaMask Mobile.
+
+Follow the skill at:
+.agents/skills/performance-failure-autofix/SKILL.md
+
+All agent output (analysis notes, Slack message, PR title/body, commit messages) MUST be in English.
+
+## Trigger context
+
+A GitHub Actions workflow run just completed. Use the run URL / run id from the trigger payload.
+
+## Hard early exits (no Slack, no PR)
+
+1. The workflow is not one of: "Build Apps and Run Performance E2E Tests", "Performance E2E Tests for Release Builds", "Performance E2E Tests for Experimental Builds".
+2. Conclusion is success with zero failed performance tests.
+3. You cannot authenticate to GitHub Actions.
+
+## Required workflow
+
+1. Identify every failed performance test in the run (all devices/platforms present in the matrix).
+2. For each failure:
+   - Parse the job log for the test title, platform, device, BrowserStack session URL, and the first failing assertion.
+   - Download and inspect GitHub Actions artifacts (screenshots, test-results JSON, traces when present).
+   - Download and watch the BrowserStack session video using BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY (REST: GET /sessions/{id}.json → video_url).
+   - Classify: quality_gates_exceeded vs functional / flaky / infra.
+3. Decide whether a code fix is allowed:
+   - If ALL failures are quality_gates_exceeded (and screenshots/video show the happy path completed): DO NOT open a PR. Send Slack only.
+   - If ANY failure is functional / flaky / infra with a concrete fix in app or performance test code: implement the fix and open a draft PR.
+4. Slack: DM Javier Vera (Slack user id UEYQL2PEV) using the template in the skill. One message per run.
+5. PR: draft, English title/body, link the Actions run and BrowserStack sessions, explain root cause and why it is not a QG-only case. Push with Cursor branch naming rules for this environment.
+
+## Constraints
+
+- Do not widen quality-gate thresholds unless a product/QA owner explicitly asked in the trigger context.
+- Do not rotate or print BrowserStack secrets.
+- Do not reply on public Slack channels; DM Javier only.
+- Prefer the smallest correct fix.
+- If BrowserStack video download fails, still analyze from logs + screenshots and state the gap in Slack.
+```
+
+## Manual / on-demand run
+
+You can also invoke the same skill without a workflow trigger:
+
+1. Open a Cloud Agent on `MetaMask/metamask-mobile`.
+2. Paste:
+
+```text
+Follow .agents/skills/performance-failure-autofix/SKILL.md
+
+Analyze GitHub Actions run: <PASTE_RUN_URL>
+
+All output in English. DM Slack summary to Javier Vera (UEYQL2PEV). Open a draft PR only if a non-quality-gate fix is justified.
+```
+
+Or use the Cursor command:
+
+```text
+/performance-failure-autofix <github-actions-run-url>
+```
+
+## Acceptance checklist (after enabling)
+
+- [ ] Automation triggers on a failed performance workflow (or completed with failures).
+- [ ] Non-performance workflows are ignored (no Slack spam).
+- [ ] QG-only failure → Slack DM only, no PR.
+- [ ] Functional failure → Slack DM + draft PR with fix.
+- [ ] BrowserStack video is downloaded when credentials are present.
+- [ ] All agent-facing text is English.

--- a/.agents/skills/performance-failure-autofix/SKILL.md
+++ b/.agents/skills/performance-failure-autofix/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: performance-failure-autofix
+description: >
+  Investigate failed MetaMask Mobile performance E2E tests from a GitHub Actions
+  run: download artifacts, review BrowserStack recordings/screenshots, classify
+  failures (quality-gate vs functional), propose and implement a fix in the app
+  or performance test when appropriate, DM Javier Vera on Slack, and open a PR.
+  Use when a performance workflow fails, when triage of BrowserStack recordings
+  is needed, or when running the Cursor Automation for performance autofix.
+---
+
+# Performance Failure Autofix Agent
+
+**Goal:** For each **failed** performance test in a given GitHub Actions run,
+reproduce the investigation done by a QA engineer: artifacts → screenshots →
+BrowserStack video → root cause → Slack DM → PR (when a code fix is warranted).
+
+All agent output (Slack, PR title/body, commit messages, comments) **must be in
+English**.
+
+## When to use
+
+- Cursor Automation triggered by a performance workflow completion/failure
+- Manual: user pastes a performance Actions run URL / run id
+- Manual: `/performance-failure-autofix` command
+
+## Workflows in scope
+
+Only these GitHub Actions workflow `name:` values:
+
+- `Build Apps and Run Performance E2E Tests`
+- `Performance E2E Tests for Release Builds`
+- `Performance E2E Tests for Experimental Builds`
+
+If the trigger is a different workflow, **no-op** (do not Slack/PR).
+
+If conclusion is `success` / `cancelled` / `skipped` with zero failed tests in
+`summary.json` / `failed-tests-by-team.json`, **no-op**.
+
+## Required tools / secrets
+
+| Need | How |
+|------|-----|
+| GitHub Actions logs + artifacts | `gh` (GitHub App / token already available) |
+| BrowserStack session + video | Runtime secrets `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY` |
+| Slack DM to Javier Vera | Slack MCP `slack_send_message` with channel_id `UEYQL2PEV` (Javier Vera) |
+| PR creation | git + `ManagePullRequest` / GitHub App |
+
+Never print BrowserStack credentials, tokens, or auth_token query params in
+Slack, PRs, commits, or logs.
+
+## Decision tree
+
+```
+Failed performance tests in run?
+├─ No → no-op
+└─ Yes → for EACH failed test:
+   ├─ Download device-matching artifacts + aggregated-reports
+   ├─ Classify failureReason:
+   │  ├─ quality_gates_exceeded ONLY (test completed, timers over threshold)
+   │  │  → Analyze (video/screenshot optional). Do NOT open a code-fix PR.
+   │  │  → Slack DM: metrics, recording link, “threshold/regression triage” note.
+   │  └─ functional failure (assert/timeout/crash/selector/stale/etc.)
+   │     OR mix of functional + quality gates
+   │     → Mandatory: screenshot(s) + BrowserStack video frames
+   │     → Root-cause: APP bug vs TEST/infra flake
+   │     → If high-confidence fixable in ≤ ~small diff:
+   │        implement fix → PR → Slack DM with PR link
+   │     → Else: Slack DM with findings + recommended next step (no PR)
+```
+
+**Quality-gate-only failures are triage/reporting, not autofix PRs.** Raising
+thresholds without product/QA agreement is forbidden unless the user explicitly
+asks for a threshold change.
+
+## Investigation steps (per failed test)
+
+1. **Identify the run**
+   - From trigger payload or user-provided URL: `run_id`, `head_sha`, `head_branch`, `html_url`.
+   - `gh run view <run_id> --repo MetaMask/metamask-mobile --json conclusion,headBranch,headSha,url,displayTitle,workflowName`
+
+2. **Download artifacts**
+   - Always: `aggregated-reports` (`summary.json`, `performance-results.json`).
+   - Per failed device: artifacts named like
+     `android-*-test-results-<Device>-<os>` /
+     `ios-*-test-results-<Device>-<os>` matching the failure’s device.
+   - Parse `failedTestsStats.failedTestsByTeam` and per-test
+     `failureReason`, `qualityGates`, `recordingLink` / `videoURL`, `sessionId`.
+
+3. **Playwright report media**
+   - From the device artifact `test-reports/playwright-report/`:
+     - Extract embedded report (`playwrightReport` script → zip → `report.json`).
+     - Collect attachments for the failed test: `*-error-screenshot`, traces, stdout/stderr.
+   - Read screenshots with the image tool (do not rely on filenames alone).
+
+4. **BrowserStack recording (required for functional failures)**
+   - Session API:
+     `GET https://api-cloud.browserstack.com/app-automate/sessions/<sessionId>.json`
+     with Basic auth from env secrets.
+   - Download `video_url` to a local mp4 under `/tmp` and/or `/opt/cursor/artifacts/`.
+   - Extract frames (`ffmpeg` fps≈1/2) and visually inspect the failing step window.
+   - Prefer the session id from the **failed attempt that produced quality-gate /
+     assert evidence** (often in stdout / `failed-tests-by-team.json`), not a
+     skipped retry session.
+
+5. **Classify root cause (pick one primary)**
+   - `quality_gate_only` — flow completed; timer(s) over threshold
+   - `selector_flake` — Index out of bounds / stale element / retry then success then QG fail
+   - `test_bug` — wrong locator, missing wait, incorrect flow for current UI
+   - `app_regression` — UI/state clearly wrong vs expected product behavior
+   - `infra` — BrowserStack session/device, missing app URL, build upload
+   - `unknown` — insufficient evidence
+
+6. **Fix gate (PR only if ALL true)**
+   - Primary class is `test_bug` or `app_regression` (not `quality_gate_only`, not pure `infra`)
+   - You can name exact file(s) + one-line cause
+   - Fix is minimal and matches repo patterns (TypeScript, existing PO / TimerHelper / assertions)
+   - You verified the failure is reproducible from artifacts/video (not a one-off cancel)
+   - Prefer test/PO fixes when the UI is correct but automation is brittle
+   - Prefer app fixes only when the video shows incorrect product behavior
+
+7. **Implement + PR**
+   - Branch: `cursor/perf-autofix-<short-slug>-a093` (or the automation’s configured prefix)
+   - Commit message: clear, English, focused on the fix
+   - PR title/body in English; link the Actions run + BrowserStack session
+   - Do not request reviewers unless tools say so
+   - Do not approve PRs
+
+8. **Slack DM Javier Vera (always when there was ≥1 failed test)**
+   - Tool: `slack_send_message`
+   - `channel_id`: `UEYQL2PEV` (Javier Vera — Staff QA Engineer)
+   - Use the Slack message template below
+   - One DM per run (aggregate all failed tests). If a PR was opened, include it.
+   - Never include secrets or raw credential values.
+
+## Slack DM template (English)
+
+```text
+:rotating_light: *Performance E2E failure triage*
+
+*Run:* <workflow name> — <conclusion>
+*Link:* <actions run url>
+*Branch / SHA:* `<branch>` / `<shortsha>`
+*Device focus:* <device(s) with failures>
+
+*Failures (<N>):*
+1. *<test name>* — `<failureReason>`
+   - Class: `<quality_gate_only|test_bug|app_regression|selector_flake|infra|unknown>`
+   - Key signal: <1–2 lines from metrics or video>
+   - Recording: <browserstack session url>
+   - Screenshot: <note if attached / path>
+
+*Proposed action:*
+- <no PR — quality gate only / needs human threshold review>
+- OR <PR: url> — <one-line fix summary>
+
+*Notes:* <optional, short>
+```
+
+## Implementation references in-repo
+
+- Specs: `tests/performance/**`
+- Page objects: `tests/page-objects/**`
+- Assertions / waits: `tests/framework/PlaywrightAssertions.ts`, `tests/framework/Utilities.ts`
+- Timers / QG: `tests/framework/TimerHelper.ts`, `tests/framework/quality-gates/`
+- BrowserStack client: `tests/framework/services/providers/browserstack/BrowserStackAPI.ts`
+- Workflow: `.github/workflows/run-performance-e2e.yml`
+- Guide: `tests/performance/README.md`
+
+## Hard rules
+
+- English only for Slack, PRs, commits, and user-facing summaries from this skill
+- Do not invent BrowserStack session IDs
+- Do not raise performance thresholds in autofix PRs
+- Do not commit secrets, videos, or large binaries into the repo
+- Prefer one focused PR per run (or per clear root cause if multiple unrelated fails)
+- If credentials are missing, still triage from artifacts/screenshots and Slack that
+  video review was skipped due to missing `BROWSERSTACK_*` secrets
+
+## Cursor Automation setup
+
+See [AUTOMATION.md](AUTOMATION.md) for the paste-ready Cursor Automation prompt,
+trigger configuration, tools, and secrets checklist.

--- a/.cursor/commands/performance-failure-autofix.md
+++ b/.cursor/commands/performance-failure-autofix.md
@@ -1,0 +1,23 @@
+# Performance Failure Autofix
+
+Follow the skill at `.agents/skills/performance-failure-autofix/SKILL.md` and the
+canonical guide at `docs/testing/performance-failure-autofix.md`.
+
+## Input
+
+`$ARGUMENTS` should be a GitHub Actions run URL or run id for a MetaMask Mobile
+performance workflow. If empty, ask for the run URL.
+
+## Instructions
+
+1. All agent output (analysis, Slack, PR, commits) must be in English.
+2. Investigate every failed performance test in the run: Actions artifacts,
+   Playwright screenshots, and BrowserStack session videos when
+   `BROWSERSTACK_*` secrets are available.
+3. Classify each failure (`quality_gate_only`, `test_bug`, `app_regression`,
+   `selector_flake`, `infra`, `unknown`).
+4. DM Javier Vera on Slack (`channel_id: UEYQL2PEV`) using the skill template.
+5. Open a draft PR with a proposed fix only when the failure is not
+   quality-gates-only and a high-confidence minimal fix exists in the app or
+   performance test. Do not raise quality-gate thresholds unless explicitly
+   requested.

--- a/.gitignore
+++ b/.gitignore
@@ -218,21 +218,25 @@ release-signoffs.json
 # MetaMask/skills (public) and optionally Consensys/skills (private overlay),
 # or hand-authored locally. (See ADR #57.) Only IDE/bugbot config under
 # `.cursor/` is tracked via the carve-outs below.
+# Use trailing `/*` (not bare dir) so selective `!` carve-outs can re-include files.
 .claude/skills/
 .claude/commands/
-.agents/skills/
+.agents/skills/*
+!.agents/skills/performance-failure-autofix/
+!.agents/skills/performance-failure-autofix/**
 .ai-pr-analyzer/skills/*
 .ai-pr-analyzer/flaky*
 .cursor/rules/*
 !.cursor/rules/*.mdc
 .cursor/skills/
-.cursor/commands/
+.cursor/commands/*
 # Carve-outs: IDE/bugbot config that must stay tracked
 !.cursor/rules/*.mdc
 !.cursor/BUGBOT.md
 !.cursor/hooks.json
 !.cursor/worktrees.json
 !.claude/settings.json
+!.cursor/commands/performance-failure-autofix.md
 
 # Build environment validation
 build-env.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ scripts/                  # Build and automation scripts
 | [`docs/testing/e2e-testing.md`](docs/testing/e2e-testing.md)                               | Detox smoke/regression — Page Objects, gestures                              |
 | [`docs/testing/appium-smoke-testing.md`](docs/testing/appium-smoke-testing.md)             | Appium smoke — main-e2e builds, `yarn appium-smoke:*`                        |
 | [`docs/testing/component-view-tests.md`](docs/testing/component-view-tests.md)             | `*.view.test.tsx` — framework, presets, renderers                            |
+| [`docs/testing/performance-failure-autofix.md`](docs/testing/performance-failure-autofix.md) | Performance E2E failure triage agent + Cursor Automation (artifacts, BrowserStack, Slack, fix PR) |
 | [`docs/readme/version-gated-feature-flags.md`](docs/readme/version-gated-feature-flags.md) | Version-gated remote flags — `validatedVersionGatedFeatureFlag` in selectors |
 
 General coding, UI, deeplink-handler, and PR-creation guidance now lives in the centralized `mms-*` skill set installed via `yarn skills` (see `.agents/skills/mms-*` after sync).

--- a/docs/testing/performance-failure-autofix.md
+++ b/docs/testing/performance-failure-autofix.md
@@ -1,0 +1,93 @@
+# Performance Failure Autofix (Agent + Cursor Automation)
+
+Canonical guide for investigating failed MetaMask Mobile **performance E2E**
+runs with a Cursor agent / Cursor Automation: artifacts → BrowserStack
+recordings → classification → Slack DM → optional fix PR.
+
+Agent skill (execution SSOT):
+[`.agents/skills/performance-failure-autofix/SKILL.md`](../../.agents/skills/performance-failure-autofix/SKILL.md)
+
+Cursor Automation paste-ready config:
+[`.agents/skills/performance-failure-autofix/AUTOMATION.md`](../../.agents/skills/performance-failure-autofix/AUTOMATION.md)
+
+Cursor command: `/performance-failure-autofix`
+
+**All agent output must be in English** (Slack, PRs, commits, summaries).
+
+## What it does
+
+When a performance GitHub Actions run finishes with failed tests, the agent:
+
+1. Lists every failed performance test in the run.
+2. Downloads GitHub Actions artifacts (aggregated reports, Playwright screenshots).
+3. Downloads and reviews BrowserStack App Automate session videos (when
+   `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` are available).
+4. Classifies each failure:
+   - `quality_gate_only` — flow completed; timer(s) over threshold
+   - `test_bug` / `selector_flake` — automation issue
+   - `app_regression` — incorrect product behavior on video
+   - `infra` / `unknown`
+5. **Slack DM** Javier Vera (`UEYQL2PEV`) with a structured English triage report.
+6. Opens a **draft PR with a proposed fix** only when the failure is **not**
+   quality-gates-only and a high-confidence, minimal fix exists in the app or
+   the performance test.
+
+## Workflows in scope
+
+| Workflow name | File |
+| ------------- | ---- |
+| Build Apps and Run Performance E2E Tests | `.github/workflows/run-performance-e2e.yml` |
+| Performance E2E Tests for Release Builds | `.github/workflows/run-performance-e2e-release.yml` |
+| Performance E2E Tests for Experimental Builds | `.github/workflows/run-performance-e2e-experimental.yml` |
+
+Other workflows → **no-op** (no Slack, no PR).
+
+## Fix gate
+
+| Classification | Slack DM | Fix PR |
+| -------------- | -------- | ------ |
+| All failures are `quality_gate_only` | Yes | **No** (threshold / regression triage for humans) |
+| Any `test_bug` / `app_regression` with concrete fix | Yes | Yes (draft) |
+| `infra` / `unknown` / low confidence | Yes | **No** (recommendations only) |
+
+Do **not** raise quality-gate thresholds in autofix PRs unless a product/QA
+owner explicitly requests it.
+
+## Enable the Cursor Automation
+
+Cursor Automations are configured in the product UI
+([cursor.com/automations](https://cursor.com/automations)), not as repo YAML.
+
+1. Create automation → name `Performance E2E failure triage + fix`.
+2. Repository: `MetaMask/metamask-mobile`.
+3. Trigger: GitHub **Workflow run completed** (or failed), filtered to
+   Performance workflows when the UI allows; otherwise rely on the prompt’s
+   early-exit gate.
+4. Enable tools: GitHub (Actions + PRs), Slack (DM), shell/code edit.
+5. Add runtime secrets: `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`.
+6. Paste the agent prompt from
+   [AUTOMATION.md](../../.agents/skills/performance-failure-autofix/AUTOMATION.md).
+
+### Slack destination
+
+- User: Javier Vera
+- Slack user id: `UEYQL2PEV`
+- Delivery: DM via `slack_send_message` (`channel_id: UEYQL2PEV`)
+
+### Manual run
+
+```text
+Follow .agents/skills/performance-failure-autofix/SKILL.md
+
+Analyze GitHub Actions run: <PASTE_RUN_URL>
+
+All output in English. DM Slack summary to Javier Vera (UEYQL2PEV).
+Open a draft PR only if a non-quality-gate fix is justified.
+```
+
+Or: `/performance-failure-autofix <github-actions-run-url>`
+
+## Related docs
+
+- [tests/performance/README.md](../../tests/performance/README.md)
+- [docs/performance/](../performance/)

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -24,6 +24,12 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Canonical guide: patterns, Page Objects, assertions, gestures, prohibited patterns.
 - [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke: main-e2e builds, `yarn appium-smoke:*`, local setup, CI.
 
+### Performance E2E failure autofix (Cursor Automation)
+
+- [docs/testing/performance-failure-autofix.md](../docs/testing/performance-failure-autofix.md) — Agent + Automation: investigate failed performance runs (artifacts, BrowserStack video), Slack DM Javier Vera, open fix PR when not quality-gates-only.
+- Skill: [`.agents/skills/performance-failure-autofix/SKILL.md`](../.agents/skills/performance-failure-autofix/SKILL.md)
+- Command: `/performance-failure-autofix`
+
 ## Canonical Sources (read these, do not duplicate)
 
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Patterns, Page Objects, assertions, gestures, prohibited patterns.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an in-repo agent skill + Cursor Automation setup so a Cursor agent can triage **failed performance E2E runs** the same way a QA engineer would: GitHub Actions artifacts, Playwright screenshots, BrowserStack session videos → root-cause classification → Slack DM → optional fix PR.

**All agent output is English** (Slack, PRs, commits).

## What was added

| Path | Purpose |
| ---- | ------- |
| `.agents/skills/performance-failure-autofix/SKILL.md` | Agent execution SSOT (decision tree, investigation steps, Slack template, fix gate) |
| `.agents/skills/performance-failure-autofix/AUTOMATION.md` | Paste-ready Cursor Automation prompt, triggers, tools, secrets |
| `.cursor/commands/performance-failure-autofix.md` | `/performance-failure-autofix <run-url>` command |
| `docs/testing/performance-failure-autofix.md` | Canonical human-facing guide |
| `AGENTS.md` / `tests/AGENTS.md` / `.gitignore` carve-outs | Discovery + track skill/command in git |

## Behavior

1. Trigger on performance workflow completion (or manual run URL).
2. For **each** failed performance test: download artifacts, inspect screenshots, download/watch BrowserStack video.
3. Classify: `quality_gate_only` vs `test_bug` / `app_regression` / `selector_flake` / `infra` / `unknown`.
4. **Always** Slack DM **Javier Vera** (`UEYQL2PEV`) with the English triage report.
5. **Open a draft PR with a proposed fix only when the failure is not quality-gates-only** and a high-confidence minimal fix exists (app or performance test). Threshold bumps are forbidden unless explicitly requested.

## How to enable the Cursor Automation (required follow-up)

Cursor Automations are configured in the product UI, not as repo YAML:

1. Open [cursor.com/automations](https://cursor.com/automations) → Create.
2. Name: `Performance E2E failure triage + fix`.
3. Repo: `MetaMask/metamask-mobile`.
4. Trigger: GitHub **Workflow run completed** (prefer Performance workflows).
5. Enable tools: GitHub (Actions + PRs), Slack (DM), shell/code edit.
6. Add secrets: `BROWSERSTACK_USERNAME`, `BROWSERSTACK_ACCESS_KEY`.
7. Paste the prompt from `.agents/skills/performance-failure-autofix/AUTOMATION.md`.

Full checklist: `docs/testing/performance-failure-autofix.md`.

## Manual invocation

```text
/performance-failure-autofix https://github.com/MetaMask/metamask-mobile/actions/runs/<id>
```

## Notes

- This PR ships the **agent playbook + setup docs**, not a live Automation instance (Automations live in Cursor).
- QG-only failures (e.g. Import SRP step timer over threshold with successful happy-path video) → Slack only, no autofix PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0985ebe3-94ed-43c9-9906-d3549807a093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0985ebe3-94ed-43c9-9906-d3549807a093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

