### PR TITLE
fix: Vertically center pressable Toast content

### DIFF
--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -79,6 +79,10 @@ const styleSheet = (params: { theme: Theme }) => {
     pressableContent: {
       flex: 1,
       flexDirection: 'row',
+      alignItems: 'center',
+      gap: 16,
+    },
+    pressableContentTopAligned: {
       alignItems: 'flex-start',
     },
   });

--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -61,9 +61,6 @@ const styleSheet = (params: { theme: Theme }) => {
     baseWithCloseIconButton: {
       paddingRight: 8,
     },
-    label: {
-      color: colors.text.default,
-    },
     description: {
       marginTop: 2,
     },

--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -573,6 +573,86 @@ describe('Toast', () => {
     expect(screen.getByTestId(ToastSelectorsIDs.PRESSABLE)).toBeOnTheScreen();
   });
 
+  it('vertically centers pressable toast content by default', async () => {
+    const toastOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [
+        { label: 'Conversion complete', isBold: true },
+        { label: '\n' },
+        { label: '$50.00 added to Money account.' },
+      ],
+      hasNoTimeout: true,
+      onPress: jest.fn(),
+    };
+
+    render(<Toast ref={toastRef} />);
+
+    await act(async () => {
+      toastRef.current?.showToast(toastOptions);
+      jest.runAllTimers();
+    });
+
+    await act(async () => {
+      fireEvent(screen.getByText('Conversion complete'), 'onTextLayout', {
+        nativeEvent: { lines: [{ text: 'Conversion complete' }] },
+      });
+      fireEvent(
+        screen.getByText('$50.00 added to Money account.'),
+        'onTextLayout',
+        {
+          nativeEvent: {
+            lines: [{ text: '$50.00 added to Money account.' }],
+          },
+        },
+      );
+    });
+
+    const pressable = screen.getByTestId(ToastSelectorsIDs.PRESSABLE);
+    const flat = StyleSheet.flatten(pressable.props.style);
+
+    expect(flat.alignItems).toBe('center');
+  });
+
+  it('top-aligns pressable toast content when multi-line description requires it', async () => {
+    const toastOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [
+        { label: 'Title', isBold: true },
+        { label: '\n' },
+        { label: 'Long description that wraps' },
+      ],
+      hasNoTimeout: true,
+      onPress: jest.fn(),
+    };
+
+    render(<Toast ref={toastRef} />);
+
+    await act(async () => {
+      toastRef.current?.showToast(toastOptions);
+      jest.runAllTimers();
+    });
+
+    await act(async () => {
+      fireEvent(screen.getByText('Title'), 'onTextLayout', {
+        nativeEvent: { lines: [{ text: 'Title' }] },
+      });
+      fireEvent(
+        screen.getByText('Long description that wraps'),
+        'onTextLayout',
+        {
+          nativeEvent: {
+            lines: [{ text: 'Long description' }, { text: 'that wraps' }],
+          },
+        },
+      );
+    });
+
+    const pressable = screen.getByTestId(ToastSelectorsIDs.PRESSABLE);
+    const flat = StyleSheet.flatten(pressable.props.style);
+
+    expect(flat.alignItems).toBe('flex-start');
+  });
+
   it('calls onPress when the toast content is pressed', async () => {
     const onPress = jest.fn();
     const toastOptions: ToastOptions = {

--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -289,6 +289,42 @@ describe('Toast', () => {
       expect(screen.getByText('Description line')).toBeOnTheScreen();
     });
 
+    it('renders non-bold label segments alongside bold segments', async () => {
+      render(<Toast ref={toastRef} />);
+      const options: ToastOptions = {
+        variant: ToastVariants.Plain,
+        labelOptions: [
+          { label: 'Normal weight', isBold: false },
+          { label: ' Bold weight', isBold: true },
+        ],
+        hasNoTimeout: true,
+      };
+
+      await showToast(toastRef, options);
+
+      expect(screen.getByText('Normal weight')).toBeOnTheScreen();
+      expect(screen.getByText(' Bold weight')).toBeOnTheScreen();
+    });
+
+    it('falls back to stable keys when label is not a string', async () => {
+      render(<Toast ref={toastRef} />);
+      // Runtime-only path for Sonar S6479 key fallbacks (`typeof label === 'string'`).
+      const nonStringLabel = 42 as unknown as string;
+      const options: ToastOptions = {
+        variant: ToastVariants.Plain,
+        labelOptions: [
+          { label: nonStringLabel, isBold: false },
+          { label: '\n' },
+          { label: nonStringLabel },
+        ],
+        hasNoTimeout: true,
+      };
+
+      await showToast(toastRef, options);
+
+      expect(screen.getAllByText('42')).toHaveLength(2);
+    });
+
     it('uses custom startAccessory instead of avatar', async () => {
       render(<Toast ref={toastRef} />);
       const options: ToastOptions = {

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -139,7 +139,9 @@ const mapLegacyButtonVariant = (variant?: ButtonVariants): ButtonVariant => {
   return ButtonVariant.Primary;
 };
 
-const LEGACY_ICON_COLOR_TO_DS: Record<string, IconColor> = {
+// Lazy map so incomplete Jest mocks of design-system-react-native do not
+// crash Toast barrel imports (e.g. ToastContext-only consumers).
+const getLegacyIconColorToDs = (): Record<string, IconColor> => ({
   Default: IconColor.IconDefault,
   Inverse: IconColor.OverlayInverse,
   Alternative: IconColor.IconAlternative,
@@ -151,13 +153,17 @@ const LEGACY_ICON_COLOR_TO_DS: Record<string, IconColor> = {
   ErrorAlternative: IconColor.ErrorAlternative,
   Warning: IconColor.WarningDefault,
   Info: IconColor.InfoDefault,
-};
+});
 
 const resolveToastIconAppearance = (
   iconColor?: string,
-): { color?: IconColor; style?: { color: string } } => {
+): { color?: IconColor; style?: StyleProp<ViewStyle> } => {
   if (!iconColor) {
     return {};
+  }
+
+  if (!IconColor) {
+    return { style: { color: iconColor } as ViewStyle };
   }
 
   const dsIconColors = Object.values(IconColor) as string[];
@@ -165,12 +171,15 @@ const resolveToastIconAppearance = (
     return { color: iconColor as IconColor };
   }
 
-  if (iconColor in LEGACY_ICON_COLOR_TO_DS) {
-    return { color: LEGACY_ICON_COLOR_TO_DS[iconColor] };
+  const legacyIconColorToDs = getLegacyIconColorToDs();
+  if (iconColor in legacyIconColorToDs) {
+    return { color: legacyIconColorToDs[iconColor] };
   }
 
   // Call sites may pass raw theme colors (e.g. theme.colors.success.default).
-  return { style: { color: iconColor } };
+  // Icon uses fill="currentColor"; RN SVG reads `color` from style at runtime
+  // even though ViewStyle does not declare it.
+  return { style: { color: iconColor } as ViewStyle };
 };
 
 /**

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -345,22 +345,26 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
 
   const renderInlineLabelSegments = (segments: ToastLabelOptions) => (
     <Text variant={TextVariant.BodyMD} onTextLayout={handleTitleTextLayout}>
-      {segments.map(({ label, isBold }) => (
-        <Text
-          key={
-            typeof label === 'string'
-              ? `${label}-${isBold === false ? 'normal' : 'bold'}`
-              : `toast-label-${isBold === false ? 'normal' : 'bold'}`
-          }
-          variant={
-            isBold === false ? TextVariant.BodySM : TextVariant.BodyMDMedium
-          }
-          color={isBold === false ? TextColor.Alternative : undefined}
-          style={isBold === false ? undefined : styles.label}
-        >
-          {label}
-        </Text>
-      ))}
+      {segments.map(({ label, isBold }) => {
+        const weightKey = isBold === false ? 'normal' : 'bold';
+        const segmentKey =
+          typeof label === 'string'
+            ? `${label}-${weightKey}`
+            : `toast-label-${weightKey}`;
+
+        return (
+          <Text
+            key={segmentKey}
+            variant={
+              isBold === false ? TextVariant.BodySM : TextVariant.BodyMDMedium
+            }
+            color={isBold === false ? TextColor.Alternative : undefined}
+            style={isBold === false ? undefined : styles.label}
+          >
+            {label}
+          </Text>
+        );
+      })}
     </Text>
   );
 

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -553,7 +553,10 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
     <Animated.View onLayout={onAnimatedViewLayout} style={baseStyle}>
       {toastOptions.onPress ? (
         <Pressable
-          style={styles.pressableContent}
+          style={[
+            styles.pressableContent,
+            shouldTopAlign && styles.pressableContentTopAligned,
+          ]}
           onPress={toastOptions.onPress}
           testID={ToastSelectorsIDs.PRESSABLE}
         >

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -345,9 +345,13 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
 
   const renderInlineLabelSegments = (segments: ToastLabelOptions) => (
     <Text variant={TextVariant.BodyMD} onTextLayout={handleTitleTextLayout}>
-      {segments.map(({ label, isBold }, index) => (
+      {segments.map(({ label, isBold }) => (
         <Text
-          key={`toast-label-${index}`}
+          key={
+            typeof label === 'string'
+              ? `${label}-${isBold === false ? 'normal' : 'bold'}`
+              : `toast-label-${isBold === false ? 'normal' : 'bold'}`
+          }
           variant={
             isBold === false ? TextVariant.BodySM : TextVariant.BodyMDMedium
           }
@@ -386,9 +390,10 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
             style={styles.description}
             onTextLayout={handleDescriptionTextLayout}
           >
-            {descriptionLabelOptions.map(({ label }, index) => (
+            {/* Prefer label content over array index so keys stay stable (Sonar S6479). */}
+            {descriptionLabelOptions.map(({ label }) => (
               <Text
-                key={`toast-description-label-${index}`}
+                key={typeof label === 'string' ? label : 'toast-description'}
                 variant={TextVariant.BodySM}
                 color={TextColor.Alternative}
               >

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -30,13 +30,18 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // External dependencies.
 import Avatar, { AvatarSize, AvatarVariant } from '../Avatars/Avatar';
-import Icon, { IconSize } from '../Icons/Icon';
-import Text, { TextColor, TextVariant } from '../Texts/Text';
 import {
   Button,
   ButtonSize,
   ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
   IconName as DsIconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 
 // Internal dependencies.
@@ -132,6 +137,40 @@ const mapLegacyButtonVariant = (variant?: ButtonVariants): ButtonVariant => {
     return ButtonVariant.Secondary;
   }
   return ButtonVariant.Primary;
+};
+
+const LEGACY_ICON_COLOR_TO_DS: Record<string, IconColor> = {
+  Default: IconColor.IconDefault,
+  Inverse: IconColor.OverlayInverse,
+  Alternative: IconColor.IconAlternative,
+  Muted: IconColor.IconMuted,
+  Primary: IconColor.PrimaryDefault,
+  PrimaryAlternative: IconColor.PrimaryAlternative,
+  Success: IconColor.SuccessDefault,
+  Error: IconColor.ErrorDefault,
+  ErrorAlternative: IconColor.ErrorAlternative,
+  Warning: IconColor.WarningDefault,
+  Info: IconColor.InfoDefault,
+};
+
+const resolveToastIconAppearance = (
+  iconColor?: string,
+): { color?: IconColor; style?: { color: string } } => {
+  if (!iconColor) {
+    return {};
+  }
+
+  const dsIconColors = Object.values(IconColor) as string[];
+  if (dsIconColors.includes(iconColor)) {
+    return { color: iconColor as IconColor };
+  }
+
+  if (iconColor in LEGACY_ICON_COLOR_TO_DS) {
+    return { color: LEGACY_ICON_COLOR_TO_DS[iconColor] };
+  }
+
+  // Call sites may pass raw theme colors (e.g. theme.colors.success.default).
+  return { style: { color: iconColor } };
 };
 
 /**
@@ -344,7 +383,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   };
 
   const renderInlineLabelSegments = (segments: ToastLabelOptions) => (
-    <Text variant={TextVariant.BodyMD} onTextLayout={handleTitleTextLayout}>
+    <Text variant={TextVariant.BodyMd} onTextLayout={handleTitleTextLayout}>
       {segments.map(({ label, isBold }) => {
         const weightKey = isBold === false ? 'normal' : 'bold';
         const segmentKey =
@@ -355,11 +394,9 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
         return (
           <Text
             key={segmentKey}
-            variant={
-              isBold === false ? TextVariant.BodySM : TextVariant.BodyMDMedium
-            }
-            color={isBold === false ? TextColor.Alternative : undefined}
-            style={isBold === false ? undefined : styles.label}
+            variant={isBold === false ? TextVariant.BodySm : TextVariant.BodyMd}
+            fontWeight={isBold === false ? undefined : FontWeight.Medium}
+            color={isBold === false ? TextColor.TextAlternative : undefined}
           >
             {label}
           </Text>
@@ -389,8 +426,8 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
           : null}
         {descriptionLabelOptions.length > 0 ? (
           <Text
-            variant={TextVariant.BodySM}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
             style={styles.description}
             onTextLayout={handleDescriptionTextLayout}
           >
@@ -398,8 +435,8 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
             {descriptionLabelOptions.map(({ label }) => (
               <Text
                 key={typeof label === 'string' ? label : 'toast-description'}
-                variant={TextVariant.BodySM}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
               >
                 {label}
               </Text>
@@ -413,8 +450,8 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const renderDescription = (descriptionOptions?: ToastDescriptionOptions) =>
     descriptionOptions && (
       <Text
-        variant={TextVariant.BodySM}
-        color={TextColor.Alternative}
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
         style={styles.description}
         onTextLayout={handleDescriptionTextLayout}
       >
@@ -501,8 +538,14 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
       }
       case ToastVariants.Icon: {
         const { iconName, iconColor, backgroundColor } = toastOptions;
+        const iconAppearance = resolveToastIconAppearance(iconColor);
         const icon = (
-          <Icon name={iconName} size={IconSize.Lg} color={iconColor} />
+          <Icon
+            name={iconName as DsIconName}
+            size={IconSize.Lg}
+            color={iconAppearance.color}
+            style={iconAppearance.style}
+          />
         );
         const hasIconBackground =
           backgroundColor != null && backgroundColor !== 'transparent';

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -57,6 +57,20 @@ jest.mock('@metamask/design-system-react-native', () => {
         { testID: 'rewards-nudge-start-accessory-box' },
         children,
       ),
+    // Required by Toast.tsx module init via Toast barrel import.
+    IconColor: {
+      IconDefault: 'IconDefault',
+      OverlayInverse: 'OverlayInverse',
+      IconAlternative: 'IconAlternative',
+      IconMuted: 'IconMuted',
+      PrimaryDefault: 'PrimaryDefault',
+      PrimaryAlternative: 'PrimaryAlternative',
+      SuccessDefault: 'SuccessDefault',
+      ErrorDefault: 'ErrorDefault',
+      ErrorAlternative: 'ErrorAlternative',
+      WarningDefault: 'WarningDefault',
+      InfoDefault: 'InfoDefault',
+    },
   };
 });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

### 1. What is the reason for this change?

- Situation: Money deposit/send toasts pass `onPress` so users can open transaction details. When `onPress` is set, the shared legacy `Toast` wraps content in a `Pressable` whose style hard-coded `alignItems: 'flex-start'`.
- Impact: That overrode the toast’s default vertical centering, so the leading icon and close button sat at the top of the two-line text instead of aligning with the text block’s vertical center. This was observed as I tested `8.5.0` prior to its release.

- Deprecation: Legacy toast `Text`/`Icon` imports from `component-library` are deprecated in favor of `@metamask/design-system-react-native`. Continuing to use them blocks design-system migration and risks token/API drift (variants, colors, icon color enums).

- Code maintainability issues: Sonar S6479 also flagged toast label/description segments that used array-index React keys (`toast-label-${index}`). Index-based keys are unstable when toast option lists change, so React may remount or reuse the wrong text nodes. That maintainability finding failed the Sonar quality gate on this PR.

### 2. What is the improvement/solution?

- Alignment fix: Updates `pressableContent` to match the non-pressable toast row: `alignItems: 'center'` and `gap: 16` by default. Applies `alignItems: 'flex-start'` only when `shouldTopAlign` is true (multi-line title/description or below-text action buttons), consistent with the outer toast layout.

- Design-system migration: Replaces deprecated component-library `Text` and `Icon` with `@metamask/design-system-react-native` equivalents:
  - Text tokens updated to DS variants/colors (`BodyMd`/`BodySm`, `TextAlternative`, `FontWeight.Medium` for bold segments).
  - Icon colors resolved through a legacy→DS mapper (`LEGACY_ICON_COLOR_TO_DS` / `resolveToastIconAppearance`), with a style fallback when callers pass raw theme colors.

- Code maintainability fix: Replaces index-based React keys on toast label/description segments with content-based keys so segments reconcile stably when toast options update. Non-string labels fall back to `toast-label-${weightKey}` / a stable description key.

- Testing: Adds unit tests covering pressable centering vs top-align, non-bold/bold label segments, and non-string label key fallbacks.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed vertical alignment of icon and close button on tappable toast notifications

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

- `Pressable` was introduced in this PR: https://github.com/MetaMask/metamask-mobile/pull/33028
- This updated the position and animation: https://github.com/MetaMask/metamask-mobile/pull/32933

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pressable toast vertical alignment

  Scenario: Money conversion success toast centers icon and close button
    Given the user has a Money account
    And the user completes a crypto conversion to mUSD

    When the "Conversion complete" toast appears
    Then the success icon, two-line text, and close button are vertically centered in the toast
    And tapping the toast still navigates to the transaction details screen
    And tapping the close button dismisses the toast without navigating

  Scenario: Money conversion in-progress toast centers spinner and close button
    Given the user has submitted a crypto conversion to mUSD that is still pending

    When the "Converting crypto" toast appears
    Then the spinner, two-line text, and close button are vertically centered in the toast
```


Field | Value
-- | --
Source branch | toast/pressable-alignment
Build name | main-rc
Build commit SHA | dce4b31f212e4dd1c096dff7abb399b98bcd841d
Build version | 8.5.0
Build number | 6158
TestFlight group | MetaMask BETA & Release Candidates
Workflow branch ref | main



## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Converting crypto (in progress) — icon/text/close top-aligned within the toast:

![Converting crypto toast before — content not vertically centered](https://i.imgur.com/Ef8wnXw.jpeg)

Conversion complete (success) — same misalignment:

![Conversion complete toast before — content not vertically centered](https://i.imgur.com/wUqixNQ.jpeg)

### **After**
<img width="590" height="1278" alt="IMG_4966" src="https://github.com/user-attachments/assets/306fe6d4-9eff-4872-9980-b65a9f7e514c" />
<img width="590" height="1278" alt="IMG_4967" src="https://github.com/user-attachments/assets/415178f4-1328-4690-8faa-f141c030fa22" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to legacy Toast presentation and tests; alignment and typography token changes are user-visible but low blast radius.
> 
> **Overview**
> Fixes **tappable toasts** (e.g. Money conversion success/in-progress) where the `Pressable` wrapper forced `alignItems: 'flex-start'`, so the leading icon and close button sat at the top instead of aligning with the text block.
> 
> **Pressable layout** now matches the non-pressable row: default `alignItems: 'center'` and `gap: 16` on `pressableContent`, with `pressableContentTopAligned` applied only when existing `shouldTopAlign` is true (wrapped multi-line description, etc.).
> 
> **Design-system migration** in legacy `Toast`: `Text` and `Icon` come from `@metamask/design-system-react-native` with updated variants/colors and `FontWeight.Medium` for bold segments; icon colors go through `resolveToastIconAppearance` (legacy enum → DS, raw theme color via style).
> 
> **Maintainability**: label/description segment React keys are content-based instead of array indices; rewards toast tests stub `IconColor` so partial DS mocks do not break Toast barrel imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb91bc790308b962ff780b529f705bfd05b9ab20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->