### PR TITLE
fix: skip failing tests

### DIFF
--- a/tests/smoke-appium/account-activity/web-socket-connection.spec.ts
+++ b/tests/smoke-appium/account-activity/web-socket-connection.spec.ts
@@ -82,7 +82,8 @@ appiumTest.describe(
       },
     );
 
-    appiumTest(
+    // TODO: Flaky test — to be investigated. Skipped until root cause is fixed.
+    appiumTest.skip(
       'resubscribes after lock and unlock',
       async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(

--- a/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
@@ -15,7 +15,8 @@ import {
 appiumTest.describe(
   SmokeSeedlessOnboarding('Google Login - Lock and Unlock'),
   () => {
-    appiumTest(
+    // TODO: Flaky test — to be investigated. Skipped until root cause is fixed.
+    appiumTest.skip(
       'onboards with Google login, locks, and unlocks the app',
       async ({ driver: _driver, currentDeviceDetails }) => {
         const fixture = PlatformDetector.isIOS()

--- a/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
@@ -14,7 +14,8 @@ import {
 appiumTest.describe(
   SmokeSeedlessOnboarding('Google Login - Reset Wallet'),
   () => {
-    appiumTest(
+    // TODO: Flaky test — to be investigated. Skipped until root cause is fixed.
+    appiumTest.skip(
       'onboards with Google login, locks, and resets the wallet',
       async ({ driver: _driver, currentDeviceDetails }) => {
         const fixture = PlatformDetector.isIOS()


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Skips failing tests to unblock CI

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2086

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

NA


## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

NA

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that reduces smoke coverage until flakes are fixed; no application or production behavior is modified.
> 
> **Overview**
> Temporarily **skips three flaky Appium smoke tests** so CI can pass while the failures are investigated (MMQA-2086).
> 
> In `web-socket-connection.spec.ts`, the **“resubscribes after lock and unlock”** account-activity WebSocket case is changed from `appiumTest` to `appiumTest.skip` with a TODO noting flakiness. The same skip pattern is applied to seedless Google flows: **lock/unlock** (`google-login-lock-unlock.spec.ts`) and **reset wallet** (`google-login-reset-wallet.spec.ts`). Test bodies are unchanged; only execution is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd87ad4d5c8727714f558d98f2327403403094c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->