### PR TITLE
chore: prefix token watchlist analytics event names

### DIFF
--- a/app/components/UI/Assets/watchlist/components/WatchlistEmptyCTA/WatchlistEmptyCTA.test.tsx
+++ b/app/components/UI/Assets/watchlist/components/WatchlistEmptyCTA/WatchlistEmptyCTA.test.tsx
@@ -89,7 +89,7 @@ describe('WatchlistEmptyCTA', () => {
     mockMutate.mockImplementation(() => undefined);
     mockCreateEventBuilder.mockReturnValue({
       addProperties: jest.fn().mockReturnThis(),
-      build: jest.fn().mockReturnValue({ name: 'Watchlist Token Added' }),
+      build: jest.fn().mockReturnValue({ name: 'Token Watchlist Token Added' }),
     });
     mockUseSuggestedWatchlistItemsQuery.mockReturnValue({
       data: [

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -91,9 +91,9 @@ enum EVENT_NAME {
   TOKEN_DETAILS_OPENED = 'Token Details Opened',
   TOKEN_DETAILS_CLOSED = 'Token Details Closed',
   TOKEN_DETAILS_SHARED = 'Token Details Shared',
-  WATCHLIST_TOKEN_ADDED = 'Watchlist Token Added',
-  WATCHLIST_TOKEN_REMOVED = 'Watchlist Token Removed',
-  WATCHLIST_PAGE_VIEWED = 'Watchlist Page Viewed',
+  WATCHLIST_TOKEN_ADDED = 'Token Watchlist Token Added',
+  WATCHLIST_TOKEN_REMOVED = 'Token Watchlist Token Removed',
+  WATCHLIST_PAGE_VIEWED = 'Token Watchlist Page Viewed',
   TOKEN_DETAILS_CTA_CLICKED = 'Token Details CTA Clicked',
   TOKEN_DETAILS_ACTION_CLICKED = 'Token Details Action Clicked',
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Renames three v1 **token watchlist** MetaMetrics event strings to match updated segment schema naming ([Consensys/segment-schema#681](https://github.com/Consensys/segment-schema/pull/681)), per data council feedback to distinguish token watchlist from potential future watchlist types (e.g. trader watchlist).

Follow-up to merged instrumentation ([#33675](https://github.com/MetaMask/metamask-mobile/pull/33675)); **no behavior changes** — only event name strings.

| Previous name | New name |
|---------------|----------|
| `Watchlist Page Viewed` | `Token Watchlist Page Viewed` |
| `Watchlist Token Added` | `Token Watchlist Token Added` |
| `Watchlist Token Removed` | `Token Watchlist Token Removed` |

**Mobile changes:** `MetaMetrics.events.ts` (+ one test hardcoded string in `WatchlistEmptyCTA.test.tsx`). All emit sites continue to use `MetaMetricsEvents.*` constants.

**Segment schema:** companion update on `chore/add-watchlist-events` in segment-schema repo (same `name:` values in the three watchlist yaml files).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->


Related: [Consensys/segment-schema#681](https://github.com/Consensys/segment-schema/pull/681)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token watchlist analytics event rename

  Scenario: Page viewed emits renamed event
    Given token watchlist FF is enabled
    When user opens fullscreen watchlist from homepage
    Then Segment / MetaMetrics shows "Token Watchlist Page Viewed" (not "Watchlist Page Viewed")

  Scenario: Star add emits renamed event
    Given user taps empty star on Token Details for an unwatched token
    Then Segment / MetaMetrics shows "Token Watchlist Token Added"

  Scenario: Star remove emits renamed event
    Given user taps filled star on Token Details for a watched token
    Then Segment / MetaMetrics shows "Token Watchlist Token Removed"
```

- [x] `yarn jest app/components/UI/Assets/watchlist` (148 tests passed)

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — analytics-only string rename; verification via Segment / MetaMetrics event logs.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.