### PR TITLE
feat(activity): add first-class RampsOrder support in Activity

### DIFF
--- a/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
@@ -198,6 +198,18 @@ describe('RampDetails', () => {
     expect(getByText('€58.88')).toBeOnTheScreen();
   });
 
+  it('shows Not available for missing FiatOrder transaction hash', () => {
+    const item = makeItem({
+      ...baseOrder,
+      txHash: undefined,
+      sellTxHash: undefined,
+    });
+
+    const { getAllByText } = render(<RampDetails item={item} />);
+
+    expect(getAllByText('Not available').length).toBeGreaterThan(0);
+  });
+
   it('opens the block explorer when the footer button is pressed', () => {
     const { getByText } = render(<RampDetails item={makeItem(baseOrder)} />);
 
@@ -263,5 +275,44 @@ describe('RampDetails', () => {
     await waitFor(() => {
       expect(ClipboardManager.setString).toHaveBeenCalledWith('po-1');
     });
+  });
+
+  it('renders native RampsOrder sell amounts and destination', () => {
+    const { mapRampsOrder } = jest.requireActual(
+      '../../../../util/activity-adapters',
+    );
+    const { RampsOrderStatus } = jest.requireActual(
+      '@metamask/ramps-controller',
+    );
+    const order = {
+      isOnlyLink: false,
+      success: true,
+      cryptoAmount: '0.085',
+      fiatAmount: 61.88,
+      providerOrderId: 'sell-po-1',
+      createdAt: Date.UTC(2025, 11, 10, 10, 34),
+      totalFeesFiat: 3,
+      walletAddress: '0x232123456789abcdef123456789abcdef12321',
+      status: RampsOrderStatus.Completed,
+      network: { name: 'Ethereum', chainId: 'eip155:1' },
+      canBeUpdated: false,
+      idHasExpired: false,
+      excludeFromPurchases: false,
+      timeDescriptionPending: '',
+      orderType: 'SELL',
+      id: '/providers/transak/orders/sell-po-1',
+      cryptoCurrency: { symbol: 'ETH', decimals: 18 },
+      fiatCurrency: { symbol: 'EUR', decimals: 2 },
+      provider: { name: 'Transak' },
+    };
+    const item = mapRampsOrder({ order }) as RampActivityListItem;
+
+    const { getByText } = render(<RampDetails item={item} />);
+
+    expect(getByText('-0.085 ETH')).toBeOnTheScreen();
+    expect(getByText('Destination')).toBeOnTheScreen();
+    expect(getByText('Transak')).toBeOnTheScreen();
+    expect(getByText('EUR value')).toBeOnTheScreen();
+    expect(getByText('Total received')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
@@ -160,4 +160,44 @@ describe('RampDetails', () => {
       params: { url: 'https://etherscan.io/tx/0xhash', title: 'etherscan.io' },
     });
   });
+
+  it('renders native RampsOrder details via RampRampsOrderDetails', () => {
+    const { mapRampsOrder } = jest.requireActual(
+      '../../../../util/activity-adapters',
+    );
+    const { RampsOrderStatus } = jest.requireActual(
+      '@metamask/ramps-controller',
+    );
+    const order = {
+      isOnlyLink: false,
+      success: true,
+      cryptoAmount: '5.01',
+      fiatAmount: 6.27,
+      providerOrderId: 'po-1',
+      providerOrderLink: 'https://example.com',
+      createdAt: Date.UTC(2025, 11, 10, 10, 34),
+      totalFeesFiat: 1.26,
+      txHash: '0x232123456789abcdef123456789abcdef12321',
+      walletAddress: '0x232123456789abcdef123456789abcdef12321',
+      status: RampsOrderStatus.Completed,
+      network: { name: 'Ethereum', chainId: 'eip155:1' },
+      canBeUpdated: false,
+      idHasExpired: false,
+      excludeFromPurchases: false,
+      timeDescriptionPending: '',
+      orderType: 'BUY',
+      id: '/providers/transak/orders/po-1',
+      cryptoCurrency: { symbol: 'mUSD', decimals: 6 },
+      fiatCurrency: { symbol: 'USD', decimals: 2 },
+      provider: { name: 'Transak' },
+    };
+    const item = mapRampsOrder({ order }) as RampActivityListItem;
+
+    const { getByText } = render(<RampDetails item={item} />);
+
+    expect(getByText('+5.01 mUSD')).toBeOnTheScreen();
+    expect(getByText('/providers/transak/orders/po-1')).toBeOnTheScreen();
+    expect(getByText('$1.26')).toBeOnTheScreen();
+    expect(getByText('$6.27')).toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { OrderOrderTypeEnum } from '@consensys/on-ramp-sdk/dist/API';
@@ -14,6 +14,7 @@ import {
   findBlockExplorerUrlForChain,
   getBlockExplorerTxUrl,
 } from '../../../../util/networks';
+import ClipboardManager from '../../../../core/ClipboardManager';
 import { mapRampOrder } from '../../../../util/activity-adapters';
 import { useAccountNames } from '../../../hooks/DisplayName/useAccountNames';
 import { RampDetails, type RampActivityListItem } from './RampDetails';
@@ -45,6 +46,10 @@ jest.mock('../../../../util/networks', () => ({
   ...jest.requireActual('../../../../util/networks'),
   findBlockExplorerUrlForChain: jest.fn(),
   getBlockExplorerTxUrl: jest.fn(),
+}));
+
+jest.mock('../../../../core/ClipboardManager', () => ({
+  setString: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@metamask/design-system-react-native', () => {
@@ -116,12 +121,34 @@ describe('RampDetails', () => {
 
     expect(getByText('+5.01 mUSD')).toBeOnTheScreen();
     expect(getByText('Confirmed')).toBeOnTheScreen();
-    expect(getByText('0d13232233944')).toBeOnTheScreen();
+    expect(getByText('...233944')).toBeOnTheScreen();
     expect(getByText('Transaction fee')).toBeOnTheScreen();
     expect(getByText('Total amount')).toBeOnTheScreen();
     expect(getByText('$1.26')).toBeOnTheScreen();
     expect(getByText('$6.27')).toBeOnTheScreen();
     expect(queryByText('Destination')).toBeNull();
+    expect(queryByText('View on Mercuryo')).toBeNull();
+  });
+
+  it('shows provider link and copies the full FiatOrder id', async () => {
+    const item = makeItem({
+      ...baseOrder,
+      data: { providerOrderLink: 'https://mercuryo.io/order/abc' },
+    });
+
+    const { getByText, getByTestId } = render(<RampDetails item={item} />);
+
+    expect(getByText('View on Mercuryo')).toBeOnTheScreen();
+    fireEvent.press(getByTestId('ramp-provider-order-link'));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: { url: 'https://mercuryo.io/order/abc' },
+    });
+
+    fireEvent.press(getByTestId('ramp-order-id-copy'));
+    await waitFor(() => {
+      expect(ClipboardManager.setString).toHaveBeenCalledWith('0d13232233944');
+    });
   });
 
   it('renders sell-specific destination and received total rows', () => {
@@ -161,7 +188,7 @@ describe('RampDetails', () => {
     });
   });
 
-  it('renders native RampsOrder details via RampRampsOrderDetails', () => {
+  it('renders native RampsOrder details via RampRampsOrderDetails', async () => {
     const { mapRampsOrder } = jest.requireActual(
       '../../../../util/activity-adapters',
     );
@@ -193,11 +220,23 @@ describe('RampDetails', () => {
     };
     const item = mapRampsOrder({ order }) as RampActivityListItem;
 
-    const { getByText } = render(<RampDetails item={item} />);
+    const { getByText, getByTestId } = render(<RampDetails item={item} />);
 
     expect(getByText('+5.01 mUSD')).toBeOnTheScreen();
-    expect(getByText('/providers/transak/orders/po-1')).toBeOnTheScreen();
+    expect(getByText('po-1')).toBeOnTheScreen();
+    expect(getByText('View on Transak')).toBeOnTheScreen();
     expect(getByText('$1.26')).toBeOnTheScreen();
     expect(getByText('$6.27')).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId('ramp-provider-order-link'));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: { url: 'https://example.com' },
+    });
+
+    fireEvent.press(getByTestId('ramp-order-id-copy'));
+    await waitFor(() => {
+      expect(ClipboardManager.setString).toHaveBeenCalledWith('po-1');
+    });
   });
 });

--- a/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
@@ -136,7 +136,7 @@ describe('RampDetails', () => {
       data: {
         providerOrderLink: 'https://mercuryo.io/order/abc',
         statusDescription: 'Card purchases typically take a few minutes',
-      },
+      } as FiatOrder['data'],
     });
 
     const { getByText, getByTestId } = render(<RampDetails item={item} />);
@@ -161,7 +161,9 @@ describe('RampDetails', () => {
     (getProviderName as jest.Mock).mockReturnValue('');
     const item = makeItem({
       ...baseOrder,
-      data: { providerOrderLink: 'https://example.com/order/1' },
+      data: {
+        providerOrderLink: 'https://example.com/order/1',
+      } as FiatOrder['data'],
     });
 
     const { getByText, queryByText } = render(<RampDetails item={item} />);

--- a/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.test.tsx
@@ -133,12 +133,18 @@ describe('RampDetails', () => {
   it('shows provider link and copies the full FiatOrder id', async () => {
     const item = makeItem({
       ...baseOrder,
-      data: { providerOrderLink: 'https://mercuryo.io/order/abc' },
+      data: {
+        providerOrderLink: 'https://mercuryo.io/order/abc',
+        statusDescription: 'Card purchases typically take a few minutes',
+      },
     });
 
     const { getByText, getByTestId } = render(<RampDetails item={item} />);
 
     expect(getByText('View on Mercuryo')).toBeOnTheScreen();
+    expect(
+      getByText('Card purchases typically take a few minutes'),
+    ).toBeOnTheScreen();
     fireEvent.press(getByTestId('ramp-provider-order-link'));
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
@@ -149,6 +155,19 @@ describe('RampDetails', () => {
     await waitFor(() => {
       expect(ClipboardManager.setString).toHaveBeenCalledWith('0d13232233944');
     });
+  });
+
+  it('falls back to View Order when provider name is missing', () => {
+    (getProviderName as jest.Mock).mockReturnValue('');
+    const item = makeItem({
+      ...baseOrder,
+      data: { providerOrderLink: 'https://example.com/order/1' },
+    });
+
+    const { getByText, queryByText } = render(<RampDetails item={item} />);
+
+    expect(getByText('View Order')).toBeOnTheScreen();
+    expect(queryByText('View on Mercuryo')).toBeNull();
   });
 
   it('renders sell-specific destination and received total rows', () => {
@@ -217,6 +236,7 @@ describe('RampDetails', () => {
       cryptoCurrency: { symbol: 'mUSD', decimals: 6 },
       fiatCurrency: { symbol: 'USD', decimals: 2 },
       provider: { name: 'Transak' },
+      statusDescription: 'Payment failed. Please place another order.',
     };
     const item = mapRampsOrder({ order }) as RampActivityListItem;
 
@@ -225,6 +245,9 @@ describe('RampDetails', () => {
     expect(getByText('+5.01 mUSD')).toBeOnTheScreen();
     expect(getByText('po-1')).toBeOnTheScreen();
     expect(getByText('View on Transak')).toBeOnTheScreen();
+    expect(
+      getByText('Payment failed. Please place another order.'),
+    ).toBeOnTheScreen();
     expect(getByText('$1.26')).toBeOnTheScreen();
     expect(getByText('$6.27')).toBeOnTheScreen();
 

--- a/app/components/Views/ActivityDetails/templates/RampDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetails.tsx
@@ -1,202 +1,24 @@
-import React, { useMemo } from 'react';
-import { Pressable } from 'react-native';
-import {
-  AvatarTokenSize,
-  Box,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
-  Text,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import { strings } from '../../../../../locales/i18n';
-import ClipboardManager from '../../../../core/ClipboardManager';
-import { getProviderName } from '../../../../reducers/fiatOrders';
+import React from 'react';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
-import { renderShortAddress } from '../../../../util/address';
-import type { ActivityListItem } from '../../../../util/activity-adapters';
-import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
-import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
-import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
-import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
-import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
+import type { RampsOrder } from '@metamask/ramps-controller';
 import {
-  ActivityDetailRow,
-  ActivityDetailSection,
-} from '../components/ActivityDetailsLayout';
-import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
+  isRampFiatOrder,
+  isRampRampsOrder,
+  type ActivityListItem,
+} from '../../../../util/activity-adapters';
 import {
-  formatRampActivityDate,
-  formatRampActivityFiatAmount,
-  formatRampActivityFiatTotal,
-  getRampActivityExplorerChainId,
-  getRampActivityHeroAmount,
-  getRampActivityHeroToken,
-  getRampActivityTransactionHash,
-  isRampSellOrder,
-  mapRampActivityStatus,
-  valueOrUnavailable,
-} from './rampDetailsUtils';
+  RampFiatOrderDetails,
+  type RampFiatActivityListItem,
+} from './RampFiatOrderDetails';
+import {
+  RampRampsOrderDetails,
+  type RampRampsActivityListItem,
+} from './RampRampsOrderDetails';
 
 export type RampActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
-  raw: { type: 'rampOrder'; data: FiatOrder };
+  raw: { type: 'rampOrder'; data: FiatOrder | RampsOrder };
 };
-
-function RampDetailsHero({ order }: Readonly<{ order: FiatOrder }>) {
-  const token = getRampActivityHeroToken(order);
-
-  return (
-    <Box
-      twClassName="flex-row items-center gap-3"
-      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
-    >
-      <ActivityDetailsAvatar
-        tokens={[token]}
-        chainId={getRampActivityExplorerChainId(order.network)}
-        size={AvatarTokenSize.Xl}
-        showNetworkBadge
-      />
-      <Text
-        variant={TextVariant.DisplayMd}
-        twClassName="shrink"
-        color={
-          isRampSellOrder(order)
-            ? TextColor.TextDefault
-            : TextColor.SuccessDefault
-        }
-      >
-        {getRampActivityHeroAmount(order)}
-      </Text>
-    </Box>
-  );
-}
-
-function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
-  if (!hash) {
-    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
-  }
-
-  return (
-    <Box twClassName="flex-row items-center gap-1">
-      <Text>{renderShortAddress(hash, 4)}</Text>
-      <Pressable
-        onPress={() => ClipboardManager.setString(hash)}
-        testID="ramp-transaction-id-copy"
-      >
-        <Icon
-          name={IconName.Copy}
-          size={IconSize.Sm}
-          color={IconColor.IconAlternative}
-        />
-      </Pressable>
-    </Box>
-  );
-}
-
-function RampDetailsMetadata({
-  chainId,
-  formattedDate,
-  order,
-  providerName,
-  transactionHash,
-}: {
-  readonly chainId: string;
-  readonly formattedDate: string;
-  readonly order: FiatOrder;
-  readonly providerName: string;
-  readonly transactionHash?: string;
-}) {
-  const isSell = isRampSellOrder(order);
-
-  return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('activity_details.status')}
-        value={<ActivityDetailsStatus status={mapRampActivityStatus(order)} />}
-        testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
-      />
-
-      <ActivityDetailRow
-        label={strings('activity_details.date')}
-        value={formattedDate}
-        testID={ActivityDetailsSelectorsIDs.DATE_ROW}
-      />
-
-      <ActivityDetailRow
-        label={strings('transaction_details.label.order_id')}
-        value={order.id}
-      />
-
-      <ActivityDetailRow
-        label={strings('activity_details.account')}
-        value={
-          <ActivityDetailsAccountValue
-            address={order.account}
-            chainId={chainId}
-          />
-        }
-        testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
-      />
-
-      {isSell ? (
-        <ActivityDetailRow label="Destination" value={providerName} />
-      ) : null}
-
-      <ActivityDetailRow
-        label={strings('activity_details.transaction_id')}
-        value={<RampTransactionIdValue hash={transactionHash} />}
-        testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
-      />
-    </ActivityDetailSection>
-  );
-}
-
-function RampDetailsAmounts({
-  fiatValue,
-  order,
-  totalReceived,
-  transactionFee,
-}: {
-  readonly fiatValue?: string;
-  readonly order: FiatOrder;
-  readonly totalReceived?: string;
-  readonly transactionFee?: string;
-}) {
-  if (isRampSellOrder(order)) {
-    return (
-      <ActivityDetailSection>
-        <ActivityDetailRow
-          label={`${order.currency} value`}
-          value={valueOrUnavailable(fiatValue)}
-        />
-        <ActivityDetailRow
-          label="Fees"
-          value={valueOrUnavailable(transactionFee)}
-        />
-        <ActivityDetailRow
-          label="Total received"
-          value={valueOrUnavailable(totalReceived)}
-        />
-      </ActivityDetailSection>
-    );
-  }
-
-  return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('transaction_details.label.transaction_fee')}
-        value={valueOrUnavailable(transactionFee)}
-      />
-      <ActivityDetailRow
-        label={strings('transaction_details.label.total_amount')}
-        value={valueOrUnavailable(fiatValue)}
-      />
-    </ActivityDetailSection>
-  );
-}
 
 export function isRampActivityListItem(
   item: ActivityListItem,
@@ -204,55 +26,22 @@ export function isRampActivityListItem(
   return item.raw?.type === 'rampOrder';
 }
 
+/**
+ * Dispatches to FiatOrder or RampsOrder details. Branch only on data shape —
+ * not provider / navigation target.
+ */
 export function RampDetails({
   item,
 }: Readonly<{ item: RampActivityListItem }>) {
-  const order = item.raw.data;
-  const transactionHash = getRampActivityTransactionHash(order);
-  const chainId = getRampActivityExplorerChainId(order.network);
-  const providerName = getProviderName(order.provider, order.data);
+  const { data } = item.raw;
 
-  const formattedDate = useMemo(
-    () => formatRampActivityDate(order.createdAt),
-    [order.createdAt],
-  );
+  if (isRampRampsOrder(data)) {
+    return <RampRampsOrderDetails item={item as RampRampsActivityListItem} />;
+  }
 
-  const transactionFee =
-    formatRampActivityFiatAmount(order.fee, order.currency) ??
-    formatRampActivityFiatAmount(order.cryptoFee, order.currency);
-  const fiatValue = formatRampActivityFiatAmount(order.amount, order.currency);
-  const totalReceived = formatRampActivityFiatTotal(
-    order.amount,
-    order.fee,
-    order.currency,
-  );
+  if (isRampFiatOrder(data)) {
+    return <RampFiatOrderDetails item={item as RampFiatActivityListItem} />;
+  }
 
-  return (
-    <ActivityDetailsTemplateFrame
-      hero={<RampDetailsHero order={order} />}
-      metadata={
-        <RampDetailsMetadata
-          chainId={chainId}
-          formattedDate={formattedDate}
-          order={order}
-          providerName={providerName}
-          transactionHash={transactionHash}
-        />
-      }
-      details={
-        <RampDetailsAmounts
-          fiatValue={fiatValue}
-          order={order}
-          totalReceived={totalReceived}
-          transactionFee={transactionFee}
-        />
-      }
-      footer={
-        <ActivityDetailsBlockExplorerButton
-          chainId={chainId}
-          hash={transactionHash}
-        />
-      }
-    />
-  );
+  return null;
 }

--- a/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
@@ -61,7 +61,7 @@ export function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
 }
 
 /**
- * Status label with optional "View on {provider}" link beneath it (OrderContent).
+ * Status label with optional "View on {provider}" link (OrderContent).
  */
 export function RampStatusWithProviderLink({
   status,
@@ -84,7 +84,12 @@ export function RampStatusWithProviderLink({
     });
   }, [navigation, providerOrderLink]);
 
-  const showProviderLink = Boolean(providerOrderLink && providerName);
+  const showProviderLink = Boolean(providerOrderLink);
+  const providerLinkLabel = providerName
+    ? strings('ramps_order_details.view_on_provider', {
+        provider: providerName,
+      })
+    : strings('ramps_order_details.view_order');
 
   return (
     <Box twClassName="items-end gap-1">
@@ -101,9 +106,7 @@ export function RampStatusWithProviderLink({
               fontWeight={FontWeight.Medium}
               color={TextColor.PrimaryDefault}
             >
-              {strings('ramps_order_details.view_on_provider', {
-                provider: providerName,
-              })}
+              {providerLinkLabel}
             </Text>
             <Icon
               name={IconName.Export}
@@ -113,6 +116,31 @@ export function RampStatusWithProviderLink({
           </Box>
         </Pressable>
       ) : null}
+    </Box>
+  );
+}
+
+/**
+ * Full-width centered status description (Aggregator Stage / OrderContent copy).
+ * Placed below the metadata section (after Transaction ID) with equal spacing
+ * to the following SectionDivider (`marginVertical={3}` → 12px).
+ */
+export function RampStatusDescription({
+  description,
+}: Readonly<{ description?: string }>) {
+  if (!description) {
+    return null;
+  }
+
+  return (
+    <Box twClassName="w-full mt-3" testID="ramp-status-description">
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        twClassName="text-center"
+      >
+        {description}
+      </Text>
     </Box>
   );
 }

--- a/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import {
+  AvatarTokenSize,
   Box,
   FontWeight,
   Icon,
@@ -16,12 +17,19 @@ import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { ButtonIconSizes } from '../../../../component-library/components/Buttons/ButtonIcon';
 import { IconColor as LegacyIconColor } from '../../../../component-library/components/Icons/Icon';
-import type { Status } from '../../../../util/activity-adapters';
+import type { Status, TokenAmount } from '../../../../util/activity-adapters';
+import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
 import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
 import { ActivityDetailsTransactionId } from '../components/ActivityDetailsTransactionId';
+import {
+  ActivityDetailRow,
+  ActivityDetailSection,
+} from '../components/ActivityDetailsLayout';
+import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
 // eslint-disable-next-line import-x/no-restricted-paths -- reuse shared copy button (clipboard + CopySuccess feedback)
 import CopyButton from '../../confirmations/components/UI/copy-button/copy-button';
-import { formatShortRampOrderId } from './rampDetailsUtils';
+import { formatShortRampOrderId, valueOrUnavailable } from './rampDetailsUtils';
 
 /**
  * Truncated order id in a muted pill with copy feedback (Copy → CopySuccess),
@@ -142,5 +150,163 @@ export function RampStatusDescription({
         {description}
       </Text>
     </Box>
+  );
+}
+
+/** Shared hero for FiatOrder / RampsOrder Activity details. */
+export function RampDetailsHeroView({
+  token,
+  chainId,
+  amountLabel,
+  isSell,
+}: Readonly<{
+  token: TokenAmount;
+  chainId: string;
+  amountLabel: string;
+  isSell: boolean;
+}>) {
+  return (
+    <Box
+      twClassName="flex-row items-center gap-3"
+      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
+    >
+      <ActivityDetailsAvatar
+        tokens={[token]}
+        chainId={chainId}
+        size={AvatarTokenSize.Xl}
+        showNetworkBadge
+      />
+      <Text
+        variant={TextVariant.DisplayMd}
+        twClassName="shrink"
+        color={isSell ? TextColor.TextDefault : TextColor.SuccessDefault}
+      >
+        {amountLabel}
+      </Text>
+    </Box>
+  );
+}
+
+/** Shared metadata rows + optional status description. */
+export function RampDetailsMetadataSection({
+  status,
+  providerName,
+  providerOrderLink,
+  statusDescription,
+  formattedDate,
+  orderId,
+  accountAddress,
+  chainId,
+  isSell,
+  transactionHash,
+}: Readonly<{
+  status: Status;
+  providerName: string;
+  providerOrderLink?: string;
+  statusDescription?: string;
+  formattedDate: string;
+  orderId?: string;
+  accountAddress?: string;
+  chainId: string;
+  isSell: boolean;
+  transactionHash?: string;
+}>) {
+  return (
+    <>
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={strings('activity_details.status')}
+          value={
+            <RampStatusWithProviderLink
+              status={status}
+              providerName={providerName}
+              providerOrderLink={providerOrderLink}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
+        />
+
+        <ActivityDetailRow
+          label={strings('activity_details.date')}
+          value={formattedDate}
+          testID={ActivityDetailsSelectorsIDs.DATE_ROW}
+        />
+
+        <ActivityDetailRow
+          label={strings('transaction_details.label.order_id')}
+          value={<RampOrderIdValue orderId={orderId} />}
+        />
+
+        <ActivityDetailRow
+          label={strings('activity_details.account')}
+          value={
+            <ActivityDetailsAccountValue
+              address={accountAddress}
+              chainId={chainId}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
+        />
+
+        {isSell ? (
+          <ActivityDetailRow label="Destination" value={providerName} />
+        ) : null}
+
+        <ActivityDetailRow
+          label={strings('activity_details.transaction_id')}
+          value={<RampTransactionIdValue hash={transactionHash} />}
+          testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
+        />
+      </ActivityDetailSection>
+
+      <RampStatusDescription description={statusDescription} />
+    </>
+  );
+}
+
+/** Shared buy/sell fiat amount rows. */
+export function RampDetailsAmountsSection({
+  currency,
+  isSell,
+  fiatValue,
+  transactionFee,
+  totalReceived,
+}: Readonly<{
+  currency: string;
+  isSell: boolean;
+  fiatValue?: string;
+  transactionFee?: string;
+  totalReceived?: string;
+}>) {
+  if (isSell) {
+    return (
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={`${currency} value`}
+          value={valueOrUnavailable(fiatValue)}
+        />
+        <ActivityDetailRow
+          label="Fees"
+          value={valueOrUnavailable(transactionFee)}
+        />
+        <ActivityDetailRow
+          label="Total received"
+          value={valueOrUnavailable(totalReceived)}
+        />
+      </ActivityDetailSection>
+    );
+  }
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('transaction_details.label.transaction_fee')}
+        value={valueOrUnavailable(transactionFee)}
+      />
+      <ActivityDetailRow
+        label={strings('transaction_details.label.total_amount')}
+        value={valueOrUnavailable(fiatValue)}
+      />
+    </ActivityDetailSection>
   );
 }

--- a/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback } from 'react';
+import { Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Box,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import Routes from '../../../../constants/navigation/Routes';
+import { ButtonIconSizes } from '../../../../component-library/components/Buttons/ButtonIcon';
+import { IconColor as LegacyIconColor } from '../../../../component-library/components/Icons/Icon';
+import type { Status } from '../../../../util/activity-adapters';
+import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
+import { ActivityDetailsTransactionId } from '../components/ActivityDetailsTransactionId';
+// eslint-disable-next-line import-x/no-restricted-paths -- reuse shared copy button (clipboard + CopySuccess feedback)
+import CopyButton from '../../confirmations/components/UI/copy-button/copy-button';
+import { formatShortRampOrderId } from './rampDetailsUtils';
+
+/**
+ * Truncated order id in a muted pill with copy feedback (Copy → CopySuccess),
+ * matching ActivityDetailsTransactionId.
+ */
+export function RampOrderIdValue({
+  orderId,
+}: Readonly<{ orderId: string | undefined }>) {
+  if (!orderId) {
+    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
+  }
+
+  return (
+    <Box twClassName="flex-row items-center gap-1 rounded-lg bg-muted py-1 pl-3 pr-1">
+      <Text variant={TextVariant.BodyMd}>
+        {formatShortRampOrderId(orderId)}
+      </Text>
+      <CopyButton
+        copyText={orderId}
+        size={ButtonIconSizes.Sm}
+        iconColor={LegacyIconColor.Alternative}
+        testID="ramp-order-id-copy"
+      />
+    </Box>
+  );
+}
+
+/**
+ * Transaction hash copy pill, or "Not available" when missing.
+ */
+export function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
+  if (!hash) {
+    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
+  }
+
+  return <ActivityDetailsTransactionId hash={hash} />;
+}
+
+/**
+ * Status label with optional "View on {provider}" link beneath it (OrderContent).
+ */
+export function RampStatusWithProviderLink({
+  status,
+  providerName,
+  providerOrderLink,
+}: Readonly<{
+  status: Status;
+  providerName?: string;
+  providerOrderLink?: string;
+}>) {
+  const navigation = useNavigation();
+
+  const handleProviderLinkPress = useCallback(() => {
+    if (!providerOrderLink) {
+      return;
+    }
+    navigation.navigate(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: { url: providerOrderLink },
+    });
+  }, [navigation, providerOrderLink]);
+
+  const showProviderLink = Boolean(providerOrderLink && providerName);
+
+  return (
+    <Box twClassName="items-end gap-1">
+      <ActivityDetailsStatus status={status} />
+      {showProviderLink ? (
+        <Pressable
+          onPress={handleProviderLinkPress}
+          testID="ramp-provider-order-link"
+          accessibilityRole="link"
+        >
+          <Box twClassName="flex-row items-center gap-1">
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.PrimaryDefault}
+            >
+              {strings('ramps_order_details.view_on_provider', {
+                provider: providerName,
+              })}
+            </Text>
+            <Icon
+              name={IconName.Export}
+              size={IconSize.Sm}
+              color={IconColor.PrimaryDefault}
+            />
+          </Box>
+        </Pressable>
+      ) : null}
+    </Box>
+  );
+}

--- a/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampDetailsShared.tsx
@@ -206,7 +206,7 @@ export function RampDetailsMetadataSection({
   statusDescription?: string;
   formattedDate: string;
   orderId?: string;
-  accountAddress?: string;
+  accountAddress: string;
   chainId: string;
   isSell: boolean;
   transactionHash?: string;

--- a/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
@@ -1,26 +1,18 @@
 import React, { useMemo } from 'react';
-import { Pressable } from 'react-native';
 import {
   AvatarTokenSize,
   Box,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import ClipboardManager from '../../../../core/ClipboardManager';
 import { getProviderName } from '../../../../reducers/fiatOrders';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
-import { renderShortAddress } from '../../../../util/address';
 import type { ActivityListItem } from '../../../../util/activity-adapters';
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
 import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
 import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
-import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
 import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
 import {
   ActivityDetailRow,
@@ -28,9 +20,15 @@ import {
 } from '../components/ActivityDetailsLayout';
 import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
 import {
+  RampOrderIdValue,
+  RampStatusWithProviderLink,
+  RampTransactionIdValue,
+} from './RampDetailsShared';
+import {
   formatRampActivityDate,
   formatRampActivityFiatAmount,
   formatRampActivityFiatTotal,
+  getFiatOrderProviderOrderLink,
   getRampActivityExplorerChainId,
   getRampActivityHeroAmount,
   getRampActivityHeroToken,
@@ -44,28 +42,6 @@ export type RampFiatActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
   raw: { type: 'rampOrder'; data: FiatOrder };
 };
-
-function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
-  if (!hash) {
-    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
-  }
-
-  return (
-    <Box twClassName="flex-row items-center gap-1">
-      <Text>{renderShortAddress(hash, 4)}</Text>
-      <Pressable
-        onPress={() => ClipboardManager.setString(hash)}
-        testID="ramp-transaction-id-copy"
-      >
-        <Icon
-          name={IconName.Copy}
-          size={IconSize.Sm}
-          color={IconColor.IconAlternative}
-        />
-      </Pressable>
-    </Box>
-  );
-}
 
 function RampDetailsHero({ order }: Readonly<{ order: FiatOrder }>) {
   const token = getRampActivityHeroToken(order);
@@ -110,12 +86,19 @@ function RampDetailsMetadata({
   readonly transactionHash?: string;
 }) {
   const isSell = isRampSellOrder(order);
+  const providerOrderLink = getFiatOrderProviderOrderLink(order);
 
   return (
     <ActivityDetailSection>
       <ActivityDetailRow
         label={strings('activity_details.status')}
-        value={<ActivityDetailsStatus status={mapRampActivityStatus(order)} />}
+        value={
+          <RampStatusWithProviderLink
+            status={mapRampActivityStatus(order)}
+            providerName={providerName}
+            providerOrderLink={providerOrderLink}
+          />
+        }
         testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
       />
 
@@ -127,7 +110,7 @@ function RampDetailsMetadata({
 
       <ActivityDetailRow
         label={strings('transaction_details.label.order_id')}
-        value={order.id}
+        value={<RampOrderIdValue orderId={order.id} />}
       />
 
       <ActivityDetailRow

--- a/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
@@ -1,0 +1,253 @@
+import React, { useMemo } from 'react';
+import { Pressable } from 'react-native';
+import {
+  AvatarTokenSize,
+  Box,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import ClipboardManager from '../../../../core/ClipboardManager';
+import { getProviderName } from '../../../../reducers/fiatOrders';
+import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import { renderShortAddress } from '../../../../util/address';
+import type { ActivityListItem } from '../../../../util/activity-adapters';
+import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
+import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
+import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
+import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
+import {
+  ActivityDetailRow,
+  ActivityDetailSection,
+} from '../components/ActivityDetailsLayout';
+import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
+import {
+  formatRampActivityDate,
+  formatRampActivityFiatAmount,
+  formatRampActivityFiatTotal,
+  getRampActivityExplorerChainId,
+  getRampActivityHeroAmount,
+  getRampActivityHeroToken,
+  getRampActivityTransactionHash,
+  isRampSellOrder,
+  mapRampActivityStatus,
+  valueOrUnavailable,
+} from './rampDetailsUtils';
+
+export type RampFiatActivityListItem = ActivityListItem & {
+  type: 'buy' | 'sell';
+  raw: { type: 'rampOrder'; data: FiatOrder };
+};
+
+function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
+  if (!hash) {
+    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
+  }
+
+  return (
+    <Box twClassName="flex-row items-center gap-1">
+      <Text>{renderShortAddress(hash, 4)}</Text>
+      <Pressable
+        onPress={() => ClipboardManager.setString(hash)}
+        testID="ramp-transaction-id-copy"
+      >
+        <Icon
+          name={IconName.Copy}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+        />
+      </Pressable>
+    </Box>
+  );
+}
+
+function RampDetailsHero({ order }: Readonly<{ order: FiatOrder }>) {
+  const token = getRampActivityHeroToken(order);
+
+  return (
+    <Box
+      twClassName="flex-row items-center gap-3"
+      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
+    >
+      <ActivityDetailsAvatar
+        tokens={[token]}
+        chainId={getRampActivityExplorerChainId(order.network)}
+        size={AvatarTokenSize.Xl}
+        showNetworkBadge
+      />
+      <Text
+        variant={TextVariant.DisplayMd}
+        twClassName="shrink"
+        color={
+          isRampSellOrder(order)
+            ? TextColor.TextDefault
+            : TextColor.SuccessDefault
+        }
+      >
+        {getRampActivityHeroAmount(order)}
+      </Text>
+    </Box>
+  );
+}
+
+function RampDetailsMetadata({
+  chainId,
+  formattedDate,
+  order,
+  providerName,
+  transactionHash,
+}: {
+  readonly chainId: string;
+  readonly formattedDate: string;
+  readonly order: FiatOrder;
+  readonly providerName: string;
+  readonly transactionHash?: string;
+}) {
+  const isSell = isRampSellOrder(order);
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('activity_details.status')}
+        value={<ActivityDetailsStatus status={mapRampActivityStatus(order)} />}
+        testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
+      />
+
+      <ActivityDetailRow
+        label={strings('activity_details.date')}
+        value={formattedDate}
+        testID={ActivityDetailsSelectorsIDs.DATE_ROW}
+      />
+
+      <ActivityDetailRow
+        label={strings('transaction_details.label.order_id')}
+        value={order.id}
+      />
+
+      <ActivityDetailRow
+        label={strings('activity_details.account')}
+        value={
+          <ActivityDetailsAccountValue
+            address={order.account}
+            chainId={chainId}
+          />
+        }
+        testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
+      />
+
+      {isSell ? (
+        <ActivityDetailRow label="Destination" value={providerName} />
+      ) : null}
+
+      <ActivityDetailRow
+        label={strings('activity_details.transaction_id')}
+        value={<RampTransactionIdValue hash={transactionHash} />}
+        testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
+      />
+    </ActivityDetailSection>
+  );
+}
+
+function RampDetailsAmounts({
+  fiatValue,
+  order,
+  totalReceived,
+  transactionFee,
+}: {
+  readonly fiatValue?: string;
+  readonly order: FiatOrder;
+  readonly totalReceived?: string;
+  readonly transactionFee?: string;
+}) {
+  if (isRampSellOrder(order)) {
+    return (
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={`${order.currency} value`}
+          value={valueOrUnavailable(fiatValue)}
+        />
+        <ActivityDetailRow
+          label="Fees"
+          value={valueOrUnavailable(transactionFee)}
+        />
+        <ActivityDetailRow
+          label="Total received"
+          value={valueOrUnavailable(totalReceived)}
+        />
+      </ActivityDetailSection>
+    );
+  }
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('transaction_details.label.transaction_fee')}
+        value={valueOrUnavailable(transactionFee)}
+      />
+      <ActivityDetailRow
+        label={strings('transaction_details.label.total_amount')}
+        value={valueOrUnavailable(fiatValue)}
+      />
+    </ActivityDetailSection>
+  );
+}
+
+/** Legacy FiatOrder ActivityDetails template — extract of prior RampDetails. */
+export function RampFiatOrderDetails({
+  item,
+}: Readonly<{ item: RampFiatActivityListItem }>) {
+  const order = item.raw.data;
+  const transactionHash = getRampActivityTransactionHash(order);
+  const chainId = getRampActivityExplorerChainId(order.network);
+  const providerName = getProviderName(order.provider, order.data);
+
+  const formattedDate = useMemo(
+    () => formatRampActivityDate(order.createdAt),
+    [order.createdAt],
+  );
+
+  const transactionFee =
+    formatRampActivityFiatAmount(order.fee, order.currency) ??
+    formatRampActivityFiatAmount(order.cryptoFee, order.currency);
+  const fiatValue = formatRampActivityFiatAmount(order.amount, order.currency);
+  const totalReceived = formatRampActivityFiatTotal(
+    order.amount,
+    order.fee,
+    order.currency,
+  );
+
+  return (
+    <ActivityDetailsTemplateFrame
+      hero={<RampDetailsHero order={order} />}
+      metadata={
+        <RampDetailsMetadata
+          chainId={chainId}
+          formattedDate={formattedDate}
+          order={order}
+          providerName={providerName}
+          transactionHash={transactionHash}
+        />
+      }
+      details={
+        <RampDetailsAmounts
+          fiatValue={fiatValue}
+          order={order}
+          totalReceived={totalReceived}
+          transactionFee={transactionFee}
+        />
+      }
+      footer={
+        <ActivityDetailsBlockExplorerButton
+          chainId={chainId}
+          hash={transactionHash}
+        />
+      }
+    />
+  );
+}

--- a/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
@@ -1,29 +1,13 @@
 import React, { useMemo } from 'react';
-import {
-  AvatarTokenSize,
-  Box,
-  Text,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import { strings } from '../../../../../locales/i18n';
 import { getProviderName } from '../../../../reducers/fiatOrders';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
 import type { ActivityListItem } from '../../../../util/activity-adapters';
-import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
-import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
 import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
 import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
 import {
-  ActivityDetailRow,
-  ActivityDetailSection,
-} from '../components/ActivityDetailsLayout';
-import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
-import {
-  RampOrderIdValue,
-  RampStatusDescription,
-  RampStatusWithProviderLink,
-  RampTransactionIdValue,
+  RampDetailsAmountsSection,
+  RampDetailsHeroView,
+  RampDetailsMetadataSection,
 } from './RampDetailsShared';
 import {
   formatRampActivityDate,
@@ -37,7 +21,6 @@ import {
   getRampActivityTransactionHash,
   isRampSellOrder,
   mapRampActivityStatus,
-  valueOrUnavailable,
 } from './rampDetailsUtils';
 
 export type RampFiatActivityListItem = ActivityListItem & {
@@ -45,154 +28,12 @@ export type RampFiatActivityListItem = ActivityListItem & {
   raw: { type: 'rampOrder'; data: FiatOrder };
 };
 
-function RampDetailsHero({ order }: Readonly<{ order: FiatOrder }>) {
-  const token = getRampActivityHeroToken(order);
-
-  return (
-    <Box
-      twClassName="flex-row items-center gap-3"
-      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
-    >
-      <ActivityDetailsAvatar
-        tokens={[token]}
-        chainId={getRampActivityExplorerChainId(order.network)}
-        size={AvatarTokenSize.Xl}
-        showNetworkBadge
-      />
-      <Text
-        variant={TextVariant.DisplayMd}
-        twClassName="shrink"
-        color={
-          isRampSellOrder(order)
-            ? TextColor.TextDefault
-            : TextColor.SuccessDefault
-        }
-      >
-        {getRampActivityHeroAmount(order)}
-      </Text>
-    </Box>
-  );
-}
-
-function RampDetailsMetadata({
-  chainId,
-  formattedDate,
-  order,
-  providerName,
-  transactionHash,
-}: {
-  readonly chainId: string;
-  readonly formattedDate: string;
-  readonly order: FiatOrder;
-  readonly providerName: string;
-  readonly transactionHash?: string;
-}) {
-  const isSell = isRampSellOrder(order);
-  const providerOrderLink = getFiatOrderProviderOrderLink(order);
-  const statusDescription = getFiatOrderStatusDescription(order);
-
-  return (
-    <>
-      <ActivityDetailSection>
-        <ActivityDetailRow
-          label={strings('activity_details.status')}
-          value={
-            <RampStatusWithProviderLink
-              status={mapRampActivityStatus(order)}
-              providerName={providerName}
-              providerOrderLink={providerOrderLink}
-            />
-          }
-          testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
-        />
-
-        <ActivityDetailRow
-          label={strings('activity_details.date')}
-          value={formattedDate}
-          testID={ActivityDetailsSelectorsIDs.DATE_ROW}
-        />
-
-        <ActivityDetailRow
-          label={strings('transaction_details.label.order_id')}
-          value={<RampOrderIdValue orderId={order.id} />}
-        />
-
-        <ActivityDetailRow
-          label={strings('activity_details.account')}
-          value={
-            <ActivityDetailsAccountValue
-              address={order.account}
-              chainId={chainId}
-            />
-          }
-          testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
-        />
-
-        {isSell ? (
-          <ActivityDetailRow label="Destination" value={providerName} />
-        ) : null}
-
-        <ActivityDetailRow
-          label={strings('activity_details.transaction_id')}
-          value={<RampTransactionIdValue hash={transactionHash} />}
-          testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
-        />
-      </ActivityDetailSection>
-
-      <RampStatusDescription description={statusDescription} />
-    </>
-  );
-}
-
-function RampDetailsAmounts({
-  fiatValue,
-  order,
-  totalReceived,
-  transactionFee,
-}: {
-  readonly fiatValue?: string;
-  readonly order: FiatOrder;
-  readonly totalReceived?: string;
-  readonly transactionFee?: string;
-}) {
-  if (isRampSellOrder(order)) {
-    return (
-      <ActivityDetailSection>
-        <ActivityDetailRow
-          label={`${order.currency} value`}
-          value={valueOrUnavailable(fiatValue)}
-        />
-        <ActivityDetailRow
-          label="Fees"
-          value={valueOrUnavailable(transactionFee)}
-        />
-        <ActivityDetailRow
-          label="Total received"
-          value={valueOrUnavailable(totalReceived)}
-        />
-      </ActivityDetailSection>
-    );
-  }
-
-  return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('transaction_details.label.transaction_fee')}
-        value={valueOrUnavailable(transactionFee)}
-      />
-      <ActivityDetailRow
-        label={strings('transaction_details.label.total_amount')}
-        value={valueOrUnavailable(fiatValue)}
-      />
-    </ActivityDetailSection>
-  );
-}
-
 /** Legacy FiatOrder ActivityDetails template — extract of prior RampDetails. */
 export function RampFiatOrderDetails({
   item,
 }: Readonly<{ item: RampFiatActivityListItem }>) {
   const order = item.raw.data;
+  const isSell = isRampSellOrder(order);
   const transactionHash = getRampActivityTransactionHash(order);
   const chainId = getRampActivityExplorerChainId(order.network);
   const providerName = getProviderName(order.provider, order.data);
@@ -214,22 +55,35 @@ export function RampFiatOrderDetails({
 
   return (
     <ActivityDetailsTemplateFrame
-      hero={<RampDetailsHero order={order} />}
-      metadata={
-        <RampDetailsMetadata
+      hero={
+        <RampDetailsHeroView
+          token={getRampActivityHeroToken(order)}
           chainId={chainId}
-          formattedDate={formattedDate}
-          order={order}
+          amountLabel={getRampActivityHeroAmount(order)}
+          isSell={isSell}
+        />
+      }
+      metadata={
+        <RampDetailsMetadataSection
+          status={mapRampActivityStatus(order)}
           providerName={providerName}
+          providerOrderLink={getFiatOrderProviderOrderLink(order)}
+          statusDescription={getFiatOrderStatusDescription(order)}
+          formattedDate={formattedDate}
+          orderId={order.id}
+          accountAddress={order.account}
+          chainId={chainId}
+          isSell={isSell}
           transactionHash={transactionHash}
         />
       }
       details={
-        <RampDetailsAmounts
+        <RampDetailsAmountsSection
+          currency={order.currency}
+          isSell={isSell}
           fiatValue={fiatValue}
-          order={order}
-          totalReceived={totalReceived}
           transactionFee={transactionFee}
+          totalReceived={totalReceived}
         />
       }
       footer={

--- a/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampFiatOrderDetails.tsx
@@ -21,6 +21,7 @@ import {
 import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
 import {
   RampOrderIdValue,
+  RampStatusDescription,
   RampStatusWithProviderLink,
   RampTransactionIdValue,
 } from './RampDetailsShared';
@@ -29,6 +30,7 @@ import {
   formatRampActivityFiatAmount,
   formatRampActivityFiatTotal,
   getFiatOrderProviderOrderLink,
+  getFiatOrderStatusDescription,
   getRampActivityExplorerChainId,
   getRampActivityHeroAmount,
   getRampActivityHeroToken,
@@ -87,53 +89,58 @@ function RampDetailsMetadata({
 }) {
   const isSell = isRampSellOrder(order);
   const providerOrderLink = getFiatOrderProviderOrderLink(order);
+  const statusDescription = getFiatOrderStatusDescription(order);
 
   return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('activity_details.status')}
-        value={
-          <RampStatusWithProviderLink
-            status={mapRampActivityStatus(order)}
-            providerName={providerName}
-            providerOrderLink={providerOrderLink}
-          />
-        }
-        testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
-      />
+    <>
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={strings('activity_details.status')}
+          value={
+            <RampStatusWithProviderLink
+              status={mapRampActivityStatus(order)}
+              providerName={providerName}
+              providerOrderLink={providerOrderLink}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
+        />
 
-      <ActivityDetailRow
-        label={strings('activity_details.date')}
-        value={formattedDate}
-        testID={ActivityDetailsSelectorsIDs.DATE_ROW}
-      />
+        <ActivityDetailRow
+          label={strings('activity_details.date')}
+          value={formattedDate}
+          testID={ActivityDetailsSelectorsIDs.DATE_ROW}
+        />
 
-      <ActivityDetailRow
-        label={strings('transaction_details.label.order_id')}
-        value={<RampOrderIdValue orderId={order.id} />}
-      />
+        <ActivityDetailRow
+          label={strings('transaction_details.label.order_id')}
+          value={<RampOrderIdValue orderId={order.id} />}
+        />
 
-      <ActivityDetailRow
-        label={strings('activity_details.account')}
-        value={
-          <ActivityDetailsAccountValue
-            address={order.account}
-            chainId={chainId}
-          />
-        }
-        testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
-      />
+        <ActivityDetailRow
+          label={strings('activity_details.account')}
+          value={
+            <ActivityDetailsAccountValue
+              address={order.account}
+              chainId={chainId}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
+        />
 
-      {isSell ? (
-        <ActivityDetailRow label="Destination" value={providerName} />
-      ) : null}
+        {isSell ? (
+          <ActivityDetailRow label="Destination" value={providerName} />
+        ) : null}
 
-      <ActivityDetailRow
-        label={strings('activity_details.transaction_id')}
-        value={<RampTransactionIdValue hash={transactionHash} />}
-        testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
-      />
-    </ActivityDetailSection>
+        <ActivityDetailRow
+          label={strings('activity_details.transaction_id')}
+          value={<RampTransactionIdValue hash={transactionHash} />}
+          testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
+        />
+      </ActivityDetailSection>
+
+      <RampStatusDescription description={statusDescription} />
+    </>
   );
 }
 

--- a/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
@@ -1,20 +1,13 @@
 import React, { useMemo } from 'react';
-import { Pressable } from 'react-native';
 import type { RampsOrder } from '@metamask/ramps-controller';
 import {
   AvatarTokenSize,
   Box,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import ClipboardManager from '../../../../core/ClipboardManager';
-import { renderShortAddress } from '../../../../util/address';
 import type { ActivityListItem } from '../../../../util/activity-adapters';
 import {
   getRampsOrderCreatedAt,
@@ -26,13 +19,17 @@ import {
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
 import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
 import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
-import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
 import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
 import {
   ActivityDetailRow,
   ActivityDetailSection,
 } from '../components/ActivityDetailsLayout';
 import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
+import {
+  RampOrderIdValue,
+  RampStatusWithProviderLink,
+  RampTransactionIdValue,
+} from './RampDetailsShared';
 import {
   formatRampActivityDate,
   formatRampActivityFiatAmount,
@@ -46,28 +43,6 @@ export type RampRampsActivityListItem = ActivityListItem & {
   type: 'buy' | 'sell';
   raw: { type: 'rampOrder'; data: RampsOrder };
 };
-
-function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
-  if (!hash) {
-    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
-  }
-
-  return (
-    <Box twClassName="flex-row items-center gap-1">
-      <Text>{renderShortAddress(hash, 4)}</Text>
-      <Pressable
-        onPress={() => ClipboardManager.setString(hash)}
-        testID="ramp-transaction-id-copy"
-      >
-        <Icon
-          name={IconName.Copy}
-          size={IconSize.Sm}
-          color={IconColor.IconAlternative}
-        />
-      </Pressable>
-    </Box>
-  );
-}
 
 function isRampsSellOrder(order: RampsOrder) {
   return mapRampsOrderType(order.orderType) === 'sell';
@@ -136,7 +111,11 @@ function RampDetailsMetadata({
       <ActivityDetailRow
         label={strings('activity_details.status')}
         value={
-          <ActivityDetailsStatus status={mapRampsOrderActivityStatus(order)} />
+          <RampStatusWithProviderLink
+            status={mapRampsOrderActivityStatus(order)}
+            providerName={providerName}
+            providerOrderLink={order.providerOrderLink}
+          />
         }
         testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
       />
@@ -149,7 +128,7 @@ function RampDetailsMetadata({
 
       <ActivityDetailRow
         label={strings('transaction_details.label.order_id')}
-        value={order.id ?? ''}
+        value={<RampOrderIdValue orderId={order.providerOrderId} />}
       />
 
       <ActivityDetailRow

--- a/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
@@ -27,6 +27,7 @@ import {
 import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
 import {
   RampOrderIdValue,
+  RampStatusDescription,
   RampStatusWithProviderLink,
   RampTransactionIdValue,
 } from './RampDetailsShared';
@@ -35,6 +36,7 @@ import {
   formatRampActivityFiatAmount,
   formatRampActivityFiatTotal,
   getRampActivityExplorerChainId,
+  getRampsOrderStatusDescription,
   mapRampsOrderActivityStatus,
   valueOrUnavailable,
 } from './rampDetailsUtils';
@@ -105,53 +107,58 @@ function RampDetailsMetadata({
   readonly transactionHash?: string;
 }) {
   const isSell = isRampsSellOrder(order);
+  const statusDescription = getRampsOrderStatusDescription(order);
 
   return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('activity_details.status')}
-        value={
-          <RampStatusWithProviderLink
-            status={mapRampsOrderActivityStatus(order)}
-            providerName={providerName}
-            providerOrderLink={order.providerOrderLink}
-          />
-        }
-        testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
-      />
+    <>
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={strings('activity_details.status')}
+          value={
+            <RampStatusWithProviderLink
+              status={mapRampsOrderActivityStatus(order)}
+              providerName={providerName}
+              providerOrderLink={order.providerOrderLink}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
+        />
 
-      <ActivityDetailRow
-        label={strings('activity_details.date')}
-        value={formattedDate}
-        testID={ActivityDetailsSelectorsIDs.DATE_ROW}
-      />
+        <ActivityDetailRow
+          label={strings('activity_details.date')}
+          value={formattedDate}
+          testID={ActivityDetailsSelectorsIDs.DATE_ROW}
+        />
 
-      <ActivityDetailRow
-        label={strings('transaction_details.label.order_id')}
-        value={<RampOrderIdValue orderId={order.providerOrderId} />}
-      />
+        <ActivityDetailRow
+          label={strings('transaction_details.label.order_id')}
+          value={<RampOrderIdValue orderId={order.providerOrderId} />}
+        />
 
-      <ActivityDetailRow
-        label={strings('activity_details.account')}
-        value={
-          <ActivityDetailsAccountValue
-            address={order.walletAddress}
-            chainId={chainId}
-          />
-        }
-        testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
-      />
+        <ActivityDetailRow
+          label={strings('activity_details.account')}
+          value={
+            <ActivityDetailsAccountValue
+              address={order.walletAddress}
+              chainId={chainId}
+            />
+          }
+          testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
+        />
 
-      {isSell ? (
-        <ActivityDetailRow label="Destination" value={providerName} />
-      ) : null}
+        {isSell ? (
+          <ActivityDetailRow label="Destination" value={providerName} />
+        ) : null}
 
-      <ActivityDetailRow
-        label={strings('activity_details.transaction_id')}
-        value={<RampTransactionIdValue hash={transactionHash} />}
-        testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
-      />
-    </ActivityDetailSection>
+        <ActivityDetailRow
+          label={strings('activity_details.transaction_id')}
+          value={<RampTransactionIdValue hash={transactionHash} />}
+          testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
+        />
+      </ActivityDetailSection>
+
+      <RampStatusDescription description={statusDescription} />
+    </>
   );
 }
 

--- a/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
@@ -1,13 +1,5 @@
 import React, { useMemo } from 'react';
 import type { RampsOrder } from '@metamask/ramps-controller';
-import {
-  AvatarTokenSize,
-  Box,
-  Text,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import { strings } from '../../../../../locales/i18n';
 import type { ActivityListItem } from '../../../../util/activity-adapters';
 import {
   getRampsOrderCreatedAt,
@@ -16,20 +8,12 @@ import {
   toRampsOrderCaipChainId,
   toRampsOrderToken,
 } from '../../../../util/activity-adapters/adapters/ramps-order-helpers';
-import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
-import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
 import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
 import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
 import {
-  ActivityDetailRow,
-  ActivityDetailSection,
-} from '../components/ActivityDetailsLayout';
-import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
-import {
-  RampOrderIdValue,
-  RampStatusDescription,
-  RampStatusWithProviderLink,
-  RampTransactionIdValue,
+  RampDetailsAmountsSection,
+  RampDetailsHeroView,
+  RampDetailsMetadataSection,
 } from './RampDetailsShared';
 import {
   formatRampActivityDate,
@@ -38,7 +22,6 @@ import {
   getRampActivityExplorerChainId,
   getRampsOrderStatusDescription,
   mapRampsOrderActivityStatus,
-  valueOrUnavailable,
 } from './rampDetailsUtils';
 
 export type RampRampsActivityListItem = ActivityListItem & {
@@ -60,151 +43,14 @@ function getRampsHeroAmount(order: RampsOrder) {
   return `${sign}${amount} ${symbol}`.trim();
 }
 
-function RampDetailsHero({ order }: Readonly<{ order: RampsOrder }>) {
-  const isSell = isRampsSellOrder(order);
-  const token = toRampsOrderToken(order, isSell ? 'out' : 'in');
-  const chainId =
+function getRampsExplorerChainId(order: RampsOrder) {
+  return (
     toRampsOrderCaipChainId(order) ??
     getRampActivityExplorerChainId(
       typeof order.network === 'object' && order.network?.chainId
         ? order.network.chainId
         : String(order.network ?? ''),
-    );
-
-  return (
-    <Box
-      twClassName="flex-row items-center gap-3"
-      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
-    >
-      <ActivityDetailsAvatar
-        tokens={[token]}
-        chainId={chainId}
-        size={AvatarTokenSize.Xl}
-        showNetworkBadge
-      />
-      <Text
-        variant={TextVariant.DisplayMd}
-        twClassName="shrink"
-        color={isSell ? TextColor.TextDefault : TextColor.SuccessDefault}
-      >
-        {getRampsHeroAmount(order)}
-      </Text>
-    </Box>
-  );
-}
-
-function RampDetailsMetadata({
-  chainId,
-  formattedDate,
-  order,
-  providerName,
-  transactionHash,
-}: {
-  readonly chainId: string;
-  readonly formattedDate: string;
-  readonly order: RampsOrder;
-  readonly providerName: string;
-  readonly transactionHash?: string;
-}) {
-  const isSell = isRampsSellOrder(order);
-  const statusDescription = getRampsOrderStatusDescription(order);
-
-  return (
-    <>
-      <ActivityDetailSection>
-        <ActivityDetailRow
-          label={strings('activity_details.status')}
-          value={
-            <RampStatusWithProviderLink
-              status={mapRampsOrderActivityStatus(order)}
-              providerName={providerName}
-              providerOrderLink={order.providerOrderLink}
-            />
-          }
-          testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
-        />
-
-        <ActivityDetailRow
-          label={strings('activity_details.date')}
-          value={formattedDate}
-          testID={ActivityDetailsSelectorsIDs.DATE_ROW}
-        />
-
-        <ActivityDetailRow
-          label={strings('transaction_details.label.order_id')}
-          value={<RampOrderIdValue orderId={order.providerOrderId} />}
-        />
-
-        <ActivityDetailRow
-          label={strings('activity_details.account')}
-          value={
-            <ActivityDetailsAccountValue
-              address={order.walletAddress}
-              chainId={chainId}
-            />
-          }
-          testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
-        />
-
-        {isSell ? (
-          <ActivityDetailRow label="Destination" value={providerName} />
-        ) : null}
-
-        <ActivityDetailRow
-          label={strings('activity_details.transaction_id')}
-          value={<RampTransactionIdValue hash={transactionHash} />}
-          testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
-        />
-      </ActivityDetailSection>
-
-      <RampStatusDescription description={statusDescription} />
-    </>
-  );
-}
-
-function RampDetailsAmounts({
-  fiatValue,
-  order,
-  totalReceived,
-  transactionFee,
-}: {
-  readonly fiatValue?: string;
-  readonly order: RampsOrder;
-  readonly totalReceived?: string;
-  readonly transactionFee?: string;
-}) {
-  const currency = order.fiatCurrency?.symbol ?? '';
-
-  if (isRampsSellOrder(order)) {
-    return (
-      <ActivityDetailSection>
-        <ActivityDetailRow
-          label={`${currency} value`}
-          value={valueOrUnavailable(fiatValue)}
-        />
-        <ActivityDetailRow
-          label="Fees"
-          value={valueOrUnavailable(transactionFee)}
-        />
-        <ActivityDetailRow
-          label="Total received"
-          value={valueOrUnavailable(totalReceived)}
-        />
-      </ActivityDetailSection>
-    );
-  }
-
-  return (
-    <ActivityDetailSection>
-      <ActivityDetailRow
-        label={strings('transaction_details.label.transaction_fee')}
-        value={valueOrUnavailable(transactionFee)}
-      />
-      <ActivityDetailRow
-        label={strings('transaction_details.label.total_amount')}
-        value={valueOrUnavailable(fiatValue)}
-      />
-    </ActivityDetailSection>
+    )
   );
 }
 
@@ -213,14 +59,9 @@ export function RampRampsOrderDetails({
   item,
 }: Readonly<{ item: RampRampsActivityListItem }>) {
   const order = item.raw.data;
+  const isSell = isRampsSellOrder(order);
   const transactionHash = getRampsOrderTransactionHash(order);
-  const chainId =
-    toRampsOrderCaipChainId(order) ??
-    getRampActivityExplorerChainId(
-      typeof order.network === 'object' && order.network?.chainId
-        ? order.network.chainId
-        : String(order.network ?? ''),
-    );
+  const chainId = getRampsExplorerChainId(order);
   const providerName = order.provider?.name ?? '';
   const currency = order.fiatCurrency?.symbol ?? '';
 
@@ -242,22 +83,35 @@ export function RampRampsOrderDetails({
 
   return (
     <ActivityDetailsTemplateFrame
-      hero={<RampDetailsHero order={order} />}
-      metadata={
-        <RampDetailsMetadata
+      hero={
+        <RampDetailsHeroView
+          token={toRampsOrderToken(order, isSell ? 'out' : 'in')}
           chainId={chainId}
-          formattedDate={formattedDate}
-          order={order}
+          amountLabel={getRampsHeroAmount(order)}
+          isSell={isSell}
+        />
+      }
+      metadata={
+        <RampDetailsMetadataSection
+          status={mapRampsOrderActivityStatus(order)}
           providerName={providerName}
+          providerOrderLink={order.providerOrderLink}
+          statusDescription={getRampsOrderStatusDescription(order)}
+          formattedDate={formattedDate}
+          orderId={order.providerOrderId}
+          accountAddress={order.walletAddress}
+          chainId={chainId}
+          isSell={isSell}
           transactionHash={transactionHash}
         />
       }
       details={
-        <RampDetailsAmounts
+        <RampDetailsAmountsSection
+          currency={currency}
+          isSell={isSell}
           fiatValue={fiatValue}
-          order={order}
-          totalReceived={totalReceived}
           transactionFee={transactionFee}
+          totalReceived={totalReceived}
         />
       }
       footer={

--- a/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/RampRampsOrderDetails.tsx
@@ -1,0 +1,285 @@
+import React, { useMemo } from 'react';
+import { Pressable } from 'react-native';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import {
+  AvatarTokenSize,
+  Box,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import ClipboardManager from '../../../../core/ClipboardManager';
+import { renderShortAddress } from '../../../../util/address';
+import type { ActivityListItem } from '../../../../util/activity-adapters';
+import {
+  getRampsOrderCreatedAt,
+  getRampsOrderTransactionHash,
+  mapRampsOrderType,
+  toRampsOrderCaipChainId,
+  toRampsOrderToken,
+} from '../../../../util/activity-adapters/adapters/ramps-order-helpers';
+import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+import { ActivityDetailsAvatar } from '../components/ActivityDetailsAvatar';
+import { ActivityDetailsBlockExplorerButton } from '../components/ActivityDetailsFooter';
+import { ActivityDetailsStatus } from '../components/ActivityDetailsStatus';
+import { ActivityDetailsTemplateFrame } from '../components/ActivityDetailsTemplateFrame';
+import {
+  ActivityDetailRow,
+  ActivityDetailSection,
+} from '../components/ActivityDetailsLayout';
+import { ActivityDetailsAccountValue } from '../components/ActivityDetailsAccountValue';
+import {
+  formatRampActivityDate,
+  formatRampActivityFiatAmount,
+  formatRampActivityFiatTotal,
+  getRampActivityExplorerChainId,
+  mapRampsOrderActivityStatus,
+  valueOrUnavailable,
+} from './rampDetailsUtils';
+
+export type RampRampsActivityListItem = ActivityListItem & {
+  type: 'buy' | 'sell';
+  raw: { type: 'rampOrder'; data: RampsOrder };
+};
+
+function RampTransactionIdValue({ hash }: Readonly<{ hash?: string }>) {
+  if (!hash) {
+    return <Text>{strings('transactions.tx_details_not_available')}</Text>;
+  }
+
+  return (
+    <Box twClassName="flex-row items-center gap-1">
+      <Text>{renderShortAddress(hash, 4)}</Text>
+      <Pressable
+        onPress={() => ClipboardManager.setString(hash)}
+        testID="ramp-transaction-id-copy"
+      >
+        <Icon
+          name={IconName.Copy}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+        />
+      </Pressable>
+    </Box>
+  );
+}
+
+function isRampsSellOrder(order: RampsOrder) {
+  return mapRampsOrderType(order.orderType) === 'sell';
+}
+
+function getRampsHeroAmount(order: RampsOrder) {
+  const amount =
+    order.cryptoAmount === undefined || order.cryptoAmount === null
+      ? '0'
+      : String(order.cryptoAmount);
+  const symbol = order.cryptoCurrency?.symbol ?? '';
+  const sign = isRampsSellOrder(order) ? '-' : '+';
+  return `${sign}${amount} ${symbol}`.trim();
+}
+
+function RampDetailsHero({ order }: Readonly<{ order: RampsOrder }>) {
+  const isSell = isRampsSellOrder(order);
+  const token = toRampsOrderToken(order, isSell ? 'out' : 'in');
+  const chainId =
+    toRampsOrderCaipChainId(order) ??
+    getRampActivityExplorerChainId(
+      typeof order.network === 'object' && order.network?.chainId
+        ? order.network.chainId
+        : String(order.network ?? ''),
+    );
+
+  return (
+    <Box
+      twClassName="flex-row items-center gap-3"
+      testID={ActivityDetailsSelectorsIDs.AMOUNT_HEADER}
+    >
+      <ActivityDetailsAvatar
+        tokens={[token]}
+        chainId={chainId}
+        size={AvatarTokenSize.Xl}
+        showNetworkBadge
+      />
+      <Text
+        variant={TextVariant.DisplayMd}
+        twClassName="shrink"
+        color={isSell ? TextColor.TextDefault : TextColor.SuccessDefault}
+      >
+        {getRampsHeroAmount(order)}
+      </Text>
+    </Box>
+  );
+}
+
+function RampDetailsMetadata({
+  chainId,
+  formattedDate,
+  order,
+  providerName,
+  transactionHash,
+}: {
+  readonly chainId: string;
+  readonly formattedDate: string;
+  readonly order: RampsOrder;
+  readonly providerName: string;
+  readonly transactionHash?: string;
+}) {
+  const isSell = isRampsSellOrder(order);
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('activity_details.status')}
+        value={
+          <ActivityDetailsStatus status={mapRampsOrderActivityStatus(order)} />
+        }
+        testID={ActivityDetailsSelectorsIDs.STATUS_ROW}
+      />
+
+      <ActivityDetailRow
+        label={strings('activity_details.date')}
+        value={formattedDate}
+        testID={ActivityDetailsSelectorsIDs.DATE_ROW}
+      />
+
+      <ActivityDetailRow
+        label={strings('transaction_details.label.order_id')}
+        value={order.id ?? ''}
+      />
+
+      <ActivityDetailRow
+        label={strings('activity_details.account')}
+        value={
+          <ActivityDetailsAccountValue
+            address={order.walletAddress}
+            chainId={chainId}
+          />
+        }
+        testID={ActivityDetailsSelectorsIDs.ACCOUNT_ROW}
+      />
+
+      {isSell ? (
+        <ActivityDetailRow label="Destination" value={providerName} />
+      ) : null}
+
+      <ActivityDetailRow
+        label={strings('activity_details.transaction_id')}
+        value={<RampTransactionIdValue hash={transactionHash} />}
+        testID={ActivityDetailsSelectorsIDs.TRANSACTION_ID_ROW}
+      />
+    </ActivityDetailSection>
+  );
+}
+
+function RampDetailsAmounts({
+  fiatValue,
+  order,
+  totalReceived,
+  transactionFee,
+}: {
+  readonly fiatValue?: string;
+  readonly order: RampsOrder;
+  readonly totalReceived?: string;
+  readonly transactionFee?: string;
+}) {
+  const currency = order.fiatCurrency?.symbol ?? '';
+
+  if (isRampsSellOrder(order)) {
+    return (
+      <ActivityDetailSection>
+        <ActivityDetailRow
+          label={`${currency} value`}
+          value={valueOrUnavailable(fiatValue)}
+        />
+        <ActivityDetailRow
+          label="Fees"
+          value={valueOrUnavailable(transactionFee)}
+        />
+        <ActivityDetailRow
+          label="Total received"
+          value={valueOrUnavailable(totalReceived)}
+        />
+      </ActivityDetailSection>
+    );
+  }
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('transaction_details.label.transaction_fee')}
+        value={valueOrUnavailable(transactionFee)}
+      />
+      <ActivityDetailRow
+        label={strings('transaction_details.label.total_amount')}
+        value={valueOrUnavailable(fiatValue)}
+      />
+    </ActivityDetailSection>
+  );
+}
+
+/** Native RampsOrder ActivityDetails template — visual parity with Fiat path. */
+export function RampRampsOrderDetails({
+  item,
+}: Readonly<{ item: RampRampsActivityListItem }>) {
+  const order = item.raw.data;
+  const transactionHash = getRampsOrderTransactionHash(order);
+  const chainId =
+    toRampsOrderCaipChainId(order) ??
+    getRampActivityExplorerChainId(
+      typeof order.network === 'object' && order.network?.chainId
+        ? order.network.chainId
+        : String(order.network ?? ''),
+    );
+  const providerName = order.provider?.name ?? '';
+  const currency = order.fiatCurrency?.symbol ?? '';
+
+  const formattedDate = useMemo(
+    () => formatRampActivityDate(getRampsOrderCreatedAt(order)),
+    [order],
+  );
+
+  const transactionFee = formatRampActivityFiatAmount(
+    order.totalFeesFiat,
+    currency,
+  );
+  const fiatValue = formatRampActivityFiatAmount(order.fiatAmount, currency);
+  const totalReceived = formatRampActivityFiatTotal(
+    order.fiatAmount,
+    order.totalFeesFiat,
+    currency,
+  );
+
+  return (
+    <ActivityDetailsTemplateFrame
+      hero={<RampDetailsHero order={order} />}
+      metadata={
+        <RampDetailsMetadata
+          chainId={chainId}
+          formattedDate={formattedDate}
+          order={order}
+          providerName={providerName}
+          transactionHash={transactionHash}
+        />
+      }
+      details={
+        <RampDetailsAmounts
+          fiatValue={fiatValue}
+          order={order}
+          totalReceived={totalReceived}
+          transactionFee={transactionFee}
+        />
+      }
+      footer={
+        <ActivityDetailsBlockExplorerButton
+          chainId={chainId}
+          hash={transactionHash}
+        />
+      }
+    />
+  );
+}

--- a/app/components/Views/ActivityDetails/templates/rampDetailsUtils.test.ts
+++ b/app/components/Views/ActivityDetails/templates/rampDetailsUtils.test.ts
@@ -1,0 +1,102 @@
+import type { RampsOrder } from '@metamask/ramps-controller';
+import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import {
+  formatShortRampOrderId,
+  getFiatOrderProviderOrderLink,
+  getFiatOrderStatusDescription,
+  getRampsOrderStatusDescription,
+  valueOrUnavailable,
+} from './rampDetailsUtils';
+
+describe('rampDetailsUtils', () => {
+  describe('formatShortRampOrderId', () => {
+    it('returns ellipsis for missing ids', () => {
+      expect(formatShortRampOrderId(undefined)).toBe('...');
+      expect(formatShortRampOrderId('')).toBe('...');
+    });
+
+    it('keeps short ids intact', () => {
+      expect(formatShortRampOrderId('po-1')).toBe('po-1');
+      expect(formatShortRampOrderId('12345678')).toBe('12345678');
+    });
+
+    it('truncates long ids to ellipsis plus last six characters', () => {
+      expect(
+        formatShortRampOrderId('bba639be-5c56-44f0-aa51-4e9a4f0e25e6'),
+      ).toBe('...0e25e6');
+    });
+  });
+
+  describe('getFiatOrderProviderOrderLink', () => {
+    it('reads providerOrderLink from order data when present', () => {
+      const order = {
+        data: { providerOrderLink: 'https://example.com/order' },
+      } as FiatOrder;
+
+      expect(getFiatOrderProviderOrderLink(order)).toBe(
+        'https://example.com/order',
+      );
+    });
+
+    it('returns undefined when the link is missing or not a string', () => {
+      expect(
+        getFiatOrderProviderOrderLink({ data: {} } as FiatOrder),
+      ).toBeUndefined();
+      expect(
+        getFiatOrderProviderOrderLink({
+          data: { providerOrderLink: 123 },
+        } as unknown as FiatOrder),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getFiatOrderStatusDescription', () => {
+    it('returns non-empty statusDescription from order data', () => {
+      const order = {
+        data: { statusDescription: 'Order completed' },
+      } as FiatOrder;
+
+      expect(getFiatOrderStatusDescription(order)).toBe('Order completed');
+    });
+
+    it('returns undefined for empty or missing descriptions', () => {
+      expect(
+        getFiatOrderStatusDescription({
+          data: { statusDescription: '' },
+        } as FiatOrder),
+      ).toBeUndefined();
+      expect(
+        getFiatOrderStatusDescription({ data: {} } as FiatOrder),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getRampsOrderStatusDescription', () => {
+    it('returns non-empty statusDescription from RampsOrder', () => {
+      expect(
+        getRampsOrderStatusDescription({
+          statusDescription: 'Payment failed',
+        } as RampsOrder),
+      ).toBe('Payment failed');
+    });
+
+    it('returns undefined when absent or empty', () => {
+      expect(getRampsOrderStatusDescription({} as RampsOrder)).toBeUndefined();
+      expect(
+        getRampsOrderStatusDescription({
+          statusDescription: '',
+        } as RampsOrder),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('valueOrUnavailable', () => {
+    it('returns the value when defined', () => {
+      expect(valueOrUnavailable('$1.00')).toBe('$1.00');
+    });
+
+    it('falls back to the unavailable string', () => {
+      expect(valueOrUnavailable(undefined)).toBe('Not available');
+    });
+  });
+});

--- a/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
+++ b/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
@@ -94,3 +94,20 @@ export function formatRampActivityDate(timestamp: number) {
   }).format(date);
   return `${month} ${date.getDate()}, ${date.getFullYear()} at ${timeString}`;
 }
+
+/** Matches OrderContent short id: `...` + last 6 chars when longer than 8. */
+export function formatShortRampOrderId(orderId: string | undefined): string {
+  if (!orderId) {
+    return '...';
+  }
+  return orderId.length > 8 ? `...${orderId.slice(-6)}` : orderId;
+}
+
+export function getFiatOrderProviderOrderLink(
+  order: FiatOrder,
+): string | undefined {
+  const data = order.data as { providerOrderLink?: unknown } | undefined;
+  return typeof data?.providerOrderLink === 'string'
+    ? data.providerOrderLink
+    : undefined;
+}

--- a/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
+++ b/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
@@ -1,4 +1,5 @@
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import type { RampsOrder } from '@metamask/ramps-controller';
 import { getIntlDateTimeFormatter } from '../../../../util/intl';
 import { renderFiat } from '../../../../util/number/bigint';
 import {
@@ -7,6 +8,7 @@ import {
   mapRampOrderType,
   toRampOrderToken,
 } from '../../../../util/activity-adapters/adapters/ramp-order-helpers';
+import { mapRampsOrderStatus } from '../../../../util/activity-adapters/adapters/ramps-order-helpers';
 import I18n, { strings } from '../../../../../locales/i18n';
 
 type RenderFiatCurrencyCode = Parameters<typeof renderFiat>[1];
@@ -74,6 +76,10 @@ export function valueOrUnavailable(value: string | undefined) {
 
 export function mapRampActivityStatus(order: FiatOrder) {
   return mapRampOrderStatus(order.state);
+}
+
+export function mapRampsOrderActivityStatus(order: RampsOrder) {
+  return mapRampsOrderStatus(order.status);
 }
 
 export function formatRampActivityDate(timestamp: number) {

--- a/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
+++ b/app/components/Views/ActivityDetails/templates/rampDetailsUtils.ts
@@ -111,3 +111,29 @@ export function getFiatOrderProviderOrderLink(
     ? data.providerOrderLink
     : undefined;
 }
+
+/**
+ * Provider status copy from Aggregator/Deposit `order.data.statusDescription`
+ * (same field OrderDetails Stage / DepositOrderContent render).
+ */
+export function getFiatOrderStatusDescription(
+  order: FiatOrder,
+): string | undefined {
+  const data = order.data as { statusDescription?: unknown } | undefined;
+  return typeof data?.statusDescription === 'string' &&
+    data.statusDescription.length > 0
+    ? data.statusDescription
+    : undefined;
+}
+
+/**
+ * Native RampsOrder `statusDescription` (OrderContent terminal info row).
+ */
+export function getRampsOrderStatusDescription(
+  order: RampsOrder,
+): string | undefined {
+  const description = order.statusDescription;
+  return typeof description === 'string' && description.length > 0
+    ? description
+    : undefined;
+}

--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -21,7 +21,10 @@ import { useUnifiedTxActions } from './useUnifiedTxActions';
 import Engine from '../../../core/Engine';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import Routes from '../../../constants/navigation/Routes';
-import { FIAT_ORDER_PROVIDERS } from '../../../constants/on-ramp';
+import {
+  FIAT_ORDER_PROVIDERS,
+  FIAT_ORDER_STATES,
+} from '../../../constants/on-ramp';
 import decodeTransaction from '../../UI/TransactionElement/utils';
 import { handleUnifiedSwapsTxHistoryItemClick } from '../../UI/Bridge/utils/transaction-history';
 
@@ -281,6 +284,50 @@ jest.mock('./hooks/useLocalActivityItems', () => ({
 jest.mock('./hooks/useRampActivityItems', () => ({
   useRampActivityItems: jest.fn(),
 }));
+
+const mockGoToBuy = jest.fn();
+jest.mock('../../UI/Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: jest.fn(() => ({ goToBuy: mockGoToBuy })),
+}));
+
+jest.mock('../../UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails', () => {
+  const RoutesActual = jest.requireActual(
+    '../../../constants/navigation/Routes',
+  );
+  return {
+    createOrderDetailsNavDetails: (params: { orderId: string }) => [
+      RoutesActual.default.RAMP.ORDER_DETAILS,
+      params,
+    ],
+  };
+});
+
+jest.mock('../../UI/Ramp/Views/OrderDetails', () => {
+  const RoutesActual = jest.requireActual(
+    '../../../constants/navigation/Routes',
+  );
+  return {
+    createRampsOrderDetailsNavDetails: (params: { orderId: string }) => [
+      RoutesActual.default.RAMP.RAMPS_ORDER_DETAILS,
+      params,
+    ],
+  };
+});
+
+jest.mock(
+  '../../UI/Ramp/Views/OrderDetails/DepositOrderDetails/DepositOrderDetails',
+  () => {
+    const RoutesActual = jest.requireActual(
+      '../../../constants/navigation/Routes',
+    );
+    return {
+      createDepositOrderDetailsNavDetails: (params: { orderId: string }) => [
+        RoutesActual.default.DEPOSIT.ORDER_DETAILS,
+        params,
+      ],
+    };
+  },
+);
 
 jest.mock('./useUnifiedTxActions', () => ({
   useUnifiedTxActions: jest.fn(),
@@ -1202,6 +1249,32 @@ describe('ActivityList', () => {
     });
   });
 
+  it('routes deposit CREATED rows to goToBuy when the redesign flag is off', () => {
+    selectorValues.isTxRedesign = false;
+    (useRampActivityItems as jest.Mock).mockReturnValue([
+      {
+        ...rampItem,
+        hash: '0xdeposit-created',
+        raw: {
+          ...rampItem.raw,
+          data: {
+            ...rampItem.raw.data,
+            id: 'deposit-created-id',
+            provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+            state: FIAT_ORDER_STATES.CREATED,
+          },
+        },
+      },
+    ]);
+
+    render(<ActivityList header={<></>} />);
+
+    fireEvent.press(screen.getByTestId('row-0xdeposit-created'));
+
+    expect(mockGoToBuy).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('routes deposit rows to the deposit details screen when the transactions redesign flag is off', () => {
     selectorValues.isTxRedesign = false;
     (useRampActivityItems as jest.Mock).mockReturnValue([
@@ -1214,6 +1287,7 @@ describe('ActivityList', () => {
             ...rampItem.raw.data,
             id: 'deposit-order-id',
             provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+            state: FIAT_ORDER_STATES.COMPLETED,
           },
         },
       },

--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -1192,6 +1192,37 @@ describe('ActivityList', () => {
     expect(legacyCalls).toHaveLength(0);
   });
 
+  it('routes Ramp sell rows to legacy OrderDetails even when the redesign flag is on', () => {
+    selectorValues.isTxRedesign = true;
+    (useRampActivityItems as jest.Mock).mockReturnValue([
+      {
+        ...rampItem,
+        type: 'sell',
+        hash: '0xramp-sell',
+        raw: {
+          ...rampItem.raw,
+          data: {
+            ...rampItem.raw.data,
+            id: 'ramp-sell-order-id',
+            orderType: 'SELL',
+          },
+        },
+      },
+    ]);
+
+    render(<ActivityList header={<></>} />);
+
+    fireEvent.press(screen.getByTestId('row-0xramp-sell'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.ORDER_DETAILS, {
+      orderId: 'ramp-sell-order-id',
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      Routes.ACTIVITY_DETAILS,
+      expect.anything(),
+    );
+  });
+
   it('routes Ramp rows to the redesigned ActivityDetails screen when the transactions redesign flag is on', () => {
     selectorValues.isTxRedesign = true;
     (useRampActivityItems as jest.Mock).mockReturnValue([rampItem]);

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -29,7 +29,6 @@ import { strings } from '../../../../locales/i18n';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import Routes from '../../../constants/navigation/Routes';
 import { RPC } from '../../../constants/network';
-import { FIAT_ORDER_PROVIDERS } from '../../../constants/on-ramp';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain/multichain';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
@@ -117,6 +116,11 @@ import { normalizeTransaction } from './helpers/adapters';
 import { useLocalActivityItems } from './hooks/useLocalActivityItems';
 import { getActivityDetailsRoute } from './getActivityDetailsRoute';
 import { useRampActivityItems } from './hooks/useRampActivityItems';
+import {
+  navigateToRampOrderTarget,
+  resolveRampOrderTarget,
+} from './utils/resolveRampOrderTarget';
+import { useRampNavigation } from '../../UI/Ramp/hooks/useRampNavigation';
 import {
   INITIAL_PERPS_ACTIVITY_SOURCE_STATE,
   PerpsActivitySource,
@@ -241,6 +245,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
     // Local EVM transactions mapped through the shared adapter
     const localActivityItems = useLocalActivityItems();
     const rampActivityItems = useRampActivityItems();
+    const { goToBuy } = useRampNavigation();
 
     const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
     const [perpsSource, setPerpsSource] = useState<PerpsActivitySourceState>(
@@ -815,6 +820,14 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         const { raw } = item;
         if (!raw) return;
 
+        // CREATED deposit never opens a details screen (matches OrdersList).
+        if (raw.type === 'rampOrder') {
+          if (resolveRampOrderTarget(raw.data) === 'deposit-resume-buy') {
+            goToBuy();
+            return;
+          }
+        }
+
         // Non-EVM swaps/bridges submitted from this device carry a
         // bridge-history entry. Cross-chain bridges keep their dedicated
         // bridge-status screen, mirroring hasDedicatedDetailScreen for local
@@ -876,25 +889,10 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         }
 
         if (raw.type === 'rampOrder') {
-          if (!isTransactionsRedesignEnabled) {
-            if (raw.data.provider === FIAT_ORDER_PROVIDERS.DEPOSIT) {
-              navigation.navigate(Routes.DEPOSIT.ORDER_DETAILS, {
-                orderId: raw.data.id,
-              });
-            } else if (raw.data.provider === FIAT_ORDER_PROVIDERS.RAMPS_V2) {
-              navigation.navigate(Routes.RAMP.RAMPS_ORDER_DETAILS, {
-                orderId: raw.data.id,
-              });
-            } else {
-              navigation.navigate(Routes.RAMP.ORDER_DETAILS, {
-                orderId: raw.data.id,
-              });
-            }
-            return;
-          }
-          navigation.navigate(Routes.ACTIVITY_DETAILS, {
-            chainId: item.chainId,
-            txIdentifier: item.hash ?? raw.data.id,
+          navigateToRampOrderTarget({
+            data: raw.data,
+            navigation,
+            goToBuy,
           });
           return;
         }
@@ -1033,6 +1031,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
       [
         bridgeHistory,
         getBridgeHistoryItemByHash,
+        goToBuy,
         isTransactionsRedesignEnabled,
         navigation,
         selectedAccountGroupEvmAddress,

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -820,12 +820,37 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         const { raw } = item;
         if (!raw) return;
 
-        // CREATED deposit never opens a details screen (matches OrdersList).
+        // Ramp rows own their redesign gate: flag ON → ActivityDetails /
+        // TemplateLoader; flag OFF → OrdersList destinations. Kept ahead of the
+        // shared redesign early-return so CREATED deposits always resume buy and
+        // flag-OFF never accidentally hits ActivityDetails.
         if (raw.type === 'rampOrder') {
           if (resolveRampOrderTarget(raw.data) === 'deposit-resume-buy') {
             goToBuy();
             return;
           }
+
+          if (isTransactionsRedesignEnabled) {
+            const detailsRoute = getActivityDetailsRoute(item);
+            if (detailsRoute) {
+              navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
+              return;
+            }
+            // Mappers always set hash (txHash || id); keep the pre-native
+            // fallback keyed by order id if a row somehow lacks hash.
+            navigation.navigate(Routes.ACTIVITY_DETAILS, {
+              chainId: item.chainId,
+              txIdentifier: item.hash ?? raw.data.id,
+            });
+            return;
+          }
+
+          navigateToRampOrderTarget({
+            data: raw.data,
+            navigation,
+            goToBuy,
+          });
+          return;
         }
 
         // Non-EVM swaps/bridges submitted from this device carry a
@@ -884,15 +909,6 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
           navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
             screen: Routes.PREDICT.ACTIVITY_DETAIL,
             params: { activity: predictActivityToItem(raw.data) },
-          });
-          return;
-        }
-
-        if (raw.type === 'rampOrder') {
-          navigateToRampOrderTarget({
-            data: raw.data,
-            navigation,
-            goToBuy,
           });
           return;
         }

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -824,31 +824,33 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         // TemplateLoader; flag OFF → OrdersList destinations. Kept ahead of the
         // shared redesign early-return so CREATED deposits always resume buy and
         // flag-OFF never accidentally hits ActivityDetails.
+        // Sell/offramp always uses legacy OrderDetails — that screen owns the
+        // Continue → Send Transaction flow which ActivityDetails does not.
         if (raw.type === 'rampOrder') {
           if (resolveRampOrderTarget(raw.data) === 'deposit-resume-buy') {
             goToBuy();
             return;
           }
 
-          if (isTransactionsRedesignEnabled) {
-            const detailsRoute = getActivityDetailsRoute(item);
-            if (detailsRoute) {
-              navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
-              return;
-            }
-            // Mappers always set hash (txHash || id); keep the pre-native
-            // fallback keyed by order id if a row somehow lacks hash.
-            navigation.navigate(Routes.ACTIVITY_DETAILS, {
-              chainId: item.chainId,
-              txIdentifier: item.hash ?? raw.data.id,
+          if (item.type === 'sell' || !isTransactionsRedesignEnabled) {
+            navigateToRampOrderTarget({
+              data: raw.data,
+              navigation,
+              goToBuy,
             });
             return;
           }
 
-          navigateToRampOrderTarget({
-            data: raw.data,
-            navigation,
-            goToBuy,
+          const detailsRoute = getActivityDetailsRoute(item);
+          if (detailsRoute) {
+            navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
+            return;
+          }
+          // Mappers always set hash (txHash || id); keep the pre-native
+          // fallback keyed by order id if a row somehow lacks hash.
+          navigation.navigate(Routes.ACTIVITY_DETAILS, {
+            chainId: item.chainId,
+            txIdentifier: item.hash ?? raw.data.id,
           });
           return;
         }

--- a/app/components/Views/ActivityList/hooks/useRampActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/useRampActivityItems.test.ts
@@ -111,10 +111,11 @@ describe('useRampActivityItems', () => {
     expect(result.current[0].hash).toBe('0xbuyhash');
   });
 
-  it('includes v2 controller orders resolved by canonical order id', () => {
+  it('includes v2 controller orders with native RampsOrder in raw.data', () => {
     const v2Order = createV2Order({
       id: '/providers/transak/orders/v2-order-1',
       providerOrderId: 'v2-order-1',
+      cryptoCurrency: { symbol: 'mUSD', decimals: 6 },
     });
     mockedUseRampsOrders.mockReturnValue({
       orders: [v2Order],
@@ -134,7 +135,13 @@ describe('useRampActivityItems', () => {
     expect(result.current[0]).toMatchObject({
       type: 'buy',
       hash: '0xbuyhash',
+      raw: { type: 'rampOrder', data: v2Order },
+      data: { token: { amount: '5.01', symbol: 'mUSD', direction: 'in' } },
     });
+    expect(result.current[0].raw?.data).not.toHaveProperty(
+      'provider',
+      FIAT_ORDER_PROVIDERS.RAMPS_V2,
+    );
   });
 
   it('includes v2 orders with non-EVM CAIP-2 network metadata', () => {
@@ -164,6 +171,7 @@ describe('useRampActivityItems', () => {
       type: 'buy',
       chainId: solanaChainId,
       hash: '0xbuyhash',
+      raw: { type: 'rampOrder', data: v2Order },
     });
   });
 });

--- a/app/components/Views/ActivityList/hooks/useRampActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/useRampActivityItems.ts
@@ -1,7 +1,8 @@
 /**
- * Maps stored fiat Ramp orders into the shared `ActivityListItem` shape for the
- * unified Activity list. Merges legacy Redux orders with v2 RampsController
- * orders, matching the Orders list behavior.
+ * Maps ramp orders into the shared `ActivityListItem` shape for the unified
+ * Activity list. Merges legacy Redux FiatOrder[] with v2 RampsController
+ * RampsOrder[] via mergeDisplayOrders, then maps each source natively —
+ * no RampsOrder → FiatOrder conversion.
  */
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -10,71 +11,55 @@ import { getOrders } from '../../../../reducers/fiatOrders';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
 import { useRampsOrders } from '../../../UI/Ramp/hooks/useRampsOrders';
 import { mergeDisplayOrders } from '../../../UI/Ramp/utils/displayOrder';
-import { rampsOrderToFiatOrder } from '../../../UI/Ramp/orderProcessor/unifiedOrderProcessor';
 import {
   mapRampOrder,
+  mapRampsOrder,
   type ActivityListItem,
 } from '../../../../util/activity-adapters';
-
-function getRampsOrderId(order: RampsOrder): string {
-  return order.id ?? order.providerOrderId;
-}
 
 function findV2Order(
   v2Orders: RampsOrder[],
   displayId: string,
 ): RampsOrder | undefined {
   return v2Orders.find(
-    (order) =>
-      getRampsOrderId(order) === displayId ||
-      order.providerOrderId === displayId,
+    (order) => order.providerOrderId === displayId || order.id === displayId,
   );
-}
-
-function toMergedFiatOrders(
-  legacyOrders: FiatOrder[],
-  v2Orders: RampsOrder[],
-): FiatOrder[] {
-  const displayOrders = mergeDisplayOrders(legacyOrders, v2Orders);
-  const legacyById = new Map(legacyOrders.map((order) => [order.id, order]));
-
-  const mergedOrders: FiatOrder[] = [];
-
-  for (const displayOrder of displayOrders) {
-    if (displayOrder.source === 'legacy') {
-      const legacyOrder = legacyById.get(displayOrder.id);
-      if (legacyOrder) {
-        mergedOrders.push(legacyOrder);
-      }
-      continue;
-    }
-
-    const v2Order = findV2Order(v2Orders, displayOrder.id);
-    if (v2Order) {
-      mergedOrders.push(rampsOrderToFiatOrder(v2Order));
-    }
-  }
-
-  return mergedOrders;
 }
 
 export function useRampActivityItems(): ActivityListItem[] {
   const legacyOrders = useSelector(getOrders);
   const { orders: v2Orders } = useRampsOrders();
 
-  const mergedOrders = useMemo(
-    () => toMergedFiatOrders(legacyOrders, v2Orders),
-    [legacyOrders, v2Orders],
-  );
-
   return useMemo(() => {
+    const displayOrders = mergeDisplayOrders(legacyOrders, v2Orders);
+    const legacyById = new Map(
+      legacyOrders.map((order: FiatOrder) => [order.id, order]),
+    );
     const result: ActivityListItem[] = [];
-    for (const order of mergedOrders) {
-      const item = mapRampOrder({ order });
+
+    for (const displayOrder of displayOrders) {
+      if (displayOrder.source === 'legacy') {
+        const legacyOrder = legacyById.get(displayOrder.id);
+        if (!legacyOrder) {
+          continue;
+        }
+        const item = mapRampOrder({ order: legacyOrder });
+        if (item) {
+          result.push(item);
+        }
+        continue;
+      }
+
+      const v2Order = findV2Order(v2Orders, displayOrder.id);
+      if (!v2Order) {
+        continue;
+      }
+      const item = mapRampsOrder({ order: v2Order });
       if (item) {
         result.push(item);
       }
     }
+
     return result;
-  }, [mergedOrders]);
+  }, [legacyOrders, v2Orders]);
 }

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.test.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.test.ts
@@ -5,7 +5,35 @@ import {
   FIAT_ORDER_STATES,
 } from '../../../../constants/on-ramp';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
-import { resolveRampOrderTarget } from './resolveRampOrderTarget';
+import {
+  navigateToRampOrderTarget,
+  resolveRampOrderTarget,
+} from './resolveRampOrderTarget';
+
+jest.mock(
+  '../../../UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails',
+  () => ({
+    createOrderDetailsNavDetails: jest.fn(
+      ({ orderId }: { orderId: string }) => ['OrderDetails', { orderId }],
+    ),
+  }),
+);
+jest.mock('../../../UI/Ramp/Views/OrderDetails', () => ({
+  createRampsOrderDetailsNavDetails: jest.fn(
+    ({ orderId }: { orderId: string }) => ['RampsOrderDetails', { orderId }],
+  ),
+}));
+jest.mock(
+  '../../../UI/Ramp/Views/OrderDetails/DepositOrderDetails/DepositOrderDetails',
+  () => ({
+    createDepositOrderDetailsNavDetails: jest.fn(
+      ({ orderId }: { orderId: string }) => [
+        'DepositOrderDetails',
+        { orderId },
+      ],
+    ),
+  }),
+);
 
 const fiatBase = {
   id: 'fiat-1',
@@ -84,5 +112,57 @@ describe('resolveRampOrderTarget', () => {
         state: FIAT_ORDER_STATES.COMPLETED,
       }),
     ).toBe('aggregator-details');
+  });
+});
+
+describe('navigateToRampOrderTarget', () => {
+  const navigation = { navigate: jest.fn() };
+  const goToBuy = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates native RampsOrder with providerOrderId (OrdersList parity)', () => {
+    navigateToRampOrderTarget({
+      data: rampsBase,
+      navigation,
+      goToBuy,
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith('RampsOrderDetails', {
+      orderId: 'po-1',
+    });
+    expect(navigation.navigate).not.toHaveBeenCalledWith(
+      'RampsOrderDetails',
+      expect.objectContaining({ orderId: rampsBase.id }),
+    );
+  });
+
+  it('does not navigate when native RampsOrder lacks providerOrderId', () => {
+    navigateToRampOrderTarget({
+      data: { ...rampsBase, providerOrderId: '' },
+      navigation,
+      goToBuy,
+    });
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates FiatOrder RAMPS_V2 shim with FiatOrder.id', () => {
+    navigateToRampOrderTarget({
+      data: {
+        ...fiatBase,
+        id: 'legacy-v2-id',
+        provider: FIAT_ORDER_PROVIDERS.RAMPS_V2,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      },
+      navigation,
+      goToBuy,
+    });
+
+    expect(navigation.navigate).toHaveBeenCalledWith('RampsOrderDetails', {
+      orderId: 'legacy-v2-id',
+    });
   });
 });

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.test.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.test.ts
@@ -1,0 +1,88 @@
+import { OrderOrderTypeEnum } from '@consensys/on-ramp-sdk/dist/API';
+import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
+import {
+  FIAT_ORDER_PROVIDERS,
+  FIAT_ORDER_STATES,
+} from '../../../../constants/on-ramp';
+import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import { resolveRampOrderTarget } from './resolveRampOrderTarget';
+
+const fiatBase = {
+  id: 'fiat-1',
+  createdAt: 1,
+  amount: '10',
+  currency: 'USD',
+  cryptocurrency: 'ETH',
+  account: '0xabc',
+  network: '1',
+  excludeFromPurchases: false,
+  orderType: OrderOrderTypeEnum.Buy,
+  data: {},
+} as FiatOrder;
+
+const rampsBase: RampsOrder = {
+  isOnlyLink: false,
+  success: true,
+  cryptoAmount: '1',
+  fiatAmount: 10,
+  providerOrderId: 'po-1',
+  providerOrderLink: 'https://example.com',
+  createdAt: 1,
+  totalFeesFiat: 1,
+  txHash: '0xhash',
+  walletAddress: '0xabc',
+  status: RampsOrderStatus.Completed,
+  network: { name: 'Ethereum', chainId: 'eip155:1' },
+  canBeUpdated: false,
+  idHasExpired: false,
+  excludeFromPurchases: false,
+  timeDescriptionPending: '',
+  orderType: 'BUY',
+  id: '/providers/transak/orders/po-1',
+};
+
+describe('resolveRampOrderTarget', () => {
+  it('routes native RampsOrder to ramps-v2-details', () => {
+    expect(resolveRampOrderTarget(rampsBase)).toBe('ramps-v2-details');
+  });
+
+  it('routes DEPOSIT CREATED FiatOrder to deposit-resume-buy', () => {
+    expect(
+      resolveRampOrderTarget({
+        ...fiatBase,
+        provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+        state: FIAT_ORDER_STATES.CREATED,
+      }),
+    ).toBe('deposit-resume-buy');
+  });
+
+  it('routes DEPOSIT completed FiatOrder to deposit-details', () => {
+    expect(
+      resolveRampOrderTarget({
+        ...fiatBase,
+        provider: FIAT_ORDER_PROVIDERS.DEPOSIT,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      }),
+    ).toBe('deposit-details');
+  });
+
+  it('routes legacy RAMPS_V2 FiatOrder to ramps-v2-details', () => {
+    expect(
+      resolveRampOrderTarget({
+        ...fiatBase,
+        provider: FIAT_ORDER_PROVIDERS.RAMPS_V2,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      }),
+    ).toBe('ramps-v2-details');
+  });
+
+  it('routes aggregator FiatOrder to aggregator-details', () => {
+    expect(
+      resolveRampOrderTarget({
+        ...fiatBase,
+        provider: FIAT_ORDER_PROVIDERS.AGGREGATOR,
+        state: FIAT_ORDER_STATES.COMPLETED,
+      }),
+    ).toBe('aggregator-details');
+  });
+});

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
@@ -69,12 +69,14 @@ export function navigateToRampOrderTarget({
   }
 
   if (isRampRampsOrder(data)) {
-    if (!data.id) {
+    // OrdersList/DisplayOrder keys v2 rows by providerOrderId; Ramps OrderDetails
+    // resolves via getOrderById → providerOrderId match only. Use that for
+    // flag-OFF nav — not RampsOrder.id (canonical Activity identifier).
+    const orderId = data.providerOrderId;
+    if (!orderId) {
       return;
     }
-    navigation.navigate(
-      ...createRampsOrderDetailsNavDetails({ orderId: data.id }),
-    );
+    navigation.navigate(...createRampsOrderDetailsNavDetails({ orderId }));
     return;
   }
 

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
@@ -1,0 +1,97 @@
+/**
+ * Activity-owned mirror of OrdersList.handleItemPress routing.
+ * Must stay in sync with OrdersList.tsx (Ramps folder is import-only).
+ */
+import type { RampsOrder } from '@metamask/ramps-controller';
+import {
+  FIAT_ORDER_PROVIDERS,
+  FIAT_ORDER_STATES,
+} from '../../../../constants/on-ramp';
+import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import {
+  isRampFiatOrder,
+  isRampRampsOrder,
+} from '../../../../util/activity-adapters';
+import { createOrderDetailsNavDetails } from '../../../UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails';
+import { createRampsOrderDetailsNavDetails } from '../../../UI/Ramp/Views/OrderDetails';
+import { createDepositOrderDetailsNavDetails } from '../../../UI/Ramp/Views/OrderDetails/DepositOrderDetails/DepositOrderDetails';
+
+export type RampOrderTarget =
+  | 'ramps-v2-details'
+  | 'deposit-details'
+  | 'deposit-resume-buy'
+  | 'aggregator-details';
+
+export function resolveRampOrderTarget(
+  data: FiatOrder | RampsOrder,
+): RampOrderTarget {
+  if (isRampRampsOrder(data)) {
+    return 'ramps-v2-details';
+  }
+
+  if (data.provider === FIAT_ORDER_PROVIDERS.DEPOSIT) {
+    if (data.state === FIAT_ORDER_STATES.CREATED) {
+      return 'deposit-resume-buy';
+    }
+    return 'deposit-details';
+  }
+
+  if (data.provider === FIAT_ORDER_PROVIDERS.RAMPS_V2) {
+    return 'ramps-v2-details';
+  }
+
+  return 'aggregator-details';
+}
+
+export interface NavigateToRampOrderTargetArgs {
+  data: FiatOrder | RampsOrder;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors React Navigation's navigate spread of create*NavDetails
+  navigation: { navigate: (...args: any[]) => void };
+  goToBuy: () => void;
+}
+
+/**
+ * Flag-OFF consumer: navigates to the same destinations OrdersList uses.
+ * Always pass goToBuy from useRampNavigation().
+ */
+export function navigateToRampOrderTarget({
+  data,
+  navigation,
+  goToBuy,
+}: NavigateToRampOrderTargetArgs): void {
+  const target = resolveRampOrderTarget(data);
+
+  if (target === 'deposit-resume-buy') {
+    goToBuy();
+    return;
+  }
+
+  if (isRampRampsOrder(data)) {
+    if (!data.id) {
+      return;
+    }
+    navigation.navigate(
+      ...createRampsOrderDetailsNavDetails({ orderId: data.id }),
+    );
+    return;
+  }
+
+  // Narrowed FiatOrder
+  if (!isRampFiatOrder(data)) {
+    return;
+  }
+
+  const orderId = data.id;
+
+  switch (target) {
+    case 'ramps-v2-details':
+      navigation.navigate(...createRampsOrderDetailsNavDetails({ orderId }));
+      return;
+    case 'deposit-details':
+      navigation.navigate(...createDepositOrderDetailsNavDetails({ orderId }));
+      return;
+    case 'aggregator-details':
+    default:
+      navigation.navigate(...createOrderDetailsNavDetails({ orderId }));
+  }
+}

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
@@ -51,7 +51,9 @@ export interface NavigateToRampOrderTargetArgs {
 }
 
 /**
- * Flag-OFF consumer: navigates to the same destinations OrdersList uses.
+ * Flag-OFF only: navigates to the same destinations OrdersList uses.
+ * Callers must gate on `!isTransactionsRedesignEnabled` (ActivityList does —
+ * redesign ON goes to ActivityDetails / TemplateLoader instead).
  * Always pass goToBuy from useRampNavigation().
  */
 export function navigateToRampOrderTarget({

--- a/app/util/activity-adapters/adapters/ramp-order-guards.ts
+++ b/app/util/activity-adapters/adapters/ramp-order-guards.ts
@@ -10,7 +10,7 @@ import type { FiatOrder } from '../../../reducers/fiatOrders/types';
 export function isRampFiatOrder(
   data: FiatOrder | RampsOrder,
 ): data is FiatOrder {
-  return typeof (data as FiatOrder).provider === 'string' && 'state' in data;
+  return typeof (data as FiatOrder).provider === 'string';
 }
 
 export function isRampRampsOrder(

--- a/app/util/activity-adapters/adapters/ramp-order-guards.ts
+++ b/app/util/activity-adapters/adapters/ramp-order-guards.ts
@@ -1,0 +1,20 @@
+import type { RampsOrder } from '@metamask/ramps-controller';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { FiatOrder } from '../../../reducers/fiatOrders/types';
+
+/**
+ * Discriminates legacy fiat Redux orders from native RampsController orders.
+ * FiatOrder.provider is a FIAT_ORDER_PROVIDERS string; RampsOrder.provider is
+ * an object (or absent).
+ */
+export function isRampFiatOrder(
+  data: FiatOrder | RampsOrder,
+): data is FiatOrder {
+  return typeof (data as FiatOrder).provider === 'string' && 'state' in data;
+}
+
+export function isRampRampsOrder(
+  data: FiatOrder | RampsOrder,
+): data is RampsOrder {
+  return !isRampFiatOrder(data);
+}

--- a/app/util/activity-adapters/adapters/ramps-order-helpers.ts
+++ b/app/util/activity-adapters/adapters/ramps-order-helpers.ts
@@ -107,13 +107,16 @@ export function toRampsOrderToken(
   order: RampsOrder,
   direction: TokenAmount['direction'],
 ): TokenAmount {
+  // RampsOrder.cryptoAmount is already human-readable. Activity TokenAmount
+  // amounts are treated as atomic when `decimals` is set
+  // (`getHumanReadableTokenAmount` → formatUnits), so do not attach decimals
+  // from cryptoCurrency metadata here.
   return {
     amount:
       order.cryptoAmount === undefined || order.cryptoAmount === null
         ? undefined
         : String(order.cryptoAmount),
     assetId: order.cryptoCurrency?.assetId,
-    decimals: order.cryptoCurrency?.decimals,
     symbol: order.cryptoCurrency?.symbol,
     direction,
   };

--- a/app/util/activity-adapters/adapters/ramps-order-helpers.ts
+++ b/app/util/activity-adapters/adapters/ramps-order-helpers.ts
@@ -1,0 +1,120 @@
+import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
+import {
+  isCaipChainId,
+  parseCaipChainId,
+  toCaipChainId,
+  type CaipChainId,
+} from '@metamask/utils';
+import { getDecimalChainId } from '../../../util/networks';
+import type { Status, TokenAmount } from '../types';
+import {
+  toRampOrderCaipChainId,
+  type RampActivityKind,
+} from './ramp-order-helpers';
+
+/**
+ * Maps a RampsController order type string to an activity kind.
+ * DEPOSIT is treated as buy at the activity layer (mirrors legacy Deposit).
+ */
+export function mapRampsOrderType(
+  orderType: string | null | undefined,
+): RampActivityKind | null {
+  switch (orderType) {
+    case 'BUY':
+    case 'DEPOSIT':
+      return 'buy';
+    case 'SELL':
+      return 'sell';
+    default:
+      return null;
+  }
+}
+
+export function mapRampsOrderStatus(status: RampsOrderStatus): Status {
+  switch (status) {
+    case RampsOrderStatus.Completed:
+      return 'success';
+    case RampsOrderStatus.Failed:
+    case RampsOrderStatus.IdExpired:
+      return 'failed';
+    case RampsOrderStatus.Cancelled:
+      return 'cancelled';
+    case RampsOrderStatus.Pending:
+    case RampsOrderStatus.Created:
+    case RampsOrderStatus.Precreated:
+    case RampsOrderStatus.Unknown:
+    default:
+      return 'pending';
+  }
+}
+
+function toEpochMs(value: unknown): number {
+  if (typeof value === 'number' && value > 0) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const ms = new Date(value).getTime();
+    if (!Number.isNaN(ms)) {
+      return ms;
+    }
+  }
+  return 0;
+}
+
+export function getRampsOrderCreatedAt(order: RampsOrder): number {
+  return toEpochMs(order.createdAt);
+}
+
+/**
+ * Resolves CAIP-2 chain id from `network` (object or decimal/CAIP string) or
+ * `cryptoCurrency.chainId`.
+ */
+export function toRampsOrderCaipChainId(order: RampsOrder): CaipChainId | null {
+  const network = order.network as RampsOrder['network'] | string | null;
+  if (network && typeof network === 'object' && network.chainId) {
+    return toRampOrderCaipChainId(network.chainId);
+  }
+  if (typeof network === 'string' && network) {
+    return toRampOrderCaipChainId(network);
+  }
+
+  const cryptoChainId = order.cryptoCurrency?.chainId;
+  if (cryptoChainId) {
+    try {
+      if (isCaipChainId(cryptoChainId)) {
+        const { namespace, reference } = parseCaipChainId(cryptoChainId);
+        return toCaipChainId(namespace, reference);
+      }
+      const chainReference = getDecimalChainId(cryptoChainId);
+      if (chainReference && !Number.isNaN(Number(chainReference))) {
+        return toCaipChainId('eip155', chainReference);
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function getRampsOrderTransactionHash(
+  order: RampsOrder,
+): string | undefined {
+  return order.txHash || undefined;
+}
+
+export function toRampsOrderToken(
+  order: RampsOrder,
+  direction: TokenAmount['direction'],
+): TokenAmount {
+  return {
+    amount:
+      order.cryptoAmount === undefined || order.cryptoAmount === null
+        ? undefined
+        : String(order.cryptoAmount),
+    assetId: order.cryptoCurrency?.assetId,
+    decimals: order.cryptoCurrency?.decimals,
+    symbol: order.cryptoCurrency?.symbol,
+    direction,
+  };
+}

--- a/app/util/activity-adapters/adapters/ramps-order.test.ts
+++ b/app/util/activity-adapters/adapters/ramps-order.test.ts
@@ -1,0 +1,194 @@
+import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
+import { mapRampsOrder } from './ramps-order';
+import { rampsOrderToFiatOrder } from '../../../components/UI/Ramp/orderProcessor/unifiedOrderProcessor';
+import { mapRampOrder } from './ramp-order';
+
+const baseOrder: RampsOrder = {
+  isOnlyLink: false,
+  success: true,
+  cryptoAmount: '5.01',
+  fiatAmount: 6.27,
+  providerOrderId: 'provider-order-1',
+  providerOrderLink: 'https://example.com/order/1',
+  createdAt: 1_700_000_000_000,
+  totalFeesFiat: 1.26,
+  txHash: '0xbuyhash',
+  walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+  status: RampsOrderStatus.Completed,
+  network: { name: 'Ethereum', chainId: 'eip155:1' },
+  canBeUpdated: false,
+  idHasExpired: false,
+  excludeFromPurchases: false,
+  timeDescriptionPending: '5-10 minutes',
+  orderType: 'BUY',
+  id: '/providers/transak/orders/provider-order-1',
+  cryptoCurrency: {
+    symbol: 'mUSD',
+    decimals: 6,
+    assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+    chainId: 'eip155:1',
+  },
+  fiatCurrency: { symbol: 'USD', decimals: 2 },
+};
+
+describe('mapRampsOrder', () => {
+  it('maps a buy order to buy with an incoming token', () => {
+    expect(mapRampsOrder({ order: baseOrder })).toEqual({
+      type: 'buy',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 1_700_000_000_000,
+      hash: '0xbuyhash',
+      raw: { type: 'rampOrder', data: baseOrder },
+      data: {
+        from: baseOrder.walletAddress,
+        token: {
+          amount: '5.01',
+          symbol: 'mUSD',
+          assetId: baseOrder.cryptoCurrency?.assetId,
+          decimals: 6,
+          direction: 'in',
+        },
+      },
+    });
+  });
+
+  it('maps DEPOSIT orderType to buy', () => {
+    expect(
+      mapRampsOrder({ order: { ...baseOrder, orderType: 'DEPOSIT' } }),
+    ).toMatchObject({
+      type: 'buy',
+      data: { token: { direction: 'in' } },
+    });
+  });
+
+  it('maps a sell order to sell with an outgoing token', () => {
+    expect(
+      mapRampsOrder({
+        order: {
+          ...baseOrder,
+          orderType: 'SELL',
+          cryptoAmount: '0.085',
+          cryptoCurrency: { symbol: 'ETH', decimals: 18 },
+        },
+      }),
+    ).toMatchObject({
+      type: 'sell',
+      hash: '0xbuyhash',
+      data: {
+        token: {
+          amount: '0.085',
+          symbol: 'ETH',
+          direction: 'out',
+        },
+      },
+    });
+  });
+
+  it.each([
+    [RampsOrderStatus.Pending, 'pending'],
+    [RampsOrderStatus.Created, 'pending'],
+    [RampsOrderStatus.Failed, 'failed'],
+    [RampsOrderStatus.Cancelled, 'cancelled'],
+  ] as const)('maps %s status to %s', (status, expected) => {
+    expect(mapRampsOrder({ order: { ...baseOrder, status } })?.status).toBe(
+      expected,
+    );
+  });
+
+  it('falls back to canonical order id when no transaction hash is available', () => {
+    const order = {
+      ...baseOrder,
+      txHash: '',
+      id: '/providers/moonpay/orders/844a3b07',
+      providerOrderId: 'different-provider-id',
+    };
+
+    expect(mapRampsOrder({ order })?.hash).toBe(
+      '/providers/moonpay/orders/844a3b07',
+    );
+  });
+
+  it('normalizes ISO createdAt strings to epoch ms', () => {
+    const order = {
+      ...baseOrder,
+      createdAt: '2026-06-23T20:12:39.739Z' as unknown as number,
+    };
+
+    expect(mapRampsOrder({ order })?.timestamp).toBe(
+      new Date('2026-06-23T20:12:39.739Z').getTime(),
+    );
+  });
+
+  it('maps decimal network string to eip155 CAIP-2', () => {
+    const order = {
+      ...baseOrder,
+      network: '1' as unknown as RampsOrder['network'],
+      cryptoCurrency: undefined,
+    };
+
+    expect(mapRampsOrder({ order })?.chainId).toBe('eip155:1');
+  });
+
+  it('maps non-EVM CAIP-2 network metadata', () => {
+    const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    expect(
+      mapRampsOrder({
+        order: {
+          ...baseOrder,
+          network: { name: 'Solana', chainId: solanaChainId },
+          cryptoCurrency: { symbol: 'SOL', chainId: solanaChainId },
+        },
+      }),
+    ).toMatchObject({
+      type: 'buy',
+      chainId: solanaChainId,
+    });
+  });
+
+  it('returns null for excluded orders', () => {
+    expect(
+      mapRampsOrder({
+        order: { ...baseOrder, excludeFromPurchases: true },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for unknown order types', () => {
+    expect(
+      mapRampsOrder({ order: { ...baseOrder, orderType: 'UNKNOWN' } }),
+    ).toBeNull();
+  });
+
+  it('matches top-level ActivityListItem fields with the converted FiatOrder path', () => {
+    const converted = mapRampOrder({
+      order: rampsOrderToFiatOrder(baseOrder),
+    });
+    const native = mapRampsOrder({ order: baseOrder });
+
+    expect(native).toMatchObject({
+      type: converted?.type,
+      chainId: converted?.chainId,
+      status: converted?.status,
+      hash: converted?.hash,
+      data: {
+        token: {
+          amount:
+            converted?.data && 'token' in converted.data
+              ? converted.data.token?.amount
+              : undefined,
+          symbol:
+            converted?.data && 'token' in converted.data
+              ? converted.data.token?.symbol
+              : undefined,
+          direction:
+            converted?.data && 'token' in converted.data
+              ? converted.data.token?.direction
+              : undefined,
+        },
+      },
+    });
+    expect(native?.raw?.type).toBe('rampOrder');
+    expect(native?.raw?.data).toBe(baseOrder);
+  });
+});

--- a/app/util/activity-adapters/adapters/ramps-order.test.ts
+++ b/app/util/activity-adapters/adapters/ramps-order.test.ts
@@ -46,11 +46,39 @@ describe('mapRampsOrder', () => {
           amount: '5.01',
           symbol: 'mUSD',
           assetId: baseOrder.cryptoCurrency?.assetId,
-          decimals: 6,
           direction: 'in',
         },
       },
     });
+  });
+
+  it('keeps human-readable cryptoAmount without token decimals', () => {
+    const order = {
+      ...baseOrder,
+      cryptoAmount: '30',
+      cryptoCurrency: {
+        symbol: 'mUSD',
+        decimals: 6,
+        assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+        chainId: 'eip155:1',
+      },
+    };
+
+    expect(mapRampsOrder({ order })).toMatchObject({
+      data: {
+        token: {
+          amount: '30',
+          symbol: 'mUSD',
+          assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+          direction: 'in',
+        },
+      },
+    });
+    expect(mapRampsOrder({ order })?.data).toEqual(
+      expect.objectContaining({
+        token: expect.not.objectContaining({ decimals: expect.anything() }),
+      }),
+    );
   });
 
   it('maps DEPOSIT orderType to buy', () => {

--- a/app/util/activity-adapters/adapters/ramps-order.ts
+++ b/app/util/activity-adapters/adapters/ramps-order.ts
@@ -1,0 +1,63 @@
+/**
+ * Maps native RampsController orders into the shared `ActivityListItem` shape.
+ * Parallel to `mapRampOrder` for legacy FiatOrder — no conversion between the
+ * two order types.
+ */
+import type { RampsOrder } from '@metamask/ramps-controller';
+import type { ActivityListItem } from '../types';
+import {
+  getRampsOrderCreatedAt,
+  getRampsOrderTransactionHash,
+  mapRampsOrderStatus,
+  mapRampsOrderType,
+  toRampsOrderCaipChainId,
+  toRampsOrderToken,
+} from './ramps-order-helpers';
+
+export interface MapRampsOrderArgs {
+  order: RampsOrder;
+}
+
+/**
+ * Returns `null` for orders that should not surface in the activity feed or
+ * cannot be normalized safely.
+ */
+export function mapRampsOrder({
+  order,
+}: MapRampsOrderArgs): ActivityListItem | null {
+  if (order.excludeFromPurchases) {
+    return null;
+  }
+
+  const type = mapRampsOrderType(order.orderType);
+  if (!type) {
+    return null;
+  }
+
+  const chainId = toRampsOrderCaipChainId(order);
+  if (!chainId) {
+    return null;
+  }
+
+  const isSell = type === 'sell';
+  const transactionHash = getRampsOrderTransactionHash(order);
+  // Prefer on-chain hash; fall back to canonical RampsOrder.id (not
+  // providerOrderId) for stable row identity before a tx lands.
+  const hash = transactionHash || order.id;
+  if (!hash) {
+    return null;
+  }
+
+  return {
+    type,
+    chainId,
+    status: mapRampsOrderStatus(order.status),
+    timestamp: getRampsOrderCreatedAt(order),
+    hash,
+    raw: { type: 'rampOrder', data: order },
+    data: {
+      from: order.walletAddress,
+      token: toRampsOrderToken(order, isSell ? 'out' : 'in'),
+    },
+  };
+}

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -22,6 +22,11 @@ export { mapLocalTransaction } from './adapters/local-transaction';
 export { mapPredictActivity } from './adapters/predict-activity';
 export { mapPerpsTransaction } from './adapters/perps-transaction';
 export { mapRampOrder } from './adapters/ramp-order';
+export { mapRampsOrder } from './adapters/ramps-order';
+export {
+  isRampFiatOrder,
+  isRampRampsOrder,
+} from './adapters/ramp-order-guards';
 export {
   mobileActivityAdapterEnvironment,
   type ActivityAdapterEnvironment,

--- a/app/util/activity-adapters/types.ts
+++ b/app/util/activity-adapters/types.ts
@@ -11,6 +11,7 @@ import type { TransactionGroup } from './adapters/transaction-group';
 import type { PerpsTransaction } from '../../components/UI/Perps/types/transactionHistory';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { PredictActivity } from '../../components/UI/Predict/types';
+import type { RampsOrder } from '@metamask/ramps-controller';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { FiatOrder } from '../../reducers/fiatOrders/types';
 
@@ -134,7 +135,7 @@ interface ActivityData<Type extends ActivityKind, Data> {
     | { type: 'localTransaction'; data: TransactionGroup }
     | { type: 'perpsTransaction'; data: PerpsTransaction }
     | { type: 'predictActivity'; data: PredictActivity }
-    | { type: 'rampOrder'; data: FiatOrder };
+    | { type: 'rampOrder'; data: FiatOrder | RampsOrder };
   data: Data;
 }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6426,6 +6426,7 @@
     "failed": "Failed",
     "cancelled": "Cancelled",
     "view_on_provider": "View on {{provider}}",
+    "view_order": "View Order",
     "order_id": "Order ID",
     "date_and_time": "Date and time",
     "fees": "Fees",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity previously treated v2 ramp orders as second-class citizens: `useRampActivityItems` converted `RampsOrder` → `FiatOrder` via `rampsOrderToFiatOrder`, and details/navigation assumed the FiatOrder shape. That made Activity diverge from OrdersList routing and blocked first-class fields (provider links, `statusDescription`, native ids) from reaching the redesigned details templates.

This PR maps `RampsOrder` natively end-to-end in Activity (list + details), keeps flag-OFF navigation in parity with OrdersList, and preserves critical offramp UX:

- **Native adapter:** `mapRampsOrder` / helpers / guards; `raw.data` is `FiatOrder | RampsOrder` with type guards.
- **List:** `useRampActivityItems` maps each display source natively (no Activity-path conversion).
- **Details:** `RampDetails` dispatches to `RampFiatOrderDetails` | `RampRampsOrderDetails`, with shared Order ID copy pill, provider link (“View on {provider}” / “View Order” fallback), and centered `statusDescription` below Transaction ID.
- **Navigation:** `resolveRampOrderTarget` / `navigateToRampOrderTarget` mirror OrdersList. Redesign ON → ActivityDetails for buys; **sells always open legacy OrderDetails** (Send Transaction / Continue order). CREATED deposits still call `goToBuy()`. Flag-OFF native rows navigate with `providerOrderId` (OrderDetails lookup key).
- **Amounts:** native tokens omit `decimals` so human-readable `cryptoAmount` is not re-scaled by `formatUnits` (same class of bug as #33428 / #33537 for FiatOrder).

Does not modify screens under `app/components/UI/Ramp/` except for navigation imports.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved Activity Buy/Sell so ramp orders use first-class details, correct amounts, provider links, and keep sell Send Transaction on the classic order details screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33428

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Activity first-class RampsOrder

  Background:
    Given I am logged into MetaMask Mobile
    And the redesigned Activity list is enabled
    And I have buy and sell ramp history (legacy FiatOrder and/or native RampsOrder)

  Scenario: Buy opens redesigned Activity details
    Given I open Activity and filter to Buy/Sell
    When I tap a completed buy / deposit row
    Then Activity Details shows the crypto amount, status, truncated Order ID with copy success icon
    And if providerOrderLink exists I see "View on {provider}" or "View Order"
    And if statusDescription exists it appears centered below Transaction ID

  Scenario: Sell keeps legacy OrderDetails for Send Transaction
    Given I have a sell order that still needs Continue / Send Transaction
    When I tap the sell row with redesign enabled
    Then I land on legacy Aggregator/Ramps Order Details (not Activity Details)
    And I can continue the Send Transaction flow

  Scenario: CREATED deposit resumes buy
    Given I have a DEPOSIT order in CREATED state
    When I tap that row (redesign on or off)
    Then the buy flow resumes via goToBuy instead of a details screen

  Scenario: Flag OFF navigation matches OrdersList
    Given transactions redesign is disabled
    When I tap aggregator, deposit, RAMPS_V2 shim, or native RampsOrder rows
    Then I navigate to the same OrderDetails destinations OrdersList uses
    And native RampsOrder uses providerOrderId for lookup

  Scenario: Human-readable amounts on the list
    Given I have a buy of an integer ERC-20 amount with token decimals in metadata (e.g. 30 mUSD)
    When I view the Buy/Sell list
    Then the row shows "+30 mUSD" (or locale equivalent), not a micro amount like "+0.00003"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of this change. -->

### **Before**

N/A — Ramps order were not natively supported 

### **After**


<img width="300" alt="image" src="https://github.com/user-attachments/assets/7c592713-191b-4cd7-82ed-e8d9f9f42602" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for-Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Activity list press routing and ramp order identity (Fiat vs Ramps shapes) across adapters and details; sell/offramp and deposit CREATED paths are explicitly special-cased to avoid UX regressions.
> 
> **Overview**
> Activity now treats **RampsController `RampsOrder`** the same as legacy **`FiatOrder`** end-to-end, without converting v2 orders into fiat shape in the list path.
> 
> **List & adapters:** `useRampActivityItems` maps legacy and v2 sources separately via `mapRampOrder` / `mapRampsOrder`; `raw.data` is `FiatOrder | RampsOrder` with `isRampFiatOrder` / `isRampRampsOrder`. Native mapping omits token `decimals` so human-readable `cryptoAmount` is not re-scaled on rows.
> 
> **Details UI:** `RampDetails` is a thin dispatcher to `RampFiatOrderDetails` and `RampRampsOrderDetails`, with shared pieces in `RampDetailsShared` (truncated order ID + copy, optional **View on {provider}** / **View Order**, centered `statusDescription`).
> 
> **Navigation:** `resolveRampOrderTarget` / `navigateToRampOrderTarget` mirror OrdersList. With redesign **on**, buy/deposit rows go to Activity Details; **sells always use legacy OrderDetails** (Send Transaction flow). CREATED deposits call `goToBuy()` regardless of flag. With redesign **off**, native v2 nav uses `providerOrderId` for lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522a3706007316e311a18182fd88bde954865a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->