### PR TITLE
feat(perps): add Pro order form UI

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -474,6 +474,7 @@ export const PerpsProOrderFormSelectorsIDs = {
   LIMIT_PRICE_INPUT: 'perps-pro-order-form-limit-price-input',
   MID_PRICE_BUTTON: 'perps-pro-order-form-mid-price',
   SIZE_INPUT: 'perps-pro-order-form-size-input',
+  SIZE_SLIDER: 'perps-pro-order-form-size-slider',
   SIZE_UNIT_BUTTON: 'perps-pro-order-form-size-unit',
   KEYBOARD_CLOSE: 'perps-pro-order-form-keyboard-close',
   AVAILABLE_BALANCE: 'perps-pro-order-form-available-balance',
@@ -486,7 +487,9 @@ export const PerpsProOrderFormSelectorsIDs = {
   SUMMARY_MARGIN: 'perps-pro-order-form-summary-margin',
   SUMMARY_LIQUIDATION: 'perps-pro-order-form-summary-liquidation',
   SUMMARY_SLIPPAGE: 'perps-pro-order-form-summary-slippage',
+  SUMMARY_SLIPPAGE_BUTTON: 'perps-pro-order-form-summary-slippage-button',
   SUMMARY_FEES: 'perps-pro-order-form-summary-fees',
+  SUMMARY_FEES_BUTTON: 'perps-pro-order-form-summary-fees-button',
   SUMMARY_FEES_VALUE: 'perps-pro-order-form-summary-fees-value',
 };
 

--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -464,6 +464,32 @@ export const PerpsProMarketViewSelectorsIDs = {
   POSITIONS_PANEL: 'perps-pro-market-positions-panel',
 };
 
+export const PerpsProOrderFormSelectorsIDs = {
+  CONTAINER: 'perps-pro-order-form',
+  DIRECTION_CONTROL: 'perps-pro-order-form-direction-control',
+  DIRECTION_LONG: 'perps-pro-order-form-direction-long',
+  DIRECTION_SHORT: 'perps-pro-order-form-direction-short',
+  LEVERAGE_BUTTON: 'perps-pro-order-form-leverage',
+  ORDER_TYPE_BUTTON: 'perps-pro-order-form-order-type',
+  LIMIT_PRICE_INPUT: 'perps-pro-order-form-limit-price-input',
+  MID_PRICE_BUTTON: 'perps-pro-order-form-mid-price',
+  SIZE_INPUT: 'perps-pro-order-form-size-input',
+  SIZE_UNIT_BUTTON: 'perps-pro-order-form-size-unit',
+  KEYBOARD_CLOSE: 'perps-pro-order-form-keyboard-close',
+  AVAILABLE_BALANCE: 'perps-pro-order-form-available-balance',
+  ADD_FUNDS_BUTTON: 'perps-pro-order-form-add-funds',
+  REDUCE_ONLY: 'perps-pro-order-form-reduce-only',
+  TPSL: 'perps-pro-order-form-tpsl',
+  NOTICE: 'perps-pro-order-form-notice',
+  PLACE_ORDER_BUTTON: 'perps-pro-order-form-place-order',
+  SUMMARY: 'perps-pro-order-form-summary',
+  SUMMARY_MARGIN: 'perps-pro-order-form-summary-margin',
+  SUMMARY_LIQUIDATION: 'perps-pro-order-form-summary-liquidation',
+  SUMMARY_SLIPPAGE: 'perps-pro-order-form-summary-slippage',
+  SUMMARY_FEES: 'perps-pro-order-form-summary-fees',
+  SUMMARY_FEES_VALUE: 'perps-pro-order-form-summary-fees-value',
+};
+
 // ========================================
 // PERPS MARKET HEADER SELECTORS
 // ========================================

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -111,6 +111,14 @@ describe('PerpsProMarketView', () => {
     );
   });
 
+  it('keeps the fixture Place Order action disabled until wiring lands', () => {
+    const { getByTestId } = renderView();
+
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON),
+    ).toBeDisabled();
+  });
+
   it('keeps the header fixed while the market summary scrolls', () => {
     const { getByTestId } = renderView();
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { within } from '@testing-library/react-native';
+import { fireEvent, within } from '@testing-library/react-native';
 import PerpsProMarketView from './';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
+  PerpsOrderTypeBottomSheetSelectorsIDs,
 } from '../../Perps.testIds';
 
 interface MockRouteParams {
@@ -117,6 +118,84 @@ describe('PerpsProMarketView', () => {
     expect(
       getByTestId(PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON),
     ).toBeDisabled();
+  });
+
+  it('opens the order type sheet from the form', () => {
+    const { getByTestId } = renderView();
+
+    fireEvent.press(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+
+    expect(
+      getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
+
+  it('updates the form to Market and closes the order type sheet', () => {
+    const { getByTestId, queryByTestId } = renderView();
+    fireEvent.press(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+
+    fireEvent.press(
+      getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION),
+    );
+
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    ).toHaveTextContent('Market');
+    expect(
+      queryByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('restores the limit price input when Limit is selected', () => {
+    const { getByTestId, queryByTestId } = renderView();
+    fireEvent.press(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+    fireEvent.press(
+      getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION),
+    );
+    fireEvent.press(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+
+    fireEvent.press(
+      getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION),
+    );
+
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('closes the order type sheet without changing the current selection', () => {
+    const { getByTestId, queryByTestId } = renderView();
+    fireEvent.press(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+
+    fireEvent.press(
+      getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    ).toHaveTextContent('Limit');
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders the Pro summary and available balance copy from Figma', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -119,6 +119,17 @@ describe('PerpsProMarketView', () => {
     ).toBeDisabled();
   });
 
+  it('renders the Pro summary and available balance copy from Figma', () => {
+    const { getByTestId } = renderView();
+
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.SUMMARY_LIQUIDATION),
+    ).toHaveTextContent(/Est Liquidation/);
+    expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.AVAILABLE_BALANCE),
+    ).toHaveTextContent('-- available');
+  });
+
   it('keeps the header fixed while the market summary scrolls', () => {
     const { getByTestId } = renderView();
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -3,7 +3,10 @@ import { within } from '@testing-library/react-native';
 import PerpsProMarketView from './';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
-import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
+import {
+  PerpsProMarketViewSelectorsIDs,
+  PerpsProOrderFormSelectorsIDs,
+} from '../../Perps.testIds';
 
 interface MockRouteParams {
   market?: { symbol: string };
@@ -85,11 +88,27 @@ describe('PerpsProMarketView', () => {
       getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL),
     ).toBeOnTheScreen();
     expect(
+      getByTestId(PerpsProOrderFormSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(
       getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_BOOK_PANEL),
     ).toBeOnTheScreen();
     expect(
       getByTestId(PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL),
     ).toBeOnTheScreen();
+  });
+
+  it('dismisses the native keyboard interactively without swallowing taps', () => {
+    const { getByTestId } = renderView();
+
+    expect(getByTestId(PerpsProMarketViewSelectorsIDs.SCROLL_VIEW)).toHaveProp(
+      'keyboardDismissMode',
+      'interactive',
+    );
+    expect(getByTestId(PerpsProMarketViewSelectorsIDs.SCROLL_VIEW)).toHaveProp(
+      'keyboardShouldPersistTaps',
+      'handled',
+    );
   });
 
   it('keeps the header fixed while the market summary scrolls', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -5,14 +5,18 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { getPerpsDisplaySymbol } from '@metamask/perps-controller';
+import {
+  getPerpsDisplaySymbol,
+  type OrderType,
+} from '@metamask/perps-controller';
 import { useRoute, type RouteProp } from '@react-navigation/native';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
+import PerpsOrderTypeBottomSheetView from '../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
 import type { PerpsStackParamList } from '../../types/navigation';
 import PerpsProChartPanel from './components/PerpsProChartPanel';
 import PerpsProMarketHeader from './components/PerpsProMarketHeader';
@@ -37,6 +41,22 @@ const PerpsProMarketView = () => {
   const route =
     useRoute<RouteProp<PerpsStackParamList, 'PerpsMarketDetails'>>();
   const market = route.params?.market;
+
+  const [orderType, setOrderType] = useState<OrderType>('limit');
+  const [isOrderTypeSheetVisible, setIsOrderTypeSheetVisible] = useState(false);
+
+  const handleOrderTypeButtonPress = useCallback(() => {
+    setIsOrderTypeSheetVisible(true);
+  }, []);
+
+  const handleOrderTypeSheetClose = useCallback(() => {
+    setIsOrderTypeSheetVisible(false);
+  }, []);
+
+  const handleOrderTypeSelect = useCallback((newOrderType: OrderType) => {
+    setOrderType(newOrderType);
+    setIsOrderTypeSheetVisible(false);
+  }, []);
 
   if (!market?.symbol) {
     return (
@@ -77,12 +97,26 @@ const PerpsProMarketView = () => {
         <PerpsProChartPanel />
         <PerpsProStatsBar />
         <PerpsProMarketLayout
-          orderForm={<PerpsProOrderFormPanel />}
+          orderForm={
+            <PerpsProOrderFormPanel
+              orderType={orderType}
+              onOrderTypeChange={setOrderType}
+              onOrderTypeButtonPress={handleOrderTypeButtonPress}
+            />
+          }
           orderBook={<PerpsProOrderBookPanel />}
         />
         <SectionDivider />
         <PerpsProPositionsPanel />
       </ScrollView>
+      <PerpsOrderTypeBottomSheetView
+        isVisible={isOrderTypeSheetVisible}
+        onClose={handleOrderTypeSheetClose}
+        onSelect={handleOrderTypeSelect}
+        currentOrderType={orderType}
+        title={strings('perps.pro_order_form.choose_order_type')}
+        showSelectedIcon
+      />
     </SafeAreaView>
   );
 };

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -70,6 +70,8 @@ const PerpsProMarketView = () => {
         contentContainerStyle={styles.scrollContent}
         testID={PerpsProMarketViewSelectorsIDs.SCROLL_VIEW}
         showsVerticalScrollIndicator={false}
+        keyboardDismissMode="interactive"
+        keyboardShouldPersistTaps="handled"
       >
         <PerpsProMarketSummary />
         <PerpsProChartPanel />

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -100,7 +100,6 @@ const PerpsProMarketView = () => {
           orderForm={
             <PerpsProOrderFormPanel
               orderType={orderType}
-              onOrderTypeChange={setOrderType}
               onOrderTypeButtonPress={handleOrderTypeButtonPress}
             />
           }

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -5,6 +5,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { Keyboard, Platform } from 'react-native';
 export const PERPS_PRO_INPUT_ACCESSORY_ID =
@@ -18,6 +19,7 @@ interface PerpsProCompactInputProps {
   endAccessory?: React.ReactNode;
   footer?: React.ReactNode;
   placeholder?: string;
+  placeholderColor?: 'default' | 'muted';
 }
 const PerpsProCompactInput = ({
   label,
@@ -28,7 +30,9 @@ const PerpsProCompactInput = ({
   endAccessory,
   footer,
   placeholder = '0',
+  placeholderColor = 'muted',
 }: PerpsProCompactInputProps) => {
+  const tw = useTailwind();
   const inputAccessoryViewID =
     Platform.OS === 'ios' ? PERPS_PRO_INPUT_ACCESSORY_ID : undefined;
   const input = (
@@ -40,6 +44,7 @@ const PerpsProCompactInput = ({
       onSubmitEditing={Keyboard.dismiss}
       inputAccessoryViewID={inputAccessoryViewID}
       placeholder={placeholder}
+      placeholderTextColor={tw.color(`text-${placeholderColor}`)}
       textVariant={TextVariant.BodySm}
       isStateStylesDisabled
       twClassName="flex-1 border-0 bg-transparent p-0 font-medium"

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -1,0 +1,64 @@
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Input,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React from 'react';
+import { Keyboard, Platform } from 'react-native';
+export const PERPS_PRO_INPUT_ACCESSORY_ID =
+  'perps-pro-order-form-input-accessory';
+interface PerpsProCompactInputProps {
+  label: string;
+  value: string;
+  onChangeText: (value: string) => void;
+  testID: string;
+  endAccessory?: React.ReactNode;
+  footer?: React.ReactNode;
+  placeholder?: string;
+}
+const PerpsProCompactInput = ({
+  label,
+  value,
+  onChangeText,
+  testID,
+  endAccessory,
+  footer,
+  placeholder = '0',
+}: PerpsProCompactInputProps) => {
+  const inputAccessoryViewID =
+    Platform.OS === 'ios' ? PERPS_PRO_INPUT_ACCESSORY_ID : undefined;
+  return (
+    <Box twClassName="rounded-xl bg-muted p-3" testID={`${testID}-container`}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+      >
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {label}
+        </Text>
+        {endAccessory}
+      </Box>
+      <Input
+        value={value}
+        onChangeText={onChangeText}
+        keyboardType="decimal-pad"
+        returnKeyType="done"
+        onSubmitEditing={Keyboard.dismiss}
+        inputAccessoryViewID={inputAccessoryViewID}
+        placeholder={placeholder}
+        isStateStylesDisabled
+        twClassName="border-0 bg-transparent p-0"
+        testID={testID}
+        accessibilityLabel={label}
+      />
+      {footer}
+    </Box>
+  );
+};
+export default PerpsProCompactInput;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -23,6 +23,7 @@ interface PerpsProCompactInputProps {
   placeholder?: string;
   placeholderColor?: 'default' | 'muted';
 }
+
 const PerpsProCompactInput = ({
   label,
   value,
@@ -37,6 +38,7 @@ const PerpsProCompactInput = ({
   const tw = useTailwind();
   const inputAccessoryViewID =
     Platform.OS === 'ios' ? getPerpsProInputAccessoryID(testID) : undefined;
+
   const input = (
     <Input
       value={value}
@@ -80,4 +82,5 @@ const PerpsProCompactInput = ({
     </Box>
   );
 };
+
 export default PerpsProCompactInput;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -1,8 +1,5 @@
 import {
   Box,
-  BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
   Input,
   Text,
   TextColor,
@@ -17,6 +14,7 @@ interface PerpsProCompactInputProps {
   value: string;
   onChangeText: (value: string) => void;
   testID: string;
+  variant?: 'stacked' | 'inline';
   endAccessory?: React.ReactNode;
   footer?: React.ReactNode;
   placeholder?: string;
@@ -26,37 +24,51 @@ const PerpsProCompactInput = ({
   value,
   onChangeText,
   testID,
+  variant = 'stacked',
   endAccessory,
   footer,
   placeholder = '0',
 }: PerpsProCompactInputProps) => {
   const inputAccessoryViewID =
     Platform.OS === 'ios' ? PERPS_PRO_INPUT_ACCESSORY_ID : undefined;
+  const input = (
+    <Input
+      value={value}
+      onChangeText={onChangeText}
+      keyboardType="decimal-pad"
+      returnKeyType="done"
+      onSubmitEditing={Keyboard.dismiss}
+      inputAccessoryViewID={inputAccessoryViewID}
+      placeholder={placeholder}
+      textVariant={TextVariant.BodySm}
+      isStateStylesDisabled
+      twClassName="flex-1 border-0 bg-transparent p-0"
+      testID={testID}
+      accessibilityLabel={label}
+    />
+  );
+
+  if (variant === 'inline') {
+    return (
+      <Box
+        twClassName="h-12 flex-row items-center border-t border-muted px-3"
+        testID={`${testID}-container`}
+      >
+        {input}
+        {endAccessory}
+      </Box>
+    );
+  }
+
   return (
     <Box twClassName="rounded-xl bg-muted p-3" testID={`${testID}-container`}>
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
-      >
+      <Box twClassName="flex-row items-center justify-between">
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {label}
         </Text>
         {endAccessory}
       </Box>
-      <Input
-        value={value}
-        onChangeText={onChangeText}
-        keyboardType="decimal-pad"
-        returnKeyType="done"
-        onSubmitEditing={Keyboard.dismiss}
-        inputAccessoryViewID={inputAccessoryViewID}
-        placeholder={placeholder}
-        isStateStylesDisabled
-        twClassName="border-0 bg-transparent p-0"
-        testID={testID}
-        accessibilityLabel={label}
-      />
+      {input}
       {footer}
     </Box>
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -42,7 +42,7 @@ const PerpsProCompactInput = ({
       placeholder={placeholder}
       textVariant={TextVariant.BodySm}
       isStateStylesDisabled
-      twClassName="flex-1 border-0 bg-transparent p-0"
+      twClassName="flex-1 border-0 bg-transparent p-0 font-medium"
       testID={testID}
       accessibilityLabel={label}
     />

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -8,8 +8,10 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { Keyboard, Platform } from 'react-native';
-export const PERPS_PRO_INPUT_ACCESSORY_ID =
-  'perps-pro-order-form-input-accessory';
+
+export const getPerpsProInputAccessoryID = (testID: string) =>
+  `${testID}-input-accessory`;
+
 interface PerpsProCompactInputProps {
   label: string;
   value: string;
@@ -34,7 +36,7 @@ const PerpsProCompactInput = ({
 }: PerpsProCompactInputProps) => {
   const tw = useTailwind();
   const inputAccessoryViewID =
-    Platform.OS === 'ios' ? PERPS_PRO_INPUT_ACCESSORY_ID : undefined;
+    Platform.OS === 'ios' ? getPerpsProInputAccessoryID(testID) : undefined;
   const input = (
     <Input
       value={value}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
+import PerpsProOrderForm from './PerpsProOrderForm';
+import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
+jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
+jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
+jest.mock(
+  '../../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView',
+  () => 'PerpsOrderTypeBottomSheetView',
+);
+const host = (name: string) => name as unknown as React.ComponentType<unknown>;
+const createProps = (
+  overrides: Partial<PerpsProOrderFormProps> = {},
+): PerpsProOrderFormProps => ({
+  direction: 'long',
+  onDirectionChange: jest.fn(),
+  marginModeLabel: 'Isolated',
+  leverageLabel: '3x',
+  orderType: 'market',
+  onOrderTypeChange: jest.fn(),
+  limitPrice: '',
+  onLimitPriceChange: jest.fn(),
+  size: '',
+  onSizeChange: jest.fn(),
+  balancePercentage: 0,
+  onBalancePercentageChange: jest.fn(),
+  availableBalance: 'Available balance: --',
+  reduceOnly: false,
+  onReduceOnlyChange: jest.fn(),
+  isTPSLConfigured: false,
+  onTPSLPress: jest.fn(),
+  notices: [],
+  summary: {
+    margin: '--',
+    liquidationPrice: '--',
+    slippage: '--',
+  },
+  placeOrderLabel: 'Place order',
+  placeOrderIntent: 'long',
+  onPlaceOrderPress: jest.fn(),
+  ...overrides,
+});
+describe('PerpsProOrderForm', () => {
+  it('controls Limit Price visibility and passes raw native input text', () => {
+    const onSizeChange = jest.fn();
+    const onLimitPriceChange = jest.fn();
+    const { rerender } = render(
+      <PerpsProOrderForm
+        {...createProps({
+          orderType: 'limit',
+          onSizeChange,
+          onLimitPriceChange,
+        })}
+      />,
+    );
+    fireEvent.changeText(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.SIZE_INPUT),
+      '1..2',
+    );
+    fireEvent.changeText(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
+      '.123',
+    );
+    expect(onSizeChange).toHaveBeenCalledWith('1..2');
+    expect(onLimitPriceChange).toHaveBeenCalledWith('.123');
+
+    rerender(<PerpsProOrderForm {...createProps({ orderType: 'market' })} />);
+    expect(
+      screen.queryByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('reports direction and shared order-type selections', () => {
+    const onDirectionChange = jest.fn();
+    const onOrderTypeChange = jest.fn();
+    render(
+      <PerpsProOrderForm
+        {...createProps({
+          onDirectionChange,
+          onOrderTypeChange,
+        })}
+      />,
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.DIRECTION_SHORT),
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+    fireEvent(
+      screen.UNSAFE_getByType(host('PerpsOrderTypeBottomSheetView')),
+      'onSelect',
+      'limit',
+    );
+    expect(onDirectionChange).toHaveBeenCalledWith('short');
+    expect(onOrderTypeChange).toHaveBeenCalledWith('limit');
+    expect(
+      screen.UNSAFE_getByType(host('PerpsOrderTypeBottomSheetView')),
+    ).toHaveProp('isVisible', false);
+  });
+
+  it('reports reduce-only, TP/SL, and Place Order actions', () => {
+    const onReduceOnlyChange = jest.fn();
+    const onTPSLPress = jest.fn();
+    const onPlaceOrderPress = jest.fn();
+    render(
+      <PerpsProOrderForm
+        {...createProps({
+          onReduceOnlyChange,
+          onTPSLPress,
+          onPlaceOrderPress,
+        })}
+      />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.REDUCE_ONLY),
+    );
+    fireEvent.press(screen.getByTestId(PerpsProOrderFormSelectorsIDs.TPSL));
+    fireEvent.press(
+      screen.getByTestId(PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON),
+    );
+
+    expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
+    expect(onTPSLPress).toHaveBeenCalledTimes(1);
+    expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Slippage data-driven and renders typed notices', () => {
+    render(
+      <PerpsProOrderForm
+        {...createProps({
+          notices: [{ id: 'risk', variant: 'inline', message: 'Risk warning' }],
+          summary: {
+            margin: '--',
+            liquidationPrice: '--',
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId(PerpsProOrderFormSelectorsIDs.SUMMARY_SLIPPAGE),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`${PerpsProOrderFormSelectorsIDs.NOTICE}-risk`),
+    ).toHaveTextContent('Risk warning');
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { IconName } from '@metamask/design-system-react-native';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
+import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
 
@@ -69,6 +70,30 @@ describe('PerpsProOrderForm', () => {
       renderForm({ orderType: 'market' });
 
       expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
+    });
+
+    it('connects each iOS numeric input to its own keyboard accessory', () => {
+      renderForm({ orderType: 'limit' });
+
+      const sizeAccessoryID = getPerpsProInputAccessoryID(ids.SIZE_INPUT);
+      const limitPriceAccessoryID = getPerpsProInputAccessoryID(
+        ids.LIMIT_PRICE_INPUT,
+      );
+
+      expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp(
+        'inputAccessoryViewID',
+        sizeAccessoryID,
+      );
+      expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toHaveProp(
+        'inputAccessoryViewID',
+        limitPriceAccessoryID,
+      );
+      expect(sizeAccessoryID).not.toBe(limitPriceAccessoryID);
+      expect(
+        screen
+          .UNSAFE_getAllByType(host('RCTInputAccessoryView'))
+          .map((accessory) => accessory.props.nativeID),
+      ).toEqual([sizeAccessoryID, limitPriceAccessoryID]);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -10,7 +10,9 @@ jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
 
 const host = (name: string) => name as unknown as React.ComponentType<unknown>;
+
 const ids = PerpsProOrderFormSelectorsIDs;
+
 const createProps = (
   overrides: Partial<PerpsProOrderFormProps> = {},
 ): PerpsProOrderFormProps => ({
@@ -37,6 +39,7 @@ const createProps = (
   onPlaceOrderPress: jest.fn(),
   ...overrides,
 });
+
 const renderForm = (overrides: Partial<PerpsProOrderFormProps> = {}) =>
   render(<PerpsProOrderForm {...createProps(overrides)} />);
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { IconName } from '@metamask/design-system-react-native';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
 jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
-jest.mock(
-  '../../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView',
-  () => 'PerpsOrderTypeBottomSheetView',
-);
 const host = (name: string) => name as unknown as React.ComponentType<unknown>;
+const ids = PerpsProOrderFormSelectorsIDs;
 const createProps = (
   overrides: Partial<PerpsProOrderFormProps> = {},
 ): PerpsProOrderFormProps => ({
@@ -19,6 +17,7 @@ const createProps = (
   leverageLabel: '3x',
   orderType: 'market',
   onOrderTypeChange: jest.fn(),
+  onOrderTypeButtonPress: jest.fn(),
   limitPrice: '',
   onLimitPriceChange: jest.fn(),
   size: '',
@@ -31,96 +30,72 @@ const createProps = (
   isTPSLConfigured: false,
   onTPSLPress: jest.fn(),
   notices: [],
-  summary: {
-    margin: '--',
-    liquidationPrice: '--',
-    slippage: '--',
-  },
+  summary: { margin: '--', liquidationPrice: '--', slippage: '--' },
   placeOrderLabel: 'Place order',
   placeOrderIntent: 'long',
   onPlaceOrderPress: jest.fn(),
   ...overrides,
 });
+const renderForm = (overrides: Partial<PerpsProOrderFormProps> = {}) =>
+  render(<PerpsProOrderForm {...createProps(overrides)} />);
+const expectIcon = (testID: string, name: string) =>
+  expect(screen.getByTestId(testID)).toHaveProp('name', name);
+
 describe('PerpsProOrderForm', () => {
   it('controls Limit Price visibility and passes raw native input text', () => {
     const onSizeChange = jest.fn();
     const onLimitPriceChange = jest.fn();
-    const { rerender } = render(
-      <PerpsProOrderForm
-        {...createProps({
-          orderType: 'limit',
-          onSizeChange,
-          onLimitPriceChange,
-        })}
-      />,
-    );
-    fireEvent.changeText(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.SIZE_INPUT),
-      '1..2',
-    );
-    fireEvent.changeText(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
-      '.123',
-    );
+    const { rerender } = renderForm({
+      orderType: 'limit',
+      onSizeChange,
+      onLimitPriceChange,
+    });
+    fireEvent.changeText(screen.getByTestId(ids.SIZE_INPUT), '1..2');
+    fireEvent.changeText(screen.getByTestId(ids.LIMIT_PRICE_INPUT), '.123');
     expect(onSizeChange).toHaveBeenCalledWith('1..2');
     expect(onLimitPriceChange).toHaveBeenCalledWith('.123');
+    expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toHaveProp(
+      'placeholder',
+      'Set limit price',
+    );
 
     rerender(<PerpsProOrderForm {...createProps({ orderType: 'market' })} />);
-    expect(
-      screen.queryByTestId(PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT),
-    ).not.toBeOnTheScreen();
+    expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
   });
 
-  it('reports direction and shared order-type selections', () => {
-    const onDirectionChange = jest.fn();
-    const onOrderTypeChange = jest.fn();
-    render(
-      <PerpsProOrderForm
-        {...createProps({
-          onDirectionChange,
-          onOrderTypeChange,
-        })}
-      />,
-    );
-    fireEvent.press(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.DIRECTION_SHORT),
-    );
-    fireEvent.press(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON),
-    );
-    fireEvent(
-      screen.UNSAFE_getByType(host('PerpsOrderTypeBottomSheetView')),
-      'onSelect',
-      'limit',
-    );
-    expect(onDirectionChange).toHaveBeenCalledWith('short');
-    expect(onOrderTypeChange).toHaveBeenCalledWith('limit');
+  it('renders the Figma control affordances', () => {
+    renderForm({ orderType: 'limit', reduceOnly: true });
+
+    expectIcon(`${ids.ORDER_TYPE_BUTTON}-chevron`, IconName.ArrowRight);
+    // Selected indicator is now a Box with a Check icon inside
     expect(
-      screen.UNSAFE_getByType(host('PerpsOrderTypeBottomSheetView')),
-    ).toHaveProp('isVisible', false);
+      screen.getByTestId(`${ids.REDUCE_ONLY}-indicator`),
+    ).toBeOnTheScreen();
+    expect(screen.UNSAFE_getByType(host('PerpsSlider'))).toHaveProp(
+      'variant',
+      'compact',
+    );
+  });
+
+  it('reports direction and calls order type button press callback', () => {
+    const onDirectionChange = jest.fn();
+    const onOrderTypeButtonPress = jest.fn();
+    renderForm({ onDirectionChange, onOrderTypeButtonPress });
+    fireEvent.press(screen.getByTestId(ids.DIRECTION_SHORT));
+    fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
+    expect(onDirectionChange).toHaveBeenCalledWith('short');
+    expect(onOrderTypeButtonPress).toHaveBeenCalledTimes(1);
   });
 
   it('reports reduce-only, TP/SL, and Place Order actions', () => {
     const onReduceOnlyChange = jest.fn();
     const onTPSLPress = jest.fn();
     const onPlaceOrderPress = jest.fn();
-    render(
-      <PerpsProOrderForm
-        {...createProps({
-          onReduceOnlyChange,
-          onTPSLPress,
-          onPlaceOrderPress,
-        })}
-      />,
-    );
+    renderForm({ onReduceOnlyChange, onTPSLPress, onPlaceOrderPress });
 
-    fireEvent.press(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.REDUCE_ONLY),
-    );
-    fireEvent.press(screen.getByTestId(PerpsProOrderFormSelectorsIDs.TPSL));
-    fireEvent.press(
-      screen.getByTestId(PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON),
-    );
+    fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+    fireEvent.press(screen.getByTestId(ids.TPSL));
+    fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
 
     expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
     expect(onTPSLPress).toHaveBeenCalledTimes(1);
@@ -128,23 +103,14 @@ describe('PerpsProOrderForm', () => {
   });
 
   it('keeps Slippage data-driven and renders typed notices', () => {
-    render(
-      <PerpsProOrderForm
-        {...createProps({
-          notices: [{ id: 'risk', variant: 'inline', message: 'Risk warning' }],
-          summary: {
-            margin: '--',
-            liquidationPrice: '--',
-          },
-        })}
-      />,
-    );
+    renderForm({
+      notices: [{ id: 'risk', variant: 'inline', message: 'Risk warning' }],
+      summary: { margin: '--', liquidationPrice: '--' },
+    });
 
-    expect(
-      screen.queryByTestId(PerpsProOrderFormSelectorsIDs.SUMMARY_SLIPPAGE),
-    ).not.toBeOnTheScreen();
-    expect(
-      screen.getByTestId(`${PerpsProOrderFormSelectorsIDs.NOTICE}-risk`),
-    ).toHaveTextContent('Risk warning');
+    expect(screen.queryByTestId(ids.SUMMARY_SLIPPAGE)).not.toBeOnTheScreen();
+    expect(screen.getByTestId(`${ids.NOTICE}-risk`)).toHaveTextContent(
+      'Risk warning',
+    );
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -75,6 +75,9 @@ describe('PerpsProOrderForm', () => {
       'variant',
       'compact',
     );
+    expect(screen.getByTestId(ids.CONTAINER)).toHaveStyle({ gap: 16 });
+    expect(screen.getByTestId(ids.SUMMARY)).toHaveStyle({ gap: 4 });
+    expect(screen.getByTestId(ids.SUMMARY_MARGIN)).toHaveStyle({ height: 20 });
   });
 
   it('reports direction and calls order type button press callback', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -4,8 +4,10 @@ import { IconName } from '@metamask/design-system-react-native';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
+
 jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
+
 const host = (name: string) => name as unknown as React.ComponentType<unknown>;
 const ids = PerpsProOrderFormSelectorsIDs;
 const createProps = (
@@ -16,7 +18,6 @@ const createProps = (
   marginModeLabel: 'Isolated',
   leverageLabel: '3x',
   orderType: 'market',
-  onOrderTypeChange: jest.fn(),
   onOrderTypeButtonPress: jest.fn(),
   limitPrice: '',
   onLimitPriceChange: jest.fn(),
@@ -24,11 +25,10 @@ const createProps = (
   onSizeChange: jest.fn(),
   balancePercentage: 0,
   onBalancePercentageChange: jest.fn(),
-  availableBalance: 'Available balance: --',
+  availableBalance: '-- available',
   reduceOnly: false,
   onReduceOnlyChange: jest.fn(),
   isTPSLConfigured: false,
-  onTPSLPress: jest.fn(),
   notices: [],
   summary: { margin: '--', liquidationPrice: '--', slippage: '--' },
   placeOrderLabel: 'Place order',
@@ -38,82 +38,194 @@ const createProps = (
 });
 const renderForm = (overrides: Partial<PerpsProOrderFormProps> = {}) =>
   render(<PerpsProOrderForm {...createProps(overrides)} />);
-const expectIcon = (testID: string, name: string) =>
-  expect(screen.getByTestId(testID)).toHaveProp('name', name);
 
 describe('PerpsProOrderForm', () => {
-  it('controls Limit Price visibility and passes raw native input text', () => {
-    const onSizeChange = jest.fn();
-    const onLimitPriceChange = jest.fn();
-    const { rerender } = renderForm({
-      orderType: 'limit',
-      onSizeChange,
-      onLimitPriceChange,
-    });
-    fireEvent.changeText(screen.getByTestId(ids.SIZE_INPUT), '1..2');
-    fireEvent.changeText(screen.getByTestId(ids.LIMIT_PRICE_INPUT), '.123');
-    expect(onSizeChange).toHaveBeenCalledWith('1..2');
-    expect(onLimitPriceChange).toHaveBeenCalledWith('.123');
-    expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toHaveProp(
-      'placeholder',
-      'Set limit price',
-    );
+  describe('inputs', () => {
+    it('passes raw size text to onSizeChange', () => {
+      const onSizeChange = jest.fn();
+      renderForm({ onSizeChange });
 
-    rerender(<PerpsProOrderForm {...createProps({ orderType: 'market' })} />);
-    expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
-  });
+      fireEvent.changeText(screen.getByTestId(ids.SIZE_INPUT), '1..2');
 
-  it('renders the Figma control affordances', () => {
-    renderForm({ orderType: 'limit', reduceOnly: true });
-
-    expectIcon(`${ids.ORDER_TYPE_BUTTON}-chevron`, IconName.ArrowRight);
-    // Selected indicator is now a Box with a Check icon inside
-    expect(
-      screen.getByTestId(`${ids.REDUCE_ONLY}-indicator`),
-    ).toBeOnTheScreen();
-    expect(screen.UNSAFE_getByType(host('PerpsSlider'))).toHaveProp(
-      'variant',
-      'compact',
-    );
-    expect(screen.getByTestId(ids.CONTAINER)).toHaveStyle({ gap: 16 });
-    expect(screen.getByTestId(ids.SUMMARY)).toHaveStyle({ gap: 4 });
-    expect(screen.getByTestId(ids.SUMMARY_MARGIN)).toHaveStyle({ height: 20 });
-  });
-
-  it('reports direction and calls order type button press callback', () => {
-    const onDirectionChange = jest.fn();
-    const onOrderTypeButtonPress = jest.fn();
-    renderForm({ onDirectionChange, onOrderTypeButtonPress });
-    fireEvent.press(screen.getByTestId(ids.DIRECTION_SHORT));
-    fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
-    expect(onDirectionChange).toHaveBeenCalledWith('short');
-    expect(onOrderTypeButtonPress).toHaveBeenCalledTimes(1);
-  });
-
-  it('reports reduce-only, TP/SL, and Place Order actions', () => {
-    const onReduceOnlyChange = jest.fn();
-    const onTPSLPress = jest.fn();
-    const onPlaceOrderPress = jest.fn();
-    renderForm({ onReduceOnlyChange, onTPSLPress, onPlaceOrderPress });
-
-    fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
-    fireEvent.press(screen.getByTestId(ids.TPSL));
-    fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
-
-    expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
-    expect(onTPSLPress).toHaveBeenCalledTimes(1);
-    expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps Slippage data-driven and renders typed notices', () => {
-    renderForm({
-      notices: [{ id: 'risk', variant: 'inline', message: 'Risk warning' }],
-      summary: { margin: '--', liquidationPrice: '--' },
+      expect(onSizeChange).toHaveBeenCalledWith('1..2');
     });
 
-    expect(screen.queryByTestId(ids.SUMMARY_SLIPPAGE)).not.toBeOnTheScreen();
-    expect(screen.getByTestId(`${ids.NOTICE}-risk`)).toHaveTextContent(
-      'Risk warning',
-    );
+    it('passes raw limit price text to onLimitPriceChange', () => {
+      const onLimitPriceChange = jest.fn();
+      renderForm({ orderType: 'limit', onLimitPriceChange });
+
+      fireEvent.changeText(screen.getByTestId(ids.LIMIT_PRICE_INPUT), '.123');
+
+      expect(onLimitPriceChange).toHaveBeenCalledWith('.123');
+    });
+
+    it('renders limit price input for limit orders', () => {
+      renderForm({ orderType: 'limit' });
+
+      expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
+    });
+
+    it('omits limit price input for market orders', () => {
+      renderForm({ orderType: 'market' });
+
+      expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('controls', () => {
+    it('renders the order type chevron from Figma', () => {
+      renderForm();
+
+      expect(screen.getByTestId(`${ids.ORDER_TYPE_BUTTON}-chevron`)).toHaveProp(
+        'name',
+        IconName.ArrowRight,
+      );
+    });
+
+    it('passes compact accessibility props to the size slider', () => {
+      renderForm();
+
+      expect(screen.UNSAFE_getByType(host('PerpsSlider'))).toHaveProp(
+        'variant',
+        'compact',
+      );
+      expect(screen.UNSAFE_getByType(host('PerpsSlider'))).toHaveProp(
+        'testID',
+        ids.SIZE_SLIDER,
+      );
+      expect(screen.UNSAFE_getByType(host('PerpsSlider'))).toHaveProp(
+        'accessibilityLabel',
+        'Order size percentage',
+      );
+    });
+
+    it('calls onDirectionChange when Short is pressed', () => {
+      const onDirectionChange = jest.fn();
+      renderForm({ onDirectionChange });
+
+      fireEvent.press(screen.getByTestId(ids.DIRECTION_SHORT));
+
+      expect(onDirectionChange).toHaveBeenCalledWith('short');
+    });
+
+    it('calls onOrderTypeButtonPress when order type is pressed', () => {
+      const onOrderTypeButtonPress = jest.fn();
+      renderForm({ onOrderTypeButtonPress });
+
+      fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
+
+      expect(onOrderTypeButtonPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes Reduce only with checked checkbox semantics', () => {
+      renderForm({ reduceOnly: true });
+
+      expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
+        'accessibilityRole',
+        'checkbox',
+      );
+      expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
+        'accessibilityState',
+        { checked: true },
+      );
+    });
+
+    it('calls onReduceOnlyChange with the next checked value', () => {
+      const onReduceOnlyChange = jest.fn();
+      renderForm({ onReduceOnlyChange });
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+
+      expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
+    });
+
+    it('exposes TP/SL as a button action', () => {
+      renderForm({ onTPSLPress: jest.fn() });
+
+      expect(screen.getByTestId(ids.TPSL)).toHaveProp(
+        'accessibilityRole',
+        'button',
+      );
+    });
+
+    it('calls onTPSLPress when TP/SL is pressed', () => {
+      const onTPSLPress = jest.fn();
+      renderForm({ onTPSLPress });
+
+      fireEvent.press(screen.getByTestId(ids.TPSL));
+
+      expect(onTPSLPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onPlaceOrderPress when Place Order is pressed', () => {
+      const onPlaceOrderPress = jest.fn();
+      renderForm({ onPlaceOrderPress });
+
+      fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
+
+      expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables Place Order when requested', () => {
+      renderForm({ isPlaceOrderDisabled: true });
+
+      expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
+    });
+
+    it.each([
+      ['leverage', ids.LEVERAGE_BUTTON],
+      ['Mid price', ids.MID_PRICE_BUTTON],
+      ['size denomination', ids.SIZE_UNIT_BUTTON],
+      ['Add funds', ids.ADD_FUNDS_BUTTON],
+      ['TP/SL', ids.TPSL],
+      ['slippage', ids.SUMMARY_SLIPPAGE_BUTTON],
+      ['fees', ids.SUMMARY_FEES_BUTTON],
+    ])('disables deferred %s action without a callback', (_name, testID) => {
+      renderForm({ orderType: 'limit' });
+
+      expect(screen.getByTestId(testID)).toBeDisabled();
+    });
+  });
+
+  describe('conditional content', () => {
+    it('omits Slippage when no display value is provided', () => {
+      renderForm({
+        summary: { margin: '--', liquidationPrice: '--' },
+      });
+
+      expect(screen.queryByTestId(ids.SUMMARY_SLIPPAGE)).not.toBeOnTheScreen();
+    });
+
+    it('renders an inline typed notice', () => {
+      renderForm({
+        notices: [{ id: 'risk', variant: 'inline', message: 'Risk warning' }],
+      });
+
+      expect(screen.getByTestId(`${ids.NOTICE}-risk`)).toHaveTextContent(
+        'Risk warning',
+      );
+    });
+  });
+
+  describe('Figma layout', () => {
+    it('uses 16-point spacing between form sections', () => {
+      renderForm();
+
+      expect(screen.getByTestId(ids.CONTAINER)).toHaveStyle({ gap: 16 });
+    });
+
+    it('uses 4-point spacing between summary rows', () => {
+      renderForm();
+
+      expect(screen.getByTestId(ids.SUMMARY)).toHaveStyle({ gap: 4 });
+    });
+
+    it('uses 20-point summary row height', () => {
+      renderForm();
+
+      expect(screen.getByTestId(ids.SUMMARY_MARGIN)).toHaveStyle({
+        height: 20,
+      });
+    });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -310,6 +310,7 @@ const PerpsProOrderForm = ({
             onChangeText={onSizeChange}
             testID={ids.SIZE_INPUT}
             placeholder="0.00"
+            placeholderColor="default"
             endAccessory={
               <ButtonIcon
                 iconName={IconName.SwapHorizontal}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -3,33 +3,30 @@ import {
   BannerAlertSeverity,
   Box,
   BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
   ButtonBase,
   ButtonBaseSize,
   ButtonIcon,
   ButtonIconSize,
   ButtonSemantic,
   ButtonSemanticSeverity,
-  Checkbox,
   FilterButton,
+  FontWeight,
   Icon,
+  IconColor,
   IconName,
   IconSize,
   KeyValueRow,
-  KeyValueRowVariant,
   SegmentedControl,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import React, { useState } from 'react';
-import { InputAccessoryView, Keyboard, Platform, View } from 'react-native';
+import React from 'react';
+import { InputAccessoryView, Keyboard, Platform } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsFeesDisplay from '../../../../components/PerpsFeesDisplay';
 import PerpsSlider from '../../../../components/PerpsSlider';
-import PerpsOrderTypeBottomSheetView from '../../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
 import PerpsProCompactInput, {
   PERPS_PRO_INPUT_ACCESSORY_ID,
 } from './PerpsProCompactInput';
@@ -39,6 +36,9 @@ import type {
   PerpsProOrderNotice,
   PerpsProOrderSummaryProps,
 } from './PerpsProOrderForm.types';
+const ids = PerpsProOrderFormSelectorsIDs;
+const buttonIcon = (iconName: IconName, onPress?: () => void) =>
+  onPress ? { iconName, onPress } : undefined;
 interface SelectionRowProps {
   label: string;
   isSelected: boolean;
@@ -50,36 +50,39 @@ const SelectionRow = ({
   isSelected,
   onChange,
   testID,
-}: SelectionRowProps) => (
-  <ButtonBase
-    size={ButtonBaseSize.Sm}
-    twClassName="rounded-xl bg-muted px-3 py-4"
-    isFullWidth
-    onPress={() => onChange(!isSelected)}
-    testID={testID}
-    accessibilityState={{ selected: isSelected }}
-  >
+}: SelectionRowProps) => {
+  const indicator = isSelected ? (
     <Box
-      twClassName="w-full"
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Between}
+      twClassName="size-5 items-center justify-center rounded-full bg-icon-default"
+      testID={`${testID}-indicator`}
     >
-      <Text variant={TextVariant.BodySm}>{label}</Text>
-      <View
-        pointerEvents="none"
-        accessibilityElementsHidden
-        importantForAccessibility="no-hide-descendants"
-      >
-        <Checkbox
-          isSelected={isSelected}
-          onChange={() => undefined}
-          testID={`${testID}-checkbox`}
-        />
-      </View>
+      <Icon
+        name={IconName.CheckBold}
+        size={IconSize.Xs}
+        color={IconColor.PrimaryInverse}
+      />
     </Box>
-  </ButtonBase>
-);
+  ) : (
+    <Box
+      twClassName="size-5 rounded-full border-2 border-muted"
+      testID={`${testID}-indicator`}
+    />
+  );
+  return (
+    <ButtonBase
+      twClassName="h-12 rounded-xl bg-muted px-3"
+      contentWrapperProps={{ twClassName: 'w-full justify-between' }}
+      textProps={{ variant: TextVariant.BodySm, fontWeight: FontWeight.Medium }}
+      endAccessory={indicator}
+      isFullWidth
+      onPress={() => onChange(!isSelected)}
+      testID={testID}
+      accessibilityState={{ selected: isSelected }}
+    >
+      {label}
+    </ButtonBase>
+  );
+};
 const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) => (
   <Box twClassName="gap-2">
     {notices.map((notice) =>
@@ -89,14 +92,14 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) => (
           severity={BannerAlertSeverity.Warning}
           title={notice.title}
           description={notice.message}
-          testID={`${PerpsProOrderFormSelectorsIDs.NOTICE}-${notice.id}`}
+          testID={`${ids.NOTICE}-${notice.id}`}
         />
       ) : (
         <Text
           key={notice.id}
           variant={TextVariant.BodyXs}
           color={TextColor.ErrorDefault}
-          testID={`${PerpsProOrderFormSelectorsIDs.NOTICE}-${notice.id}`}
+          testID={`${ids.NOTICE}-${notice.id}`}
         >
           {notice.message}
         </Text>
@@ -114,50 +117,41 @@ const OrderSummary = ({
   onSlippagePress,
   onFeesInfoPress,
 }: PerpsProOrderSummaryProps) => (
-  <Box twClassName="gap-2" testID={PerpsProOrderFormSelectorsIDs.SUMMARY}>
+  <Box twClassName="gap-2" testID={ids.SUMMARY}>
     <KeyValueRow
-      variant={KeyValueRowVariant.Summary}
       keyLabel={strings('perps.order.margin')}
       value={margin}
-      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_MARGIN}
+      testID={ids.SUMMARY_MARGIN}
     />
     <KeyValueRow
-      variant={KeyValueRowVariant.Summary}
       keyLabel={strings('perps.order.liquidation_price')}
       value={liquidationPrice}
-      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_LIQUIDATION}
+      testID={ids.SUMMARY_LIQUIDATION}
     />
     {slippage !== undefined ? (
       <KeyValueRow
-        variant={KeyValueRowVariant.Summary}
         keyLabel={strings('perps.slippage.slippage')}
         value={slippage}
-        valueEndButtonIconProps={
-          onSlippagePress
-            ? { iconName: IconName.ArrowRight, onPress: onSlippagePress }
-            : undefined
-        }
-        testID={PerpsProOrderFormSelectorsIDs.SUMMARY_SLIPPAGE}
+        valueEndButtonIconProps={buttonIcon(
+          IconName.ArrowRight,
+          onSlippagePress,
+        )}
+        testID={ids.SUMMARY_SLIPPAGE}
       />
     ) : null}
     <KeyValueRow
-      variant={KeyValueRowVariant.Summary}
       keyLabel={strings('perps.order.fees')}
       value={
         <PerpsFeesDisplay
           fee={fee}
           originalFee={originalFee}
           feeDiscountPercentage={feeDiscountPercentage}
-          testID={PerpsProOrderFormSelectorsIDs.SUMMARY_FEES_VALUE}
+          testID={ids.SUMMARY_FEES_VALUE}
           variant={TextVariant.BodyXs}
         />
       }
-      keyEndButtonIconProps={
-        onFeesInfoPress
-          ? { iconName: IconName.Info, onPress: onFeesInfoPress }
-          : undefined
-      }
-      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_FEES}
+      keyEndButtonIconProps={buttonIcon(IconName.Info, onFeesInfoPress)}
+      testID={ids.SUMMARY_FEES}
     />
   </Box>
 );
@@ -169,6 +163,7 @@ const PerpsProOrderForm = ({
   onLeveragePress,
   orderType,
   onOrderTypeChange,
+  onOrderTypeButtonPress,
   limitPrice,
   onLimitPriceChange,
   onUseMidPricePress,
@@ -191,14 +186,10 @@ const PerpsProOrderForm = ({
   isPlaceOrderLoading = false,
   onPlaceOrderPress,
 }: PerpsProOrderFormProps) => {
-  const [isOrderTypeSheetVisible, setIsOrderTypeSheetVisible] = useState(false);
-  const handleOrderTypeChange = (nextOrderType: typeof orderType) => {
-    onOrderTypeChange(nextOrderType);
-    setIsOrderTypeSheetVisible(false);
-  };
+  const isLong = direction === 'long';
   return (
     <>
-      <Box twClassName="gap-4" testID={PerpsProOrderFormSelectorsIDs.CONTAINER}>
+      <Box twClassName="gap-4" testID={ids.CONTAINER}>
         <SegmentedControl
           value={direction}
           onChange={(value) =>
@@ -206,70 +197,71 @@ const PerpsProOrderForm = ({
           }
           isFullWidth
           size={ButtonBaseSize.Sm}
-          testID={PerpsProOrderFormSelectorsIDs.DIRECTION_CONTROL}
+          testID={ids.DIRECTION_CONTROL}
         >
           <FilterButton
             value="long"
-            testID={PerpsProOrderFormSelectorsIDs.DIRECTION_LONG}
+            twClassName={isLong ? 'bg-success-muted' : ''}
+            textProps={isLong ? { color: TextColor.SuccessDefault } : undefined}
+            testID={ids.DIRECTION_LONG}
           >
             {strings('perps.market.long')}
           </FilterButton>
           <FilterButton
             value="short"
-            testID={PerpsProOrderFormSelectorsIDs.DIRECTION_SHORT}
+            twClassName={!isLong ? 'bg-error-muted' : ''}
+            textProps={!isLong ? { color: TextColor.ErrorDefault } : undefined}
+            testID={ids.DIRECTION_SHORT}
           >
             {strings('perps.market.short')}
           </FilterButton>
         </SegmentedControl>
-
-        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2">
-          <Box twClassName="flex-1 rounded-lg bg-muted px-3 py-2">
+        <Box twClassName="flex-row items-center justify-between">
+          <Box twClassName="h-8 justify-center rounded-lg bg-muted px-2">
             <Text variant={TextVariant.BodySm}>{marginModeLabel}</Text>
           </Box>
           <ButtonBase
             size={ButtonBaseSize.Sm}
             onPress={onLeveragePress}
             isDisabled={!onLeveragePress}
-            twClassName="flex-1 rounded-lg bg-muted"
-            testID={PerpsProOrderFormSelectorsIDs.LEVERAGE_BUTTON}
+            twClassName="rounded-lg bg-muted px-2"
+            testID={ids.LEVERAGE_BUTTON}
           >
             {leverageLabel}
           </ButtonBase>
         </Box>
-
-        <Box twClassName="rounded-xl bg-muted">
+        <Box twClassName="overflow-hidden rounded-xl bg-muted">
           <ButtonBase
-            size={ButtonBaseSize.Sm}
-            onPress={() => setIsOrderTypeSheetVisible(true)}
-            twClassName="w-full justify-between px-3 py-3"
-            testID={PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON}
+            onPress={onOrderTypeButtonPress}
+            twClassName="h-12 w-full bg-transparent px-3"
+            contentWrapperProps={{ twClassName: 'w-full justify-between' }}
+            textProps={{ variant: TextVariant.BodySm }}
+            endIconName={IconName.ArrowRight}
+            endIconProps={{
+              size: IconSize.Sm,
+              testID: `${ids.ORDER_TYPE_BUTTON}-chevron`,
+            }}
+            testID={ids.ORDER_TYPE_BUTTON}
           >
-            <Box
-              twClassName="w-full"
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Between}
-            >
-              <Text variant={TextVariant.BodySm}>
-                {orderType === 'market'
-                  ? strings('perps.order.type.market.title')
-                  : strings('perps.order.type.limit.title')}
-              </Text>
-              <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
-            </Box>
+            {orderType === 'market'
+              ? strings('perps.order.type.market.title')
+              : strings('perps.order.type.limit.title')}
           </ButtonBase>
           {orderType === 'limit' ? (
             <PerpsProCompactInput
-              label={strings('perps.order.limit_price')}
+              label={strings('perps.order.limit_price_modal.title')}
               value={limitPrice}
               onChangeText={onLimitPriceChange}
-              testID={PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT}
+              testID={ids.LIMIT_PRICE_INPUT}
+              variant="inline"
+              placeholder={strings('perps.order.limit_price_modal.title')}
               endAccessory={
                 <ButtonBase
                   size={ButtonBaseSize.Sm}
                   onPress={onUseMidPricePress}
                   isDisabled={!onUseMidPricePress}
-                  testID={PerpsProOrderFormSelectorsIDs.MID_PRICE_BUTTON}
+                  twClassName="h-12 bg-transparent px-0"
+                  testID={ids.MID_PRICE_BUTTON}
                 >
                   {strings('perps.order.limit_price_modal.mid_price')}
                 </ButtonBase>
@@ -277,18 +269,18 @@ const PerpsProOrderForm = ({
             />
           ) : null}
         </Box>
-
         <PerpsProCompactInput
           label={strings('perps.pro_order_form.size_usd')}
           value={size}
           onChangeText={onSizeChange}
-          testID={PerpsProOrderFormSelectorsIDs.SIZE_INPUT}
+          testID={ids.SIZE_INPUT}
+          placeholder="0.00"
           endAccessory={
             <ButtonIcon
               iconName={IconName.SwapHorizontal}
               size={ButtonIconSize.Xs}
               onPress={onSizeUnitPress}
-              testID={PerpsProOrderFormSelectorsIDs.SIZE_UNIT_BUTTON}
+              testID={ids.SIZE_UNIT_BUTTON}
               accessibilityLabel={strings(
                 'perps.pro_order_form.toggle_size_unit',
               )}
@@ -302,46 +294,39 @@ const PerpsProOrderForm = ({
               maximumValue={100}
               showPercentageLabels={false}
               showPercentageMarkers
+              variant="compact"
             />
           }
         />
-
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-1"
-        >
+        <Box twClassName="flex-row items-center gap-1">
           <Text
             variant={TextVariant.BodyXs}
             color={TextColor.TextAlternative}
-            testID={PerpsProOrderFormSelectorsIDs.AVAILABLE_BALANCE}
+            testID={ids.AVAILABLE_BALANCE}
           >
             {availableBalance}
           </Text>
           <ButtonIcon
-            iconName={IconName.Add}
+            iconName={IconName.AddCircle}
             size={ButtonIconSize.Xs}
             onPress={onAddFundsPress}
-            testID={PerpsProOrderFormSelectorsIDs.ADD_FUNDS_BUTTON}
+            testID={ids.ADD_FUNDS_BUTTON}
             accessibilityLabel={strings('perps.add_funds')}
           />
         </Box>
-
         <SelectionRow
           label={strings('perps.order.reduce_only')}
           isSelected={reduceOnly}
           onChange={onReduceOnlyChange}
-          testID={PerpsProOrderFormSelectorsIDs.REDUCE_ONLY}
+          testID={ids.REDUCE_ONLY}
         />
         <SelectionRow
           label={strings('perps.pro_order_form.tpsl')}
           isSelected={isTPSLConfigured}
           onChange={() => onTPSLPress?.()}
-          testID={PerpsProOrderFormSelectorsIDs.TPSL}
+          testID={ids.TPSL}
         />
-
         <Notices notices={notices} />
-
         <ButtonSemantic
           severity={
             placeOrderIntent === 'long'
@@ -353,14 +338,12 @@ const PerpsProOrderForm = ({
           isDisabled={isPlaceOrderDisabled}
           isLoading={isPlaceOrderLoading}
           onPress={onPlaceOrderPress}
-          testID={PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON}
+          testID={ids.PLACE_ORDER_BUTTON}
         >
           {placeOrderLabel}
         </ButtonSemantic>
-
         <OrderSummary {...summary} />
       </Box>
-
       {Platform.OS === 'ios' ? (
         <InputAccessoryView nativeID={PERPS_PRO_INPUT_ACCESSORY_ID}>
           <Box
@@ -371,7 +354,7 @@ const PerpsProOrderForm = ({
               iconName={IconName.ArrowDown}
               size={ButtonIconSize.Sm}
               onPress={Keyboard.dismiss}
-              testID={PerpsProOrderFormSelectorsIDs.KEYBOARD_CLOSE}
+              testID={ids.KEYBOARD_CLOSE}
               accessibilityLabel={strings(
                 'perps.pro_order_form.close_keyboard',
               )}
@@ -379,15 +362,6 @@ const PerpsProOrderForm = ({
           </Box>
         </InputAccessoryView>
       ) : null}
-
-      <PerpsOrderTypeBottomSheetView
-        isVisible={isOrderTypeSheetVisible}
-        onClose={() => setIsOrderTypeSheetVisible(false)}
-        onSelect={handleOrderTypeChange}
-        currentOrderType={orderType}
-        title={strings('perps.pro_order_form.choose_order_type')}
-        showSelectedIcon
-      />
     </>
   );
 };

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -1,0 +1,395 @@
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonBase,
+  ButtonBaseSize,
+  ButtonIcon,
+  ButtonIconSize,
+  ButtonSemantic,
+  ButtonSemanticSeverity,
+  Checkbox,
+  FilterButton,
+  Icon,
+  IconName,
+  IconSize,
+  KeyValueRow,
+  KeyValueRowVariant,
+  SegmentedControl,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React, { useState } from 'react';
+import { InputAccessoryView, Keyboard, Platform, View } from 'react-native';
+import { strings } from '../../../../../../../../locales/i18n';
+import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
+import PerpsFeesDisplay from '../../../../components/PerpsFeesDisplay';
+import PerpsSlider from '../../../../components/PerpsSlider';
+import PerpsOrderTypeBottomSheetView from '../../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
+import PerpsProCompactInput, {
+  PERPS_PRO_INPUT_ACCESSORY_ID,
+} from './PerpsProCompactInput';
+import type {
+  PerpsProOrderDirection,
+  PerpsProOrderFormProps,
+  PerpsProOrderNotice,
+  PerpsProOrderSummaryProps,
+} from './PerpsProOrderForm.types';
+interface SelectionRowProps {
+  label: string;
+  isSelected: boolean;
+  onChange: (value: boolean) => void;
+  testID: string;
+}
+const SelectionRow = ({
+  label,
+  isSelected,
+  onChange,
+  testID,
+}: SelectionRowProps) => (
+  <ButtonBase
+    size={ButtonBaseSize.Sm}
+    twClassName="rounded-xl bg-muted px-3 py-4"
+    isFullWidth
+    onPress={() => onChange(!isSelected)}
+    testID={testID}
+    accessibilityState={{ selected: isSelected }}
+  >
+    <Box
+      twClassName="w-full"
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+    >
+      <Text variant={TextVariant.BodySm}>{label}</Text>
+      <View
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Checkbox
+          isSelected={isSelected}
+          onChange={() => undefined}
+          testID={`${testID}-checkbox`}
+        />
+      </View>
+    </Box>
+  </ButtonBase>
+);
+const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) => (
+  <Box twClassName="gap-2">
+    {notices.map((notice) =>
+      notice.variant === 'banner' ? (
+        <BannerAlert
+          key={notice.id}
+          severity={BannerAlertSeverity.Warning}
+          title={notice.title}
+          description={notice.message}
+          testID={`${PerpsProOrderFormSelectorsIDs.NOTICE}-${notice.id}`}
+        />
+      ) : (
+        <Text
+          key={notice.id}
+          variant={TextVariant.BodyXs}
+          color={TextColor.ErrorDefault}
+          testID={`${PerpsProOrderFormSelectorsIDs.NOTICE}-${notice.id}`}
+        >
+          {notice.message}
+        </Text>
+      ),
+    )}
+  </Box>
+);
+const OrderSummary = ({
+  margin,
+  liquidationPrice,
+  slippage,
+  fee,
+  originalFee,
+  feeDiscountPercentage,
+  onSlippagePress,
+  onFeesInfoPress,
+}: PerpsProOrderSummaryProps) => (
+  <Box twClassName="gap-2" testID={PerpsProOrderFormSelectorsIDs.SUMMARY}>
+    <KeyValueRow
+      variant={KeyValueRowVariant.Summary}
+      keyLabel={strings('perps.order.margin')}
+      value={margin}
+      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_MARGIN}
+    />
+    <KeyValueRow
+      variant={KeyValueRowVariant.Summary}
+      keyLabel={strings('perps.order.liquidation_price')}
+      value={liquidationPrice}
+      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_LIQUIDATION}
+    />
+    {slippage !== undefined ? (
+      <KeyValueRow
+        variant={KeyValueRowVariant.Summary}
+        keyLabel={strings('perps.slippage.slippage')}
+        value={slippage}
+        valueEndButtonIconProps={
+          onSlippagePress
+            ? { iconName: IconName.ArrowRight, onPress: onSlippagePress }
+            : undefined
+        }
+        testID={PerpsProOrderFormSelectorsIDs.SUMMARY_SLIPPAGE}
+      />
+    ) : null}
+    <KeyValueRow
+      variant={KeyValueRowVariant.Summary}
+      keyLabel={strings('perps.order.fees')}
+      value={
+        <PerpsFeesDisplay
+          fee={fee}
+          originalFee={originalFee}
+          feeDiscountPercentage={feeDiscountPercentage}
+          testID={PerpsProOrderFormSelectorsIDs.SUMMARY_FEES_VALUE}
+          variant={TextVariant.BodyXs}
+        />
+      }
+      keyEndButtonIconProps={
+        onFeesInfoPress
+          ? { iconName: IconName.Info, onPress: onFeesInfoPress }
+          : undefined
+      }
+      testID={PerpsProOrderFormSelectorsIDs.SUMMARY_FEES}
+    />
+  </Box>
+);
+const PerpsProOrderForm = ({
+  direction,
+  onDirectionChange,
+  marginModeLabel,
+  leverageLabel,
+  onLeveragePress,
+  orderType,
+  onOrderTypeChange,
+  limitPrice,
+  onLimitPriceChange,
+  onUseMidPricePress,
+  size,
+  onSizeChange,
+  onSizeUnitPress,
+  balancePercentage,
+  onBalancePercentageChange,
+  availableBalance,
+  onAddFundsPress,
+  reduceOnly,
+  onReduceOnlyChange,
+  isTPSLConfigured,
+  onTPSLPress,
+  notices,
+  summary,
+  placeOrderLabel,
+  placeOrderIntent,
+  isPlaceOrderDisabled = false,
+  isPlaceOrderLoading = false,
+  onPlaceOrderPress,
+}: PerpsProOrderFormProps) => {
+  const [isOrderTypeSheetVisible, setIsOrderTypeSheetVisible] = useState(false);
+  const handleOrderTypeChange = (nextOrderType: typeof orderType) => {
+    onOrderTypeChange(nextOrderType);
+    setIsOrderTypeSheetVisible(false);
+  };
+  return (
+    <>
+      <Box twClassName="gap-4" testID={PerpsProOrderFormSelectorsIDs.CONTAINER}>
+        <SegmentedControl
+          value={direction}
+          onChange={(value) =>
+            onDirectionChange(value as PerpsProOrderDirection)
+          }
+          isFullWidth
+          size={ButtonBaseSize.Sm}
+          testID={PerpsProOrderFormSelectorsIDs.DIRECTION_CONTROL}
+        >
+          <FilterButton
+            value="long"
+            testID={PerpsProOrderFormSelectorsIDs.DIRECTION_LONG}
+          >
+            {strings('perps.market.long')}
+          </FilterButton>
+          <FilterButton
+            value="short"
+            testID={PerpsProOrderFormSelectorsIDs.DIRECTION_SHORT}
+          >
+            {strings('perps.market.short')}
+          </FilterButton>
+        </SegmentedControl>
+
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-2">
+          <Box twClassName="flex-1 rounded-lg bg-muted px-3 py-2">
+            <Text variant={TextVariant.BodySm}>{marginModeLabel}</Text>
+          </Box>
+          <ButtonBase
+            size={ButtonBaseSize.Sm}
+            onPress={onLeveragePress}
+            isDisabled={!onLeveragePress}
+            twClassName="flex-1 rounded-lg bg-muted"
+            testID={PerpsProOrderFormSelectorsIDs.LEVERAGE_BUTTON}
+          >
+            {leverageLabel}
+          </ButtonBase>
+        </Box>
+
+        <Box twClassName="rounded-xl bg-muted">
+          <ButtonBase
+            size={ButtonBaseSize.Sm}
+            onPress={() => setIsOrderTypeSheetVisible(true)}
+            twClassName="w-full justify-between px-3 py-3"
+            testID={PerpsProOrderFormSelectorsIDs.ORDER_TYPE_BUTTON}
+          >
+            <Box
+              twClassName="w-full"
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
+            >
+              <Text variant={TextVariant.BodySm}>
+                {orderType === 'market'
+                  ? strings('perps.order.type.market.title')
+                  : strings('perps.order.type.limit.title')}
+              </Text>
+              <Icon name={IconName.ArrowDown} size={IconSize.Sm} />
+            </Box>
+          </ButtonBase>
+          {orderType === 'limit' ? (
+            <PerpsProCompactInput
+              label={strings('perps.order.limit_price')}
+              value={limitPrice}
+              onChangeText={onLimitPriceChange}
+              testID={PerpsProOrderFormSelectorsIDs.LIMIT_PRICE_INPUT}
+              endAccessory={
+                <ButtonBase
+                  size={ButtonBaseSize.Sm}
+                  onPress={onUseMidPricePress}
+                  isDisabled={!onUseMidPricePress}
+                  testID={PerpsProOrderFormSelectorsIDs.MID_PRICE_BUTTON}
+                >
+                  {strings('perps.order.limit_price_modal.mid_price')}
+                </ButtonBase>
+              }
+            />
+          ) : null}
+        </Box>
+
+        <PerpsProCompactInput
+          label={strings('perps.pro_order_form.size_usd')}
+          value={size}
+          onChangeText={onSizeChange}
+          testID={PerpsProOrderFormSelectorsIDs.SIZE_INPUT}
+          endAccessory={
+            <ButtonIcon
+              iconName={IconName.SwapHorizontal}
+              size={ButtonIconSize.Xs}
+              onPress={onSizeUnitPress}
+              testID={PerpsProOrderFormSelectorsIDs.SIZE_UNIT_BUTTON}
+              accessibilityLabel={strings(
+                'perps.pro_order_form.toggle_size_unit',
+              )}
+            />
+          }
+          footer={
+            <PerpsSlider
+              value={balancePercentage}
+              onValueChange={onBalancePercentageChange}
+              minimumValue={0}
+              maximumValue={100}
+              showPercentageLabels={false}
+              showPercentageMarkers
+            />
+          }
+        />
+
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-1"
+        >
+          <Text
+            variant={TextVariant.BodyXs}
+            color={TextColor.TextAlternative}
+            testID={PerpsProOrderFormSelectorsIDs.AVAILABLE_BALANCE}
+          >
+            {availableBalance}
+          </Text>
+          <ButtonIcon
+            iconName={IconName.Add}
+            size={ButtonIconSize.Xs}
+            onPress={onAddFundsPress}
+            testID={PerpsProOrderFormSelectorsIDs.ADD_FUNDS_BUTTON}
+            accessibilityLabel={strings('perps.add_funds')}
+          />
+        </Box>
+
+        <SelectionRow
+          label={strings('perps.order.reduce_only')}
+          isSelected={reduceOnly}
+          onChange={onReduceOnlyChange}
+          testID={PerpsProOrderFormSelectorsIDs.REDUCE_ONLY}
+        />
+        <SelectionRow
+          label={strings('perps.pro_order_form.tpsl')}
+          isSelected={isTPSLConfigured}
+          onChange={() => onTPSLPress?.()}
+          testID={PerpsProOrderFormSelectorsIDs.TPSL}
+        />
+
+        <Notices notices={notices} />
+
+        <ButtonSemantic
+          severity={
+            placeOrderIntent === 'long'
+              ? ButtonSemanticSeverity.Success
+              : ButtonSemanticSeverity.Danger
+          }
+          size={ButtonBaseSize.Lg}
+          isFullWidth
+          isDisabled={isPlaceOrderDisabled}
+          isLoading={isPlaceOrderLoading}
+          onPress={onPlaceOrderPress}
+          testID={PerpsProOrderFormSelectorsIDs.PLACE_ORDER_BUTTON}
+        >
+          {placeOrderLabel}
+        </ButtonSemantic>
+
+        <OrderSummary {...summary} />
+      </Box>
+
+      {Platform.OS === 'ios' ? (
+        <InputAccessoryView nativeID={PERPS_PRO_INPUT_ACCESSORY_ID}>
+          <Box
+            twClassName="border-t border-muted bg-default px-3 py-2"
+            alignItems={BoxAlignItems.End}
+          >
+            <ButtonIcon
+              iconName={IconName.ArrowDown}
+              size={ButtonIconSize.Sm}
+              onPress={Keyboard.dismiss}
+              testID={PerpsProOrderFormSelectorsIDs.KEYBOARD_CLOSE}
+              accessibilityLabel={strings(
+                'perps.pro_order_form.close_keyboard',
+              )}
+            />
+          </Box>
+        </InputAccessoryView>
+      ) : null}
+
+      <PerpsOrderTypeBottomSheetView
+        isVisible={isOrderTypeSheetVisible}
+        onClose={() => setIsOrderTypeSheetVisible(false)}
+        onSelect={handleOrderTypeChange}
+        currentOrderType={orderType}
+        title={strings('perps.pro_order_form.choose_order_type')}
+        showSelectedIcon
+      />
+    </>
+  );
+};
+
+export default PerpsProOrderForm;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -41,7 +41,9 @@ import type {
   PerpsProOrderNotice,
   PerpsProOrderSummaryProps,
 } from './PerpsProOrderForm.types';
+
 const ids = PerpsProOrderFormSelectorsIDs;
+
 const buttonIcon = (iconName: IconName, testID: string, onPress?: () => void) =>
   ({
     iconName,
@@ -50,18 +52,22 @@ const buttonIcon = (iconName: IconName, testID: string, onPress?: () => void) =>
     size: ButtonIconSize.Xs,
     testID,
   }) as const;
+
 const summaryKeyTextProps = {
   variant: TextVariant.BodyXs,
   fontWeight: FontWeight.Regular,
 };
+
 const summaryValueTextProps = {
   variant: TextVariant.BodyXs,
   fontWeight: FontWeight.Medium,
 };
+
 interface SelectionIndicatorProps {
   isSelected: boolean;
   testID: string;
 }
+
 const SelectionIndicator = ({ isSelected, testID }: SelectionIndicatorProps) =>
   isSelected ? (
     <Box
@@ -85,6 +91,7 @@ interface ReduceOnlyRowProps extends SelectionIndicatorProps {
   label: string;
   onChange: (value: boolean) => void;
 }
+
 const ReduceOnlyRow = ({
   label,
   isSelected,
@@ -111,6 +118,7 @@ interface TPSLRowProps extends SelectionIndicatorProps {
   label: string;
   onPress?: () => void;
 }
+
 const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
   const isDisabled = !onPress;
 
@@ -179,6 +187,7 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
       )}
     </Box>
   ) : null;
+
 const OrderSummary = ({
   margin,
   liquidationPrice,
@@ -244,6 +253,7 @@ const OrderSummary = ({
     />
   </Box>
 );
+
 const PerpsProOrderForm = ({
   direction,
   onDirectionChange,
@@ -275,6 +285,7 @@ const PerpsProOrderForm = ({
   onPlaceOrderPress,
 }: PerpsProOrderFormProps) => {
   const isLong = direction === 'long';
+
   return (
     <>
       <Box twClassName="gap-4" testID={ids.CONTAINER}>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -22,7 +22,12 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import React from 'react';
-import { InputAccessoryView, Keyboard, Platform } from 'react-native';
+import {
+  InputAccessoryView,
+  Keyboard,
+  Platform,
+  Pressable,
+} from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsFeesDisplay from '../../../../components/PerpsFeesDisplay';
@@ -37,8 +42,14 @@ import type {
   PerpsProOrderSummaryProps,
 } from './PerpsProOrderForm.types';
 const ids = PerpsProOrderFormSelectorsIDs;
-const buttonIcon = (iconName: IconName, onPress?: () => void) =>
-  onPress ? { iconName, onPress, size: ButtonIconSize.Xs } : undefined;
+const buttonIcon = (iconName: IconName, testID: string, onPress?: () => void) =>
+  ({
+    iconName,
+    onPress,
+    isDisabled: !onPress,
+    size: ButtonIconSize.Xs,
+    testID,
+  }) as const;
 const summaryKeyTextProps = {
   variant: TextVariant.BodyXs,
   fontWeight: FontWeight.Regular,
@@ -47,19 +58,12 @@ const summaryValueTextProps = {
   variant: TextVariant.BodyXs,
   fontWeight: FontWeight.Medium,
 };
-interface SelectionRowProps {
-  label: string;
+interface SelectionIndicatorProps {
   isSelected: boolean;
-  onChange: (value: boolean) => void;
   testID: string;
 }
-const SelectionRow = ({
-  label,
-  isSelected,
-  onChange,
-  testID,
-}: SelectionRowProps) => {
-  const indicator = isSelected ? (
+const SelectionIndicator = ({ isSelected, testID }: SelectionIndicatorProps) =>
+  isSelected ? (
     <Box
       twClassName="size-5 items-center justify-center rounded-full bg-icon-default"
       testID={`${testID}-indicator`}
@@ -76,19 +80,60 @@ const SelectionRow = ({
       testID={`${testID}-indicator`}
     />
   );
+
+interface ReduceOnlyRowProps extends SelectionIndicatorProps {
+  label: string;
+  onChange: (value: boolean) => void;
+}
+const ReduceOnlyRow = ({
+  label,
+  isSelected,
+  onChange,
+  testID,
+}: ReduceOnlyRowProps) => (
+  <Pressable
+    accessibilityRole="checkbox"
+    accessibilityState={{ checked: isSelected }}
+    accessibilityLabel={label}
+    onPress={() => onChange(!isSelected)}
+    testID={testID}
+  >
+    <Box twClassName="h-12 flex-row items-center justify-between rounded-xl bg-muted px-3">
+      <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        {label}
+      </Text>
+      <SelectionIndicator isSelected={isSelected} testID={testID} />
+    </Box>
+  </Pressable>
+);
+
+interface TPSLRowProps extends SelectionIndicatorProps {
+  label: string;
+  onPress?: () => void;
+}
+const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
+  const isDisabled = !onPress;
+
   return (
-    <ButtonBase
-      twClassName="h-12 rounded-xl bg-muted px-3"
-      contentWrapperProps={{ twClassName: 'w-full justify-between' }}
-      textProps={{ variant: TextVariant.BodySm, fontWeight: FontWeight.Medium }}
-      endAccessory={indicator}
-      isFullWidth
-      onPress={() => onChange(!isSelected)}
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled }}
+      accessibilityLabel={label}
+      disabled={isDisabled}
+      onPress={onPress}
       testID={testID}
-      accessibilityState={{ selected: isSelected }}
     >
-      {label}
-    </ButtonBase>
+      <Box
+        twClassName={`h-12 flex-row items-center justify-between rounded-xl bg-muted px-3${
+          isDisabled ? ' opacity-50' : ''
+        }`}
+      >
+        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+          {label}
+        </Text>
+        <SelectionIndicator isSelected={isSelected} testID={testID} />
+      </Box>
+    </Pressable>
   );
 };
 const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
@@ -147,7 +192,11 @@ const OrderSummary = ({
       <KeyValueRow
         keyLabel={strings('perps.slippage.slippage')}
         value={slippage}
-        valueEndButtonIconProps={buttonIcon(IconName.Edit, onSlippagePress)}
+        valueEndButtonIconProps={buttonIcon(
+          IconName.Edit,
+          ids.SUMMARY_SLIPPAGE_BUTTON,
+          onSlippagePress,
+        )}
         keyTextProps={summaryKeyTextProps}
         valueTextProps={summaryValueTextProps}
         twClassName="h-5"
@@ -165,7 +214,11 @@ const OrderSummary = ({
           variant={TextVariant.BodyXs}
         />
       }
-      keyEndButtonIconProps={buttonIcon(IconName.Info, onFeesInfoPress)}
+      keyEndButtonIconProps={buttonIcon(
+        IconName.Info,
+        ids.SUMMARY_FEES_BUTTON,
+        onFeesInfoPress,
+      )}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
       twClassName="h-5"
@@ -180,7 +233,6 @@ const PerpsProOrderForm = ({
   leverageLabel,
   onLeveragePress,
   orderType,
-  onOrderTypeChange,
   onOrderTypeButtonPress,
   limitPrice,
   onLimitPriceChange,
@@ -315,6 +367,7 @@ const PerpsProOrderForm = ({
               <ButtonIcon
                 iconName={IconName.SwapHorizontal}
                 size={ButtonIconSize.Xs}
+                isDisabled={!onSizeUnitPress}
                 onPress={onSizeUnitPress}
                 testID={ids.SIZE_UNIT_BUTTON}
                 accessibilityLabel={strings(
@@ -331,6 +384,10 @@ const PerpsProOrderForm = ({
                 showPercentageLabels={false}
                 showPercentageMarkers
                 variant="compact"
+                testID={ids.SIZE_SLIDER}
+                accessibilityLabel={strings(
+                  'perps.pro_order_form.size_percentage',
+                )}
               />
             }
           />
@@ -346,22 +403,23 @@ const PerpsProOrderForm = ({
               iconName={IconName.AddCircle}
               size={ButtonIconSize.Xs}
               iconProps={{ color: IconColor.IconAlternative }}
+              isDisabled={!onAddFundsPress}
               onPress={onAddFundsPress}
               testID={ids.ADD_FUNDS_BUTTON}
               accessibilityLabel={strings('perps.add_funds')}
             />
           </Box>
         </Box>
-        <SelectionRow
+        <ReduceOnlyRow
           label={strings('perps.order.reduce_only')}
           isSelected={reduceOnly}
           onChange={onReduceOnlyChange}
           testID={ids.REDUCE_ONLY}
         />
-        <SelectionRow
+        <TPSLRow
           label={strings('perps.pro_order_form.tpsl')}
           isSelected={isTPSLConfigured}
-          onChange={() => onTPSLPress?.()}
+          onPress={onTPSLPress}
           testID={ids.TPSL}
         />
         <Notices notices={notices} />

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -33,7 +33,7 @@ import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsFeesDisplay from '../../../../components/PerpsFeesDisplay';
 import PerpsSlider from '../../../../components/PerpsSlider';
 import PerpsProCompactInput, {
-  PERPS_PRO_INPUT_ACCESSORY_ID,
+  getPerpsProInputAccessoryID,
 } from './PerpsProCompactInput';
 import type {
   PerpsProOrderDirection,
@@ -136,6 +136,24 @@ const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
     </Pressable>
   );
 };
+
+const KeyboardAccessory = ({ inputTestID }: { inputTestID: string }) => (
+  <InputAccessoryView nativeID={getPerpsProInputAccessoryID(inputTestID)}>
+    <Box
+      twClassName="border-t border-muted bg-default px-3 py-2"
+      alignItems={BoxAlignItems.End}
+    >
+      <ButtonIcon
+        iconName={IconName.ArrowDown}
+        size={ButtonIconSize.Sm}
+        onPress={Keyboard.dismiss}
+        testID={`${ids.KEYBOARD_CLOSE}-${inputTestID}`}
+        accessibilityLabel={strings('perps.pro_order_form.close_keyboard')}
+      />
+    </Box>
+  </InputAccessoryView>
+);
+
 const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
   notices.length > 0 ? (
     <Box twClassName="gap-2">
@@ -441,22 +459,12 @@ const PerpsProOrderForm = ({
         <OrderSummary {...summary} />
       </Box>
       {Platform.OS === 'ios' ? (
-        <InputAccessoryView nativeID={PERPS_PRO_INPUT_ACCESSORY_ID}>
-          <Box
-            twClassName="border-t border-muted bg-default px-3 py-2"
-            alignItems={BoxAlignItems.End}
-          >
-            <ButtonIcon
-              iconName={IconName.ArrowDown}
-              size={ButtonIconSize.Sm}
-              onPress={Keyboard.dismiss}
-              testID={ids.KEYBOARD_CLOSE}
-              accessibilityLabel={strings(
-                'perps.pro_order_form.close_keyboard',
-              )}
-            />
-          </Box>
-        </InputAccessoryView>
+        <>
+          <KeyboardAccessory inputTestID={ids.SIZE_INPUT} />
+          {orderType === 'limit' ? (
+            <KeyboardAccessory inputTestID={ids.LIMIT_PRICE_INPUT} />
+          ) : null}
+        </>
       ) : null}
     </>
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -136,7 +136,7 @@ const OrderSummary = ({
       testID={ids.SUMMARY_MARGIN}
     />
     <KeyValueRow
-      keyLabel={strings('perps.order.liquidation_price')}
+      keyLabel={strings('perps.pro_order_form.est_liquidation')}
       value={liquidationPrice}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
@@ -345,6 +345,7 @@ const PerpsProOrderForm = ({
             <ButtonIcon
               iconName={IconName.AddCircle}
               size={ButtonIconSize.Xs}
+              iconProps={{ color: IconColor.IconAlternative }}
               onPress={onAddFundsPress}
               testID={ids.ADD_FUNDS_BUTTON}
               accessibilityLabel={strings('perps.add_funds')}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -38,7 +38,15 @@ import type {
 } from './PerpsProOrderForm.types';
 const ids = PerpsProOrderFormSelectorsIDs;
 const buttonIcon = (iconName: IconName, onPress?: () => void) =>
-  onPress ? { iconName, onPress } : undefined;
+  onPress ? { iconName, onPress, size: ButtonIconSize.Xs } : undefined;
+const summaryKeyTextProps = {
+  variant: TextVariant.BodyXs,
+  fontWeight: FontWeight.Regular,
+};
+const summaryValueTextProps = {
+  variant: TextVariant.BodyXs,
+  fontWeight: FontWeight.Medium,
+};
 interface SelectionRowProps {
   label: string;
   isSelected: boolean;
@@ -83,30 +91,31 @@ const SelectionRow = ({
     </ButtonBase>
   );
 };
-const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) => (
-  <Box twClassName="gap-2">
-    {notices.map((notice) =>
-      notice.variant === 'banner' ? (
-        <BannerAlert
-          key={notice.id}
-          severity={BannerAlertSeverity.Warning}
-          title={notice.title}
-          description={notice.message}
-          testID={`${ids.NOTICE}-${notice.id}`}
-        />
-      ) : (
-        <Text
-          key={notice.id}
-          variant={TextVariant.BodyXs}
-          color={TextColor.ErrorDefault}
-          testID={`${ids.NOTICE}-${notice.id}`}
-        >
-          {notice.message}
-        </Text>
-      ),
-    )}
-  </Box>
-);
+const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
+  notices.length > 0 ? (
+    <Box twClassName="gap-2">
+      {notices.map((notice) =>
+        notice.variant === 'banner' ? (
+          <BannerAlert
+            key={notice.id}
+            severity={BannerAlertSeverity.Warning}
+            title={notice.title}
+            description={notice.message}
+            testID={`${ids.NOTICE}-${notice.id}`}
+          />
+        ) : (
+          <Text
+            key={notice.id}
+            variant={TextVariant.BodyXs}
+            color={TextColor.ErrorDefault}
+            testID={`${ids.NOTICE}-${notice.id}`}
+          >
+            {notice.message}
+          </Text>
+        ),
+      )}
+    </Box>
+  ) : null;
 const OrderSummary = ({
   margin,
   liquidationPrice,
@@ -117,25 +126,31 @@ const OrderSummary = ({
   onSlippagePress,
   onFeesInfoPress,
 }: PerpsProOrderSummaryProps) => (
-  <Box twClassName="gap-2" testID={ids.SUMMARY}>
+  <Box twClassName="gap-1" testID={ids.SUMMARY}>
     <KeyValueRow
       keyLabel={strings('perps.order.margin')}
       value={margin}
+      keyTextProps={summaryKeyTextProps}
+      valueTextProps={summaryValueTextProps}
+      twClassName="h-5"
       testID={ids.SUMMARY_MARGIN}
     />
     <KeyValueRow
       keyLabel={strings('perps.order.liquidation_price')}
       value={liquidationPrice}
+      keyTextProps={summaryKeyTextProps}
+      valueTextProps={summaryValueTextProps}
+      twClassName="h-5"
       testID={ids.SUMMARY_LIQUIDATION}
     />
     {slippage !== undefined ? (
       <KeyValueRow
         keyLabel={strings('perps.slippage.slippage')}
         value={slippage}
-        valueEndButtonIconProps={buttonIcon(
-          IconName.ArrowRight,
-          onSlippagePress,
-        )}
+        valueEndButtonIconProps={buttonIcon(IconName.Edit, onSlippagePress)}
+        keyTextProps={summaryKeyTextProps}
+        valueTextProps={summaryValueTextProps}
+        twClassName="h-5"
         testID={ids.SUMMARY_SLIPPAGE}
       />
     ) : null}
@@ -151,6 +166,9 @@ const OrderSummary = ({
         />
       }
       keyEndButtonIconProps={buttonIcon(IconName.Info, onFeesInfoPress)}
+      keyTextProps={summaryKeyTextProps}
+      valueTextProps={summaryValueTextProps}
+      twClassName="h-5"
       testID={ids.SUMMARY_FEES}
     />
   </Box>
@@ -202,23 +220,39 @@ const PerpsProOrderForm = ({
           <FilterButton
             value="long"
             twClassName={isLong ? 'bg-success-muted' : ''}
-            textProps={isLong ? { color: TextColor.SuccessDefault } : undefined}
             testID={ids.DIRECTION_LONG}
           >
-            {strings('perps.market.long')}
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isLong ? TextColor.SuccessDefault : TextColor.TextAlternative
+              }
+            >
+              {strings('perps.market.long')}
+            </Text>
           </FilterButton>
           <FilterButton
             value="short"
             twClassName={!isLong ? 'bg-error-muted' : ''}
-            textProps={!isLong ? { color: TextColor.ErrorDefault } : undefined}
             testID={ids.DIRECTION_SHORT}
           >
-            {strings('perps.market.short')}
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isLong ? TextColor.TextAlternative : TextColor.ErrorDefault
+              }
+            >
+              {strings('perps.market.short')}
+            </Text>
           </FilterButton>
         </SegmentedControl>
         <Box twClassName="flex-row items-center justify-between">
           <Box twClassName="h-8 justify-center rounded-lg bg-muted px-2">
-            <Text variant={TextVariant.BodySm}>{marginModeLabel}</Text>
+            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              {marginModeLabel}
+            </Text>
           </Box>
           <ButtonBase
             size={ButtonBaseSize.Sm}
@@ -269,50 +303,52 @@ const PerpsProOrderForm = ({
             />
           ) : null}
         </Box>
-        <PerpsProCompactInput
-          label={strings('perps.pro_order_form.size_usd')}
-          value={size}
-          onChangeText={onSizeChange}
-          testID={ids.SIZE_INPUT}
-          placeholder="0.00"
-          endAccessory={
-            <ButtonIcon
-              iconName={IconName.SwapHorizontal}
-              size={ButtonIconSize.Xs}
-              onPress={onSizeUnitPress}
-              testID={ids.SIZE_UNIT_BUTTON}
-              accessibilityLabel={strings(
-                'perps.pro_order_form.toggle_size_unit',
-              )}
-            />
-          }
-          footer={
-            <PerpsSlider
-              value={balancePercentage}
-              onValueChange={onBalancePercentageChange}
-              minimumValue={0}
-              maximumValue={100}
-              showPercentageLabels={false}
-              showPercentageMarkers
-              variant="compact"
-            />
-          }
-        />
-        <Box twClassName="flex-row items-center gap-1">
-          <Text
-            variant={TextVariant.BodyXs}
-            color={TextColor.TextAlternative}
-            testID={ids.AVAILABLE_BALANCE}
-          >
-            {availableBalance}
-          </Text>
-          <ButtonIcon
-            iconName={IconName.AddCircle}
-            size={ButtonIconSize.Xs}
-            onPress={onAddFundsPress}
-            testID={ids.ADD_FUNDS_BUTTON}
-            accessibilityLabel={strings('perps.add_funds')}
+        <Box twClassName="gap-2">
+          <PerpsProCompactInput
+            label={strings('perps.pro_order_form.size_usd')}
+            value={size}
+            onChangeText={onSizeChange}
+            testID={ids.SIZE_INPUT}
+            placeholder="0.00"
+            endAccessory={
+              <ButtonIcon
+                iconName={IconName.SwapHorizontal}
+                size={ButtonIconSize.Xs}
+                onPress={onSizeUnitPress}
+                testID={ids.SIZE_UNIT_BUTTON}
+                accessibilityLabel={strings(
+                  'perps.pro_order_form.toggle_size_unit',
+                )}
+              />
+            }
+            footer={
+              <PerpsSlider
+                value={balancePercentage}
+                onValueChange={onBalancePercentageChange}
+                minimumValue={0}
+                maximumValue={100}
+                showPercentageLabels={false}
+                showPercentageMarkers
+                variant="compact"
+              />
+            }
           />
+          <Box twClassName="flex-row items-center gap-1">
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              testID={ids.AVAILABLE_BALANCE}
+            >
+              {availableBalance}
+            </Text>
+            <ButtonIcon
+              iconName={IconName.AddCircle}
+              size={ButtonIconSize.Xs}
+              onPress={onAddFundsPress}
+              testID={ids.ADD_FUNDS_BUTTON}
+              accessibilityLabel={strings('perps.add_funds')}
+            />
+          </Box>
         </Box>
         <SelectionRow
           label={strings('perps.order.reduce_only')}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
@@ -23,7 +23,6 @@ export interface PerpsProOrderFormProps {
   leverageLabel: string;
   onLeveragePress?: () => void;
   orderType: OrderType;
-  onOrderTypeChange: (orderType: OrderType) => void;
   onOrderTypeButtonPress: () => void;
   limitPrice: string;
   onLimitPriceChange: (value: string) => void;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
@@ -1,0 +1,54 @@
+import type { OrderType } from '@metamask/perps-controller';
+export type PerpsProOrderDirection = 'long' | 'short';
+export type PerpsProOrderNotice =
+  | {
+      id: string;
+      variant: 'banner';
+      title?: string;
+      message: string;
+    }
+  | {
+      id: string;
+      variant: 'inline';
+      message: string;
+    };
+export interface PerpsProOrderSummaryProps {
+  margin: string;
+  liquidationPrice: string;
+  slippage?: string;
+  fee?: number;
+  originalFee?: number;
+  feeDiscountPercentage?: number;
+  onSlippagePress?: () => void;
+  onFeesInfoPress?: () => void;
+}
+export interface PerpsProOrderFormProps {
+  direction: PerpsProOrderDirection;
+  onDirectionChange: (direction: PerpsProOrderDirection) => void;
+  marginModeLabel: string;
+  leverageLabel: string;
+  onLeveragePress?: () => void;
+  orderType: OrderType;
+  onOrderTypeChange: (orderType: OrderType) => void;
+  limitPrice: string;
+  onLimitPriceChange: (value: string) => void;
+  onUseMidPricePress?: () => void;
+  size: string;
+  onSizeChange: (value: string) => void;
+  onSizeUnitPress?: () => void;
+  balancePercentage: number;
+  onBalancePercentageChange: (value: number) => void;
+  availableBalance: string;
+  onAddFundsPress?: () => void;
+  reduceOnly: boolean;
+  onReduceOnlyChange: (value: boolean) => void;
+  isTPSLConfigured: boolean;
+  onTPSLPress?: () => void;
+  notices: PerpsProOrderNotice[];
+  summary: PerpsProOrderSummaryProps;
+  placeOrderLabel: string;
+  placeOrderIntent: PerpsProOrderDirection;
+  isPlaceOrderDisabled?: boolean;
+  isPlaceOrderLoading?: boolean;
+  onPlaceOrderPress: () => void;
+}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.types.ts
@@ -1,17 +1,11 @@
 import type { OrderType } from '@metamask/perps-controller';
 export type PerpsProOrderDirection = 'long' | 'short';
-export type PerpsProOrderNotice =
-  | {
-      id: string;
-      variant: 'banner';
-      title?: string;
-      message: string;
-    }
-  | {
-      id: string;
-      variant: 'inline';
-      message: string;
-    };
+export interface PerpsProOrderNotice {
+  id: string;
+  variant: 'banner' | 'inline';
+  title?: string;
+  message: string;
+}
 export interface PerpsProOrderSummaryProps {
   margin: string;
   liquidationPrice: string;
@@ -30,6 +24,7 @@ export interface PerpsProOrderFormProps {
   onLeveragePress?: () => void;
   orderType: OrderType;
   onOrderTypeChange: (orderType: OrderType) => void;
+  onOrderTypeButtonPress: () => void;
   limitPrice: string;
   onLimitPriceChange: (value: string) => void;
   onUseMidPricePress?: () => void;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -5,9 +5,19 @@ import { strings } from '../../../../../../../locales/i18n';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import PerpsProOrderForm from './PerpsProOrderForm/PerpsProOrderForm';
 import type { PerpsProOrderDirection } from './PerpsProOrderForm/PerpsProOrderForm.types';
-const PerpsProOrderFormPanel = () => {
+
+export interface PerpsProOrderFormPanelProps {
+  orderType: OrderType;
+  onOrderTypeChange: (orderType: OrderType) => void;
+  onOrderTypeButtonPress: () => void;
+}
+
+const PerpsProOrderFormPanel = ({
+  orderType,
+  onOrderTypeChange,
+  onOrderTypeButtonPress,
+}: PerpsProOrderFormPanelProps) => {
   const [direction, setDirection] = useState<PerpsProOrderDirection>('long');
-  const [orderType, setOrderType] = useState<OrderType>('market');
   const [limitPrice, setLimitPrice] = useState('');
   const [size, setSize] = useState('');
   const [balancePercentage, setBalancePercentage] = useState(0);
@@ -25,7 +35,8 @@ const PerpsProOrderFormPanel = () => {
         leverageLabel="3x"
         onLeveragePress={() => undefined}
         orderType={orderType}
-        onOrderTypeChange={setOrderType}
+        onOrderTypeChange={onOrderTypeChange}
+        onOrderTypeButtonPress={onOrderTypeButtonPress}
         limitPrice={limitPrice}
         onLimitPriceChange={setLimitPrice}
         onUseMidPricePress={() => undefined}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -1,20 +1,61 @@
 import { Box } from '@metamask/design-system-react-native';
-import React from 'react';
+import type { OrderType } from '@metamask/perps-controller';
+import React, { useState } from 'react';
+import { strings } from '../../../../../../../locales/i18n';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import PerpsProOrderForm from './PerpsProOrderForm/PerpsProOrderForm';
+import type { PerpsProOrderDirection } from './PerpsProOrderForm/PerpsProOrderForm.types';
+const PerpsProOrderFormPanel = () => {
+  const [direction, setDirection] = useState<PerpsProOrderDirection>('long');
+  const [orderType, setOrderType] = useState<OrderType>('market');
+  const [limitPrice, setLimitPrice] = useState('');
+  const [size, setSize] = useState('');
+  const [balancePercentage, setBalancePercentage] = useState(0);
+  const [reduceOnly, setReduceOnly] = useState(false);
 
-/**
- * Pro-mode order form column placeholder (left column).
- *
- * Scaffold only: empty container sized to the Figma order-form column. The
- * inline order-form capability populates this slot.
- */
-const PerpsProOrderFormPanel = () => (
-  <Box
-    testID={PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL}
-    twClassName="flex-1 py-4"
-  >
-    <Box twClassName="flex-1 rounded-xl bg-muted" />
-  </Box>
-);
+  return (
+    <Box
+      testID={PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL}
+      twClassName="flex-1 py-4"
+    >
+      <PerpsProOrderForm
+        direction={direction}
+        onDirectionChange={setDirection}
+        marginModeLabel={strings('perps.pro_order_form.isolated')}
+        leverageLabel="3x"
+        onLeveragePress={() => undefined}
+        orderType={orderType}
+        onOrderTypeChange={setOrderType}
+        limitPrice={limitPrice}
+        onLimitPriceChange={setLimitPrice}
+        onUseMidPricePress={() => undefined}
+        size={size}
+        onSizeChange={setSize}
+        onSizeUnitPress={() => undefined}
+        balancePercentage={balancePercentage}
+        onBalancePercentageChange={setBalancePercentage}
+        availableBalance={strings(
+          'perps.pro_order_form.available_balance_unavailable',
+        )}
+        onAddFundsPress={() => undefined}
+        reduceOnly={reduceOnly}
+        onReduceOnlyChange={setReduceOnly}
+        isTPSLConfigured={false}
+        onTPSLPress={() => undefined}
+        notices={[]}
+        summary={{
+          margin: '--',
+          liquidationPrice: '--',
+          slippage: '--',
+          onSlippagePress: () => undefined,
+          onFeesInfoPress: () => undefined,
+        }}
+        placeOrderLabel={strings('perps.pro_order_form.place_order')}
+        placeOrderIntent={direction}
+        onPlaceOrderPress={() => undefined}
+      />
+    </Box>
+  );
+};
 
 export default PerpsProOrderFormPanel;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -63,6 +63,7 @@ const PerpsProOrderFormPanel = ({
         }}
         placeOrderLabel={strings('perps.pro_order_form.place_order')}
         placeOrderIntent={direction}
+        isPlaceOrderDisabled
         onPlaceOrderPress={() => undefined}
       />
     </Box>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -8,13 +8,11 @@ import type { PerpsProOrderDirection } from './PerpsProOrderForm/PerpsProOrderFo
 
 export interface PerpsProOrderFormPanelProps {
   orderType: OrderType;
-  onOrderTypeChange: (orderType: OrderType) => void;
   onOrderTypeButtonPress: () => void;
 }
 
 const PerpsProOrderFormPanel = ({
   orderType,
-  onOrderTypeChange,
   onOrderTypeButtonPress,
 }: PerpsProOrderFormPanelProps) => {
   const [direction, setDirection] = useState<PerpsProOrderDirection>('long');
@@ -33,33 +31,25 @@ const PerpsProOrderFormPanel = ({
         onDirectionChange={setDirection}
         marginModeLabel={strings('perps.pro_order_form.isolated')}
         leverageLabel="3x"
-        onLeveragePress={() => undefined}
         orderType={orderType}
-        onOrderTypeChange={onOrderTypeChange}
         onOrderTypeButtonPress={onOrderTypeButtonPress}
         limitPrice={limitPrice}
         onLimitPriceChange={setLimitPrice}
-        onUseMidPricePress={() => undefined}
         size={size}
         onSizeChange={setSize}
-        onSizeUnitPress={() => undefined}
         balancePercentage={balancePercentage}
         onBalancePercentageChange={setBalancePercentage}
         availableBalance={strings(
           'perps.pro_order_form.available_balance_unavailable',
         )}
-        onAddFundsPress={() => undefined}
         reduceOnly={reduceOnly}
         onReduceOnlyChange={setReduceOnly}
         isTPSLConfigured={false}
-        onTPSLPress={() => undefined}
         notices={[]}
         summary={{
           margin: '--',
           liquidationPrice: '--',
           slippage: '--',
-          onSlippagePress: () => undefined,
-          onFeesInfoPress: () => undefined,
         }}
         placeOrderLabel={strings('perps.pro_order_form.place_order')}
         placeOrderIntent={direction}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, memo } from 'react';
 import type { BottomSheetRef } from '@metamask/design-system-react-native';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   type OrderType,
 } from '@metamask/perps-controller';
+
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import PerpsOrderTypeBottomSheetView from './PerpsOrderTypeBottomSheetView';
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
@@ -1,11 +1,5 @@
-import React, { useRef, useEffect, useCallback, memo } from 'react';
-import {
-  BottomSheet,
-  BottomSheetHeader,
-  BottomSheetRef,
-  ListItemSelect,
-} from '@metamask/design-system-react-native';
-import { strings } from '../../../../../../locales/i18n';
+import React, { useCallback, memo } from 'react';
+import type { BottomSheetRef } from '@metamask/design-system-react-native';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   PERPS_EVENT_PROPERTY,
@@ -13,7 +7,7 @@ import {
   type OrderType,
 } from '@metamask/perps-controller';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
-import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+import PerpsOrderTypeBottomSheetView from './PerpsOrderTypeBottomSheetView';
 
 interface PerpsOrderTypeBottomSheetProps {
   isVisible?: boolean;
@@ -34,34 +28,7 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
   direction = 'long',
   sheetRef: externalSheetRef,
 }) => {
-  const internalSheetRef = useRef<BottomSheetRef>(null);
-  const sheetRef = externalSheetRef || internalSheetRef;
   const { track } = usePerpsEventTracking();
-
-  useEffect(() => {
-    if (isVisible && !externalSheetRef) {
-      sheetRef.current?.onOpenBottomSheet();
-    }
-  }, [isVisible, externalSheetRef, sheetRef]);
-
-  const handleClose = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-  }, [sheetRef]);
-
-  const orderTypes = [
-    {
-      type: 'market' as OrderType,
-      title: strings('perps.order.type.market.title'),
-      description: strings('perps.order.type.market.description'),
-      testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
-    },
-    {
-      type: 'limit' as OrderType,
-      title: strings('perps.order.type.limit.title'),
-      description: strings('perps.order.type.limit.description'),
-      testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
-    },
-  ];
 
   const handleSelect = useCallback(
     (type: OrderType) => {
@@ -82,40 +49,18 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
       }
 
       onSelect(type);
-      handleClose();
     },
-    [currentOrderType, track, asset, direction, onSelect, handleClose],
+    [currentOrderType, track, asset, direction, onSelect],
   );
 
-  if (!isVisible) return null;
-
   return (
-    <BottomSheet
-      ref={sheetRef}
-      testID={PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER}
-      goBack={!externalSheetRef ? onClose : undefined}
-      onClose={externalSheetRef ? onClose : undefined}
-    >
-      <BottomSheetHeader
-        onClose={handleClose}
-        closeButtonProps={{
-          testID: PerpsOrderTypeBottomSheetSelectorsIDs.CLOSE_BUTTON,
-        }}
-      >
-        {strings('perps.order.type.title')}
-      </BottomSheetHeader>
-      {orderTypes.map(({ type, title, description, testID }) => (
-        <ListItemSelect
-          key={type}
-          title={title}
-          description={description}
-          isSelected={currentOrderType === type}
-          showSelectedIcon={false}
-          onPress={() => handleSelect(type)}
-          testID={testID}
-        />
-      ))}
-    </BottomSheet>
+    <PerpsOrderTypeBottomSheetView
+      isVisible={isVisible}
+      onClose={onClose}
+      onSelect={handleSelect}
+      currentOrderType={currentOrderType}
+      sheetRef={externalSheetRef}
+    />
   );
 };
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -8,6 +8,7 @@ import type { OrderType } from '@metamask/perps-controller';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+
 export interface PerpsOrderTypeBottomSheetViewProps {
   isVisible?: boolean;
   onClose: () => void;
@@ -17,6 +18,7 @@ export interface PerpsOrderTypeBottomSheetViewProps {
   showSelectedIcon?: boolean;
   sheetRef?: React.RefObject<BottomSheetRef | null>;
 }
+
 const PerpsOrderTypeBottomSheetView = ({
   isVisible = true,
   onClose,
@@ -42,14 +44,17 @@ const PerpsOrderTypeBottomSheetView = ({
       testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
     },
   ] as const;
+
   useEffect(() => {
     if (isVisible && !externalSheetRef) {
       sheetRef.current?.onOpenBottomSheet();
     }
   }, [isVisible, externalSheetRef, sheetRef]);
+
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
   }, [sheetRef]);
+
   const handleSelect = useCallback(
     (orderType: OrderType) => {
       onSelect(orderType);
@@ -57,9 +62,11 @@ const PerpsOrderTypeBottomSheetView = ({
     },
     [handleClose, onSelect],
   );
+
   if (!isVisible) {
     return null;
   }
+
   return (
     <BottomSheet
       ref={sheetRef}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -1,0 +1,100 @@
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
+  ListItemSelect,
+} from '@metamask/design-system-react-native';
+import type { OrderType } from '@metamask/perps-controller';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { strings } from '../../../../../../locales/i18n';
+import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+export interface PerpsOrderTypeBottomSheetViewProps {
+  isVisible?: boolean;
+  onClose: () => void;
+  onSelect: (orderType: OrderType) => void;
+  currentOrderType?: OrderType;
+  title?: string;
+  showSelectedIcon?: boolean;
+  sheetRef?: React.RefObject<BottomSheetRef | null>;
+}
+const PerpsOrderTypeBottomSheetView = ({
+  isVisible = true,
+  onClose,
+  onSelect,
+  currentOrderType,
+  title = strings('perps.order.type.title'),
+  showSelectedIcon = false,
+  sheetRef: externalSheetRef,
+}: PerpsOrderTypeBottomSheetViewProps) => {
+  const internalSheetRef = useRef<BottomSheetRef>(null);
+  const sheetRef = externalSheetRef ?? internalSheetRef;
+  const orderTypes: {
+    type: OrderType;
+    title: string;
+    description: string;
+    testID: string;
+  }[] = [
+    {
+      type: 'market',
+      title: strings('perps.order.type.market.title'),
+      description: strings('perps.order.type.market.description'),
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+    },
+    {
+      type: 'limit',
+      title: strings('perps.order.type.limit.title'),
+      description: strings('perps.order.type.limit.description'),
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
+    },
+  ];
+  useEffect(() => {
+    if (isVisible && !externalSheetRef) {
+      sheetRef.current?.onOpenBottomSheet();
+    }
+  }, [isVisible, externalSheetRef, sheetRef]);
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, [sheetRef]);
+  const handleSelect = useCallback(
+    (orderType: OrderType) => {
+      onSelect(orderType);
+      handleClose();
+    },
+    [handleClose, onSelect],
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      testID={PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER}
+      goBack={!externalSheetRef ? onClose : undefined}
+      onClose={externalSheetRef ? onClose : undefined}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        closeButtonProps={{
+          testID: PerpsOrderTypeBottomSheetSelectorsIDs.CLOSE_BUTTON,
+        }}
+      >
+        {title}
+      </BottomSheetHeader>
+      {orderTypes.map((orderType) => (
+        <ListItemSelect
+          key={orderType.type}
+          title={orderType.title}
+          description={orderType.description}
+          isSelected={currentOrderType === orderType.type}
+          showSelectedIcon={showSelectedIcon}
+          onPress={() => handleSelect(orderType.type)}
+          testID={orderType.testID}
+        />
+      ))}
+    </BottomSheet>
+  );
+};
+
+export default PerpsOrderTypeBottomSheetView;

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -28,12 +28,7 @@ const PerpsOrderTypeBottomSheetView = ({
 }: PerpsOrderTypeBottomSheetViewProps) => {
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef ?? internalSheetRef;
-  const orderTypes: {
-    type: OrderType;
-    title: string;
-    description: string;
-    testID: string;
-  }[] = [
+  const orderTypes = [
     {
       type: 'market',
       title: strings('perps.order.type.market.title'),
@@ -46,7 +41,7 @@ const PerpsOrderTypeBottomSheetView = ({
       description: strings('perps.order.type.limit.description'),
       testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
     },
-  ];
+  ] as const;
   useEffect(() => {
     if (isVisible && !externalSheetRef) {
       sheetRef.current?.onOpenBottomSheet();
@@ -62,11 +57,9 @@ const PerpsOrderTypeBottomSheetView = ({
     },
     [handleClose, onSelect],
   );
-
   if (!isVisible) {
     return null;
   }
-
   return (
     <BottomSheet
       ref={sheetRef}

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
@@ -53,7 +53,7 @@ const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
       borderRadius: thumbSize / 2,
       position: 'absolute',
       top: (trackHeight - thumbSize) / 2,
-      left: -thumbSize / 2,
+      left: isCompact ? 0 : -thumbSize / 2,
       elevation: 4,
       borderColor: colors.icon.default,
     },

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
@@ -15,8 +15,14 @@ const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
 
   return StyleSheet.create({
     container: {
-      paddingTop: isCompact ? 16 : 8,
-      paddingBottom: isCompact ? 12 : 8,
+      minHeight: isCompact ? 44 : undefined,
+      marginVertical: isCompact ? -6 : 0,
+      paddingVertical: isCompact ? 0 : 8,
+      justifyContent: 'center',
+    },
+    interactionArea: {
+      minHeight: isCompact ? 44 : undefined,
+      justifyContent: 'center',
     },
     sliderContainer: {
       flexDirection: 'row',
@@ -95,7 +101,7 @@ const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
       backgroundColor: colors.text.muted,
       borderRadius: 2.5,
       position: 'absolute',
-      top: isCompact ? 0 : 2,
+      top: isCompact ? 20 : 2,
       transform: [{ translateX: -2.5 }],
       zIndex: -2,
     },

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
@@ -36,7 +36,9 @@ const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
     },
     progress: {
       height: trackHeight,
-      backgroundColor: colors.icon.alternative,
+      backgroundColor: isCompact
+        ? colors.icon.default
+        : colors.icon.alternative,
       borderRadius: 20,
       position: 'absolute',
       left: 0,
@@ -45,7 +47,9 @@ const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
     thumb: {
       width: thumbSize,
       height: thumbSize,
-      backgroundColor: colors.icon.defaultPressed,
+      backgroundColor: isCompact
+        ? colors.icon.default
+        : colors.icon.defaultPressed,
       borderRadius: thumbSize / 2,
       position: 'absolute',
       top: (trackHeight - thumbSize) / 2,

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.styles.ts
@@ -1,32 +1,41 @@
 import { StyleSheet } from 'react-native';
 import type { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+interface PerpsSliderStyleVars {
+  showPercentageLabels: boolean;
+  variant: 'default' | 'compact';
+}
+
+const styleSheet = (params: { theme: Theme; vars: PerpsSliderStyleVars }) => {
+  const { theme, vars } = params;
   const { colors } = theme;
+  const isCompact = vars.variant === 'compact';
+  const trackHeight = isCompact ? 4 : 8;
+  const thumbSize = isCompact ? 16 : 32;
 
   return StyleSheet.create({
     container: {
-      paddingVertical: 8,
+      paddingTop: isCompact ? 16 : 8,
+      paddingBottom: isCompact ? 12 : 8,
     },
     sliderContainer: {
       flexDirection: 'row',
       alignItems: 'center',
-      marginHorizontal: 16,
+      marginHorizontal: isCompact ? 0 : 16,
     },
     trackContainer: {
       flex: 1,
       position: 'relative',
-      paddingBottom: 30,
+      paddingBottom: vars.showPercentageLabels ? 30 : 0,
     },
     track: {
-      height: 8,
+      height: trackHeight,
       backgroundColor: colors.border.muted,
       borderRadius: 20,
       position: 'relative',
     },
     progress: {
-      height: 8,
+      height: trackHeight,
       backgroundColor: colors.icon.alternative,
       borderRadius: 20,
       position: 'absolute',
@@ -34,13 +43,13 @@ const styleSheet = (params: { theme: Theme }) => {
       top: 0,
     },
     thumb: {
-      width: 32,
-      height: 32,
+      width: thumbSize,
+      height: thumbSize,
       backgroundColor: colors.icon.defaultPressed,
-      borderRadius: 16,
+      borderRadius: thumbSize / 2,
       position: 'absolute',
-      top: -13,
-      left: -16,
+      top: (trackHeight - thumbSize) / 2,
+      left: -thumbSize / 2,
       elevation: 4,
       borderColor: colors.icon.default,
     },
@@ -82,7 +91,7 @@ const styleSheet = (params: { theme: Theme }) => {
       backgroundColor: colors.text.muted,
       borderRadius: 2.5,
       position: 'absolute',
-      top: 2,
+      top: isCompact ? 0 : 2,
       transform: [{ translateX: -2.5 }],
       zIndex: -2,
     },

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react-native';
 import PerpsSlider from './PerpsSlider';
+import styleSheet from './PerpsSlider.styles';
 import { mockTheme } from '../../../../../util/theme';
 
 // react-native-reanimated is already mocked globally via setUpTests() in testSetup.js
@@ -51,11 +52,13 @@ describe('PerpsSlider', () => {
     );
     useStyles.mockImplementation(
       (
-        styleSheet: (params: {
+        createStyles: (params: {
           theme: typeof mockTheme;
+          vars: Record<string, unknown>;
         }) => Record<string, unknown>,
+        vars: Record<string, unknown>,
       ) => ({
-        styles: styleSheet({ theme: mockTheme }),
+        styles: createStyles({ theme: mockTheme, vars }),
       }),
     );
   });
@@ -84,6 +87,17 @@ describe('PerpsSlider', () => {
       expect(screen.queryByText('75%')).toBeNull();
       expect(screen.queryByText('100%')).toBeNull();
       expect(screen.getByTestId('perps-slider-marker-25')).toBeOnTheScreen();
+    });
+
+    it('uses the compact Figma geometry', () => {
+      const styles = styleSheet({
+        theme: mockTheme,
+        vars: { showPercentageLabels: false, variant: 'compact' },
+      });
+
+      expect(styles.track).toMatchObject({ height: 4 });
+      expect(styles.thumb).toMatchObject({ width: 16, height: 16 });
+      expect(styles.sliderContainer).toMatchObject({ marginHorizontal: 0 });
     });
 
     it('hides markers without hiding percentage labels', () => {

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -83,6 +83,16 @@ describe('PerpsSlider', () => {
       expect(screen.queryByText('50%')).toBeNull();
       expect(screen.queryByText('75%')).toBeNull();
       expect(screen.queryByText('100%')).toBeNull();
+      expect(screen.getByTestId('perps-slider-marker-25')).toBeOnTheScreen();
+    });
+
+    it('hides markers without hiding percentage labels', () => {
+      render(<PerpsSlider {...defaultProps} showPercentageMarkers={false} />);
+
+      expect(
+        screen.queryByTestId('perps-slider-marker-25'),
+      ).not.toBeOnTheScreen();
+      expect(screen.getByText('25%')).toBeOnTheScreen();
     });
 
     it('renders quick values when provided', () => {

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -105,6 +105,7 @@ describe('PerpsSlider', () => {
         left: 0,
         backgroundColor: mockTheme.colors.icon.default,
       });
+      expect(styles.interactionArea).toMatchObject({ minHeight: 44 });
       expect(styles.sliderContainer).toMatchObject({ marginHorizontal: 0 });
     });
 
@@ -591,16 +592,149 @@ describe('PerpsSlider', () => {
   });
 
   describe('Accessibility', () => {
+    it('exposes compact slider value with adjustable semantics', () => {
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          value={42}
+          variant="compact"
+          showPercentageLabels={false}
+          testID="perps-slider"
+          accessibilityLabel="Order size percentage"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+
+      expect(slider).toHaveProp('accessibilityRole', 'adjustable');
+      expect(slider).toHaveProp('accessibilityLabel', 'Order size percentage');
+      expect(slider).toHaveProp('accessibilityValue', {
+        min: 0,
+        max: 100,
+        now: 42,
+        text: '42%',
+      });
+    });
+
+    it('increments the value by the configured step', () => {
+      const onValueChange = jest.fn();
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          value={50}
+          step={5}
+          onValueChange={onValueChange}
+          testID="perps-slider"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+      act(() =>
+        slider.props.onAccessibilityAction({
+          nativeEvent: { actionName: 'increment' },
+        }),
+      );
+
+      expect(onValueChange).toHaveBeenCalledWith(55);
+    });
+
+    it('decrements the value by the configured step', () => {
+      const onValueChange = jest.fn();
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          value={50}
+          step={5}
+          onValueChange={onValueChange}
+          testID="perps-slider"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+      act(() =>
+        slider.props.onAccessibilityAction({
+          nativeEvent: { actionName: 'decrement' },
+        }),
+      );
+
+      expect(onValueChange).toHaveBeenCalledWith(45);
+    });
+
+    it('does not decrement below the minimum value', () => {
+      const onValueChange = jest.fn();
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          value={0}
+          onValueChange={onValueChange}
+          testID="perps-slider"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+      act(() =>
+        slider.props.onAccessibilityAction({
+          nativeEvent: { actionName: 'decrement' },
+        }),
+      );
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not increment above the maximum value', () => {
+      const onValueChange = jest.fn();
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          value={100}
+          onValueChange={onValueChange}
+          testID="perps-slider"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+      act(() =>
+        slider.props.onAccessibilityAction({
+          nativeEvent: { actionName: 'increment' },
+        }),
+      );
+
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores accessibility actions while disabled', () => {
+      const onValueChange = jest.fn();
+      render(
+        <PerpsSlider
+          {...defaultProps}
+          onValueChange={onValueChange}
+          disabled
+          testID="perps-slider"
+        />,
+      );
+
+      const slider = screen.getByTestId('perps-slider');
+      act(() =>
+        slider.props.onAccessibilityAction({
+          nativeEvent: { actionName: 'increment' },
+        }),
+      );
+
+      expect(slider).toHaveProp('accessibilityState', { disabled: true });
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
     it('provides accessible touch targets for percentage buttons', () => {
       // Act
       render(<PerpsSlider {...defaultProps} />);
 
       // Assert - All percentage button labels should be rendered and accessible
-      expect(screen.getByText('0%')).toBeOnTheScreen();
-      expect(screen.getByText('25%')).toBeOnTheScreen();
-      expect(screen.getByText('50%')).toBeOnTheScreen();
-      expect(screen.getByText('75%')).toBeOnTheScreen();
-      expect(screen.getByText('100%')).toBeOnTheScreen();
+      for (const percent of [0, 25, 50, 75, 100]) {
+        expect(screen.getByLabelText(`${percent}%`)).toHaveProp(
+          'accessibilityRole',
+          'button',
+        );
+      }
     });
 
     it('provides accessible touch targets for quick value buttons', () => {

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -96,7 +96,14 @@ describe('PerpsSlider', () => {
       });
 
       expect(styles.track).toMatchObject({ height: 4 });
-      expect(styles.thumb).toMatchObject({ width: 16, height: 16 });
+      expect(styles.progress).toMatchObject({
+        backgroundColor: mockTheme.colors.icon.default,
+      });
+      expect(styles.thumb).toMatchObject({
+        width: 16,
+        height: 16,
+        backgroundColor: mockTheme.colors.icon.default,
+      });
       expect(styles.sliderContainer).toMatchObject({ marginHorizontal: 0 });
     });
 

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -102,6 +102,7 @@ describe('PerpsSlider', () => {
       expect(styles.thumb).toMatchObject({
         width: 16,
         height: 16,
+        left: 0,
         backgroundColor: mockTheme.colors.icon.default,
       });
       expect(styles.sliderContainer).toMatchObject({ marginHorizontal: 0 });

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -133,7 +133,17 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
   }));
 
   const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
+    transform: [
+      {
+        translateX:
+          variant === 'compact'
+            ? Math.max(
+                0,
+                Math.min(translateX.value - 8, sliderWidth.value - 16),
+              )
+            : translateX.value,
+      },
+    ],
   }));
 
   // JS callback wrapper

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
+import { Text } from '@metamask/design-system-react-native';
 import {
   type AccessibilityActionEvent,
   TouchableOpacity,
@@ -9,6 +10,7 @@ import {
   GestureDetector,
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
+import LinearGradient from 'react-native-linear-gradient';
 import Animated, {
   configureReanimatedLogger,
   ReanimatedLogLevel,
@@ -21,10 +23,8 @@ import {
   ImpactMoment,
   type HapticImpactMoment,
 } from '../../../../../util/haptics';
-import LinearGradient from 'react-native-linear-gradient';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './PerpsSlider.styles';
-import { Text } from '@metamask/design-system-react-native';
 
 // Only configure reanimated logger in non-test environments
 if (

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -44,6 +44,7 @@ interface PerpsSliderProps {
   disabled?: boolean;
   progressColor?: 'default' | 'gradient';
   quickValues?: number[];
+  variant?: 'default' | 'compact';
 }
 
 const PerpsSlider: React.FC<PerpsSliderProps> = ({
@@ -57,8 +58,12 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
   disabled = false,
   progressColor = 'default',
   quickValues,
+  variant = 'default',
 }) => {
-  const { styles } = useStyles(styleSheet, {});
+  const { styles } = useStyles(styleSheet, {
+    showPercentageLabels,
+    variant,
+  });
 
   // Shared values for animations
   const sliderWidth = useSharedValue(0);

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import {
+  type AccessibilityActionEvent,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import {
   Gesture,
   GestureDetector,
@@ -45,6 +49,8 @@ interface PerpsSliderProps {
   progressColor?: 'default' | 'gradient';
   quickValues?: number[];
   variant?: 'default' | 'compact';
+  testID?: string;
+  accessibilityLabel?: string;
 }
 
 const PerpsSlider: React.FC<PerpsSliderProps> = ({
@@ -59,6 +65,8 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
   progressColor = 'default',
   quickValues,
   variant = 'default',
+  testID,
+  accessibilityLabel,
 }) => {
   const { styles } = useStyles(styleSheet, {
     showPercentageLabels,
@@ -243,30 +251,88 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
     ],
   );
 
+  const handleAccessibilityAction = useCallback(
+    (event: AccessibilityActionEvent) => {
+      if (disabled) {
+        return;
+      }
+
+      const { actionName } = event.nativeEvent;
+      if (actionName !== 'increment' && actionName !== 'decrement') {
+        return;
+      }
+
+      const currentValue = Math.min(
+        maximumValue,
+        Math.max(minimumValue, value),
+      );
+      const delta = actionName === 'increment' ? step : -step;
+      const nextValue = Math.min(
+        maximumValue,
+        Math.max(minimumValue, currentValue + delta),
+      );
+
+      if (nextValue !== currentValue) {
+        onValueChange(nextValue);
+        checkThresholdCrossing(nextValue);
+      }
+    },
+    [
+      checkThresholdCrossing,
+      disabled,
+      maximumValue,
+      minimumValue,
+      onValueChange,
+      step,
+      value,
+    ],
+  );
+
   const percentageSteps = [0, 25, 50, 75, 100];
+  const range = maximumValue - minimumValue;
+  const clampedValue = Math.min(maximumValue, Math.max(minimumValue, value));
+  const percentage =
+    range === 0 ? 0 : Math.round(((clampedValue - minimumValue) / range) * 100);
 
   return (
     <GestureHandlerRootView style={styles.container}>
       <View style={styles.sliderContainer}>
         <View style={styles.trackContainer} onLayout={handleLayout}>
           <GestureDetector gesture={composed}>
-            <Animated.View style={styles.track}>
-              {progressColor === 'gradient' ? (
-                <Animated.View style={progressStyle}>
-                  <LinearGradient
-                    colors={['green', 'yellow', 'red']}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 1, y: 0 }}
-                    style={styles.gradientProgress}
-                  />
-                </Animated.View>
-              ) : (
-                <Animated.View style={[styles.progress, progressStyle]} />
-              )}
-              <Animated.View
-                style={[styles.thumb, thumbStyle]}
-                hitSlop={{ top: 25, bottom: 25, left: 25, right: 25 }}
-              />
+            <Animated.View
+              style={styles.interactionArea}
+              testID={testID}
+              accessible
+              accessibilityRole="adjustable"
+              accessibilityLabel={accessibilityLabel}
+              accessibilityState={{ disabled }}
+              accessibilityValue={{
+                min: minimumValue,
+                max: maximumValue,
+                now: clampedValue,
+                text: `${percentage}%`,
+              }}
+              accessibilityActions={[
+                { name: 'increment' },
+                { name: 'decrement' },
+              ]}
+              onAccessibilityAction={handleAccessibilityAction}
+            >
+              <Animated.View style={styles.track}>
+                {progressColor === 'gradient' ? (
+                  <Animated.View style={progressStyle}>
+                    <LinearGradient
+                      colors={['green', 'yellow', 'red']}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 0 }}
+                      style={styles.gradientProgress}
+                    />
+                  </Animated.View>
+                ) : (
+                  <Animated.View style={[styles.progress, progressStyle]} />
+                )}
+                <Animated.View style={[styles.thumb, thumbStyle]} />
+              </Animated.View>
             </Animated.View>
           </GestureDetector>
 
@@ -335,6 +401,9 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
                   style={[styles.percentageWrapper, wrapperStyle]}
                   onPress={() => handlePressPercentage(percent)}
                   disabled={disabled}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${percent}%`}
+                  accessibilityState={{ disabled }}
                 >
                   <Text style={styles.percentageText}>{percent}%</Text>
                 </TouchableOpacity>

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -39,6 +39,7 @@ interface PerpsSliderProps {
   minimumValue?: number;
   maximumValue?: number;
   step?: number;
+  showPercentageMarkers?: boolean;
   showPercentageLabels?: boolean;
   disabled?: boolean;
   progressColor?: 'default' | 'gradient';
@@ -51,6 +52,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
   minimumValue = 0,
   maximumValue = 100,
   step = 1,
+  showPercentageMarkers = true,
   showPercentageLabels = true,
   disabled = false,
   progressColor = 'default',
@@ -254,7 +256,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
           </GestureDetector>
 
           {/* Percentage dots positioned on the track */}
-          {showPercentageLabels &&
+          {showPercentageMarkers &&
             percentageSteps.map((percent) => {
               // Don't show dots at 0% and 100%
 
@@ -282,6 +284,7 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
               return (
                 <View
                   key={`dot-${percent}`}
+                  testID={`perps-slider-marker-${percent}`}
                   style={[styles.percentageDot, dotStyle]}
                 />
               );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1499,6 +1499,16 @@
       "metamask_fee_tooltip_deposit": "MetaMask does not charge any fees for deposits to Hyperliquid",
       "metamask_fee_tooltip_withdrawal": "MetaMask does not charge any fees for withdrawals from Hyperliquid"
     },
+    "pro_order_form": {
+      "isolated": "Isolated",
+      "choose_order_type": "Choose order type",
+      "size_usd": "Size USD",
+      "toggle_size_unit": "Switch size denomination",
+      "available_balance_unavailable": "Available balance: --",
+      "tpsl": "Take profit / Stop loss",
+      "place_order": "Place order",
+      "close_keyboard": "Close keyboard"
+    },
     "order": {
       "title": "New order",
       "leverage": "Leverage",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1503,6 +1503,7 @@
       "isolated": "Isolated",
       "choose_order_type": "Choose order type",
       "size_usd": "Size USD",
+      "size_percentage": "Order size percentage",
       "toggle_size_unit": "Switch size denomination",
       "available_balance_unavailable": "-- available",
       "est_liquidation": "Est Liquidation",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1504,7 +1504,8 @@
       "choose_order_type": "Choose order type",
       "size_usd": "Size USD",
       "toggle_size_unit": "Switch size denomination",
-      "available_balance_unavailable": "Available balance: --",
+      "available_balance_unavailable": "-- available",
+      "est_liquidation": "Est Liquidation",
       "tpsl": "TP / SL",
       "place_order": "Place order",
       "close_keyboard": "Close keyboard"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1505,7 +1505,7 @@
       "size_usd": "Size USD",
       "toggle_size_unit": "Switch size denomination",
       "available_balance_unavailable": "Available balance: --",
-      "tpsl": "Take profit / Stop loss",
+      "tpsl": "TP / SL",
       "place_order": "Place order",
       "close_keyboard": "Close keyboard"
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Introduces the prop driven Perps Pro order form UI and mounts it in the Pro market scaffold using presentation only local state.

This provides the complete visual and interaction layer required by the Pro trading layout, including direction, order type, native numeric inputs, leverage, size slider, reduce-only, TP/SL, notices, summary rows, and Place Order states. It also shares the existing order type bottom-sheet presentation and extends `PerpsSlider` to support markers without labels.

Business state, validation, analytics, navigation, and order submission remain deferred to TAT-3595. The Pro route remains protected by the existing temporary gate, so Lite behavior is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added inline pro order form UI for perps Pro mode

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3580

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5ae9ed4f-f8d2-4118-8a0d-6de43f324740





## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new trading UI and shared slider/bottom-sheet changes, but order submission and business logic stay deferred and Place Order remains disabled in the scaffold.
> 
> **Overview**
> **Adds the Pro perps order form** to replace the order-form column placeholder: a prop-driven `PerpsProOrderForm` (long/short, margin/leverage labels, order type row, limit price when applicable, size with compact slider, reduce-only, TP/SL, notices, summary, semantic Place Order) plus `PerpsProCompactInput` with iOS decimal-pad accessories.
> 
> **Wires the Pro market screen** so `PerpsProMarketView` owns order-type state, opens shared `PerpsOrderTypeBottomSheetView` (custom title + selected icon), passes type into `PerpsProOrderFormPanel` (local presentation state, disabled Place Order, placeholder summary/balance), and sets scroll `keyboardDismissMode` / `keyboardShouldPersistTaps`.
> 
> **Refactors order-type selection** by extracting `PerpsOrderTypeBottomSheetView`; the existing `PerpsOrderTypeBottomSheet` wrapper keeps analytics and delegates to the view.
> 
> **Extends `PerpsSlider`** with optional `compact` styling, `showPercentageMarkers` independent of labels, and adjustable accessibility actions; Pro form uses compact + markers without labels.
> 
> Adds `PerpsProOrderFormSelectorsIDs`, `perps.pro_order_form` strings, and unit/integration tests for the form, market view, and slider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634b6c5079be41dcea7135a4c18df7f312a319b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->