### PR TITLE
test: MMQA-2070 PoC Predict BTC Up/Down dwell + BrowserStack profiling artifacts

### DIFF
--- a/tests/framework/PlatformLocator.ts
+++ b/tests/framework/PlatformLocator.ts
@@ -12,11 +12,20 @@ export class PlatformDetector {
    * For Detox, reads from the Detox device object.
    */
   static getPlatform(): 'android' | 'ios' {
-    if (FrameworkDetector.isDetox()) {
+    if (FrameworkDetector.isAppium()) {
+      return getCachedPlatform();
+    }
+
+    if (
+      FrameworkDetector.isDetox() &&
+      typeof device !== 'undefined' &&
+      device !== null
+    ) {
       return device.getPlatform() as 'android' | 'ios';
     }
 
-    // For Appium/WebdriverIO, read from cache (no HTTP call)
+    // Playwright/Appium path (including when FrameworkDetector still defaults
+    // to Detox before the driver fixture pins Appium).
     return getCachedPlatform();
   }
 

--- a/tests/page-objects/Predict/PredictCryptoUpDownDetailsPage.ts
+++ b/tests/page-objects/Predict/PredictCryptoUpDownDetailsPage.ts
@@ -1,0 +1,39 @@
+import {
+  Assertions,
+  Matchers,
+  PlaywrightMatchers,
+  encapsulated,
+  type EncapsulatedElementType,
+} from '../../framework';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants';
+import { PredictCryptoUpDownDetailsSelectorsIDs } from '../../../app/components/UI/Predict/Predict.testIds';
+
+class PredictCryptoUpDownDetailsPage {
+  get container(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(PredictCryptoUpDownDetailsSelectorsIDs.SCREEN),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          PredictCryptoUpDownDetailsSelectorsIDs.SCREEN,
+          { exact: true },
+        ),
+    });
+  }
+
+  async waitForScreenToDisplay(
+    options: { timeout?: number; description?: string } = {},
+  ): Promise<void> {
+    const {
+      timeout = resolveE2EWaitTimeoutMs(30_000),
+      description = 'Predict crypto up/down details screen',
+    } = options;
+
+    await Assertions.expectElementToBeVisible(this.container, {
+      timeout,
+      description,
+    });
+  }
+}
+
+export default new PredictCryptoUpDownDetailsPage();

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -21,9 +21,12 @@ import {
   PredictBalanceSelectorsText,
   PredictFeedSelectorsIDs,
   PredictMarketListSelectorsIDs,
+  PredictSearchSelectorsIDs,
   getPredictFeedSelector,
   getPredictMarketListSelector,
+  getPredictSearchSelector,
 } from '../../../app/components/UI/Predict/Predict.testIds';
+import { TEXTFIELDSEARCH_TEST_ID } from '../../../app/component-library/components/Form/TextFieldSearch/TextFieldSearch.constants';
 
 type CategoryTab = 'trending' | 'new' | 'sports' | 'crypto' | 'politics';
 type CategoryTabScrollDirection = 'left' | 'right';
@@ -101,6 +104,44 @@ class PredictMarketList {
     return encapsulated({
       detox: () => Matchers.getElementByText('Add funds'),
       appium: () => PlaywrightMatchers.getElementByText('Add funds'),
+    });
+  }
+
+  get searchButton(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(PredictSearchSelectorsIDs.SEARCH_BUTTON),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          PredictSearchSelectorsIDs.SEARCH_BUTTON,
+          { exact: true },
+        ),
+    });
+  }
+
+  get searchInput(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByID(TEXTFIELDSEARCH_TEST_ID),
+      appium: () =>
+        PlaywrightMatchers.getElementById(TEXTFIELDSEARCH_TEST_ID, {
+          exact: true,
+        }),
+    });
+  }
+
+  getSearchResultCard(cardIndex: number): EncapsulatedElementType {
+    const resultCardId = getPredictSearchSelector.resultCard(cardIndex);
+    return encapsulated({
+      detox: () => Matchers.getElementByID(resultCardId),
+      appium: () =>
+        PlaywrightMatchers.getElementById(resultCardId, { exact: true }),
+    });
+  }
+
+  getMarketByTitle(title: string | RegExp): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByText(title),
+      appium: () => PlaywrightMatchers.getElementByText(title),
     });
   }
 
@@ -414,6 +455,50 @@ class PredictMarketList {
     await UnifiedGestures.waitAndTap(this.addFundsButton, {
       description: 'Predict add funds button',
     });
+  }
+
+  async tapSearchButton(): Promise<void> {
+    await UnifiedGestures.waitAndTap(this.searchButton, {
+      description: 'Predict search button',
+    });
+  }
+
+  async typeSearchQuery(query: string): Promise<void> {
+    await UnifiedGestures.typeText(this.searchInput, query, {
+      description: 'Predict search input',
+      hideKeyboard: true,
+    });
+  }
+
+  async tapSearchResultCard(cardIndex: number = 0): Promise<void> {
+    const card = this.getSearchResultCard(cardIndex);
+    await UnifiedGestures.waitAndTap(card, {
+      description: `Predict search result card ${cardIndex}`,
+      timeout: 60_000,
+    });
+  }
+
+  async tapMarketByTitle(title: string | RegExp): Promise<void> {
+    const market = this.getMarketByTitle(title);
+    const titleDescription =
+      title instanceof RegExp ? title.source : String(title);
+
+    await Utilities.executeWithRetry(
+      async () => {
+        await Assertions.expectElementToBeVisible(market, {
+          timeout: 15_000,
+          description: `Predict market titled ${titleDescription}`,
+        });
+        await UnifiedGestures.waitAndTap(market, {
+          description: `Predict market titled ${titleDescription}`,
+          timeout: 15_000,
+        });
+      },
+      {
+        timeout: 60_000,
+        description: `Tap predict market titled ${titleDescription}`,
+      },
+    );
   }
 
   async tapBackButton(): Promise<void> {

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -370,36 +370,6 @@ class PredictMarketList {
     );
   }
 
-  getMarketByTitle(title: string | RegExp): EncapsulatedElementType {
-    return encapsulated({
-      detox: () => Matchers.getElementByText(title),
-      appium: () => PlaywrightMatchers.getElementByText(title),
-    });
-  }
-
-  async tapMarketByTitle(title: string | RegExp): Promise<void> {
-    const market = this.getMarketByTitle(title);
-    const titleDescription =
-      title instanceof RegExp ? title.source : String(title);
-
-    await Utilities.executeWithRetry(
-      async () => {
-        await Assertions.expectElementToBeVisible(market, {
-          timeout: 15_000,
-          description: `Predict market titled ${titleDescription}`,
-        });
-        await UnifiedGestures.waitAndTap(market, {
-          description: `Predict market titled ${titleDescription}`,
-          timeout: 15_000,
-        });
-      },
-      {
-        timeout: 60_000,
-        description: `Tap predict market titled ${titleDescription}`,
-      },
-    );
-  }
-
   async tapCategoryTab(
     category: CategoryTab,
     options: { direction?: CategoryTabScrollDirection } = {},

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -370,6 +370,36 @@ class PredictMarketList {
     );
   }
 
+  getMarketByTitle(title: string | RegExp): EncapsulatedElementType {
+    return encapsulated({
+      detox: () => Matchers.getElementByText(title),
+      appium: () => PlaywrightMatchers.getElementByText(title),
+    });
+  }
+
+  async tapMarketByTitle(title: string | RegExp): Promise<void> {
+    const market = this.getMarketByTitle(title);
+    const titleDescription =
+      title instanceof RegExp ? title.source : String(title);
+
+    await Utilities.executeWithRetry(
+      async () => {
+        await Assertions.expectElementToBeVisible(market, {
+          timeout: 15_000,
+          description: `Predict market titled ${titleDescription}`,
+        });
+        await UnifiedGestures.waitAndTap(market, {
+          description: `Predict market titled ${titleDescription}`,
+          timeout: 15_000,
+        });
+      },
+      {
+        timeout: 60_000,
+        description: `Tap predict market titled ${titleDescription}`,
+      },
+    );
+  }
+
   async tapCategoryTab(
     category: CategoryTab,
     options: { direction?: CategoryTabScrollDirection } = {},

--- a/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
+++ b/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
@@ -1,21 +1,13 @@
 import { test as perfTest } from '../../../framework/fixtures/playwright';
 import TimerHelper from '../../../framework/TimerHelper';
 import { loginToAppPlaywright } from '../../../flows/wallet.flow';
-import {
-  asPlaywrightElement,
-  PlaywrightAssertions,
-  sleep,
-} from '../../../framework';
+import { asPlaywrightElement, PlaywrightAssertions } from '../../../framework';
 import TabBarComponent from '../../../page-objects/wallet/TabBarComponent';
 import ToastModal from '../../../page-objects/wallet/ToastModal';
 import WalletActionsBottomSheet from '../../../page-objects/wallet/WalletActionsBottomSheet';
 import PredictMarketList from '../../../page-objects/Predict/PredictMarketList';
 import PredictCryptoUpDownDetailsPage from '../../../page-objects/Predict/PredictCryptoUpDownDetailsPage';
 import { Performance, PerformancePredict } from '../../../tags.performance.js';
-
-const BTC_UP_OR_DOWN_TITLE = /BTC Up or Down/;
-const DWELL_DURATION_MS = 5 * 60 * 1000;
-const DWELL_KEEPALIVE_INTERVAL_MS = 30_000;
 
 /*
  * Scenario: Predict BTC Up or Down dwell (BrowserStack app profiling PoC)
@@ -25,77 +17,74 @@ const DWELL_KEEPALIVE_INTERVAL_MS = 30_000;
  * BrowserStack app profiling can capture a sustained session.
  */
 perfTest.describe(`${Performance} ${PerformancePredict}`, () => {
-  perfTest.setTimeout(15 * 60 * 1000);
-
   perfTest(
     'Predict BTC Up or Down - 5 minute dwell for profiling',
     { tag: '@team-predict' },
-    async ({ currentDeviceDetails, driver, performanceTracker }) => {
+    async ({ currentDeviceDetails, driver, performanceTracker }, testInfo) => {
+      // Login to the app
       await loginToAppPlaywright();
+      perfTest.setTimeout(15 * 60 * 1000);
 
-      const navigateToPredictTimer = new TimerHelper(
-        'Time since user taps Predict until Predict Market List is displayed',
+      // Timer 1: Navigate to Predict tab
+      const timer1 = new TimerHelper(
+        'Time since user taps Predict button until Predict Market List is displayed',
         { ios: 8000, android: 5000 },
         currentDeviceDetails.platform,
       );
-
       await ToastModal.waitForToastToDismiss();
+
       await TabBarComponent.tapActions();
+
       await WalletActionsBottomSheet.tapPredictButton();
-      await navigateToPredictTimer.measure(async () => {
+      await timer1.measure(async () => {
         await PlaywrightAssertions.expectElementToBeVisible(
           asPlaywrightElement(PredictMarketList.container),
+          { timeout: 60000 },
         );
       });
 
       await PredictMarketList.tapCategoryTab('crypto');
 
-      const openMarketTimer = new TimerHelper(
-        'Time since user taps BTC Up or Down until crypto up/down details are visible',
+      // Timer 2: Open BTC Up or Down market details
+      const timer2 = new TimerHelper(
+        'Time since user taps BTC Up or Down market until details are visible',
         { ios: 5000, android: 8000 },
         currentDeviceDetails.platform,
       );
 
-      await PredictMarketList.tapMarketByTitle(BTC_UP_OR_DOWN_TITLE);
-      await openMarketTimer.measure(async () => {
+      await PredictMarketList.tapMarketCard('crypto', 1);
+      await timer2.measure(async () => {
         await PlaywrightAssertions.expectElementToBeVisible(
           asPlaywrightElement(PredictCryptoUpDownDetailsPage.container),
         );
       });
 
-      const dwellTimer = new TimerHelper(
-        'Dwell on BTC Up or Down market details for BrowserStack app profiling',
-      );
-      dwellTimer.start();
-
-      const dwellDeadline = Date.now() + DWELL_DURATION_MS;
+      // Stay on the market details screen for 5 minutes (profiling window)
+      const dwellMs = 5 * 60 * 1000;
+      const pollMs = 30 * 1000;
+      const dwellDeadline = Date.now() + dwellMs;
       while (Date.now() < dwellDeadline) {
-        await PlaywrightAssertions.expectElementToBeVisible(
-          asPlaywrightElement(PredictCryptoUpDownDetailsPage.container),
-          { timeout: 10_000 },
-        );
-
+        await driver.getWindowSize();
         const remainingMs = dwellDeadline - Date.now();
         if (remainingMs <= 0) {
           break;
         }
-        await sleep(Math.min(DWELL_KEEPALIVE_INTERVAL_MS, remainingMs));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(pollMs, remainingMs)),
+        );
       }
 
-      dwellTimer.stop();
+      // Add all timers to performance tracker
+      performanceTracker.addTimers(timer1, timer2);
 
-      performanceTracker.addTimers(
-        navigateToPredictTimer,
-        openMarketTimer,
-        dwellTimer,
-      );
+      // Attach performance metrics to test report
 
       console.log('Predict BTC Up or Down dwell profiling PoC completed');
+      console.log(`Navigate to Predict: ${timer1.getDuration()}ms`);
+      console.log(`Open Market Details: ${timer2.getDuration()}ms`);
       console.log(
-        `Navigate to Predict: ${navigateToPredictTimer.getDuration()}ms`,
+        `Total Time: ${(timer1.getDuration() ?? 0) + (timer2.getDuration() ?? 0)}ms`,
       );
-      console.log(`Open BTC Up or Down: ${openMarketTimer.getDuration()}ms`);
-      console.log(`Dwell duration: ${dwellTimer.getDuration()}ms`);
     },
   );
 });

--- a/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
+++ b/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
@@ -1,0 +1,101 @@
+import { test as perfTest } from '../../../framework/fixtures/playwright';
+import TimerHelper from '../../../framework/TimerHelper';
+import { loginToAppPlaywright } from '../../../flows/wallet.flow';
+import {
+  asPlaywrightElement,
+  PlaywrightAssertions,
+  sleep,
+} from '../../../framework';
+import TabBarComponent from '../../../page-objects/wallet/TabBarComponent';
+import ToastModal from '../../../page-objects/wallet/ToastModal';
+import WalletActionsBottomSheet from '../../../page-objects/wallet/WalletActionsBottomSheet';
+import PredictMarketList from '../../../page-objects/Predict/PredictMarketList';
+import PredictCryptoUpDownDetailsPage from '../../../page-objects/Predict/PredictCryptoUpDownDetailsPage';
+import { Performance, PerformancePredict } from '../../../tags.performance.js';
+
+const BTC_UP_OR_DOWN_TITLE = /BTC Up or Down/;
+const DWELL_DURATION_MS = 5 * 60 * 1000;
+const DWELL_KEEPALIVE_INTERVAL_MS = 30_000;
+
+/*
+ * Scenario: Predict BTC Up or Down dwell (BrowserStack app profiling PoC)
+ *
+ * Login with the SRP-preloaded build, open Predict, filter Crypto, open a
+ * BTC Up or Down market, and remain on that screen for 5 minutes so
+ * BrowserStack app profiling can capture a sustained session.
+ */
+perfTest.describe(`${Performance} ${PerformancePredict}`, () => {
+  perfTest.setTimeout(15 * 60 * 1000);
+
+  perfTest(
+    'Predict BTC Up or Down - 5 minute dwell for profiling',
+    { tag: '@team-predict' },
+    async ({ currentDeviceDetails, performanceTracker }) => {
+      await loginToAppPlaywright();
+
+      const navigateToPredictTimer = new TimerHelper(
+        'Time since user taps Predict until Predict Market List is displayed',
+        { ios: 8000, android: 5000 },
+        currentDeviceDetails.platform,
+      );
+
+      await ToastModal.waitForToastToDismiss();
+      await TabBarComponent.tapActions();
+      await WalletActionsBottomSheet.tapPredictButton();
+      await navigateToPredictTimer.measure(async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(PredictMarketList.container),
+        );
+      });
+
+      await PredictMarketList.tapCategoryTab('crypto');
+
+      const openMarketTimer = new TimerHelper(
+        'Time since user taps BTC Up or Down until crypto up/down details are visible',
+        { ios: 5000, android: 8000 },
+        currentDeviceDetails.platform,
+      );
+
+      await PredictMarketList.tapMarketByTitle(BTC_UP_OR_DOWN_TITLE);
+      await openMarketTimer.measure(async () => {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(PredictCryptoUpDownDetailsPage.container),
+        );
+      });
+
+      const dwellTimer = new TimerHelper(
+        'Dwell on BTC Up or Down market details for BrowserStack app profiling',
+      );
+      dwellTimer.start();
+
+      const dwellDeadline = Date.now() + DWELL_DURATION_MS;
+      while (Date.now() < dwellDeadline) {
+        await PlaywrightAssertions.expectElementToBeVisible(
+          asPlaywrightElement(PredictCryptoUpDownDetailsPage.container),
+          { timeout: 10_000 },
+        );
+
+        const remainingMs = dwellDeadline - Date.now();
+        if (remainingMs <= 0) {
+          break;
+        }
+        await sleep(Math.min(DWELL_KEEPALIVE_INTERVAL_MS, remainingMs));
+      }
+
+      dwellTimer.stop();
+
+      performanceTracker.addTimers(
+        navigateToPredictTimer,
+        openMarketTimer,
+        dwellTimer,
+      );
+
+      console.log('Predict BTC Up or Down dwell profiling PoC completed');
+      console.log(
+        `Navigate to Predict: ${navigateToPredictTimer.getDuration()}ms`,
+      );
+      console.log(`Open BTC Up or Down: ${openMarketTimer.getDuration()}ms`);
+      console.log(`Dwell duration: ${dwellTimer.getDuration()}ms`);
+    },
+  );
+});

--- a/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
+++ b/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
@@ -9,12 +9,15 @@ import PredictMarketList from '../../../page-objects/Predict/PredictMarketList';
 import PredictCryptoUpDownDetailsPage from '../../../page-objects/Predict/PredictCryptoUpDownDetailsPage';
 import { Performance, PerformancePredict } from '../../../tags.performance.js';
 
+const BTC_UP_OR_DOWN_SEARCH_QUERY = 'Bitcoin Up or Down';
+const BTC_UP_OR_DOWN_TITLE = /Bitcoin Up or Down/;
+
 /*
  * Scenario: Predict BTC Up or Down dwell (BrowserStack app profiling PoC)
  *
- * Login with the SRP-preloaded build, open Predict, filter Crypto, open a
- * BTC Up or Down market, and remain on that screen for 5 minutes so
- * BrowserStack app profiling can capture a sustained session.
+ * Login with the SRP-preloaded build, open Predict, search for a Bitcoin Up or
+ * Down market, open it, and remain on that screen for 5 minutes so BrowserStack
+ * app profiling can capture a sustained session.
  */
 perfTest.describe(`${Performance} ${PerformancePredict}`, () => {
   perfTest(
@@ -43,16 +46,16 @@ perfTest.describe(`${Performance} ${PerformancePredict}`, () => {
         );
       });
 
-      await PredictMarketList.tapCategoryTab('crypto');
-
-      // Timer 2: Open BTC Up or Down market details
+      // Timer 2: Search and open Bitcoin Up or Down market details
       const timer2 = new TimerHelper(
-        'Time since user taps BTC Up or Down market until details are visible',
+        'Time since user searches Bitcoin Up or Down until details are visible',
         { ios: 5000, android: 8000 },
         currentDeviceDetails.platform,
       );
 
-      await PredictMarketList.tapMarketCard('crypto', 1);
+      await PredictMarketList.tapSearchButton();
+      await PredictMarketList.typeSearchQuery(BTC_UP_OR_DOWN_SEARCH_QUERY);
+      await PredictMarketList.tapMarketByTitle(BTC_UP_OR_DOWN_TITLE);
       await timer2.measure(async () => {
         await PlaywrightAssertions.expectElementToBeVisible(
           asPlaywrightElement(PredictCryptoUpDownDetailsPage.container),

--- a/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
+++ b/tests/performance/login/predict/predict-btc-up-down-dwell.spec.ts
@@ -30,7 +30,7 @@ perfTest.describe(`${Performance} ${PerformancePredict}`, () => {
   perfTest(
     'Predict BTC Up or Down - 5 minute dwell for profiling',
     { tag: '@team-predict' },
-    async ({ currentDeviceDetails, performanceTracker }) => {
+    async ({ currentDeviceDetails, driver, performanceTracker }) => {
       await loginToAppPlaywright();
 
       const navigateToPredictTimer = new TimerHelper(

--- a/tests/reporters/generators/JsonReportGenerator.test.ts
+++ b/tests/reporters/generators/JsonReportGenerator.test.ts
@@ -158,6 +158,54 @@ describe('JsonReportGenerator', () => {
     );
   });
 
+  it('writes a standalone BrowserStack app profiling JSON artifact', () => {
+    const profilingData = {
+      data: {
+        'io.metamask': {
+          status: 'success',
+          metrics: { cpu: { avg: 12, max: 40 } },
+        },
+      },
+    };
+    const data = makeReportData({
+      metrics: [
+        makeMetricsEntry({
+          testName: 'Predict BTC Up or Down dwell',
+          sessionId: 'abc123def456789',
+          profilingData,
+        }),
+      ],
+    });
+
+    const files = generator.generate(data, '/reports');
+
+    expect(files.some((f) => f.includes('browserstack-app-profiling-'))).toBe(
+      true,
+    );
+
+    const profilingCall = mockWriteFileSync.mock.calls.find((c: unknown[]) =>
+      (c[0] as string).includes('browserstack-app-profiling-'),
+    );
+    expect(profilingCall).toBeDefined();
+    expect(JSON.parse(profilingCall[1] as string)).toEqual(profilingData);
+  });
+
+  it('does not write profiling artifacts when profilingData has an error', () => {
+    const data = makeReportData({
+      metrics: [
+        makeMetricsEntry({
+          profilingData: { error: 'No profiling data returned' },
+        }),
+      ],
+    });
+
+    const files = generator.generate(data, '/reports');
+
+    expect(files.every((f) => !f.includes('browserstack-app-profiling-'))).toBe(
+      true,
+    );
+  });
+
   it('returns array of written file paths', () => {
     const files = generator.generate(makeReportData(), '/reports');
     expect(Array.isArray(files)).toBe(true);

--- a/tests/reporters/generators/JsonReportGenerator.ts
+++ b/tests/reporters/generators/JsonReportGenerator.ts
@@ -24,6 +24,13 @@ export class JsonReportGenerator {
     );
     writtenFiles.push(...deviceFiles);
 
+    // Persist raw BrowserStack app profiling JSON as standalone artifacts
+    const profilingFiles = this.generateProfilingArtifacts(
+      reportData.metrics,
+      reportsDir,
+    );
+    writtenFiles.push(...profilingFiles);
+
     // Generate failed-tests-by-team report
     const failedTestsFile = this.generateFailedTestsByTeamReport(
       reportData.failedTestsByTeam,
@@ -76,6 +83,47 @@ export class JsonReportGenerator {
       logger.info(`Device-specific report saved: ${jsonPath}`);
       writtenFiles.push(jsonPath);
     });
+
+    return writtenFiles;
+  }
+
+  /**
+   * Write the raw BrowserStack app profiling JSON returned by
+   * `/appprofiling/v2` as standalone report artifacts (one file per test
+   * that has profiling data). These are uploaded with
+   * `tests/reporters/reports` in the performance pipeline.
+   */
+  private generateProfilingArtifacts(
+    metrics: MetricsEntry[],
+    reportsDir: string,
+  ): string[] {
+    const writtenFiles: string[] = [];
+
+    for (const metric of metrics) {
+      const profilingData = metric.profilingData;
+      if (!profilingData || profilingData.error) {
+        continue;
+      }
+
+      const safeTestName = (metric.testName ?? 'Unknown')
+        .replace(/[^a-zA-Z0-9]/g, '_')
+        .substring(0, 40);
+      const safeDeviceName = (metric.device?.name ?? 'Unknown').replace(
+        /[^a-zA-Z0-9]/g,
+        '_',
+      );
+      const sessionSuffix = metric.sessionId
+        ? `-${metric.sessionId.substring(0, 12)}`
+        : '';
+      const jsonPath = path.join(
+        reportsDir,
+        `browserstack-app-profiling-${safeTestName}-${safeDeviceName}-${metric.device?.osVersion ?? 'unknown'}${sessionSuffix}.json`,
+      );
+
+      fs.writeFileSync(jsonPath, JSON.stringify(profilingData, null, 2));
+      logger.info(`BrowserStack app profiling artifact saved: ${jsonPath}`);
+      writtenFiles.push(jsonPath);
+    }
 
     return writtenFiles;
   }


### PR DESCRIPTION
## Summary
- Adds a simple performance PoC scenario (`predict-btc-up-down-dwell.spec.ts`) that logs in with the SRP-preloaded build, opens Predict → Crypto, taps a **BTC Up or Down** market, and stays on that screen for **5 minutes** (with keepalive checks so BrowserStack idle timeout does not kill the session).
- Extends Predict page objects with `tapMarketByTitle` and a minimal crypto up/down details page object.
- Persists the raw BrowserStack `/appprofiling/v2` JSON as standalone files (`browserstack-app-profiling-*.json`) under `tests/reporters/reports`, which the performance pipeline already uploads as artifacts.

## Test plan
- [ ] Run the new scenario on BrowserStack Android (imported-wallet / login build):
  `yarn run-playwright:android-bs --grep "Predict BTC Up or Down - 5 minute dwell for profiling"`
- [ ] Confirm the test reaches BTC Up or Down details and remains there for ~5 minutes
- [ ] Confirm artifacts include `browserstack-app-profiling-*.json` under the uploaded `tests/reporters/reports` artifact
- [ ] Confirm existing performance report generation still works (HTML/CSV/metrics JSON)


Made with [Cursor](https://cursor.com)