### PR TITLE
fix: label trader position CTA as Trade

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.test.tsx
@@ -146,6 +146,13 @@ describe('TraderPositionBuyCta', () => {
     );
   });
 
+  it('labels the spot position action as Trade', () => {
+    const { getByText, queryByText } = renderCta();
+
+    expect(getByText('Trade')).toBeOnTheScreen();
+    expect(queryByText('Buy')).toBeNull();
+  });
+
   describe('control variant', () => {
     beforeEach(() => setVariant(false));
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.tsx
@@ -172,7 +172,7 @@ const TraderPositionBuyCta: React.FC<TraderPositionBuyCtaProps> = ({
           onPress={handleBuyPress}
           testID={buyButtonTestID}
         >
-          {strings('social_leaderboard.trader_position.buy')}
+          {strings('social_leaderboard.trader_position.trade')}
         </Button>
       </Box>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Changes the primary action label on spot trader-position pages from **Buy** to **Trade**, matching the existing perps label. The action handler is unchanged, so the control variant continues to open the QuickBuy bottom sheet and the treatment variant retains its existing swaps behavior.

Automated validation:
- `yarn jest app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.test.tsx --runInBand --coverage=false`
- `yarn eslint app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.tsx app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.test.tsx`
- `yarn prettier --check app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.tsx app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionBuyCta.test.tsx`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Changed the trader position action label from Buy to Trade for spot assets

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — requested via Slack

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trader position action label

  Scenario: Trade a spot asset from a trader position
    Given the user is viewing a non-perps trader position
    And the Top Traders Buy Action experiment resolves to the control variant
    When the trader position page loads
    Then the primary action label reads "Trade"
    When the user taps "Trade"
    Then the QuickBuy bottom sheet opens for the selected asset
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — this is a copy-only change covered by the targeted component test.

### **Before**

N/A — the button label read "Buy".

### **After**

N/A — the button label reads "Trade".

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable to this copy-only change; covered by the component test.
- [x] I've tested with a power user scenario
  - Not applicable to this copy-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable; this change does not add or modify an operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1784797433576289?thread_ts=1784797433.576289&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-fa45ea27-0734-5d12-becb-850d2b23ef58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa45ea27-0734-5d12-becb-850d2b23ef58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

