### PR TITLE
fix: deep links foreground notifications

### DIFF
--- a/android/app/src/main/java/io/metamask/nativeModules/NotificationModule.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/NotificationModule.kt
@@ -2,16 +2,20 @@ package io.metamask.nativeModules
 
 import android.content.Intent
 import android.os.Bundle
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableNativeMap
+import java.lang.ref.WeakReference
 
 class NotificationModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(context) {
 
   companion object {
+    private const val NOTIFICATION_OPENED_EVENT = "metamask.notification_opened"
     private var savedNotificationData: Bundle? = null
+    private var moduleReference: WeakReference<NotificationModule>? = null
 
     private val FCM_KEYS = setOf(
       "google.message_id", "google.sent_time", "google.ttl",
@@ -37,9 +41,14 @@ class NotificationModule(context: ReactApplicationContext) : ReactContextBaseJav
 
         if (hasFCMData) {
           savedNotificationData = Bundle(extras)
+          moduleReference?.get()?.emitNotificationOpened(extras)
         }
       }
     }
+  }
+
+  init {
+    moduleReference = WeakReference(this)
   }
 
   override fun getName(): String = "NotificationModule"
@@ -58,10 +67,24 @@ class NotificationModule(context: ReactApplicationContext) : ReactContextBaseJav
     }
   }
 
+  private fun emitNotificationOpened(data: Bundle) {
+    if (reactApplicationContext.hasActiveReactInstance()) {
+      reactApplicationContext.emitDeviceEvent(
+        NOTIFICATION_OPENED_EVENT,
+        createRemoteMessageStructure(data),
+      )
+    }
+  }
+
   private fun createRemoteMessageStructure(data: Bundle): WritableNativeMap {
     val result = WritableNativeMap()
     val dataMap = WritableNativeMap()
     val notificationMap = WritableNativeMap()
+
+    data.getBundle("notification")?.getBundle("data")?.let {
+      result.putMap("data", Arguments.fromBundle(it))
+      return result
+    }
 
     data.keySet()
       .filterNot { it == "profile" || it.contains("UserHandle") }

--- a/android/app/src/main/java/io/metamask/nativeModules/NotificationModule.kt
+++ b/android/app/src/main/java/io/metamask/nativeModules/NotificationModule.kt
@@ -30,6 +30,11 @@ class NotificationModule(context: ReactApplicationContext) : ReactContextBaseJav
       "gcm.notification.click_action"
     )
 
+    internal fun shouldEmitNotificationOpened(extras: Bundle): Boolean =
+      extras.containsKey("google.message_id") ||
+        extras.containsKey("message_id") ||
+        extras.getBundle("notification")?.getBundle("data") != null
+
     fun saveNotificationIntent(intent: Intent?) {
       intent?.extras?.let { extras ->
         val hasFCMData = extras.keySet().any { key ->
@@ -41,7 +46,9 @@ class NotificationModule(context: ReactApplicationContext) : ReactContextBaseJav
 
         if (hasFCMData) {
           savedNotificationData = Bundle(extras)
-          moduleReference?.get()?.emitNotificationOpened(extras)
+          if (shouldEmitNotificationOpened(extras)) {
+            moduleReference?.get()?.emitNotificationOpened(extras)
+          }
         }
       }
     }

--- a/app/core/DeeplinkManager/DeeplinkManager.test.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.test.ts
@@ -1,6 +1,13 @@
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { waitFor } from '@testing-library/react-native';
-import FCMService from '../../util/notifications/services/FCMService';
+import {
+  EventType,
+  type Notification as NotifeeNotification,
+} from '@notifee/react-native';
+import FCMService, {
+  toPushTapResult,
+} from '../../util/notifications/services/FCMService';
+import NotificationsService from '../../util/notifications/services/NotificationService';
 import NavigationService from '../NavigationService';
 import SharedDeeplinkManager, {
   DeeplinkManager,
@@ -34,6 +41,7 @@ jest.mock('./handlers/legacy/handleRewardsUrl');
 jest.mock('./handlers/legacy/handleDeeplink');
 jest.mock('./handlers/legacy/handleFastOnboarding');
 jest.mock('../../util/notifications/services/FCMService');
+jest.mock('../../util/notifications/services/NotificationService');
 jest.mock('../Braze/BrazeDeeplinks');
 jest.mock('../AppStateEventListener', () => ({
   AppOpenedPushProvider: { Braze: 'braze', Wallet: 'wallet' },
@@ -157,10 +165,23 @@ describe('DeeplinkManager.start() - FCM Push Notification Integration', () => {
       FCMService.onClickPushNotificationWhenAppSuspended,
     );
     const mockHandleDeeplink = jest.mocked(handleDeeplink);
+    const mockToPushTapResult = jest.mocked(toPushTapResult);
+    const mockOnForegroundEvent = jest.mocked(
+      NotificationsService.onForegroundEvent,
+    );
+    const mockHandleNotificationEvent = jest.mocked(
+      NotificationsService.handleNotificationEvent,
+    );
     const mockGetBrazeInitialPush = jest.mocked(getBrazeInitialPush);
     const mockSubscribeToBrazePushOpens = jest.mocked(
       subscribeToBrazePushOpens,
     );
+
+    mockOnClickPushNotificationWhenAppClosed.mockResolvedValue({
+      opened: false,
+      deeplink: null,
+    });
+    mockOnClickPushNotificationWhenAppSuspended.mockImplementation(() => null);
 
     // Mock Braze to prevent errors during DeeplinkManager.start()
     mockGetBrazeInitialPush.mockResolvedValue({
@@ -173,6 +194,9 @@ describe('DeeplinkManager.start() - FCM Push Notification Integration', () => {
       mockOnClickPushNotificationWhenAppClosed,
       mockOnClickPushNotificationWhenAppSuspended,
       mockHandleDeeplink,
+      mockToPushTapResult,
+      mockOnForegroundEvent,
+      mockHandleNotificationEvent,
     };
   };
 
@@ -257,6 +281,79 @@ describe('DeeplinkManager.start() - FCM Push Notification Integration', () => {
       expect(
         mocks.mockOnClickPushNotificationWhenAppSuspended,
       ).toHaveBeenCalledWith(expect.any(Function));
+      expect(mocks.mockHandleDeeplink).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Notifee Push Notification', () => {
+    const triggerNotifeePress = async (
+      mocks: ReturnType<typeof arrangeMocks>,
+      notification: NotifeeNotification,
+    ) => {
+      DeeplinkManager.start();
+      const foregroundEventHandler =
+        mocks.mockOnForegroundEvent.mock.calls[0][0];
+      await foregroundEventHandler({
+        type: EventType.PRESS,
+        detail: { notification },
+      });
+      const notificationCallback =
+        mocks.mockHandleNotificationEvent.mock.calls[0][0].callback;
+      notificationCallback?.(notification);
+    };
+
+    it('routes a Notifee press through wallet push attribution', async () => {
+      const deeplink = 'https://link.metamask.io/rewards';
+      const notification = {
+        data: {
+          dataStr: JSON.stringify({
+            deeplink,
+            notification_type: 'platform',
+            notification_subtype: 'take_profit_executed',
+          }),
+        },
+      } as NotifeeNotification;
+      const tapResult = {
+        opened: true,
+        deeplink,
+        notificationType: 'platform',
+        notificationSubtype: 'take_profit_executed',
+      };
+      const mocks = arrangeMocks();
+      mocks.mockToPushTapResult.mockReturnValue(tapResult);
+
+      await triggerNotifeePress(mocks, notification);
+
+      expect(mocks.mockToPushTapResult).toHaveBeenCalledWith(
+        notification.data,
+        true,
+      );
+      expect(AppStateEventProcessor.markOpenedFromPush).toHaveBeenCalledWith({
+        provider: 'wallet',
+        notificationType: 'platform',
+        notificationSubtype: 'take_profit_executed',
+      });
+      expect(mocks.mockHandleDeeplink).toHaveBeenCalledWith({
+        uri: deeplink,
+        source: AppConstants.DEEPLINKS.ORIGIN_PUSH_NOTIFICATION,
+      });
+    });
+
+    it('ignores a Notifee press without wallet push fields', async () => {
+      const notification = {
+        data: {
+          dataStr: JSON.stringify({ action: 'tx' }),
+        },
+      } as NotifeeNotification;
+      const mocks = arrangeMocks();
+      mocks.mockToPushTapResult.mockReturnValue({
+        opened: true,
+        deeplink: null,
+      });
+
+      await triggerNotifeePress(mocks, notification);
+
+      expect(AppStateEventProcessor.markOpenedFromPush).not.toHaveBeenCalled();
       expect(mocks.mockHandleDeeplink).not.toHaveBeenCalled();
     });
   });

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -3,9 +3,12 @@
 import parseDeeplink from './utils/parseDeeplink';
 import branch from 'react-native-branch';
 import { Linking } from 'react-native';
+import type { Notification as NotifeeNotification } from '@notifee/react-native';
 import Logger from '../../util/Logger';
 import { handleDeeplink } from './handlers/legacy/handleDeeplink';
-import FCMService from '../../util/notifications/services/FCMService';
+import FCMService, {
+  toPushTapResult,
+} from '../../util/notifications/services/FCMService';
 import AppConstants from '../AppConstants';
 import { BranchParams } from './types/deepLinkAnalytics.types';
 import {
@@ -17,6 +20,7 @@ import {
   AppStateEventProcessor,
 } from '../AppStateEventListener';
 import type { DeeplinkIntent } from './types/DeeplinkIntent';
+import NotificationsService from '../../util/notifications/services/NotificationService';
 
 // `false` means the deeplink was handled but intentionally rejected, for
 // example when the user dismisses the interstitial during startup resolution.
@@ -191,6 +195,28 @@ export class DeeplinkManager {
       if (tap.opened) {
         onPushTap(AppOpenedPushProvider.Wallet, tap);
       }
+    });
+
+    const handleNotifeeNotification = (
+      notification: NotifeeNotification | undefined,
+    ) => {
+      if (!notification) {
+        return;
+      }
+
+      const tap = toPushTapResult(notification.data, true);
+      if (!tap.deeplink && !tap.notificationType && !tap.notificationSubtype) {
+        return;
+      }
+
+      onPushTap(AppOpenedPushProvider.Wallet, tap);
+    };
+
+    NotificationsService.onForegroundEvent(async (event) => {
+      await NotificationsService.handleNotificationEvent({
+        ...event,
+        callback: handleNotifeeNotification,
+      });
     });
 
     getBrazeInitialPush().then(({ opened, deeplink }) => {

--- a/app/util/notifications/pushNotificationDeeplink.test.ts
+++ b/app/util/notifications/pushNotificationDeeplink.test.ts
@@ -1,0 +1,71 @@
+import {
+  extractPushNotificationData,
+  extractPushNotificationDeeplink,
+} from './pushNotificationDeeplink';
+
+describe('extractPushNotificationData', () => {
+  it('returns flat RNFirebase data unchanged', () => {
+    const data = {
+      deeplink: 'https://link.metamask.io/rewards',
+      notification_id: 'test-notification-id',
+    };
+
+    const result = extractPushNotificationData(data);
+
+    expect(result).toStrictEqual(data);
+  });
+
+  it('extracts serialized Notifee data', () => {
+    const notificationData = {
+      deeplink: 'https://link.metamask.io/rewards',
+      notification_id: 'test-notification-id',
+    };
+
+    const result = extractPushNotificationData({
+      dataStr: JSON.stringify(notificationData),
+    });
+
+    expect(result).toStrictEqual(notificationData);
+  });
+
+  it('returns the wrapper for malformed serialized data', () => {
+    const data = { dataStr: '{not-json' };
+
+    const result = extractPushNotificationData(data);
+
+    expect(result).toStrictEqual(data);
+  });
+});
+
+describe('extractPushNotificationDeeplink', () => {
+  it('extracts a flat RNFirebase deeplink', () => {
+    const data = {
+      deeplink: 'https://link.metamask.io/rewards',
+      metadata: '{}',
+    };
+
+    const result = extractPushNotificationDeeplink(data);
+
+    expect(result).toBe('https://link.metamask.io/rewards');
+  });
+
+  it('extracts a deeplink from serialized Notifee data', () => {
+    const data = {
+      dataStr: JSON.stringify({
+        deeplink: 'https://link.metamask.io/rewards',
+      }),
+    };
+
+    const result = extractPushNotificationDeeplink(data);
+
+    expect(result).toBe('https://link.metamask.io/rewards');
+  });
+
+  it('returns undefined for malformed serialized data', () => {
+    const data = { dataStr: '{not-json' };
+
+    const result = extractPushNotificationDeeplink(data);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/util/notifications/pushNotificationDeeplink.ts
+++ b/app/util/notifications/pushNotificationDeeplink.ts
@@ -1,0 +1,54 @@
+type UnknownRecord = Record<string, unknown>;
+type PushNotificationData = Record<string, string | object>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isPushNotificationData = (
+  value: unknown,
+): value is PushNotificationData =>
+  isRecord(value) &&
+  Object.values(value).every(
+    (entry) =>
+      typeof entry === 'string' ||
+      (typeof entry === 'object' && entry !== null),
+  );
+
+const getDeeplink = (value: unknown): string | undefined =>
+  isRecord(value) && typeof value.deeplink === 'string'
+    ? value.deeplink
+    : undefined;
+
+export const extractPushNotificationData = (
+  value: unknown,
+): PushNotificationData | undefined => {
+  if (!isPushNotificationData(value)) {
+    return undefined;
+  }
+
+  if (typeof value.dataStr !== 'string') {
+    return value;
+  }
+
+  try {
+    const data = JSON.parse(value.dataStr);
+    return isPushNotificationData(data) ? data : value;
+  } catch {
+    return value;
+  }
+};
+
+/**
+ * Normalizes the payload shapes used by RNFirebase and locally displayed
+ * Notifee notifications into one deeplink contract.
+ */
+export const extractPushNotificationDeeplink = (
+  value: unknown,
+): string | undefined => {
+  const deeplink = getDeeplink(value);
+  if (deeplink) {
+    return deeplink;
+  }
+
+  return getDeeplink(extractPushNotificationData(value));
+};

--- a/app/util/notifications/services/FCMService.test.ts
+++ b/app/util/notifications/services/FCMService.test.ts
@@ -5,7 +5,7 @@ import messaging, {
 import FCMService from './FCMService';
 import { EVENT_NAME } from '../../../core/Analytics';
 import { analytics } from '../../analytics/analytics';
-import { NativeModules, Platform } from 'react-native';
+import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 import { getSessionProfileId } from '../utils/get-session-profile-id';
 
 // Firebase Mock
@@ -398,6 +398,27 @@ describe('FCMService - onClickPushNotificationWhenAppClosed', () => {
         });
       });
 
+      it('returns a classified tap from serialized Notifee data', async () => {
+        const deeplink = 'https://link.metamask.io/rewards';
+        const { result, mocks } = await arrangeAct({
+          dataStr: JSON.stringify(createMockPushAnalyticsFcmData({ deeplink })),
+        });
+
+        expect(result).toEqual({
+          opened: true,
+          deeplink,
+          notificationType: 'platform',
+          notificationSubtype: 'take_profit_executed',
+        });
+        assertMockInitialNotificationCalled(mocks);
+        assertTrackEventCalledWith(mocks.mockTrackEvent, {
+          notification_id: 'test-notification-id',
+          notification_type: 'platform',
+          notification_subtype: 'take_profit_executed',
+          deeplink,
+        });
+      });
+
       // On-chain activity notifications commonly carry no CTA link, so the tap
       // must still be reported as an open even with no deeplink to return.
       it('reports an open with no deeplink when no deeplink present', async () => {
@@ -437,6 +458,10 @@ describe('FCMService - onClickPushNotificationWhenAppClosed', () => {
 });
 
 describe('FCMService - onClickPushNotificationWhenAppSuspended', () => {
+  beforeEach(() => {
+    Platform.OS = 'ios';
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -513,6 +538,46 @@ describe('FCMService - onClickPushNotificationWhenAppSuspended', () => {
       notification_type: 'platform',
       notification_subtype: 'take_profit_executed',
       deeplink: 'https://test.metamask.io/perps-asset?symbol=ETH',
+    });
+  });
+
+  it('reports serialized Notifee data from the Android native event', async () => {
+    const deeplink = 'https://link.metamask.io/rewards';
+    const mocks = arrangeMocks();
+    let nativeNotificationHandler:
+      | ((remoteMessage: FirebaseMessagingTypes.RemoteMessage) => Promise<void>)
+      | undefined;
+
+    Platform.OS = 'android';
+    jest
+      .spyOn(DeviceEventEmitter, 'addListener')
+      .mockImplementation((eventType, listener) => {
+        expect(eventType).toBe('metamask.notification_opened');
+        nativeNotificationHandler = listener as (
+          remoteMessage: FirebaseMessagingTypes.RemoteMessage,
+        ) => Promise<void>;
+        return { remove: jest.fn() } as never;
+      });
+
+    FCMService.onClickPushNotificationWhenAppSuspended(mocks.deeplinkCallback);
+    await nativeNotificationHandler?.(
+      createMockRemoteMessage({
+        dataStr: JSON.stringify(createMockPushAnalyticsFcmData({ deeplink })),
+      }),
+    );
+
+    expect(mocks.mockOnNotificationOpenedApp).not.toHaveBeenCalled();
+    expect(mocks.deeplinkCallback).toHaveBeenCalledWith({
+      opened: true,
+      deeplink,
+      notificationType: 'platform',
+      notificationSubtype: 'take_profit_executed',
+    });
+    assertTrackEventCalledWith(mocks.mockTrackEvent, {
+      notification_id: 'test-notification-id',
+      notification_type: 'platform',
+      notification_subtype: 'take_profit_executed',
+      deeplink,
     });
   });
 

--- a/app/util/notifications/services/FCMService.ts
+++ b/app/util/notifications/services/FCMService.ts
@@ -2,12 +2,15 @@ import { toPushAnalyticsPayload } from '@metamask/notification-services-controll
 import messaging, {
   type FirebaseMessagingTypes,
 } from '@react-native-firebase/messaging';
-import { NativeModules, Platform } from 'react-native';
-import Logger from '../../../util/Logger';
+import { DeviceEventEmitter, NativeModules, Platform } from 'react-native';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { analytics } from '../../analytics/analytics';
 import { AnalyticsEventBuilder } from '../../analytics/AnalyticsEventBuilder';
 import { toFcmDataStringRecord } from '../utils/fcm-data';
+import {
+  extractPushNotificationData,
+  extractPushNotificationDeeplink,
+} from '../pushNotificationDeeplink';
 
 async function getInitialNotification() {
   // Tried many different approaches, but @react-native-firebase setup is unable to hold and track the initial open intent from a push notification
@@ -28,7 +31,9 @@ async function analyticsTrackPushClickEvent(
   remoteMessage?: FirebaseMessagingTypes.RemoteMessage | null,
 ) {
   try {
-    const data = toFcmDataStringRecord(remoteMessage?.data);
+    const data = toFcmDataStringRecord(
+      extractPushNotificationData(remoteMessage?.data),
+    );
     const payload = toPushAnalyticsPayload(data);
 
     const properties = payload
@@ -51,6 +56,8 @@ async function analyticsTrackPushClickEvent(
 
 type UnsubscribeFunc = () => void;
 
+const ANDROID_NOTIFICATION_OPENED_EVENT = 'metamask.notification_opened';
+
 /**
  * A notification tap, and what the payload carried with it. `opened` is true
  * even when there is no deeplink — on-chain activity notifications commonly
@@ -63,14 +70,14 @@ export interface PushTapResult {
   notificationSubtype?: string;
 }
 
-function toPushTapResult(
-  remoteMessage?: FirebaseMessagingTypes.RemoteMessage | null,
-): PushTapResult {
-  const data = toFcmDataStringRecord(remoteMessage?.data);
-  const payload = toPushAnalyticsPayload(data);
+export function toPushTapResult(data: unknown, opened: boolean): PushTapResult {
+  const normalizedData = toFcmDataStringRecord(
+    extractPushNotificationData(data),
+  );
+  const payload = toPushAnalyticsPayload(normalizedData);
   return {
-    opened: Boolean(remoteMessage),
-    deeplink: data?.deeplink ?? null,
+    opened,
+    deeplink: extractPushNotificationDeeplink(data) ?? null,
     notificationType: payload?.notification_type,
     notificationSubtype: payload?.notification_subtype,
   };
@@ -224,7 +231,7 @@ class FCMService {
     try {
       const remoteMessage = await getInitialNotification();
       await analyticsTrackPushClickEvent(remoteMessage);
-      return toPushTapResult(remoteMessage);
+      return toPushTapResult(remoteMessage?.data, Boolean(remoteMessage));
     } catch {
       return { opened: false, deeplink: null };
     }
@@ -234,14 +241,27 @@ class FCMService {
     tapCallback: (tap: PushTapResult) => void,
   ) => {
     try {
-      messaging().onNotificationOpenedApp(async (remoteMessage) => {
+      const handleOpenedNotification = async (
+        remoteMessage?: FirebaseMessagingTypes.RemoteMessage,
+      ) => {
         try {
           await analyticsTrackPushClickEvent(remoteMessage);
-          tapCallback(toPushTapResult(remoteMessage));
+          tapCallback(
+            toPushTapResult(remoteMessage?.data, Boolean(remoteMessage)),
+          );
         } catch {
           // Do nothing
         }
-      });
+      };
+
+      if (Platform.OS === 'android') {
+        DeviceEventEmitter.addListener(
+          ANDROID_NOTIFICATION_OPENED_EVENT,
+          handleOpenedNotification,
+        );
+      } else {
+        messaging().onNotificationOpenedApp(handleOpenedNotification);
+      }
     } catch {
       // Do nothing
     }

--- a/app/util/notifications/types/notification/index.ts
+++ b/app/util/notifications/types/notification/index.ts
@@ -5,7 +5,7 @@ export enum PressActionId {
   OPEN_NOTIFICATIONS_VIEW = 'open-notifications-view-press-action-id',
 }
 
-export const LAUNCH_ACTIVITY = 'com.metamask.ui.MainActivity';
+export const LAUNCH_ACTIVITY = 'default';
 
 export const NotificationTypes = {
   TRANSACTION: 'transaction',

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -27,6 +27,8 @@ class AppDelegate: ExpoAppDelegate {
 
   private var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
   private var reactNativeFactory: RCTReactNativeFactory?
+  private weak var displacedNotificationCenterDelegate: UNUserNotificationCenterDelegate?
+  private var isForwardingNotificationResponse = false
 
   @objc static var braze: Braze?
 
@@ -120,7 +122,7 @@ class AppDelegate: ExpoAppDelegate {
     // Braze (push.automation=true) and Notifee both try to set themselves as delegate
     // during startup; we must win so our willPresent forwards to Firebase and triggers
     // messaging().onMessage() in JS. We reassert on every foreground entry (see below).
-    UNUserNotificationCenter.current().delegate = self
+    claimNotificationCenterDelegate()
 
     return superResult
   }
@@ -131,7 +133,16 @@ class AppDelegate: ExpoAppDelegate {
     // it asynchronously. Notifee tap forwarding is handled explicitly in didReceive
     // (via NotifeeCoreUNUserNotificationCenter.instance()) rather than through Notifee's
     // own delegate chain, so holding this slot does not break Notifee press events.
-    UNUserNotificationCenter.current().delegate = self
+    claimNotificationCenterDelegate()
+  }
+
+  private func claimNotificationCenterDelegate() {
+    let center = UNUserNotificationCenter.current()
+    if let currentDelegate = center.delegate,
+       (currentDelegate as AnyObject) !== self {
+      displacedNotificationCenterDelegate = currentDelegate
+    }
+    center.delegate = self
   }
 
   override func application(
@@ -208,6 +219,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
   ) {
     let userInfo = response.notification.request.content.userInfo
 
+    // RNFirebase/Notifee may have captured AppDelegate as their original
+    // delegate before we reclaimed the center. Stop that delegate chain when
+    // it returns here, otherwise forwarding would recurse indefinitely.
+    if isForwardingNotificationResponse {
+      completionHandler()
+      return
+    }
+
     // Notifee-created notification: forward to Notifee so onForegroundEvent(PRESS) fires.
     // We own the delegate (see applicationDidBecomeActive), so Notifee never receives this
     // through its own delegate chain — explicit forwarding is required.
@@ -220,6 +239,20 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     // Braze-originated notification: let Braze track the open and handle deep links.
     if AppDelegate.braze?.notifications.handleUserNotification(
       response: response, withCompletionHandler: completionHandler) == true {
+      return
+    }
+
+    let responseSelector = #selector(
+      UNUserNotificationCenterDelegate.userNotificationCenter(
+        _:didReceive:withCompletionHandler:))
+    if let delegate = displacedNotificationCenterDelegate,
+       delegate.responds(to: responseSelector) {
+      isForwardingNotificationResponse = true
+      delegate.userNotificationCenter?(
+        center,
+        didReceive: response,
+        withCompletionHandler: completionHandler)
+      isForwardingNotificationResponse = false
       return
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixed a problem when tapping on notification that contains deeplink in foreground doesn't redirect user to given screen.

The important distinction is that foreground FCM messages are displayed manually through Notifee. The resulting system notification is therefore a local Notifee notification, not an Android/iOS notification displayed directly by Firebase. Its tap does not always pass through RNFirebase’s notification-open callbacks.

The corrected flow is:

`FCM message → Notifee system notification → native tap event → JavaScript → deeplink extraction → DeeplinkManager`

### JavaScript 📜

#### What changed 🤔 

- Added `extractPushNotificationDeeplink` to support the two payload forms we actually receive:

  - RNFirebase: `{ deeplink: "..." }`
  - Notifee: `{ dataStr: "{\"deeplink\":\"...\"}" }`

- Added `dispatchPushNotificationDeeplink` so all push notification sources use the same navigation logic and push-notification origin.
- Registered the Notifee foreground-event listener on both platforms.
- Added an Android `DeviceEventEmitter` listener for notification taps forwarded by the native module.
- Reused the same opened-notification handler for RNFirebase and the Android native event.
- Kept `toFcmDataStringRecord` for analytics payloads rather than replacing it globally.
- Added tests for flat, serialized, malformed, cold-start, and Android native-event payloads.

#### Why it is needed ❓ 

The internal notification service already converts the CTA link into a top-level `deeplink` before delivering it to the app. However, when the message is displayed by Notifee, the original data is serialized inside `dataStr`.

`toFcmDataStringRecord` only converts top-level values to strings. Given a Notifee payload, it produces something like:

```ts
{
  dataStr: '{"deeplink":"https://link.metamask.io/rewards"}',
}
```

It does not deserialize `dataStr`, so reading `.deeplink` from its result returns `undefined`.

The new extractor is deliberately narrow: it handles only the flat RNFirebase payload and the serialized Notifee payload observed on the devices.

### What was missing originally 💡 

JavaScript only handled notification opens reported by RNFirebase. There was no complete route from a Notifee press event to `handleDeeplink`, and the Notifee payload shape was not decoded before looking for the link.

### Android 🤖 

#### What changed 🤔 

- Changed the Notifee launch activity from the obsolete hardcoded `com.metamask.ui.MainActivity` to Notifee’s `"default"` launcher activity.
- Extended `NotificationModule` to emit `metamask.notification_opened` when a notification intent reaches `MainActivity`.
- Added support for Notifee’s nested launch-intent structure:

```text
notification
└── data
    └── dataStr
```

- Preserved the existing storage of notification data for cold starts.
- Used a weak reference to the native module to avoid retaining it statically.

#### Why it is needed ❓

A foreground FCM message is displayed as a local Notifee notification. When the user taps it, Android opens `MainActivity` using Notifee’s intent.

That intent is not a normal Firebase notification-open intent. RNFirebase therefore does not necessarily recognize it or invoke `onNotificationOpenedApp`.

The native event bridges that Activity intent into the React Native runtime. JavaScript can then process it through the same analytics and deep-link handler used for RNFirebase opens.

Using `"default"` lets Notifee resolve the application’s actual launcher activity instead of depending on a class name that no longer exists.

#### What was missing originally 💡 

`NotificationModule.saveNotificationIntent` only stored notification extras for later retrieval through `getInitialNotification`. It did not notify JavaScript when a new intent arrived while the React Native runtime was already active.

It also expected Firebase-style flat extras and did not understand the nested payload created by Notifee.

### iOS 🍎 

#### What changed 🤔 

- Added a helper that consistently reclaims `UNUserNotificationCenter.delegate`.
- Preserved a weak reference to the delegate displaced by `AppDelegate`.
- Explicitly forwarded Notifee notification responses to `NotifeeCoreUNUserNotificationCenter`.
- Forwarded other notification responses to the previously installed delegate when appropriate.
- Added a recursion guard to prevent delegate forwarding from looping back into `AppDelegate`.

#### Why it is needed ❓ 

iOS allows only one `UNUserNotificationCenter` delegate. Braze, RNFirebase, Notifee, and the application delegate may all participate in notification processing.

The app needs to own the delegate so foreground Firebase delivery remains reliable. However, reclaiming that delegate displaces the SDK delegate that Notifee installed. Without forwarding, Notifee never sees the notification response and cannot emit `EventType.PRESS` to JavaScript.

The new delegate forwarding preserves application ownership while still allowing Notifee and the other notification SDKs to process the tap.

#### What was missing originally 💡 

The app reclaimed `UNUserNotificationCenter.delegate`, but ordinary Notifee responses were not forwarded to Notifee’s delegate implementation. As a result, the system tap reached iOS, but the corresponding Notifee press event never reached JavaScript.

The recursion guard is required because SDK delegate chains can eventually point back to `AppDelegate`; blindly forwarding could otherwise produce repeated callbacks or an infinite loop.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: redirect user to deeplink when notification received in foreground and user taps on it

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-353

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user opened mobile app
    Given user sees home screen

    When user receives push notification that contains deeplink while app is in foreground and taps it
    Then user should be redirected by deeplink
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

|Android|iOS|
|--------|----|
|<video src="https://github.com/user-attachments/assets/3e23ee4e-9c12-4bcf-a146-b6d14a421ea3">|<video src="https://github.com/user-attachments/assets/d3419aff-31ea-407e-88c2-16b7781b3735">|

### **After**

|Android|iOS|
|--------|----|
|<video src="https://github.com/user-attachments/assets/1b58ad27-7be0-406d-8e6d-6ea9282d2ee8">|<video src="https://github.com/user-attachments/assets/6977e51f-3e74-474f-bdb9-bd64dfade9c3">|

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-platform notification tap routing and iOS delegate chaining; mistakes could drop taps or mis-route deeplinks, but scope is narrow and covered by new unit/integration tests.
> 
> **Overview**
> Fixes **foreground** push taps (FCM shown via Notifee) not opening deeplinks because RNFirebase open callbacks and flat `deeplink` parsing never saw Notifee’s serialized `dataStr` payload.
> 
> **JavaScript** adds `extractPushNotificationData` / `extractPushNotificationDeeplink` for RNFirebase vs Notifee shapes, refactors exported `toPushTapResult` to use them, and wires **Notifee** `onForegroundEvent` → `handleNotificationEvent` in `DeeplinkManager` into the existing wallet `onPushTap` / `handleDeeplink` flow. **Android** `NotificationModule` emits `metamask.notification_opened` when a tap intent arrives (including nested `notification.data`), and `FCMService` subscribes on Android instead of only `onNotificationOpenedApp`. **iOS** reclaims `UNUserNotificationCenter` delegate via `claimNotificationCenterDelegate`, forwards Notifee responses explicitly, and forwards other taps to the displaced delegate with a recursion guard. Notifee `LAUNCH_ACTIVITY` switches from obsolete `com.metamask.ui.MainActivity` to `"default"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5db56172dabb80b7a421bad39298d1732e843ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->