### PR TITLE
fix(agentic-cli): remove double top-inset on iOS AgenticCliDashboardWebview header

### DIFF
--- a/app/components/Views/AgenticCliDashboardWebview/index.tsx
+++ b/app/components/Views/AgenticCliDashboardWebview/index.tsx
@@ -104,7 +104,7 @@ const AgenticCliDashboardWebview: React.FC = () => {
       getHeaderCompactStandardNavbarOptions({
         title: strings('sdk_connect_v2.agentic_cli_dashboard_webview.title'),
         onBack: close,
-        includesTopInset: true,
+        includesTopInset: Platform.OS === 'android',
         twClassName: 'bg-default rounded-t-2xl',
       }),
     );


### PR DESCRIPTION
## **Description**

**TL;DR** — On iOS, the AgenticCliDashboardWebview "Select project" screen shows a large empty band above the header title. The header sets `includesTopInset: true`, which stacks on top of the OS-owned top gap that iOS Native Stack already provides for `presentation: 'modal'`. Fix: make the inset platform-conditional (`Platform.OS === 'android'`) so Android still clears the status bar and iOS relies solely on its modal chrome.

**Root cause** — `getHeaderCompactStandardNavbarOptions` applies `marginTop: insets.top` when `includesTopInset` is `true`. Every other consumer of this helper (`PrivateKeyList`, `AddressList`, `useSendNavbar`, …) uses `presentation: 'card'` where the inset is correct. `AgenticCliDashboardWebview` is the only consumer using `presentation: 'modal'` — where iOS renders as a page sheet that already handles the top area, so the safe-area inset is redundant and produces visible double-inset whitespace on iOS only. Introduced in #30911.

**Scope** — Single-line change to `app/components/Views/AgenticCliDashboardWebview/index.tsx`. Other consumers of `HeaderCompactStandard` are unchanged.

```ts
// before
includesTopInset: true,
// after
includesTopInset: Platform.OS === 'android',
```

## Screenshot (before vs after)
<img width="912" height="939" alt="Screenshot 2026-07-22 at 4 21 18 PM" src="https://github.com/user-attachments/assets/406a19f2-c56d-4766-a399-9871c4a58025" />

<img width="933" height="1043" alt="Screenshot 2026-07-22 at 4 22 11 PM" src="https://github.com/user-attachments/assets/88330fbc-b845-4610-8349-95e24fc9b3be" />

## **Changelog**

CHANGELOG entry: Fixed a visual bug where the MetaMask Agent CLI authorization screen on iOS displayed excessive empty space above the header title.

## **Related issues**

Fixes: [MMAI-928](https://consensyssoftware.atlassian.net/browse/MMAI-928)
Refs: [MMAI-925](https://consensyssoftware.atlassian.net/browse/MMAI-925)

## **Manual testing steps**

```gherkin
Feature: AgenticCliDashboardWebview header spacing

  Scenario: iOS — header sits directly under the modal top area
    Given the app is unlocked on an iOS dev build
    And the MetaMask Agent CLI is running and displays a QR code
    When user opens the QR scanner and scans the CLI code
    Then the "Select project" modal opens
    And the header title sits directly below the OS modal top area
    And there is no additional empty band above the header title

  Scenario: Android — header still clears the status bar
    Given the app is unlocked on an Android dev build
    And the MetaMask Agent CLI is running and displays a QR code
    When user opens the QR scanner and scans the CLI code
    Then the "Select project" modal opens
    And the header title sits below the status bar with the usual safe-area gap
    And the layout matches the pre-fix Android layout (unchanged)
```

## **Screenshots/Recordings**

### **Before**

<!-- iOS: large empty band between status bar and "Select project" title -->

### **After**

<!-- iOS: header sits directly under the modal top area; Android unchanged -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMAI-928]: https://consensyssoftware.atlassian.net/browse/MMAI-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI spacing change scoped to one modal screen; Android behavior is preserved.
> 
> **Overview**
> Fixes excess empty space above the **Select project** header on iOS when opening the Agentic CLI dashboard modal.
> 
> `getHeaderCompactStandardNavbarOptions` is now called with **`includesTopInset: Platform.OS === 'android'`** instead of always `true`, so iOS modal presentation does not add safe-area `marginTop` on top of the stack’s own top chrome. Android still applies the inset so the title clears the status bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0259b2c95237633e69bf58312238987a7d0d8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->