### PR TITLE
chore: bump react-native-permissions to 5.6.0

### DIFF
--- a/app/__mocks__/react-native-permissions.ts
+++ b/app/__mocks__/react-native-permissions.ts
@@ -11,7 +11,7 @@ export const RESULTS = {
 };
 export const PERMISSIONS = {
   IOS: {
-    BLUETOOTH_PERIPHERAL: 'ios.permission.BLUETOOTH_PERIPHERAL',
+    BLUETOOTH: 'ios.permission.BLUETOOTH',
   },
   ANDROID: {
     ACCESS_FINE_LOCATION: 'android.permission.ACCESS_FINE_LOCATION',

--- a/app/components/hooks/useBluetoothPermissions.test.ts
+++ b/app/components/hooks/useBluetoothPermissions.test.ts
@@ -15,7 +15,7 @@ import { AppState } from 'react-native';
 jest.mock('react-native-permissions', () => ({
   PERMISSIONS: {
     IOS: {
-      BLUETOOTH_PERIPHERAL: 'iosBluetooth',
+      BLUETOOTH: 'iosBluetooth',
     },
     ANDROID: {
       ACCESS_FINE_LOCATION: 'androidLocation',

--- a/app/components/hooks/useBluetoothPermissions.ts
+++ b/app/components/hooks/useBluetoothPermissions.ts
@@ -19,9 +19,7 @@ const useBluetoothPermissions = () => {
   const deviceOSVersion = Number(getSystemVersion()) || 0;
 
   const checkIosPermission = async () => {
-    const bluetoothPermissionStatus = await request(
-      PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL,
-    );
+    const bluetoothPermissionStatus = await request(PERMISSIONS.IOS.BLUETOOTH);
     const bluetoothAllowed = bluetoothPermissionStatus === RESULTS.GRANTED;
 
     if (bluetoothAllowed) {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -2,6 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
+require File.join(File.dirname(`node --print "require.resolve('react-native-permissions/package.json')"`), "scripts/setup")
 
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
@@ -10,6 +11,9 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWO
 
 platform :ios, '15.1'
 prepare_react_native_project!
+
+# react-native-permissions v4+: select permission handlers compiled into RNPermissions
+setup_permissions(['Bluetooth'])
 # Ensures that versions from Gemfile is respected
 ensure_bundler!
 
@@ -91,7 +95,6 @@ def common_target_logic
 
    # Comment the next line if you don't want to use dynamic frameworks
   # use_frameworks!
-	pod 'Permission-BluetoothPeripheral', :path => '../node_modules/react-native-permissions/ios/BluetoothPeripheral'
   pod 'GzipSwift'
 
   # Pod for fixing react-native-quick-crypto issue: https://github.com/margelo/react-native-quick-crypto/issues/244

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -694,8 +694,6 @@ PODS:
     - SocketRocket
     - Yoga
   - OpenSSL-Universal (3.6.0000)
-  - Permission-BluetoothPeripheral (3.10.1):
-    - RNPermissions
   - PromisesObjC (2.4.0)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -4058,7 +4056,7 @@ PODS:
     - React-Core
   - RNOS (1.2.6):
     - React
-  - RNPermissions (3.10.1):
+  - RNPermissions (5.6.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4526,7 +4524,6 @@ DEPENDENCIES:
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - NitroTextDecoder (from `../node_modules/react-native-nitro-text-decoder`)
   - OpenSSL-Universal
-  - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -4796,8 +4793,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-nitro-modules"
   NitroTextDecoder:
     :path: "../node_modules/react-native-nitro-text-decoder"
-  Permission-BluetoothPeripheral:
-    :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -5133,7 +5128,6 @@ SPEC CHECKSUMS:
   NitroModules: ea5dc6c43666f4a75e71e372eaca6d3605856e51
   NitroTextDecoder: 9b50be860ed7488349bc31791b6fe96778a43db0
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
-  Permission-BluetoothPeripheral: 34ab829f159c6cf400c57bac05f5ba1b0af7a86e
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
   RCTDeprecation: c5e70bcdbc24b9edbca24b96f3997319f01ba8fb
@@ -5255,7 +5249,7 @@ SPEC CHECKSUMS:
   RNKeychain: 483402cf2b90647eb0cf569cebbc069d32addea4
   RNNotifee: 5165d37aaf980031837be3caece2eae5a6d73ae8
   RNOS: d07e5090b5060c6f2b83116d740a32cfdb33afe3
-  RNPermissions: b65e9cc101a4e6b58ec1f8d018b0b167f6eb63d5
+  RNPermissions: 4f5f8b17b9fff4e0abcf16361c3c1374cb25a6fb
   RNReanimated: 292cd58688552a22b3fc1cefcfbc49b336dfed68
   RNScreens: 9269ab4971b2bd24917be84295d2c2ae7d06e9be
   RNSensors: 4690be00931bc60be7c7bd457701edefaff965e3
@@ -5278,6 +5272,6 @@ SPEC CHECKSUMS:
   Yoga: cf2a67aa1c8a225f0cb98a5f531d6f305d3f12e5
   YttriumWrapper: cbddb60c835ebc4232d9f57064084ab30686a18e
 
-PODFILE CHECKSUM: ce15306de63511205459a8f7b045fe8da6ce1b9f
+PODFILE CHECKSUM: 765be4dd3d78fecfb151a4b9e4a55956b1ebf8aa
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
     "react-native-nitro-websockets": "^1.0.3",
     "react-native-os": "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch",
     "react-native-pager-view": "8.0.0",
-    "react-native-permissions": "^3.7.2",
+    "react-native-permissions": "^5.6.0",
     "react-native-progress": "3.5.0",
     "react-native-qrcode-svg": "6.3.21",
     "react-native-quick-base64": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36304,7 +36304,7 @@ __metadata:
     react-native-os: "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch"
     react-native-pager-view: "npm:8.0.0"
     react-native-performance: "npm:^6.0.0"
-    react-native-permissions: "npm:^3.7.2"
+    react-native-permissions: "npm:^5.6.0"
     react-native-progress: "npm:3.5.0"
     react-native-qrcode-svg: "npm:6.3.21"
     react-native-quick-base64: "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch"
@@ -40912,17 +40912,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-permissions@npm:^3.7.2":
-  version: 3.10.1
-  resolution: "react-native-permissions@npm:3.10.1"
+"react-native-permissions@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "react-native-permissions@npm:5.6.0"
   peerDependencies:
-    react: ">=16.13.1"
-    react-native: ">=0.63.3"
-    react-native-windows: ">=0.62.0"
+    react: "*"
+    react-native: "*"
+    react-native-windows: "*"
   peerDependenciesMeta:
     react-native-windows:
       optional: true
-  checksum: 10/afd3db79cd5a82f04e1382d63d125d783923e272d3919298680b46d86422ca357ce9774f93c5113615ab6021015e0e5ea5a6ba137c1ab78f1a47f962c0adf959
+  checksum: 10/3c140d9d08b0a266e28fdf5e6e87016080e41864da7a99360c3d5754c56f7a73f983a47fd973b6d3e7cd7a55868ab4a34519bc971a6580dc226fa74ae114181f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (Wave 4 — verified required). 3.7.2 is out of support and incompatible with the RN 0.85 toolchain; 5.6.0 is the validated target. Landing it now on 0.83 isolates any regression and gives it soak time on main.

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `react-native-permissions` from `^3.7.2` to `^5.6.0` as part of the incremental pre-upgrade dependency work for React Native 0.85.

Changes required by the v4/v5 API:

- `PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL` renamed to `PERMISSIONS.IOS.BLUETOOTH` — updated `useBluetoothPermissions.ts`, its test mock, and the global `app/__mocks__/react-native-permissions.ts` (Android constants unchanged)
- iOS Podfile migrated from the per-permission pod (`Permission-BluetoothPeripheral`) to the v4+ `setup_permissions(['Bluetooth'])` flow — permission handlers are now compiled into `RNPermissions` directly
- `NSBluetoothAlwaysUsageDescription` was already present in both Info.plists (required by the Bluetooth handler) — no plist change needed

Our only usage of this library is Bluetooth permissions for Ledger hardware wallet flows (`useBluetoothPermissions`, `LedgerBluetoothAdapter`).

Verified locally: `yarn lint:tsc` green, both consumer test suites pass (103 tests), `pod install` resolves cleanly (RNPermissions 5.6.0, `Permission-BluetoothPeripheral` pod removed).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bluetooth permissions for Ledger

  Scenario: user connects a Ledger device
    Given the app is freshly installed
    When user starts the Ledger pairing flow
    Then the OS Bluetooth permission prompt appears
    And granting it allows device scanning to proceed on both iOS and Android
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OS permission prompts for Ledger Bluetooth on iOS and changes native iOS pod wiring; scope is narrow but device manual testing is important.
> 
> **Overview**
> **Upgrades `react-native-permissions` from ^3.7.2 to ^5.6.0** ahead of the RN 0.85 migration, with lockfile and iOS pod updates (`RNPermissions` 5.6.0).
> 
> For **v4/v5 breaking changes**, iOS Bluetooth permission requests now use `PERMISSIONS.IOS.BLUETOOTH` instead of `BLUETOOTH_PERIPHERAL` in `useBluetoothPermissions` and in Jest mocks. Android permission usage is unchanged.
> 
> On **iOS**, the Podfile drops the `Permission-BluetoothPeripheral` subpod and adopts `setup_permissions(['Bluetooth'])` so the Bluetooth handler is built into `RNPermissions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f27627cd0f3b7cd1c311ca6b5091382c4f6736a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->