### PR TITLE
test: add component view and integration tests for tracking perps close poisition metric

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.view.test.tsx
@@ -17,7 +17,12 @@ import { renderPerpsClosePositionView } from '../../../../../../tests/component-
 import {
   PerpsAmountDisplaySelectorsIDs,
   PerpsClosePositionViewSelectorsIDs,
+  PerpsOrderHeaderSelectorsIDs,
+  PerpsOrderTypeBottomSheetSelectorsIDs,
+  PerpsLimitPriceBottomSheetSelectorsIDs,
 } from '../../Perps.testIds';
+import type { DeepPartial } from '../../../../../util/test/renderWithProvider';
+import type { RootState } from '../../../../../reducers';
 
 const TIMEOUT_MS = 5000;
 
@@ -202,6 +207,216 @@ describe('PerpsClosePositionView', () => {
             symbol: 'ETH',
             size: '1',
           }),
+        }),
+      );
+    });
+  });
+
+  it('forwards the analytics tracking data to closePosition on a full market close', async () => {
+    const closePosition = Engine.context.PerpsController
+      .closePosition as jest.Mock;
+    const position = createLongPositionForViews({ unrealizedPnl: '150' });
+
+    const { stream } = renderPerpsClosePositionView({
+      initialParams: {
+        position,
+        source: 'position_screen',
+      },
+      streamOverrides: {
+        account: createFundedAccountForViews('10000'),
+        positions: [position],
+        marketData: [createEthMarketForViews()],
+      },
+    });
+
+    act(() => {
+      stream.emitPrices({
+        ETH: {
+          symbol: 'ETH',
+          price: '2500',
+          timestamp: Date.now(),
+          isTradable: true,
+        },
+      });
+    });
+
+    const confirmButton = await screen.findByTestId(
+      PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+      {},
+      { timeout: TIMEOUT_MS },
+    );
+
+    await waitFor(() => {
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    fireEvent.press(confirmButton);
+
+    await waitFor(() => {
+      expect(closePosition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderType: 'market',
+          position: expect.objectContaining({ symbol: 'ETH' }),
+          trackingData: expect.objectContaining({
+            source: 'position_screen',
+            entryPoint: 'position_screen',
+            inputMethod: 'default',
+            marketPrice: 2500,
+            realizedPnl: 150,
+            receivedAmount: 833.33,
+            totalFee: expect.any(Number),
+            metamaskFee: expect.any(Number),
+          }),
+        }),
+      );
+    });
+  });
+
+  it('forwards the analytics tracking data to closePosition on a partial market close', async () => {
+    const closePosition = Engine.context.PerpsController
+      .closePosition as jest.Mock;
+    const position = createLongPositionForViews({ unrealizedPnl: '150' });
+
+    const { stream } = renderPerpsClosePositionView({
+      initialParams: {
+        position,
+        source: 'position_screen',
+      },
+      streamOverrides: {
+        account: createFundedAccountForViews('10000'),
+        positions: [position],
+        marketData: [createEthMarketForViews()],
+      },
+    });
+
+    act(() => {
+      stream.emitPrices({
+        ETH: {
+          symbol: 'ETH',
+          price: '2500',
+          timestamp: Date.now(),
+          isTradable: true,
+        },
+      });
+    });
+
+    fireEvent.press(
+      await screen.findByTestId(PerpsAmountDisplaySelectorsIDs.TOUCHABLE),
+    );
+    fireEvent.press(screen.getByText('50%'));
+    fireEvent.press(screen.getByText(strings('perps.deposit.done_button')));
+
+    const confirmButton = await screen.findByTestId(
+      PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+      {},
+      { timeout: TIMEOUT_MS },
+    );
+
+    await waitFor(() => {
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    fireEvent.press(confirmButton);
+
+    await waitFor(() => {
+      expect(closePosition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: '0.5',
+          trackingData: expect.objectContaining({
+            inputMethod: 'percentage',
+            realizedPnl: 75,
+          }),
+        }),
+      );
+    });
+  });
+
+  it('forwards the limit order type to closePosition when a limit close is submitted', async () => {
+    const closePosition = Engine.context.PerpsController
+      .closePosition as jest.Mock;
+    const position = createLongPositionForViews();
+
+    const { stream } = renderPerpsClosePositionView({
+      initialParams: {
+        position,
+        source: 'position_screen',
+      },
+      streamOverrides: {
+        account: createFundedAccountForViews('10000'),
+        positions: [position],
+        marketData: [createEthMarketForViews()],
+      },
+      overrides: {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                perpsClosePositionLimitOrderEnabled: {
+                  enabled: true,
+                  minimumVersion: '0.0.0',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as DeepPartial<RootState>,
+    });
+
+    act(() => {
+      stream.emitPrices({
+        ETH: {
+          symbol: 'ETH',
+          price: '2500',
+          timestamp: Date.now(),
+          isTradable: true,
+        },
+      });
+    });
+
+    fireEvent.press(
+      await screen.findByTestId(PerpsOrderHeaderSelectorsIDs.ORDER_TYPE_BUTTON),
+    );
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
+      ),
+    );
+
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsClosePositionViewSelectorsIDs.LIMIT_PRICE_ROW,
+      ),
+    );
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsLimitPriceBottomSheetSelectorsIDs.PRESET_MID,
+      ),
+    );
+    fireEvent.press(
+      await screen.findByTestId(
+        PerpsLimitPriceBottomSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+
+    const confirmButton = await screen.findByTestId(
+      PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+      {},
+      { timeout: TIMEOUT_MS },
+    );
+
+    await waitFor(() => {
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    fireEvent.press(confirmButton);
+
+    await waitFor(() => {
+      expect(closePosition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderType: 'limit',
+          price: '2500',
+          usdAmount: undefined,
+          maxSlippageBps: undefined,
         }),
       );
     });

--- a/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
+++ b/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
@@ -24,6 +24,8 @@ import { type OrderResult, type Position } from '@metamask/perps-controller';
 
 import { buildPerpsFlowHarness } from '../../../../../tests/integration/harnesses/perps-flow';
 import { usePerpsTrading } from '../hooks/usePerpsTrading';
+import { PerpsAnalyticsEvent } from '@metamask/perps-controller/types';
+import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants/eventNames';
 
 describe('Perps order lifecycle — FLOW integration', () => {
   describe('opening a position via the hook chain', () => {
@@ -132,6 +134,98 @@ describe('Perps order lifecycle — FLOW integration', () => {
           ],
         }),
       );
+    });
+  });
+
+  describe('closing a position via the hook chain', () => {
+    const openLongBTC: Position = {
+      symbol: 'BTC',
+      size: '0.1', // positive = long
+      entryPrice: '50000',
+      positionValue: '5000',
+      unrealizedPnl: '250',
+      marginUsed: '500',
+      leverage: { type: 'cross', value: 10 },
+      liquidationPrice: '45000',
+      maxLeverage: 50,
+      returnOnEquity: '0.5',
+      cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+      takeProfitCount: 0,
+      stopLossCount: 0,
+    };
+
+    it('emits Perp Position Close Transaction with status executed on a successful full close', async () => {
+      const perps = buildPerpsFlowHarness();
+      perps.harness.setupTradingReady();
+      perps.harness.mocks.subscription.getCachedPositions.mockReturnValue([
+        openLongBTC,
+      ]);
+      const { result } = perps.renderHookWithFlow(() => usePerpsTrading());
+
+      let closeResult: OrderResult | null = null;
+      await act(async () => {
+        closeResult = await result.current.closePosition({
+          symbol: 'BTC',
+          orderType: 'market',
+          currentPrice: 50_000,
+          trackingData: {
+            totalFee: 5,
+            marketPrice: 50_000,
+            source: 'position_screen',
+          },
+        });
+      });
+
+      expect(closeResult).toMatchObject({ success: true });
+
+      const closeEvent = perps.analytics.lastByName(
+        PerpsAnalyticsEvent.PositionCloseTransaction,
+      );
+      expect(closeEvent).toMatchObject({
+        status: PERPS_EVENT_VALUE.STATUS.EXECUTED,
+        asset: 'BTC',
+        order_type: 'market',
+        close_type: PERPS_EVENT_VALUE.CLOSE_TYPE.FULL,
+        open_position_size: 0.1,
+        percentage_closed: 100,
+        dollar_pnl: 250,
+        percent_pnl: 50,
+        leverage: 10,
+        fee: 5,
+        source: 'position_screen',
+      });
+    });
+
+    it('emits Perp Position Close Transaction with status failed when the provider rejects the close', async () => {
+      const perps = buildPerpsFlowHarness();
+      perps.harness.setupTradingReady();
+      perps.harness.mocks.subscription.getCachedPositions.mockReturnValue([
+        openLongBTC,
+      ]);
+      perps.harness.mocks.exchangeClient.order.mockResolvedValueOnce({
+        status: 'err',
+        response: 'Insufficient margin',
+      });
+      const { result } = perps.renderHookWithFlow(() => usePerpsTrading());
+
+      let closeResult: OrderResult | null = null;
+      await act(async () => {
+        closeResult = await result.current.closePosition({
+          symbol: 'BTC',
+          orderType: 'market',
+          currentPrice: 50_000,
+        });
+      });
+
+      expect(closeResult).toMatchObject({ success: false });
+
+      const closeEvent = perps.analytics.lastByName(
+        PerpsAnalyticsEvent.PositionCloseTransaction,
+      );
+      expect(closeEvent).toMatchObject({
+        status: PERPS_EVENT_VALUE.STATUS.FAILED,
+        asset: 'BTC',
+      });
     });
   });
 });

--- a/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
+++ b/app/components/UI/Perps/integration/orderLifecycleFlow.integration.test.ts
@@ -227,5 +227,49 @@ describe('Perps order lifecycle — FLOW integration', () => {
         asset: 'BTC',
       });
     });
+
+    it('emits a partially_filled Perp Position Close Transaction when the fill is partial', async () => {
+      const perps = buildPerpsFlowHarness();
+      perps.harness.setupTradingReady();
+      perps.harness.mocks.subscription.getCachedPositions.mockReturnValue([
+        openLongBTC,
+      ]);
+      perps.harness.mocks.exchangeClient.order.mockResolvedValueOnce({
+        status: 'ok',
+        response: {
+          data: {
+            statuses: [
+              { filled: { oid: 123, totalSz: '0.05', avgPx: '50000' } },
+            ],
+          },
+        },
+      });
+      const { result } = perps.renderHookWithFlow(() => usePerpsTrading());
+
+      let closeResult: OrderResult | null = null;
+      await act(async () => {
+        closeResult = await result.current.closePosition({
+          symbol: 'BTC',
+          size: '0.1',
+          orderType: 'market',
+          currentPrice: 50_000,
+        });
+      });
+
+      expect(closeResult).toMatchObject({ success: true });
+
+      const events = perps.analytics.byName(
+        PerpsAnalyticsEvent.PositionCloseTransaction,
+      );
+      const partialEvent = events.find(
+        (e) => e.status === PERPS_EVENT_VALUE.STATUS.PARTIALLY_FILLED,
+      );
+      expect(partialEvent).toMatchObject({
+        status: PERPS_EVENT_VALUE.STATUS.PARTIALLY_FILLED,
+        asset: 'BTC',
+        amount_filled: 0.05,
+        remaining_amount: 0.05,
+      });
+    });
   });
 });

--- a/tests/integration/harnesses/perps-flow.ts
+++ b/tests/integration/harnesses/perps-flow.ts
@@ -163,6 +163,8 @@ import {
 import { TradingService } from '@metamask/perps-controller/services/TradingService';
 import type {
   FlipPositionParams,
+  PerpsAnalyticsEvent,
+  PerpsAnalyticsProperties,
   ServiceContext,
 } from '@metamask/perps-controller';
 import { createMockInfrastructure } from '../../../app/components/UI/Perps/__mocks__/serviceMocks';
@@ -197,6 +199,28 @@ function installMockEngineContext() {
   });
 }
 
+/**
+ * Query helpers over the real `TradingService`'s `metrics.trackPerpsEvent`
+ * mock. Scalable accessor for asserting ANY perps analytics event emitted by
+ * the trading flow (trade/close/cancel/risk, executed/failed/partially_filled)
+ * without each test re-deriving matches from `mock.calls`.
+ */
+export interface PerpsAnalyticsQueries {
+  /** The raw jest mock backing `metrics.trackPerpsEvent`. */
+  trackPerpsEvent: jest.Mock;
+  /** All emitted events as `{ event, properties }`, in call order. */
+  all: () => {
+    event: PerpsAnalyticsEvent;
+    properties: PerpsAnalyticsProperties;
+  }[];
+  /** Every emission of a given event name, in call order. */
+  byName: (event: PerpsAnalyticsEvent) => PerpsAnalyticsProperties[];
+  /** The most recent emission of a given event name, or undefined. */
+  lastByName: (
+    event: PerpsAnalyticsEvent,
+  ) => PerpsAnalyticsProperties | undefined;
+}
+
 export interface PerpsFlowHarness {
   /** The underlying provider-level harness (provider, mocks, helpers). */
   harness: PerpsIntegrationHarness;
@@ -209,6 +233,12 @@ export interface PerpsFlowHarness {
    * tests can spy on its methods or assert it was called for a specific flow.
    */
   tradingService: TradingService;
+  /**
+   * Analytics query helpers over the real `TradingService`'s emitted events.
+   * Use these to assert `Perp Trade Transaction` / `Perp Position Close
+   * Transaction` etc. with their status + properties.
+   */
+  analytics: PerpsAnalyticsQueries;
 }
 
 /*
@@ -230,7 +260,33 @@ export function buildPerpsFlowHarness(
   const harness = buildPerpsIntegrationHarness(options);
 
   // Real TradingService — same platform deps shape the inner harness uses.
-  const tradingService = new TradingService(createMockInfrastructure());
+  // Capture the infrastructure so its mocked `metrics.trackPerpsEvent` (the
+  // real service calls it to emit analytics) is reachable for assertions.
+  const tradingServiceInfra = createMockInfrastructure();
+  const tradingService = new TradingService(tradingServiceInfra);
+
+  const trackPerpsEvent = tradingServiceInfra.metrics
+    .trackPerpsEvent as jest.Mock;
+  const analytics: PerpsAnalyticsQueries = {
+    trackPerpsEvent,
+    all: () =>
+      trackPerpsEvent.mock.calls.map(([event, properties]) => ({
+        event: event as PerpsAnalyticsEvent,
+        properties: properties as PerpsAnalyticsProperties,
+      })),
+    byName: (event) =>
+      trackPerpsEvent.mock.calls
+        .filter(([emitted]) => emitted === event)
+        .map(([, properties]) => properties as PerpsAnalyticsProperties),
+    lastByName: (event) => {
+      const matches = trackPerpsEvent.mock.calls.filter(
+        ([emitted]) => emitted === event,
+      );
+      return matches.length > 0
+        ? (matches[matches.length - 1][1] as PerpsAnalyticsProperties)
+        : undefined;
+    },
+  };
   const renderHookWithFlow = <Result, Props>(
     hook: (props: Props) => Result,
     renderOptions: PerpsFlowRenderOptions = {},
@@ -243,10 +299,9 @@ export function buildPerpsFlowHarness(
     return renderHookWithProvider(hook, { state: stateBuilder.build() });
   };
 
-  // Minimal ServiceContext factory. PerpsController's real
-  // `#createServiceContext` builds a richer one (state manager callbacks,
-  // saveTradeConfiguration, etc.); the trading-flow methods don't require
-  // those for the seam we're testing, so a minimal version is sufficient.
+  // Minimal ServiceContext. `getPositions` resolves from the provider (WS cache)
+  // so close/flip flows hit TradingService's position-found branch, which emits
+  // the rich position-derived analytics props.
   const buildServiceContext = (method: string): ServiceContext => ({
     tracingContext: {
       provider: 'hyperliquid',
@@ -256,6 +311,7 @@ export function buildPerpsFlowHarness(
       controller: 'PerpsController',
       method,
     },
+    getPositions: () => harness.provider.getPositions(),
   });
 
   // Stub for reportOrderToDataLake — PerpsController has its own impl that
@@ -331,5 +387,5 @@ export function buildPerpsFlowHarness(
   };
   installMockEngineContext();
 
-  return { harness, renderHookWithFlow, tradingService };
+  return { harness, renderHookWithFlow, tradingService, analytics };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds component view tests to assert PerpsClosePositionView forwards correct tracking data / order type to closePosition
Adds integration test to assert real TradingService emits Perp Position Close Transaction with the right status 
Updates the harness to add reusable analytics query helper + wire getPositions so the full position-derived event is emitted

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2047, https://consensyssoftware.atlassian.net/browse/MMQA-2048

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

NA

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

NA

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and harness utilities; no production paths or runtime behavior modified.
> 
> **Overview**
> **Adds automated coverage for perps close-position metrics** without changing production behavior.
> 
> **Component view tests** on `PerpsClosePositionView` assert that `closePosition` receives the expected **analytics `trackingData`** (full vs partial market close, including `inputMethod` and PnL) and that **limit closes** pass `orderType: 'limit'` with the right price and without market-only fields when the limit-order feature flag is on.
> 
> **Flow integration tests** exercise `usePerpsTrading.closePosition` end-to-end and assert **`Perp Position Close Transaction`** analytics for **executed**, **failed**, and **partially_filled** outcomes.
> 
> The **`perps-flow` harness** now exposes reusable **`analytics`** helpers (`byName`, `lastByName`, etc.) over `metrics.trackPerpsEvent`, and **`ServiceContext.getPositions`** is wired to the provider so close flows emit position-derived event properties in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e1c38826674883d50449713b1e38980df7775d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->