### PR TITLE
feat(agentic-cli): use push onboarding bottom sheet for CLI login nudge

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -50,7 +50,6 @@ import PerpsWebSocketHealthToast, {
   WebSocketHealthToastProvider,
 } from '../../UI/Perps/components/PerpsWebSocketHealthToast';
 import { ControllerEventToastBridge } from './ControllerEventToastBridge';
-import { CliLoginPushNudgeListener } from '../../UI/CliLoginPushNudge';
 import { usePredictToastRegistrations } from '../../UI/Predict/hooks/usePredictToastRegistrations';
 import { usePerpsWithdrawToastRegistrations } from '../../UI/Perps/hooks/usePerpsWithdrawToastRegistrations';
 import { useQuickBuyToastRegistrations } from '../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations';
@@ -1495,7 +1494,6 @@ const App: React.FC = () => {
         <PerpsWebSocketHealthToast />
         {__DEV__ && <AgentStepHud />}
         <ControllerEventToastBridge registrations={toastRegistrations} />
-        <CliLoginPushNudgeListener />
         <ProfilerManager />
         {/* Dev/QA-only visual inspector — no-op unless DESIGNER_MODE=true (see docs/designer-mode.md) */}
         <DesignerModeOverlay />

--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -34,6 +34,7 @@ import {
 
 import ProtectYourWalletModal from '../../UI/ProtectYourWalletModal';
 import PushNotificationOnboardingRoot from '../../Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot';
+import { CliLoginPushNudgeListener } from '../../UI/CliLoginPushNudge';
 import MainNavigator from './MainNavigator';
 import { query } from '@metamask/controller-utils';
 import EarnTransactionMonitor from '../../UI/Earn/components/EarnTransactionMonitor';
@@ -415,6 +416,7 @@ const Main = (props) => {
         <RootRPCMethodsUI navigation={props.navigation} />
         <ProtectWalletMandatoryModal />
         <PushNotificationOnboardingRoot />
+        <CliLoginPushNudgeListener />
       </View>
     </React.Fragment>
   );

--- a/app/components/Nav/Main/index.test.tsx
+++ b/app/components/Nav/Main/index.test.tsx
@@ -89,6 +89,11 @@ jest.mock(
   }),
 );
 
+jest.mock('../../UI/CliLoginPushNudge', () => ({
+  CliLoginPushNudgeListener: () =>
+    mockReact.createElement('CliLoginPushNudgeListenerMock'),
+}));
+
 jest.mock('../../UI/ReviewModal', () => ({
   __esModule: true,
   default: () => mockReact.createElement('ReviewModalMock'),

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CliLoginPushNudgeListener from './CliLoginPushNudgeListener';
+
+const mockNewUserSheet = jest.fn();
+const mockUseCliLoginPushNudge = jest.fn();
+
+jest.mock(
+  '../../Views/Notifications/PushNotificationOnboarding/NewUserSheet',
+  () => ({
+    __esModule: true,
+    default: (props: unknown) => {
+      mockNewUserSheet(props);
+      return null;
+    },
+  }),
+);
+
+jest.mock('./useCliLoginPushNudge', () => ({
+  useCliLoginPushNudge: () => mockUseCliLoginPushNudge(),
+}));
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+describe('CliLoginPushNudgeListener', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseCliLoginPushNudge.mockReturnValue({
+      isVisible: true,
+      onYes: jest.fn(),
+      onNotNow: jest.fn(),
+      onClose: jest.fn(),
+    });
+  });
+
+  it('uses the CLI-specific copy and notification preview', () => {
+    render(<CliLoginPushNudgeListener />);
+
+    expect(mockNewUserSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testID: 'cli-login-push-nudge',
+        title: 'sdk_connect_v2.push_nudge.title',
+        body: 'sdk_connect_v2.push_nudge.description',
+        yesLabel: 'sdk_connect_v2.push_nudge.turn_on_button',
+        previewTitle: 'sdk_connect_v2.push_nudge.preview_title',
+        previewMessage: 'sdk_connect_v2.push_nudge.preview_message',
+        previewTimestamp: 'sdk_connect_v2.push_nudge.preview_timestamp',
+      }),
+    );
+  });
+});

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -1,18 +1,29 @@
-import { useEffect } from 'react';
-import { subscribeCliLoginPushNudge } from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
+import React from 'react';
+import { strings } from '../../../../locales/i18n';
+import NewUserSheet from '../../Views/Notifications/PushNotificationOnboarding/NewUserSheet';
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 
 /**
- * Bridges the non-React CLI QR-login service layer to the toast UI (MMAI-925).
- * Mount once inside the ToastContext provider; subscribes to the module-level
- * push-nudge signal and shows the toast when emitted.
+ * Bridges the non-React CLI QR-login service layer to the push-permission
+ * bottom sheet (MMAI-925). Mount once near the app root; subscribes to the
+ * module-level push-nudge signal and shows the shared "Never miss a move"
+ * sheet (with CLI-specific copy) when emitted.
  */
 const CliLoginPushNudgeListener = () => {
-  const { showNudge } = useCliLoginPushNudge();
+  const { isVisible, onYes, onNotNow, onClose } = useCliLoginPushNudge();
 
-  useEffect(() => subscribeCliLoginPushNudge(() => showNudge()), [showNudge]);
-
-  return null;
+  return (
+    <NewUserSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      onYes={onYes}
+      onNotNow={onNotNow}
+      title={strings('sdk_connect_v2.push_nudge.title')}
+      body={strings('sdk_connect_v2.push_nudge.description')}
+      showPreview={false}
+      testID="cli-login-push-nudge"
+    />
+  );
 };
 
 export default CliLoginPushNudgeListener;

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { strings } from '../../../../locales/i18n';
 import NewUserSheet from '../../Views/Notifications/PushNotificationOnboarding/NewUserSheet';
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
@@ -14,15 +14,41 @@ import { useCliLoginPushNudge } from './useCliLoginPushNudge';
  */
 const CliLoginPushNudgeListener = () => {
   const { isVisible, onYes, onNotNow, onClose } = useCliLoginPushNudge();
+  // Copy-review preview only: make the CLI sheet available immediately after an
+  // authenticated development build launches. It never ships in production.
+  const [isDevPreviewVisible, setIsDevPreviewVisible] = useState(__DEV__);
+
+  const dismissDevPreview = useCallback(() => {
+    setIsDevPreviewVisible(false);
+  }, []);
+
+  const handleYes = useCallback(async () => {
+    dismissDevPreview();
+    await onYes();
+  }, [dismissDevPreview, onYes]);
+
+  const handleNotNow = useCallback(() => {
+    dismissDevPreview();
+    onNotNow();
+  }, [dismissDevPreview, onNotNow]);
+
+  const handleClose = useCallback(
+    (hasPendingAction?: boolean) => {
+      dismissDevPreview();
+      onClose(hasPendingAction);
+    },
+    [dismissDevPreview, onClose],
+  );
 
   return (
     <NewUserSheet
-      isVisible={isVisible}
-      onClose={onClose}
-      onYes={onYes}
-      onNotNow={onNotNow}
+      isVisible={isVisible || isDevPreviewVisible}
+      onClose={handleClose}
+      onYes={handleYes}
+      onNotNow={handleNotNow}
       title={strings('sdk_connect_v2.push_nudge.title')}
       body={strings('sdk_connect_v2.push_nudge.description')}
+      yesLabel={strings('sdk_connect_v2.push_nudge.turn_on_button')}
       showPreview={false}
       testID="cli-login-push-nudge"
     />

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -24,7 +24,9 @@ const CliLoginPushNudgeListener = () => {
       title={strings('sdk_connect_v2.push_nudge.title')}
       body={strings('sdk_connect_v2.push_nudge.description')}
       yesLabel={strings('sdk_connect_v2.push_nudge.turn_on_button')}
-      showPreview={false}
+      previewTitle={strings('sdk_connect_v2.push_nudge.preview_title')}
+      previewMessage={strings('sdk_connect_v2.push_nudge.preview_message')}
+      previewTimestamp={strings('sdk_connect_v2.push_nudge.preview_timestamp')}
       testID="cli-login-push-nudge"
     />
   );

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -5,9 +5,12 @@ import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 
 /**
  * Bridges the non-React CLI QR-login service layer to the push-permission
- * bottom sheet (MMAI-925). Mount once near the app root; subscribes to the
- * module-level push-nudge signal and shows the shared "Never miss a move"
- * sheet (with CLI-specific copy) when emitted.
+ * bottom sheet (MMAI-925). Mounted once inside the authenticated Main flow
+ * (alongside PushNotificationOnboardingRoot) so the BottomSheet layers above
+ * native-stack screens on iOS; a sibling of <AppFlow /> in App.tsx would
+ * render behind those screens. Subscribes to the module-level push-nudge
+ * signal and shows the shared "Never miss a move" sheet (with CLI-specific
+ * copy) when emitted.
  */
 const CliLoginPushNudgeListener = () => {
   const { isVisible, onYes, onNotNow, onClose } = useCliLoginPushNudge();

--- a/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
+++ b/app/components/UI/CliLoginPushNudge/CliLoginPushNudgeListener.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React from 'react';
 import { strings } from '../../../../locales/i18n';
 import NewUserSheet from '../../Views/Notifications/PushNotificationOnboarding/NewUserSheet';
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
@@ -14,38 +14,13 @@ import { useCliLoginPushNudge } from './useCliLoginPushNudge';
  */
 const CliLoginPushNudgeListener = () => {
   const { isVisible, onYes, onNotNow, onClose } = useCliLoginPushNudge();
-  // Copy-review preview only: make the CLI sheet available immediately after an
-  // authenticated development build launches. It never ships in production.
-  const [isDevPreviewVisible, setIsDevPreviewVisible] = useState(__DEV__);
-
-  const dismissDevPreview = useCallback(() => {
-    setIsDevPreviewVisible(false);
-  }, []);
-
-  const handleYes = useCallback(async () => {
-    dismissDevPreview();
-    await onYes();
-  }, [dismissDevPreview, onYes]);
-
-  const handleNotNow = useCallback(() => {
-    dismissDevPreview();
-    onNotNow();
-  }, [dismissDevPreview, onNotNow]);
-
-  const handleClose = useCallback(
-    (hasPendingAction?: boolean) => {
-      dismissDevPreview();
-      onClose(hasPendingAction);
-    },
-    [dismissDevPreview, onClose],
-  );
 
   return (
     <NewUserSheet
-      isVisible={isVisible || isDevPreviewVisible}
-      onClose={handleClose}
-      onYes={handleYes}
-      onNotNow={handleNotNow}
+      isVisible={isVisible}
+      onClose={onClose}
+      onYes={onYes}
+      onNotNow={onNotNow}
       title={strings('sdk_connect_v2.push_nudge.title')}
       body={strings('sdk_connect_v2.push_nudge.description')}
       yesLabel={strings('sdk_connect_v2.push_nudge.turn_on_button')}

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
 
 const mockEnableNotifications = jest.fn();
+let mockEnableNotificationsError: unknown;
 const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
 const mockOpenSystemSettings = jest.fn();
@@ -20,6 +21,7 @@ jest.mock('../../../util/notifications/constants', () => ({
 jest.mock('../../../util/notifications/hooks/useNotifications', () => ({
   useEnableNotifications: () => ({
     enableNotifications: mockEnableNotifications,
+    error: mockEnableNotificationsError,
   }),
 }));
 
@@ -56,6 +58,7 @@ describe('useCliLoginPushNudge', () => {
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
+    mockEnableNotificationsError = undefined;
     mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     jest
@@ -130,6 +133,20 @@ describe('useCliLoginPushNudge', () => {
       "We couldn't enable notifications. Please try again later.",
     );
     expect(result.current.isVisible).toBe(false);
+  });
+
+  it('shows an error exposed by the notification hook', async () => {
+    const { rerender } = renderNudge();
+    mockEnableNotificationsError = new Error('Network error');
+
+    await act(async () => {
+      rerender({});
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Something went wrong',
+      "We couldn't enable notifications. Please try again later.",
+    );
   });
 
   it('enables via the OS dialog when push is still promptable on iOS', async () => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
 // eslint-disable-next-line react-native/split-platform-components
 import { AppState, PermissionsAndroid, Platform } from 'react-native';
 import { renderHook, act } from '@testing-library/react-native';
-import { ToastContext } from '../../../component-library/components/Toast';
-import type {
-  ToastRef,
-  ToastOptions,
-} from '../../../component-library/components/Toast/Toast.types';
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
+import {
+  emitCliLoginPushNudge,
+  __resetCliLoginPushNudgeListenersForTests,
+} from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
 
 const mockEnableNotifications = jest.fn();
 const mockIsPushPermissionPromptable = jest.fn();
@@ -34,41 +32,26 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   isPushPermissionGranted: () => mockIsPushPermissionGranted(),
 }));
 
-jest.mock('../../../../locales/i18n', () => ({
-  strings: (key: string) => key,
+jest.mock('../../../core/SDKConnectV2/services/logger', () => ({
+  __esModule: true,
+  default: { warn: jest.fn() },
 }));
 
 describe('useCliLoginPushNudge', () => {
-  let showToast: jest.Mock;
-  let closeToast: jest.Mock;
   let appStateChangeHandler: ((state: string) => void) | undefined;
   let removeMocks: jest.Mock[];
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => {
-    const toastRef = {
-      current: { showToast, closeToast } as unknown as ToastRef,
-    };
-    return (
-      <ToastContext.Provider value={{ toastRef }}>
-        {children}
-      </ToastContext.Provider>
-    );
-  };
+  const renderNudge = () => renderHook(() => useCliLoginPushNudge());
 
-  const renderNudge = () =>
-    renderHook(() => useCliLoginPushNudge(), { wrapper });
-
-  const tapTurnOn = async () => {
-    const options = showToast.mock.calls[0][0] as ToastOptions;
-    await act(async () => {
-      await options.linkButtonOptions?.onPress?.();
+  const emit = () => {
+    act(() => {
+      emitCliLoginPushNudge();
     });
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    showToast = jest.fn();
-    closeToast = jest.fn();
+    __resetCliLoginPushNudgeListenersForTests();
     appStateChangeHandler = undefined;
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
@@ -94,100 +77,79 @@ describe('useCliLoginPushNudge', () => {
     jest.restoreAllMocks();
   });
 
-  it('does not show the toast when the notifications feature is disabled', () => {
+  it('is hidden initially', () => {
+    const { result } = renderNudge();
+
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('becomes visible when the nudge signal is emitted', () => {
+    const { result } = renderNudge();
+
+    emit();
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('stays hidden when the notifications feature is disabled', () => {
     mockIsNotificationsFeatureEnabled.mockReturnValue(false);
     const { result } = renderNudge();
 
-    let shown: boolean | undefined;
-    act(() => {
-      shown = result.current.showNudge();
-    });
+    emit();
 
-    expect(shown).toBe(false);
-    expect(showToast).not.toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
   });
 
-  it('shows a toast with a Turn on action when enabled', () => {
-    const { result } = renderNudge();
-
-    let shown: boolean | undefined;
-    act(() => {
-      shown = result.current.showNudge();
-    });
-
-    expect(shown).toBe(true);
-    expect(showToast).toHaveBeenCalledTimes(1);
-    const options = showToast.mock.calls[0][0] as ToastOptions;
-    expect(options.linkButtonOptions?.onPress).toBeDefined();
-    expect(options.closeButtonOptions?.onPress).toBeDefined();
-  });
-
-  it('enables and closes without opening settings when push is already granted', async () => {
+  it('enables notifications when push is already granted', async () => {
     mockIsPushPermissionGranted.mockResolvedValue(true);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
 
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-    expect(closeToast).toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
   });
 
-  it('enables via the OS dialog when push is still promptable', async () => {
+  it('enables via the OS dialog when push is still promptable on iOS', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(true);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
 
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-    expect(closeToast).toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
   });
 
-  it('does not open settings when the user denies the OS dialog', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(true);
-    mockIsPushPermissionGranted.mockResolvedValue(false);
-    const { result } = renderNudge();
-
-    act(() => {
-      result.current.showNudge();
-    });
-    await tapTurnOn();
-
-    expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
-    expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-    expect(closeToast).toHaveBeenCalled();
-  });
-
-  it('opens device settings when the OS can no longer show its dialog', async () => {
+  it('opens device settings when iOS can no longer show its dialog', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
 
     expect(mockEnableNotifications).not.toHaveBeenCalled();
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+    expect(result.current.isVisible).toBe(false);
   });
 
-  it('re-enables on return from settings when permission becomes granted', async () => {
+  it('enables on return from settings when permission becomes granted', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
-
-    expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
 
     mockIsPushPermissionGranted.mockResolvedValue(true);
     await act(async () => {
@@ -197,70 +159,93 @@ describe('useCliLoginPushNudge', () => {
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it('closes the toast without re-enabling when the user returns still not granted', async () => {
+  it('does not enable on foreground return when permission is still not granted', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
 
     mockEnableNotifications.mockClear();
-    closeToast.mockClear();
     await act(async () => {
       appStateChangeHandler?.('active');
     });
 
     expect(mockEnableNotifications).not.toHaveBeenCalled();
-    expect(closeToast).toHaveBeenCalled();
   });
 
-  it('does not block Turn on after opening settings when the user never returns', async () => {
+  it('does not block a repeat Yes after opening settings when the user never returns', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-
-    await tapTurnOn();
-    await tapTurnOn();
+    await act(async () => {
+      await result.current.onYes();
+    });
 
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(2);
   });
 
-  it('cancels a pending settings-return retry when a new nudge is shown', async () => {
-    mockIsPushPermissionPromptable.mockResolvedValue(false);
+  it('hides on "Not now" without enabling', () => {
     const { result } = renderNudge();
+    emit();
 
     act(() => {
-      result.current.showNudge();
+      result.current.onNotNow();
     });
-    await tapTurnOn();
+
+    expect(result.current.isVisible).toBe(false);
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
+  });
+
+  it('ignores button-driven close but hides on genuine dismissal', () => {
+    const { result } = renderNudge();
+    emit();
+
+    act(() => {
+      result.current.onClose(true);
+    });
+    expect(result.current.isVisible).toBe(true);
+
+    act(() => {
+      result.current.onClose(false);
+    });
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('cancels a pending settings-return retry when a new nudge is emitted', async () => {
+    mockIsPushPermissionPromptable.mockResolvedValue(false);
+    const { result } = renderNudge();
+    emit();
+
+    await act(async () => {
+      await result.current.onYes();
+    });
 
     expect(removeMocks).toHaveLength(1);
 
-    act(() => {
-      result.current.showNudge();
-    });
+    emit();
 
     expect(removeMocks[0]).toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(true);
   });
 
   it('does not run a superseded settings-return retry after a new nudge', async () => {
     mockIsPushPermissionPromptable.mockResolvedValue(false);
     const { result } = renderNudge();
+    emit();
 
-    act(() => {
-      result.current.showNudge();
+    await act(async () => {
+      await result.current.onYes();
     });
-    await tapTurnOn();
 
-    act(() => {
-      result.current.showNudge();
-    });
+    emit();
 
     mockIsPushPermissionGranted.mockClear();
     mockIsPushPermissionGranted.mockResolvedValue(true);
@@ -274,24 +259,21 @@ describe('useCliLoginPushNudge', () => {
   });
 
   describe('android 13+', () => {
-    let requestMock: jest.SpyInstance;
-
     beforeEach(() => {
       Platform.OS = 'android';
       jest.spyOn(Platform, 'Version', 'get').mockReturnValue(33);
-      requestMock = jest
-        .spyOn(PermissionsAndroid, 'request')
-        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
     });
 
     it('opens settings when the OS permanently denied the permission', async () => {
-      requestMock.mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
       const { result } = renderNudge();
+      emit();
 
-      act(() => {
-        result.current.showNudge();
+      await act(async () => {
+        await result.current.onYes();
       });
-      await tapTurnOn();
 
       expect(PermissionsAndroid.request).toHaveBeenCalledWith(
         PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
@@ -301,12 +283,15 @@ describe('useCliLoginPushNudge', () => {
     });
 
     it('opens settings when the user denies the OS dialog', async () => {
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
       const { result } = renderNudge();
+      emit();
 
-      act(() => {
-        result.current.showNudge();
+      await act(async () => {
+        await result.current.onYes();
       });
-      await tapTurnOn();
 
       expect(PermissionsAndroid.request).toHaveBeenCalledTimes(1);
       expect(mockEnableNotifications).not.toHaveBeenCalled();
@@ -314,17 +299,18 @@ describe('useCliLoginPushNudge', () => {
     });
 
     it('enables notifications when the OS grants push permission', async () => {
-      requestMock.mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
       const { result } = renderNudge();
+      emit();
 
-      act(() => {
-        result.current.showNudge();
+      await act(async () => {
+        await result.current.onYes();
       });
-      await tapTurnOn();
 
       expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
       expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-      expect(closeToast).toHaveBeenCalled();
     });
   });
 
@@ -336,11 +322,11 @@ describe('useCliLoginPushNudge', () => {
 
     it('opens settings without a runtime dialog when push is not granted', async () => {
       const { result } = renderNudge();
+      emit();
 
-      act(() => {
-        result.current.showNudge();
+      await act(async () => {
+        await result.current.onYes();
       });
-      await tapTurnOn();
 
       expect(PermissionsAndroid.request).not.toHaveBeenCalled();
       expect(mockEnableNotifications).not.toHaveBeenCalled();

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line react-native/split-platform-components
-import { AppState, PermissionsAndroid, Platform } from 'react-native';
+import { Alert, AppState, PermissionsAndroid, Platform } from 'react-native';
 import { renderHook, act } from '@testing-library/react-native';
 import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 import {
@@ -61,6 +61,7 @@ describe('useCliLoginPushNudge', () => {
     jest
       .spyOn(PermissionsAndroid, 'request')
       .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
+    jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
     Platform.OS = 'ios';
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
@@ -111,6 +112,23 @@ describe('useCliLoginPushNudge', () => {
 
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it('shows an error when enabling notifications fails', async () => {
+    mockIsPushPermissionGranted.mockResolvedValue(true);
+    mockEnableNotifications.mockRejectedValue(new Error('Network error'));
+    const { result } = renderNudge();
+    emit();
+
+    await act(async () => {
+      await result.current.onYes();
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Something went wrong',
+      "We couldn't enable notifications. Please try again later.",
+    );
     expect(result.current.isVisible).toBe(false);
   });
 

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
 
 const mockEnableNotifications = jest.fn();
-let mockEnableNotificationsError: unknown;
 const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
 const mockOpenSystemSettings = jest.fn();
@@ -21,7 +20,6 @@ jest.mock('../../../util/notifications/constants', () => ({
 jest.mock('../../../util/notifications/hooks/useNotifications', () => ({
   useEnableNotifications: () => ({
     enableNotifications: mockEnableNotifications,
-    error: mockEnableNotificationsError,
   }),
 }));
 
@@ -58,7 +56,6 @@ describe('useCliLoginPushNudge', () => {
     removeMocks = [];
     mockIsNotificationsFeatureEnabled.mockReturnValue(true);
     mockEnableNotifications.mockResolvedValue(undefined);
-    mockEnableNotificationsError = undefined;
     mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
     jest
@@ -133,20 +130,6 @@ describe('useCliLoginPushNudge', () => {
       "We couldn't enable notifications. Please try again later.",
     );
     expect(result.current.isVisible).toBe(false);
-  });
-
-  it('shows an error exposed by the notification hook', async () => {
-    const { rerender } = renderNudge();
-    mockEnableNotificationsError = new Error('Network error');
-
-    await act(async () => {
-      rerender({});
-    });
-
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Something went wrong',
-      "We couldn't enable notifications. Please try again later.",
-    );
   });
 
   it('enables via the OS dialog when push is still promptable on iOS', async () => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -39,10 +39,10 @@ export function useCliLoginPushNudge(): {
   onClose: (hasPendingAction?: boolean) => void;
 } {
   const [isVisible, setIsVisible] = useState(false);
-  const { enableNotifications, error: enableNotificationsError } =
-    useEnableNotifications({
-      nudgeEnablePush: true,
-    });
+  const { enableNotifications } = useEnableNotifications({
+    nudgeEnablePush: true,
+    throwOnError: true,
+  });
 
   const inFlightRef = useRef(false);
   // Bumped each time a new nudge is shown so a fresh CLI login supersedes any
@@ -254,12 +254,6 @@ export function useCliLoginPushNudge(): {
     },
     [clearForegroundRetry],
   );
-
-  useEffect(() => {
-    if (enableNotificationsError) {
-      showEnableNotificationsError();
-    }
-  }, [enableNotificationsError, showEnableNotificationsError]);
 
   return { isVisible, onYes, onNotNow, onClose };
 }

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 // PermissionsAndroid usage below is gated behind `Platform.OS === 'android'`.
 // eslint-disable-next-line react-native/split-platform-components
-import { AppState, PermissionsAndroid, Platform } from 'react-native';
+import { Alert, AppState, PermissionsAndroid, Platform } from 'react-native';
+import { strings } from '../../../../locales/i18n';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications/constants';
 import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
 import NotificationService, {
@@ -57,6 +58,13 @@ export function useCliLoginPushNudge(): {
     appStateSubscriptionRef.current = null;
   }, []);
 
+  const showEnableNotificationsError = useCallback(() => {
+    Alert.alert(
+      strings('notifications.notifications_enabled_error_title'),
+      strings('notifications.notifications_enabled_error_desc'),
+    );
+  }, []);
+
   const scheduleForegroundRetry = useCallback(
     (retry: () => Promise<void>) => {
       clearForegroundRetry();
@@ -67,21 +75,21 @@ export function useCliLoginPushNudge(): {
             return;
           }
           clearForegroundRetry();
-          retry().catch(() => {
-            /* enable flow logs its own failures */
+          retry().catch((error) => {
+            logger.warn(
+              'Failed to enable notifications after returning from settings',
+              error,
+            );
+            showEnableNotificationsError();
           });
         },
       );
     },
-    [clearForegroundRetry],
+    [clearForegroundRetry, showEnableNotificationsError],
   );
 
   const runEnableNotifications = useCallback(async () => {
-    try {
-      await enableNotifications();
-    } catch (error) {
-      logger.warn('Failed to enable notifications from CLI login nudge', error);
-    }
+    await enableNotifications();
   }, [enableNotifications]);
 
   const openSettingsAndScheduleRetry = useCallback(
@@ -191,12 +199,20 @@ export function useCliLoginPushNudge(): {
       }
 
       await runIosPermissionFlow(isCurrent);
+    } catch (error) {
+      logger.warn('Failed to run CLI login push permission flow', error);
+      showEnableNotificationsError();
     } finally {
       if (!appStateSubscriptionRef.current) {
         inFlightRef.current = false;
       }
     }
-  }, [runGrantedFlow, runAndroidPermissionFlow, runIosPermissionFlow]);
+  }, [
+    runGrantedFlow,
+    runAndroidPermissionFlow,
+    runIosPermissionFlow,
+    showEnableNotificationsError,
+  ]);
 
   const onYes = useCallback(() => {
     setIsVisible(false);

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -1,112 +1,61 @@
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 // PermissionsAndroid usage below is gated behind `Platform.OS === 'android'`.
 // eslint-disable-next-line react-native/split-platform-components
 import { AppState, PermissionsAndroid, Platform } from 'react-native';
-import { ToastContext } from '../../../component-library/components/Toast';
-import {
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../component-library/components/Icons/Icon';
-import { strings } from '../../../../locales/i18n';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications/constants';
 import { useEnableNotifications } from '../../../util/notifications/hooks/useNotifications';
 import NotificationService, {
   isPushPermissionGranted,
   isPushPermissionPromptable,
 } from '../../../util/notifications/services/NotificationService';
+import { subscribeCliLoginPushNudge } from '../../../core/AgenticCli/cliLoginPushNudgeSignal';
+import logger from '../../../core/SDKConnectV2/services/logger';
 
 /** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
 const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
-const NUDGE_LABELS = () => [
-  { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
-];
-
-const LOADING_LABELS = () => [
-  { label: strings('sdk_connect_v2.push_nudge.loading_title'), isBold: true },
-];
-
-const ERROR_LABELS = () => [
-  { label: strings('sdk_connect_v2.push_nudge.enable_error') },
-];
-
 /**
- * Shared toast-based push-permission nudge shown after a successful Agentic CLI
- * QR login (MMAI-925). On "Turn on", tapping the nudge signals intent to enable
- * notifications.
+ * Drives the post-CLI-login push-permission bottom sheet (MMAI-925). Subscribes
+ * to the module-level nudge signal to become visible after a successful login.
+ * On "Enable notifications": requests OS permission when needed, opens device
+ * notification settings when the OS dialog can no longer be shown, and enables
+ * MetaMask in-app notifications once native push is granted.
  *
  * iOS: when the OS can still show its permission dialog, enableNotifications()
- * requests permission; denying that dialog closes the toast without opening
- * Settings. When the OS can no longer show its dialog (e.g. after a prior
- * denial), it deep-links to device notification settings and retries once the
- * app returns to foreground.
+ * requests permission; denying that dialog does not open Settings. When the OS
+ * can no longer show its dialog (e.g. after a prior denial), it deep-links to
+ * device notification settings and retries once the app returns to foreground.
  *
  * Android: Notifee reports DENIED for both "never asked" and "permanently
- * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS). Any deny
- * after "Turn on" opens notification settings because the user already signaled
- * intent to enable.
+ * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS). Because the
+ * user already signaled intent by tapping "Enable notifications", any deny opens
+ * notification settings.
  */
 export function useCliLoginPushNudge(): {
-  showNudge: () => boolean;
+  isVisible: boolean;
+  onYes: () => Promise<void>;
+  onNotNow: () => void;
+  onClose: (hasPendingAction?: boolean) => void;
 } {
-  const { toastRef } = useContext(ToastContext);
+  const [isVisible, setIsVisible] = useState(false);
   const { enableNotifications } = useEnableNotifications({
     nudgeEnablePush: true,
   });
 
   const inFlightRef = useRef(false);
   // Bumped each time a new nudge is shown so a fresh CLI login supersedes any
-  // in-progress Turn on flow: async continuations compare their captured epoch
+  // in-progress enable flow: async continuations compare their captured epoch
   // and skip their side effects once superseded, preventing overlapping enable
-  // calls, settings opens, and toast updates.
+  // calls and settings opens.
   const flowEpochRef = useRef(0);
   const appStateSubscriptionRef = useRef<ReturnType<
     typeof AppState.addEventListener
   > | null>(null);
 
-  const showLoadingToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Loading,
-      hasNoTimeout: true,
-      labelOptions: LOADING_LABELS(),
-      descriptionOptions: {
-        description: strings('sdk_connect_v2.push_nudge.loading_description'),
-      },
-    });
-  }, [toastRef]);
-
-  const showErrorToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Danger,
-      hasNoTimeout: false,
-      labelOptions: ERROR_LABELS(),
-    });
-  }, [toastRef]);
-
   const clearForegroundRetry = useCallback(() => {
     appStateSubscriptionRef.current?.remove();
     appStateSubscriptionRef.current = null;
   }, []);
-
-  const runEnableFlow = useCallback(
-    async (isCurrent: () => boolean) => {
-      try {
-        await enableNotifications();
-        if (isCurrent()) {
-          toastRef?.current?.closeToast();
-        }
-      } catch {
-        if (isCurrent()) {
-          toastRef?.current?.closeToast();
-          showErrorToast();
-        }
-      }
-    },
-    [enableNotifications, toastRef, showErrorToast],
-  );
 
   const scheduleForegroundRetry = useCallback(
     (retry: () => Promise<void>) => {
@@ -127,13 +76,19 @@ export function useCliLoginPushNudge(): {
     [clearForegroundRetry],
   );
 
+  const runEnableNotifications = useCallback(async () => {
+    try {
+      await enableNotifications();
+    } catch (error) {
+      logger.warn('Failed to enable notifications from CLI login nudge', error);
+    }
+  }, [enableNotifications]);
+
   const openSettingsAndScheduleRetry = useCallback(
     (isCurrent: () => boolean) => {
-      toastRef?.current?.closeToast();
       // Release the in-flight guard before opening system settings so that a
-      // throw from openSystemSettings() can't leave "Turn on" permanently
-      // locked. Both iOS and Android reach this helper, so releasing here keeps
-      // them consistent. The scheduled foreground retry owns its own guard.
+      // throw from openSystemSettings() can't leave "Enable notifications"
+      // permanently locked. The scheduled foreground retry owns its own guard.
       inFlightRef.current = false;
       NotificationService.openSystemSettings();
       scheduleForegroundRetry(async () => {
@@ -143,22 +98,18 @@ export function useCliLoginPushNudge(): {
         inFlightRef.current = true;
         try {
           if (!(await isPushPermissionGranted())) {
-            if (isCurrent()) {
-              toastRef?.current?.closeToast();
-            }
             return;
           }
           if (!isCurrent()) {
             return;
           }
-          showLoadingToast();
-          await runEnableFlow(isCurrent);
+          await runEnableNotifications();
         } finally {
           inFlightRef.current = false;
         }
       });
     },
-    [runEnableFlow, scheduleForegroundRetry, showLoadingToast, toastRef],
+    [runEnableNotifications, scheduleForegroundRetry],
   );
 
   const runGrantedFlow = useCallback(
@@ -166,28 +117,20 @@ export function useCliLoginPushNudge(): {
       if (!isCurrent()) {
         return;
       }
-      showLoadingToast();
-      await enableNotifications();
-      if (isCurrent()) {
-        toastRef?.current?.closeToast();
-      }
+      await runEnableNotifications();
     },
-    [enableNotifications, showLoadingToast, toastRef],
+    [runEnableNotifications],
   );
 
   const runAndroidPermissionFlow = useCallback(
     async (isCurrent: () => boolean) => {
       // Android < 13 has no runtime dialog; when notifications are not already
       // granted they can only be enabled from system settings.
-      // openSettingsAndScheduleRetry closes the toast and opens settings, so no
-      // loading toast is needed here.
       if (Number(Platform.Version) < ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
         openSettingsAndScheduleRetry(isCurrent);
         return;
       }
-      // Android 13+ requires the POST_NOTIFICATIONS runtime permission. Don't
-      // show the loading toast before the request — it would sit behind the OS
-      // permission dialog.
+      // Android 13+ requires the POST_NOTIFICATIONS runtime permission.
       const result = await PermissionsAndroid.request(
         PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
       );
@@ -195,16 +138,15 @@ export function useCliLoginPushNudge(): {
         return;
       }
       if (result === PermissionsAndroid.RESULTS.GRANTED) {
-        // Show the loading toast only while the enable work runs, after the OS
-        // dialog is dismissed.
-        showLoadingToast();
-        await runEnableFlow(isCurrent);
+        await runEnableNotifications();
         return;
       }
-      // User tapped Turn on — any deny opens settings (no loading toast).
+      // The user tapped "Enable notifications", so any deny (dismissed dialog or
+      // permanent denial) opens notification settings — the intent to enable is
+      // unambiguous.
       openSettingsAndScheduleRetry(isCurrent);
     },
-    [openSettingsAndScheduleRetry, runEnableFlow, showLoadingToast],
+    [openSettingsAndScheduleRetry, runEnableNotifications],
   );
 
   const runIosPermissionFlow = useCallback(
@@ -217,24 +159,15 @@ export function useCliLoginPushNudge(): {
         openSettingsAndScheduleRetry(isCurrent);
         return;
       }
-      // OS can still show its dialog — request permission via enableNotifications().
-      // If the user denies, dismiss the toast without opening Settings (matches
+      // OS can still show its dialog — request permission via
+      // enableNotifications(). If the user denies, do not open Settings (matches
       // PushNotificationOnboarding).
-      showLoadingToast();
-      await enableNotifications();
-      if (isCurrent()) {
-        toastRef?.current?.closeToast();
-      }
+      await runEnableNotifications();
     },
-    [
-      enableNotifications,
-      openSettingsAndScheduleRetry,
-      showLoadingToast,
-      toastRef,
-    ],
+    [openSettingsAndScheduleRetry, runEnableNotifications],
   );
 
-  const onTapTurnOn = useCallback(async () => {
+  const runPermissionFlow = useCallback(async () => {
     if (inFlightRef.current) {
       return;
     }
@@ -251,61 +184,52 @@ export function useCliLoginPushNudge(): {
       if (!isCurrent()) {
         return;
       }
+
       if (Platform.OS === 'android') {
         await runAndroidPermissionFlow(isCurrent);
         return;
       }
+
       await runIosPermissionFlow(isCurrent);
-    } catch {
-      if (isCurrent()) {
-        toastRef?.current?.closeToast();
-        showErrorToast();
-      }
     } finally {
       if (!appStateSubscriptionRef.current) {
         inFlightRef.current = false;
       }
     }
-  }, [
-    runGrantedFlow,
-    runAndroidPermissionFlow,
-    runIosPermissionFlow,
-    showErrorToast,
-    toastRef,
-  ]);
+  }, [runGrantedFlow, runAndroidPermissionFlow, runIosPermissionFlow]);
 
-  const showNudge = useCallback((): boolean => {
-    if (!isNotificationsFeatureEnabled()) {
-      return false;
+  const onYes = useCallback(() => {
+    setIsVisible(false);
+    return runPermissionFlow();
+  }, [runPermissionFlow]);
+
+  const onNotNow = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  // BottomSheet passes hasPendingAction=true when a button (Yes/Not now) drove
+  // the close; those are handled by onYes/onNotNow, so only react to genuine
+  // dismissals (backdrop, close icon, hardware back).
+  const onClose = useCallback((hasPendingAction?: boolean) => {
+    if (hasPendingAction) {
+      return;
     }
-    // A new nudge supersedes any in-progress Turn on flow: cancel a pending
-    // foreground retry, invalidate in-flight async continuations via the epoch,
-    // and release the guard so this toast's Turn on is not blocked.
-    clearForegroundRetry();
-    flowEpochRef.current += 1;
-    inFlightRef.current = false;
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Notification,
-      hasNoTimeout: true,
-      labelOptions: NUDGE_LABELS(),
-      descriptionOptions: {
-        description: strings('sdk_connect_v2.push_nudge.description'),
-      },
-      linkButtonOptions: {
-        label: strings('sdk_connect_v2.push_nudge.turn_on_button'),
-        onPress: onTapTurnOn,
-      },
-      closeButtonOptions: {
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-        onPress: () => {
-          toastRef?.current?.closeToast();
-        },
-      },
-    });
-    return true;
-  }, [onTapTurnOn, toastRef, clearForegroundRetry]);
+    setIsVisible(false);
+  }, []);
+
+  useEffect(
+    () =>
+      subscribeCliLoginPushNudge(() => {
+        if (!isNotificationsFeatureEnabled()) {
+          return;
+        }
+        clearForegroundRetry();
+        flowEpochRef.current += 1;
+        inFlightRef.current = false;
+        setIsVisible(true);
+      }),
+    [clearForegroundRetry],
+  );
 
   useEffect(
     () => () => {
@@ -314,5 +238,5 @@ export function useCliLoginPushNudge(): {
     [clearForegroundRetry],
   );
 
-  return { showNudge };
+  return { isVisible, onYes, onNotNow, onClose };
 }

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -39,9 +39,10 @@ export function useCliLoginPushNudge(): {
   onClose: (hasPendingAction?: boolean) => void;
 } {
   const [isVisible, setIsVisible] = useState(false);
-  const { enableNotifications } = useEnableNotifications({
-    nudgeEnablePush: true,
-  });
+  const { enableNotifications, error: enableNotificationsError } =
+    useEnableNotifications({
+      nudgeEnablePush: true,
+    });
 
   const inFlightRef = useRef(false);
   // Bumped each time a new nudge is shown so a fresh CLI login supersedes any
@@ -253,6 +254,12 @@ export function useCliLoginPushNudge(): {
     },
     [clearForegroundRetry],
   );
+
+  useEffect(() => {
+    if (enableNotificationsError) {
+      showEnableNotificationsError();
+    }
+  }, [enableNotificationsError, showEnableNotificationsError]);
 
   return { isVisible, onYes, onNotNow, onClose };
 }

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
@@ -52,8 +52,8 @@ describe('NewUserSheet', () => {
   });
 
   it('renders title, body and buttons when visible', () => {
-    const { getByTestId } = renderWithProvider(
-      <NewUserSheet {...defaultProps} />,
+    const { getByTestId, getByText } = renderWithProvider(
+      <NewUserSheet {...defaultProps} yesLabel="Turn on notifications" />,
     );
     expect(getByTestId(NewUserSheetSelectorsIDs.TITLE)).toBeOnTheScreen();
     expect(getByTestId(NewUserSheetSelectorsIDs.BODY)).toBeOnTheScreen();
@@ -61,6 +61,7 @@ describe('NewUserSheet', () => {
     expect(
       getByTestId(NewUserSheetSelectorsIDs.BUTTON_NOT_NOW),
     ).toBeOnTheScreen();
+    expect(getByText('Turn on notifications')).toBeOnTheScreen();
   });
 
   it('closes the sheet before calling onYes when Yes is pressed', () => {

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
@@ -64,6 +64,33 @@ describe('NewUserSheet', () => {
     expect(getByText('Turn on notifications')).toBeOnTheScreen();
   });
 
+  it('renders custom notification-preview content', () => {
+    const { getByText } = renderWithProvider(
+      <NewUserSheet
+        {...defaultProps}
+        previewTitle="Transaction request"
+        previewMessage="Your agent needs approval on a new limit."
+        previewTimestamp="now"
+      />,
+    );
+
+    expect(getByText('Transaction request')).toBeOnTheScreen();
+    expect(
+      getByText('Your agent needs approval on a new limit.'),
+    ).toBeOnTheScreen();
+    expect(getByText('now')).toBeOnTheScreen();
+  });
+
+  it('closes when the close button is pressed', () => {
+    const { getAllByRole } = renderWithProvider(
+      <NewUserSheet {...defaultProps} />,
+    );
+
+    fireEvent.press(getAllByRole('button')[0]);
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
   it('closes the sheet before calling onYes when Yes is pressed', () => {
     const mockOnYes = jest.fn();
     const { getByTestId } = renderWithProvider(

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -24,6 +24,12 @@ export interface NewUserSheetProps {
   onYes?: () => void;
   onNotNow?: () => void;
   testID?: string;
+  /** Optional heading override. Defaults to the push-onboarding copy. */
+  title?: string;
+  /** Optional body override. Defaults to the push-onboarding copy. */
+  body?: string;
+  /** Whether to render the notification preview card. Defaults to true. */
+  showPreview?: boolean;
 }
 
 const NewUserSheet: React.FC<NewUserSheetProps> = ({
@@ -32,6 +38,9 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
   onYes,
   onNotNow,
   testID,
+  title = strings('notifications.push_onboarding.new_user.title'),
+  body = strings('notifications.push_onboarding.new_user.body'),
+  showPreview = true,
 }) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
@@ -69,9 +78,11 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
             onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
         </Box>
-        <Box twClassName="mb-2 px-6">
-          <NotifCard />
-        </Box>
+        {showPreview && (
+          <Box twClassName="mb-2 px-6">
+            <NotifCard />
+          </Box>
+        )}
 
         <Box twClassName="px-4">
           <Text
@@ -79,7 +90,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
             twClassName="mb-2 text-center"
             testID={NewUserSheetSelectorsIDs.TITLE}
           >
-            {strings('notifications.push_onboarding.new_user.title')}
+            {title}
           </Text>
 
           <Text
@@ -87,7 +98,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
             twClassName="mb-7 text-center text-alternative"
             testID={NewUserSheetSelectorsIDs.BODY}
           >
-            {strings('notifications.push_onboarding.new_user.body')}
+            {body}
           </Text>
 
           <Box twClassName="gap-3">

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -32,6 +32,10 @@ export interface NewUserSheetProps {
   yesLabel?: string;
   /** Whether to render the notification preview card. Defaults to true. */
   showPreview?: boolean;
+  /** Optional notification-preview content overrides. */
+  previewTitle?: string;
+  previewMessage?: string;
+  previewTimestamp?: string;
 }
 
 const NewUserSheet: React.FC<NewUserSheetProps> = ({
@@ -44,6 +48,9 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
   body = strings('notifications.push_onboarding.new_user.body'),
   yesLabel = strings('notifications.push_onboarding.new_user.button_yes'),
   showPreview = true,
+  previewTitle,
+  previewMessage,
+  previewTimestamp,
 }) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
 
@@ -83,7 +90,11 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
         </Box>
         {showPreview && (
           <Box twClassName="mb-2 px-6">
-            <NotifCard />
+            <NotifCard
+              title={previewTitle}
+              message={previewMessage}
+              timestamp={previewTimestamp}
+            />
           </Box>
         )}
 

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -28,6 +28,8 @@ export interface NewUserSheetProps {
   title?: string;
   /** Optional body override. Defaults to the push-onboarding copy. */
   body?: string;
+  /** Optional primary-button label override. */
+  yesLabel?: string;
   /** Whether to render the notification preview card. Defaults to true. */
   showPreview?: boolean;
 }
@@ -40,6 +42,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
   testID,
   title = strings('notifications.push_onboarding.new_user.title'),
   body = strings('notifications.push_onboarding.new_user.body'),
+  yesLabel = strings('notifications.push_onboarding.new_user.button_yes'),
   showPreview = true,
 }) => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
@@ -110,7 +113,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
               twClassName="rounded-xl"
               testID={NewUserSheetSelectorsIDs.BUTTON_YES}
             >
-              {strings('notifications.push_onboarding.new_user.button_yes')}
+              {yesLabel}
             </Button>
             <Button
               variant={ButtonVariant.Tertiary}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
@@ -194,8 +194,7 @@ const expectNotificationsOffToast = () => {
       variant: ToastVariants.Plain,
       labelOptions: [{ label: 'Notifications are off', isBold: true }],
       descriptionOptions: {
-        description:
-          "Turn them on in Settings → Notifications to stay updated on your agent's activity.",
+        description: 'Turn them on anytime in Settings → Notifications.',
       },
       startAccessory: expect.any(Object),
       hasNoTimeout: false,

--- a/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
@@ -194,7 +194,8 @@ const expectNotificationsOffToast = () => {
       variant: ToastVariants.Plain,
       labelOptions: [{ label: 'Notifications are off', isBold: true }],
       descriptionOptions: {
-        description: 'Turn them on anytime in Settings → Notifications.',
+        description:
+          "Turn them on in Settings → Notifications to stay updated on your agent's activity.",
       },
       startAccessory: expect.any(Object),
       hasNoTimeout: false,

--- a/app/util/notifications/hooks/useNotifications.test.tsx
+++ b/app/util/notifications/hooks/useNotifications.test.tsx
@@ -200,6 +200,23 @@ describe('useNotifications - useEnableNotifications()', () => {
 
     expect(hook.result.current.error).toBeDefined();
   });
+
+  it('throws helper failures when requested by the caller', async () => {
+    const mocks = arrangeMocks();
+    mocks.mockEnableNotifications.mockRejectedValue(new Error('Test Error'));
+    const hook = renderHookWithProvider(() =>
+      useEnableNotifications({ nudgeEnablePush: true, throwOnError: true }),
+    );
+
+    await expect(
+      act(async () => {
+        await hook.result.current.enableNotifications();
+      }),
+    ).rejects.toThrow('Test Error');
+
+    expect(hook.result.current.error).toBeDefined();
+    expect(mocks.mockTogglePushNotification).not.toHaveBeenCalled();
+  });
 });
 
 describe('useNotifications - useDisableNotifications()', () => {

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -109,8 +109,9 @@ export function useEnableNotifications(
     nudgeEnablePush: true,
   },
 ) {
+  const { nudgeEnablePush = true, throwOnError = false } = props;
   const { togglePushNotification, loading: pushLoading } =
-    usePushNotificationsToggle(props);
+    usePushNotificationsToggle({ nudgeEnablePush });
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
@@ -129,11 +130,11 @@ export function useEnableNotifications(
       await enableNotificationsHelper({
         hasMarketingConsent,
         productAnnouncementEnabled,
-        registerPushNotifications: Boolean(props.nudgeEnablePush),
+        registerPushNotifications: nudgeEnablePush,
       });
     } catch (enableError) {
       setError(enableError);
-      if (props.throwOnError) {
+      if (throwOnError) {
         throw enableError;
       }
     }
@@ -142,8 +143,8 @@ export function useEnableNotifications(
     });
     await updateNotificationSubscriptionExpiration();
   }, [
-    props.nudgeEnablePush,
-    props.throwOnError,
+    nudgeEnablePush,
+    throwOnError,
     hasMarketingConsent,
     productAnnouncementEnabled,
     togglePushNotification,

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -104,7 +104,11 @@ export function useContiguousLoading(
  * - `loading`: A boolean indicating if the enabling process is ongoing.
  * - `error`: A string or null value representing any error that occurred during the process.
  */
-export function useEnableNotifications(props = { nudgeEnablePush: true }) {
+export function useEnableNotifications(
+  props: { nudgeEnablePush?: boolean; throwOnError?: boolean } = {
+    nudgeEnablePush: true,
+  },
+) {
   const { togglePushNotification, loading: pushLoading } =
     usePushNotificationsToggle(props);
   const isMetamaskNotificationsEnabled = useSelector(
@@ -121,17 +125,25 @@ export function useEnableNotifications(props = { nudgeEnablePush: true }) {
   const enableNotifications = useCallback(async () => {
     assertIsFeatureEnabled();
     setError(null);
-    await enableNotificationsHelper({
-      hasMarketingConsent,
-      productAnnouncementEnabled,
-      registerPushNotifications: Boolean(props.nudgeEnablePush),
-    }).catch((e) => setError(e));
+    try {
+      await enableNotificationsHelper({
+        hasMarketingConsent,
+        productAnnouncementEnabled,
+        registerPushNotifications: Boolean(props.nudgeEnablePush),
+      });
+    } catch (enableError) {
+      setError(enableError);
+      if (props.throwOnError) {
+        throw enableError;
+      }
+    }
     await togglePushNotification(true).catch(() => {
       /* Do Nothing */
     });
     await updateNotificationSubscriptionExpiration();
   }, [
     props.nudgeEnablePush,
+    props.throwOnError,
     hasMarketingConsent,
     productAnnouncementEnabled,
     togglePushNotification,

--- a/app/util/notifications/hooks/useNotifications.ts
+++ b/app/util/notifications/hooks/useNotifications.ts
@@ -27,6 +27,13 @@ import type { RootState } from '../../../reducers';
 const selectHasMarketingConsent = (state: RootState) =>
   Boolean(state.security.dataCollectionForMarketing);
 
+interface UseEnableNotificationsProps {
+  nudgeEnablePush?: boolean;
+  throwOnError?: boolean;
+}
+
+const DEFAULT_ENABLE_NOTIFICATIONS_PROPS: UseEnableNotificationsProps = {};
+
 /**
  * Custom hook to fetch and update the list of notifications.
  * Manages loading and error states internally.
@@ -104,12 +111,9 @@ export function useContiguousLoading(
  * - `loading`: A boolean indicating if the enabling process is ongoing.
  * - `error`: A string or null value representing any error that occurred during the process.
  */
-export function useEnableNotifications(
-  props: { nudgeEnablePush?: boolean; throwOnError?: boolean } = {
-    nudgeEnablePush: true,
-  },
-) {
-  const { nudgeEnablePush = true, throwOnError = false } = props;
+export function useEnableNotifications(props?: UseEnableNotificationsProps) {
+  const { nudgeEnablePush = true, throwOnError = false } =
+    props ?? DEFAULT_ENABLE_NOTIFICATIONS_PROPS;
   const { togglePushNotification, loading: pushLoading } =
     usePushNotificationsToggle({ nudgeEnablePush });
   const isMetamaskNotificationsEnabled = useSelector(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10245,11 +10245,7 @@
     },
     "push_nudge": {
       "title": "Turn on notifications",
-      "description": "Get alerts for transactions from your CLI session.",
-      "turn_on_button": "Turn on",
-      "loading_title": "Turning on notifications",
-      "loading_description": "Give us a moment while we set things up.",
-      "enable_error": "Couldn't turn on notifications. Try again from Settings."
+      "description": "Get alerts for transactions from your CLI session."
     },
     "show_otp": {
       "title": "Enter this code",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5965,7 +5965,7 @@
           },
           "notifications_off": {
             "title": "Notifications are off",
-            "description": "Turn them on in Settings → Notifications to stay updated on your agent's activity."
+            "description": "Turn them on anytime in Settings → Notifications."
           }
         }
       },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10244,9 +10244,12 @@
       "description": "Return to the CLI to continue."
     },
     "push_nudge": {
-      "title": "You won't get transaction alerts",
-      "description": "Notifications are off. Without them, you can't approve or review transactions from your CLI session.",
-      "turn_on_button": "Turn on notifications"
+      "title": "Never miss a transaction",
+      "description": "Get real-time alerts to review and approve transactions from your CLI session.",
+      "turn_on_button": "Enable notifications",
+      "preview_title": "Transaction request",
+      "preview_message": "Your agent needs approval on a new limit.",
+      "preview_timestamp": "now"
     },
     "show_otp": {
       "title": "Enter this code",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5965,7 +5965,7 @@
           },
           "notifications_off": {
             "title": "Notifications are off",
-            "description": "Turn them on anytime in Settings → Notifications."
+            "description": "Turn them on in Settings → Notifications to stay updated on your agent's activity."
           }
         }
       },
@@ -10244,8 +10244,9 @@
       "description": "Return to the CLI to continue."
     },
     "push_nudge": {
-      "title": "Turn on notifications",
-      "description": "Get alerts for transactions from your CLI session."
+      "title": "You won't get transaction alerts",
+      "description": "Notifications are off. Without them, you can't approve or review transactions from your CLI session.",
+      "turn_on_button": "Turn on notifications"
     },
     "show_otp": {
       "title": "Enter this code",


### PR DESCRIPTION
## **Description**

Follow-up to #33688 (toast UX). Replaces the post-CLI-login toast nudge with the shared push-onboarding bottom sheet (`NewUserSheet`, "Never miss a move"), shown with CLI-specific copy and its own notification-preview card.

On **Enable notifications**:

- If native permission is promptable (or in-app notifications are off): enables MetaMask in-app notifications and requests the OS permission dialog.
- If native permission is already denied: deep-links to the device notification settings and retries automatically when the app returns to the foreground.

`NewUserSheet` gains backward-compatible optional props (`title`, `body`, `yesLabel`, `showPreview`, `previewTitle`, `previewMessage`, `previewTimestamp`) so it can be reused outside push onboarding without changing existing behavior. The CLI sheet keeps the preview card and overrides its contents with a transaction-request example; the preview icon is the existing `app/images/branding/fox.png` asset, not a generated one.

Copy is the design-reviewed version:

| Element | Copy |
| --- | --- |
| Preview | **Transaction request** · "Your agent needs approval on a new limit." · now |
| Headline | **Never miss a transaction** |
| Body | Get real-time alerts to review and approve transactions from your CLI session. |
| Primary | Enable notifications |
| Secondary | Not now |

> Note: this PR touches `NewUserSheet` under `**/Notifications/**`, so it requires engagement team review. #33688 has merged and the base is now `main`.


## Screenshot

<img width="300" alt="cli-push-nudge-dark" src="https://github.com/user-attachments/assets/f11d129f-2065-4961-904d-5b9d3c6e48a2" />

<img width="300" alt="cli-push-nudge-light" src="https://github.com/user-attachments/assets/63133d32-438d-4b6a-bb11-566d2fc15939" />




## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MMAI-925

## **Manual testing steps**

```gherkin
Feature: Push permission bottom sheet after CLI QR login

  Scenario: Notifications not set up
    Given notifications are not fully enabled
    And I complete a successful Agentic CLI QR login
    Then the "Never miss a transaction" bottom sheet appears
    And it shows the transaction-request notification preview card

  Scenario: Enable when permission is promptable
    Given the OS push permission has never been requested
    When I tap "Enable notifications"
    Then in-app notifications are enabled
    And the OS permission dialog is shown

  Scenario: Enable when permission is denied
    Given the OS push permission is denied
    When I tap "Enable notifications"
    Then I am taken to the device notification settings
    And on returning to the app it retries and enables push if I granted it
```

## **Screenshots/Recordings**

### **Before**

Toast-based nudge — see #33688.

### **After**

Flow recording (copy shown in the video predates the design review — current copy is in the screenshots below):
https://github.com/user-attachments/assets/20727719-7c7b-4049-9f45-2b863e41c926

<!-- SCREENSHOTS_PLACEHOLDER -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
