### PR TITLE
feat: delay password mismatch error until confirm meets min length

### DIFF
--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -603,6 +603,23 @@ describe('ChoosePassword', () => {
       ).toBeOnTheScreen();
     });
 
+    it('does not show a password mismatch error before confirm reaches the minimum length', async () => {
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+
+      const { passwordInput, confirmPasswordInput } =
+        getFormElements(component);
+
+      await act(async () => {
+        fireEvent.changeText(passwordInput, 'Test123456!');
+        fireEvent.changeText(confirmPasswordInput, 'x');
+      });
+
+      expect(
+        component.queryByText(strings('choose_password.password_error')),
+      ).toBeNull();
+    });
+
     it('submit button is disabled when passwords do not match', async () => {
       const component = renderWithProviders(<ChoosePassword />);
       await waitForInit();

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -56,6 +56,7 @@ import {
 import {
   passwordRequirementsMet,
   MIN_PASSWORD_LENGTH,
+  shouldShowPasswordMismatchError,
 } from '../../../util/password';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
@@ -367,10 +368,10 @@ const ChoosePassword = () => {
     if (loading) return { valid: false, shouldTrack: false };
 
     if (!canSubmit) {
-      const shouldTrackMismatch =
-        password !== '' &&
-        confirmPassword !== '' &&
-        password !== confirmPassword;
+      const shouldTrackMismatch = shouldShowPasswordMismatchError(
+        password,
+        confirmPassword,
+      );
 
       if (shouldTrackMismatch) {
         track(MetaMetricsEvents.WALLET_SETUP_FAILURE, {
@@ -725,8 +726,7 @@ const ChoosePassword = () => {
   }, []);
 
   const checkError = useCallback(
-    () =>
-      password !== '' && confirmPassword !== '' && password !== confirmPassword,
+    () => shouldShowPasswordMismatchError(password, confirmPassword),
     [password, confirmPassword],
   );
 

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -34,6 +34,7 @@ import { captureException } from '@sentry/react-native';
 import {
   passwordRequirementsMet,
   MIN_PASSWORD_LENGTH,
+  shouldShowPasswordMismatchError,
 } from '../../../util/password';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useTheme } from '../../../util/theme';
@@ -561,8 +562,7 @@ const ImportFromSecretRecoveryPhrase = ({
     }
   };
 
-  const isError =
-    password !== '' && confirmPassword !== '' && password !== confirmPassword;
+  const isError = shouldShowPasswordMismatchError(password, confirmPassword);
 
   const showWhatIsSeedPhrase = () => {
     track(MetaMetricsEvents.SRP_DEFINITION_CLICKED, {

--- a/app/components/Views/ResetPassword/index.tsx
+++ b/app/components/Views/ResetPassword/index.tsx
@@ -48,6 +48,7 @@ import {
 import {
   passwordRequirementsMet,
   MIN_PASSWORD_LENGTH,
+  shouldShowPasswordMismatchError,
 } from '../../../util/password';
 import NotificationManager from '../../../core/NotificationManager';
 import { passcodeType } from '../../../util/authentication';
@@ -404,8 +405,7 @@ const ResetPassword = ({ navigation, route }: ResetPasswordProps) => {
   }, [reauthenticate, password]);
 
   const isError = useCallback(
-    () =>
-      password !== '' && confirmPassword !== '' && password !== confirmPassword,
+    () => shouldShowPasswordMismatchError(password, confirmPassword),
     [password, confirmPassword],
   );
 

--- a/app/util/password/index.test.ts
+++ b/app/util/password/index.test.ts
@@ -1,7 +1,9 @@
 import {
   doesPasswordMatch,
   getPasswordStrengthWord,
+  MIN_PASSWORD_LENGTH,
   passwordRequirementsMet,
+  shouldShowPasswordMismatchError,
 } from '.';
 import { UNRECOGNIZED_PASSWORD_STRENGTH } from '../../constants/error';
 
@@ -91,5 +93,37 @@ describe('passwordRequirementsMet', () => {
   });
   it('should fail when password is lt 8 in length', () => {
     expect(passwordRequirementsMet('lol')).toEqual(false);
+  });
+});
+
+describe('shouldShowPasswordMismatchError', () => {
+  const password = 'a'.repeat(MIN_PASSWORD_LENGTH);
+
+  it('returns false while confirm password is shorter than the minimum length', () => {
+    expect(
+      shouldShowPasswordMismatchError(
+        password,
+        'x'.repeat(MIN_PASSWORD_LENGTH - 1),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when confirm password meets the minimum length and differs', () => {
+    expect(
+      shouldShowPasswordMismatchError(
+        password,
+        'b'.repeat(MIN_PASSWORD_LENGTH),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when passwords match', () => {
+    expect(shouldShowPasswordMismatchError(password, password)).toBe(false);
+  });
+
+  it('returns false when the password field is empty', () => {
+    expect(
+      shouldShowPasswordMismatchError('', 'b'.repeat(MIN_PASSWORD_LENGTH)),
+    ).toBe(false);
   });
 });

--- a/app/util/password/index.ts
+++ b/app/util/password/index.ts
@@ -4,6 +4,23 @@ import { UNRECOGNIZED_PASSWORD_STRENGTH } from '../../constants/error';
 
 export const MIN_PASSWORD_LENGTH = 8;
 
+/**
+ * Whether to show the inline "passwords don't match" error.
+ * Requires the confirm field to reach {@link MIN_PASSWORD_LENGTH} first so
+ * early typing does not flash a mismatch error.
+ *
+ * @param password - New password value.
+ * @param confirmPassword - Confirm password value.
+ * @returns True when the mismatch error should be shown.
+ */
+export const shouldShowPasswordMismatchError = (
+  password: string,
+  confirmPassword: string,
+): boolean =>
+  password !== '' &&
+  confirmPassword.length >= MIN_PASSWORD_LENGTH &&
+  password !== confirmPassword;
+
 export const getPasswordStrengthWord = (strength: number) => {
   if (strength < 0) {
     throw new Error(UNRECOGNIZED_PASSWORD_STRENGTH);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
The confirm-password field showed "Passwords don't match" as soon as the user typed the first character, which felt noisy while they were still entering the confirmation.

This PR waits until the confirm field reaches the existing minimum password length (8) before showing the mismatch error. The logic lives in a shared `shouldShowPasswordMismatchError` helper and is used on Create Password (`ChoosePassword`), Import from SRP, and Reset Password. Submit remains disabled until the passwords actually match.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changes premature "Passwords don't match" errors while confirming a new password

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-935

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Password confirmation mismatch feedback

 Scenario: user types a short confirm password that does not match yet
    Given MetaMask Mobile is on the Create password screen
    And the user has entered a valid new password of at least 8 characters
    When the user types fewer than 8 characters in Confirm password that do not match
    Then the "Passwords don't match" error should not be shown
    And the submit button should remain disabled

  Scenario: user enters a full-length confirm password that does not match
    Given MetaMask Mobile is on the Create password screen
    And the user has entered a valid new password of at least 8 characters
    When the user enters at least 8 characters in Confirm password that do not match
    Then the "Passwords don't match" error should be shown
    And the submit button should remain disabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/faec7d4a-4e4d-4c72-97e6-019b115a31d5


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9c51eef5-0669-4226-a3d7-ee85a846883d


https://github.com/user-attachments/assets/98263d17-0622-4d03-8e83-1622fa211e97

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



