### PR TITLE
chore: replace @react-native-community/checkbox with design-system Checkbox

### DIFF
--- a/app/components/UI/AccountApproval/index.js
+++ b/app/components/UI/AccountApproval/index.js
@@ -11,7 +11,7 @@ import TransactionHeader from '../TransactionHeader';
 
 import { MetaMetricsEvents } from '../../../core/Analytics';
 
-import CheckBox from '@react-native-community/checkbox';
+import { Checkbox } from '@metamask/design-system-react-native';
 import { shuffle } from 'lodash';
 import URL from 'url-parse';
 import AppConstants from '../../../../app/core/AppConstants';
@@ -362,16 +362,10 @@ class AccountApproval extends PureComponent {
         )}
         {hasRememberMe && (
           <View style={styles.rememberme}>
-            <CheckBox
-              style={styles.rememberCheckbox}
-              value={this.state.noPersist}
-              onValueChange={(checked) => {
+            <Checkbox
+              isSelected={this.state.noPersist}
+              onChange={(checked) => {
                 this.setState({ noPersist: checked });
-              }}
-              boxType={'square'}
-              tintColors={{
-                true: colors.primary.default,
-                false: colors.border.default,
               }}
             />
             <Text style={styles.rememberText}>

--- a/app/components/UI/AccountApproval/styles.ts
+++ b/app/components/UI/AccountApproval/styles.ts
@@ -93,10 +93,6 @@ const createStyles = (colors: ThemeColors, typography: ThemeTypography) =>
       marginLeft: 20,
       alignItems: 'center',
     },
-    rememberCheckbox: {
-      height: 20,
-      width: 20,
-    },
     rememberText: { paddingLeft: 10, color: colors.text.default },
     option: {
       flex: 1,

--- a/app/components/UI/HardwareWallet/AccountSelector/index.test.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import AccountSelector from './index';
+import { IAccount } from './types';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    AccountTrackerController: {
+      syncBalanceWithAddresses: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+jest.mock('../../../hooks/useBlockExplorer', () => () => ({
+  toBlockExplorer: jest.fn(),
+  getBlockExplorerUrl: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(),
+  }),
+}));
+
+jest.mock('../AccountDetails', () => jest.fn(() => null));
+
+const ACCOUNTS: IAccount[] = [
+  {
+    address: '0x1111111111111111111111111111111111111111',
+    balance: '0x0',
+    index: 0,
+  },
+  {
+    address: '0x2222222222222222222222222222222222222222',
+    balance: '0x0',
+    index: 1,
+  },
+];
+
+const mockState = {
+  engine: {
+    backgroundState,
+  },
+};
+
+const renderAccountSelector = (
+  props: Partial<React.ComponentProps<typeof AccountSelector>> = {},
+) =>
+  renderWithProvider(
+    <AccountSelector
+      accounts={ACCOUNTS}
+      selectedAccounts={[]}
+      nextPage={jest.fn()}
+      prevPage={jest.fn()}
+      onUnlock={jest.fn()}
+      onForget={jest.fn()}
+      {...props}
+    />,
+    { state: mockState },
+  );
+
+describe('AccountSelector', () => {
+  it('renders a checkbox for every account', () => {
+    const { getAllByRole } = renderAccountSelector();
+
+    const checkboxes = getAllByRole('checkbox');
+
+    expect(checkboxes).toHaveLength(ACCOUNTS.length);
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: false, disabled: false }),
+      );
+    });
+  });
+
+  it('selects an account when its checkbox is pressed', () => {
+    const onCheck = jest.fn();
+    const { getAllByRole } = renderAccountSelector({ onCheck });
+
+    const [firstCheckbox] = getAllByRole('checkbox');
+    fireEvent.press(firstCheckbox);
+
+    expect(onCheck).toHaveBeenCalledWith(ACCOUNTS[0].index);
+    expect(getAllByRole('checkbox')[0].props.accessibilityState).toEqual(
+      expect.objectContaining({ checked: true }),
+    );
+  });
+
+  it('does not toggle an already-imported account', () => {
+    const onCheck = jest.fn();
+    const { getAllByRole } = renderAccountSelector({
+      onCheck,
+      selectedAccounts: [ACCOUNTS[1].address],
+    });
+
+    const importedCheckbox = getAllByRole('checkbox')[1];
+    expect(importedCheckbox.props.accessibilityState).toEqual(
+      expect.objectContaining({ checked: true, disabled: true }),
+    );
+
+    fireEvent.press(importedCheckbox);
+
+    expect(onCheck).not.toHaveBeenCalled();
+    expect(getAllByRole('checkbox')[1].props.accessibilityState).toEqual(
+      expect.objectContaining({ checked: true, disabled: true }),
+    );
+  });
+});

--- a/app/components/UI/HardwareWallet/AccountSelector/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useMemo } from 'react';
 import { View, Text, FlatList, TouchableOpacity } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import CheckBox from '@react-native-community/checkbox';
+import { Checkbox } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
 
 import { strings } from '../../../../../locales/i18n';
@@ -107,19 +107,10 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
         keyExtractor={(item) => `address-${item.index}`}
         renderItem={({ item }) => (
           <View style={[styles.account]}>
-            <CheckBox
-              style={[styles.checkBox]}
-              disabled={item.exist}
-              value={item.checked}
-              onValueChange={() => onCheckBoxClick(item.index)}
-              boxType={'square'}
-              tintColors={{
-                true: colors.primary.default,
-                false: colors.border.default,
-              }}
-              onCheckColor={colors.background.default}
-              onFillColor={colors.primary.default}
-              onTintColor={colors.primary.default}
+            <Checkbox
+              isDisabled={item.exist}
+              isSelected={item.checked ?? false}
+              onChange={() => onCheckBoxClick(item.index)}
             />
             <AccountDetails
               index={item.index}

--- a/app/components/UI/HardwareWallet/AccountSelector/styles.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/styles.tsx
@@ -36,9 +36,6 @@ export const createStyle = (colors: any) =>
       paddingHorizontal: 10,
       paddingVertical: 5,
     },
-    checkBox: {
-      backgroundColor: colors.background.default,
-    },
     number: {
       ...fontStyles.normal,
       color: colors.text.default,

--- a/app/components/Views/ConnectQRHardware/index.test.tsx
+++ b/app/components/Views/ConnectQRHardware/index.test.tsx
@@ -537,10 +537,9 @@ describe('ConnectQRHardware', () => {
       fireEvent.press(button);
     });
 
-    // Pressing the address label does not toggle @react-native-community/checkbox; drive onValueChange.
     const [firstRowCheckbox] = getAllByRole('checkbox');
     await act(async () => {
-      fireEvent(firstRowCheckbox, 'onValueChange', true);
+      fireEvent.press(firstRowCheckbox);
     });
 
     const unlockButton = getByText(strings('account_selector.unlock'));

--- a/app/components/Views/LedgerSelectAccount/index.test.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.test.tsx
@@ -451,7 +451,7 @@ describe('LedgerSelectAccount', () => {
     ) => {
       const checkboxes = result.getAllByRole('checkbox');
       await act(async () => {
-        fireEvent(checkboxes[0], 'valueChange', true);
+        fireEvent.press(checkboxes[0]);
       });
       await act(async () => {
         fireEvent.press(result.getByText('Unlock'));
@@ -599,7 +599,7 @@ describe('LedgerSelectAccount', () => {
     ) => {
       const checkboxes = result.getAllByRole('checkbox');
       await act(async () => {
-        fireEvent(checkboxes[0], 'valueChange', true);
+        fireEvent.press(checkboxes[0]);
       });
       await act(async () => {
         fireEvent.press(result.getByText('Unlock'));

--- a/app/declarations/index.d.ts
+++ b/app/declarations/index.d.ts
@@ -35,23 +35,6 @@ declare module '*.png' {
   export default content;
 }
 
-declare module '@react-native-community/checkbox' {
-  import { CheckBoxProps } from '@react-native-community/checkbox';
-
-  const CheckBox: ComponentType<CheckBoxProps>;
-
-  /**
-   * @deprecated The `<CheckBox />` component has been deprecated in favor of `<Checkbox>` from `@metamask/design-system-react-native`.
-   *
-   * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Checkbox/README.md | Checkbox component}
-   *
-   * Please replace this component with the equivalent component from `@metamask/design-system-react-native`.
-   *
-   * @see {@link https://github.com/MetaMask/metamask-mobile/issues/6882 | Tracking issue}
-   */
-  export default CheckBox;
-}
-
 declare module 'react-native-vector-icons/Ionicons' {
   import { IconProps } from 'react-native-vector-icons/Ionicons';
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - Base64 (1.1.2)
-  - BEMCheckBox (1.4.1)
   - boost (1.84.0)
   - Branch (1.43.2)
   - braze-react-native-sdk (19.1.0):
@@ -3890,9 +3889,6 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNCCheckbox (0.5.20):
-    - BEMCheckBox (~> 1.4)
-    - React-Core
   - RNCClipboard (1.16.1):
     - boost
     - DoubleConversion
@@ -4631,7 +4627,6 @@ DEPENDENCIES:
   - "ReactNativePayments (from `../node_modules/@metamask/react-native-payments/lib/ios/`)"
   - rive-react-native (from `../node_modules/rive-react-native`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - "RNCCheckbox (from `../node_modules/@react-native-community/checkbox`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
@@ -4664,7 +4659,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Base64
-    - BEMCheckBox
     - Branch
     - BrazeKit
     - BrazeLocation
@@ -5004,8 +4998,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rive-react-native"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
-  RNCCheckbox:
-    :path: "../node_modules/@react-native-community/checkbox"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
@@ -5063,7 +5055,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Branch: 4ac024cb3c29b0ef628048694db3c4cfa679beb0
   braze-react-native-sdk: 81f97f9dd9aae9e89e8ff4083e473e6cb8930cd7
@@ -5240,7 +5231,6 @@ SPEC CHECKSUMS:
   rive-react-native: 3692bf8b8b617c8c801e6af54d961a2574fdbf38
   RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCCheckbox: 33b44487ca8008394ce658cc32b26eab04f426ef
   RNCClipboard: 889577746cd7ba699bd497e61a7668e6c0790e7f
   RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
   RNDateTimePicker: 97a86d7c8b51f2d51f694a9dddfe5996dfd9a407

--- a/package.json
+++ b/package.json
@@ -385,7 +385,6 @@
     "@notifee/react-native": "^9.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.1",
-    "@react-native-community/checkbox": "^0.5.20",
     "@react-native-community/cli": "20.0.0",
     "@react-native-community/cli-platform-android": "20.0.0",
     "@react-native-community/cli-platform-ios": "20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12643,20 +12643,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-community/checkbox@npm:^0.5.20":
-  version: 0.5.20
-  resolution: "@react-native-community/checkbox@npm:0.5.20"
-  peerDependencies:
-    react: "*"
-    react-native: ">= 0.62"
-    react-native-windows: ">=0.62"
-  peerDependenciesMeta:
-    react-native-windows:
-      optional: true
-  checksum: 10/f1ab95f1fbfd4853b4e798cf4b4b18ec20920106bcea9dcc8be05413a3698a0957e5175102a5acb3b45438d03c29167971daf3b0ccd66e0d6ee29f6e8a07f4f4
-  languageName: node
-  linkType: hard
-
 "@react-native-community/cli-clean@npm:20.0.0":
   version: 20.0.0
   resolution: "@react-native-community/cli-clean@npm:20.0.0"
@@ -35997,7 +35983,6 @@ __metadata:
     "@playwright/test": "npm:^1.57.0"
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-clipboard/clipboard": "npm:^1.16.1"
-    "@react-native-community/checkbox": "npm:^0.5.20"
     "@react-native-community/cli": "npm:20.0.0"
     "@react-native-community/cli-platform-android": "npm:20.0.0"
     "@react-native-community/cli-platform-ios": "npm:20.0.0"


### PR DESCRIPTION
Pre-upgrade replacement for the RN 0.85 migration (verified required). `@react-native-community/checkbox` (0.5.20) is unmaintained, flagged unsupported on the New Architecture, and RN 0.85 enforces New Arch — so the dependency is removed entirely in favor of the design-system `Checkbox`, which the deprecated module declaration already pointed to as the intended replacement.

## **Description**

<!-- mms-check: type=text required=true -->

Removes `@react-native-community/checkbox` and replaces its two remaining usages with `Checkbox` from `@metamask/design-system-react-native`:

- `app/components/UI/AccountApproval/index.js` — "do not remember me" checkbox in the SDK/QR connect approval sheet (`value`/`onValueChange` → `isSelected`/`onChange`)
- `app/components/UI/HardwareWallet/AccountSelector/index.tsx` — per-account checkbox in the QR/Ledger hardware wallet account selector (`disabled`/`value`/`onValueChange` → `isDisabled`/`isSelected`/`onChange`)

Cleanup that follows from the swap:

- Dropped the manual `tintColors`/`onCheckColor`/`onFillColor`/`onTintColor` theming and the `rememberCheckbox`/`checkBox` style entries — the design-system component styles itself via design tokens
- Removed the deprecated `declare module '@react-native-community/checkbox'` block from `app/declarations/index.d.ts`
- Updated `ConnectQRHardware` and `LedgerSelectAccount` tests: the community checkbox could not be toggled via press so tests drove `onValueChange` directly; the design-system `Checkbox` is a `Pressable` with `accessibilityRole="checkbox"`, so tests now use `fireEvent.press` (closer to real user interaction)
- Removed the dependency from `package.json`, updated `yarn.lock`, and regenerated `ios/Podfile.lock` (`RNCCheckbox` pod removed)

Verified locally: `yarn lint:tsc` green, all 70 tests across the three affected suites pass, `pod install` resolves cleanly.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/6882

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Checkbox interactions in connect approval and hardware wallet flows

  Scenario: user toggles "do not remember me" on SDK/QR connect approval
    Given user opens a dapp connection request via QR deeplink
    When user taps the "do not remember me" checkbox
    Then the checkbox toggles checked/unchecked with the design-system styling

  Scenario: user selects accounts in the QR/Ledger account selector
    Given user pairs a QR or Ledger hardware wallet
    When user taps the checkbox next to an account
    Then the account is selected and Unlock becomes enabled
    And checkboxes for already-imported accounts remain disabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only checkbox swap in two flows with no auth or transaction logic changes; risk is mainly visual/behavior parity and test coverage for toggle and disabled states.
> 
> **Overview**
> Removes **`@react-native-community/checkbox`** (unmaintained, New Architecture–incompatible) and swaps the last two usages for **`Checkbox`** from `@metamask/design-system-react-native`, ahead of RN 0.85.
> 
> **Account approval** and **hardware wallet account selector** now use `isSelected`/`onChange` (and `isDisabled` where needed) instead of `value`/`onValueChange`. Manual tint/box styling and related style entries are dropped in favor of design-system tokens.
> 
> Dependency cleanup includes **`package.json`**, **`yarn.lock`**, **`ios/Podfile.lock`** (no `RNCCheckbox` pod), and removal of the deprecated module declaration in **`app/declarations/index.d.ts`**.
> 
> Tests for QR/Ledger flows now **`fireEvent.press`** on checkboxes (design-system `Pressable` with `accessibilityRole="checkbox"`). New **`AccountSelector`** tests cover render, selection, and disabled already-imported accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561c455e47307a4188519ea773b8fd6c4a0b17fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->