### PR TITLE
feat(agentic-cli): nudge push permission after CLI QR login

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -50,6 +50,7 @@ import PerpsWebSocketHealthToast, {
   WebSocketHealthToastProvider,
 } from '../../UI/Perps/components/PerpsWebSocketHealthToast';
 import { ControllerEventToastBridge } from './ControllerEventToastBridge';
+import { CliLoginPushNudgeListener } from '../../UI/CliLoginPushNudge';
 import { usePredictToastRegistrations } from '../../UI/Predict/hooks/usePredictToastRegistrations';
 import { usePerpsWithdrawToastRegistrations } from '../../UI/Perps/hooks/usePerpsWithdrawToastRegistrations';
 import { useQuickBuyToastRegistrations } from '../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations';
@@ -1425,6 +1426,7 @@ const App: React.FC = () => {
         <PerpsWebSocketHealthToast />
         {__DEV__ && <AgentStepHud />}
         <ControllerEventToastBridge registrations={toastRegistrations} />
+        <CliLoginPushNudgeListener />
         <ProfilerManager />
         {/* Dev/QA-only visual inspector — no-op unless DESIGNER_MODE=true (see docs/designer-mode.md) */}
         <DesignerModeOverlay />

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { subscribeCliLoginPushNudge } from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
+import { useCliLoginPushNudge } from './useCliLoginPushNudge';
+
+/**
+ * Bridges the non-React CLI QR-login service layer to the toast UI (MMAI-925).
+ * Mount once inside the ToastContext provider; subscribes to the module-level
+ * push-nudge signal and shows the toast when emitted.
+ */
+const CliLoginPushNudgeListener = () => {
+  const { showNudge } = useCliLoginPushNudge();
+
+  useEffect(() => subscribeCliLoginPushNudge(() => showNudge()), [showNudge]);
+
+  return null;
+};
+
+export default CliLoginPushNudgeListener;

--- a/app/components/UI/CliLoginPushNudge/index.ts
+++ b/app/components/UI/CliLoginPushNudge/index.ts
@@ -1,0 +1,2 @@
+export { default as CliLoginPushNudgeListener } from './CliLoginPushNudgeListener';
+export { useCliLoginPushNudge } from './useCliLoginPushNudge';

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -131,6 +131,20 @@ describe('useCliLoginPushNudge', () => {
     expect(closeToast).toHaveBeenCalled();
   });
 
+  it('enables notifications directly when OS push is already granted', async () => {
+    mockIsPushPermissionGranted.mockResolvedValue(true);
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+  });
+
   it('opens device settings when the OS can no longer show its dialog', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
@@ -226,11 +240,13 @@ describe('useCliLoginPushNudge', () => {
       result.current.showNudge();
     });
 
+    mockIsPushPermissionGranted.mockClear();
     mockIsPushPermissionGranted.mockResolvedValue(true);
     await act(async () => {
       appStateChangeHandler?.('active');
     });
 
+    // The superseded retry returns before re-checking permission or enabling.
     expect(mockIsPushPermissionGranted).not.toHaveBeenCalled();
     expect(mockEnableNotifications).not.toHaveBeenCalled();
   });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -9,7 +9,8 @@ import type {
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 
 const mockEnableNotifications = jest.fn();
-const mockGetPushPermissionStatus = jest.fn();
+const mockIsPushPermissionPromptable = jest.fn();
+const mockIsPushPermissionGranted = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockIsNotificationsFeatureEnabled = jest.fn();
 
@@ -28,7 +29,8 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   default: {
     openSystemSettings: () => mockOpenSystemSettings(),
   },
-  getPushPermissionStatus: () => mockGetPushPermissionStatus(),
+  isPushPermissionPromptable: () => mockIsPushPermissionPromptable(),
+  isPushPermissionGranted: () => mockIsPushPermissionGranted(),
 }));
 
 jest.mock('../../../../locales/i18n', () => ({
@@ -70,6 +72,8 @@ describe('useCliLoginPushNudge', () => {
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
+    mockIsPushPermissionPromptable.mockResolvedValue(true);
+    mockIsPushPermissionGranted.mockResolvedValue(false);
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
       handler: (state: string) => void,
@@ -113,8 +117,8 @@ describe('useCliLoginPushNudge', () => {
     expect(options.closeButtonOptions?.onPress).toBeDefined();
   });
 
-  it('enables notifications directly when native permission is promptable', async () => {
-    mockGetPushPermissionStatus.mockResolvedValue('promptable');
+  it('enables notifications directly when the OS dialog is still promptable', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(true);
     const { result } = renderNudge();
 
     act(() => {
@@ -127,8 +131,8 @@ describe('useCliLoginPushNudge', () => {
     expect(closeToast).toHaveBeenCalled();
   });
 
-  it('opens device settings when native permission is denied', async () => {
-    mockGetPushPermissionStatus.mockResolvedValue('denied');
+  it('opens device settings when the OS can no longer show its dialog', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -140,8 +144,8 @@ describe('useCliLoginPushNudge', () => {
     expect(mockEnableNotifications).not.toHaveBeenCalled();
   });
 
-  it('enables notifications on return from settings when permission becomes grantable', async () => {
-    mockGetPushPermissionStatus.mockResolvedValueOnce('denied');
+  it('enables notifications on return from settings when permission becomes granted', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -149,7 +153,7 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
-    mockGetPushPermissionStatus.mockResolvedValue('granted');
+    mockIsPushPermissionGranted.mockResolvedValue(true);
     await act(async () => {
       appStateChangeHandler?.('active');
     });
@@ -157,8 +161,9 @@ describe('useCliLoginPushNudge', () => {
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it('closes the toast without enabling when the user returns still denied', async () => {
-    mockGetPushPermissionStatus.mockResolvedValue('denied');
+  it('closes the toast without enabling when the user returns still not granted', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -176,7 +181,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('does not block Turn on after opening settings when the user never returns', async () => {
-    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -190,7 +195,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('cancels a pending settings-return retry when a new nudge is shown', async () => {
-    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -205,5 +210,28 @@ describe('useCliLoginPushNudge', () => {
     });
 
     expect(removeMocks[0]).toHaveBeenCalled();
+  });
+
+  it('does not run a superseded settings-return retry after a new nudge', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    // A new nudge bumps the flow epoch, invalidating the pending retry.
+    act(() => {
+      result.current.showNudge();
+    });
+
+    mockIsPushPermissionGranted.mockResolvedValue(true);
+    await act(async () => {
+      appStateChangeHandler?.('active');
+    });
+
+    expect(mockIsPushPermissionGranted).not.toHaveBeenCalled();
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -9,6 +9,7 @@ import type {
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 
 const mockEnableNotifications = jest.fn();
+const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockIsNotificationsFeatureEnabled = jest.fn();
@@ -28,6 +29,7 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   default: {
     openSystemSettings: () => mockOpenSystemSettings(),
   },
+  isPushPermissionPromptable: () => mockIsPushPermissionPromptable(),
   isPushPermissionGranted: () => mockIsPushPermissionGranted(),
 }));
 
@@ -70,6 +72,7 @@ describe('useCliLoginPushNudge', () => {
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
+    mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
@@ -114,7 +117,7 @@ describe('useCliLoginPushNudge', () => {
     expect(options.closeButtonOptions?.onPress).toBeDefined();
   });
 
-  it('enables and closes without opening settings when push becomes granted', async () => {
+  it('enables and closes without opening settings when push is already granted', async () => {
     mockIsPushPermissionGranted.mockResolvedValue(true);
     const { result } = renderNudge();
 
@@ -128,7 +131,22 @@ describe('useCliLoginPushNudge', () => {
     expect(closeToast).toHaveBeenCalled();
   });
 
-  it('opens device settings when push is still not granted after enabling', async () => {
+  it('enables via the OS dialog when push is still promptable', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(true);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+    expect(closeToast).toHaveBeenCalled();
+  });
+
+  it('does not open settings when the user denies the OS dialog', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
@@ -137,14 +155,26 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
-    // enableNotifications is attempted first (requests the OS dialog when it can
-    // still be shown); only when push is still not granted do we deep-link.
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+    expect(closeToast).toHaveBeenCalled();
+  });
+
+  it('opens device settings when the OS can no longer show its dialog', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
   });
 
   it('re-enables on return from settings when permission becomes granted', async () => {
-    mockIsPushPermissionGranted.mockResolvedValue(false);
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -152,7 +182,6 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
-    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
 
     mockIsPushPermissionGranted.mockResolvedValue(true);
@@ -160,10 +189,11 @@ describe('useCliLoginPushNudge', () => {
       appStateChangeHandler?.('active');
     });
 
-    expect(mockEnableNotifications).toHaveBeenCalledTimes(2);
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
   });
 
   it('closes the toast without re-enabling when the user returns still not granted', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
@@ -183,7 +213,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('does not block Turn on after opening settings when the user never returns', async () => {
-    mockIsPushPermissionGranted.mockResolvedValue(false);
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -197,7 +227,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('cancels a pending settings-return retry when a new nudge is shown', async () => {
-    mockIsPushPermissionGranted.mockResolvedValue(false);
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -215,7 +245,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('does not run a superseded settings-return retry after a new nudge', async () => {
-    mockIsPushPermissionGranted.mockResolvedValue(false);
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -223,7 +253,6 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
-    // A new nudge bumps the flow epoch, invalidating the pending retry.
     act(() => {
       result.current.showNudge();
     });
@@ -235,7 +264,6 @@ describe('useCliLoginPushNudge', () => {
       appStateChangeHandler?.('active');
     });
 
-    // The superseded retry returns before re-checking permission or enabling.
     expect(mockIsPushPermissionGranted).not.toHaveBeenCalled();
     expect(mockEnableNotifications).not.toHaveBeenCalled();
   });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -9,7 +9,6 @@ import type {
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 
 const mockEnableNotifications = jest.fn();
-const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockIsNotificationsFeatureEnabled = jest.fn();
@@ -29,7 +28,6 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   default: {
     openSystemSettings: () => mockOpenSystemSettings(),
   },
-  isPushPermissionPromptable: () => mockIsPushPermissionPromptable(),
   isPushPermissionGranted: () => mockIsPushPermissionGranted(),
 }));
 
@@ -72,7 +70,6 @@ describe('useCliLoginPushNudge', () => {
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
-    mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
@@ -117,8 +114,8 @@ describe('useCliLoginPushNudge', () => {
     expect(options.closeButtonOptions?.onPress).toBeDefined();
   });
 
-  it('enables notifications directly when the OS dialog is still promptable', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(true);
+  it('enables and closes without opening settings when push becomes granted', async () => {
+    mockIsPushPermissionGranted.mockResolvedValue(true);
     const { result } = renderNudge();
 
     act(() => {
@@ -126,57 +123,12 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
-    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
     expect(closeToast).toHaveBeenCalled();
   });
 
-  it('enables notifications directly when OS push is already granted', async () => {
-    mockIsPushPermissionGranted.mockResolvedValue(true);
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
-    const { result } = renderNudge();
-
-    act(() => {
-      result.current.showNudge();
-    });
-    await tapTurnOn();
-
-    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
-  });
-
-  it('opens device settings when the OS can no longer show its dialog', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
-    const { result } = renderNudge();
-
-    act(() => {
-      result.current.showNudge();
-    });
-    await tapTurnOn();
-
-    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
-    expect(mockEnableNotifications).not.toHaveBeenCalled();
-  });
-
-  it('enables notifications on return from settings when permission becomes granted', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
-    const { result } = renderNudge();
-
-    act(() => {
-      result.current.showNudge();
-    });
-    await tapTurnOn();
-
-    mockIsPushPermissionGranted.mockResolvedValue(true);
-    await act(async () => {
-      appStateChangeHandler?.('active');
-    });
-
-    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
-  });
-
-  it('closes the toast without enabling when the user returns still not granted', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
+  it('opens device settings when push is still not granted after enabling', async () => {
     mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
@@ -185,6 +137,42 @@ describe('useCliLoginPushNudge', () => {
     });
     await tapTurnOn();
 
+    // enableNotifications is attempted first (requests the OS dialog when it can
+    // still be shown); only when push is still not granted do we deep-link.
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-enables on return from settings when permission becomes granted', async () => {
+    mockIsPushPermissionGranted.mockResolvedValue(false);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+
+    mockIsPushPermissionGranted.mockResolvedValue(true);
+    await act(async () => {
+      appStateChangeHandler?.('active');
+    });
+
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes the toast without re-enabling when the user returns still not granted', async () => {
+    mockIsPushPermissionGranted.mockResolvedValue(false);
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    mockEnableNotifications.mockClear();
     closeToast.mockClear();
     await act(async () => {
       appStateChangeHandler?.('active');
@@ -195,7 +183,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('does not block Turn on after opening settings when the user never returns', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -209,7 +197,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('cancels a pending settings-return retry when a new nudge is shown', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -227,7 +215,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   it('does not run a superseded settings-return retry after a new nudge', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
 
     act(() => {
@@ -242,6 +230,7 @@ describe('useCliLoginPushNudge', () => {
 
     mockIsPushPermissionGranted.mockClear();
     mockIsPushPermissionGranted.mockResolvedValue(true);
+    mockEnableNotifications.mockClear();
     await act(async () => {
       appStateChangeHandler?.('active');
     });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -39,6 +39,7 @@ describe('useCliLoginPushNudge', () => {
   let showToast: jest.Mock;
   let closeToast: jest.Mock;
   let appStateChangeHandler: ((state: string) => void) | undefined;
+  let removeMocks: jest.Mock[];
 
   const wrapper = ({ children }: { children: React.ReactNode }) => {
     const toastRef = {
@@ -66,6 +67,7 @@ describe('useCliLoginPushNudge', () => {
     showToast = jest.fn();
     closeToast = jest.fn();
     appStateChangeHandler = undefined;
+    removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
@@ -73,7 +75,9 @@ describe('useCliLoginPushNudge', () => {
       handler: (state: string) => void,
     ) => {
       appStateChangeHandler = handler;
-      return { remove: jest.fn() };
+      const remove = jest.fn();
+      removeMocks.push(remove);
+      return { remove };
     }) as unknown as typeof AppState.addEventListener);
   });
 
@@ -169,5 +173,37 @@ describe('useCliLoginPushNudge', () => {
 
     expect(mockEnableNotifications).not.toHaveBeenCalled();
     expect(closeToast).toHaveBeenCalled();
+  });
+
+  it('does not block Turn on after opening settings when the user never returns', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+
+    await tapTurnOn();
+    await tapTurnOn();
+
+    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels a pending settings-return retry when a new nudge is shown', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(removeMocks).toHaveLength(1);
+
+    act(() => {
+      result.current.showNudge();
+    });
+
+    expect(removeMocks[0]).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -68,14 +68,13 @@ describe('useCliLoginPushNudge', () => {
     appStateChangeHandler = undefined;
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_event: string, handler: (s: string) => void) => {
-        appStateChangeHandler = handler;
-        return { remove: jest.fn() } as unknown as ReturnType<
-          typeof AppState.addEventListener
-        >;
-      });
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(((
+      _event: string,
+      handler: (state: string) => void,
+    ) => {
+      appStateChangeHandler = handler;
+      return { remove: jest.fn() };
+    }) as unknown as typeof AppState.addEventListener);
   });
 
   afterEach(() => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { AppState } from 'react-native';
+import { renderHook, act } from '@testing-library/react-native';
+import { ToastContext } from '../../../component-library/components/Toast';
+import type {
+  ToastRef,
+  ToastOptions,
+} from '../../../component-library/components/Toast/Toast.types';
+import { useCliLoginPushNudge } from './useCliLoginPushNudge';
+
+const mockEnableNotifications = jest.fn();
+const mockGetPushPermissionStatus = jest.fn();
+const mockOpenSystemSettings = jest.fn();
+const mockIsNotificationsFeatureEnabled = jest.fn();
+
+jest.mock('../../../util/notifications/constants', () => ({
+  isNotificationsFeatureEnabled: () => mockIsNotificationsFeatureEnabled(),
+}));
+
+jest.mock('../../../util/notifications/hooks/useNotifications', () => ({
+  useEnableNotifications: () => ({
+    enableNotifications: mockEnableNotifications,
+  }),
+}));
+
+jest.mock('../../../util/notifications/services/NotificationService', () => ({
+  __esModule: true,
+  default: {
+    openSystemSettings: () => mockOpenSystemSettings(),
+  },
+  getPushPermissionStatus: () => mockGetPushPermissionStatus(),
+}));
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+describe('useCliLoginPushNudge', () => {
+  let showToast: jest.Mock;
+  let closeToast: jest.Mock;
+  let appStateChangeHandler: ((state: string) => void) | undefined;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const toastRef = {
+      current: { showToast, closeToast } as unknown as ToastRef,
+    };
+    return (
+      <ToastContext.Provider value={{ toastRef }}>
+        {children}
+      </ToastContext.Provider>
+    );
+  };
+
+  const renderNudge = () =>
+    renderHook(() => useCliLoginPushNudge(), { wrapper });
+
+  const tapTurnOn = async () => {
+    const options = showToast.mock.calls[0][0] as ToastOptions;
+    await act(async () => {
+      await options.linkButtonOptions?.onPress?.();
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    showToast = jest.fn();
+    closeToast = jest.fn();
+    appStateChangeHandler = undefined;
+    mockIsNotificationsFeatureEnabled.mockReturnValue(true);
+    mockEnableNotifications.mockResolvedValue(undefined);
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event: string, handler: (s: string) => void) => {
+        appStateChangeHandler = handler;
+        return { remove: jest.fn() } as unknown as ReturnType<
+          typeof AppState.addEventListener
+        >;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not show the toast when the notifications feature is disabled', () => {
+    mockIsNotificationsFeatureEnabled.mockReturnValue(false);
+    const { result } = renderNudge();
+
+    let shown: boolean | undefined;
+    act(() => {
+      shown = result.current.showNudge();
+    });
+
+    expect(shown).toBe(false);
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast with a Turn on action when enabled', () => {
+    const { result } = renderNudge();
+
+    let shown: boolean | undefined;
+    act(() => {
+      shown = result.current.showNudge();
+    });
+
+    expect(shown).toBe(true);
+    expect(showToast).toHaveBeenCalledTimes(1);
+    const options = showToast.mock.calls[0][0] as ToastOptions;
+    expect(options.linkButtonOptions?.onPress).toBeDefined();
+    expect(options.closeButtonOptions?.onPress).toBeDefined();
+  });
+
+  it('enables notifications directly when native permission is promptable', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('promptable');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+    expect(closeToast).toHaveBeenCalled();
+  });
+
+  it('opens device settings when native permission is denied', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
+  });
+
+  it('enables notifications on return from settings when permission becomes grantable', async () => {
+    mockGetPushPermissionStatus.mockResolvedValueOnce('denied');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    mockGetPushPermissionStatus.mockResolvedValue('granted');
+    await act(async () => {
+      appStateChangeHandler?.('active');
+    });
+
+    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the toast without enabling when the user returns still denied', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('denied');
+    const { result } = renderNudge();
+
+    act(() => {
+      result.current.showNudge();
+    });
+    await tapTurnOn();
+
+    closeToast.mockClear();
+    await act(async () => {
+      appStateChangeHandler?.('active');
+    });
+
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
+    expect(closeToast).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -129,6 +129,10 @@ export function useCliLoginPushNudge(): {
             inFlightRef.current = false;
           }
         });
+        // The enable work is deferred to the foreground retry, which manages
+        // its own in-flight guard. Release the guard now so a later tap is not
+        // permanently blocked if the user never returns from device settings.
+        inFlightRef.current = false;
         return;
       }
 
@@ -154,6 +158,11 @@ export function useCliLoginPushNudge(): {
     if (!isNotificationsFeatureEnabled()) {
       return false;
     }
+    // A new nudge supersedes any in-progress denied-permission flow: cancel a
+    // pending foreground retry and release the guard so this toast's Turn on
+    // is not blocked and the previous retry cannot fire on the next resume.
+    clearForegroundRetry();
+    inFlightRef.current = false;
     toastRef?.current?.showToast({
       variant: ToastVariants.Icon,
       iconName: IconName.Notification,
@@ -175,7 +184,7 @@ export function useCliLoginPushNudge(): {
       },
     });
     return true;
-  }, [onTapTurnOn, toastRef]);
+  }, [onTapTurnOn, toastRef, clearForegroundRetry]);
 
   useEffect(
     () => () => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -10,7 +10,8 @@ import { strings } from '../../../../locales/i18n';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications/constants';
 import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
 import NotificationService, {
-  getPushPermissionStatus,
+  isPushPermissionGranted,
+  isPushPermissionPromptable,
 } from '../../../util/notifications/services/NotificationService';
 import { resolveCliLoginPushNudgeTurnOnAction } from '../../../core/AgenticCli/cliLoginPushNudgeRouting';
 
@@ -28,10 +29,10 @@ const ERROR_LABELS = () => [
 
 /**
  * Shared toast-based push-permission nudge shown after a successful Agentic CLI
- * QR login (MMAI-925). On "Turn on": when native permission is promptable (or
- * MetaMask in-app notifications are off) it calls enableNotifications(), which
- * enables in-app notifications and requests the OS permission dialog. When
- * native permission is already denied it deep-links to the device notification
+ * QR login (MMAI-925). On "Turn on": when native permission is still promptable
+ * (platform-aware via isPushPermissionPromptable) it calls enableNotifications(),
+ * which enables in-app notifications and requests the OS permission dialog. When
+ * the OS can no longer show its dialog it deep-links to the device notification
  * settings and retries once the app returns to the foreground.
  */
 export function useCliLoginPushNudge(): {
@@ -43,6 +44,11 @@ export function useCliLoginPushNudge(): {
   });
 
   const inFlightRef = useRef(false);
+  // Bumped each time a new nudge is shown so a fresh CLI login supersedes any
+  // in-progress Turn on flow: async continuations compare their captured epoch
+  // and skip their side effects once superseded, preventing overlapping enable
+  // calls, settings opens, and toast updates.
+  const flowEpochRef = useRef(0);
   const appStateSubscriptionRef = useRef<ReturnType<
     typeof AppState.addEventListener
   > | null>(null);
@@ -73,15 +79,22 @@ export function useCliLoginPushNudge(): {
     appStateSubscriptionRef.current = null;
   }, []);
 
-  const runEnableFlow = useCallback(async () => {
-    try {
-      await enableNotifications();
-      toastRef?.current?.closeToast();
-    } catch {
-      toastRef?.current?.closeToast();
-      showErrorToast();
-    }
-  }, [enableNotifications, toastRef, showErrorToast]);
+  const runEnableFlow = useCallback(
+    async (isCurrent: () => boolean) => {
+      try {
+        await enableNotifications();
+        if (isCurrent()) {
+          toastRef?.current?.closeToast();
+        }
+      } catch {
+        if (isCurrent()) {
+          toastRef?.current?.closeToast();
+          showErrorToast();
+        }
+      }
+    },
+    [enableNotifications, toastRef, showErrorToast],
+  );
 
   const scheduleForegroundRetry = useCallback(
     (retry: () => Promise<void>) => {
@@ -106,25 +119,39 @@ export function useCliLoginPushNudge(): {
     }
     inFlightRef.current = true;
 
+    const epoch = flowEpochRef.current;
+    const isCurrent = () => flowEpochRef.current === epoch;
+
     try {
-      const nativePushStatus = await getPushPermissionStatus();
+      // Platform-aware: on Android any not-granted state is promptable, so we
+      // request the OS dialog rather than sending first-time users to Settings.
+      const promptable = await isPushPermissionPromptable();
+      if (!isCurrent()) {
+        return;
+      }
       const action = resolveCliLoginPushNudgeTurnOnAction({
-        nativePushStatus,
+        isPromptable: promptable,
       });
 
       if (action === 'open_device_settings') {
         toastRef?.current?.closeToast();
         NotificationService.openSystemSettings();
         scheduleForegroundRetry(async () => {
+          if (!isCurrent()) {
+            return;
+          }
           inFlightRef.current = true;
           try {
-            const retryStatus = await getPushPermissionStatus();
-            if (retryStatus === 'denied') {
+            const retryGranted = await isPushPermissionGranted();
+            if (!isCurrent()) {
+              return;
+            }
+            if (!retryGranted) {
               toastRef?.current?.closeToast();
               return;
             }
             showLoadingToast();
-            await runEnableFlow();
+            await runEnableFlow(isCurrent);
           } finally {
             inFlightRef.current = false;
           }
@@ -137,10 +164,12 @@ export function useCliLoginPushNudge(): {
       }
 
       showLoadingToast();
-      await runEnableFlow();
+      await runEnableFlow(isCurrent);
     } catch {
-      toastRef?.current?.closeToast();
-      showErrorToast();
+      if (isCurrent()) {
+        toastRef?.current?.closeToast();
+        showErrorToast();
+      }
     } finally {
       if (!appStateSubscriptionRef.current) {
         inFlightRef.current = false;
@@ -158,10 +187,11 @@ export function useCliLoginPushNudge(): {
     if (!isNotificationsFeatureEnabled()) {
       return false;
     }
-    // A new nudge supersedes any in-progress denied-permission flow: cancel a
-    // pending foreground retry and release the guard so this toast's Turn on
-    // is not blocked and the previous retry cannot fire on the next resume.
+    // A new nudge supersedes any in-progress Turn on flow: cancel a pending
+    // foreground retry, invalidate in-flight async continuations via the epoch,
+    // and release the guard so this toast's Turn on is not blocked.
     clearForegroundRetry();
+    flowEpochRef.current += 1;
     inFlightRef.current = false;
     toastRef?.current?.showToast({
       variant: ToastVariants.Icon,

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -1,0 +1,188 @@
+import { useCallback, useContext, useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+import { ToastContext } from '../../../component-library/components/Toast';
+import {
+  ToastVariants,
+  ButtonIconVariant,
+} from '../../../component-library/components/Toast/Toast.types';
+import { IconName } from '../../../component-library/components/Icons/Icon';
+import { strings } from '../../../../locales/i18n';
+import { isNotificationsFeatureEnabled } from '../../../util/notifications/constants';
+import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
+import NotificationService, {
+  getPushPermissionStatus,
+} from '../../../util/notifications/services/NotificationService';
+import { resolveCliLoginPushNudgeTurnOnAction } from '../../../core/AgenticCli/cliLoginPushNudgeRouting';
+
+const NUDGE_LABELS = () => [
+  { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
+];
+
+const LOADING_LABELS = () => [
+  { label: strings('sdk_connect_v2.push_nudge.loading_title'), isBold: true },
+];
+
+const ERROR_LABELS = () => [
+  { label: strings('sdk_connect_v2.push_nudge.enable_error') },
+];
+
+/**
+ * Shared toast-based push-permission nudge shown after a successful Agentic CLI
+ * QR login (MMAI-925). On "Turn on": when native permission is promptable (or
+ * MetaMask in-app notifications are off) it calls enableNotifications(), which
+ * enables in-app notifications and requests the OS permission dialog. When
+ * native permission is already denied it deep-links to the device notification
+ * settings and retries once the app returns to the foreground.
+ */
+export function useCliLoginPushNudge(): {
+  showNudge: () => boolean;
+} {
+  const { toastRef } = useContext(ToastContext);
+  const { enableNotifications } = useEnableNotifications({
+    nudgeEnablePush: true,
+  });
+
+  const inFlightRef = useRef(false);
+  const appStateSubscriptionRef = useRef<ReturnType<
+    typeof AppState.addEventListener
+  > | null>(null);
+
+  const showLoadingToast = useCallback(() => {
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      iconName: IconName.Loading,
+      hasNoTimeout: true,
+      labelOptions: LOADING_LABELS(),
+      descriptionOptions: {
+        description: strings('sdk_connect_v2.push_nudge.loading_description'),
+      },
+    });
+  }, [toastRef]);
+
+  const showErrorToast = useCallback(() => {
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      iconName: IconName.Danger,
+      hasNoTimeout: false,
+      labelOptions: ERROR_LABELS(),
+    });
+  }, [toastRef]);
+
+  const clearForegroundRetry = useCallback(() => {
+    appStateSubscriptionRef.current?.remove();
+    appStateSubscriptionRef.current = null;
+  }, []);
+
+  const runEnableFlow = useCallback(async () => {
+    try {
+      await enableNotifications();
+      toastRef?.current?.closeToast();
+    } catch {
+      toastRef?.current?.closeToast();
+      showErrorToast();
+    }
+  }, [enableNotifications, toastRef, showErrorToast]);
+
+  const scheduleForegroundRetry = useCallback(
+    (retry: () => Promise<void>) => {
+      clearForegroundRetry();
+      appStateSubscriptionRef.current = AppState.addEventListener(
+        'change',
+        (nextState) => {
+          if (nextState !== 'active') {
+            return;
+          }
+          clearForegroundRetry();
+          void retry();
+        },
+      );
+    },
+    [clearForegroundRetry],
+  );
+
+  const onTapTurnOn = useCallback(async () => {
+    if (inFlightRef.current) {
+      return;
+    }
+    inFlightRef.current = true;
+
+    try {
+      const nativePushStatus = await getPushPermissionStatus();
+      const action = resolveCliLoginPushNudgeTurnOnAction({
+        nativePushStatus,
+      });
+
+      if (action === 'open_device_settings') {
+        toastRef?.current?.closeToast();
+        NotificationService.openSystemSettings();
+        scheduleForegroundRetry(async () => {
+          inFlightRef.current = true;
+          try {
+            const retryStatus = await getPushPermissionStatus();
+            if (retryStatus === 'denied') {
+              toastRef?.current?.closeToast();
+              return;
+            }
+            showLoadingToast();
+            await runEnableFlow();
+          } finally {
+            inFlightRef.current = false;
+          }
+        });
+        return;
+      }
+
+      showLoadingToast();
+      await runEnableFlow();
+    } catch {
+      toastRef?.current?.closeToast();
+      showErrorToast();
+    } finally {
+      if (!appStateSubscriptionRef.current) {
+        inFlightRef.current = false;
+      }
+    }
+  }, [
+    runEnableFlow,
+    scheduleForegroundRetry,
+    showErrorToast,
+    showLoadingToast,
+    toastRef,
+  ]);
+
+  const showNudge = useCallback((): boolean => {
+    if (!isNotificationsFeatureEnabled()) {
+      return false;
+    }
+    toastRef?.current?.showToast({
+      variant: ToastVariants.Icon,
+      iconName: IconName.Notification,
+      hasNoTimeout: true,
+      labelOptions: NUDGE_LABELS(),
+      descriptionOptions: {
+        description: strings('sdk_connect_v2.push_nudge.description'),
+      },
+      linkButtonOptions: {
+        label: strings('sdk_connect_v2.push_nudge.turn_on_button'),
+        onPress: onTapTurnOn,
+      },
+      closeButtonOptions: {
+        variant: ButtonIconVariant.Icon,
+        iconName: IconName.Close,
+        onPress: () => {
+          toastRef?.current?.closeToast();
+        },
+      },
+    });
+    return true;
+  }, [onTapTurnOn, toastRef]);
+
+  useEffect(
+    () => () => {
+      clearForegroundRetry();
+    },
+    [clearForegroundRetry],
+  );
+
+  return { showNudge };
+}

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -11,6 +11,7 @@ import { isNotificationsFeatureEnabled } from '../../../util/notifications/const
 import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
 import NotificationService, {
   isPushPermissionGranted,
+  isPushPermissionPromptable,
 } from '../../../util/notifications/services/NotificationService';
 
 const NUDGE_LABELS = () => [
@@ -27,12 +28,11 @@ const ERROR_LABELS = () => [
 
 /**
  * Shared toast-based push-permission nudge shown after a successful Agentic CLI
- * QR login (MMAI-925). On "Turn on" it calls enableNotifications(), which turns
- * on in-app notifications and requests the OS permission dialog when the OS can
- * still show it. If native push is still not granted afterwards (denied, or an
- * Android POST_NOTIFICATIONS prompt that is permanently dismissed and no longer
- * shows), it deep-links to the device notification settings and retries once the
- * app returns to the foreground.
+ * QR login (MMAI-925). On "Turn on": when the OS can still show its permission
+ * dialog it calls enableNotifications() (in-app notifications + OS prompt).
+ * Denying that dialog closes the toast without opening Settings. When the OS can
+ * no longer show its dialog (e.g. iOS after a prior denial), it deep-links to
+ * device notification settings and retries once the app returns to foreground.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -122,17 +122,12 @@ export function useCliLoginPushNudge(): {
     const isCurrent = () => flowEpochRef.current === epoch;
 
     try {
-      // Attempt to enable directly. enableNotifications() turns on in-app
-      // notifications and, when the OS can still show its dialog (iOS
-      // NOT_DETERMINED, or an Android POST_NOTIFICATIONS prompt that has not
-      // been permanently dismissed), requests the native push permission.
-      showLoadingToast();
-      await enableNotifications();
-      if (!isCurrent()) {
-        return;
-      }
-
       if (await isPushPermissionGranted()) {
+        if (!isCurrent()) {
+          return;
+        }
+        showLoadingToast();
+        await enableNotifications();
         if (isCurrent()) {
           toastRef?.current?.closeToast();
         }
@@ -142,38 +137,52 @@ export function useCliLoginPushNudge(): {
         return;
       }
 
-      // Still not granted: the OS dialog was denied, or can no longer be shown
-      // at all. On Android, once POST_NOTIFICATIONS is permanently denied,
-      // requestPermission() silently no-ops (and Notifee cannot detect this up
-      // front), so the only remaining path is the device settings screen.
-      // Deep-link there and retry once the app returns to the foreground.
-      toastRef?.current?.closeToast();
-      NotificationService.openSystemSettings();
-      scheduleForegroundRetry(async () => {
-        if (!isCurrent()) {
-          return;
-        }
-        inFlightRef.current = true;
-        try {
-          if (!(await isPushPermissionGranted())) {
-            if (isCurrent()) {
-              toastRef?.current?.closeToast();
-            }
-            return;
-          }
+      const promptable = await isPushPermissionPromptable();
+      if (!isCurrent()) {
+        return;
+      }
+
+      if (!promptable) {
+        // OS dialog cannot be shown again (e.g. iOS after a prior denial).
+        // Deep-link to device settings and retry on return to foreground.
+        toastRef?.current?.closeToast();
+        NotificationService.openSystemSettings();
+        scheduleForegroundRetry(async () => {
           if (!isCurrent()) {
             return;
           }
-          showLoadingToast();
-          await runEnableFlow(isCurrent);
-        } finally {
-          inFlightRef.current = false;
-        }
-      });
-      // The enable work is deferred to the foreground retry, which manages its
-      // own in-flight guard. Release the guard now so a later tap is not
-      // permanently blocked if the user never returns from device settings.
-      inFlightRef.current = false;
+          inFlightRef.current = true;
+          try {
+            if (!(await isPushPermissionGranted())) {
+              if (isCurrent()) {
+                toastRef?.current?.closeToast();
+              }
+              return;
+            }
+            if (!isCurrent()) {
+              return;
+            }
+            showLoadingToast();
+            await runEnableFlow(isCurrent);
+          } finally {
+            inFlightRef.current = false;
+          }
+        });
+        // The enable work is deferred to the foreground retry, which manages
+        // its own in-flight guard. Release the guard now so a later tap is not
+        // permanently blocked if the user never returns from device settings.
+        inFlightRef.current = false;
+        return;
+      }
+
+      // OS can still show its dialog — request permission via enableNotifications().
+      // If the user denies, dismiss the toast without opening Settings (matches
+      // PushNotificationOnboarding).
+      showLoadingToast();
+      await enableNotifications();
+      if (isCurrent()) {
+        toastRef?.current?.closeToast();
+      }
     } catch {
       if (isCurrent()) {
         toastRef?.current?.closeToast();

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -11,9 +11,7 @@ import { isNotificationsFeatureEnabled } from '../../../util/notifications/const
 import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
 import NotificationService, {
   isPushPermissionGranted,
-  isPushPermissionPromptable,
 } from '../../../util/notifications/services/NotificationService';
-import { resolveCliLoginPushNudgeTurnOnAction } from '../../../core/AgenticCli/cliLoginPushNudgeRouting';
 
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
@@ -29,11 +27,12 @@ const ERROR_LABELS = () => [
 
 /**
  * Shared toast-based push-permission nudge shown after a successful Agentic CLI
- * QR login (MMAI-925). On "Turn on": when native permission is still promptable
- * (platform-aware via isPushPermissionPromptable) it calls enableNotifications(),
- * which enables in-app notifications and requests the OS permission dialog. When
- * the OS can no longer show its dialog it deep-links to the device notification
- * settings and retries once the app returns to the foreground.
+ * QR login (MMAI-925). On "Turn on" it calls enableNotifications(), which turns
+ * on in-app notifications and requests the OS permission dialog when the OS can
+ * still show it. If native push is still not granted afterwards (denied, or an
+ * Android POST_NOTIFICATIONS prompt that is permanently dismissed and no longer
+ * shows), it deep-links to the device notification settings and retries once the
+ * app returns to the foreground.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -123,54 +122,58 @@ export function useCliLoginPushNudge(): {
     const isCurrent = () => flowEpochRef.current === epoch;
 
     try {
-      // Platform-aware: on Android any not-granted state is promptable, so we
-      // request the OS dialog rather than sending first-time users to Settings.
-      // We also enable directly when already granted (in-app-off / unregistered
-      // case) instead of pointlessly deep-linking to device settings.
-      const [granted, promptable] = await Promise.all([
-        isPushPermissionGranted(),
-        isPushPermissionPromptable(),
-      ]);
+      // Attempt to enable directly. enableNotifications() turns on in-app
+      // notifications and, when the OS can still show its dialog (iOS
+      // NOT_DETERMINED, or an Android POST_NOTIFICATIONS prompt that has not
+      // been permanently dismissed), requests the native push permission.
+      showLoadingToast();
+      await enableNotifications();
       if (!isCurrent()) {
         return;
       }
-      const action = resolveCliLoginPushNudgeTurnOnAction({
-        isGranted: granted,
-        isPromptable: promptable,
-      });
 
-      if (action === 'open_device_settings') {
-        toastRef?.current?.closeToast();
-        NotificationService.openSystemSettings();
-        scheduleForegroundRetry(async () => {
-          if (!isCurrent()) {
-            return;
-          }
-          inFlightRef.current = true;
-          try {
-            const retryGranted = await isPushPermissionGranted();
-            if (!isCurrent()) {
-              return;
-            }
-            if (!retryGranted) {
-              toastRef?.current?.closeToast();
-              return;
-            }
-            showLoadingToast();
-            await runEnableFlow(isCurrent);
-          } finally {
-            inFlightRef.current = false;
-          }
-        });
-        // The enable work is deferred to the foreground retry, which manages
-        // its own in-flight guard. Release the guard now so a later tap is not
-        // permanently blocked if the user never returns from device settings.
-        inFlightRef.current = false;
+      if (await isPushPermissionGranted()) {
+        if (isCurrent()) {
+          toastRef?.current?.closeToast();
+        }
+        return;
+      }
+      if (!isCurrent()) {
         return;
       }
 
-      showLoadingToast();
-      await runEnableFlow(isCurrent);
+      // Still not granted: the OS dialog was denied, or can no longer be shown
+      // at all. On Android, once POST_NOTIFICATIONS is permanently denied,
+      // requestPermission() silently no-ops (and Notifee cannot detect this up
+      // front), so the only remaining path is the device settings screen.
+      // Deep-link there and retry once the app returns to the foreground.
+      toastRef?.current?.closeToast();
+      NotificationService.openSystemSettings();
+      scheduleForegroundRetry(async () => {
+        if (!isCurrent()) {
+          return;
+        }
+        inFlightRef.current = true;
+        try {
+          if (!(await isPushPermissionGranted())) {
+            if (isCurrent()) {
+              toastRef?.current?.closeToast();
+            }
+            return;
+          }
+          if (!isCurrent()) {
+            return;
+          }
+          showLoadingToast();
+          await runEnableFlow(isCurrent);
+        } finally {
+          inFlightRef.current = false;
+        }
+      });
+      // The enable work is deferred to the foreground retry, which manages its
+      // own in-flight guard. Release the guard now so a later tap is not
+      // permanently blocked if the user never returns from device settings.
+      inFlightRef.current = false;
     } catch {
       if (isCurrent()) {
         toastRef?.current?.closeToast();
@@ -182,6 +185,7 @@ export function useCliLoginPushNudge(): {
       }
     }
   }, [
+    enableNotifications,
     runEnableFlow,
     scheduleForegroundRetry,
     showErrorToast,

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -125,11 +125,17 @@ export function useCliLoginPushNudge(): {
     try {
       // Platform-aware: on Android any not-granted state is promptable, so we
       // request the OS dialog rather than sending first-time users to Settings.
-      const promptable = await isPushPermissionPromptable();
+      // We also enable directly when already granted (in-app-off / unregistered
+      // case) instead of pointlessly deep-linking to device settings.
+      const [granted, promptable] = await Promise.all([
+        isPushPermissionGranted(),
+        isPushPermissionPromptable(),
+      ]);
       if (!isCurrent()) {
         return;
       }
       const action = resolveCliLoginPushNudgeTurnOnAction({
+        isGranted: granted,
         isPromptable: promptable,
       });
 

--- a/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
@@ -51,6 +51,12 @@ jest.mock('../../../locales/i18n', () => ({
   strings: jest.fn().mockImplementation((key) => key),
 }));
 
+const mockMaybePromptPushPermissionAfterCliLogin = jest.fn();
+jest.mock('./promptPushNotificationPermission', () => ({
+  maybePromptPushPermissionAfterCliLogin: () =>
+    mockMaybePromptPushPermissionAfterCliLogin(),
+}));
+
 const mockGetBearerToken = jest.fn().mockResolvedValue('hydra-token');
 const mockIsUnlocked = jest.fn(() => true);
 const mockSubscribe = jest.fn();
@@ -232,6 +238,7 @@ describe('AgenticCliQrLoginService', () => {
       description: 'sdk_connect_v2.show_cli_link_success.description',
     });
     expect(store.dispatch).toHaveBeenCalledTimes(1);
+    expect(mockMaybePromptPushPermissionAfterCliLogin).toHaveBeenCalledTimes(1);
     expect(cleanupConnection).toHaveBeenCalledWith(conn);
     expect(setStage).toHaveBeenCalledWith('send-auth-token-to-cli');
   });

--- a/app/core/AgenticCli/AgenticCliQrLoginService.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.ts
@@ -4,6 +4,7 @@ import Engine from '../Engine';
 import { store } from '../../store';
 import { strings } from '../../../locales/i18n';
 import logger, { redactUrl } from '../SDKConnectV2/services/logger';
+import { maybePromptPushPermissionAfterCliLogin } from './promptPushNotificationPermission';
 import { AgenticCliDashboardWebviewService } from '../../components/Views/AgenticCliDashboardWebview/AgenticCliDashboardWebviewService';
 import { Connection } from '../SDKConnectV2/services/connection';
 import type { AgenticCliConnectionRequest } from './agenticCliConnectionRequest';
@@ -147,6 +148,10 @@ export async function handleAgenticCliQrLogin({
         ),
       }),
     );
+
+    // Nudge push permission so post-login transaction notifications reach the
+    // user (MMAI-925). Fire-and-forget: never rejects, never blocks login.
+    void maybePromptPushPermissionAfterCliLogin();
   } finally {
     try {
       await cleanupConnection(conn);

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
@@ -50,14 +50,25 @@ describe('cliLoginPushNudgeRouting', () => {
     it('enables notifications when the OS dialog is still promptable', () => {
       expect(
         resolveCliLoginPushNudgeTurnOnAction({
+          isGranted: false,
           isPromptable: true,
         }),
       ).toBe('enable_notifications');
     });
 
-    it('opens device settings when the OS can no longer show its dialog', () => {
+    it('enables notifications when OS push is already granted (in-app off)', () => {
       expect(
         resolveCliLoginPushNudgeTurnOnAction({
+          isGranted: true,
+          isPromptable: false,
+        }),
+      ).toBe('enable_notifications');
+    });
+
+    it('opens device settings when the OS is neither granted nor promptable', () => {
+      expect(
+        resolveCliLoginPushNudgeTurnOnAction({
+          isGranted: false,
           isPromptable: false,
         }),
       ).toBe('open_device_settings');

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
@@ -1,7 +1,4 @@
-import {
-  resolveCliLoginPushNudgeTurnOnAction,
-  shouldShowCliLoginPushNudge,
-} from './cliLoginPushNudgeRouting';
+import { shouldShowCliLoginPushNudge } from './cliLoginPushNudgeRouting';
 
 describe('cliLoginPushNudgeRouting', () => {
   describe('shouldShowCliLoginPushNudge', () => {
@@ -43,35 +40,6 @@ describe('cliLoginPushNudgeRouting', () => {
           nativePushStatus: 'granted',
         }),
       ).toBe(false);
-    });
-  });
-
-  describe('resolveCliLoginPushNudgeTurnOnAction', () => {
-    it('enables notifications when the OS dialog is still promptable', () => {
-      expect(
-        resolveCliLoginPushNudgeTurnOnAction({
-          isGranted: false,
-          isPromptable: true,
-        }),
-      ).toBe('enable_notifications');
-    });
-
-    it('enables notifications when OS push is already granted (in-app off)', () => {
-      expect(
-        resolveCliLoginPushNudgeTurnOnAction({
-          isGranted: true,
-          isPromptable: false,
-        }),
-      ).toBe('enable_notifications');
-    });
-
-    it('opens device settings when the OS is neither granted nor promptable', () => {
-      expect(
-        resolveCliLoginPushNudgeTurnOnAction({
-          isGranted: false,
-          isPromptable: false,
-        }),
-      ).toBe('open_device_settings');
     });
   });
 });

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
@@ -47,28 +47,20 @@ describe('cliLoginPushNudgeRouting', () => {
   });
 
   describe('resolveCliLoginPushNudgeTurnOnAction', () => {
-    it('enables notifications programmatically when in-app is off', () => {
+    it('enables notifications when the OS dialog is still promptable', () => {
       expect(
         resolveCliLoginPushNudgeTurnOnAction({
-          nativePushStatus: 'granted',
+          isPromptable: true,
         }),
       ).toBe('enable_notifications');
     });
 
-    it('opens device settings when native permission is denied', () => {
+    it('opens device settings when the OS can no longer show its dialog', () => {
       expect(
         resolveCliLoginPushNudgeTurnOnAction({
-          nativePushStatus: 'denied',
+          isPromptable: false,
         }),
       ).toBe('open_device_settings');
-    });
-
-    it('enables notifications when the OS dialog is still available', () => {
-      expect(
-        resolveCliLoginPushNudgeTurnOnAction({
-          nativePushStatus: 'promptable',
-        }),
-      ).toBe('enable_notifications');
     });
   });
 });

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.test.ts
@@ -1,0 +1,74 @@
+import {
+  resolveCliLoginPushNudgeTurnOnAction,
+  shouldShowCliLoginPushNudge,
+} from './cliLoginPushNudgeRouting';
+
+describe('cliLoginPushNudgeRouting', () => {
+  describe('shouldShowCliLoginPushNudge', () => {
+    it('returns true when MetaMask in-app notifications are off', () => {
+      expect(
+        shouldShowCliLoginPushNudge({
+          isMetamaskNotificationsEnabled: false,
+          isMetaMaskPushNotificationsEnabled: true,
+          nativePushStatus: 'granted',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when native push is not granted', () => {
+      expect(
+        shouldShowCliLoginPushNudge({
+          isMetamaskNotificationsEnabled: true,
+          isMetaMaskPushNotificationsEnabled: true,
+          nativePushStatus: 'promptable',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when push is not registered in the controller', () => {
+      expect(
+        shouldShowCliLoginPushNudge({
+          isMetamaskNotificationsEnabled: true,
+          isMetaMaskPushNotificationsEnabled: false,
+          nativePushStatus: 'granted',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when in-app, native, and push registration are all enabled', () => {
+      expect(
+        shouldShowCliLoginPushNudge({
+          isMetamaskNotificationsEnabled: true,
+          isMetaMaskPushNotificationsEnabled: true,
+          nativePushStatus: 'granted',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('resolveCliLoginPushNudgeTurnOnAction', () => {
+    it('enables notifications programmatically when in-app is off', () => {
+      expect(
+        resolveCliLoginPushNudgeTurnOnAction({
+          nativePushStatus: 'granted',
+        }),
+      ).toBe('enable_notifications');
+    });
+
+    it('opens device settings when native permission is denied', () => {
+      expect(
+        resolveCliLoginPushNudgeTurnOnAction({
+          nativePushStatus: 'denied',
+        }),
+      ).toBe('open_device_settings');
+    });
+
+    it('enables notifications when the OS dialog is still available', () => {
+      expect(
+        resolveCliLoginPushNudgeTurnOnAction({
+          nativePushStatus: 'promptable',
+        }),
+      ).toBe('enable_notifications');
+    });
+  });
+});

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
@@ -33,16 +33,26 @@ export function shouldShowCliLoginPushNudge({
  * Chooses the next step when the user taps "Turn on" on the CLI push nudge toast.
  * MM in-app notifications are enabled programmatically via enableNotifications().
  *
+ * The nudge can appear even when OS push is already granted (e.g. in-app
+ * notifications are off or push is not registered), so we enable directly
+ * whenever the OS is already granted OR can still show its permission dialog.
+ *
  * `isPromptable` must come from `isPushPermissionPromptable()`, which is
  * platform-aware: iOS only reports NOT_DETERMINED as promptable, while Notifee
  * does not expose that state on Android, so any not-granted Android state is
  * treated as promptable and left to `requestPermission` to resolve. We only
- * deep-link to device settings when the OS can no longer show its own dialog.
+ * deep-link to device settings when the OS is neither granted nor promptable
+ * (i.e. it can no longer show its own dialog).
  */
 export function resolveCliLoginPushNudgeTurnOnAction({
+  isGranted,
   isPromptable,
 }: {
+  isGranted: boolean;
   isPromptable: boolean;
 }): CliLoginPushNudgeTurnOnAction {
-  return isPromptable ? 'enable_notifications' : 'open_device_settings';
+  if (isGranted || isPromptable) {
+    return 'enable_notifications';
+  }
+  return 'open_device_settings';
 }

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
@@ -32,14 +32,17 @@ export function shouldShowCliLoginPushNudge({
 /**
  * Chooses the next step when the user taps "Turn on" on the CLI push nudge toast.
  * MM in-app notifications are enabled programmatically via enableNotifications().
+ *
+ * `isPromptable` must come from `isPushPermissionPromptable()`, which is
+ * platform-aware: iOS only reports NOT_DETERMINED as promptable, while Notifee
+ * does not expose that state on Android, so any not-granted Android state is
+ * treated as promptable and left to `requestPermission` to resolve. We only
+ * deep-link to device settings when the OS can no longer show its own dialog.
  */
 export function resolveCliLoginPushNudgeTurnOnAction({
-  nativePushStatus,
+  isPromptable,
 }: {
-  nativePushStatus: PushPermissionStatus;
+  isPromptable: boolean;
 }): CliLoginPushNudgeTurnOnAction {
-  if (nativePushStatus === 'denied') {
-    return 'open_device_settings';
-  }
-  return 'enable_notifications';
+  return isPromptable ? 'enable_notifications' : 'open_device_settings';
 }

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
@@ -1,0 +1,45 @@
+import type { PushPermissionStatus } from '../../util/notifications/services/NotificationService';
+
+export type CliLoginPushNudgeTurnOnAction =
+  | 'enable_notifications'
+  | 'open_device_settings';
+
+/**
+ * Whether the post-CLI-login push nudge should appear. Requires both MetaMask
+ * in-app notifications (Settings → Notifications) and native OS push permission.
+ */
+export function shouldShowCliLoginPushNudge({
+  isMetamaskNotificationsEnabled,
+  isMetaMaskPushNotificationsEnabled,
+  nativePushStatus,
+}: {
+  isMetamaskNotificationsEnabled: boolean;
+  isMetaMaskPushNotificationsEnabled: boolean;
+  nativePushStatus: PushPermissionStatus;
+}): boolean {
+  if (!isMetamaskNotificationsEnabled) {
+    return true;
+  }
+  if (nativePushStatus !== 'granted') {
+    return true;
+  }
+  if (!isMetaMaskPushNotificationsEnabled) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Chooses the next step when the user taps "Turn on" on the CLI push nudge toast.
+ * MM in-app notifications are enabled programmatically via enableNotifications().
+ */
+export function resolveCliLoginPushNudgeTurnOnAction({
+  nativePushStatus,
+}: {
+  nativePushStatus: PushPermissionStatus;
+}): CliLoginPushNudgeTurnOnAction {
+  if (nativePushStatus === 'denied') {
+    return 'open_device_settings';
+  }
+  return 'enable_notifications';
+}

--- a/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeRouting.ts
@@ -1,9 +1,5 @@
 import type { PushPermissionStatus } from '../../util/notifications/services/NotificationService';
 
-export type CliLoginPushNudgeTurnOnAction =
-  | 'enable_notifications'
-  | 'open_device_settings';
-
 /**
  * Whether the post-CLI-login push nudge should appear. Requires both MetaMask
  * in-app notifications (Settings → Notifications) and native OS push permission.
@@ -27,32 +23,4 @@ export function shouldShowCliLoginPushNudge({
     return true;
   }
   return false;
-}
-
-/**
- * Chooses the next step when the user taps "Turn on" on the CLI push nudge toast.
- * MM in-app notifications are enabled programmatically via enableNotifications().
- *
- * The nudge can appear even when OS push is already granted (e.g. in-app
- * notifications are off or push is not registered), so we enable directly
- * whenever the OS is already granted OR can still show its permission dialog.
- *
- * `isPromptable` must come from `isPushPermissionPromptable()`, which is
- * platform-aware: iOS only reports NOT_DETERMINED as promptable, while Notifee
- * does not expose that state on Android, so any not-granted Android state is
- * treated as promptable and left to `requestPermission` to resolve. We only
- * deep-link to device settings when the OS is neither granted nor promptable
- * (i.e. it can no longer show its own dialog).
- */
-export function resolveCliLoginPushNudgeTurnOnAction({
-  isGranted,
-  isPromptable,
-}: {
-  isGranted: boolean;
-  isPromptable: boolean;
-}): CliLoginPushNudgeTurnOnAction {
-  if (isGranted || isPromptable) {
-    return 'enable_notifications';
-  }
-  return 'open_device_settings';
 }

--- a/app/core/AgenticCli/cliLoginPushNudgeSignal.test.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeSignal.test.ts
@@ -1,0 +1,45 @@
+import {
+  __resetCliLoginPushNudgeListenersForTests,
+  emitCliLoginPushNudge,
+  subscribeCliLoginPushNudge,
+} from './cliLoginPushNudgeSignal';
+
+describe('cliLoginPushNudgeSignal', () => {
+  beforeEach(() => {
+    __resetCliLoginPushNudgeListenersForTests();
+  });
+
+  it('invokes every subscribed listener when emitted', () => {
+    const a = jest.fn();
+    const b = jest.fn();
+    subscribeCliLoginPushNudge(a);
+    subscribeCliLoginPushNudge(b);
+
+    emitCliLoginPushNudge();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops calling a listener after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeCliLoginPushNudge(listener);
+    emitCliLoginPushNudge();
+    unsubscribe();
+    emitCliLoginPushNudge();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues emitting to other listeners if one throws', () => {
+    const failing = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const good = jest.fn();
+    subscribeCliLoginPushNudge(failing);
+    subscribeCliLoginPushNudge(good);
+
+    expect(() => emitCliLoginPushNudge()).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/core/AgenticCli/cliLoginPushNudgeSignal.ts
+++ b/app/core/AgenticCli/cliLoginPushNudgeSignal.ts
@@ -1,0 +1,27 @@
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+export const emitCliLoginPushNudge = (): void => {
+  listeners.forEach((listener) => {
+    try {
+      listener();
+    } catch {
+      // Listeners must never break the emit loop.
+    }
+  });
+};
+
+export const subscribeCliLoginPushNudge = (
+  listener: Listener,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+// Test-only helper — resets subscribers between tests.
+export const __resetCliLoginPushNudgeListenersForTests = (): void => {
+  listeners.clear();
+};

--- a/app/core/AgenticCli/promptPushNotificationPermission.test.ts
+++ b/app/core/AgenticCli/promptPushNotificationPermission.test.ts
@@ -1,0 +1,113 @@
+import { maybePromptPushPermissionAfterCliLogin } from './promptPushNotificationPermission';
+
+const mockIsNotificationsFeatureEnabled = jest.fn();
+const mockGetPushPermissionStatus = jest.fn();
+const mockEmit = jest.fn();
+const mockSelectIsMetamaskNotificationsEnabled = jest.fn();
+const mockSelectIsMetaMaskPushNotificationsEnabled = jest.fn();
+const mockGetState = jest.fn();
+
+jest.mock('../../util/notifications/constants', () => ({
+  isNotificationsFeatureEnabled: () => mockIsNotificationsFeatureEnabled(),
+}));
+
+jest.mock('../../util/notifications/services/NotificationService', () => ({
+  getPushPermissionStatus: () => mockGetPushPermissionStatus(),
+}));
+
+jest.mock('../../store', () => ({
+  store: {
+    getState: () => mockGetState(),
+  },
+}));
+
+jest.mock('../../selectors/notifications', () => ({
+  selectIsMetamaskNotificationsEnabled: (state: unknown) =>
+    mockSelectIsMetamaskNotificationsEnabled(state),
+  selectIsMetaMaskPushNotificationsEnabled: (state: unknown) =>
+    mockSelectIsMetaMaskPushNotificationsEnabled(state),
+}));
+
+jest.mock('./cliLoginPushNudgeSignal', () => ({
+  emitCliLoginPushNudge: () => mockEmit(),
+}));
+
+jest.mock('../SDKConnectV2/services/logger', () => ({
+  __esModule: true,
+  default: { warn: jest.fn() },
+}));
+
+describe('maybePromptPushPermissionAfterCliLogin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsNotificationsFeatureEnabled.mockReturnValue(true);
+    mockGetPushPermissionStatus.mockResolvedValue('promptable');
+    mockGetState.mockReturnValue({});
+    mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(true);
+    mockSelectIsMetaMaskPushNotificationsEnabled.mockReturnValue(false);
+  });
+
+  it('bails when the notifications feature is disabled', async () => {
+    mockIsNotificationsFeatureEnabled.mockReturnValue(false);
+
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockGetPushPermissionStatus).not.toHaveBeenCalled();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when in-app, native, and push registration are all enabled', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('granted');
+    mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(true);
+    mockSelectIsMetaMaskPushNotificationsEnabled.mockReturnValue(true);
+
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('emits when native permission is granted but MetaMask in-app notifications are off', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('granted');
+    mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(false);
+    mockSelectIsMetaMaskPushNotificationsEnabled.mockReturnValue(true);
+
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the nudge signal when native push is promptable', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('promptable');
+
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the nudge signal when native permission was previously denied', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('denied');
+
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-emits the nudge on every eligible CLI login', async () => {
+    mockGetPushPermissionStatus.mockResolvedValue('promptable');
+    mockSelectIsMetamaskNotificationsEnabled.mockReturnValue(false);
+
+    await maybePromptPushPermissionAfterCliLogin();
+    await maybePromptPushPermissionAfterCliLogin();
+
+    expect(mockEmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('never rejects when the permission status lookup throws', async () => {
+    mockGetPushPermissionStatus.mockRejectedValue(new Error('status boom'));
+
+    await expect(
+      maybePromptPushPermissionAfterCliLogin(),
+    ).resolves.toBeUndefined();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/AgenticCli/promptPushNotificationPermission.ts
+++ b/app/core/AgenticCli/promptPushNotificationPermission.ts
@@ -1,0 +1,53 @@
+import {
+  selectIsMetamaskNotificationsEnabled,
+  selectIsMetaMaskPushNotificationsEnabled,
+} from '../../selectors/notifications';
+import { store } from '../../store';
+import { isNotificationsFeatureEnabled } from '../../util/notifications/constants';
+import { getPushPermissionStatus } from '../../util/notifications/services/NotificationService';
+import logger from '../SDKConnectV2/services/logger';
+import { shouldShowCliLoginPushNudge } from './cliLoginPushNudgeRouting';
+import { emitCliLoginPushNudge } from './cliLoginPushNudgeSignal';
+
+/**
+ * After a successful Agentic CLI QR login, decide whether to nudge the user to
+ * enable push notifications so post-login transaction notifications reach them
+ * (MMAI-925).
+ *
+ * When we should nudge, this emits a signal that a mounted React listener
+ * ({@link CliLoginPushNudgeListener}) turns into a non-blocking toast with a
+ * "Turn on" action. The nudge is skipped when the notifications feature is
+ * disabled or when MetaMask in-app notifications, native push, and push
+ * registration are all fully enabled.
+ *
+ * Fire-and-forget: never rejects; failures are logged and swallowed so the CLI
+ * login flow is unaffected.
+ */
+export async function maybePromptPushPermissionAfterCliLogin(): Promise<void> {
+  try {
+    if (!isNotificationsFeatureEnabled()) {
+      return;
+    }
+
+    const state = store.getState();
+    const nativePushStatus = await getPushPermissionStatus();
+    if (
+      !shouldShowCliLoginPushNudge({
+        isMetamaskNotificationsEnabled:
+          selectIsMetamaskNotificationsEnabled(state),
+        isMetaMaskPushNotificationsEnabled:
+          selectIsMetaMaskPushNotificationsEnabled(state),
+        nativePushStatus,
+      })
+    ) {
+      return;
+    }
+
+    emitCliLoginPushNudge();
+  } catch (error) {
+    logger.warn(
+      'Failed to prompt push notification permission after CLI QR login',
+      error,
+    );
+  }
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10166,6 +10166,14 @@
       "title": "MetaMask Agent CLI link successful",
       "description": "Return to the CLI to continue."
     },
+    "push_nudge": {
+      "title": "Turn on notifications",
+      "description": "Get alerts for transactions from your CLI session.",
+      "turn_on_button": "Turn on",
+      "loading_title": "Turning on notifications",
+      "loading_description": "Give us a moment while we set things up.",
+      "enable_error": "Couldn't turn on notifications. Try again from Settings."
+    },
     "show_otp": {
       "title": "Enter this code",
       "description": "Enter {{otp}} in {{dappName}} to finish connecting. This code expires in {{seconds}} seconds.",


### PR DESCRIPTION
## **Description**

After a successful Agentic CLI QR login, the app now shows a non-blocking toast prompting the user to turn on notifications, so transaction updates from their CLI session can actually reach them.

The nudge is shown only when notifications are not fully set up — i.e. when MetaMask in-app notifications are off, native OS push permission is not granted, or push registration is missing. Tapping **Turn on**:

- If native permission is promptable (or in-app notifications are off): calls `enableNotifications()`, which enables in-app notifications and requests the OS permission dialog.
- If native permission is already denied: deep-links to the device notification settings and retries automatically when the app returns to the foreground.

The nudge is fire-and-forget and never blocks or interferes with the CLI login flow. Routing and eligibility are implemented as pure, unit-tested helpers; a module-level signal bridges the non-React login service to the toast UI mounted at the app root.

## Video


https://github.com/user-attachments/assets/e57d5171-f338-475f-ab72-ff84a5efa6ff


https://github.com/user-attachments/assets/034f0fbd-d3f5-45ca-a536-8e2a0d681352



## **Changelog**

CHANGELOG entry: Added a prompt to enable push notifications after linking the MetaMask Agent CLI, so transaction updates from CLI sessions reach the user.

## **Related issues**

Fixes: MMAI-925

## **Manual testing steps**

```gherkin
Feature: Push permission nudge after CLI QR login

  Scenario: Notifications not set up
    Given notifications are not fully enabled
    And I complete a successful Agentic CLI QR login
    Then a non-blocking "Turn on notifications" toast appears

  Scenario: Turn on when permission is promptable
    Given the OS push permission has never been requested
    When I tap "Turn on"
    Then in-app notifications are enabled
    And the OS permission dialog is shown

  Scenario: Turn on when permission is denied
    Given the OS push permission is denied
    When I tap "Turn on"
    Then I am taken to the device notification settings
    And on returning to the app it retries and enables push if I granted it

  Scenario: Notifications already fully enabled
    Given in-app notifications and native push are fully enabled
    When I complete a successful Agentic CLI QR login
    Then no nudge is shown
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)