### PR TITLE
docs: fix broken file links in component-library READMEs

### DIFF
--- a/app/component-library/components/Avatars/Avatar/README.md
+++ b/app/component-library/components/Avatars/Avatar/README.md
@@ -38,7 +38,7 @@ Optional enum to select the avatar type between `JazzIcon` and `Blockies`.
 
 | <span style="color:gray;font-size:14px">TYPE</span>    | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :----------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [AvatarAccountType](./variants/AvatarAccount.types.ts) | Yes                                                     | JazzIcon                                               |
+| [AvatarAccountType](./variants/AvatarAccount/AvatarAccount.types.ts) | Yes                                                     | JazzIcon                                               |
 
 ### `accountAddress`
 
@@ -66,7 +66,7 @@ Name of icon to use.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | Yes                                                     |
+| [IconName](../../Icons/Icon/Icon.types.ts)                  | Yes                                                     |
 
 ### `iconColor`
 

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/README.md
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/README.md
@@ -4,7 +4,7 @@ AvatarAccount is a component that renders an avatar based on the users account a
 
 ## Props
 
-This component extends [AvatarBaseProps](../AvatarBase/AvatarBase.types.ts#L17) from [AvatarBase](../Avatar/Avatar.tsx) component.
+This component extends [AvatarBaseProps](../../foundation/AvatarBase/AvatarBase.types.ts#L17) from [AvatarBase](../../Avatar.tsx) component.
 
 ### `type`
 

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/README.md
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/README.md
@@ -4,7 +4,7 @@ AvatarFavicon is an image component that renders an icon that is provided in the
 
 ## Props
 
-This component extends [AvatarBaseProps](../AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../Avatar/Avatar.tsx) component.
+This component extends [AvatarBaseProps](../../foundation/AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../../Avatar.tsx) component.
 
 ### `imageSource`
 

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/README.md
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/README.md
@@ -4,7 +4,7 @@ AvatarIcon is a component that renders an icon contained within an avatar.
 
 ## Props
 
-This component extends [AvatarBaseProps](../AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../Avatar/Avatar.tsx) component.
+This component extends [AvatarBaseProps](../../foundation/AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../../Avatar.tsx) component.
 
 ### `name`
 
@@ -12,7 +12,7 @@ Name of icon to use.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | Yes                                                     |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                  | Yes                                                     |
 
 ### `iconColor`
 

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/README.md
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/README.md
@@ -4,7 +4,7 @@ AvatarNetwork is a component that renders an network image based on the user sel
 
 ## Props
 
-This component extends [AvatarBaseProps](../AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../Avatar/Avatar.tsx) component.
+This component extends [AvatarBaseProps](../../foundation/AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../../Avatar.tsx) component.
 
 ### `name`
 

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarToken/README.md
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarToken/README.md
@@ -4,7 +4,7 @@ AvatarToken is a component that renders a token image.
 
 ## Props
 
-This component extends [AvatarBaseProps](../AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../Avatar/Avatar.tsx) component.
+This component extends [AvatarBaseProps](../../foundation/AvatarBase/AvatarBase.types.ts#L18) from [AvatarBase](../../Avatar.tsx) component.
 
 ### `name`
 

--- a/app/component-library/components/Badges/Badge/README.md
+++ b/app/component-library/components/Badges/Badge/README.md
@@ -14,7 +14,7 @@ Variant of badge.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [BadgeVariant](../../Badge.types.ts)                                           | Yes                                                     |
+| [BadgeVariant](./Badge.types.ts)                                           | Yes                                                     |
 
 ## BadgeNetwork Props
 
@@ -42,7 +42,7 @@ Optional prop to control the status of BadgeStatus.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [BadgeStatusState](./BadgeStatus.types.ts)  | No                                                      | Disconnected                                               |
+| [BadgeStatusState](./variants/BadgeStatus/BadgeStatus.types.ts)  | No                                                      | Disconnected                                               |
 
 ### `borderColor`
 

--- a/app/component-library/components/Badges/Badge/variants/BadgeNetwork/README.md
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNetwork/README.md
@@ -2,7 +2,7 @@
 
 ![BadgeNetwork](./BadgeNetwork.png)
 
-BadgeNetwork is used on top of an element to display network information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
+BadgeNetwork is used on top of an element to display network information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../../../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
 
 ## Props
 

--- a/app/component-library/components/Badges/Badge/variants/BadgeNotifications/README.md
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNotifications/README.md
@@ -1,4 +1,4 @@
-BadgeNotifications is used on top of an element to display notifications information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
+BadgeNotifications is used on top of an element to display notifications information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../../../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
 
 ## Props
 

--- a/app/component-library/components/Badges/Badge/variants/BadgeStatus/README.md
+++ b/app/component-library/components/Badges/Badge/variants/BadgeStatus/README.md
@@ -2,7 +2,7 @@
 
 ![BadgeStatus](./BadgeStatus.png)
 
-BadgeStatus is used on top of an element to display status information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
+BadgeStatus is used on top of an element to display status information. **This component is not meant to be used by itself**. It is used by [BadgeWrapper](../../../BadgeWrapper/BadgeWrapper.tsx), which can render this component as a badge.
 
 ## Props
 

--- a/app/component-library/components/Badges/BadgeWrapper/README.md
+++ b/app/component-library/components/Badges/BadgeWrapper/README.md
@@ -1,6 +1,6 @@
 # BadgeWrapper
 
-BadgeWrapper is a wrapper component that attaches a [Badge](./Badge/Badge.tsx) on top of any component.
+BadgeWrapper is a wrapper component that attaches a [Badge](../Badge/Badge.tsx) on top of any component.
 
 ## Props
 

--- a/app/component-library/components/Banners/Banner/README.md
+++ b/app/component-library/components/Banners/Banner/README.md
@@ -4,7 +4,7 @@
 [BannerTip](https://metamask-consensys.notion.site/Banner-Tip-67fdb01ab850472f90abc6f4127395cb)
 ![BannerTip](./variants/BannerTip/BannerTip.png)
 
-This component is a union Banner component, which consists of [BannerAlert](../BannerAlert/BannerAlert.tsx) and [BannerTip](../BannerTip/BannerTip.tsx).
+This component is a union Banner component, which consists of [BannerAlert](./variants/BannerAlert/BannerAlert.tsx) and [BannerTip](./variants/BannerTip/BannerTip.tsx).
 
 ## Banner Props
 
@@ -14,7 +14,7 @@ Variant of Banner.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [BannerVariant](../../Banner.types.ts)               | Yes                                                     |
+| [BannerVariant](./Banner.types.ts)               | Yes                                                     |
 
 ## BannerAlert Props
 
@@ -24,7 +24,7 @@ Optional enum to determine the severity color of the BannerAlert.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [BannerAlertSeverity](./BannerAlert.types.ts)    | No                                                     | BannerAlertSeverity.Info                                |
+| [BannerAlertSeverity](./variants/BannerAlert/BannerAlert.types.ts)    | No                                                     | BannerAlertSeverity.Info                                |
 
 ## BannerTip Props
 
@@ -52,7 +52,7 @@ Optional prop to control the title's props.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [TextProps](../../../../Texts/Text/Text.types.ts)                                         | No                                                     |
+| [TextProps](../../Texts/Text/Text.types.ts)                                         | No                                                     |
 
 ### `description`
 
@@ -68,7 +68,7 @@ Optional prop to control the description's props.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [TextProps](../../../../Texts/Text/Text.types.ts)                                         | No                                                     |
+| [TextProps](../../Texts/Text/Text.types.ts)                                         | No                                                     |
 
 ### `descriptionEl`
 
@@ -100,7 +100,7 @@ Optional prop to control the action button's props.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [ButtonProps](../../../../Buttons/Button/Button.types.ts)                                  | No                                                     |
+| [ButtonProps](../../Buttons/Button/Button.types.ts)                                  | No                                                     |
 
 ### `onClose`
 
@@ -116,7 +116,7 @@ Optional prop to control the close button's props.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [ButtonIconProps](../../../../Buttons/ButtonIcon/ButtonIcon.types.ts)                                  | No                                                     |
+| [ButtonIconProps](../../Buttons/ButtonIcon/ButtonIcon.types.ts)                                  | No                                                     |
 
 ### `children`
 

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/README.md
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/README.md
@@ -6,7 +6,7 @@ BottomSheetHeader is a Header component specifically used for BottomSheets.
 
 ## Props
 
-This component extends [BottomSheetHeaderProps](../../Header/Header.types.ts) component.
+This component extends [BottomSheetHeaderProps](../../HeaderBase/HeaderBase.types.ts) component.
 
 ### `onBack`
 

--- a/app/component-library/components/Buttons/Button/README.md
+++ b/app/component-library/components/Buttons/Button/README.md
@@ -13,7 +13,7 @@ Optional props to configure text component variants.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [TextVariant](../../../../Texts/Text/Text.types.ts) | No                                                      |
+| [TextVariant](../../Texts/Text/Text.types.ts) | No                                                      |
 
 ## Common Props
 
@@ -31,7 +31,7 @@ Optional prop for the size of the button.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [ButtonSize](../../Button.types.ts)                 | Yes                                                     | Md                                                     |
+| [ButtonSize](./Button.types.ts)                 | Yes                                                     | Md                                                     |
 
 ### `onPress`
 
@@ -47,7 +47,7 @@ Optional prop for the icon name of the icon that will be displayed before the la
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `endIconName`
 
@@ -55,7 +55,7 @@ Optional prop for the icon name of the icon that will be displayed after the lab
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `isDanger`
 
@@ -71,7 +71,7 @@ Optional param to control the width of the button.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [ButtonWidthTypes](../../Button.types.ts) or number | No                                                      | ButtonWidthTypes.Auto                                  |
+| [ButtonWidthTypes](./Button.types.ts) or number | No                                                      | ButtonWidthTypes.Auto                                  |
 
 ## Usage
 

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/README.md
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/README.md
@@ -38,7 +38,7 @@ Optional prop for the icon name of the icon that will be displayed before the la
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../../../../../Icons/Icon/Icon.types.ts) | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts) | No                                                      |
 
 ### `endIconName`
 
@@ -46,7 +46,7 @@ Optional prop for the icon name of the icon that will be displayed after the lab
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../../../../../Icons/Icon/Icon.types.ts) | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts) | No                                                      |
 
 ### `isDanger`
 

--- a/app/component-library/components/Buttons/Button/variants/ButtonPrimary/README.md
+++ b/app/component-library/components/Buttons/Button/variants/ButtonPrimary/README.md
@@ -4,7 +4,7 @@ ButtonPrimary is used for primary call to actions.
 
 ## Props
 
-This component extends [ButtonBaseProps](../ButtonBase/ButtonBase.types.ts) from [ButtonBase](../ButtonBase/ButtonBase.tsx) component.
+This component extends [ButtonBaseProps](../../foundation/ButtonBase/ButtonBase.types.ts) from [ButtonBase](../../foundation/ButtonBase/ButtonBase.tsx) component.
 
 ## Common Props
 
@@ -38,7 +38,7 @@ Optional prop for the icon name of the icon that will be displayed before the la
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `endIconName`
 
@@ -46,7 +46,7 @@ Optional prop for the icon name of the icon that will be displayed after the lab
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `isDanger`
 

--- a/app/component-library/components/Buttons/Button/variants/ButtonSecondary/README.md
+++ b/app/component-library/components/Buttons/Button/variants/ButtonSecondary/README.md
@@ -4,7 +4,7 @@ ButtonSecondary is used for secondary call to actions.
 
 ## Props
 
-This component extends [ButtonBaseProps](../ButtonBase/ButtonBase.types.ts) from [ButtonBase](../ButtonBase/ButtonBase.tsx) component.
+This component extends [ButtonBaseProps](../../foundation/ButtonBase/ButtonBase.types.ts) from [ButtonBase](../../foundation/ButtonBase/ButtonBase.tsx) component.
 
 ## Common Props
 
@@ -38,7 +38,7 @@ Optional prop for the icon name of the icon that will be displayed before the la
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `endIconName`
 
@@ -46,7 +46,7 @@ Optional prop for the icon name of the icon that will be displayed after the lab
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | No                                                      |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                  | No                                                      |
 
 ### `isDanger`
 

--- a/app/component-library/components/Buttons/ButtonIcon/README.md
+++ b/app/component-library/components/Buttons/ButtonIcon/README.md
@@ -14,7 +14,7 @@ Icon name of the icon that will be displayed.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | Yes                                                     |
+| [IconName](../../Icons/Icon/Icon.types.ts)                  | Yes                                                     |
 
 ### `size`
 

--- a/app/component-library/components/Cells/Cell/README.md
+++ b/app/component-library/components/Cells/Cell/README.md
@@ -1,6 +1,6 @@
 # Cell
 
-This component is a union component, which consists of [CellDisplay](../CellDisplay/CellDisplay.tsx), [CellSelect](../CellSelect/CellSelect.tsx), and [CellMultiSelect](../CellMultiSelect/CellMultiSelect.tsx)
+This component is a union component, which consists of [CellDisplay](./variants/CellDisplay/CellDisplay.tsx), [CellSelect](./variants/CellSelect/CellSelect.tsx), and [CellMultiSelect](./variants/CellMultiSelect/CellMultiSelect.tsx)
 
 ## Common props
 
@@ -14,11 +14,11 @@ Variant of Cell.
 
 ### `avatarProps`
 
-Props for the [Avatar](../../Avatars/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
+Props for the [Avatar](../../Avatars/Avatar/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [AvatarProps](../../Avatars/Avatar.types.ts#L19)                                              | Yes                                                     |
+| [AvatarProps](../../Avatars/Avatar/Avatar.types.ts#L19)                                              | Yes                                                     |
 
 ### `title`
 

--- a/app/component-library/components/Cells/Cell/foundation/CellBase/README.md
+++ b/app/component-library/components/Cells/Cell/foundation/CellBase/README.md
@@ -8,11 +8,11 @@ This component extends React Native's [ViewProps](https://reactnative.dev/docs/v
 
 ### `avatarProps`
 
-Props for the [Avatar](../../../../Avatars/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
+Props for the [Avatar](../../../../Avatars/Avatar/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [AvatarProps](../../../../Avatars/Avatar.types.ts#L19)                                              | Yes                                                     |
+| [AvatarProps](../../../../Avatars/Avatar/Avatar.types.ts#L19)                                              | Yes                                                     |
 
 ### `title`
 

--- a/app/component-library/components/Cells/Cell/variants/CellDisplay/README.md
+++ b/app/component-library/components/Cells/Cell/variants/CellDisplay/README.md
@@ -8,11 +8,11 @@ This component extends [CellBase](../../foundation/CellBase/CellBase.types.ts#L1
 
 ### `avatarProps`
 
-Props for the [Avatar](../../../../Avatars/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
+Props for the [Avatar](../../../../Avatars/Avatar/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
 
 | <span style="color:gray;font-size:14px">TYPE</span>    | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :----------------------------------------------------- | :------------------------------------------------------ |
-| [AvatarProps](../../../../Avatars/Avatar.types.ts#L19) | Yes                                                     |
+| [AvatarProps](../../../../Avatars/Avatar/Avatar.types.ts#L19) | Yes                                                     |
 
 ### `title`
 

--- a/app/component-library/components/Cells/Cell/variants/CellMultiSelect/README.md
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiSelect/README.md
@@ -4,15 +4,15 @@ CellMultiSelect is a component used for accessing account selection.
 
 ## Props
 
-This component extends [ListItemMultiSelectProps](../../List/ListItemMultiSelect/ListItemMultiSelect.types.ts#L7) and [CellBase](../CellBase/CellBase.types.ts#L17).
+This component extends [ListItemMultiSelectProps](../../../../List/ListItemMultiSelect/ListItemMultiSelect.types.ts#L7) and [CellBase](../../foundation/CellBase/CellBase.types.ts#L17).
 
 ### `avatarProps`
 
-Props for the [Avatar](../../../../Avatars/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
+Props for the [Avatar](../../../../Avatars/Avatar/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [AvatarProps](../../../../Avatars/Avatar.types.ts#L19)                                              | Yes                                                     |
+| [AvatarProps](../../../../Avatars/Avatar/Avatar.types.ts#L19)                                              | Yes                                                     |
 
 ### `title`
 

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/README.md
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/README.md
@@ -4,15 +4,15 @@ CellSelect is a component used for accessing account selection.
 
 ## Props
 
-This component extends [ListItemSelectProps](../../List/ListItemSelect/ListItemSelect.types.ts#L7) and [CellBase](../CellBase/CellBase.types.ts#L17).
+This component extends [ListItemSelectProps](../../../../List/ListItemSelect/ListItemSelect.types.ts#L7) and [CellBase](../../foundation/CellBase/CellBase.types.ts#L17).
 
 ### `avatarProps`
 
-Props for the [Avatar](../../../../Avatars/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
+Props for the [Avatar](../../../../Avatars/Avatar/Avatar.tsx) component (with the exception of size). Avatar size is restricted to size Md(32x32) for Cells
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [AvatarProps](../../../../Avatars/Avatar.types.ts#L19)                                              | Yes                                                     |
+| [AvatarProps](../../../../Avatars/Avatar/Avatar.types.ts#L19)                                              | Yes                                                     |
 
 ### `title`
 

--- a/app/component-library/components/Form/TextField/README.md
+++ b/app/component-library/components/Form/TextField/README.md
@@ -48,7 +48,7 @@ Optional enum to select between Typography variants.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [TextVariant](../../../../Texts/Text/Text.types.ts) | No                                                      | TextVariant.BodyMd                                     |
+| [TextVariant](../../Texts/Text/Text.types.ts) | No                                                      | TextVariant.BodyMd                                     |
 
 ### `isDisabled`
 

--- a/app/component-library/components/Form/TextFieldSearch/README.md
+++ b/app/component-library/components/Form/TextFieldSearch/README.md
@@ -6,7 +6,7 @@ TextFieldSearch is an input component that allows users to enter text to search.
 
 ## Props
 
-This component extends [TextField](./foundation/Input/Input.tsx) component.
+This component extends [TextField](../TextField/foundation/Input/Input.tsx) component.
 
 ### Clear Button Behavior
 

--- a/app/component-library/components/Icons/Icon/README.md
+++ b/app/component-library/components/Icons/Icon/README.md
@@ -14,7 +14,7 @@ Optional enum to select between icon sizes.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> | <span style="color:gray;font-size:14px">DEFAULT</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------- |
-| [AvatarSize](../Avatar/Avatar.types.ts#L6)          | Yes                                                     | Md                                                     |
+| [AvatarSize](../../Avatars/Avatar/Avatar.types.ts#L6)          | Yes                                                     | Md                                                     |
 
 ### `name`
 

--- a/app/component-library/components/Navigation/TabBarItem/README.md
+++ b/app/component-library/components/Navigation/TabBarItem/README.md
@@ -20,7 +20,7 @@ Icon of the tab item.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                  | Yes                                                     |
+| [IconName](../../Icons/Icon/Icon.types.ts)                  | Yes                                                     |
 
 ### `onPress`
 

--- a/app/component-library/components/Sheet/SheetHeader/README.md
+++ b/app/component-library/components/Sheet/SheetHeader/README.md
@@ -1,6 +1,6 @@
 # SheetHeader
 
-SheetHeader is a header component and is currently used within the [BottomSheet](../BottomSheet/BottomSheet.tsx) component.
+SheetHeader is a header component and is currently used within the [BottomSheet](../../BottomSheets/BottomSheet/BottomSheet.tsx) component.
 
 ## Props
 

--- a/app/component-library/components/Texts/TextWithPrefixIcon/README.md
+++ b/app/component-library/components/Texts/TextWithPrefixIcon/README.md
@@ -1,6 +1,6 @@
 # TextWithPrefixIcon
 
-TextWithPrefixIcon is a [Text](../Text/Text.tsx) component with a prefix [Icon](../../Icons/Icon.tsx) component.
+TextWithPrefixIcon is a [Text](../Text/Text.tsx) component with a prefix [Icon](../../Icons/Icon/Icon.tsx) component.
 
 ## Props
 
@@ -12,7 +12,7 @@ Props for the Prefix Icon.
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconProps](../../Icons/Icon.types.ts)              | Yes                                                     |
+| [IconProps](../../Icons/Icon/Icon.types.ts)              | Yes                                                     |
 
 ### `variant`
 


### PR DESCRIPTION
## Description

A mechanical link audit (resolving every relative markdown link in `app/component-library` against the filesystem) found 62 broken file links across 29 READMEs — left behind by past restructures (Avatar variants/foundation split, per-component `.types.ts` files, Icon/Header moves, Cell variants, Badge variants, etc.).

Each link is rewritten to the file's current location, resolved by unique basename match within the component library (61 links had exactly one candidate; zero ambiguous). One link was resolved semantically: the BottomSheetHeader README pointed at a nonexistent `Header/Header.types.ts` and now points at `HeaderBase/HeaderBase.types.ts`, which is what `BottomSheetHeaderProps` actually extends.

Link targets only; no prose changes.

Known remaining (not fixed): `RadioButton/README.md` references `./RadioButton.png`, but no such screenshot exists anywhere in the repo — happy to remove the image reference if preferred, but that's a content decision.

## Related issues

N/A — found via link audit.

## Manual testing steps

Docs-only. Verify by clicking any changed link on GitHub's rendered README view, e.g. `app/component-library/components/Avatars/Avatar/variants/AvatarIcon/README.md`.

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable — N/A, docs only
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable — N/A
- [x] I've applied the right labels on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes; no runtime behavior, APIs, or security-sensitive code paths are affected.
> 
> **Overview**
> Fixes **broken relative links** across **29** `app/component-library` READMEs (roughly **62** targets) that were left pointing at old paths after restructures (Avatar `variants`/`foundation`, Icon under `Icon/`, Badge/Banner/Cell variant folders, co-located `.types.ts` files, and similar).
> 
> Link destinations only: props tables and “extends” references now resolve to the right **`.types.ts`**, **`foundation/`**, **`variants/`**, and cross-component paths (e.g. `Icons/Icon/Icon.types.ts`, `Avatars/Avatar/Avatar.tsx`). **BottomSheetHeader** docs no longer reference a missing `Header/Header.types.ts`; they point at **`HeaderBase/HeaderBase.types.ts`**, matching what `BottomSheetHeaderProps` extends.
> 
> No application code or README copy changes beyond href paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95896f11d3899eb538f800e1538bc16a1139f132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->