### PR TITLE
feat: add item type extraction for list components

### DIFF
--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -8,7 +8,9 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/keyring-api';
-import MultichainTransactionsView from './MultichainTransactionsView';
+import MultichainTransactionsView, {
+  getMultichainTransactionItemType,
+} from './MultichainTransactionsView';
 import { selectNonEvmTransactions } from '../../../selectors/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { ButtonProps } from '../../../component-library/components/Buttons/Button/Button.types';
@@ -124,6 +126,20 @@ describe('MultichainTransactionsView', () => {
       timestamp: 1742400000,
     },
   ];
+
+  it('uses distinct recycle pools for standard and bridge transactions', () => {
+    expect(
+      getMultichainTransactionItemType(mockTransactions[0], false, {}),
+    ).toBe('transaction');
+    expect(
+      getMultichainTransactionItemType(mockTransactions[1], false, {}),
+    ).toBe('transaction');
+    expect(
+      getMultichainTransactionItemType(mockTransactions[0], false, {
+        [mockTransactions[0].id]: {},
+      }),
+    ).toBe('bridge-transaction');
+  });
 
   const customRender = (ui: React.ReactElement) => {
     const utils = render(ui);

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -311,6 +311,9 @@ const MultichainTransactionsView = ({
               data={activityListData}
               renderItem={renderListItem}
               keyExtractor={keyExtractor}
+              getItemType={(item) =>
+                'type' in item ? item.type : 'transaction'
+              }
               ListHeaderComponent={header}
               ListEmptyComponent={renderEmptyList}
               ListFooterComponent={footer}

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -87,7 +87,7 @@ interface MultichainTransactionsViewProps {
 }
 
 export const getMultichainTransactionItemType = (
-  item: Transaction | GroupedActivityListItem,
+  item: Pick<Transaction, 'id' | 'type'> | GroupedActivityListItem,
   shouldUseActivityRedesign: boolean,
   bridgeHistoryItemsBySrcTxHash: Readonly<Record<string, unknown>>,
 ) => {
@@ -97,7 +97,7 @@ export const getMultichainTransactionItemType = (
     }
 
     const transaction =
-      item.type === 'item' && item.item.raw?.type === 'keyringTransaction'
+      'item' in item && item.item.raw?.type === 'keyringTransaction'
         ? item.item.raw.data
         : undefined;
 
@@ -106,9 +106,11 @@ export const getMultichainTransactionItemType = (
       : 'activity-item';
   }
 
-  const transaction = item as Transaction;
+  if (!('id' in item)) {
+    return item.type;
+  }
 
-  return bridgeHistoryItemsBySrcTxHash[transaction.id]
+  return bridgeHistoryItemsBySrcTxHash[item.id]
     ? 'bridge-transaction'
     : 'transaction';
 };

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -86,6 +86,33 @@ interface MultichainTransactionsViewProps {
   location?: TransactionDetailLocation;
 }
 
+export const getMultichainTransactionItemType = (
+  item: Transaction | GroupedActivityListItem,
+  shouldUseActivityRedesign: boolean,
+  bridgeHistoryItemsBySrcTxHash: Readonly<Record<string, unknown>>,
+) => {
+  if (shouldUseActivityRedesign) {
+    if (item.type === 'pending-header' || item.type === 'date-header') {
+      return item.type;
+    }
+
+    const transaction =
+      item.type === 'item' && item.item.raw?.type === 'keyringTransaction'
+        ? item.item.raw.data
+        : undefined;
+
+    return transaction && bridgeHistoryItemsBySrcTxHash[transaction.id]
+      ? 'bridge-activity'
+      : 'activity-item';
+  }
+
+  const transaction = item as Transaction;
+
+  return bridgeHistoryItemsBySrcTxHash[transaction.id]
+    ? 'bridge-transaction'
+    : 'transaction';
+};
+
 const MultichainTransactionsView = ({
   transactions,
   header,
@@ -312,7 +339,11 @@ const MultichainTransactionsView = ({
               renderItem={renderListItem}
               keyExtractor={keyExtractor}
               getItemType={(item) =>
-                'type' in item ? item.type : 'transaction'
+                getMultichainTransactionItemType(
+                  item,
+                  shouldUseActivityRedesign,
+                  bridgeHistoryItemsBySrcTxHash,
+                )
               }
               ListHeaderComponent={header}
               ListEmptyComponent={renderEmptyList}

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -721,6 +721,7 @@ const UnifiedTransactionsView = ({
               testID={UnifiedTransactionsViewSelectorsIDs.CONTAINER}
               renderItem={renderItem}
               keyExtractor={generateKey}
+              getItemType={(item) => item.kind ?? 'item'}
               ListHeaderComponent={header}
               ListEmptyComponent={
                 isInitialLoading ? renderInitialLoading : renderEmptyList


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds `getItemType` to the multichain and unified transaction FlashLists. Transaction rows, activity headers, and EVM/non-EVM transaction variants now recycle within shape-specific pools, avoiding cross-shape layout measurement churn while scrolling long activity histories.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1133

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Transaction activity list recycling

  Scenario: scroll a populated activity list
    Given I am logged into MetaMask Mobile with an account containing more than 100 transactions
    And I am viewing the Activity tab
    When I rapidly scroll through the transaction list on Android
    Then pending headers, date headers, and transaction rows render correctly
    And scrolling remains smooth in the performance monitor
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> List-only recycling hints with no auth, data, or rendering logic changes beyond scroll performance.
> 
> **Overview**
> Improves scroll performance on long activity lists by telling **FlashList** which recycle pool each row belongs to, so rows with different layouts are not reused across shapes.
> 
> **Multichain** activity now uses a new **`getMultichainTransactionItemType`** helper wired into **`getItemType`**. It separates standard vs bridge rows, and when the activity redesign is on, pending/date headers, bridge activity, and normal activity items each get their own type.
> 
> **Unified** transactions **`FlashList`** uses **`getItemType`** with each item’s existing **`kind`** (falling back to **`item`**), so EVM vs confirmed EVM vs other variants recycle separately.
> 
> A unit test asserts bridge vs non-bridge multichain rows map to different item types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fb287312fa7bc45db954b21b5776951ae069b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->