### PR TITLE
fix(money): show skeleton while money account resolves on home card (MUSD-1196)

### DIFF
--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -852,7 +852,7 @@ describe('MoneyBalanceCard', () => {
     });
   });
 
-  describe('noAccount state', () => {
+  describe('when the money account has not resolved yet', () => {
     beforeEach(() => {
       mockUseMoneyAccountInfo.mockReturnValue(
         createInfoMock({
@@ -860,14 +860,29 @@ describe('MoneyBalanceCard', () => {
           primaryMoneyAccount: undefined,
         }),
       );
+      mockUseMoneyAccountBalance.mockReturnValue(
+        createBalanceMock({
+          isBalanceLoading: true,
+          totalFiatFormatted: undefined,
+          totalFiatRaw: undefined,
+        }),
+      );
     });
 
-    it('renders the no-account message in the balance slot', () => {
+    it('renders the balance skeleton', () => {
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
       expect(
-        getByTestId(MoneyBalanceCardTestIds.BALANCE_NO_ACCOUNT),
-      ).toHaveTextContent(strings('money.balance_no_account'));
+        getByTestId(MoneyBalanceCardTestIds.BALANCE_SKELETON),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not render the no-account message', () => {
+      const { queryByText } = renderWithProvider(<MoneyBalanceCard />);
+
+      expect(
+        queryByText(strings('money.balance_no_account')),
+      ).not.toBeOnTheScreen();
     });
 
     it('does not render the balance text', () => {
@@ -884,6 +899,22 @@ describe('MoneyBalanceCard', () => {
       expect(
         queryByTestId(MoneyBalanceCardTestIds.BALANCE_ERROR),
       ).not.toBeOnTheScreen();
+    });
+
+    it('renders the balance skeleton even when the balance is not loading', () => {
+      mockUseMoneyAccountBalance.mockReturnValue(
+        createBalanceMock({
+          isBalanceLoading: false,
+          totalFiatFormatted: undefined,
+          totalFiatRaw: undefined,
+        }),
+      );
+
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+      expect(
+        getByTestId(MoneyBalanceCardTestIds.BALANCE_SKELETON),
+      ).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
@@ -11,7 +11,6 @@ export const MoneyBalanceCardTestIds = {
   BALANCE_ERROR: 'money-balance-card-balance-error',
   BALANCE_RETRY: 'money-balance-card-balance-retry',
   BALANCE_UNAVAILABLE: 'money-balance-card-balance-unavailable',
-  BALANCE_NO_ACCOUNT: 'money-balance-card-balance-no-account',
   APY_TAG: 'money-balance-card-apy-tag',
   APY_TAG_SKELETON: 'money-balance-card-apy-tag-skeleton',
   ADD_BUTTON: 'money-balance-card-add-button',

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -115,7 +115,7 @@ const MoneyBalanceCard = () => {
   let buttonVariant: ButtonVariant;
   let containerTestId: string;
 
-  if (!hasMoneyAccount || isError || isRetrying) {
+  if (isError || isRetrying) {
     buttonVariant = ButtonVariant.Secondary;
     containerTestId = MoneyBalanceCardTestIds.ERROR_CONTAINER;
   } else if (isUnavailable) {
@@ -206,19 +206,7 @@ const MoneyBalanceCard = () => {
   }, [navigation, trackTooltipClicked]);
 
   const renderBalanceSlot = () => {
-    if (!hasMoneyAccount) {
-      return (
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextAlternative}
-          testID={MoneyBalanceCardTestIds.BALANCE_NO_ACCOUNT}
-        >
-          {strings('money.balance_no_account')}
-        </Text>
-      );
-    }
-    if (isBalanceLoading || isRetrying) {
+    if (!hasMoneyAccount || isBalanceLoading || isRetrying) {
       return (
         <Skeleton
           height={24}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money balance card on the home page now shows its loading skeleton until the money account and balance have resolved, then renders the balance directly.

Bug: on cold start the card's balance slot checked `!hasMoneyAccount` before the loading check. `hasMoneyAccount` derives from `MoneyAccountController.moneyAccounts`, which is transiently empty during engine state hydration (and, on first run after the feature flag turns on, until `controller.init()` creates the account post-unlock), so the "Money account not found" error text briefly flashed beneath the home page loading skeleton before the balance loaded.

"No money account yet" is never a terminal state on this card — `MoneyAccountController.init()` idempotently creates a money account for the primary keyring, and while the account is absent the balance query is disabled and stays in its loading state. The fix therefore folds `!hasMoneyAccount` into the skeleton condition of the balance slot and removes the now-unreachable "Money account not found" branch (and its testID) from the card. The pre-resolution container/button also render the same default presentation as the existing loading-with-account state, so the Add button no longer flips variants while the account resolves. The error, retrying, unavailable, empty, funded, and privacy-mode states are unchanged.

The `money.balance_no_account` locale key is intentionally kept: `MoneyBalanceSummary` on the Money home screen still uses it and is out of this ticket's scope.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that briefly showed "Money account not found" on the home page Money balance card while the app was still loading

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1196

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Home page Money balance card loading state

  Scenario: user cold starts the app with a money account
    Given the app is fully killed and the Money account feature is enabled

    When user opens the app and unlocks the wallet
    Then the Money balance card shows the loading skeleton until the balance resolves
    And "Money account not found" is never visible
    And the resolved balance renders correctly once loaded

  Scenario: user unlocks before the money account has been created
    Given a fresh install where the money account has not been created yet

    When user opens the app and unlocks the wallet
    Then the Money balance card shows the loading skeleton while the account is created and the balance loads
    And "Money account not found" is never visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

See the recording attached to [MUSD-1196](https://consensyssoftware.atlassian.net/browse/MUSD-1196): at ~0:04 the "Money account not found" text is visible beneath the home page loading skeleton.

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8ae33403-10a7-46e4-a17b-8d8216da9f65


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state change on the home Money card with updated unit tests; error, empty, and funded flows are unchanged once the account exists.
> 
> **Overview**
> Fixes a **cold-start flash** of “Money account not found” on the wallet home **Money balance card** by treating an unresolved money account like a loading state instead of a terminal “no account” state.
> 
> **`renderBalanceSlot`** now shows the balance **skeleton** when `!hasMoneyAccount`, `isBalanceLoading`, or retrying— and drops the dedicated **no-account** copy and **`BALANCE_NO_ACCOUNT`** test ID. **Container/button styling** no longer maps missing account to the error path (`!hasMoneyAccount` removed from that branch), so the Add button doesn’t flip variants while the account hydrates or is created.
> 
> Tests were updated to assert skeleton + no `money.balance_no_account` text, including when balance loading is false but the account still hasn’t resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e7919dff18c5fa2008fb8349ef3d15092266907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUSD-1196]: https://consensyssoftware.atlassian.net/browse/MUSD-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ