### PR TITLE
fix: Polish token contract copy toast icon styling

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useCopyTokenContractAddress.ts
+++ b/app/components/UI/TokenDetails/hooks/useCopyTokenContractAddress.ts
@@ -25,9 +25,8 @@ export const useCopyTokenContractAddress = (
 
     toastRef?.current?.showToast({
       variant: ToastVariants.Icon,
-      iconName: IconName.CheckBold,
-      iconColor: colors.accent03.dark,
-      backgroundColor: colors.accent03.normal,
+      iconName: IconName.Confirmation,
+      iconColor: colors.success.default,
       labelOptions: [
         { label: strings('account_details.account_copied_to_clipboard') },
       ],


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Aligns the token contract address copy toast with the updated success toast visual pattern used elsewhere in the app.

1. **Reason:** The copy-address toast still used the older `CheckBold` icon with accent03 icon/background colors, which no longer matches the polished success toast style.
2. **Solution:** Updates `useCopyTokenContractAddress` to use `IconName.Confirmation` with `colors.success.default`, and removes the filled icon background so spacing/alignment follows the shared Toast layout.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the token contract address copy toast to use the success confirmation icon styling

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs:

**Related PRs**

| PR | Description |
|----|-------------|
| [#32933](https://github.com/MetaMask/metamask-mobile/pull/32933) | Update DS legacy toast with iOS animation and UI polish (`toast/animate-ds-legacy`)|
| [#32943](https://github.com/MetaMask/metamask-mobile/pull/32943) | Polish perps toast for new animation (`toast/polish-perps`) |
| [#32946](https://github.com/MetaMask/metamask-mobile/pull/32946) | Polish money toast for new animation (`toast/polish-money`) |
| [#32945](https://github.com/MetaMask/metamask-mobile/pull/32945) | Polish predict toast for new animation (`toast/polish-predict`) |
| [#32947](https://github.com/MetaMask/metamask-mobile/pull/32947) | Polish earn, quick-buy, rewards and gas toast for new animation (`toast/polish-features`) |

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token contract address copy toast

  Scenario: user copies a token contract address from token details
    Given the user is on the Token Details screen for a non-native token

    When the user taps the contract address copy action
    Then a toast appears with the confirmation success icon in the success color
    And the toast message indicates the address was copied to the clipboard
    And the toast uses the standard Toast vertical centering and spacing
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/e1485ca2-2d4f-444f-ba41-488a0cb0f851



### **After**


https://github.com/user-attachments/assets/25b6099b-d40c-4bb1-8ce5-c991a5fd794f



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)
