### PR TITLE
feat(rewards): add VIP transactions list view

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -12,6 +12,7 @@ import RewardsVipView from './Views/RewardsVipView';
 import RewardsVipRefereeSplashView from './Views/RewardsVipRefereeSplashView';
 import RewardsVipRefereeView from './Views/RewardsVipRefereeView';
 import RewardsVipTiersView from './Views/RewardsVipTiersView';
+import RewardsVipTransactionsView from './Views/RewardsVipTransactionsView';
 import CampaignsView from './Views/CampaignsView';
 import OndoCampaignDetailsView from './Views/OndoCampaignDetailsView';
 import OndoCampaignWinningView from './Views/OndoCampaignWinningView';
@@ -197,6 +198,11 @@ const RewardsNavigator: React.FC = () => {
       <Stack.Screen
         name={Routes.REWARDS_VIP_TIERS_VIEW}
         component={RewardsVipTiersView}
+        options={vipScreenOptions}
+      />
+      <Stack.Screen
+        name={Routes.REWARDS_VIP_TRANSACTIONS_VIEW}
+        component={RewardsVipTransactionsView}
         options={vipScreenOptions}
       />
       <Stack.Screen

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -258,6 +258,7 @@ const dashboardWithTiers: VipDashboardState = {
   localizedText: {
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
+    transactionsTitle: 'Transactions',
     swapsFeeTitle: 'Swaps fee',
     perpsFeeTitle: 'Perps fee',
     nextTierSwapsFeeDelta: '↓ 9 bps next tier',

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
@@ -1,0 +1,324 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import RewardsVipTransactionsView, {
+  REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS,
+} from './RewardsVipTransactionsView';
+import { useGetVipTransactions } from '../hooks/useGetVipTransactions';
+import { useVipDashboard } from '../hooks/useVipDashboard';
+import type {
+  VipDashboardState,
+  VipTransactionDto,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+import Routes from '../../../../constants/navigation/Routes';
+
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    goBack: mockGoBack,
+    navigate: mockNavigate,
+    addListener: jest.fn(() => jest.fn()),
+    isFocused: () => true,
+  }),
+}));
+
+jest.mock('@metamask/design-system-twrnc-preset', () => {
+  const tw = (..._args: unknown[]) => ({});
+  tw.style = jest.fn(() => ({}));
+  return { useTailwind: () => tw };
+});
+
+jest.mock('../../../Views/ErrorBoundary', () => {
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  };
+});
+
+jest.mock('../components/Vip/VipPerpsTransactionRow', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      transaction,
+      testID,
+    }: {
+      transaction: { id: string; type: string };
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(Text, null, `perps-${transaction.id}`),
+      ),
+  };
+});
+
+jest.mock('../components/Vip/VipSwapTransactionRow', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      transaction,
+      testID,
+    }: {
+      transaction: { id: string; type: string };
+      testID?: string;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID },
+        ReactActual.createElement(Text, null, `swap-${transaction.id}`),
+      ),
+  };
+});
+
+jest.mock('../utils/formatUtils', () => ({
+  formatRewardsDateLabel: (date: Date) => {
+    const month = date.toLocaleString('en-US', { month: 'short' });
+    const day = date.getDate();
+    const year = date.getFullYear();
+    return `${month} ${day}, ${year}`;
+  },
+}));
+
+jest.mock('../components/RewardsErrorBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text, Pressable } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      title,
+      onConfirm,
+    }: {
+      title: string;
+      onConfirm?: () => void;
+    }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'error-banner' },
+        ReactActual.createElement(Text, null, title),
+        onConfirm
+          ? ReactActual.createElement(
+              Pressable,
+              { testID: 'error-banner-retry', onPress: onConfirm },
+              ReactActual.createElement(Text, null, 'Retry'),
+            )
+          : null,
+      ),
+  };
+});
+
+jest.mock('../components/RewardsInfoBanner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ title }: { title: string }) =>
+      ReactActual.createElement(
+        View,
+        { testID: 'info-banner' },
+        ReactActual.createElement(Text, null, title),
+      ),
+  };
+});
+
+jest.mock('../hooks/useGetVipTransactions');
+const mockUseGetVipTransactions = jest.mocked(useGetVipTransactions);
+
+jest.mock('../hooks/useVipDashboard');
+const mockUseVipDashboard = jest.mocked(useVipDashboard);
+
+jest.mock('../hooks/useTrackRewardsPageView', () => jest.fn());
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const translations: Record<string, string> = {
+      'rewards.vip_transactions.select_type': 'Select type',
+      'rewards.vip_transactions.type_perps': 'Perps',
+      'rewards.vip_transactions.type_swap': 'Swaps',
+      'rewards.vip_transactions.error_title': 'Failed to load transactions',
+      'rewards.vip_transactions.error_description': 'Please try again.',
+      'rewards.vip_transactions.retry_button': 'Retry',
+      'rewards.vip_transactions.empty_title': 'No transactions yet',
+      'rewards.vip_transactions.empty_description':
+        'Your VIP transactions will appear here.',
+    };
+    return translations[key] ?? key;
+  },
+}));
+
+const MOCK_PERPS_TX: VipTransactionDto = {
+  id: 'tx-perps-1',
+  type: 'PERPS',
+  timestamp: '2026-03-28T14:30:00.000Z',
+  feeUsd: '1.25',
+  volumeUsd: '1000.00',
+  perps: {
+    coin: 'ETH',
+    feeCoin: 'USDC',
+    rawFee: '1250000',
+    rawNotionalVolume: '1000000000',
+    tradeId: 'trade-1',
+    orderId: 'order-1',
+  },
+};
+
+const MOCK_SWAP_TX: VipTransactionDto = {
+  id: 'tx-swap-1',
+  type: 'SWAP',
+  timestamp: '2026-03-28T12:00:00.000Z',
+  feeUsd: '0.50',
+  volumeUsd: '250.00',
+  swap: {
+    quoteId: 'quote-1',
+    srcChainId: '1',
+    srcAssetSymbol: 'ETH',
+    destChainId: '1',
+    destAssetSymbol: 'USDC',
+  },
+};
+
+const defaultDashboard = {
+  localizedText: {
+    transactionsTitle: 'Transactions',
+  },
+} as VipDashboardState;
+
+const transactionDefaults = {
+  transactions: null as VipTransactionDto[] | null,
+  isLoading: false,
+  isLoadingMore: false,
+  hasMore: false,
+  error: null as string | null,
+  loadMore: jest.fn(),
+  refresh: jest.fn(),
+  isRefreshing: false,
+};
+
+describe('RewardsVipTransactionsView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: defaultDashboard,
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: jest.fn(),
+    });
+    mockUseGetVipTransactions.mockReturnValue({ ...transactionDefaults });
+  });
+
+  it('renders localized transactions title from the VIP dashboard', () => {
+    const { getByText, getByTestId } = render(<RewardsVipTransactionsView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(getByText('Transactions')).toBeOnTheScreen();
+  });
+
+  it('falls back to Transactions when dashboard is unavailable', () => {
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: null,
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: jest.fn(),
+    });
+
+    const { getByText } = render(<RewardsVipTransactionsView />);
+
+    expect(getByText('Transactions')).toBeOnTheScreen();
+  });
+
+  it('opens the type selector sheet', () => {
+    const { getByTestId } = render(<RewardsVipTransactionsView />);
+
+    fireEvent.press(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.TYPE_SELECTOR),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.MODAL.REWARDS_SELECT_SHEET,
+      expect.objectContaining({
+        title: 'Select type',
+        selectedValue: 'PERPS',
+      }),
+    );
+  });
+
+  it('renders date-grouped perps transactions', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      transactions: [MOCK_PERPS_TX],
+    });
+
+    const { getByText, getByTestId } = render(<RewardsVipTransactionsView />);
+
+    expect(getByTestId('vip-transaction-row-0')).toBeOnTheScreen();
+    expect(getByText('perps-tx-perps-1')).toBeOnTheScreen();
+    expect(getByText(/Mar 28, 2026/)).toBeOnTheScreen();
+  });
+
+  it('renders swap rows when selected type returns swap transactions', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      transactions: [MOCK_SWAP_TX],
+    });
+
+    const { getByText } = render(<RewardsVipTransactionsView />);
+
+    expect(getByText('swap-tx-swap-1')).toBeOnTheScreen();
+  });
+
+  it('renders empty state when there are no transactions', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      transactions: [],
+    });
+
+    const { getByTestId, getByText } = render(<RewardsVipTransactionsView />);
+
+    expect(getByTestId('info-banner')).toBeOnTheScreen();
+    expect(getByText('No transactions yet')).toBeOnTheScreen();
+  });
+
+  it('renders error banner and retries on confirm', () => {
+    const refresh = jest.fn();
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      error: 'Network failure',
+      refresh,
+    });
+
+    const { getByTestId, getByText } = render(<RewardsVipTransactionsView />);
+
+    expect(getByTestId('error-banner')).toBeOnTheScreen();
+    expect(getByText('Failed to load transactions')).toBeOnTheScreen();
+    fireEvent.press(getByTestId('error-banner-retry'));
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('calls loadMore when the list reaches the end and has more pages', () => {
+    const loadMore = jest.fn();
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      transactions: [MOCK_PERPS_TX],
+      hasMore: true,
+      loadMore,
+    });
+
+    const { getByTestId } = render(<RewardsVipTransactionsView />);
+    const list = getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.LIST);
+
+    fireEvent(list, 'onEndReached');
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
@@ -114,20 +114,6 @@ jest.mock('../components/RewardsErrorBanner', () => {
   };
 });
 
-jest.mock('../components/RewardsInfoBanner', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ title }: { title: string }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'info-banner' },
-        ReactActual.createElement(Text, null, title),
-      ),
-  };
-});
-
 jest.mock('../hooks/useGetVipTransactions');
 const mockUseGetVipTransactions = jest.mocked(useGetVipTransactions);
 
@@ -146,8 +132,6 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.vip_transactions.error_description': 'Please try again.',
       'rewards.vip_transactions.retry_button': 'Retry',
       'rewards.vip_transactions.empty_title': 'No transactions yet',
-      'rewards.vip_transactions.empty_description':
-        'Your VIP transactions will appear here.',
     };
     return translations[key] ?? key;
   },
@@ -198,6 +182,7 @@ const transactionDefaults = {
   error: null as string | null,
   loadMore: jest.fn(),
   refresh: jest.fn(),
+  retry: jest.fn(),
   isRefreshing: false,
 };
 
@@ -235,6 +220,82 @@ describe('RewardsVipTransactionsView', () => {
     const { getByText } = render(<RewardsVipTransactionsView />);
 
     expect(getByText('Transactions')).toBeOnTheScreen();
+  });
+
+  it('renders layout-matching skeletons while loading with no transactions', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      isLoading: true,
+      transactions: null,
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <RewardsVipTransactionsView />,
+    );
+
+    expect(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
+    ).toBeNull();
+  });
+
+  it('renders skeletons when transactions are still null before loading starts', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      isLoading: false,
+      transactions: null,
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <RewardsVipTransactionsView />,
+    );
+
+    expect(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
+    ).toBeNull();
+  });
+
+  it('renders skeletons when refreshing an empty list', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      isRefreshing: true,
+      isLoading: false,
+      transactions: [],
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <RewardsVipTransactionsView />,
+    );
+
+    expect(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
+    ).toBeNull();
+  });
+
+  it('does not render skeletons when an error is present', () => {
+    mockUseGetVipTransactions.mockReturnValue({
+      ...transactionDefaults,
+      isLoading: true,
+      error: 'Network failure',
+      transactions: null,
+    });
+
+    const { queryByTestId, getByTestId } = render(
+      <RewardsVipTransactionsView />,
+    );
+
+    expect(
+      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
+    ).toBeNull();
+    expect(getByTestId('error-banner')).toBeOnTheScreen();
   });
 
   it('opens the type selector sheet', () => {
@@ -285,16 +346,18 @@ describe('RewardsVipTransactionsView', () => {
 
     const { getByTestId, getByText } = render(<RewardsVipTransactionsView />);
 
-    expect(getByTestId('info-banner')).toBeOnTheScreen();
+    expect(
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
+    ).toBeOnTheScreen();
     expect(getByText('No transactions yet')).toBeOnTheScreen();
   });
 
   it('renders error banner and retries on confirm', () => {
-    const refresh = jest.fn();
+    const retry = jest.fn();
     mockUseGetVipTransactions.mockReturnValue({
       ...transactionDefaults,
       error: 'Network failure',
-      refresh,
+      retry,
     });
 
     const { getByTestId, getByText } = render(<RewardsVipTransactionsView />);
@@ -302,7 +365,7 @@ describe('RewardsVipTransactionsView', () => {
     expect(getByTestId('error-banner')).toBeOnTheScreen();
     expect(getByText('Failed to load transactions')).toBeOnTheScreen();
     fireEvent.press(getByTestId('error-banner-retry'));
-    expect(refresh).toHaveBeenCalled();
+    expect(retry).toHaveBeenCalled();
   });
 
   it('calls loadMore when the list reaches the end and has more pages', () => {

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.test.tsx
@@ -260,7 +260,7 @@ describe('RewardsVipTransactionsView', () => {
     ).toBeNull();
   });
 
-  it('renders skeletons when refreshing an empty list', () => {
+  it('keeps empty state visible while pull-to-refresh runs', () => {
     mockUseGetVipTransactions.mockReturnValue({
       ...transactionDefaults,
       isRefreshing: true,
@@ -273,10 +273,10 @@ describe('RewardsVipTransactionsView', () => {
     );
 
     expect(
-      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
+      getByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
     ).toBeOnTheScreen();
     expect(
-      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY),
+      queryByTestId(REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON),
     ).toBeNull();
   });
 

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
@@ -14,6 +14,8 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
   HeaderStandard,
   Icon,
   IconColor,
@@ -28,7 +30,6 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
-import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import VipPerpsTransactionRow from '../components/Vip/VipPerpsTransactionRow';
 import VipSwapTransactionRow from '../components/Vip/VipSwapTransactionRow';
 import { useGetVipTransactions } from '../hooks/useGetVipTransactions';
@@ -50,7 +51,39 @@ export const REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS = {
   CONTAINER: 'rewards-vip-transactions-container',
   TYPE_SELECTOR: 'rewards-vip-transactions-type-selector',
   LIST: 'rewards-vip-transactions-list',
+  EMPTY: 'rewards-vip-transactions-empty',
+  SKELETON: 'rewards-vip-transactions-skeleton',
 } as const;
+
+const VipTransactionRowSkeleton: React.FC = () => {
+  const tw = useTailwind();
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="w-full py-3 gap-3"
+    >
+      <Skeleton style={tw.style('h-10 w-10 rounded-full')} />
+      <Box twClassName="flex-1 gap-2">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Skeleton style={tw.style('h-4 w-16 rounded-lg')} />
+          <Skeleton style={tw.style('h-4 w-20 rounded-lg')} />
+        </Box>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Skeleton style={tw.style('h-3 w-24 rounded-lg')} />
+          <Skeleton style={tw.style('h-3 w-12 rounded-lg')} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
 
 const RewardsVipTransactionsView: React.FC = () => {
   const tw = useTailwind();
@@ -70,6 +103,7 @@ const RewardsVipTransactionsView: React.FC = () => {
     error,
     loadMore,
     refresh,
+    retry,
     isRefreshing,
   } = useGetVipTransactions(selectedType);
 
@@ -161,30 +195,40 @@ const RewardsVipTransactionsView: React.FC = () => {
   );
 
   const onEndReached = useCallback(() => {
-    if (hasMore && !isLoadingMore) {
+    if (
+      hasMore &&
+      !isLoading &&
+      !isLoadingMore &&
+      !isRefreshing &&
+      transactions &&
+      transactions.length > 0
+    ) {
       loadMore();
     }
-  }, [hasMore, isLoadingMore, loadMore]);
+  }, [hasMore, isLoading, isLoadingMore, isRefreshing, transactions, loadMore]);
 
   const renderFooter = useCallback(() => {
-    if (!isLoadingMore) return null;
+    if (!isLoadingMore || !transactions || transactions.length === 0) {
+      return null;
+    }
     return (
       <Box twClassName="py-4 items-center">
         <ActivityIndicator />
       </Box>
     );
-  }, [isLoadingMore]);
+  }, [isLoadingMore, transactions]);
+
+  const isInitialLoadPending =
+    isLoading || isRefreshing || transactions === null;
 
   const renderEmpty = useCallback(() => {
-    if (isLoading) return null;
-
     if (error) {
       return (
         <Box twClassName="px-4 pt-2">
           <RewardsErrorBanner
             title={strings('rewards.vip_transactions.error_title')}
             description={strings('rewards.vip_transactions.error_description')}
-            onConfirm={refresh}
+            onConfirm={retry}
             confirmButtonLabel={strings(
               'rewards.vip_transactions.retry_button',
             )}
@@ -193,55 +237,64 @@ const RewardsVipTransactionsView: React.FC = () => {
       );
     }
 
+    // Any in-flight first-page load with no rows → skeletons, never empty copy.
+    if (isInitialLoadPending) {
+      return (
+        <Box
+          twClassName="px-4 pb-2"
+          testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.SKELETON}
+        >
+          <Box twClassName="pt-4 pb-1">
+            <Skeleton style={tw.style('h-3 w-24 rounded-lg')} />
+          </Box>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <VipTransactionRowSkeleton key={i} />
+          ))}
+        </Box>
+      );
+    }
+
+    // Settled empty list only.
     return (
-      <Box twClassName="px-4 pt-2">
-        <RewardsInfoBanner
-          title={strings('rewards.vip_transactions.empty_title')}
-          description={strings('rewards.vip_transactions.empty_description')}
-        />
+      <Box twClassName="p-4 items-center">
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="text-center"
+          testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.EMPTY}
+        >
+          {strings('rewards.vip_transactions.empty_title')}
+        </Text>
       </Box>
     );
-  }, [isLoading, error, refresh]);
+  }, [error, isInitialLoadPending, retry, tw]);
 
-  const renderListHeader = useCallback(() => {
-    const showSkeletons =
-      isLoading && (!transactions || transactions.length === 0);
-
-    return (
-      <Box>
-        <Pressable
-          onPress={openTypeSelector}
-          testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.TYPE_SELECTOR}
-        >
+  const renderListHeader = useCallback(
+    () => (
+      <Pressable
+        onPress={openTypeSelector}
+        testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.TYPE_SELECTOR}
+      >
+        <Box twClassName="px-4 py-3">
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            twClassName="gap-1 px-4 pt-2 pb-1"
+            twClassName="self-start border border-border-default rounded-full px-3 py-1 gap-1"
           >
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
+            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
               {selectedTypeLabel}
             </Text>
             <Icon
               name={IconName.ArrowDown}
-              size={IconSize.Sm}
-              color={IconColor.IconAlternative}
+              size={IconSize.Xs}
+              color={IconColor.IconDefault}
             />
           </Box>
-        </Pressable>
-
-        {showSkeletons ? (
-          <Box twClassName="px-4 pb-2 gap-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} style={tw.style('h-12 rounded-lg')} />
-            ))}
-          </Box>
-        ) : null}
-      </Box>
-    );
-  }, [isLoading, transactions, openTypeSelector, selectedTypeLabel, tw]);
+        </Box>
+      </Pressable>
+    ),
+    [openTypeSelector, selectedTypeLabel],
+  );
 
   return (
     <ErrorBoundary navigation={navigation} view="RewardsVipTransactionsView">

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
@@ -218,8 +218,7 @@ const RewardsVipTransactionsView: React.FC = () => {
     );
   }, [isLoadingMore, transactions]);
 
-  const isInitialLoadPending =
-    isLoading || isRefreshing || transactions === null;
+  const isInitialLoadPending = isLoading || transactions === null;
 
   const renderEmpty = useCallback(() => {
     if (error) {

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
@@ -311,6 +311,8 @@ const RewardsVipTransactionsView: React.FC = () => {
           includesTopInset
         />
 
+        {renderListHeader()}
+
         <FlatList<TransactionListItem>
           testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.LIST}
           data={groupedItems}
@@ -318,7 +320,6 @@ const RewardsVipTransactionsView: React.FC = () => {
           keyExtractor={keyExtractor}
           onEndReached={onEndReached}
           onEndReachedThreshold={0.3}
-          ListHeaderComponent={renderListHeader}
           ListFooterComponent={renderFooter}
           ListEmptyComponent={renderEmpty}
           refreshControl={

--- a/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTransactionsView.tsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+} from 'react-native';
+import {
+  useNavigation,
+  type NavigationProp,
+  type ParamListBase,
+} from '@react-navigation/native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  HeaderStandard,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Skeleton,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import ErrorBoundary from '../../../Views/ErrorBoundary';
+import RewardsErrorBanner from '../components/RewardsErrorBanner';
+import RewardsInfoBanner from '../components/RewardsInfoBanner';
+import VipPerpsTransactionRow from '../components/Vip/VipPerpsTransactionRow';
+import VipSwapTransactionRow from '../components/Vip/VipSwapTransactionRow';
+import { useGetVipTransactions } from '../hooks/useGetVipTransactions';
+import { useVipDashboard } from '../hooks/useVipDashboard';
+import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
+import { formatRewardsDateLabel } from '../utils/formatUtils';
+import { strings } from '../../../../../locales/i18n';
+import Routes from '../../../../constants/navigation/Routes';
+import type {
+  VipTransactionDto,
+  VipTransactionType,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+
+type TransactionListItem =
+  | { kind: 'date-header'; dateKey: string; label: string }
+  | { kind: 'transaction'; transaction: VipTransactionDto; index: number };
+
+export const REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS = {
+  CONTAINER: 'rewards-vip-transactions-container',
+  TYPE_SELECTOR: 'rewards-vip-transactions-type-selector',
+  LIST: 'rewards-vip-transactions-list',
+} as const;
+
+const RewardsVipTransactionsView: React.FC = () => {
+  const tw = useTailwind();
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const [selectedType, setSelectedType] = useState<VipTransactionType>('PERPS');
+
+  useTrackRewardsPageView({
+    page_type: 'vip_transactions',
+  });
+
+  const { dashboard } = useVipDashboard();
+  const {
+    transactions,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    isRefreshing,
+  } = useGetVipTransactions(selectedType);
+
+  const headerTitle =
+    dashboard?.localizedText.transactionsTitle || 'Transactions';
+
+  const typeOptions = useMemo(
+    () => [
+      {
+        key: 'PERPS',
+        value: 'PERPS',
+        label: strings('rewards.vip_transactions.type_perps'),
+      },
+      {
+        key: 'SWAP',
+        value: 'SWAP',
+        label: strings('rewards.vip_transactions.type_swap'),
+      },
+    ],
+    [],
+  );
+
+  const selectedTypeLabel =
+    typeOptions.find((option) => option.value === selectedType)?.label ??
+    selectedType;
+
+  const openTypeSelector = useCallback(() => {
+    navigation.navigate(Routes.MODAL.REWARDS_SELECT_SHEET, {
+      title: strings('rewards.vip_transactions.select_type'),
+      options: typeOptions,
+      selectedValue: selectedType,
+      onSelect: (value: string) => setSelectedType(value as VipTransactionType),
+    });
+  }, [navigation, selectedType, typeOptions]);
+
+  const groupedItems = useMemo<TransactionListItem[]>(() => {
+    if (!transactions) return [];
+    const items: TransactionListItem[] = [];
+    let lastDateKey = '';
+    transactions.forEach((transaction, index) => {
+      const dateKey = transaction.timestamp.slice(0, 10);
+      if (dateKey !== lastDateKey) {
+        lastDateKey = dateKey;
+        items.push({
+          kind: 'date-header',
+          dateKey,
+          label: formatRewardsDateLabel(new Date(transaction.timestamp)),
+        });
+      }
+      items.push({ kind: 'transaction', transaction, index });
+    });
+    return items;
+  }, [transactions]);
+
+  const renderItem = useCallback(({ item }: { item: TransactionListItem }) => {
+    if (item.kind === 'date-header') {
+      return (
+        <Box twClassName="px-4 pt-4 pb-1">
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {item.label}
+          </Text>
+        </Box>
+      );
+    }
+
+    return (
+      <Box twClassName="px-4">
+        {item.transaction.type === 'SWAP' ? (
+          <VipSwapTransactionRow
+            transaction={item.transaction}
+            testID={`vip-transaction-row-${item.index}`}
+          />
+        ) : (
+          <VipPerpsTransactionRow
+            transaction={item.transaction}
+            testID={`vip-transaction-row-${item.index}`}
+          />
+        )}
+      </Box>
+    );
+  }, []);
+
+  const keyExtractor = useCallback(
+    (item: TransactionListItem, index: number) =>
+      item.kind === 'date-header'
+        ? `header-${item.dateKey}`
+        : `transaction-${item.transaction.id}-${index}`,
+    [],
+  );
+
+  const onEndReached = useCallback(() => {
+    if (hasMore && !isLoadingMore) {
+      loadMore();
+    }
+  }, [hasMore, isLoadingMore, loadMore]);
+
+  const renderFooter = useCallback(() => {
+    if (!isLoadingMore) return null;
+    return (
+      <Box twClassName="py-4 items-center">
+        <ActivityIndicator />
+      </Box>
+    );
+  }, [isLoadingMore]);
+
+  const renderEmpty = useCallback(() => {
+    if (isLoading) return null;
+
+    if (error) {
+      return (
+        <Box twClassName="px-4 pt-2">
+          <RewardsErrorBanner
+            title={strings('rewards.vip_transactions.error_title')}
+            description={strings('rewards.vip_transactions.error_description')}
+            onConfirm={refresh}
+            confirmButtonLabel={strings(
+              'rewards.vip_transactions.retry_button',
+            )}
+          />
+        </Box>
+      );
+    }
+
+    return (
+      <Box twClassName="px-4 pt-2">
+        <RewardsInfoBanner
+          title={strings('rewards.vip_transactions.empty_title')}
+          description={strings('rewards.vip_transactions.empty_description')}
+        />
+      </Box>
+    );
+  }, [isLoading, error, refresh]);
+
+  const renderListHeader = useCallback(() => {
+    const showSkeletons =
+      isLoading && (!transactions || transactions.length === 0);
+
+    return (
+      <Box>
+        <Pressable
+          onPress={openTypeSelector}
+          testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.TYPE_SELECTOR}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-1 px-4 pt-2 pb-1"
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {selectedTypeLabel}
+            </Text>
+            <Icon
+              name={IconName.ArrowDown}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+          </Box>
+        </Pressable>
+
+        {showSkeletons ? (
+          <Box twClassName="px-4 pb-2 gap-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} style={tw.style('h-12 rounded-lg')} />
+            ))}
+          </Box>
+        ) : null}
+      </Box>
+    );
+  }, [isLoading, transactions, openTypeSelector, selectedTypeLabel, tw]);
+
+  return (
+    <ErrorBoundary navigation={navigation} view="RewardsVipTransactionsView">
+      <SafeAreaView
+        edges={{ bottom: 'additive' }}
+        style={tw.style('flex-1 bg-default')}
+        testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.CONTAINER}
+      >
+        <HeaderStandard
+          title={headerTitle}
+          titleProps={{ variant: TextVariant.HeadingSm }}
+          onBack={() => navigation.goBack()}
+          backButtonProps={{ testID: 'vip-transactions-back-button' }}
+          includesTopInset
+        />
+
+        <FlatList<TransactionListItem>
+          testID={REWARDS_VIP_TRANSACTIONS_VIEW_TEST_IDS.LIST}
+          data={groupedItems}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          onEndReached={onEndReached}
+          onEndReachedThreshold={0.3}
+          ListHeaderComponent={renderListHeader}
+          ListFooterComponent={renderFooter}
+          ListEmptyComponent={renderEmpty}
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={refresh} />
+          }
+          showsVerticalScrollIndicator={false}
+        />
+      </SafeAreaView>
+    </ErrorBoundary>
+  );
+};
+
+export default RewardsVipTransactionsView;

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -140,6 +140,7 @@ jest.mock('@metamask/design-system-react-native', () => {
       WarningDefault: 'warning',
     },
     IconName: {
+      Activity: 'Activity',
       ArrowDown: 'ArrowDown',
       ArrowRight: 'ArrowRight',
       ArrowUp: 'ArrowUp',
@@ -333,6 +334,7 @@ const defaultDashboard: VipDashboardState = {
   localizedText: {
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
+    transactionsTitle: 'Transactions',
     swapsFeeTitle: 'Swaps fee',
     perpsFeeTitle: 'Perps fee',
     revenueShareTitle: 'Revenue share',
@@ -444,10 +446,31 @@ describe('RewardsVipView', () => {
     expect(
       getByTestId(REWARDS_VIP_VIEW_TEST_IDS.INVITE_BUTTON),
     ).toBeOnTheScreen();
+    expect(
+      getByTestId(REWARDS_VIP_VIEW_TEST_IDS.TRANSACTIONS_BUTTON),
+    ).toBeOnTheScreen();
     expect(mockUseTrackRewardsPageView).toHaveBeenCalledWith({
       page_type: 'vip',
       enabled: true,
     });
+  });
+
+  it('navigates to VIP transactions view when the transactions button is pressed', () => {
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: defaultDashboard,
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: mockFetch,
+    });
+
+    const { getByTestId } = render(<RewardsVipView />);
+
+    fireEvent.press(getByTestId(REWARDS_VIP_VIEW_TEST_IDS.TRANSACTIONS_BUTTON));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.REWARDS_VIP_TRANSACTIONS_VIEW,
+    );
   });
 
   it('renders the "Last updated" row when computedAt is present', () => {
@@ -705,6 +728,7 @@ describe('RewardsVipView', () => {
         program: { id: 'mock-vip-program', name: 'Acme Rewards Beta — Custom' },
         localizedText: {
           memberIdTitle: 'Member ID',
+          transactionsTitle: 'Transactions',
           swapsFeeTitle: 'Swap fees',
           perpsFeeTitle: 'Perp fees',
           revenueShareTitle: 'Revenue',

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -56,6 +56,7 @@ import {
 
 export const REWARDS_VIP_VIEW_TEST_IDS = {
   INVITE_BUTTON: 'rewards-vip-view-invite-button',
+  TRANSACTIONS_BUTTON: 'rewards-vip-view-transactions-button',
   SCROLL: 'rewards-vip-view-scroll',
   SKELETON: 'rewards-vip-view-skeleton',
   ERROR: 'rewards-vip-view-error',
@@ -174,6 +175,14 @@ const RewardsVipViewContent: React.FC = () => {
               onPress: () =>
                 navigation.navigate(Routes.REFERRAL_REWARDS_VIEW as never),
               testID: REWARDS_VIP_VIEW_TEST_IDS.INVITE_BUTTON,
+            },
+            {
+              iconName: IconName.Activity,
+              onPress: () =>
+                navigation.navigate(
+                  Routes.REWARDS_VIP_TRANSACTIONS_VIEW as never,
+                ),
+              testID: REWARDS_VIP_VIEW_TEST_IDS.TRANSACTIONS_BUTTON,
             },
           ]}
         />

--- a/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import VipPerpsTransactionRow from './VipPerpsTransactionRow';
+import type { VipTransactionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+
+jest.mock('../../../Perps/components/PerpsTokenLogo', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ symbol }: { symbol: string }) =>
+      ReactActual.createElement(View, { testID: `token-logo-${symbol}` }),
+  };
+});
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: { fee?: string }) => {
+    if (key === 'rewards.vip_transactions.fee_label') {
+      return `Fee ${params?.fee ?? ''}`;
+    }
+    return key;
+  },
+}));
+
+jest.mock('../../utils/formatUtils', () => ({
+  formatUsd: (value: string) => `$${value}`,
+  formatRewardsTimeOnly: () => '2:30 PM',
+}));
+
+const MOCK_TX: VipTransactionDto = {
+  id: 'tx-1',
+  type: 'PERPS',
+  timestamp: '2026-03-28T14:30:00.000Z',
+  feeUsd: '1.25',
+  volumeUsd: '1000.00',
+  perps: {
+    coin: 'ETH',
+    feeCoin: 'USDC',
+    rawFee: '1250000',
+    rawNotionalVolume: '1000000000',
+    tradeId: 'trade-1',
+    orderId: 'order-1',
+  },
+};
+
+describe('VipPerpsTransactionRow', () => {
+  it('renders coin, volume, fee, and time', () => {
+    const { getByText, getByTestId } = render(
+      <VipPerpsTransactionRow transaction={MOCK_TX} testID="perps-row" />,
+    );
+
+    expect(getByTestId('perps-row')).toBeOnTheScreen();
+    expect(getByTestId('token-logo-ETH')).toBeOnTheScreen();
+    expect(getByText('ETH')).toBeOnTheScreen();
+    expect(getByText('$1000.00')).toBeOnTheScreen();
+    expect(getByText('Fee $1.25')).toBeOnTheScreen();
+    expect(getByText('2:30 PM')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.test.tsx
@@ -13,15 +13,6 @@ jest.mock('../../../Perps/components/PerpsTokenLogo', () => {
   };
 });
 
-jest.mock('../../../../../../locales/i18n', () => ({
-  strings: (key: string, params?: { fee?: string }) => {
-    if (key === 'rewards.vip_transactions.fee_label') {
-      return `Fee ${params?.fee ?? ''}`;
-    }
-    return key;
-  },
-}));
-
 jest.mock('../../utils/formatUtils', () => ({
   formatUsd: (value: string) => `$${value}`,
   formatRewardsTimeOnly: () => '2:30 PM',
@@ -44,8 +35,8 @@ const MOCK_TX: VipTransactionDto = {
 };
 
 describe('VipPerpsTransactionRow', () => {
-  it('renders coin, volume, fee, and time', () => {
-    const { getByText, getByTestId } = render(
+  it('renders coin, volume, and time without fee', () => {
+    const { getByText, getByTestId, queryByText } = render(
       <VipPerpsTransactionRow transaction={MOCK_TX} testID="perps-row" />,
     );
 
@@ -53,7 +44,7 @@ describe('VipPerpsTransactionRow', () => {
     expect(getByTestId('token-logo-ETH')).toBeOnTheScreen();
     expect(getByText('ETH')).toBeOnTheScreen();
     expect(getByText('$1000.00')).toBeOnTheScreen();
-    expect(getByText('Fee $1.25')).toBeOnTheScreen();
     expect(getByText('2:30 PM')).toBeOnTheScreen();
+    expect(queryByText(/Fee/)).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { VipTransactionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import PerpsTokenLogo from '../../../Perps/components/PerpsTokenLogo';
+import { formatRewardsTimeOnly, formatUsd } from '../../utils/formatUtils';
+import { strings } from '../../../../../../locales/i18n';
+
+export interface VipPerpsTransactionRowProps {
+  transaction: VipTransactionDto;
+  testID?: string;
+}
+
+const VipPerpsTransactionRow: React.FC<VipPerpsTransactionRowProps> = ({
+  transaction,
+  testID,
+}) => {
+  const coin = transaction.perps?.coin ?? '—';
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+      twClassName="w-full py-3"
+      gap={3}
+      testID={testID}
+    >
+      <PerpsTokenLogo
+        symbol={coin}
+        size={40}
+        recyclingKey={`${coin}-${transaction.id}`}
+      />
+
+      <Box twClassName="flex-1" justifyContent={BoxJustifyContent.Start}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {coin}
+          </Text>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {formatUsd(transaction.volumeUsd)}
+          </Text>
+        </Box>
+
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            twClassName="max-w-[60%]"
+            numberOfLines={1}
+          >
+            {strings('rewards.vip_transactions.fee_label', {
+              fee: formatUsd(transaction.feeUsd),
+            })}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {formatRewardsTimeOnly(new Date(transaction.timestamp))}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default VipPerpsTransactionRow;

--- a/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPerpsTransactionRow.tsx
@@ -12,7 +12,6 @@ import {
 import type { VipTransactionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import PerpsTokenLogo from '../../../Perps/components/PerpsTokenLogo';
 import { formatRewardsTimeOnly, formatUsd } from '../../utils/formatUtils';
-import { strings } from '../../../../../../locales/i18n';
 
 export interface VipPerpsTransactionRowProps {
   transaction: VipTransactionDto;
@@ -55,18 +54,8 @@ const VipPerpsTransactionRow: React.FC<VipPerpsTransactionRowProps> = ({
 
         <Box
           flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.Between}
+          justifyContent={BoxJustifyContent.End}
         >
-          <Text
-            variant={TextVariant.BodySm}
-            color={TextColor.TextAlternative}
-            twClassName="max-w-[60%]"
-            numberOfLines={1}
-          >
-            {strings('rewards.vip_transactions.fee_label', {
-              fee: formatUsd(transaction.feeUsd),
-            })}
-          </Text>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {formatRewardsTimeOnly(new Date(transaction.timestamp))}
           </Text>

--- a/app/components/UI/Rewards/components/Vip/VipSwapTransactionRow.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapTransactionRow.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import VipSwapTransactionRow from './VipSwapTransactionRow';
+import type { VipTransactionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const translations: Record<string, string> = {
+      'rewards.vip_transactions.swap_title': 'Swap',
+    };
+    return translations[key] ?? key;
+  },
+}));
+
+jest.mock('../../utils/formatUtils', () => ({
+  formatUsd: (value: string) => `$${value}`,
+  formatRewardsTimeOnly: () => '2:30 PM',
+}));
+
+const MOCK_TX: VipTransactionDto = {
+  id: 'tx-1',
+  type: 'SWAP',
+  timestamp: '2026-03-28T14:30:00.000Z',
+  feeUsd: '0.50',
+  volumeUsd: '250.00',
+  swap: {
+    quoteId: 'quote-1',
+    srcChainId: '1',
+    srcAssetSymbol: 'ETH',
+    destChainId: '1',
+    destAssetSymbol: 'USDC',
+  },
+};
+
+describe('VipSwapTransactionRow', () => {
+  it('renders swap title, pair detail, volume, and time', () => {
+    const { getByText, getByTestId } = render(
+      <VipSwapTransactionRow transaction={MOCK_TX} testID="swap-row" />,
+    );
+
+    expect(getByTestId('swap-row')).toBeOnTheScreen();
+    expect(getByText('Swap')).toBeOnTheScreen();
+    expect(getByText('ETH → USDC')).toBeOnTheScreen();
+    expect(getByText('$250.00')).toBeOnTheScreen();
+    expect(getByText('2:30 PM')).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Rewards/components/Vip/VipSwapTransactionRow.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipSwapTransactionRow.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { VipTransactionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import { formatRewardsTimeOnly, formatUsd } from '../../utils/formatUtils';
+import { strings } from '../../../../../../locales/i18n';
+
+export interface VipSwapTransactionRowProps {
+  transaction: VipTransactionDto;
+  testID?: string;
+}
+
+const VipSwapTransactionRow: React.FC<VipSwapTransactionRowProps> = ({
+  transaction,
+  testID,
+}) => {
+  const srcSymbol = transaction.swap?.srcAssetSymbol ?? '—';
+  const destSymbol = transaction.swap?.destAssetSymbol ?? '—';
+  const detail = `${srcSymbol} → ${destSymbol}`;
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+      twClassName="w-full py-3"
+      gap={3}
+      testID={testID}
+    >
+      <Box
+        twClassName="bg-muted rounded-full items-center justify-center size-10"
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+      >
+        <Icon
+          name={IconName.SwapHorizontal}
+          size={IconSize.Lg}
+          twClassName="text-icon-default"
+        />
+      </Box>
+
+      <Box twClassName="flex-1" justifyContent={BoxJustifyContent.Start}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {strings('rewards.vip_transactions.swap_title')}
+          </Text>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {formatUsd(transaction.volumeUsd)}
+          </Text>
+        </Box>
+
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            twClassName="max-w-[60%]"
+            numberOfLines={1}
+          >
+            {detail}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {formatRewardsTimeOnly(new Date(transaction.timestamp))}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default VipSwapTransactionRow;

--- a/app/components/UI/Rewards/hooks/useCursorPaginatedList.test.ts
+++ b/app/components/UI/Rewards/hooks/useCursorPaginatedList.test.ts
@@ -1,0 +1,392 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
+import { useCursorPaginatedList } from './useCursorPaginatedList';
+
+interface Item { id: string }
+
+const PAGE_1 = {
+  results: [{ id: '1' }],
+  has_more: true,
+  cursor: 'c2',
+};
+
+const PAGE_2 = {
+  results: [{ id: '2' }],
+  has_more: false,
+  cursor: null,
+};
+
+describe('useCursorPaginatedList', () => {
+  it('does not fetch when disabled', () => {
+    const fetchPage = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: false,
+        resetKey: 'key',
+        fetchPage,
+      }),
+    );
+
+    expect(fetchPage).not.toHaveBeenCalled();
+    expect(result.current.items).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('fetches first page and calls onFirstPage', async () => {
+    const fetchPage = jest.fn().mockResolvedValue(PAGE_1);
+    const onFirstPage = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+        onFirstPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual(PAGE_1.results);
+    });
+
+    expect(fetchPage).toHaveBeenCalledWith({
+      cursor: null,
+      isFirstPage: true,
+      forceFresh: false,
+    });
+    expect(onFirstPage).toHaveBeenCalledWith(PAGE_1.results);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('appends loadMore results without calling onFirstPage again', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockResolvedValueOnce(PAGE_2);
+    const onFirstPage = jest.fn();
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+        onFirstPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    expect(result.current.items).toEqual([{ id: '1' }, { id: '2' }]);
+    expect(onFirstPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenLastCalledWith({
+      cursor: 'c2',
+      isFirstPage: false,
+      forceFresh: false,
+    });
+  });
+
+  it('does not loadMore when hasMore is false', async () => {
+    const fetchPage = jest.fn().mockResolvedValue({
+      ...PAGE_1,
+      has_more: false,
+      cursor: null,
+    });
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces non-empty cached items immediately when disabled', () => {
+    const cached = [{ id: 'cached' }];
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: false,
+        resetKey: 'key',
+        cachedItems: cached,
+        fetchPage: jest.fn(),
+      }),
+    );
+
+    expect(result.current.items).toEqual(cached);
+  });
+
+  it('ignores empty cached lists for display', () => {
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: false,
+        resetKey: 'key',
+        cachedItems: [],
+        fetchPage: jest.fn(),
+      }),
+    );
+
+    expect(result.current.items).toBeNull();
+  });
+
+  it('refresh force-fetches first page and sets isRefreshing', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockResolvedValueOnce({
+        results: [{ id: 'fresh' }],
+        has_more: false,
+        cursor: null,
+      });
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1);
+    });
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    expect(fetchPage).toHaveBeenLastCalledWith({
+      cursor: null,
+      isFirstPage: true,
+      forceFresh: true,
+    });
+    expect(result.current.items?.[0].id).toBe('fresh');
+  });
+
+  it('retry force-fetches without setting isRefreshing', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockResolvedValueOnce({
+        results: [{ id: 'retry' }],
+        has_more: false,
+        cursor: null,
+      });
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toHaveLength(1);
+    });
+
+    await act(async () => {
+      result.current.retry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.items?.[0].id).toBe('retry');
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(fetchPage).toHaveBeenLastCalledWith({
+      cursor: null,
+      isFirstPage: true,
+      forceFresh: true,
+    });
+  });
+
+  it('sets error on fetch failure when there is no cache', async () => {
+    const fetchPage = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+        errorMessage: 'fallback',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('boom');
+    });
+
+    expect(result.current.items).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('hides cache while a first-page load is in flight', async () => {
+    let resolveFetch: (value: typeof PAGE_1) => void = () => undefined;
+    const fetchPage = jest.fn(
+      () =>
+        new Promise<typeof PAGE_1>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const cached = [{ id: 'cached' }];
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        cachedItems: cached,
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(fetchPage).toHaveBeenCalled();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.items).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      resolveFetch(PAGE_1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual(PAGE_1.results);
+    });
+  });
+
+  it('shows cache and suppresses error when first-page fetch fails', async () => {
+    const fetchPage = jest.fn().mockRejectedValue(new Error('boom'));
+    const cached = [{ id: 'cached' }];
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        cachedItems: cached,
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual(cached);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('keeps current rows visible during pull-to-refresh', async () => {
+    let resolveRefresh: (value: {
+      results: Item[];
+      has_more: boolean;
+      cursor: string | null;
+    }) => void = () => undefined;
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+    const { result } = renderHook(() =>
+      useCursorPaginatedList<Item>({
+        enabled: true,
+        resetKey: 'key',
+        fetchPage,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual(PAGE_1.results);
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(true);
+    });
+
+    expect(result.current.items).toEqual(PAGE_1.results);
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      resolveRefresh({
+        results: [{ id: 'fresh' }],
+        has_more: false,
+        cursor: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    expect(result.current.items?.[0].id).toBe('fresh');
+  });
+
+  it('refetches when resetKey changes', async () => {
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockResolvedValueOnce({
+        results: [{ id: 'other' }],
+        has_more: false,
+        cursor: null,
+      });
+
+    const { result, rerender } = renderHook(
+      ({ resetKey }: { resetKey: string }) =>
+        useCursorPaginatedList<Item>({
+          enabled: true,
+          resetKey,
+          fetchPage,
+        }),
+      { initialProps: { resetKey: 'a' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items?.[0].id).toBe('1');
+    });
+
+    rerender({ resetKey: 'b' });
+
+    await waitFor(() => {
+      expect(result.current.items?.[0].id).toBe('other');
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/UI/Rewards/hooks/useCursorPaginatedList.test.ts
+++ b/app/components/UI/Rewards/hooks/useCursorPaginatedList.test.ts
@@ -2,7 +2,9 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
 import { useCursorPaginatedList } from './useCursorPaginatedList';
 
-interface Item { id: string }
+interface Item {
+  id: string;
+}
 
 const PAGE_1 = {
   results: [{ id: '1' }],
@@ -388,5 +390,61 @@ describe('useCursorPaginatedList', () => {
     });
 
     expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears isRefreshing when resetKey changes during an in-flight refresh', async () => {
+    let resolveRefresh: (value: typeof PAGE_1) => void = () => undefined;
+    const fetchPage = jest
+      .fn()
+      .mockResolvedValueOnce(PAGE_1)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        results: [{ id: 'switched' }],
+        has_more: false,
+        cursor: null,
+      });
+
+    const { result, rerender } = renderHook(
+      ({ resetKey }: { resetKey: string }) =>
+        useCursorPaginatedList<Item>({
+          enabled: true,
+          resetKey,
+          fetchPage,
+        }),
+      { initialProps: { resetKey: 'a' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual(PAGE_1.results);
+    });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(true);
+    });
+
+    rerender({ resetKey: 'b' });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    await act(async () => {
+      resolveRefresh(PAGE_1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.items?.[0].id).toBe('switched');
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
   });
 });

--- a/app/components/UI/Rewards/hooks/useCursorPaginatedList.ts
+++ b/app/components/UI/Rewards/hooks/useCursorPaginatedList.ts
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface CursorPage<T> {
+  results: T[];
+  cursor: string | null;
+  has_more: boolean;
+}
+
+export interface UseCursorPaginatedListParams<T> {
+  /** When false, no network fetch runs; non-empty cache may still display. */
+  enabled: boolean;
+  /**
+   * Opaque key for the list identity. Changing it cancels in-flight work and
+   * starts a first-page fetch (e.g. `${subscriptionId}:${type}`).
+   */
+  resetKey: string;
+  /** First-page Redux (or other) cache. Used after failed fetches or when disabled. */
+  cachedItems?: T[] | null;
+  fetchPage: (args: {
+    cursor: string | null;
+    isFirstPage: boolean;
+    forceFresh: boolean;
+  }) => Promise<CursorPage<T>>;
+  /**
+   * Persist first-page results only. Do not call for load-more pages so the
+   * cache never holds a multi-page merge that would flash then shrink on refetch.
+   */
+  onFirstPage?: (items: T[]) => void;
+  errorMessage?: string;
+}
+
+export interface UseCursorPaginatedListResult<T> {
+  items: T[] | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadMore: () => void;
+  refresh: () => void;
+  retry: () => void;
+  isRefreshing: boolean;
+}
+
+const nonEmpty = <T>(items: T[] | null | undefined): T[] | null =>
+  items && items.length > 0 ? items : null;
+
+/**
+ * Cursor-paginated list with first-page-only external cache sync.
+ *
+ * Display states are exclusive:
+ * - First-page loading (not pull-to-refresh): no rows (skeletons in the view)
+ * - Pull-to-refresh: keep current rows under RefreshControl
+ * - Error with cache/rows: show those rows, suppress error (PTR to recover)
+ * - Error with no rows/cache: surface error
+ */
+export const useCursorPaginatedList = <T>({
+  enabled,
+  resetKey,
+  cachedItems,
+  fetchPage,
+  onFirstPage,
+  errorMessage = 'Failed to fetch',
+}: UseCursorPaginatedListParams<T>): UseCursorPaginatedListResult<T> => {
+  const [items, setItems] = useState<T[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoadingRef = useRef(false);
+  const activeRequestRef = useRef<{ cancelled: boolean } | null>(null);
+  const activePaginationRef = useRef<{ cancelled: boolean } | null>(null);
+
+  const cachedRows = nonEmpty(cachedItems);
+
+  const fetchList = useCallback(
+    async ({
+      isFirstPage,
+      currentCursor = null,
+      forceFresh = false,
+      preserveItems = false,
+    }: {
+      isFirstPage: boolean;
+      currentCursor?: string | null;
+      forceFresh?: boolean;
+      preserveItems?: boolean;
+    }): Promise<{ cancelled: boolean }> => {
+      if (!isFirstPage && isLoadingRef.current) {
+        return { cancelled: false };
+      }
+      isLoadingRef.current = true;
+
+      let request: { cancelled: boolean } | null = null;
+      if (isFirstPage) {
+        if (activeRequestRef.current) {
+          activeRequestRef.current.cancelled = true;
+        }
+        if (activePaginationRef.current) {
+          activePaginationRef.current.cancelled = true;
+          setIsLoadingMore(false);
+        }
+        request = { cancelled: false };
+        activeRequestRef.current = request;
+        if (!preserveItems) {
+          setItems(null);
+        }
+        setIsLoading(true);
+        setError(null);
+      } else {
+        request = { cancelled: false };
+        activePaginationRef.current = request;
+        setIsLoadingMore(true);
+      }
+
+      try {
+        if (!enabled) {
+          return { cancelled: false };
+        }
+
+        const data = await fetchPage({
+          cursor: currentCursor,
+          isFirstPage,
+          forceFresh,
+        });
+
+        if (request?.cancelled) {
+          return { cancelled: true };
+        }
+
+        if (isFirstPage) {
+          setItems(data.results);
+          onFirstPage?.(data.results);
+        } else {
+          setItems((prev) =>
+            prev ? [...prev, ...data.results] : data.results,
+          );
+        }
+
+        setCursor(data.cursor);
+        setHasMore(data.has_more);
+      } catch (err) {
+        if (request?.cancelled) {
+          return { cancelled: true };
+        }
+        setError(err instanceof Error ? err.message : errorMessage);
+      } finally {
+        if (!request?.cancelled) {
+          isLoadingRef.current = false;
+          if (isFirstPage) {
+            setIsLoading(false);
+          } else {
+            setIsLoadingMore(false);
+          }
+        }
+      }
+      return { cancelled: false };
+    },
+    [enabled, fetchPage, onFirstPage, errorMessage],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!isLoadingMore && !isLoading && hasMore && cursor) {
+      fetchList({ isFirstPage: false, currentCursor: cursor });
+    }
+  }, [isLoadingMore, isLoading, hasMore, cursor, fetchList]);
+
+  const refresh = useCallback(async () => {
+    setIsRefreshing(true);
+    setCursor(null);
+    setHasMore(true);
+    const result = await fetchList({
+      isFirstPage: true,
+      forceFresh: true,
+      preserveItems: true,
+    });
+    if (!result.cancelled) {
+      setIsRefreshing(false);
+    }
+  }, [fetchList]);
+
+  // Programmatic retry — uses isLoading skeletons, not RefreshControl.
+  const retry = useCallback(async () => {
+    setCursor(null);
+    setHasMore(true);
+    await fetchList({
+      isFirstPage: true,
+      forceFresh: true,
+      preserveItems: false,
+    });
+  }, [fetchList]);
+
+  // When disabled, surface non-empty cache as local items for display.
+  useEffect(() => {
+    if (!enabled && items === null && cachedRows) {
+      setItems(cachedRows);
+    }
+  }, [enabled, items, cachedRows]);
+
+  // Initial fetch / refetch when the list identity or enablement changes.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    setItems(null);
+    setCursor(null);
+    setHasMore(true);
+    setIsLoadingMore(false);
+    fetchList({ isFirstPage: true, preserveItems: false });
+
+    return () => {
+      if (activeRequestRef.current) {
+        activeRequestRef.current.cancelled = true;
+      }
+      if (activePaginationRef.current) {
+        activePaginationRef.current.cancelled = true;
+      }
+      isLoadingRef.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, resetKey, fetchList]);
+
+  const isInitialLoading = isLoading && !isRefreshing;
+  const fallbackRows = nonEmpty(items) ?? cachedRows;
+
+  let displayItems: T[] | null;
+  let displayError: string | null;
+
+  if (isInitialLoading) {
+    // Skeletons only — never cache/rows beside a first-page load.
+    displayItems = null;
+    displayError = null;
+  } else if (error) {
+    if (fallbackRows) {
+      // Cache/rows win; caller can pull-to-refresh. Keep failure invisible.
+      displayItems = fallbackRows;
+      displayError = null;
+    } else {
+      displayItems = null;
+      displayError = error;
+    }
+  } else if (items !== null) {
+    displayItems = items;
+    displayError = null;
+  } else {
+    displayItems = cachedRows;
+    displayError = null;
+  }
+
+  return {
+    items: displayItems,
+    isLoading: isInitialLoading,
+    isLoadingMore,
+    hasMore,
+    error: displayError,
+    loadMore,
+    refresh,
+    retry,
+    isRefreshing,
+  };
+};
+
+export default useCursorPaginatedList;

--- a/app/components/UI/Rewards/hooks/useCursorPaginatedList.ts
+++ b/app/components/UI/Rewards/hooks/useCursorPaginatedList.ts
@@ -170,12 +170,14 @@ export const useCursorPaginatedList = <T>({
     setIsRefreshing(true);
     setCursor(null);
     setHasMore(true);
-    const result = await fetchList({
-      isFirstPage: true,
-      forceFresh: true,
-      preserveItems: true,
-    });
-    if (!result.cancelled) {
+    try {
+      await fetchList({
+        isFirstPage: true,
+        forceFresh: true,
+        preserveItems: true,
+      });
+    } finally {
+      // Always clear — including when resetKey/enabled cancels the request.
       setIsRefreshing(false);
     }
   }, [fetchList]);
@@ -208,6 +210,7 @@ export const useCursorPaginatedList = <T>({
     setCursor(null);
     setHasMore(true);
     setIsLoadingMore(false);
+    setIsRefreshing(false);
     fetchList({ isFirstPage: true, preserveItems: false });
 
     return () => {

--- a/app/components/UI/Rewards/hooks/useGetOndoCampaignActivity.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoCampaignActivity.test.ts
@@ -221,6 +221,15 @@ describe('useGetOndoCampaignActivity', () => {
       },
     );
     expect(result.current.activityEntries).toHaveLength(2);
+    // Policy A: Redux keeps first page only — loadMore must not dispatch merges.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setOndoCampaignActivity({
+        subscriptionId: SUBSCRIPTION_ID,
+        campaignId: CAMPAIGN_ID,
+        entries: MOCK_PAGE_1.results,
+      }),
+    );
   });
 
   it('does not loadMore when hasMore is false', async () => {

--- a/app/components/UI/Rewards/hooks/useGetOndoCampaignActivity.ts
+++ b/app/components/UI/Rewards/hooks/useGetOndoCampaignActivity.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
@@ -8,6 +8,7 @@ import {
 } from '../../../../reducers/rewards/selectors';
 import { setOndoCampaignActivity } from '../../../../reducers/rewards';
 import type { OndoGmActivityEntryDto } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { useCursorPaginatedList } from './useCursorPaginatedList';
 
 export interface UseGetOndoCampaignActivityResult {
   activityEntries: OndoGmActivityEntryDto[] | null;
@@ -22,7 +23,7 @@ export interface UseGetOndoCampaignActivityResult {
 
 /**
  * Hook to fetch paginated Ondo GM campaign activity.
- * First page is cached for 1 minute by the controller.
+ * First page is cached in Redux; subsequent pages stay in local state only.
  */
 export const useGetOndoCampaignActivity = (
   campaignId: string | undefined,
@@ -36,148 +37,59 @@ export const useGetOndoCampaignActivity = (
     selectOndoCampaignActivityById(subscriptionId ?? undefined, campaignId),
   );
 
-  const [activityEntries, setActivityEntries] = useState<
-    OndoGmActivityEntryDto[] | null
-  >(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const isLoadingRef = useRef(false);
-  const activeRequestRef = useRef<{ cancelled: boolean } | null>(null);
-  const activePaginationRef = useRef<{ cancelled: boolean } | null>(null);
+  const enabled = Boolean(subscriptionId && campaignId && isOptedIn);
+  const resetKey = `${subscriptionId ?? ''}:${campaignId ?? ''}`;
 
-  const fetchActivity = useCallback(
-    async ({
-      isFirstPage,
-      currentCursor = null,
-    }: {
-      isFirstPage: boolean;
-      currentCursor?: string | null;
-    }): Promise<{ cancelled: boolean }> => {
-      if (!isFirstPage && isLoadingRef.current) {
-        return { cancelled: false };
-      }
-      isLoadingRef.current = true;
-
-      let request: { cancelled: boolean } | null = null;
-      if (isFirstPage) {
-        if (activeRequestRef.current) {
-          activeRequestRef.current.cancelled = true;
-        }
-        if (activePaginationRef.current) {
-          activePaginationRef.current.cancelled = true;
-          setIsLoadingMore(false);
-        }
-        request = { cancelled: false };
-        activeRequestRef.current = request;
-        setIsLoading(true);
-        setError(null);
-      } else {
-        request = { cancelled: false };
-        activePaginationRef.current = request;
-        setIsLoadingMore(true);
+  const fetchPage = useCallback(
+    async ({ cursor }: { cursor: string | null }) => {
+      if (!subscriptionId || !campaignId) {
+        return { results: [], cursor: null, has_more: false };
       }
 
-      try {
-        if (!subscriptionId || !campaignId || !isOptedIn) {
-          return { cancelled: false };
-        }
-
-        const data = await Engine.controllerMessenger.call(
-          'RewardsController:getOndoCampaignActivity',
-          { campaignId, subscriptionId, cursor: currentCursor },
-        );
-
-        if (request?.cancelled) {
-          return { cancelled: true };
-        }
-
-        if (isFirstPage) {
-          setActivityEntries(data.results);
-          dispatch(
-            setOndoCampaignActivity({
-              subscriptionId,
-              campaignId,
-              entries: data.results,
-            }),
-          );
-        } else {
-          setActivityEntries((prev) => {
-            const merged = prev ? [...prev, ...data.results] : data.results;
-            dispatch(
-              setOndoCampaignActivity({
-                subscriptionId,
-                campaignId,
-                entries: merged,
-              }),
-            );
-            return merged;
-          });
-        }
-
-        setCursor(data.cursor);
-        setHasMore(data.has_more);
-      } catch (err) {
-        if (request?.cancelled) {
-          return { cancelled: true };
-        }
-        setError(
-          err instanceof Error ? err.message : 'Failed to fetch activity',
-        );
-      } finally {
-        if (!request?.cancelled) {
-          isLoadingRef.current = false;
-          if (isFirstPage) {
-            setIsLoading(false);
-          } else {
-            setIsLoadingMore(false);
-          }
-        }
-      }
-      return { cancelled: false };
+      return Engine.controllerMessenger.call(
+        'RewardsController:getOndoCampaignActivity',
+        { campaignId, subscriptionId, cursor },
+      );
     },
-    [subscriptionId, campaignId, isOptedIn, dispatch],
+    [subscriptionId, campaignId],
   );
 
-  const loadMore = useCallback(() => {
-    if (!isLoadingMore && hasMore && cursor) {
-      fetchActivity({ isFirstPage: false, currentCursor: cursor });
-    }
-  }, [isLoadingMore, hasMore, cursor, fetchActivity]);
+  const onFirstPage = useCallback(
+    (entries: OndoGmActivityEntryDto[]) => {
+      if (!subscriptionId || !campaignId) {
+        return;
+      }
+      dispatch(
+        setOndoCampaignActivity({
+          subscriptionId,
+          campaignId,
+          entries,
+        }),
+      );
+    },
+    [dispatch, subscriptionId, campaignId],
+  );
 
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    setCursor(null);
-    setHasMore(true);
-    const result = await fetchActivity({ isFirstPage: true });
-    if (!result.cancelled) {
-      setIsRefreshing(false);
-    }
-  }, [fetchActivity]);
-
-  // Hydrate from Redux cache when local state is empty
-  useEffect(() => {
-    if (!isLoading && activityEntries === null && cachedActivity) {
-      setActivityEntries(cachedActivity);
-    }
-  }, [isLoading, activityEntries, cachedActivity]);
-
-  // Initial fetch
-  useEffect(() => {
-    if (!campaignId || !subscriptionId || !isOptedIn) {
-      return;
-    }
-    setActivityEntries(null);
-    setCursor(null);
-    setHasMore(true);
-    fetchActivity({ isFirstPage: true });
-  }, [campaignId, subscriptionId, isOptedIn, fetchActivity]);
+  const {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    isRefreshing,
+  } = useCursorPaginatedList<OndoGmActivityEntryDto>({
+    enabled,
+    resetKey,
+    cachedItems: cachedActivity,
+    fetchPage,
+    onFirstPage,
+    errorMessage: 'Failed to fetch activity',
+  });
 
   return {
-    activityEntries,
+    activityEntries: items,
     isLoading,
     isLoadingMore,
     hasMore,

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
@@ -1,0 +1,282 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import { useGetVipTransactions } from './useGetVipTransactions';
+import Engine from '../../../../core/Engine';
+import {
+  selectIsCurrentSubscriptionVipEnabled,
+  selectRewardsSubscriptionId,
+} from '../../../../selectors/rewards';
+import { selectVipTransactionsById } from '../../../../reducers/rewards/selectors';
+import { setVipTransactions } from '../../../../reducers/rewards';
+import type { VipTransactionDto } from '../../../../core/Engine/controllers/rewards-controller/types';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  controllerMessenger: { call: jest.fn() },
+}));
+
+jest.mock('../../../../selectors/rewards', () => ({
+  selectRewardsSubscriptionId: jest.fn(),
+  selectIsCurrentSubscriptionVipEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../reducers/rewards/selectors', () => ({
+  selectVipTransactionsById: jest.fn(),
+}));
+
+jest.mock('../../../../reducers/rewards', () => ({
+  setVipTransactions: jest.fn((payload) => ({
+    type: 'rewards/setVipTransactions',
+    payload,
+  })),
+}));
+
+const mockCall = Engine.controllerMessenger.call as jest.MockedFunction<
+  typeof Engine.controllerMessenger.call
+>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
+const mockSelectVipTransactionsById =
+  selectVipTransactionsById as jest.MockedFunction<
+    typeof selectVipTransactionsById
+  >;
+
+const SUBSCRIPTION_ID = 'sub-456';
+
+const MOCK_TX: VipTransactionDto = {
+  id: 'tx-1',
+  type: 'PERPS',
+  timestamp: '2026-03-28T14:30:00.000Z',
+  feeUsd: '1.25',
+  volumeUsd: '1000.00',
+  perps: {
+    coin: 'ETH',
+    feeCoin: 'USDC',
+    rawFee: '1250000',
+    rawNotionalVolume: '1000000000',
+    tradeId: 'trade-1',
+    orderId: 'order-1',
+  },
+};
+
+const MOCK_PAGE_1 = {
+  results: [MOCK_TX],
+  has_more: true,
+  cursor: 'page-2-cursor',
+};
+
+const MOCK_PAGE_2 = {
+  results: [{ ...MOCK_TX, id: 'tx-2', timestamp: '2026-03-27T10:00:00.000Z' }],
+  has_more: false,
+  cursor: null,
+};
+
+interface SelectorState {
+  subscriptionId: string | null;
+  cachedTransactions: VipTransactionDto[] | null;
+  isVipEnabled?: boolean;
+}
+
+function setupSelectors(state: SelectorState) {
+  const isVipEnabled = state.isVipEnabled ?? true;
+  const mockTxSelector = jest.fn().mockReturnValue(state.cachedTransactions);
+  mockSelectVipTransactionsById.mockReturnValue(mockTxSelector);
+
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectRewardsSubscriptionId) return state.subscriptionId;
+    if (selector === selectIsCurrentSubscriptionVipEnabled) return isVipEnabled;
+    if (selector === mockTxSelector) return state.cachedTransactions;
+    return undefined;
+  });
+}
+
+describe('useGetVipTransactions', () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: null,
+    });
+  });
+
+  it('does not fetch when subscriptionId is missing', async () => {
+    setupSelectors({ subscriptionId: null, cachedTransactions: null });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    expect(mockCall).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.transactions).toBeNull();
+  });
+
+  it('does not fetch when VIP is not enabled', async () => {
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: null,
+      isVipEnabled: false,
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    expect(mockCall).not.toHaveBeenCalled();
+    expect(result.current.transactions).toBeNull();
+  });
+
+  it('fetches first page and dispatches result', async () => {
+    mockCall.mockResolvedValueOnce(MOCK_PAGE_1 as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.transactions).toEqual(MOCK_PAGE_1.results);
+    });
+
+    expect(mockCall).toHaveBeenCalledWith(
+      'RewardsController:getVipTransactions',
+      {
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        cursor: null,
+        forceFresh: false,
+      },
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setVipTransactions({
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        transactions: MOCK_PAGE_1.results,
+      }),
+    );
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets error on fetch failure', async () => {
+    mockCall.mockRejectedValueOnce(new Error('Network failure') as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network failure');
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.transactions).toBeNull();
+  });
+
+  it('loads more pages and appends results', async () => {
+    mockCall
+      .mockResolvedValueOnce(MOCK_PAGE_1 as never)
+      .mockResolvedValueOnce(MOCK_PAGE_2 as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(true);
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(2);
+    expect(mockCall).toHaveBeenLastCalledWith(
+      'RewardsController:getVipTransactions',
+      {
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        cursor: 'page-2-cursor',
+        forceFresh: undefined,
+      },
+    );
+    expect(result.current.transactions).toHaveLength(2);
+  });
+
+  it('does not loadMore when hasMore is false', async () => {
+    const noMorePage = { ...MOCK_PAGE_1, has_more: false, cursor: null };
+    mockCall.mockResolvedValueOnce(noMorePage as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.hasMore).toBe(false);
+    });
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates from Redux cache when local state is empty', async () => {
+    const cached = [MOCK_TX];
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: cached,
+      isVipEnabled: false,
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.transactions).toEqual(cached);
+    });
+  });
+
+  it('refresh resets and re-fetches first page with forceFresh', async () => {
+    mockCall.mockResolvedValueOnce(MOCK_PAGE_1 as never).mockResolvedValueOnce({
+      results: [{ ...MOCK_TX, volumeUsd: '9999.00' }],
+      has_more: false,
+      cursor: null,
+    } as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.transactions).toHaveLength(1);
+    });
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    expect(mockCall).toHaveBeenCalledTimes(2);
+    expect(mockCall).toHaveBeenLastCalledWith(
+      'RewardsController:getVipTransactions',
+      {
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        cursor: null,
+        forceFresh: true,
+      },
+    );
+    expect(result.current.transactions?.[0].volumeUsd).toBe('9999.00');
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('calls selectVipTransactionsById with subscriptionId and type', () => {
+    renderHook(() => useGetVipTransactions('SWAP'));
+
+    expect(mockSelectVipTransactionsById).toHaveBeenCalledWith(
+      SUBSCRIPTION_ID,
+      'SWAP',
+    );
+  });
+});

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
@@ -202,6 +202,15 @@ describe('useGetVipTransactions', () => {
       },
     );
     expect(result.current.transactions).toHaveLength(2);
+    // Policy A: Redux keeps first page only — loadMore must not dispatch merges.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setVipTransactions({
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        transactions: MOCK_PAGE_1.results,
+      }),
+    );
   });
 
   it('does not loadMore when hasMore is false', async () => {
@@ -248,7 +257,7 @@ describe('useGetVipTransactions', () => {
     expect(result.current.transactions).toBeNull();
   });
 
-  it('exposes cached transactions immediately so empty UI does not flash', () => {
+  it('exposes cached transactions when VIP is disabled and no fetch runs', () => {
     const cached = [MOCK_TX];
     setupSelectors({
       subscriptionId: SUBSCRIPTION_ID,
@@ -259,6 +268,54 @@ describe('useGetVipTransactions', () => {
     const { result } = renderHook(() => useGetVipTransactions('PERPS'));
 
     expect(result.current.transactions).toEqual(cached);
+  });
+
+  it('hides cached transactions while an enabled first-page fetch is in flight', async () => {
+    let resolveFetch: (value: typeof MOCK_PAGE_1) => void = () => undefined;
+    mockCall.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as never,
+    );
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: [MOCK_TX],
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(mockCall).toHaveBeenCalled();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.transactions).toBeNull();
+
+    await act(async () => {
+      resolveFetch(MOCK_PAGE_1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.transactions).toEqual(MOCK_PAGE_1.results);
+    });
+  });
+
+  it('shows cache and suppresses error when first-page fetch fails', async () => {
+    mockCall.mockRejectedValueOnce(new Error('Network failure') as never);
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: [MOCK_TX],
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.transactions).toEqual([MOCK_TX]);
+    expect(result.current.error).toBeNull();
   });
 
   it('refresh resets and re-fetches first page with forceFresh', async () => {

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.test.ts
@@ -236,6 +236,31 @@ describe('useGetVipTransactions', () => {
     });
   });
 
+  it('does not treat an empty cached list as displayable rows', () => {
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: [],
+      isVipEnabled: false,
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    expect(result.current.transactions).toBeNull();
+  });
+
+  it('exposes cached transactions immediately so empty UI does not flash', () => {
+    const cached = [MOCK_TX];
+    setupSelectors({
+      subscriptionId: SUBSCRIPTION_ID,
+      cachedTransactions: cached,
+      isVipEnabled: false,
+    });
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    expect(result.current.transactions).toEqual(cached);
+  });
+
   it('refresh resets and re-fetches first page with forceFresh', async () => {
     mockCall.mockResolvedValueOnce(MOCK_PAGE_1 as never).mockResolvedValueOnce({
       results: [{ ...MOCK_TX, volumeUsd: '9999.00' }],
@@ -269,6 +294,39 @@ describe('useGetVipTransactions', () => {
     );
     expect(result.current.transactions?.[0].volumeUsd).toBe('9999.00');
     expect(result.current.hasMore).toBe(false);
+  });
+
+  it('retry force-fetches without setting isRefreshing', async () => {
+    mockCall.mockResolvedValueOnce(MOCK_PAGE_1 as never).mockResolvedValueOnce({
+      results: [{ ...MOCK_TX, volumeUsd: '50.00' }],
+      has_more: false,
+      cursor: null,
+    } as never);
+
+    const { result } = renderHook(() => useGetVipTransactions('PERPS'));
+
+    await waitFor(() => {
+      expect(result.current.transactions).toHaveLength(1);
+    });
+
+    await act(async () => {
+      result.current.retry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.transactions?.[0].volumeUsd).toBe('50.00');
+    });
+
+    expect(result.current.isRefreshing).toBe(false);
+    expect(mockCall).toHaveBeenLastCalledWith(
+      'RewardsController:getVipTransactions',
+      {
+        subscriptionId: SUBSCRIPTION_ID,
+        type: 'PERPS',
+        cursor: null,
+        forceFresh: true,
+      },
+    );
   });
 
   it('calls selectVipTransactionsById with subscriptionId and type', () => {

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
@@ -20,6 +20,7 @@ export interface UseGetVipTransactionsResult {
   error: string | null;
   loadMore: () => void;
   refresh: () => void;
+  retry: () => void;
   isRefreshing: boolean;
 }
 
@@ -151,10 +152,10 @@ export const useGetVipTransactions = (
   );
 
   const loadMore = useCallback(() => {
-    if (!isLoadingMore && hasMore && cursor) {
+    if (!isLoadingMore && !isLoading && hasMore && cursor) {
       fetchTransactions({ isFirstPage: false, currentCursor: cursor });
     }
-  }, [isLoadingMore, hasMore, cursor, fetchTransactions]);
+  }, [isLoadingMore, isLoading, hasMore, cursor, fetchTransactions]);
 
   const refresh = useCallback(async () => {
     setIsRefreshing(true);
@@ -169,9 +170,27 @@ export const useGetVipTransactions = (
     }
   }, [fetchTransactions]);
 
-  // Hydrate from Redux cache when local state is empty
+  // Programmatic retry (e.g. error banner) — uses isLoading skeletons, not
+  // RefreshControl's refreshing spinner, to avoid shifting the whole screen.
+  const retry = useCallback(async () => {
+    setCursor(null);
+    setHasMore(true);
+    await fetchTransactions({
+      isFirstPage: true,
+      forceFresh: true,
+    });
+  }, [fetchTransactions]);
+
+  // Hydrate from Redux cache when local state is empty. Only hydrate non-empty
+  // caches — an empty [] from a prior fetch should not suppress the loading
+  // skeleton on the next visit while a refetch is in flight.
   useEffect(() => {
-    if (!isLoading && transactions === null && cachedTransactions) {
+    if (
+      !isLoading &&
+      transactions === null &&
+      cachedTransactions &&
+      cachedTransactions.length > 0
+    ) {
       setTransactions(cachedTransactions);
     }
   }, [isLoading, transactions, cachedTransactions]);
@@ -181,20 +200,51 @@ export const useGetVipTransactions = (
     if (!subscriptionId || !isVipEnabled) {
       return;
     }
-    setTransactions(null);
+
+    const hasCachedRows =
+      Array.isArray(cachedTransactions) && cachedTransactions.length > 0;
+
+    // Keep non-empty cached rows visible while refetching. Seed null (not [])
+    // when there is no cache or only an empty cache so the empty message does
+    // not flash beside loading indicators.
+    setTransactions(hasCachedRows ? cachedTransactions : null);
     setCursor(null);
     setHasMore(true);
+    setIsLoadingMore(false);
     fetchTransactions({ isFirstPage: true });
+
+    return () => {
+      if (activeRequestRef.current) {
+        activeRequestRef.current.cancelled = true;
+      }
+      if (activePaginationRef.current) {
+        activePaginationRef.current.cancelled = true;
+      }
+      isLoadingRef.current = false;
+    };
+    // Intentionally omit cachedTransactions from deps — we only seed from
+    // cache when the fetch key (subscription/type) changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subscriptionId, isVipEnabled, type, fetchTransactions]);
 
+  // Prefer live local state, but fall back to a non-empty Redux cache so real
+  // rows never disappear during refetch. Empty [] cache is ignored so loading
+  // can show skeletons instead of a premature empty message.
+  const cachedRows =
+    cachedTransactions && cachedTransactions.length > 0
+      ? cachedTransactions
+      : null;
+  const displayedTransactions = transactions ?? cachedRows;
+
   return {
-    transactions,
+    transactions: displayedTransactions,
     isLoading,
     isLoadingMore,
     hasMore,
     error,
     loadMore,
     refresh,
+    retry,
     isRefreshing,
   };
 };

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import {
+  selectIsCurrentSubscriptionVipEnabled,
+  selectRewardsSubscriptionId,
+} from '../../../../selectors/rewards';
+import { selectVipTransactionsById } from '../../../../reducers/rewards/selectors';
+import { setVipTransactions } from '../../../../reducers/rewards';
+import type {
+  VipTransactionDto,
+  VipTransactionType,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+
+export interface UseGetVipTransactionsResult {
+  transactions: VipTransactionDto[] | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadMore: () => void;
+  refresh: () => void;
+  isRefreshing: boolean;
+}
+
+/**
+ * Hook to fetch paginated VIP transactions for a given type.
+ * First page is cached by the RewardsController; subsequent pages use cursor.
+ */
+export const useGetVipTransactions = (
+  type: VipTransactionType,
+): UseGetVipTransactionsResult => {
+  const dispatch = useDispatch();
+  const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isVipEnabled = useSelector(selectIsCurrentSubscriptionVipEnabled);
+  const cachedTransactions = useSelector(
+    selectVipTransactionsById(subscriptionId ?? undefined, type),
+  );
+
+  const [transactions, setTransactions] = useState<VipTransactionDto[] | null>(
+    null,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const isLoadingRef = useRef(false);
+  const activeRequestRef = useRef<{ cancelled: boolean } | null>(null);
+  const activePaginationRef = useRef<{ cancelled: boolean } | null>(null);
+
+  const fetchTransactions = useCallback(
+    async ({
+      isFirstPage,
+      currentCursor = null,
+      forceFresh = false,
+    }: {
+      isFirstPage: boolean;
+      currentCursor?: string | null;
+      forceFresh?: boolean;
+    }): Promise<{ cancelled: boolean }> => {
+      if (!isFirstPage && isLoadingRef.current) {
+        return { cancelled: false };
+      }
+      isLoadingRef.current = true;
+
+      let request: { cancelled: boolean } | null = null;
+      if (isFirstPage) {
+        if (activeRequestRef.current) {
+          activeRequestRef.current.cancelled = true;
+        }
+        if (activePaginationRef.current) {
+          activePaginationRef.current.cancelled = true;
+          setIsLoadingMore(false);
+        }
+        request = { cancelled: false };
+        activeRequestRef.current = request;
+        setIsLoading(true);
+        setError(null);
+      } else {
+        request = { cancelled: false };
+        activePaginationRef.current = request;
+        setIsLoadingMore(true);
+      }
+
+      try {
+        if (!subscriptionId || !isVipEnabled) {
+          return { cancelled: false };
+        }
+
+        const data = await Engine.controllerMessenger.call(
+          'RewardsController:getVipTransactions',
+          {
+            subscriptionId,
+            type,
+            cursor: currentCursor,
+            forceFresh: isFirstPage ? forceFresh : undefined,
+          },
+        );
+
+        if (request?.cancelled) {
+          return { cancelled: true };
+        }
+
+        if (isFirstPage) {
+          setTransactions(data.results);
+          dispatch(
+            setVipTransactions({
+              subscriptionId,
+              type,
+              transactions: data.results,
+            }),
+          );
+        } else {
+          setTransactions((prev) => {
+            const merged = prev ? [...prev, ...data.results] : data.results;
+            dispatch(
+              setVipTransactions({
+                subscriptionId,
+                type,
+                transactions: merged,
+              }),
+            );
+            return merged;
+          });
+        }
+
+        setCursor(data.cursor);
+        setHasMore(data.has_more);
+      } catch (err) {
+        if (request?.cancelled) {
+          return { cancelled: true };
+        }
+        setError(
+          err instanceof Error ? err.message : 'Failed to fetch transactions',
+        );
+      } finally {
+        if (!request?.cancelled) {
+          isLoadingRef.current = false;
+          if (isFirstPage) {
+            setIsLoading(false);
+          } else {
+            setIsLoadingMore(false);
+          }
+        }
+      }
+      return { cancelled: false };
+    },
+    [subscriptionId, type, isVipEnabled, dispatch],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!isLoadingMore && hasMore && cursor) {
+      fetchTransactions({ isFirstPage: false, currentCursor: cursor });
+    }
+  }, [isLoadingMore, hasMore, cursor, fetchTransactions]);
+
+  const refresh = useCallback(async () => {
+    setIsRefreshing(true);
+    setCursor(null);
+    setHasMore(true);
+    const result = await fetchTransactions({
+      isFirstPage: true,
+      forceFresh: true,
+    });
+    if (!result.cancelled) {
+      setIsRefreshing(false);
+    }
+  }, [fetchTransactions]);
+
+  // Hydrate from Redux cache when local state is empty
+  useEffect(() => {
+    if (!isLoading && transactions === null && cachedTransactions) {
+      setTransactions(cachedTransactions);
+    }
+  }, [isLoading, transactions, cachedTransactions]);
+
+  // Initial fetch / refetch when type or subscription changes
+  useEffect(() => {
+    if (!subscriptionId || !isVipEnabled) {
+      return;
+    }
+    setTransactions(null);
+    setCursor(null);
+    setHasMore(true);
+    fetchTransactions({ isFirstPage: true });
+  }, [subscriptionId, isVipEnabled, type, fetchTransactions]);
+
+  return {
+    transactions,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    isRefreshing,
+  };
+};
+
+export default useGetVipTransactions;

--- a/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
+++ b/app/components/UI/Rewards/hooks/useGetVipTransactions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import {
@@ -11,6 +11,7 @@ import type {
   VipTransactionDto,
   VipTransactionType,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { useCursorPaginatedList } from './useCursorPaginatedList';
 
 export interface UseGetVipTransactionsResult {
   transactions: VipTransactionDto[] | null;
@@ -26,7 +27,7 @@ export interface UseGetVipTransactionsResult {
 
 /**
  * Hook to fetch paginated VIP transactions for a given type.
- * First page is cached by the RewardsController; subsequent pages use cursor.
+ * First page is cached in Redux; subsequent pages stay in local state only.
  */
 export const useGetVipTransactions = (
   type: VipTransactionType,
@@ -38,206 +39,73 @@ export const useGetVipTransactions = (
     selectVipTransactionsById(subscriptionId ?? undefined, type),
   );
 
-  const [transactions, setTransactions] = useState<VipTransactionDto[] | null>(
-    null,
-  );
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const isLoadingRef = useRef(false);
-  const activeRequestRef = useRef<{ cancelled: boolean } | null>(null);
-  const activePaginationRef = useRef<{ cancelled: boolean } | null>(null);
+  const enabled = Boolean(subscriptionId && isVipEnabled);
+  const resetKey = `${subscriptionId ?? ''}:${type}`;
 
-  const fetchTransactions = useCallback(
+  const fetchPage = useCallback(
     async ({
+      cursor,
       isFirstPage,
-      currentCursor = null,
-      forceFresh = false,
+      forceFresh,
     }: {
+      cursor: string | null;
       isFirstPage: boolean;
-      currentCursor?: string | null;
-      forceFresh?: boolean;
-    }): Promise<{ cancelled: boolean }> => {
-      if (!isFirstPage && isLoadingRef.current) {
-        return { cancelled: false };
-      }
-      isLoadingRef.current = true;
-
-      let request: { cancelled: boolean } | null = null;
-      if (isFirstPage) {
-        if (activeRequestRef.current) {
-          activeRequestRef.current.cancelled = true;
-        }
-        if (activePaginationRef.current) {
-          activePaginationRef.current.cancelled = true;
-          setIsLoadingMore(false);
-        }
-        request = { cancelled: false };
-        activeRequestRef.current = request;
-        setIsLoading(true);
-        setError(null);
-      } else {
-        request = { cancelled: false };
-        activePaginationRef.current = request;
-        setIsLoadingMore(true);
+      forceFresh: boolean;
+    }) => {
+      if (!subscriptionId) {
+        return { results: [], cursor: null, has_more: false };
       }
 
-      try {
-        if (!subscriptionId || !isVipEnabled) {
-          return { cancelled: false };
-        }
-
-        const data = await Engine.controllerMessenger.call(
-          'RewardsController:getVipTransactions',
-          {
-            subscriptionId,
-            type,
-            cursor: currentCursor,
-            forceFresh: isFirstPage ? forceFresh : undefined,
-          },
-        );
-
-        if (request?.cancelled) {
-          return { cancelled: true };
-        }
-
-        if (isFirstPage) {
-          setTransactions(data.results);
-          dispatch(
-            setVipTransactions({
-              subscriptionId,
-              type,
-              transactions: data.results,
-            }),
-          );
-        } else {
-          setTransactions((prev) => {
-            const merged = prev ? [...prev, ...data.results] : data.results;
-            dispatch(
-              setVipTransactions({
-                subscriptionId,
-                type,
-                transactions: merged,
-              }),
-            );
-            return merged;
-          });
-        }
-
-        setCursor(data.cursor);
-        setHasMore(data.has_more);
-      } catch (err) {
-        if (request?.cancelled) {
-          return { cancelled: true };
-        }
-        setError(
-          err instanceof Error ? err.message : 'Failed to fetch transactions',
-        );
-      } finally {
-        if (!request?.cancelled) {
-          isLoadingRef.current = false;
-          if (isFirstPage) {
-            setIsLoading(false);
-          } else {
-            setIsLoadingMore(false);
-          }
-        }
-      }
-      return { cancelled: false };
+      return Engine.controllerMessenger.call(
+        'RewardsController:getVipTransactions',
+        {
+          subscriptionId,
+          type,
+          cursor,
+          forceFresh: isFirstPage ? forceFresh : undefined,
+        },
+      );
     },
-    [subscriptionId, type, isVipEnabled, dispatch],
+    [subscriptionId, type],
   );
 
-  const loadMore = useCallback(() => {
-    if (!isLoadingMore && !isLoading && hasMore && cursor) {
-      fetchTransactions({ isFirstPage: false, currentCursor: cursor });
-    }
-  }, [isLoadingMore, isLoading, hasMore, cursor, fetchTransactions]);
-
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    setCursor(null);
-    setHasMore(true);
-    const result = await fetchTransactions({
-      isFirstPage: true,
-      forceFresh: true,
-    });
-    if (!result.cancelled) {
-      setIsRefreshing(false);
-    }
-  }, [fetchTransactions]);
-
-  // Programmatic retry (e.g. error banner) — uses isLoading skeletons, not
-  // RefreshControl's refreshing spinner, to avoid shifting the whole screen.
-  const retry = useCallback(async () => {
-    setCursor(null);
-    setHasMore(true);
-    await fetchTransactions({
-      isFirstPage: true,
-      forceFresh: true,
-    });
-  }, [fetchTransactions]);
-
-  // Hydrate from Redux cache when local state is empty. Only hydrate non-empty
-  // caches — an empty [] from a prior fetch should not suppress the loading
-  // skeleton on the next visit while a refetch is in flight.
-  useEffect(() => {
-    if (
-      !isLoading &&
-      transactions === null &&
-      cachedTransactions &&
-      cachedTransactions.length > 0
-    ) {
-      setTransactions(cachedTransactions);
-    }
-  }, [isLoading, transactions, cachedTransactions]);
-
-  // Initial fetch / refetch when type or subscription changes
-  useEffect(() => {
-    if (!subscriptionId || !isVipEnabled) {
-      return;
-    }
-
-    const hasCachedRows =
-      Array.isArray(cachedTransactions) && cachedTransactions.length > 0;
-
-    // Keep non-empty cached rows visible while refetching. Seed null (not [])
-    // when there is no cache or only an empty cache so the empty message does
-    // not flash beside loading indicators.
-    setTransactions(hasCachedRows ? cachedTransactions : null);
-    setCursor(null);
-    setHasMore(true);
-    setIsLoadingMore(false);
-    fetchTransactions({ isFirstPage: true });
-
-    return () => {
-      if (activeRequestRef.current) {
-        activeRequestRef.current.cancelled = true;
+  const onFirstPage = useCallback(
+    (transactions: VipTransactionDto[]) => {
+      if (!subscriptionId) {
+        return;
       }
-      if (activePaginationRef.current) {
-        activePaginationRef.current.cancelled = true;
-      }
-      isLoadingRef.current = false;
-    };
-    // Intentionally omit cachedTransactions from deps — we only seed from
-    // cache when the fetch key (subscription/type) changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subscriptionId, isVipEnabled, type, fetchTransactions]);
+      dispatch(
+        setVipTransactions({
+          subscriptionId,
+          type,
+          transactions,
+        }),
+      );
+    },
+    [dispatch, subscriptionId, type],
+  );
 
-  // Prefer live local state, but fall back to a non-empty Redux cache so real
-  // rows never disappear during refetch. Empty [] cache is ignored so loading
-  // can show skeletons instead of a premature empty message.
-  const cachedRows =
-    cachedTransactions && cachedTransactions.length > 0
-      ? cachedTransactions
-      : null;
-  const displayedTransactions = transactions ?? cachedRows;
+  const {
+    items,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    loadMore,
+    refresh,
+    retry,
+    isRefreshing,
+  } = useCursorPaginatedList<VipTransactionDto>({
+    enabled,
+    resetKey,
+    cachedItems: cachedTransactions,
+    fetchPage,
+    onFirstPage,
+    errorMessage: 'Failed to fetch transactions',
+  });
 
   return {
-    transactions: displayedTransactions,
+    transactions: items,
     isLoading,
     isLoadingMore,
     hasMore,

--- a/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
@@ -136,6 +136,7 @@ describe('useVipDashboard', () => {
     localizedText: {
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
+      transactionsTitle: 'Transactions',
       swapsFeeTitle: 'Swaps fee',
       perpsFeeTitle: 'Perps fee',
       nextTierSwapsFeeDelta: '↓ 9 bps next tier',

--- a/app/components/UI/Rewards/types/navigation.ts
+++ b/app/components/UI/Rewards/types/navigation.ts
@@ -93,6 +93,7 @@ export type RewardsStackParamList = {
   RewardsVipSplashView: undefined;
   RewardsVipView: undefined;
   RewardsVipTiersView: undefined;
+  RewardsVipTransactionsView: undefined;
   RewardsVipRefereeSplashView: undefined;
   RewardsVipRefereeView: undefined;
   RewardsCampaignsView: undefined;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -116,6 +116,7 @@ const Routes = {
   REWARDS_VIP_SPLASH_VIEW: 'RewardsVipSplashView',
   REWARDS_VIP_VIEW: 'RewardsVipView',
   REWARDS_VIP_TIERS_VIEW: 'RewardsVipTiersView',
+  REWARDS_VIP_TRANSACTIONS_VIEW: 'RewardsVipTransactionsView',
   REWARDS_VIP_REFEREE_SPLASH_VIEW: 'RewardsVipRefereeSplashView',
   REWARDS_VIP_REFEREE_VIEW: 'RewardsVipRefereeView',
   REWARDS_CAMPAIGNS_VIEW: 'RewardsCampaignsView',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -665,6 +665,31 @@ export type RewardsControllerGetVipRefereeDashboardAction = {
   handler: RewardsController['getVipRefereeDashboard'];
 };
 
+export type RewardsControllerGetVipTransactionsAction = {
+  type: `RewardsController:getVipTransactions`;
+  handler: RewardsController['getVipTransactions'];
+};
+
+export type RewardsControllerGetVipTransactionsIfChangedAction = {
+  type: `RewardsController:getVipTransactionsIfChanged`;
+  handler: RewardsController['getVipTransactionsIfChanged'];
+};
+
+export type RewardsControllerGetVipTransactionsLastUpdatedAction = {
+  type: `RewardsController:getVipTransactionsLastUpdated`;
+  handler: RewardsController['getVipTransactionsLastUpdated'];
+};
+
+export type RewardsControllerHasVipTransactionsChangedAction = {
+  type: `RewardsController:hasVipTransactionsChanged`;
+  handler: RewardsController['hasVipTransactionsChanged'];
+};
+
+export type RewardsControllerLookupVipTransactionAction = {
+  type: `RewardsController:lookupVipTransaction`;
+  handler: RewardsController['lookupVipTransaction'];
+};
+
 /**
  * Post a benefit impression with caching to prevent duplicate impressions within a short time frame
  * @param subscriptionId - The subscription ID for authentication
@@ -884,6 +909,11 @@ export type RewardsControllerMethodActions =
   | RewardsControllerGetBenefitsAction
   | RewardsControllerGetVIPDashboardAction
   | RewardsControllerGetVipRefereeDashboardAction
+  | RewardsControllerGetVipTransactionsAction
+  | RewardsControllerGetVipTransactionsIfChangedAction
+  | RewardsControllerGetVipTransactionsLastUpdatedAction
+  | RewardsControllerHasVipTransactionsChangedAction
+  | RewardsControllerLookupVipTransactionAction
   | RewardsControllerPostBenefitImpressionAction
   | RewardsControllerApplyReferralCodeAction
   | RewardsControllerApplyBonusCodeAction

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -645,26 +645,6 @@ export type RewardsControllerGetBenefitsAction = {
   handler: RewardsController['getBenefits'];
 };
 
-/**
- * Get the VIP dashboard with caching.
- * @param subscriptionId - The subscription ID for authentication
- * @returns Promise<VipDashboardState | null> - The dashboard data, or null when the user is not VIP
- */
-export type RewardsControllerGetVIPDashboardAction = {
-  type: `RewardsController:getVIPDashboard`;
-  handler: RewardsController['getVIPDashboard'];
-};
-
-/**
- * Get the VIP referee stats with caching.
- * @param subscriptionId - The subscription ID for authentication
- * @returns Promise<VipRefereeMeState | null> - The referee stats, or null when the user is not a VIP referee
- */
-export type RewardsControllerGetVipRefereeDashboardAction = {
-  type: `RewardsController:getVipRefereeDashboard`;
-  handler: RewardsController['getVipRefereeDashboard'];
-};
-
 export type RewardsControllerGetVipTransactionsAction = {
   type: `RewardsController:getVipTransactions`;
   handler: RewardsController['getVipTransactions'];
@@ -688,6 +668,26 @@ export type RewardsControllerHasVipTransactionsChangedAction = {
 export type RewardsControllerLookupVipTransactionAction = {
   type: `RewardsController:lookupVipTransaction`;
   handler: RewardsController['lookupVipTransaction'];
+};
+
+/**
+ * Get the VIP dashboard with caching.
+ * @param subscriptionId - The subscription ID for authentication
+ * @returns Promise<VipDashboardState | null> - The dashboard data, or null when the user is not VIP
+ */
+export type RewardsControllerGetVIPDashboardAction = {
+  type: `RewardsController:getVIPDashboard`;
+  handler: RewardsController['getVIPDashboard'];
+};
+
+/**
+ * Get the VIP referee stats with caching.
+ * @param subscriptionId - The subscription ID for authentication
+ * @returns Promise<VipRefereeMeState | null> - The referee stats, or null when the user is not a VIP referee
+ */
+export type RewardsControllerGetVipRefereeDashboardAction = {
+  type: `RewardsController:getVipRefereeDashboard`;
+  handler: RewardsController['getVipRefereeDashboard'];
 };
 
 /**
@@ -907,13 +907,13 @@ export type RewardsControllerMethodActions =
   | RewardsControllerClaimRewardAction
   | RewardsControllerGetSeasonOneLineaRewardTokensAction
   | RewardsControllerGetBenefitsAction
-  | RewardsControllerGetVIPDashboardAction
-  | RewardsControllerGetVipRefereeDashboardAction
   | RewardsControllerGetVipTransactionsAction
   | RewardsControllerGetVipTransactionsIfChangedAction
   | RewardsControllerGetVipTransactionsLastUpdatedAction
   | RewardsControllerHasVipTransactionsChangedAction
   | RewardsControllerLookupVipTransactionAction
+  | RewardsControllerGetVIPDashboardAction
+  | RewardsControllerGetVipRefereeDashboardAction
   | RewardsControllerPostBenefitImpressionAction
   | RewardsControllerApplyReferralCodeAction
   | RewardsControllerApplyBonusCodeAction

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -21963,6 +21963,251 @@ describe('RewardsController', () => {
     });
   });
 
+  describe('VIP transactions', () => {
+    const subscriptionId = 'sub-vip-transactions';
+    const transaction = {
+      id: 'transaction-id',
+      type: 'PERPS' as const,
+      timestamp: '2026-07-20T12:00:00.000Z',
+      feeUsd: '1.00',
+      volumeUsd: '100.00',
+      perps: {
+        coin: 'ETH',
+        feeCoin: 'USDC',
+        rawFee: '1',
+        rawNotionalVolume: '100',
+        tradeId: '123',
+        orderId: '456',
+      },
+    };
+    const page = {
+      results: [transaction],
+      has_more: false,
+      cursor: null,
+    };
+    let vipTransactionsMessenger: jest.Mocked<RewardsControllerMessenger>;
+
+    beforeEach(() => {
+      vipTransactionsMessenger = {
+        subscribe: jest.fn(),
+        call: jest.fn(),
+        registerActionHandler: jest.fn(),
+        registerMethodActionHandlers: jest.fn(),
+        unregisterActionHandler: jest.fn(),
+        publish: jest.fn(),
+        clearEventSubscriptions: jest.fn(),
+        registerInitialEventPayload: jest.fn(),
+        unsubscribe: jest.fn(),
+      } as unknown as jest.Mocked<RewardsControllerMessenger>;
+    });
+
+    it('does not fetch transactions when VIP is disabled', async () => {
+      const disabledController = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: getRewardsControllerDefaultState(),
+        isVipDisabled: () => true,
+      });
+
+      await expect(
+        disabledController.getVipTransactions({
+          subscriptionId,
+          type: 'PERPS',
+          cursor: null,
+        }),
+      ).resolves.toEqual({ results: [], has_more: false, cursor: null });
+      expect(vipTransactionsMessenger.call).not.toHaveBeenCalled();
+    });
+
+    it('fetches and caches the first page by subscription and type', async () => {
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+      vipTransactionsMessenger.call.mockResolvedValue(page as never);
+
+      await expect(
+        ctrl.getVipTransactions({
+          subscriptionId,
+          type: 'PERPS',
+          cursor: null,
+        }),
+      ).resolves.toEqual(page);
+
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactions',
+        subscriptionId,
+        'PERPS',
+        null,
+      );
+      expect(ctrl.state.vipTransactions[`${subscriptionId}:PERPS`]).toEqual(
+        expect.objectContaining(page),
+      );
+    });
+
+    it('uses the cached first page when last-updated has not changed', async () => {
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          vipTransactions: {
+            [`${subscriptionId}:PERPS`]: {
+              ...page,
+              lastFetched: Date.now() - 1000,
+            },
+          },
+        },
+      });
+      vipTransactionsMessenger.call.mockResolvedValue(
+        new Date(transaction.timestamp) as never,
+      );
+
+      await expect(
+        ctrl.getVipTransactions({
+          subscriptionId,
+          type: 'PERPS',
+          cursor: null,
+          forceFresh: true,
+        }),
+      ).resolves.toEqual(page);
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledTimes(1);
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactionsLastUpdated',
+        subscriptionId,
+        'PERPS',
+      );
+    });
+
+    it('replaces a stale first page when the newest timestamp changes', async () => {
+      const freshPage = {
+        ...page,
+        results: [
+          {
+            ...transaction,
+            id: 'fresh-transaction-id',
+            timestamp: '2026-07-21T12:00:00.000Z',
+          },
+        ],
+      };
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          vipTransactions: {
+            [`${subscriptionId}:PERPS`]: {
+              ...page,
+              lastFetched: Date.now() - 1000,
+            },
+          },
+        },
+      });
+      vipTransactionsMessenger.call
+        .mockResolvedValueOnce(
+          new Date(freshPage.results[0].timestamp) as never,
+        )
+        .mockResolvedValueOnce(freshPage as never);
+
+      await expect(
+        ctrl.getVipTransactions({
+          subscriptionId,
+          type: 'PERPS',
+          cursor: null,
+        }),
+      ).resolves.toEqual(freshPage);
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactions',
+        subscriptionId,
+        'PERPS',
+        null,
+      );
+      expect(
+        ctrl.state.vipTransactions[`${subscriptionId}:PERPS`].results[0].id,
+      ).toBe('fresh-transaction-id');
+    });
+
+    it('fetches cursor pages directly without changing first-page cache', async () => {
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+      vipTransactionsMessenger.call.mockResolvedValue(page as never);
+
+      await ctrl.getVipTransactions({
+        subscriptionId,
+        type: 'SWAP',
+        cursor: 'page-2',
+      });
+
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactions',
+        subscriptionId,
+        'SWAP',
+        'page-2',
+      );
+      expect(ctrl.state.vipTransactions).toEqual({});
+    });
+
+    it('looks up a transaction without caching it', async () => {
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: getRewardsControllerDefaultState(),
+      });
+      vipTransactionsMessenger.call.mockResolvedValue(transaction as never);
+
+      await expect(
+        ctrl.lookupVipTransaction(subscriptionId, '123'),
+      ).resolves.toEqual(transaction);
+      expect(vipTransactionsMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:lookupVipTransaction',
+        subscriptionId,
+        '123',
+      );
+      expect(ctrl.state.vipTransactions).toEqual({});
+    });
+
+    it('returns null from lookup without a network call when VIP is disabled', async () => {
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: getRewardsControllerDefaultState(),
+        isVipDisabled: () => true,
+      });
+
+      await expect(
+        ctrl.lookupVipTransaction(subscriptionId, '123'),
+      ).resolves.toBeNull();
+      expect(vipTransactionsMessenger.call).not.toHaveBeenCalled();
+    });
+
+    it('invalidates every transaction type for the subscription', () => {
+      const otherSubscriptionId = 'other-subscription';
+      const ctrl = new RewardsController({
+        messenger: vipTransactionsMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          vipTransactions: {
+            [`${subscriptionId}:PERPS`]: {
+              ...page,
+              lastFetched: Date.now(),
+            },
+            [`${subscriptionId}:SWAP`]: {
+              ...page,
+              lastFetched: Date.now(),
+            },
+            [`${otherSubscriptionId}:PERPS`]: {
+              ...page,
+              lastFetched: Date.now(),
+            },
+          },
+        },
+      });
+
+      ctrl.invalidateSubscriptionCache({ subscriptionId });
+
+      expect(ctrl.state.vipTransactions).toEqual({
+        [`${otherSubscriptionId}:PERPS`]: expect.any(Object),
+      });
+    });
+  });
+
   describe('getOndoCampaignActivity', () => {
     let ondoActivityMessenger: jest.Mocked<RewardsControllerMessenger>;
     const mockCampaignId = 'campaign-ondo-activity';

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7436,6 +7436,7 @@ describe('RewardsController', () => {
       localizedText: {
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
+        transactionsTitle: 'Transactions',
         swapsFeeTitle: 'Swaps fee',
         perpsFeeTitle: 'Perps fee',
         nextTierSwapsFeeDelta: '↓ 9 bps next tier',
@@ -10628,6 +10629,7 @@ describe('RewardsController', () => {
               localizedText: {
                 periodTitle: 'Jun 1 - Jun 30',
                 memberIdTitle: 'Member ID',
+                transactionsTitle: 'Transactions',
                 swapsFeeTitle: 'Swaps fee',
                 perpsFeeTitle: 'Perps fee',
                 nextTierSwapsFeeDelta: '↓ 9 bps next tier',
@@ -17525,6 +17527,7 @@ describe('RewardsController', () => {
       vipDashboard: {},
       vipRefereeDashboard: {},
       vipPerpsFees: {},
+      vipTransactions: {},
     });
   });
 
@@ -17564,6 +17567,7 @@ describe('RewardsController', () => {
       vipDashboard: {},
       vipRefereeDashboard: {},
       vipPerpsFees: {},
+      vipTransactions: {},
     });
   });
 
@@ -17605,6 +17609,7 @@ describe('RewardsController', () => {
       unlockedRewards: {},
       vipDashboard: {},
       vipRefereeDashboard: {},
+      vipTransactions: {},
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -62,6 +62,10 @@ import {
   type VipRefereeMeState,
   type VipFeesResponseDto,
   type VipPerpsFeesState,
+  type GetVipTransactionsDto,
+  type PaginatedVipTransactionsDto,
+  type VipTransactionDto,
+  type VipTransactionsState,
   CampaignType,
 } from './types';
 import {
@@ -128,6 +132,10 @@ const VIP_DASHBOARD_CACHE_THRESHOLD_MS = 1000 * 60 * 5;
 // VIP perps fees cache threshold — read on every perps trade UI render, so
 // cache for the same 5-minute window as the legacy public-discount path.
 const VIP_PERPS_FEES_CACHE_THRESHOLD_MS = 1000 * 60 * 5;
+
+// VIP transactions cache threshold (first page only).
+// Disabled so each first-page read checks the backend last-updated timestamp.
+const VIP_TRANSACTIONS_CACHE_THRESHOLD_MS = 0;
 
 // Active boosts cache threshold
 const ACTIVE_BOOSTS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
@@ -397,6 +405,12 @@ const metadata: StateMetadata<RewardsControllerState> = {
     includeInDebugSnapshot: false,
     usedInUi: false,
   },
+  vipTransactions: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: true,
+  },
 };
 
 export { defaultRewardsControllerState, getRewardsControllerDefaultState };
@@ -554,6 +568,9 @@ const MESSENGER_EXPOSED_METHODS = [
   'getPredictThePitchPrizePool',
   'getPerpsDiscountForAccount',
   'getVipTierForAccount',
+  'getVipTransactions',
+  'getVipTransactionsIfChanged',
+  'getVipTransactionsLastUpdated',
   'getPointsEvents',
   'getPointsEventsIfChanged',
   'getPointsEventsLastUpdated',
@@ -569,6 +586,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'hasActiveSeason',
   'hasActivityChanged',
   'hasPointsEventsChanged',
+  'hasVipTransactionsChanged',
   'invalidateReferralDetailsCache',
   'invalidateSubscriptionAndAccounts',
   'invalidateSubscriptionCache',
@@ -577,6 +595,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'isVipFeatureEnabled',
   'linkAccountsToSubscriptionCandidate',
   'linkAccountToSubscriptionCandidate',
+  'lookupVipTransaction',
   'logout',
   'optIn',
   'optInToCampaign',
@@ -770,6 +789,31 @@ export class RewardsController extends BaseController<
       })),
       cursor: state.cursor,
       has_more: state.has_more,
+    };
+  }
+
+  #convertVipTransactionsToState(
+    transactions: PaginatedVipTransactionsDto,
+  ): VipTransactionsState {
+    return {
+      results: transactions.results.map((transaction) => ({
+        ...transaction,
+      })),
+      has_more: transactions.has_more,
+      cursor: transactions.cursor,
+      lastFetched: Date.now(),
+    };
+  }
+
+  #convertVipTransactionsStateToDto(
+    state: VipTransactionsState,
+  ): PaginatedVipTransactionsDto {
+    return {
+      results: state.results.map((transaction) => ({
+        ...transaction,
+      })),
+      has_more: state.has_more,
+      cursor: state.cursor,
     };
   }
 
@@ -4591,6 +4635,136 @@ export class RewardsController extends BaseController<
     });
   }
 
+  async getVipTransactions(
+    params: GetVipTransactionsDto,
+  ): Promise<PaginatedVipTransactionsDto> {
+    if (!this.isVipFeatureEnabled()) {
+      return { results: [], has_more: false, cursor: null };
+    }
+
+    const { subscriptionId, type, cursor, forceFresh } = params;
+    if (cursor) {
+      return this.#withAuthRetry(
+        () =>
+          this.messenger.call(
+            'RewardsDataService:getVipTransactions',
+            subscriptionId,
+            type,
+            cursor,
+          ),
+        subscriptionId,
+      );
+    }
+
+    if (forceFresh) {
+      return this.#withAuthRetry(
+        () => this.getVipTransactionsIfChanged(subscriptionId, type),
+        subscriptionId,
+      );
+    }
+
+    const key = `${subscriptionId}:${type}`;
+    return wrapWithCache<PaginatedVipTransactionsDto>({
+      key,
+      ttl: VIP_TRANSACTIONS_CACHE_THRESHOLD_MS,
+      readCache: (cacheKey) => {
+        const cached = this.state.vipTransactions[cacheKey];
+        return cached
+          ? {
+              payload: this.#convertVipTransactionsStateToDto(cached),
+              lastFetched: cached.lastFetched,
+            }
+          : undefined;
+      },
+      fetchFresh: () =>
+        this.#withAuthRetry(
+          () => this.getVipTransactionsIfChanged(subscriptionId, type),
+          subscriptionId,
+        ),
+      writeCache: (cacheKey, transactions) => {
+        this.update((state) => {
+          state.vipTransactions[cacheKey] =
+            this.#convertVipTransactionsToState(transactions);
+        });
+      },
+    });
+  }
+
+  async getVipTransactionsIfChanged(
+    subscriptionId: string,
+    type: GetVipTransactionsDto['type'],
+  ): Promise<PaginatedVipTransactionsDto> {
+    if (!this.isVipFeatureEnabled()) {
+      return { results: [], has_more: false, cursor: null };
+    }
+
+    const key = `${subscriptionId}:${type}`;
+    if (!(await this.hasVipTransactionsChanged(subscriptionId, type))) {
+      const cached = this.state.vipTransactions[key];
+      return cached
+        ? this.#convertVipTransactionsStateToDto(cached)
+        : { results: [], has_more: false, cursor: null };
+    }
+
+    return this.messenger.call(
+      'RewardsDataService:getVipTransactions',
+      subscriptionId,
+      type,
+      null,
+    );
+  }
+
+  async getVipTransactionsLastUpdated(
+    subscriptionId: string,
+    type: GetVipTransactionsDto['type'],
+  ): Promise<Date | null> {
+    if (!this.isVipFeatureEnabled()) return null;
+    return this.#withAuthRetry(
+      () =>
+        this.messenger.call(
+          'RewardsDataService:getVipTransactionsLastUpdated',
+          subscriptionId,
+          type,
+        ),
+      subscriptionId,
+    );
+  }
+
+  async hasVipTransactionsChanged(
+    subscriptionId: string,
+    type: GetVipTransactionsDto['type'],
+  ): Promise<boolean> {
+    if (!this.isVipFeatureEnabled()) return false;
+
+    const cached = this.state.vipTransactions[`${subscriptionId}:${type}`];
+    const cachedLatestTimestamp = cached?.results[0]?.timestamp;
+    if (!cachedLatestTimestamp) return true;
+
+    const lastUpdated = await this.getVipTransactionsLastUpdated(
+      subscriptionId,
+      type,
+    );
+    return lastUpdated
+      ? lastUpdated.toISOString() !== cachedLatestTimestamp
+      : true;
+  }
+
+  async lookupVipTransaction(
+    subscriptionId: string,
+    key: string,
+  ): Promise<VipTransactionDto | null> {
+    if (!this.isVipFeatureEnabled()) return null;
+    return this.#withAuthRetry(
+      () =>
+        this.messenger.call(
+          'RewardsDataService:lookupVipTransaction',
+          subscriptionId,
+          key,
+        ),
+      subscriptionId,
+    );
+  }
+
   /**
    * Get the VIP dashboard with caching.
    * @param subscriptionId - The subscription ID for authentication
@@ -4976,6 +5150,11 @@ export class RewardsController extends BaseController<
         delete state.vipDashboard?.[subscriptionId];
         delete state.vipRefereeDashboard?.[subscriptionId];
         delete state.vipPerpsFees?.[subscriptionId];
+        deleteMatchingCacheEntries(
+          state.vipTransactions,
+          (key) =>
+            key === subscriptionId || key.startsWith(`${subscriptionId}:`),
+        );
         delete state.offDeviceSubscriptionAccounts?.[subscriptionId];
         delete state.subscriptionReferralDetails?.[subscriptionId];
       }

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -979,6 +979,16 @@ export class RewardsController extends BaseController<
     return `${subscriptionId}:${campaignId}`;
   }
 
+  /**
+   * Create VIP transactions composite key for state storage
+   */
+  #createVIPCompositeKey(
+    subscriptionId: string,
+    type: GetVipTransactionsDto['type'],
+  ): string {
+    return `${subscriptionId}:${type}`;
+  }
+
   #matchesSeasonSubscriptionCacheKey(
     key: string,
     subscriptionId: string,
@@ -4663,7 +4673,7 @@ export class RewardsController extends BaseController<
       );
     }
 
-    const key = `${subscriptionId}:${type}`;
+    const key = this.#createVIPCompositeKey(subscriptionId, type);
     return wrapWithCache<PaginatedVipTransactionsDto>({
       key,
       ttl: VIP_TRANSACTIONS_CACHE_THRESHOLD_MS,
@@ -4698,7 +4708,7 @@ export class RewardsController extends BaseController<
       return { results: [], has_more: false, cursor: null };
     }
 
-    const key = `${subscriptionId}:${type}`;
+    const key = this.#createVIPCompositeKey(subscriptionId, type);
     if (!(await this.hasVipTransactionsChanged(subscriptionId, type))) {
       const cached = this.state.vipTransactions[key];
       return cached
@@ -4736,7 +4746,10 @@ export class RewardsController extends BaseController<
   ): Promise<boolean> {
     if (!this.isVipFeatureEnabled()) return false;
 
-    const cached = this.state.vipTransactions[`${subscriptionId}:${type}`];
+    const cached =
+      this.state.vipTransactions[
+        this.#createVIPCompositeKey(subscriptionId, type)
+      ];
     const cachedLatestTimestamp = cached?.results[0]?.timestamp;
     if (!cachedLatestTimestamp) return true;
 

--- a/app/core/Engine/controllers/rewards-controller/defaultState.ts
+++ b/app/core/Engine/controllers/rewards-controller/defaultState.ts
@@ -11,6 +11,7 @@ export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
   vipDashboard: {},
   vipRefereeDashboard: {},
   vipPerpsFees: {},
+  vipTransactions: {},
   seasons: {},
   subscriptionReferralDetails: {},
   seasonStatuses: {},

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -4456,6 +4456,7 @@ describe('RewardsDataService', () => {
       localizedText: {
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
+        transactionsTitle: 'Transactions',
         swapsFeeTitle: 'Swaps fee',
         perpsFeeTitle: 'Perps fee',
         nextTierSwapsFeeDelta: '↓ 9 bps next tier',

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -214,6 +214,18 @@ describe('RewardsDataService', () => {
         expect.any(Function),
       );
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactions',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:lookupVipTransaction',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getVipTransactionsLastUpdated',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
         'RewardsDataService:postBenefitImpression',
         expect.any(Function),
       );
@@ -4639,6 +4651,126 @@ describe('RewardsDataService', () => {
       await expect(service.getVipFees(mockSubscriptionId)).rejects.toThrow(
         'Get VIP fees failed: 500',
       );
+    });
+  });
+
+  describe('VIP transactions', () => {
+    const subscriptionId = 'sub-vip-transactions';
+    const token = 'vip-transactions-token';
+    const transaction = {
+      id: 'transaction-id',
+      type: 'PERPS' as const,
+      timestamp: '2026-07-20T12:00:00.000Z',
+      feeUsd: '1.00',
+      volumeUsd: '100.00',
+      perps: {
+        coin: 'ETH',
+        feeCoin: 'USDC',
+        rawFee: '1',
+        rawNotionalVolume: '100',
+        tradeId: '123',
+        orderId: '456',
+      },
+    };
+
+    beforeEach(() => {
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token,
+      });
+    });
+
+    it('fetches an encoded page of VIP transactions', async () => {
+      const page = {
+        results: [transaction],
+        has_more: false,
+        cursor: null,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(page),
+      } as unknown as Response);
+
+      const result = await service.getVipTransactions(
+        subscriptionId,
+        'PERPS',
+        'next cursor',
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://uat.rewards.test/vip/transactions?type=PERPS&cursor=next%20cursor',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual(page);
+    });
+
+    it('looks up a VIP transaction by encoded natural key', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(transaction),
+      } as unknown as Response);
+
+      await expect(
+        service.lookupVipTransaction(subscriptionId, 'quote/id?'),
+      ).resolves.toEqual(transaction);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://uat.rewards.test/vip/transactions/lookup?key=quote%2Fid%3F',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('returns the VIP transaction last-updated timestamp as a Date', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+          lastUpdated: '2026-07-20T12:00:00.000Z',
+        }),
+      } as unknown as Response);
+
+      await expect(
+        service.getVipTransactionsLastUpdated(subscriptionId, 'SWAP'),
+      ).resolves.toEqual(new Date('2026-07-20T12:00:00.000Z'));
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://uat.rewards.test/vip/transactions/last-updated?type=SWAP',
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+
+    it('returns null when no VIP transaction has been recorded', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ lastUpdated: null }),
+      } as unknown as Response);
+
+      await expect(
+        service.getVipTransactionsLastUpdated(subscriptionId, 'PERPS'),
+      ).resolves.toBeNull();
+    });
+
+    it.each([
+      [
+        'getVipTransactions',
+        () => service.getVipTransactions(subscriptionId, 'PERPS', null),
+      ],
+      [
+        'lookupVipTransaction',
+        () => service.lookupVipTransaction(subscriptionId, '123'),
+      ],
+      [
+        'getVipTransactionsLastUpdated',
+        () => service.getVipTransactionsLastUpdated(subscriptionId, 'PERPS'),
+      ],
+    ])('throws when %s receives an unsuccessful response', async (_, call) => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      await expect(call()).rejects.toThrow('failed: 500');
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -46,6 +46,10 @@ import type {
   VipDashboardDto,
   VipRefereeMeDto,
   VipFeesResponseDto,
+  VipTransactionDto,
+  VipTransactionType,
+  PaginatedVipTransactionsDto,
+  VipTransactionsLastUpdatedDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import Logger from '../../../../../util/Logger';
@@ -358,6 +362,21 @@ export interface RewardsDataServiceGetVipFeesAction {
   handler: RewardsDataService['getVipFees'];
 }
 
+export interface RewardsDataServiceGetVipTransactionsAction {
+  type: `${typeof SERVICE_NAME}:getVipTransactions`;
+  handler: RewardsDataService['getVipTransactions'];
+}
+
+export interface RewardsDataServiceLookupVipTransactionAction {
+  type: `${typeof SERVICE_NAME}:lookupVipTransaction`;
+  handler: RewardsDataService['lookupVipTransaction'];
+}
+
+export interface RewardsDataServiceGetVipTransactionsLastUpdatedAction {
+  type: `${typeof SERVICE_NAME}:getVipTransactionsLastUpdated`;
+  handler: RewardsDataService['getVipTransactionsLastUpdated'];
+}
+
 export interface RewardsDataServicePostBenefitImpressionAction {
   type: `${typeof SERVICE_NAME}:postBenefitImpression`;
   handler: RewardsDataService['postBenefitImpression'];
@@ -397,6 +416,9 @@ export type RewardsDataServiceActions =
   | RewardsDataServiceGetVIPDashboardAction
   | RewardsDataServiceGetVipRefereeDashboardAction
   | RewardsDataServiceGetVipFeesAction
+  | RewardsDataServiceGetVipTransactionsAction
+  | RewardsDataServiceLookupVipTransactionAction
+  | RewardsDataServiceGetVipTransactionsLastUpdatedAction
   | RewardsDataServicePostBenefitImpressionAction
   | RewardsDataServiceGetCampaignParticipantStatusAction
   | RewardsDataServiceGetClientVersionRequirementsAction
@@ -654,6 +676,18 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:getVipFees`,
       this.getVipFees.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getVipTransactions`,
+      this.getVipTransactions.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:lookupVipTransaction`,
+      this.lookupVipTransaction.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getVipTransactionsLastUpdated`,
+      this.getVipTransactionsLastUpdated.bind(this),
     );
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:postBenefitImpression`,
@@ -1686,6 +1720,62 @@ export class RewardsDataService {
     }
 
     return (await response.json()) as VipFeesResponseDto;
+  }
+
+  async getVipTransactions(
+    subscriptionId: string,
+    type: VipTransactionType,
+    cursor: string | null,
+  ): Promise<PaginatedVipTransactionsDto> {
+    const query = [`type=${encodeURIComponent(type)}`];
+    if (cursor) {
+      query.push(`cursor=${encodeURIComponent(cursor)}`);
+    }
+    const response = await this.makeRequest(
+      `/vip/transactions?${query.join('&')}`,
+      { method: 'GET' },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      throw new Error(`Get VIP transactions failed: ${response.status}`);
+    }
+    return (await response.json()) as PaginatedVipTransactionsDto;
+  }
+
+  async lookupVipTransaction(
+    subscriptionId: string,
+    key: string,
+  ): Promise<VipTransactionDto> {
+    const response = await this.makeRequest(
+      `/vip/transactions/lookup?key=${encodeURIComponent(key)}`,
+      { method: 'GET' },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      throw new Error(`Lookup VIP transaction failed: ${response.status}`);
+    }
+    return (await response.json()) as VipTransactionDto;
+  }
+
+  async getVipTransactionsLastUpdated(
+    subscriptionId: string,
+    type: VipTransactionType,
+  ): Promise<Date | null> {
+    const response = await this.makeRequest(
+      `/vip/transactions/last-updated?type=${encodeURIComponent(type)}`,
+      { method: 'GET' },
+      subscriptionId,
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Get VIP transactions last updated failed: ${response.status}`,
+      );
+    }
+    const result = (await response.json()) as VipTransactionsLastUpdatedDto;
+    return result.lastUpdated ? new Date(result.lastUpdated) : null;
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -198,6 +198,78 @@ export type VipFeesResponseDto = {
   updatedAt: string | null;
 };
 
+export type VipTransactionType = 'PERPS' | 'SWAP';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipPerpsTransactionDetailDto = {
+  coin: string;
+  feeCoin: string;
+  rawFee: string;
+  rawNotionalVolume: string;
+  tradeId: string;
+  orderId: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipSwapTransactionDetailDto = {
+  quoteId: string;
+  bridgeId?: string;
+  srcChainId: string;
+  srcAssetSymbol?: string;
+  destChainId: string;
+  destAssetSymbol?: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipTransactionDto = {
+  id: string;
+  type: VipTransactionType;
+  timestamp: string;
+  feeUsd: string;
+  volumeUsd: string;
+  perps?: VipPerpsTransactionDetailDto;
+  swap?: VipSwapTransactionDetailDto;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type PaginatedVipTransactionsDto = {
+  results: VipTransactionDto[];
+  has_more: boolean;
+  cursor: string | null;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type GetVipTransactionsDto = {
+  subscriptionId: string;
+  type: VipTransactionType;
+  cursor: string | null;
+  forceFresh?: boolean;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipTransactionsLastUpdatedDto = {
+  lastUpdated: string | null;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipTransactionEntryState = {
+  id: string;
+  type: VipTransactionType;
+  timestamp: string;
+  feeUsd: string;
+  volumeUsd: string;
+  perps?: VipPerpsTransactionDetailDto;
+  swap?: VipSwapTransactionDetailDto;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipTransactionsState = {
+  results: VipTransactionEntryState[];
+  has_more: boolean;
+  cursor: string | null;
+  lastFetched: number;
+};
+
 // Per-subscription cache for VIP perps builder fee.
 // We store the raw bips string from the backend rather than a derived
 // discount so the cache stays valid if the perps base fee constant changes.
@@ -2371,6 +2443,10 @@ export type RewardsControllerState = {
   };
   vipPerpsFees: {
     [subscriptionId: string]: VipPerpsFeesState;
+  };
+  /** First-page VIP transactions keyed by subscriptionId:type. */
+  vipTransactions: {
+    [compositeId: string]: VipTransactionsState;
   };
   seasonStatuses: { [compositeId: string]: SeasonStatusState };
   activeBoosts: { [compositeId: string]: ActiveBoostsState };

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -107,6 +107,7 @@ export type VipTierDto = {
 export type VipLocalizedTextDto = {
   periodTitle: string;
   memberIdTitle: string;
+  transactionsTitle: string;
   swapsFeeTitle: string;
   perpsFeeTitle: string;
   revenueShareTitle: string;

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -61,6 +61,9 @@ import {
   RewardsDataServiceGetVIPDashboardAction,
   RewardsDataServiceGetVipRefereeDashboardAction,
   RewardsDataServiceGetVipFeesAction,
+  RewardsDataServiceGetVipTransactionsAction,
+  RewardsDataServiceLookupVipTransactionAction,
+  RewardsDataServiceGetVipTransactionsLastUpdatedAction,
   RewardsDataServicePostBenefitImpressionAction,
   RewardsDataServiceGetClientVersionRequirementsAction,
   RewardsDataServiceGetFirstPredictOnUsAction,
@@ -139,6 +142,9 @@ type AllowedActions =
   | RewardsDataServiceGetVIPDashboardAction
   | RewardsDataServiceGetVipRefereeDashboardAction
   | RewardsDataServiceGetVipFeesAction
+  | RewardsDataServiceGetVipTransactionsAction
+  | RewardsDataServiceLookupVipTransactionAction
+  | RewardsDataServiceGetVipTransactionsLastUpdatedAction
   | RewardsDataServiceGetPerpsTradingCampaignParticipantOutcomeAction
   | RewardsDataServiceGetPredictThePitchLeaderboardAction
   | RewardsDataServiceGetPredictThePitchLeaderboardPositionAction
@@ -225,6 +231,9 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getVIPDashboard',
       'RewardsDataService:getVipRefereeDashboard',
       'RewardsDataService:getVipFees',
+      'RewardsDataService:getVipTransactions',
+      'RewardsDataService:lookupVipTransaction',
+      'RewardsDataService:getVipTransactionsLastUpdated',
       'RewardsDataService:postBenefitImpression',
       'RewardsDataService:getClientVersionRequirements',
       'RewardsDataService:getFirstPredictOnUs',

--- a/app/reducers/rewards/compositeKeys.test.ts
+++ b/app/reducers/rewards/compositeKeys.test.ts
@@ -1,6 +1,7 @@
 import {
   buildCampaignOutcomeToastCompositeKey,
   buildSubscriptionCampaignCompositeKey,
+  buildSubscriptionVipTransactionCompositeKey,
 } from './compositeKeys';
 
 describe('rewards compositeKeys', () => {
@@ -9,6 +10,14 @@ describe('rewards compositeKeys', () => {
       expect(buildSubscriptionCampaignCompositeKey('sub-1', 'camp-2')).toBe(
         'sub-1:camp-2',
       );
+    });
+  });
+
+  describe('buildSubscriptionVipTransactionCompositeKey', () => {
+    it('joins subscription id and vip transaction type', () => {
+      expect(
+        buildSubscriptionVipTransactionCompositeKey('sub-1', 'PERPS'),
+      ).toBe('sub-1:PERPS');
     });
   });
 

--- a/app/reducers/rewards/compositeKeys.ts
+++ b/app/reducers/rewards/compositeKeys.ts
@@ -1,3 +1,5 @@
+import type { VipTransactionType } from '../../core/Engine/controllers/rewards-controller/types';
+
 export type CampaignOutcomeToastVariant = 'winner' | 'non_winner';
 
 /**
@@ -9,6 +11,17 @@ export function buildSubscriptionCampaignCompositeKey(
   campaignId: string,
 ): string {
   return `${subscriptionId}:${campaignId}`;
+}
+
+/**
+ * Composite key for subscription-scoped VIP transactions in the rewards Redux
+ * slice (`subscriptionId:type`).
+ */
+export function buildSubscriptionVipTransactionCompositeKey(
+  subscriptionId: string,
+  type: VipTransactionType,
+): string {
+  return `${subscriptionId}:${type}`;
 }
 
 /**

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -46,6 +46,7 @@ import rewardsReducer, {
   setOndoCampaignLeaderboardPosition,
   setOndoCampaignPortfolioPosition,
   setOndoCampaignActivity,
+  setVipTransactions,
   setOndoCampaignDeposits,
   setOndoCampaignDepositsLoading,
   setOndoCampaignDepositsError,
@@ -98,6 +99,7 @@ import {
   PredictThePitchPositionsDto,
   PredictThePitchPrizePoolDto,
   VipDashboardState,
+  VipTransactionDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { AccountGroupId } from '@metamask/account-api';
 import { brandColor } from '@metamask/design-tokens';
@@ -2119,6 +2121,7 @@ describe('rewardsReducer', () => {
         ondoCampaignLeaderboardPositions: {},
         ondoCampaignPortfolio: {},
         ondoCampaignActivity: {},
+        vipTransactions: {},
         ondoCampaignDeposits: {},
         versionGuardMinimumMobileVersion: null,
         versionGuardLoading: false,
@@ -2253,6 +2256,7 @@ describe('rewardsReducer', () => {
         ondoCampaignLeaderboardPositions: {},
         ondoCampaignPortfolio: {},
         ondoCampaignActivity: {},
+        vipTransactions: {},
         ondoCampaignDeposits: {},
         versionGuardMinimumMobileVersion: null,
         versionGuardLoading: false,
@@ -4891,6 +4895,7 @@ describe('setVipDashboard', () => {
     localizedText: {
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
+      transactionsTitle: 'Transactions',
       swapsFeeTitle: 'Swaps fee',
       perpsFeeTitle: 'Perps fee',
       nextTierSwapsFeeDelta: '↓ 9 bps next tier',
@@ -6124,6 +6129,58 @@ describe('setOndoCampaignActivity', () => {
     const state = rewardsReducer(initialState, action);
 
     expect(state.ondoCampaignActivity['sub-1:campaign-1']).toBeNull();
+  });
+});
+
+describe('setVipTransactions', () => {
+  const mockTransactions: VipTransactionDto[] = [
+    {
+      id: 'transaction-1',
+      type: 'SWAP',
+      timestamp: '2026-07-22T12:00:00.000Z',
+      feeUsd: '1.25',
+      volumeUsd: '250.00',
+      swap: {
+        quoteId: 'quote-1',
+        srcChainId: '1',
+        destChainId: '59144',
+      },
+    },
+  ];
+
+  it('sets transactions by subscription and transaction type', () => {
+    const action = setVipTransactions({
+      subscriptionId: 'sub-1',
+      type: 'SWAP',
+      transactions: mockTransactions,
+    });
+
+    const state = rewardsReducer(initialState, action);
+
+    expect(state.vipTransactions['sub-1:SWAP']).toEqual(mockTransactions);
+  });
+
+  it('stores null for a loaded transaction type with no result', () => {
+    const action = setVipTransactions({
+      subscriptionId: 'sub-1',
+      type: 'PERPS',
+      transactions: null,
+    });
+
+    const state = rewardsReducer(initialState, action);
+
+    expect(state.vipTransactions['sub-1:PERPS']).toBeNull();
+  });
+
+  it('clears transactions when rewards state resets', () => {
+    const stateWithTransactions: RewardsState = {
+      ...initialState,
+      vipTransactions: { 'sub-1:SWAP': mockTransactions },
+    };
+
+    const state = rewardsReducer(stateWithTransactions, resetRewardsState());
+
+    expect(state.vipTransactions).toEqual({});
   });
 });
 

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -26,10 +26,13 @@ import {
   PredictThePitchPrizePoolDto,
   VipDashboardState,
   VipRefereeMeState,
+  VipTransactionDto,
+  VipTransactionType,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import {
   buildCampaignOutcomeToastCompositeKey,
   buildSubscriptionCampaignCompositeKey,
+  buildSubscriptionVipTransactionCompositeKey,
 } from './compositeKeys';
 import {
   type CampaignResourceCacheEntry,
@@ -156,6 +159,8 @@ export interface RewardsState {
   vipRefereeDashboardError: boolean;
   vipSplashAccepted: Record<string, boolean>;
   vipRefereeSplashAccepted: Record<string, boolean>;
+  // VIP transactions (keyed by `${subscriptionId}:${type}`)
+  vipTransactions: Record<string, VipTransactionDto[] | null>;
 
   // Campaigns state
   campaigns: CampaignDto[];
@@ -323,6 +328,7 @@ export const initialState: RewardsState = {
   vipRefereeDashboardError: false,
   vipSplashAccepted: {},
   vipRefereeSplashAccepted: {},
+  vipTransactions: {},
 
   // Campaigns initial state
   campaigns: [],
@@ -495,6 +501,7 @@ const rewardsSlice = createSlice({
       state.vipRefereeDashboardError = false;
       state.vipSplashAccepted = {};
       state.vipRefereeSplashAccepted = {};
+      state.vipTransactions = {};
     },
 
     setOnboardingActiveStep: (state, action: PayloadAction<OnboardingStep>) => {
@@ -861,6 +868,21 @@ const rewardsSlice = createSlice({
       action: PayloadAction<{ subscriptionId: string }>,
     ) => {
       state.vipRefereeSplashAccepted[action.payload.subscriptionId] = true;
+    },
+
+    setVipTransactions: (
+      state,
+      action: PayloadAction<{
+        subscriptionId: string;
+        type: VipTransactionType;
+        transactions: VipTransactionDto[] | null;
+      }>,
+    ) => {
+      const key = buildSubscriptionVipTransactionCompositeKey(
+        action.payload.subscriptionId,
+        action.payload.type,
+      );
+      state.vipTransactions[key] = action.payload.transactions;
     },
 
     setOndoCampaignActivity: (
@@ -1276,6 +1298,7 @@ const rewardsSlice = createSlice({
               vipSplashAccepted: action.payload.rewards.vipSplashAccepted ?? {},
               vipRefereeSplashAccepted:
                 action.payload.rewards.vipRefereeSplashAccepted ?? {},
+              vipTransactions: action.payload.rewards.vipTransactions ?? {},
               campaignParticipantStatuses:
                 action.payload.rewards.campaignParticipantStatuses ?? {},
               ondoCampaignLeaderboardPositions:
@@ -1361,6 +1384,7 @@ export const {
   setVipRefereeDashboardLoading,
   acceptVipInvite,
   acceptVipRefereeInvite,
+  setVipTransactions,
   // Campaigns actions
   setCampaigns,
   setCampaignsLoading,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -77,6 +77,7 @@ import {
   selectOndoCampaignPortfolio,
   selectOndoCampaignPortfolioById,
   selectOndoCampaignActivityById,
+  selectVipTransactionsById,
   selectPredictThePitchLeaderboardByCampaignId,
   selectPredictThePitchLeaderboardLoadingByCampaignId,
   selectPredictThePitchLeaderboardErrorByCampaignId,
@@ -103,6 +104,7 @@ import {
   OndoGmActivityEntryDto,
   SubscriptionBenefitDto,
   VipDashboardState,
+  VipTransactionDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { RootState } from '..';
 import { RewardsState, AccountOptInBannerInfoStatus } from '.';
@@ -3251,6 +3253,7 @@ describe('Rewards selectors', () => {
       localizedText: {
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
+        transactionsTitle: 'Transactions',
         swapsFeeTitle: 'Swaps fee',
         perpsFeeTitle: 'Perps fee',
         nextTierSwapsFeeDelta: '↓ 9 bps next tier',
@@ -4253,6 +4256,51 @@ describe('Rewards selectors', () => {
       expect(
         selectOndoCampaignActivityById('sub-1', 'campaign-1')(state),
       ).toEqual(mockEntries);
+    });
+  });
+
+  describe('selectVipTransactionsById', () => {
+    const mockTransactions: VipTransactionDto[] = [
+      {
+        id: 'transaction-1',
+        type: 'PERPS',
+        timestamp: '2026-07-22T12:00:00.000Z',
+        feeUsd: '2.50',
+        volumeUsd: '500.00',
+        perps: {
+          coin: 'ETH',
+          feeCoin: 'USDC',
+          rawFee: '2.50',
+          rawNotionalVolume: '500.00',
+          tradeId: 'trade-1',
+          orderId: 'order-1',
+        },
+      },
+    ];
+
+    it('returns null when an identifier is undefined', () => {
+      const state = createMockRootState({
+        vipTransactions: { 'sub-1:PERPS': mockTransactions },
+      });
+
+      expect(selectVipTransactionsById(undefined, 'PERPS')(state)).toBeNull();
+      expect(selectVipTransactionsById('sub-1', undefined)(state)).toBeNull();
+    });
+
+    it('returns null when transactions do not exist', () => {
+      const state = createMockRootState({ vipTransactions: {} });
+
+      expect(selectVipTransactionsById('sub-1', 'PERPS')(state)).toBeNull();
+    });
+
+    it('returns transactions for the specified subscription and type', () => {
+      const state = createMockRootState({
+        vipTransactions: { 'sub-1:PERPS': mockTransactions },
+      });
+
+      expect(selectVipTransactionsById('sub-1', 'PERPS')(state)).toEqual(
+        mockTransactions,
+      );
     });
   });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -5,6 +5,7 @@ import { RewardsTab, OnboardingStep } from './types';
 import { hasMinimumRequiredVersion } from '../../util/remoteFeatureFlag';
 import {
   buildSubscriptionCampaignCompositeKey,
+  buildSubscriptionVipTransactionCompositeKey,
   buildCampaignOutcomeToastCompositeKey,
   type CampaignOutcomeToastVariant,
 } from './compositeKeys';
@@ -15,6 +16,7 @@ import type {
   PerpsTradingCampaignVolumeDto,
   PredictThePitchLeaderboardDto,
   PredictThePitchPrizePoolDto,
+  VipTransactionType,
 } from '../../core/Engine/controllers/rewards-controller/types';
 
 export const selectActiveTab = (state: RootState): RewardsTab =>
@@ -414,6 +416,15 @@ export const selectOndoCampaignActivityById =
     subscriptionId && campaignId && state.rewards.ondoCampaignActivity
       ? (state.rewards.ondoCampaignActivity[
           buildSubscriptionCampaignCompositeKey(subscriptionId, campaignId)
+        ] ?? null)
+      : null;
+
+export const selectVipTransactionsById =
+  (subscriptionId: string | undefined, type: VipTransactionType | undefined) =>
+  (state: RootState) =>
+    subscriptionId && type && state.rewards.vipTransactions
+      ? (state.rewards.vipTransactions[
+          buildSubscriptionVipTransactionCompositeKey(subscriptionId, type)
         ] ?? null)
       : null;
 

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -837,6 +837,7 @@
     "vipDashboard": {},
     "vipPerpsFees": {},
     "vipRefereeDashboard": {},
+    "vipTransactions": {},
     "subscriptionReferralDetails": {},
     "subscriptions": {},
     "rewardsEnvUrl": null

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9431,6 +9431,19 @@
       "swaps_volume_info_title": "Swaps volume",
       "swaps_volume_info_description": "Your swaps volume updates once per day, so recent swaps may take up to 24 hours to appear here."
     },
+    "vip_transactions": {
+      "select_type": "Select type",
+      "type_perps": "Perps",
+      "type_swap": "Swaps",
+      "swap_title": "Swap",
+      "perps_title": "Perps",
+      "fee_label": "Fee {{fee}}",
+      "error_title": "Failed to load transactions",
+      "error_description": "Something went wrong while loading your transactions. Please try again.",
+      "retry_button": "Retry",
+      "empty_title": "No transactions yet",
+      "empty_description": "Your VIP transactions will appear here once you have activity."
+    },
     "referral_title": "Referrals",
     "referral_stats_earned_from_referrals": "Earned from referrals",
     "referral_stats_referrals": "Referrals",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9441,8 +9441,7 @@
       "error_title": "Failed to load transactions",
       "error_description": "Something went wrong while loading your transactions. Please try again.",
       "retry_button": "Retry",
-      "empty_title": "No transactions yet",
-      "empty_description": "Your VIP transactions will appear here once you have activity."
+      "empty_title": "No transactions yet. Your VIP transactions will appear here once you have activity."
     },
     "referral_title": "Referrals",
     "referral_stats_earned_from_referrals": "Earned from referrals",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9437,7 +9437,6 @@
       "type_swap": "Swaps",
       "swap_title": "Swap",
       "perps_title": "Perps",
-      "fee_label": "Fee {{fee}}",
       "error_title": "Failed to load transactions",
       "error_description": "Something went wrong while loading your transactions. Please try again.",
       "retry_button": "Retry",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds a VIP transactions screen so VIP users can review the Perps and Swap fills that counted toward their VIP points.

VIP dashboard users previously had no in-app way to inspect those individual counting transactions. This PR wires the backend VIP transactions APIs into `RewardsController` (paginated list + per-type freshness cache), Redux, and a date-grouped list UI reachable from the VIP dashboard header Activity icon. Users can filter between Perps and Swap via a bordered type selector, paginate, pull-to-refresh, and retry failures without the list jumping.

Depends on the rewards API work in consensys-vertical-apps/va-mmcx-rewards#729 (including `transactionsTitle` localized text).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a VIP transactions screen so users can view Perps and Swap fills that counted toward their VIP points

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: VIP transactions mobile UI; pairs with backend https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/729

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: VIP transactions list

  Scenario: user opens VIP transactions from the dashboard
    Given the user is opted into Rewards and is a VIP user with a loaded VIP dashboard
    And the rewards API exposes VIP transactions endpoints

    When the user taps the Activity icon in the VIP dashboard header
    Then the VIP transactions screen opens with the localized transactions title
    And the Perps type filter is selected by default
    And either skeleton rows load, then a date-grouped list of Perps transactions, or a centered empty state if there are none

  Scenario: user switches to Swap transactions
    Given the user is on the VIP transactions screen

    When the user opens the type selector and chooses Swap
    Then the list reloads for Swap transactions
    And skeletons or previous non-empty cached Swap rows are shown while loading
    And an empty message is not shown while a load is in progress

  Scenario: user recovers from a fetch error
    Given the VIP transactions request fails

    When the user taps retry on the error banner
    Then the list retries without pull-to-refresh jumping the screen
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — screenshots to be attached before marking ready for review (VIP transactions list, type switch, empty/loading/error states).

### **Before**

N/A — feature did not exist.

### **After**

https://github.com/user-attachments/assets/f94dc810-43bd-4f59-8269-f1e8af0f0f5d

<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-07-22 at 19 35 38" src="https://github.com/user-attachments/assets/f99a9460-644a-4ffa-a0d2-edd0f3823546" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-07-22 at 19 35 48" src="https://github.com/user-attachments/assets/4ce2ede9-1faf-4a85-9d54-6d11e049a9f0" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-07-22 at 18 52 03" src="https://github.com/user-attachments/assets/dce8a567-4049-4fce-a7ab-03ca295501cb" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-07-22 at 18 52 13" src="https://github.com/user-attachments/assets/352d6804-c050-459b-be5a-92e6a081f3f7" />


N/A — screenshots to be attached before marking ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New rewards VIP API surface and dual-layer caching (controller + Redux) with pagination; scope is large but patterns mirror existing Ondo activity and include broad tests.
> 
> **Overview**
> Adds a **VIP transactions** screen so users can review Perps and Swap activity that counts toward VIP points, opened from a new **Activity** header action on the VIP dashboard.
> 
> The stack wires rewards API pagination through `RewardsController` (first-page cache keyed by subscription + type, last-updated freshness checks), Redux (`setVipTransactions` / `selectVipTransactionsById`), and a date-grouped list with Perps vs Swap filtering via the existing select sheet, infinite scroll, pull-to-refresh, and error retry. Row components show perps coin/volume/time and swap pair/volume/time.
> 
> Introduces shared **`useCursorPaginatedList`** for cursor pagination (first page only in Redux; load-more stays local) and refactors **`useGetOndoCampaignActivity`** onto it so Ondo activity no longer merges paginated results into Redux.
> 
> Also extends VIP dashboard localized copy with **`transactionsTitle`** and adds i18n under `rewards.vip_transactions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0120d7b1fd0a933eec754e5dec58684aaadaac2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->