### PR TITLE
fix(walletconnect): attach eip155 accounts when proposal mixes eip155 with adapter namespaces

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { fireEvent, waitFor, within } from '@testing-library/react-native';
 import {
   Caip25EndowmentPermissionName,
   Caip25CaveatType,
@@ -1857,6 +1857,86 @@ describe('MultichainAccountConnect', () => {
       const ethereumSelected = queryByTestId('Ethereum-selected');
 
       expect(ethereumSelected).toBeTruthy();
+    });
+
+    it('attaches accounts for namespaces added via the network editor (regression WPN-1704)', async () => {
+      // Simulates the WalletConnect eip155+tron repro: the permission request
+      // arrives with only a non-EVM chain scope, the user manually checks an
+      // EVM network on the edit-networks screen, and the granted permission
+      // must contain accounts for the newly added eip155 scope. Before the
+      // fix, selectedCaipAccountIds was not recomputed on network selection,
+      // so the eip155 scope was persisted with an empty accounts array.
+      const mockAcceptPermissions = jest.fn().mockResolvedValue(undefined);
+      Engine.context.PermissionController.acceptPermissionsRequest =
+        mockAcceptPermissions;
+      // No pre-existing permission for the origin.
+      (
+        Engine.context.PermissionController.getCaveat as jest.Mock
+      ).mockImplementation(() => {
+        throw new PermissionDoesNotExistError(
+          'Permission does not exist',
+          Caip25EndowmentPermissionName,
+        );
+      });
+
+      const { getByTestId, findByTestId } = renderWithProvider(
+        <MultichainAccountConnect
+          route={{
+            params: {
+              hostInfo: {
+                metadata: {
+                  id: 'mockId',
+                  origin: 'https://example.com',
+                },
+                permissions: createMockCaip25Permission({
+                  // Non-EVM chain scope only, as produced by the WC session
+                  // proposal handler when only an adapter namespace seeded
+                  // the caveat value.
+                  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+                    accounts: [],
+                  },
+                }),
+              },
+              permissionRequestId: 'test-network-editor-accounts-sync',
+            },
+          }}
+        />,
+        { state: createMockState() },
+      );
+
+      // Open the edit networks screen.
+      fireEvent.press(
+        getByTestId(
+          ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
+        ),
+      );
+
+      // Ethereum Mainnet is not pre-selected: only the requested non-EVM
+      // chain is.
+      const ethereumRow = await findByTestId('Ethereum Mainnet-not-selected');
+      fireEvent.press(within(ethereumRow).getByText('Ethereum Mainnet'));
+
+      // Confirm the network selection.
+      fireEvent.press(
+        await findByTestId('multiconnect-connect-network-button'),
+      );
+
+      // Approve the connection.
+      fireEvent.press(await findByTestId(CommonSelectorsIDs.CONNECT_BUTTON));
+
+      await waitFor(() => {
+        expect(mockAcceptPermissions).toHaveBeenCalledTimes(1);
+      });
+
+      const caveatValue =
+        mockAcceptPermissions.mock.calls[0][0].permissions[
+          Caip25EndowmentPermissionName
+        ].caveats[0].value;
+
+      // The manually added eip155 scope must have accounts attached.
+      expect(caveatValue.optionalScopes['eip155:1']).toEqual({
+        accounts: [`eip155:1:${MOCK_ADDRESS_1}`],
+      });
     });
   });
 

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -384,7 +384,6 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     connectedAccountGroups,
     supportedAccountGroups,
     connectedAccountGroupWithRequested,
-    caipAccountIdsOfConnectedAndRequestedAccountGroups,
     selectedAndRequestedAccountGroups,
   } = useAccountGroupsForPermissions(
     existingPermissionsCaip25CaveatValue,
@@ -415,49 +414,28 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     [networkConfigurations, selectedChainIds],
   );
 
-  const { suggestedAccountGroups, suggestedCaipAccountIds } = useMemo(() => {
+  const suggestedAccountGroups = useMemo(() => {
     if (connectedAccountGroups.length > 0) {
-      return {
-        suggestedAccountGroups: connectedAccountGroupWithRequested,
-        suggestedCaipAccountIds:
-          caipAccountIdsOfConnectedAndRequestedAccountGroups,
-      };
+      return connectedAccountGroupWithRequested;
     }
 
     if (supportedAccountGroups.length === 0) {
-      return {
-        suggestedAccountGroups: [],
-        suggestedCaipAccountIds: [],
-      };
+      return [];
     }
 
     if (requestedCaipAccountIds.length === 0) {
       const [defaultSelectedAccountGroup] = supportedAccountGroups;
 
-      return {
-        suggestedAccountGroups: [defaultSelectedAccountGroup],
-        suggestedCaipAccountIds: getCaip25AccountIdsFromAccountGroupAndScope(
-          [defaultSelectedAccountGroup],
-          requestedAndAlreadyConnectedCaipChainIdsOrDefault,
-        ),
-      };
+      return [defaultSelectedAccountGroup];
     }
 
-    return {
-      suggestedAccountGroups: selectedAndRequestedAccountGroups,
-      suggestedCaipAccountIds: getCaip25AccountIdsFromAccountGroupAndScope(
-        selectedAndRequestedAccountGroups,
-        requestedAndAlreadyConnectedCaipChainIdsOrDefault,
-      ),
-    };
+    return selectedAndRequestedAccountGroups;
   }, [
     connectedAccountGroups.length,
     supportedAccountGroups,
     requestedCaipAccountIds.length,
     selectedAndRequestedAccountGroups,
-    requestedAndAlreadyConnectedCaipChainIdsOrDefault,
     connectedAccountGroupWithRequested,
-    caipAccountIdsOfConnectedAndRequestedAccountGroups,
   ]);
 
   const [selectedAccountGroupIds, setSelectedAccountGroupIds] = useState<
@@ -468,9 +446,32 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     ),
   );
 
-  const [selectedCaipAccountIds, setSelectedCaipAccountIds] = useState<
-    CaipAccountId[]
-  >(suggestedCaipAccountIds);
+  // The CAIP account ids to grant are always derived from the currently
+  // selected account groups and chain selection. Deriving (rather than
+  // duplicating in state) guarantees that any update to either selection keeps
+  // the granted accounts in sync — e.g. namespaces added via the network
+  // editor get accounts attached (WPN-1704).
+  const selectedCaipAccountIds = useMemo(() => {
+    const selectedGroupIds = new Set(selectedAccountGroupIds);
+    const selectedAccountGroups = Array.from(
+      new Set([
+        ...supportedAccountGroups,
+        ...connectedAccountGroupWithRequested,
+      ]),
+    ).filter((group: AccountGroupWithInternalAccounts) =>
+      selectedGroupIds.has(group.id),
+    );
+
+    return getCaip25AccountIdsFromAccountGroupAndScope(
+      selectedAccountGroups,
+      selectedChainIds,
+    );
+  }, [
+    selectedAccountGroupIds,
+    selectedChainIds,
+    supportedAccountGroups,
+    connectedAccountGroupWithRequested,
+  ]);
 
   const [screen, setScreen] = useState<AccountConnectScreens>(
     AccountConnectScreens.SingleConnect,
@@ -573,10 +574,9 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
 
     if (previousIdentitiesListSize.current !== currentLength) {
       setSelectedAccountGroupIds(suggestedAccountGroupIds);
-      setSelectedCaipAccountIds(suggestedCaipAccountIds);
       previousIdentitiesListSize.current = currentLength;
     }
-  }, [suggestedAccountGroupIds, suggestedCaipAccountIds]);
+  }, [suggestedAccountGroupIds]);
 
   const cancelPermissionRequest = useCallback(
     (requestId: string) => {
@@ -757,64 +757,34 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
 
   const handleAccountGroupsSelected = useCallback(
     (newSelectedAccountGroupIds: AccountGroupId[]) => {
-      const updatedSelectedChains = [...selectedChainIds];
-
-      // Create lookup sets for selected account group IDs
+      // Sanitize the incoming ids against the groups the edit screen offers.
+      // The granted account ids are derived from this selection (see the
+      // selectedCaipAccountIds memo above).
       const selectedGroupIds = new Set(newSelectedAccountGroupIds);
-
-      // Filter to only selected account groups
       const selectedAccountGroups = supportedAccountGroups.filter(
         (group: AccountGroupWithInternalAccounts) =>
           selectedGroupIds.has(group.id),
       );
 
-      const caip25AccountIds = getCaip25AccountIdsFromAccountGroupAndScope(
-        selectedAccountGroups,
-        updatedSelectedChains,
-      );
-
-      setSelectedChainIds(updatedSelectedChains);
       setSelectedAccountGroupIds(
         selectedAccountGroups.map(
           (group: AccountGroupWithInternalAccounts) => group.id,
         ),
       );
-      setSelectedCaipAccountIds(caip25AccountIds);
       setScreen(AccountConnectScreens.SingleConnect);
     },
-    [selectedChainIds, supportedAccountGroups],
+    [supportedAccountGroups],
   );
 
   const handleNetworksSelected = useCallback(
     (newSelectedChainIds: CaipChainId[]) => {
-      // Recompute the selected account ids against the new chain selection so
-      // that scopes added here (e.g. manually checking EVM networks) get
-      // accounts attached when the permission is granted. Without this, newly
-      // selected chains would be persisted with empty account lists.
-      const selectedGroupIds = new Set(selectedAccountGroupIds);
-      const selectedAccountGroups = Array.from(
-        new Set([
-          ...supportedAccountGroups,
-          ...connectedAccountGroupWithRequested,
-        ]),
-      ).filter((group: AccountGroupWithInternalAccounts) =>
-        selectedGroupIds.has(group.id),
-      );
-
-      const caip25AccountIds = getCaip25AccountIdsFromAccountGroupAndScope(
-        selectedAccountGroups,
-        newSelectedChainIds,
-      );
-
+      // The granted account ids follow this chain selection automatically via
+      // the selectedCaipAccountIds memo, so namespaces added here get accounts
+      // attached when the permission is granted (WPN-1704).
       setSelectedChainIds(newSelectedChainIds);
-      setSelectedCaipAccountIds(caip25AccountIds);
       setScreen(AccountConnectScreens.SingleConnect);
     },
-    [
-      selectedAccountGroupIds,
-      supportedAccountGroups,
-      connectedAccountGroupWithRequested,
-    ],
+    [],
   );
 
   const handleConfirm = useCallback(async () => {

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -787,10 +787,34 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
 
   const handleNetworksSelected = useCallback(
     (newSelectedChainIds: CaipChainId[]) => {
+      // Recompute the selected account ids against the new chain selection so
+      // that scopes added here (e.g. manually checking EVM networks) get
+      // accounts attached when the permission is granted. Without this, newly
+      // selected chains would be persisted with empty account lists.
+      const selectedGroupIds = new Set(selectedAccountGroupIds);
+      const selectedAccountGroups = Array.from(
+        new Set([
+          ...supportedAccountGroups,
+          ...connectedAccountGroupWithRequested,
+        ]),
+      ).filter((group: AccountGroupWithInternalAccounts) =>
+        selectedGroupIds.has(group.id),
+      );
+
+      const caip25AccountIds = getCaip25AccountIdsFromAccountGroupAndScope(
+        selectedAccountGroups,
+        newSelectedChainIds,
+      );
+
       setSelectedChainIds(newSelectedChainIds);
+      setSelectedCaipAccountIds(caip25AccountIds);
       setScreen(AccountConnectScreens.SingleConnect);
     },
-    [setScreen, setSelectedChainIds],
+    [
+      selectedAccountGroupIds,
+      supportedAccountGroups,
+      connectedAccountGroupWithRequested,
+    ],
   );
 
   const handleConfirm = useCallback(async () => {

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -70,7 +70,6 @@ import {
 } from '../../MultichainAccounts/shared/utils.ts';
 import { getPhishingTestResultAsync } from '../../../../util/phishingDetection.ts';
 import {
-  CaipAccountId,
   CaipChainId,
   KnownCaipNamespace,
   parseCaipChainId,

--- a/app/core/WalletConnect/WalletConnectV2.test.ts
+++ b/app/core/WalletConnect/WalletConnectV2.test.ts
@@ -189,6 +189,10 @@ jest.mock('../../selectors/networkController', () => ({
     ticker: 'ETH',
   }),
   selectEvmNetworkConfigurationsByChainId: jest.fn().mockReturnValue({}),
+  selectNetworkConfigurationsByCaipChainId: jest.fn().mockReturnValue({
+    'eip155:1': { name: 'Ethereum Mainnet' },
+    'eip155:137': { name: 'Polygon' },
+  }),
   selectSelectedNetworkClientId: jest.fn().mockReturnValue('mainnet'),
   selectNetworkClientId: jest.fn().mockReturnValue('mainnet'),
   selectRpcUrl: jest.fn().mockReturnValue('https://mainnet.infura.io/v3/123'),
@@ -1103,6 +1107,75 @@ describe('WC2Manager', () => {
           originalGetCaveatImpl,
         );
       }
+    });
+
+    it('seeds requested eip155 chains into the permission request when a proposal mixes eip155 with an adapter namespace (Tron)', async () => {
+      // Regression test for WPN-1704: a proposal with both eip155 and tron
+      // used to raise a permission request whose only chain scopes were
+      // Tron's, so the approval UI pre-selected Tron only and eip155 settled
+      // with no accounts.
+      mockApproveSession.mockResolvedValue({
+        topic: 'test-topic',
+        pairingTopic: 'mixed-pairing',
+        peer: {
+          metadata: { url: 'https://example.com', name: 'Test App', icons: [] },
+        },
+      });
+
+      const mixedProposal = {
+        id: 43,
+        params: {
+          id: 43,
+          pairingTopic: 'mixed-pairing',
+          proposer: {
+            publicKey: 'mixed-public-key',
+            metadata: {
+              name: 'Multichain Dapp',
+              description: 'Multichain Dapp',
+              url: 'https://multichain.example.com',
+              icons: ['https://multichain.example.com/icon.png'],
+            },
+          },
+          expiryTimestamp: Date.now() + 300000,
+          relays: [{ protocol: 'irn' }],
+          requiredNamespaces: {},
+          optionalNamespaces: {
+            eip155: {
+              chains: ['eip155:1', 'eip155:137'],
+              methods: ['eth_sendTransaction', 'personal_sign'],
+              events: ['chainChanged', 'accountsChanged'],
+            },
+            tron: {
+              chains: ['tron:0x2b6653dc'],
+              methods: ['tron_signTransaction', 'tron_signMessage'],
+              events: [],
+            },
+          },
+        },
+        verifyContext: {
+          verified: {
+            verifyUrl: 'https://multichain.example.com',
+            validation: 'VALID' as const,
+            origin: 'https://multichain.example.com',
+          },
+        },
+      };
+
+      await manager.onSessionProposal(mixedProposal);
+
+      const requestPermissionsMock = Engine.context.PermissionController
+        .requestPermissions as jest.Mock;
+      expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
+
+      const requestedCaveatValue =
+        requestPermissionsMock.mock.calls[0][1]['endowment:caip25'].caveats[0]
+          .value;
+
+      // Both the requested eip155 chains and the Tron adapter scope must be
+      // present so the approval UI pre-selects EVM and Tron together.
+      expect(Object.keys(requestedCaveatValue.optionalScopes)).toEqual(
+        expect.arrayContaining(['eip155:1', 'eip155:137', 'tron:728126428']),
+      );
     });
 
     it('logs "invalid wallet status" error to console on session proposal with invalid wallet status', async () => {

--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -33,6 +33,7 @@ import getAllUrlParams from '../SDKConnect/utils/getAllUrlParams.util';
 import { wait, waitForKeychainUnlocked } from '../SDKConnect/utils/wait.util';
 import extractApprovedAccounts from './extractApprovedAccounts';
 import {
+  enrichCaveatValueForEip155,
   getHostname,
   getScopedPermissions,
   hideWCLoadingState,
@@ -637,9 +638,17 @@ export class WC2Manager {
 
       // Let every non-EVM adapter enrich the CAIP-25 caveat value before
       // we persist permissions.
-      const enrichedCaveatValue = enrichCaveatValueByAdapters({
+      const adapterEnrichedCaveatValue = enrichCaveatValueByAdapters({
         proposal: proposal.params,
         caveatValue,
+      });
+
+      // Seed the requested eip155 chains too, so the approval UI pre-selects
+      // EVM networks alongside any adapter namespaces (e.g. Tron) instead of
+      // defaulting to the adapter namespace only.
+      const enrichedCaveatValue = enrichCaveatValueForEip155({
+        proposal: proposal.params,
+        caveatValue: adapterEnrichedCaveatValue,
       });
 
       // Important: Use hostname as the origin for permission request to ensure consistency

--- a/app/core/WalletConnect/wc-utils.test.ts
+++ b/app/core/WalletConnect/wc-utils.test.ts
@@ -4,6 +4,7 @@ import {
   showWCLoadingState,
   isValidWCURI,
   waitForNetworkModalOnboarding,
+  enrichCaveatValueForEip155,
   getScopedPermissions,
   networkModalOnboardingConfig,
   getHostname,
@@ -12,6 +13,11 @@ import {
   getUnverifiedRequestOrigin,
   isEIP155RedirectMethodForChain,
 } from './wc-utils';
+import type { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
+import {
+  selectEvmChainId,
+  selectNetworkConfigurationsByCaipChainId,
+} from '../../selectors/networkController';
 import type { WalletKitTypes } from '@reown/walletkit';
 import type {
   NavigationContainerRef,
@@ -49,6 +55,8 @@ jest.mock('../../selectors/networkController', () => ({
   selectProviderConfig: jest
     .fn()
     .mockReturnValue({ chainId: '0x1' }) as jest.Mock,
+  selectEvmChainId: jest.fn().mockReturnValue('0x1'),
+  selectNetworkConfigurationsByCaipChainId: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('../../selectors/smartTransactionsController', () => ({
@@ -258,6 +266,143 @@ describe('WalletConnect Utils', () => {
           method: 'eth_sendTransaction',
         }),
       ).toBe(false);
+    });
+  });
+
+  describe('enrichCaveatValueForEip155', () => {
+    const buildCaveatValue = (
+      optionalScopes: Caip25CaveatValue['optionalScopes'] = {
+        'wallet:eip155': { accounts: [] },
+      },
+    ): Caip25CaveatValue => ({
+      requiredScopes: {},
+      optionalScopes,
+      sessionProperties: {},
+      isMultichainOrigin: false,
+    });
+
+    beforeEach(() => {
+      (selectEvmChainId as unknown as jest.Mock).mockReturnValue('0x1');
+      (
+        selectNetworkConfigurationsByCaipChainId as unknown as jest.Mock
+      ).mockReturnValue({
+        'eip155:1': { name: 'Ethereum Mainnet' },
+        'eip155:137': { name: 'Polygon' },
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': { name: 'Solana' },
+      });
+    });
+
+    it('seeds requested eip155 chains the wallet has configured', () => {
+      const result = enrichCaveatValueForEip155({
+        proposal: {
+          requiredNamespaces: {},
+          optionalNamespaces: {
+            eip155: {
+              chains: ['eip155:1', 'eip155:137'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+            tron: {
+              chains: ['tron:0x2b6653dc'],
+              methods: ['tron_signMessage'],
+              events: [],
+            },
+          },
+        },
+        caveatValue: buildCaveatValue({
+          'wallet:eip155': { accounts: [] },
+          'tron:728126428': { accounts: [] },
+        }),
+      });
+
+      expect(Object.keys(result.optionalScopes).sort()).toEqual([
+        'eip155:1',
+        'eip155:137',
+        'tron:728126428',
+        'wallet:eip155',
+      ]);
+      expect(result.optionalScopes['eip155:1']).toEqual({ accounts: [] });
+      expect(result.optionalScopes['eip155:137']).toEqual({ accounts: [] });
+    });
+
+    it('supports chain-scoped namespace keys (eip155:<reference>)', () => {
+      const result = enrichCaveatValueForEip155({
+        proposal: {
+          requiredNamespaces: {
+            'eip155:137': {
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+          },
+          optionalNamespaces: {},
+        },
+        caveatValue: buildCaveatValue(),
+      });
+
+      expect(result.optionalScopes['eip155:137']).toEqual({ accounts: [] });
+    });
+
+    it('filters out requested eip155 chains the wallet has not configured', () => {
+      const result = enrichCaveatValueForEip155({
+        proposal: {
+          requiredNamespaces: {},
+          optionalNamespaces: {
+            eip155: {
+              chains: ['eip155:1', 'eip155:999999'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+          },
+        },
+        caveatValue: buildCaveatValue(),
+      });
+
+      expect(result.optionalScopes['eip155:1']).toEqual({ accounts: [] });
+      expect(result.optionalScopes['eip155:999999']).toBeUndefined();
+    });
+
+    it('falls back to the wallet selected EVM chain when no requested eip155 chain is configured', () => {
+      (selectEvmChainId as unknown as jest.Mock).mockReturnValue('0x89');
+
+      const result = enrichCaveatValueForEip155({
+        proposal: {
+          requiredNamespaces: {},
+          optionalNamespaces: {
+            eip155: {
+              chains: ['eip155:999999'],
+              methods: ['eth_sendTransaction'],
+              events: ['chainChanged'],
+            },
+          },
+        },
+        caveatValue: buildCaveatValue(),
+      });
+
+      expect(result.optionalScopes['eip155:137']).toEqual({ accounts: [] });
+      expect(result.optionalScopes['eip155:999999']).toBeUndefined();
+    });
+
+    it('returns the caveat value unchanged when the proposal requests no eip155 chains', () => {
+      const caveatValue = buildCaveatValue({
+        'wallet:eip155': { accounts: [] },
+        'tron:728126428': { accounts: [] },
+      });
+
+      const result = enrichCaveatValueForEip155({
+        proposal: {
+          requiredNamespaces: {},
+          optionalNamespaces: {
+            tron: {
+              chains: ['tron:0x2b6653dc'],
+              methods: ['tron_signMessage'],
+              events: [],
+            },
+          },
+        },
+        caveatValue,
+      });
+
+      expect(result).toBe(caveatValue);
     });
   });
 

--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -1,3 +1,4 @@
+import type { Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 import { rpcErrors } from '@metamask/rpc-errors';
 import {
   CaipAccountId,
@@ -16,6 +17,7 @@ import qs from 'qs';
 import Routes from '../../../app/constants/navigation/Routes';
 import { store } from '../../../app/store';
 import {
+  selectEvmChainId,
   selectEvmNetworkConfigurationsByChainId,
   selectNetworkConfigurations,
   selectNetworkConfigurationsByCaipChainId,
@@ -26,7 +28,8 @@ import DevLogger from '../SDKConnect/utils/DevLogger';
 import { wait } from '../SDKConnect/utils/wait.util';
 import { WalletKitTypes } from '@reown/walletkit';
 import { EVM_APPROVED_METHODS, EVM_METHODS_TO_REDIRECT } from './wc-config';
-import type { NamespaceConfig } from './multichain/types';
+import type { NamespaceConfig, ProposalParamsLight } from './multichain/types';
+import { enrichCaveatValueForNamespace } from './multichain/utils';
 
 export interface WCMultiVersionParams {
   protocol: string;
@@ -253,6 +256,51 @@ export const getScopedPermissions = async ({
   };
 
   return namespaces;
+};
+
+/**
+ * Seed the EVM (eip155) chains a WalletConnect proposal requested into the
+ * CAIP-25 caveat value before the permission request is raised, mirroring
+ * what non-EVM adapters do via `enrichCaveatValue`.
+ *
+ * Without this, a proposal combining eip155 with a namespace that has an
+ * adapter (e.g. Tron) produces a permission request whose only chain scopes
+ * are the adapter's, so the approval UI pre-selects only that namespace and
+ * leaves EVM networks unchecked.
+ *
+ * Only chains the wallet has a network configuration for are carried
+ * through; if the proposal requested eip155 chains but none are configured,
+ * we fall back to the wallet's currently selected EVM chain. Proposals that
+ * do not reference any eip155 chain are returned unchanged.
+ *
+ * Should be removed when we'll create a specific adapter for Eip155 chains.
+ */
+export const enrichCaveatValueForEip155 = ({
+  proposal,
+  caveatValue,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+}): Caip25CaveatValue => {
+  const state = store.getState();
+  const configuredCaipChainIds = Object.keys(
+    selectNetworkConfigurationsByCaipChainId(state),
+  ) as CaipChainId[];
+  const supportedEvmScopes = new Set<CaipChainId>(
+    configuredCaipChainIds.filter((caipChainId) =>
+      caipChainId.startsWith(`${KnownCaipNamespace.Eip155}:`),
+    ),
+  );
+  const walletChainIdDecimal = parseInt(selectEvmChainId(state), 16);
+
+  return enrichCaveatValueForNamespace({
+    proposal,
+    caveatValue,
+    namespace: KnownCaipNamespace.Eip155,
+    supportedScopes: supportedEvmScopes,
+    fallbackScope:
+      `${KnownCaipNamespace.Eip155}:${walletChainIdDecimal}` as CaipChainId,
+  });
 };
 
 export const isSwitchingChainRequest = (


### PR DESCRIPTION
## **Description**

When a WalletConnect session proposal requests both `eip155` and an adapter namespace (e.g. `tron`), two bugs combined so that the settled session's `eip155` namespace came back with the right chains and methods but an **empty `accounts` array**, while Tron got a real account (reported by Reown, reproducible on lab.reown.com `multichain-all` with any connect button since they all propose all chains):

1. **The permission request never contained the requested eip155 chains.** In `WC2Manager.onSessionProposal`, the CAIP-25 caveat value passed to `requestPermissions` starts as the default (`wallet:eip155` only) and is enriched only by registered non-EVM adapters (currently Tron). Since nothing seeded the proposal's `eip155:*` chains, the approval UI's "specifically requested chains" branch pre-selected **only Tron**, leaving EVM networks unchecked.

2. **Manually checking EVM networks didn't attach accounts.** `handleNetworksSelected` in `MultichainAccountConnect` updated `selectedChainIds` but never recomputed `selectedCaipAccountIds`. Since the initial account IDs were derived from the Tron-only default chain list, the confirm path (`setChainIdsInCaip25CaveatValue` + `setNonSCACaipAccountIdsInCaip25CaveatValue`) persisted the newly added `eip155` scopes with `accounts: []` — `setNonSCACaipAccountIdsInCaip25CaveatValue` only fills scopes whose namespace appears in the provided account IDs. The post-approval `updatePermittedChains(channelId, ['eip155:<current>'])` call then added the current EVM chain (which is why the namespace looked "correctly shaped"), but synced accounts from the caveat's existing (Tron-only) accounts, so eip155 stayed empty.

**Fixes:**

- Added `enrichCaveatValueForEip155` (`wc-utils.ts`), called from `onSessionProposal` right after `enrichCaveatValueByAdapters`. It reuses the existing `enrichCaveatValueForNamespace` util to seed the proposal's requested `eip155` chains (filtered to configured networks, falling back to the wallet's current EVM chain) into the caveat's `optionalScopes`, exactly mirroring what the Tron adapter does for its namespace. The approval UI now pre-selects the requested EVM networks alongside Tron.
- `handleNetworksSelected` now recomputes `selectedCaipAccountIds` from the currently selected account groups against the new chain selection (same logic `handleAccountGroupsSelected` already used), so any namespace added via the edit-networks screen gets accounts attached.

## **Changelog**

CHANGELOG entry: Fixed WalletConnect connections requesting both EVM and non-EVM chains (e.g. eip155 + tron) connecting without any EVM account attached

## **Related issues**

Fixes: [WPN-1704](https://consensyssoftware.atlassian.net/browse/WPN-1704)

## **Manual testing steps**

Feature: WalletConnect multichain session proposal (eip155 + tron)

  Scenario: dapp proposes eip155 and tron together
    Given a build with the tron feature flag enabled
    And a dapp (e.g. https://lab.reown.com/appkit/?name=multichain-all) configured for eip155 and tron

    When the user connects via WalletConnect and scans the QR code
    Then the permission screen pre-selects the requested EVM networks and Tron
    And approving settles a session where the eip155 namespace contains accounts (e.g. eip155:1:0x...)

  Scenario: user manually adds EVM networks on the permission screen
    Given a WalletConnect connection request where only a non-EVM network is pre-selected

    When the user opens "Edit networks", checks an EVM network, taps Update, and approves
    Then the granted permission contains accounts for the newly added EVM scopes
    And the settled session's eip155 namespace contains those accounts

## **Screenshots/Recordings**

### **Before**

Session settles with `eip155: { chains: [...], methods: [...], accounts: [] }` while `tron` gets a real account. Permission screen pre-selects only Tron.

https://github.com/user-attachments/assets/2a3d3668-3376-414e-bbd5-b6705452bfb0


### **After**

Permission screen pre-selects requested EVM networks and Tron; settled session attaches accounts to both namespaces.


https://github.com/user-attachments/assets/4bf6d923-c0c5-4ec0-83a9-225397b7e176


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPN-1704]: https://consensyssoftware.atlassian.net/browse/WPN-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CAIP-25 permissions are built for WalletConnect and multichain connect approval; incorrect logic could grant wrong or empty accounts, but scope is a targeted bugfix with regression tests.
> 
> **Overview**
> Fixes **WPN-1704**, where WalletConnect sessions that request **eip155** together with an adapter namespace (e.g. Tron) could settle with correct EVM chains but **no eip155 accounts**.
> 
> **WalletConnect proposal handling** now calls new **`enrichCaveatValueForEip155`** after adapter enrichment so requested **eip155** chains (limited to configured networks, with fallback to the active EVM chain) are added to the CAIP-25 caveat before `requestPermissions`. The connect UI can pre-select EVM networks alongside Tron instead of only the adapter scope.
> 
> **Connect approval UI** no longer keeps **`selectedCaipAccountIds`** in separate state. It is **derived** from the selected account groups and **`selectedChainIds`**, so adding EVM networks in the network editor updates granted accounts for those scopes on approve.
> 
> Regression tests cover mixed eip155+Tron proposals, **`enrichCaveatValueForEip155`**, and the network-editor account sync path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962e40b8bd0901b38989684beca95128ab05386d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->