### PR TITLE
chore: bump react-native-share to 12.3.1 and regenerate patch

### DIFF
--- a/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch
+++ b/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch
@@ -1,18 +1,18 @@
 diff --git a/android/src/main/java/cl/json/social/ShareIntent.java b/android/src/main/java/cl/json/social/ShareIntent.java
-index c9e6d29d965c02c86279a648d40b4de66864038a..7d31b02dc37593bb5df56ea2b4d469bc34b1cb3c 100644
+index 2481000c8d5bdd0a3c8594429eedaefbc7eadfc2..c652aef2177c01a58d534ddfd8d727f5354858de 100644
 --- a/android/src/main/java/cl/json/social/ShareIntent.java
 +++ b/android/src/main/java/cl/json/social/ShareIntent.java
-@@ -278,14 +278,22 @@ public abstract class ShareIntent {
+@@ -296,14 +296,22 @@ public abstract class ShareIntent {
          if (ShareIntent.hasValidKey("excludedActivityTypes", options)) {
              if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
                  chooser.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, getExcludedComponentArray(options.getArray("excludedActivityTypes")));
--                activity.startActivityForResult(chooser, RNShareModule.SHARE_REQUEST_CODE);
+-                activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
              } else {
--                activity.startActivityForResult(excludeChooserIntent(this.getIntent(),options), RNShareModule.SHARE_REQUEST_CODE);
+-                activity.startActivityForResult(excludeChooserIntent(this.getIntent(),options), RNShareImpl.SHARE_REQUEST_CODE);
 +                chooser = excludeChooserIntent(this.getIntent(), options);
              }
 -        } else {
--            activity.startActivityForResult(chooser, RNShareModule.SHARE_REQUEST_CODE);
+-            activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
          }
  
 +        // Use startActivity instead of startActivityForResult. The latter
@@ -27,5 +27,5 @@ index c9e6d29d965c02c86279a648d40b4de66864038a..7d31b02dc37593bb5df56ea2b4d469bc
 +        // success even when the user cancels). Only the pre-22 path, which has no
 +        // chosen-target callback, needs the immediate best-effort callback.
          if (intentSender == null) {
-             TargetChosenReceiver.sendCallback(true, true, "OK");
-         }
+             WritableMap reply = Arguments.createMap();
+             reply.putBoolean("success", true);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4269,8 +4269,34 @@ PODS:
     - Sentry/HybridSDK (= 8.58.0)
     - SocketRocket
     - Yoga
-  - RNShare (7.3.7):
+  - RNShare (12.3.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNSVG (15.15.5):
     - boost
     - DoubleConversion
@@ -5260,7 +5286,7 @@ SPEC CHECKSUMS:
   RNScreens: 9269ab4971b2bd24917be84295d2c2ae7d06e9be
   RNSensors: 4690be00931bc60be7c7bd457701edefaff965e3
   RNSentry: 2511157b1e29381d4b1aee195e3ede5e685e8862
-  RNShare: d03cdc71e750246a48b81dcd62bd792bf57a758e
+  RNShare: bf3fa119b277d4a1729553e870039427bcb80c93
   RNSVG: 6470d6f2636d71bd4bbc44a4f27fb7444e437b2f
   RNVectorIcons: c13cc1db346e960ecd0aafcdd5d0bb458133b9c1
   RNWorklets: a3184955a41f2be46898a937e2821469c8c8da42

--- a/package.json
+++ b/package.json
@@ -544,7 +544,7 @@
     "react-native-safe-area-context": "~5.8.0",
     "react-native-screens": "~4.25.2",
     "react-native-sensors": "patch:react-native-sensors@npm%3A5.3.0#~/.yarn/patches/react-native-sensors-npm-5.3.0-318d1d324d.patch",
-    "react-native-share": "patch:react-native-share@npm%3A7.3.7#~/.yarn/patches/react-native-share-npm-7.3.7-5b491ea831.patch",
+    "react-native-share": "patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch",
     "react-native-size-matters": "0.4.0",
     "react-native-skeleton-placeholder": "^5.0.0",
     "react-native-step-indicator": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36259,7 +36259,7 @@ __metadata:
     react-native-safe-area-context: "npm:~5.8.0"
     react-native-screens: "npm:~4.25.2"
     react-native-sensors: "patch:react-native-sensors@npm%3A5.3.0#~/.yarn/patches/react-native-sensors-npm-5.3.0-318d1d324d.patch"
-    react-native-share: "patch:react-native-share@npm%3A7.3.7#~/.yarn/patches/react-native-share-npm-7.3.7-5b491ea831.patch"
+    react-native-share: "patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch"
     react-native-size-matters: "npm:0.4.0"
     react-native-skeleton-placeholder: "npm:^5.0.0"
     react-native-step-indicator: "npm:^1.0.3"
@@ -40982,17 +40982,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-share@npm:7.3.7":
-  version: 7.3.7
-  resolution: "react-native-share@npm:7.3.7"
-  checksum: 10/e7cc767504e9b4c8b7eb7f8b8d8ce3236d4e726651e8613eaab2f569fb925201914a70eedc820f902f3e58bd34ae970c084da6af4dbb23f68015e2fe748c3c6f
+"react-native-share@npm:12.3.1":
+  version: 12.3.1
+  resolution: "react-native-share@npm:12.3.1"
+  checksum: 10/9ddd8048cc31b664df95215bcc4d29e406b63eee9137f41dbe4da3d2e078fffd6d8733bfc9492a7abc1fea51aab5a5058540249f4431a52f24c43fbcd34aa9b6
   languageName: node
   linkType: hard
 
-"react-native-share@patch:react-native-share@npm%3A7.3.7#~/.yarn/patches/react-native-share-npm-7.3.7-5b491ea831.patch":
-  version: 7.3.7
-  resolution: "react-native-share@patch:react-native-share@npm%3A7.3.7#~/.yarn/patches/react-native-share-npm-7.3.7-5b491ea831.patch::version=7.3.7&hash=39fbda"
-  checksum: 10/63e64747b31a93ac4f05238338acab9c63a5512d7b7927ec24f99b0e6c1ffcdf86906265c83f47146f720b04c5ba8eae083dafef7577ff81549242f5ad89e0a7
+"react-native-share@patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch":
+  version: 12.3.1
+  resolution: "react-native-share@patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch::version=12.3.1&hash=3edc5e"
+  checksum: 10/04f94ecad21889a297edde2f7aba1e8498156f197aeb2b171160791669038c07e932f34fe1a1b6b20abf05ea391519c142cad5b029caba8e91b27e67253027e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (Wave 4 — verified required). 7.3.7 calls `BackHandler.removeEventListener`, which is removed from React Native (fixed upstream in react-native-share 12.0.5), so the old version cannot survive the 0.85 bump. Landing 12.3.1 now on 0.83 isolates any regression and gives it soak time on main.

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `react-native-share` from `7.3.7` (patched) to `12.3.1` and regenerates our Yarn patch against the new version.

- **Patch regenerated, not dropped**: 12.3.1 still launches the Android share chooser via `startActivityForResult`, which notifies every registered `ActivityEventListener` with a null intent when the chooser is dismissed (crashing modules that dereference `data` without a null check) and emits a premature success callback. The MetaMask patch (switch to `startActivity` + only fire the immediate callback on the pre-IntentSender path) ports cleanly onto 12.3.1 — `ShareIntent.java` structure is unchanged apart from the `RNShareModule` → `RNShareImpl` rename. Old 7.3.7 patch file deleted.
- **No app-code changes needed**: audited all 18 importing files. Every option key we pass (`url`, `urls`, `filename`, `filenames`, `message`, `title`, `subject`, `type`, `failOnCancel`, `saveToFiles`, `useInternalStorage`) still exists in the 12.x `ShareOptions` schema, we don't use `shareSingle`/`Share.Social`/`isPackageInstalled`, and result consumers (`result.success`, `dismissedAction`) match the 12.x `ShareOpenResult` shape.

Verified locally: `yarn lint:tsc` green; all 8 consumer test suites pass (138 tests: logs, handleWebShare, handleWebDownload, SimpleWebview, ExperimentalSettings, AccountActions, ReferralDetails, PerpsHeroCardView); `pod install` resolves RNShare 12.3.1; patched `startActivity(chooser)` confirmed present in installed module.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: System share sheet

  Scenario: user shares an address
    Given the user is on the account actions sheet
    When user taps Share address
    Then the OS share sheet opens and sharing to a target succeeds

  Scenario: user dismisses the Android share chooser
    Given the share chooser is open on Android
    When user dismisses it without choosing a target
    Then the app does not crash and no false success is reported

  Scenario: user downloads a file from the in-app browser
    Given a file download is triggered in the browser
    When the share/save sheet appears
    Then saving to Files works (iOS) and the file is shared via content:// URI (Android)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major native dependency jump affects every system share flow on Android and iOS; the patched Android activity/callback behavior needs manual verification on dismiss and share success.
> 
> **Overview**
> Upgrades **`react-native-share`** from **7.3.7** to **12.3.1** in `package.json` / `yarn.lock` and refreshes **`ios/Podfile.lock`** so iOS resolves **RNShare 12.3.1** (with the broader Fabric/New Architecture pod graph that version expects).
> 
> The existing Yarn patch is **repointed to 12.3.1** and still changes Android **`ShareIntent.java`**: the share chooser is launched with **`startActivity`** instead of **`startActivityForResult`**, and the immediate JS success callback is only sent on the pre–IntentSender path so dismissals do not crash other `ActivityEventListener`s or report false success. No application TypeScript/JavaScript changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a43bc996879f0e2cc52165fc9393eef73d54e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->