### PR TITLE
chore: complete BigInt migration burndown for AssetOverview Price components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,6 @@ const utilNumberImportBurndownFiles = [
   'app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx',
   'app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx',
   'app/components/UI/AccountInfoCard/index.js',
-  'app/components/UI/AssetOverview/Price/Price.advanced.tsx',
-  'app/components/UI/AssetOverview/Price/Price.legacy.tsx',
   'app/components/UI/AssetOverview/utils/marketDetails.ts',
   'app/components/UI/Bridge/components/QuoteSelectorView/QuoteRow.tsx',
   'app/components/UI/Bridge/components/QuoteSelectorView/index.tsx',

--- a/docs/bigint-migration-guide.md
+++ b/docs/bigint-migration-guide.md
@@ -124,8 +124,6 @@ Includes Stake UI and Money paths owned via `**/Earn/**`, `**/earn/**`, `**/Mone
 
 ### @MetaMask/metamask-assets
 
-- `app/components/UI/AssetOverview/Price/Price.advanced.tsx`
-- `app/components/UI/AssetOverview/Price/Price.legacy.tsx`
 - `app/components/UI/AssetOverview/utils/marketDetails.ts`
 - `app/components/UI/CollectibleOverview/index.js`
 - `app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.test.ts`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Completes the BN.js → BigInt burndown for `Price.advanced.tsx` and `Price.legacy.tsx`.

These files no longer import `app/util/number/index.js`. Currency formatting was migrated to `TokenPriceTitleHub`, which already uses `app/util/number/bigint`, in #32204. This PR removes the stale ESLint allowlist entries and updates the migration guide burndown list so legacy imports cannot creep back in.

## Related issues

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3716

## Manual testing steps

N/A — behavior-preserving; no runtime code changes.

## Screenshots/Recordings

N/A

## Changed files

| File | Change | Verification |
| --- | --- | --- |
| `.eslintrc.js` | Removed `Price.advanced.tsx` and `Price.legacy.tsx` from `utilNumberImportBurndownFiles` | `yarn eslint` on touched Price files |
| `docs/bigint-migration-guide.md` | Removed migrated paths from burndown documentation | Review only |

## Verification

- `yarn jest app/util/number/bigint-parity.test.ts` — PASS
- `yarn jest app/components/UI/AssetOverview/Price/Price.advanced.test.tsx` — PASS
- `yarn jest app/components/UI/AssetOverview/Price/Price.legacy.test.tsx` — PASS
- `yarn jest app/components/UI/AssetOverview/Price/Price.test.tsx` — PASS
- `yarn eslint .eslintrc.js app/components/UI/AssetOverview/Price/Price.advanced.tsx app/components/UI/AssetOverview/Price/Price.legacy.tsx` — PASS (pre-existing react-compiler warning only)

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bed50392-d7ad-4f58-bfca-c48d4cab3a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bed50392-d7ad-4f58-bfca-c48d4cab3a62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

