### PR TITLE
feat(money): add instrumentation for money account api data service

### DIFF
--- a/app/core/Engine/controllers/money-account-api-data-service-init.test.ts
+++ b/app/core/Engine/controllers/money-account-api-data-service-init.test.ts
@@ -1,19 +1,34 @@
+import { AppState } from 'react-native';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import {
   Env,
   MoneyAccountApiDataService,
   MoneyAccountApiDataServiceMessenger,
+  MoneyAccountApiDataServiceTraceCallback,
+  MoneyAccountApiDataServiceTraceRequest,
 } from '@metamask/money-account-api-data-service';
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { getMoneyAccountApiDataServiceMessenger } from '../messengers/money-account-api-data-service-messenger';
 import { MessengerClientInitRequest } from '../types';
 import { buildMessengerClientInitRequestMock } from '../utils/test-utils';
 import { moneyAccountApiDataServiceInit } from './money-account-api-data-service-init';
+import { trace, TraceOperation } from '../../../util/trace';
 
 jest.mock('@metamask/money-account-api-data-service', () => ({
   ...jest.requireActual('@metamask/money-account-api-data-service'),
   MoneyAccountApiDataService: jest.fn().mockImplementation(() => ({})),
 }));
+
+jest.mock('../../../util/trace', () => ({
+  ...jest.requireActual('../../../util/trace'),
+  trace: jest.fn(),
+}));
+
+interface MoneyAccountApiDataServiceOptions {
+  messenger: MoneyAccountApiDataServiceMessenger;
+  env: Env;
+  trace?: MoneyAccountApiDataServiceTraceCallback;
+}
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<MoneyAccountApiDataServiceMessenger>
@@ -28,6 +43,11 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
 }
+
+const getServiceConstructorOptions = (): MoneyAccountApiDataServiceOptions => {
+  const serviceMock = jest.mocked(MoneyAccountApiDataService);
+  return serviceMock.mock.calls[0][0] as MoneyAccountApiDataServiceOptions;
+};
 
 describe('moneyAccountApiDataServiceInit', () => {
   beforeEach(() => {
@@ -50,5 +70,116 @@ describe('moneyAccountApiDataServiceInit', () => {
         env: Env.PRD,
       }),
     );
+  });
+
+  it('passes a trace callback to the service', () => {
+    moneyAccountApiDataServiceInit(getInitRequestMock());
+
+    expect(getServiceConstructorOptions().trace).toStrictEqual(
+      expect.any(Function),
+    );
+  });
+});
+
+describe('trace tagging', () => {
+  const createTraceRequest = (
+    overrides: Partial<MoneyAccountApiDataServiceTraceRequest> = {},
+  ): MoneyAccountApiDataServiceTraceRequest => ({
+    id: 'test-trace-id',
+    name: 'MoneyAccountApiDataService:fetchPositions',
+    startTime: 1000,
+    tags: { source: 'unit-test' },
+    data: {},
+    ...overrides,
+  });
+
+  const getTraceCallback = (): MoneyAccountApiDataServiceTraceCallback => {
+    const traceCallback = getServiceConstructorOptions().trace;
+    if (!traceCallback) {
+      throw new Error('MoneyAccountApiDataService trace callback was not set');
+    }
+    return traceCallback;
+  };
+
+  const setAppStateCurrentState = (currentState: string | undefined) => {
+    Object.defineProperty(AppState, 'currentState', {
+      value: currentState,
+      configurable: true,
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setAppStateCurrentState('active');
+  });
+
+  it('tags requests with MoneyAccountDataFetch operation and current app state', async () => {
+    setAppStateCurrentState('background');
+    moneyAccountApiDataServiceInit(getInitRequestMock());
+    const traceCallback = getTraceCallback();
+
+    await traceCallback(createTraceRequest());
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'test-trace-id',
+        name: 'MoneyAccountApiDataService:fetchPositions',
+        startTime: 1000,
+        op: TraceOperation.MoneyAccountDataFetch,
+        tags: { source: 'unit-test' },
+        data: expect.objectContaining({ app_state: 'background' }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('tags trace requests with unknown app state when currentState is unset', async () => {
+    setAppStateCurrentState(undefined);
+    moneyAccountApiDataServiceInit(getInitRequestMock());
+    const traceCallback = getTraceCallback();
+
+    await traceCallback(createTraceRequest());
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ app_state: 'unknown' }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('preserves data already provided by the caller', async () => {
+    setAppStateCurrentState('active');
+    moneyAccountApiDataServiceInit(getInitRequestMock());
+    const traceCallback = getTraceCallback();
+
+    await traceCallback(
+      createTraceRequest({ data: { success: true, errorName: '' } }),
+    );
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          success: true,
+          errorName: '',
+          app_state: 'active',
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('forwards the callback function to trace', async () => {
+    setAppStateCurrentState('active');
+    moneyAccountApiDataServiceInit(getInitRequestMock());
+    const traceCallback = getTraceCallback();
+    const callback = jest.fn();
+
+    await traceCallback(createTraceRequest(), callback);
+
+    expect(trace).toHaveBeenCalledWith(expect.anything(), callback);
   });
 });

--- a/app/core/Engine/controllers/money-account-api-data-service-init.test.ts
+++ b/app/core/Engine/controllers/money-account-api-data-service-init.test.ts
@@ -86,7 +86,7 @@ describe('trace tagging', () => {
     overrides: Partial<MoneyAccountApiDataServiceTraceRequest> = {},
   ): MoneyAccountApiDataServiceTraceRequest => ({
     id: 'test-trace-id',
-    name: 'MoneyAccountApiDataService:fetchPositions',
+    name: 'Money Account API Fetch Positions',
     startTime: 1000,
     tags: { source: 'unit-test' },
     data: {},
@@ -126,7 +126,7 @@ describe('trace tagging', () => {
     expect(trace).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'test-trace-id',
-        name: 'MoneyAccountApiDataService:fetchPositions',
+        name: 'Money Account API Fetch Positions',
         startTime: 1000,
         op: TraceOperation.MoneyAccountDataFetch,
         tags: { source: 'unit-test' },

--- a/app/core/Engine/controllers/money-account-api-data-service-init.ts
+++ b/app/core/Engine/controllers/money-account-api-data-service-init.ts
@@ -1,9 +1,39 @@
+import { AppState } from 'react-native';
 import {
   Env,
   MoneyAccountApiDataService,
   type MoneyAccountApiDataServiceMessenger,
+  type MoneyAccountApiDataServiceTraceRequest,
+  type MoneyAccountApiDataServiceTraceCallback,
 } from '@metamask/money-account-api-data-service';
+import type { TraceContext } from '@metamask/controller-utils';
 import { MessengerClientInitFunction } from '../types';
+import { trace, TraceOperation, type TraceRequest } from '../../../util/trace';
+
+/**
+ * Adapter that bridges the service's trace interface to the mobile Sentry
+ * trace utility.  The service emits a backdated, fire-and-forget trace in
+ * each method's `finally` block with `startTime`, `success`, `errorName`,
+ * and `operation` attributes — the adapter simply forwards these into
+ * Sentry's `startSpan` via the shared `trace()` helper.
+ */
+const sentryTrace: MoneyAccountApiDataServiceTraceCallback = async <T>(
+  request: MoneyAccountApiDataServiceTraceRequest,
+  fn: (context?: TraceContext) => T = () => undefined as T,
+): Promise<T> => {
+  const taggedRequest: TraceRequest = {
+    id: request.id,
+    name: request.name as TraceRequest['name'],
+    startTime: request.startTime,
+    op: TraceOperation.MoneyAccountDataFetch,
+    tags: request.tags,
+    data: {
+      ...request.data,
+      app_state: AppState.currentState ?? 'unknown',
+    },
+  };
+  return await Promise.resolve(trace(taggedRequest, fn));
+};
 
 /**
  * Initialize the money account API data service.
@@ -22,6 +52,7 @@ export const moneyAccountApiDataServiceInit: MessengerClientInitFunction<
   const controller = new MoneyAccountApiDataService({
     messenger: controllerMessenger,
     env: Env.PRD,
+    trace: sentryTrace,
   });
 
   return { controller };

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-api-data-service": "^0.2.0",
+    "@metamask/money-account-api-data-service": "^0.3.0",
     "@metamask/money-account-balance-service": "^2.3.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9353,6 +9353,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/money-account-api-data-service@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/money-account-api-data-service@npm:0.3.0"
+  dependencies:
+    "@metamask/base-data-service": "npm:^0.1.3"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@tanstack/query-core": "npm:^4.43.0"
+  checksum: 10/eed99d9167d85215e64706714c4c3efa8556bdd772d6f2df83ca5ac08989316d8269c2a136c1545a47dacee20519a2bd94acf9905a284bb6910bd1565119728f
+  languageName: node
+  linkType: hard
+
 "@metamask/money-account-balance-service@npm:^2.3.0":
   version: 2.3.0
   resolution: "@metamask/money-account-balance-service@npm:2.3.0"
@@ -35936,7 +35950,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-api-data-service": "npm:^0.2.0"
+    "@metamask/money-account-api-data-service": "npm:^0.3.0"
     "@metamask/money-account-balance-service": "npm:^2.3.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.2.0"


### PR DESCRIPTION
## **Description**

Adds Sentry tracing instrumentation to `MoneyAccountApiDataService` network calls (`fetchPositions`, `fetchInterest`, `fetchHistory`, `fetchRateHistory`).

Bumps `@metamask/money-account-api-data-service` to `^0.3.0` which exposes an optional `trace` constructor callback ([MetaMask/core#9451](https://github.com/MetaMask/core/pull/9451)), then wires a Sentry adapter into the service init — matching the pattern already established in `money-account-balance-service-init.ts`.

### Changes

- Bumped `@metamask/money-account-api-data-service` from `^0.2.0` to `^0.3.0`
- Added `sentryTrace` adapter in `money-account-api-data-service-init.ts` that:
  - Forwards trace requests into the shared `trace()` utility (Sentry `startSpan`)
  - Tags spans with `op: TraceOperation.MoneyAccountDataFetch` for Sentry filtering
  - Includes `app_state` (foreground/background) in trace data for performance segmentation
  - Passes through service-provided `tags` and `data` (e.g. `success`, `errorName`)
- Passed `trace: sentryTrace` to the `MoneyAccountApiDataService` constructor
- Added unit tests covering trace callback forwarding, operation tagging, app state enrichment, and caller data preservation

## **Changelog**

CHANGELOG entry: Instrument Money Account API data service HTTP calls with Sentry tracing

## **Related issues**

Fixes: N/A
Related: https://consensyssoftware.atlassian.net/browse/MUSD-1044

Related:
- Core tracing PR: https://github.com/MetaMask/core/pull/9451
- Balance service tracing (prior art): https://github.com/MetaMask/core/pull/9434

## **Manual testing steps**

```gherkin
Feature: Sentry tracing for Money Account API calls

  Scenario: Traces appear in Sentry for API data service calls
    Given the user has metrics consent enabled
    And the user has a funded Money Account

    When the user navigates to Money home (triggering fetchPositions)
    Then a Sentry span is emitted with operation "money.account.data_fetch"
    And the span includes startTime, success, and app_state attributes

  Scenario: Trace failures do not impact queries
    Given Sentry is unreachable or throws internally

    When the user triggers a Money API fetch
    Then the balance still loads successfully
    And no user-facing error is shown
```

## **Screenshots/Recordings**

N/A — observability-only change with no visual impact

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wiring with no changes to fetch logic or user-facing behavior; pattern matches existing balance service tracing.
> 
> **Overview**
> Wires **Sentry tracing** into `MoneyAccountApiDataService` by bumping `@metamask/money-account-api-data-service` to **^0.3.0** and passing a new `sentryTrace` adapter at init time, mirroring the balance service pattern.
> 
> The adapter forwards the package’s optional trace callback into the shared `trace()` helper, sets `op` to `TraceOperation.MoneyAccountDataFetch`, and enriches span data with **`app_state`** (or `unknown` when unset) while preserving caller `tags` and `data`. Unit tests cover constructor wiring, operation tagging, app state handling, data merge behavior, and callback forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a1f8816c7090c313b522f704eba31cbf4967bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->