### PR TITLE
feat(ukyc): combine sessionId and idosSessionid

### DIFF
--- a/app/components/Views/SumSubDemo/useSumSubDemo.ts
+++ b/app/components/Views/SumSubDemo/useSumSubDemo.ts
@@ -18,9 +18,8 @@ async function getBearerToken(): Promise<string> {
 }
 
 interface CreateSessionResponse {
-  sessionId: string;
   wrappedUserKey: string;
-  idosSessionId: string;
+  sessionId: string;
 }
 
 async function createSession(
@@ -60,9 +59,8 @@ interface SubmitWrappedKeyResponse {
 }
 
 async function fetchAccessToken(
-  sessionId: string,
   wrappedUserKey: string,
-  idosSessionId: string,
+  sessionId: string,
   jwtToken: string,
 ): Promise<SubmitWrappedKeyResponse> {
   const bearerToken = await getBearerToken();
@@ -74,7 +72,7 @@ async function fetchAccessToken(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${bearerToken}`,
       },
-      body: JSON.stringify({ wrappedUserKey, jwtToken, idosSessionId }),
+      body: JSON.stringify({ wrappedUserKey, jwtToken }),
     },
   );
 
@@ -116,14 +114,16 @@ const useSumSubDemo = () => {
         if (!moonPayUserId) {
           throw new Error('Auth customer ID not provided');
         }
-        const { sessionId, idosSessionId, wrappedUserKey } =
-          await createSession(mockJwtToken, moonPayAccessToken, moonPayUserId);
+        const { sessionId, wrappedUserKey } = await createSession(
+          mockJwtToken,
+          moonPayAccessToken,
+          moonPayUserId,
+        );
 
         setStatus('Fetching access token...');
         const { applicantAccessToken } = await fetchAccessToken(
-          sessionId,
           wrappedUserKey,
-          idosSessionId,
+          sessionId,
           mockJwtToken,
         );
 
@@ -132,12 +132,7 @@ const useSumSubDemo = () => {
           applicantAccessToken,
           async () => {
             const { applicantAccessToken: refreshedAccessToken } =
-              await fetchAccessToken(
-                sessionId,
-                wrappedUserKey,
-                idosSessionId,
-                mockJwtToken,
-              );
+              await fetchAccessToken(wrappedUserKey, sessionId, mockJwtToken);
             return refreshedAccessToken;
           },
         )


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the SumSub demo hook and UKYC API payload shapes; no auth or core wallet logic changes.
> 
> **Overview**
> Aligns the **SumSub demo** UKYC client with a backend that no longer exposes a separate **idos** session identifier.
> 
> `CreateSessionResponse` now only includes `wrappedUserKey` and `sessionId` (no `idosSessionId`). The `POST /sessions/{sessionId}/wrapped-key` body sends `{ wrappedUserKey, jwtToken }` only. Session creation and SumSub token refresh both use the unified `sessionId` end to end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5beef5be81649af365daaceb20655993b5f293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->