### PR TITLE
fix: disable Predict GTM so seedless Google lock/reset Appium tests can run.

### DIFF
--- a/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
@@ -15,8 +15,7 @@ import {
 appiumTest.describe(
   SmokeSeedlessOnboarding('Google Login - Lock and Unlock'),
   () => {
-    // TODO: Flaky test — to be investigated. Skipped until root cause is fixed.
-    appiumTest.skip(
+    appiumTest(
       'onboards with Google login, locks, and unlocks the app',
       async ({ driver: _driver, currentDeviceDetails }) => {
         const fixture = PlatformDetector.isIOS()

--- a/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
@@ -14,8 +14,7 @@ import {
 appiumTest.describe(
   SmokeSeedlessOnboarding('Google Login - Reset Wallet'),
   () => {
-    // TODO: Flaky test — to be investigated. Skipped until root cause is fixed.
-    appiumTest.skip(
+    appiumTest(
       'onboards with Google login, locks, and resets the wallet',
       async ({ driver: _driver, currentDeviceDetails }) => {
         const fixture = PlatformDetector.isIOS()

--- a/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
+++ b/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
@@ -16,8 +16,11 @@ import { OnboardingSelectorIDs } from '../../../../app/components/Views/Onboardi
 import { createOAuthMockttpService } from '../../../api-mocking/seedless-onboarding/index.js';
 import { E2EOAuthHelpers } from '../../../module-mocking/oauth/index.js';
 import { resolveE2EWaitTimeoutMs } from '../../../framework/Constants.js';
+import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import { remoteFeaturePredictGtmOnboardingModalDisabled } from '../../../api-mocking/mock-responses/feature-flags-mocks.js';
 import {
   dismissExperienceEnhancerModal,
+  dismisspredictionsModalPlaywright,
   dismissPushNotificationExistingUserSheet,
   loginToAppPlaywright,
   waitForWalletHomePlaywright,
@@ -148,6 +151,18 @@ const waitForCreatePasswordScreenPlaywright = async (
   );
 };
 
+/**
+ * Disable Predict GTM full-screen modal so post-onboarding actions (accounts
+ * menu → lock) are not blocked. Matches qr-sync / add-srp seedless smoke setup.
+ */
+const disablePredictGtmOnboardingModal = async (
+  mockServer: Mockttp,
+): Promise<void> => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeaturePredictGtmOnboardingModalDisabled(),
+  });
+};
+
 export async function setupGoogleNewUserOAuthMock(
   mockServer: Mockttp,
 ): Promise<void> {
@@ -156,6 +171,7 @@ export async function setupGoogleNewUserOAuthMock(
   const oAuthMockttpService = createOAuthMockttpService();
   oAuthMockttpService.configureGoogleNewUser();
   await oAuthMockttpService.setup(mockServer);
+  await disablePredictGtmOnboardingModal(mockServer);
 }
 
 export async function setupGoogleExistingUserOAuthMock(
@@ -176,6 +192,7 @@ export async function setupAppleNewUserOAuthMock(
   const oAuthMockttpService = createOAuthMockttpService();
   oAuthMockttpService.configureAppleNewUser();
   await oAuthMockttpService.setup(mockServer);
+  await disablePredictGtmOnboardingModal(mockServer);
 }
 
 export async function setupAppleExistingUserOAuthMock(
@@ -273,6 +290,9 @@ export const completeSocialLoginOnboarding = async (
   await dismissPushNotificationExistingUserSheet();
   await dismissExperienceEnhancerModal();
   await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(60_000));
+  // Predict GTM can still appear if remote flags race the mock; dismiss if present
+  // so accounts-menu → lock is not blocked (Android lock/unlock / reset smokes).
+  await dismisspredictionsModalPlaywright();
 };
 
 export const completeGoogleNewUserOnboarding = (): Promise<void> =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Android Appium seedless Google lock/unlock and reset-wallet smokes were failing after Google new-user onboarding because the **Predict GTM** full-screen modal blocked accounts menu → Lock → Yes, so the suite never reached the Login screen.

Sister seedless specs (add-SRP, QR sync) already disable Predict GTM. This PR aligns the shared helpers:

1. Disable Predict GTM in Google/Apple new-user OAuth mocks via `remoteFeaturePredictGtmOnboardingModalDisabled`
2. Dismiss Predict GTM after social onboarding if it still appears (flag race)
3. Unskip `google-login-lock-unlock.spec.ts` and `google-login-reset-wallet.spec.ts`


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Seedless Google lock and reset Appium smokes

  Scenario: Google new-user Android can lock and unlock after onboarding
    Given Appium seedless smoke with Google new-user OAuth mocks
    And Predict GTM onboarding modal is disabled (and dismissed if it races)
    When the user completes Google new-user onboarding
    And the test locks the app from the accounts menu
    Then the Login screen is visible
    And unlock with the onboarding password returns to wallet home

  Scenario: Google new-user Android can lock and reset wallet
    Given the same Google new-user Appium setup with Predict GTM disabled
    When the user completes Google new-user onboarding and locks the app
    Then reset wallet from the Login screen completes without GTM blocking the lock path
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E test helpers and spec skip flags; no production app behavior is modified.
> 
> **Overview**
> Re-enables the **Google Login - Lock and Unlock** and **Google Login - Reset Wallet** Appium seedless smokes that were skipped as flaky.
> 
> The failures came from the **Predict GTM** full-screen modal blocking **accounts menu → Lock** after Google new-user onboarding on Android. Shared `seedless-helpers` now matches other seedless smokes (e.g. QR sync): **remote feature flags** disable the Predict GTM onboarding modal in **Google/Apple new-user** OAuth mock setup, and **`dismisspredictionsModalPlaywright`** runs after social onboarding when flags race the mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc78665124912c471617417189b5e97c7cee3b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->