### PR TITLE
chore: bump react-native-view-shot to 5.1.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3215,7 +3215,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-view-shot (4.0.3):
+  - react-native-view-shot (5.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -5200,7 +5200,7 @@ SPEC CHECKSUMS:
   react-native-slider: 4faf1b2266c73f1afb7b30cc6ebb3df238a37c0b
   react-native-tcp-socket: 120072c8020262032773f80f0daaf3964aaa08a1
   react-native-video: ce907959c67ad2abaa0411082db621036944737a
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
+  react-native-view-shot: 39463aa6cfaeab0a3533cc63f869d52d025ef2ff
   react-native-wallet: e082f2023e0fc86b51ac6c0a7596dcdf17ee30b0
   react-native-webview-mm: 7aecbcdea6e0a0172f11dcbfd97e6921781b32a8
   React-NativeModulesApple: 70b1879ac2b642ef784fb6d43360c40803b0a142

--- a/package.json
+++ b/package.json
@@ -554,7 +554,7 @@
     "react-native-url-polyfill": "^1.3.0",
     "react-native-vector-icons": "10.2.0",
     "react-native-video": "^6.19.0",
-    "react-native-view-shot": "4.0.3",
+    "react-native-view-shot": "5.1.1",
     "react-native-vision-camera": "^4.7.3",
     "react-native-worklets": "patch:react-native-worklets@npm%3A0.7.4#~/.yarn/patches/react-native-worklets-npm-0.7.4-072a5d46f9.patch",
     "react-redux": "^8.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36273,7 +36273,7 @@ __metadata:
     react-native-url-polyfill: "npm:^1.3.0"
     react-native-vector-icons: "npm:10.2.0"
     react-native-video: "npm:^6.19.0"
-    react-native-view-shot: "npm:4.0.3"
+    react-native-view-shot: "npm:5.1.1"
     react-native-vision-camera: "npm:^4.7.3"
     react-native-worklets: "patch:react-native-worklets@npm%3A0.7.4#~/.yarn/patches/react-native-worklets-npm-0.7.4-072a5d46f9.patch"
     react-redux: "npm:^8.1.3"
@@ -41186,15 +41186,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-view-shot@npm:4.0.3":
-  version: 4.0.3
-  resolution: "react-native-view-shot@npm:4.0.3"
+"react-native-view-shot@npm:5.1.1":
+  version: 5.1.1
+  resolution: "react-native-view-shot@npm:5.1.1"
   dependencies:
     html2canvas: "npm:^1.4.1"
   peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10/5e4f133a69754cd5fd29bf762bfa5bf399f4c0b192972808cf4194e4775ac5d4415e01079e52be7d31bc5b25fe7efbd5e95f4a33967bab0f36725d4cc8903345
+    react: ">=18.0.0"
+    react-native: ">=0.76.0"
+  checksum: 10/3900501edc2600f27e5e2acc514ce8303556b48906c1fd6ffddfc8c58a4d21ee68f82890b74cddb08bdc8d4a47dc3c775907e3f215d4dcd00ed8d14022705311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pre-upgrade dependency bump for the RN 0.85 migration (Wave 4 — verified required). 4.0.3 is Paper-only and fails with "Failed to snapshot view tag" under Fabric/New Architecture, so it cannot survive the RN 0.85 upgrade. 5.1.1 adds Fabric support. Landing it now on 0.83 isolates any regression and gives it soak time on main.

## **Description**

<!-- mms-check: type=text required=true -->

Bumps `react-native-view-shot` from `4.0.3` to `5.1.1` as part of the incremental pre-upgrade dependency work for React Native 0.85.

Version-only change — our entire usage surface is:

- `captureScreen({ format, quality })` — browser tab thumbnails (`app/components/Views/Browser/index.js`)
- `captureRef(ref, { format, quality })` — Perps hero card sharing (`PerpsHeroCardView.tsx`)

Both signatures are unchanged in 5.x (verified against the shipped typings). No patch file involved, single lockfile resolution.

Verified locally: `yarn lint:tsc` green; consumer test suites pass (59 tests: PerpsHeroCardView + Browser functions/lifecycle); `pod install` resolves react-native-view-shot 5.1.1.

Note for reviewers: the upgrade spike flagged a residual bridgeless-iOS caveat to spot-check on 5.1.1 — covered by the manual steps below.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: View snapshots

  Scenario: browser tab thumbnails
    Given the user has multiple browser tabs open
    When user opens the tab switcher
    Then each tab shows a rendered thumbnail (not blank)

  Scenario: Perps hero card share
    Given the user has a Perps position
    When user opens the hero card view and taps share
    Then a PNG of the card is captured and the share sheet opens with it
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — dependency version bump, no visual changes expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native snapshotting used for browser thumbnails and Perps share; a major-version native module change can regress capture on iOS/Android despite unchanged JS APIs.
> 
> **Overview**
> Bumps **`react-native-view-shot`** from **4.0.3** to **5.1.1** in `package.json`, with matching **`yarn.lock`** and **`ios/Podfile.lock`** updates. No application code changes.
> 
> The upgrade is prep for RN 0.85: 4.x is Paper-only and breaks under Fabric/New Architecture; 5.1.1 adds Fabric support. Peer deps in the lockfile now require `react >=18` and `react-native >=0.76`. Existing call sites (`captureScreen` for browser tab thumbnails, `captureRef` for Perps hero share) are unchanged in 5.x.
> 
> Reviewers should manually verify snapshots on iOS (including any bridgeless caveat noted in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b92c383960820948522a182ab577b6695f7903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->