### PR TITLE
fix: remove approval text in swaps

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -11,7 +11,6 @@ export const BridgeViewSelectorsIDs = {
   QUOTE_DETAILS_SKELETON: 'bridge-quote-details-skeleton',
   MISSING_PRICE_BANNER: 'bridge-missing-price-banner',
   NO_QUOTES_BANNER: 'bridge-no-quotes',
-  APPROVAL_TOOLTIP: 'bridge-approval-text',
 } as const;
 
 export type BridgeViewSelectorsIDsType = typeof BridgeViewSelectorsIDs;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.test.tsx
@@ -64,17 +64,6 @@ jest.mock('../../components/SwapsConfirmButton/index.tsx', () => ({
   },
 }));
 
-// Mock ApprovalTooltip to avoid the navigation dependency of useTooltipModal.
-jest.mock('../../components/ApprovalText', () => {
-  const MockReact = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      MockReact.createElement(View, { testID: 'approval-tooltip' }),
-  };
-});
-
 jest.mock('../../../Rewards/components/RewardsVipBadge/RewardsVipBadge', () => {
   const MockReact = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
@@ -545,135 +534,48 @@ describe('BridgeViewFooter', () => {
     });
   });
 
-  describe('Approval Disclaimer', () => {
-    it('displays approval needed text when quote requires approval', async () => {
-      const mockQuote = {
-        ...mockQuoteWithMetadata,
-        approval: {
-          chainId: '0x1',
-          to: '0xToken',
-          data: '0xApprovalData',
+  it('does not display an approval row when quote requires approval', () => {
+    const mockQuote = {
+      ...mockQuoteWithMetadata,
+      approval: {
+        chainId: '0x1',
+        to: '0xToken',
+        data: '0xApprovalData',
+      },
+    };
+    jest
+      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mockImplementation(() => ({
+        ...mockUseBridgeQuoteData,
+        activeQuote: mockQuote,
+      }));
+
+    const testState = buildActiveQuoteState({
+      bridgeControllerOverrides: {
+        quotes: [mockQuote as unknown as QuoteResponse],
+      },
+      bridgeReducerOverrides: {
+        sourceAmount: '1.5',
+        sourceToken: {
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          chainId: '0x1' as Hex,
+          decimals: 6,
+          image: '',
+          name: 'USD Coin',
+          symbol: 'USDC',
         },
-      };
+      },
+    });
 
-      jest
-        .mocked(useBridgeQuoteData as unknown as jest.Mock)
-        .mockImplementation(() => ({
-          ...mockUseBridgeQuoteData,
-          activeQuote: mockQuote,
-        }));
+    const { queryByText } = renderFooter(testState);
 
-      const testState = createBridgeTestState({
-        bridgeControllerOverrides: {
-          quotesLoadingStatus: RequestStatus.FETCHED,
-          quotes: [mockQuote as unknown as QuoteResponse],
-          quotesLastFetched: Date.now(),
-        },
-        bridgeReducerOverrides: {
-          sourceAmount: '1.5',
-          sourceToken: {
-            address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-            chainId: '0x1' as Hex,
-            decimals: 6,
-            image: '',
-            name: 'USD Coin',
-            symbol: 'USDC',
-          },
-        },
-      });
-
-      const { getByText } = renderFooter(testState as DeepPartial<RootState>);
-
-      await waitFor(() => {
-        const approvalText = strings('bridge.approval_needed', {
+    expect(
+      queryByText(
+        strings('bridge.approval_needed', {
           amount: '1.5',
           symbol: 'USDC',
-        });
-        expect(getByText(approvalText, { exact: false })).toBeTruthy();
-      });
-    });
-
-    it('displays approval tooltip when quote requires approval', async () => {
-      const mockQuote = {
-        ...mockQuoteWithMetadata,
-        approval: {
-          chainId: '0x1',
-          to: '0xToken',
-          data: '0xApprovalData',
-        },
-      };
-
-      jest
-        .mocked(useBridgeQuoteData as unknown as jest.Mock)
-        .mockImplementation(() => ({
-          ...mockUseBridgeQuoteData,
-          activeQuote: mockQuote,
-        }));
-
-      const testState = createBridgeTestState({
-        bridgeControllerOverrides: {
-          quotesLoadingStatus: RequestStatus.FETCHED,
-          quotes: [mockQuote as unknown as QuoteResponse],
-          quotesLastFetched: Date.now(),
-        },
-        bridgeReducerOverrides: {
-          sourceAmount: '1.5',
-          sourceToken: {
-            address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-            chainId: '0x1' as Hex,
-            decimals: 6,
-            image: '',
-            name: 'USD Coin',
-            symbol: 'USDC',
-          },
-        },
-      });
-
-      const { getByTestId } = renderFooter(testState as DeepPartial<RootState>);
-
-      await waitFor(() => {
-        expect(getByTestId('approval-tooltip')).toBeTruthy();
-      });
-    });
-
-    it('does not display approval text when quote does not require approval', async () => {
-      const mockQuote = {
-        ...mockQuoteWithMetadata,
-        approval: null,
-      };
-
-      jest
-        .mocked(useBridgeQuoteData as unknown as jest.Mock)
-        .mockImplementation(() => ({
-          ...mockUseBridgeQuoteData,
-          activeQuote: mockQuote,
-        }));
-
-      const { queryByText } = renderFooter(buildActiveQuoteState());
-
-      await waitFor(() => {
-        expect(queryByText(/approval needed/i, { exact: false })).toBeNull();
-      });
-    });
-
-    it('does not display approval tooltip when quote does not require approval', async () => {
-      const mockQuote = {
-        ...mockQuoteWithMetadata,
-        approval: null,
-      };
-
-      jest
-        .mocked(useBridgeQuoteData as unknown as jest.Mock)
-        .mockImplementation(() => ({
-          ...mockUseBridgeQuoteData,
-          activeQuote: mockQuote,
-        }));
-
-      const { queryByTestId } = renderFooter(buildActiveQuoteState());
-
-      await waitFor(() => {
-        expect(queryByTestId('approval-tooltip')).toBeNull();
-      });
-    });
+        }),
+      ),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeViewFooter.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Box } from '../../../Box/Box';
-import {
-  FlexDirection,
-  AlignItems,
-  JustifyContent,
-} from '../../../Box/box.types';
+import { FlexDirection, AlignItems } from '../../../Box/box.types';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
 import {
   selectSourceAmount,
@@ -20,7 +16,6 @@ import BannerAlert from '../../../../../component-library/components/Banners/Ban
 import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
 import { isHardwareAccount } from '../../../../../util/address';
-import ApprovalTooltip from '../../components/ApprovalText';
 import {
   DiscountType,
   MetaMetricsSwapsEventSource,
@@ -97,11 +92,6 @@ export const BridgeViewFooter = ({
     return null;
   }
 
-  const approval =
-    activeQuote?.approval && sourceAmount && sourceToken
-      ? { amount: sourceAmount, symbol: sourceToken.symbol }
-      : null;
-
   return (
     isValidSourceAmount &&
     activeQuote &&
@@ -167,27 +157,6 @@ export const BridgeViewFooter = ({
               </Text>
             )}
           </Box>
-
-          {approval && (
-            <Box
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
-              justifyContent={JustifyContent.center}
-              testID={BridgeViewSelectorsIDs.APPROVAL_TOOLTIP}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-                testID={BridgeViewSelectorsIDs.APPROVAL_TOOLTIP}
-              >
-                {strings('bridge.approval_needed', approval)}
-              </Text>
-              <ApprovalTooltip
-                amount={approval.amount}
-                symbol={approval.symbol}
-              />
-            </Box>
-          )}
         </Box>
       </Box>
     )


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes the token approval disclaimer row and its info tooltip from the Swaps quote footer. Updates the footer tests and removes the unused approval-row test ID.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the token approval disclaimer row from Swaps quotes

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4821

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swaps quote footer approval disclosure

  Scenario: ERC-20 swap quote requires token approval
    Given a user enters a swap amount for an ERC-20 token
    And the selected quote requires token approval

    When the Swaps quote footer is displayed
    Then the fee disclaimer is displayed below the confirm button
    And the token approval disclaimer row and info tooltip are not displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


<img width="598" height="1144" alt="Screenshot 2026-07-22 at 2 34 31 PM" src="https://github.com/user-attachments/assets/94b883e4-16f3-4a99-b3ec-03fe5d4adef9" />

### **After**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-07-22 at 2 36 46 PM" src="https://github.com/user-attachments/assets/7ee9e63f-b578-4140-b1a1-66c7e0cc853a" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Footer-only UI removal with no changes to quote handling or transaction submission; regression risk is limited to missing approval disclosure before confirm.
> 
> **Overview**
> Removes the **token approval disclaimer** from the Swaps/Bridge quote footer when a quote includes an `approval` payload. Users no longer see the `bridge.approval_needed` copy or the **`ApprovalTooltip`** info control under the fee disclaimer; confirm and other footer behavior (fee disclaimer, Blockaid, hardware wallet banner) is unchanged.
> 
> Test updates drop the `ApprovalTooltip` mock and collapse approval coverage to a single assertion that the approval string is absent when approval is required. **`APPROVAL_TOOLTIP`** is removed from `BridgeView.testIds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1200d51acc6f6376a47bcf860c59630206e02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->