### PR TITLE
fix(quickbuy): sync keypad and footer height reveal animations

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import CollapsibleReveal from './CollapsibleReveal';
+
+describe('CollapsibleReveal', () => {
+  it('snaps initially expanded content into view without unmounting', () => {
+    render(
+      <CollapsibleReveal expanded snapExpandedOnMount testID="reveal">
+        <Text testID="reveal-child">content</Text>
+      </CollapsibleReveal>,
+    );
+
+    expect(screen.getByTestId('reveal')).toBeOnTheScreen();
+    expect(screen.getByTestId('reveal-child')).toBeOnTheScreen();
+    expect(screen.getByTestId('reveal-content').props.pointerEvents).toBe(
+      'auto',
+    );
+  });
+
+  it('disables pointer events while collapsed and kept mounted', () => {
+    render(
+      <CollapsibleReveal
+        expanded={false}
+        snapExpandedOnMount={false}
+        unmountWhenCollapsed={false}
+        testID="reveal"
+      >
+        <Text testID="reveal-child">content</Text>
+      </CollapsibleReveal>,
+    );
+
+    expect(screen.getByTestId('reveal-child')).toBeOnTheScreen();
+    expect(screen.getByTestId('reveal-content').props.pointerEvents).toBe(
+      'none',
+    );
+  });
+
+  it('unmounts when collapsed with unmountWhenCollapsed', () => {
+    render(
+      <CollapsibleReveal
+        expanded={false}
+        snapExpandedOnMount={false}
+        unmountWhenCollapsed
+        testID="reveal"
+      >
+        <Text testID="reveal-child">content</Text>
+      </CollapsibleReveal>,
+    );
+
+    expect(screen.queryByTestId('reveal')).toBeNull();
+    expect(screen.queryByTestId('reveal-child')).toBeNull();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.tsx
@@ -87,6 +87,8 @@ const CollapsibleReveal: React.FC<CollapsibleRevealProps> = ({
     opacitySV.value = withTiming(0, KEYPAD_REVEAL_TIMING);
     animatedHeightSV.value = withTiming(0, KEYPAD_REVEAL_TIMING, (finished) => {
       if (finished && unmountWhenCollapsed) {
+        // Reanimated v3 API — scheduleOnRN is v4-only and not available here.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
         runOnJS(setIsMounted)(false);
       }
     });
@@ -165,6 +167,7 @@ const CollapsibleReveal: React.FC<CollapsibleRevealProps> = ({
         style={isNatural ? undefined : styles.measuredContent}
         onLayout={isNatural ? undefined : handleAnimatedContentLayout}
         pointerEvents={expanded ? 'auto' : 'none'}
+        testID={testID ? `${testID}-content` : undefined}
       >
         {children}
       </View>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/CollapsibleReveal.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  StyleSheet,
+  View,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { KEYPAD_REVEAL_TIMING } from '../keypadAnimation';
+
+const styles = StyleSheet.create({
+  measuredContent: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+  },
+});
+
+interface CollapsibleRevealProps {
+  /** When true, animates to the measured content height; when false, to 0. */
+  expanded: boolean;
+  /**
+   * When true (default), initially-expanded content lays out naturally first
+   * then locks height (no 0→snap). Avoids stuttering the bottom-sheet open.
+   * Keypad should pass false so the first open animates 0 → height.
+   */
+  snapExpandedOnMount?: boolean;
+  /**
+   * When false, stays mounted at height 0 while collapsed so intrinsic height
+   * can be pre-measured and the next expand starts in sync with a sibling
+   * collapse (keypad + footer).
+   */
+  unmountWhenCollapsed?: boolean;
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * Animates container height and opacity between collapsed and expanded.
+ * Used by keypad (expand) and footer (collapse) so both share one timing curve
+ * and the bottom sheet never dips then grows. Opacity softens the clipped edge
+ * as the surface reveals over content beneath.
+ */
+const CollapsibleReveal: React.FC<CollapsibleRevealProps> = ({
+  expanded,
+  snapExpandedOnMount = true,
+  unmountWhenCollapsed = true,
+  children,
+  style,
+  testID,
+}) => {
+  // Natural layout first when starting expanded — avoids a height-0 frame that
+  // makes BottomSheetDialog stutter on open. Switch to animated once measured.
+  const [layoutMode, setLayoutMode] = useState<'natural' | 'animated'>(
+    snapExpandedOnMount && expanded ? 'natural' : 'animated',
+  );
+  const [isMounted, setIsMounted] = useState(expanded || !unmountWhenCollapsed);
+  const measuredHeightSV = useSharedValue(0);
+  const animatedHeightSV = useSharedValue(0);
+  const opacitySV = useSharedValue(expanded ? 1 : 0);
+  const isNatural = layoutMode === 'natural';
+
+  useEffect(() => {
+    if (isNatural) {
+      return;
+    }
+
+    if (expanded) {
+      setIsMounted(true);
+      opacitySV.value = withTiming(1, KEYPAD_REVEAL_TIMING);
+      if (measuredHeightSV.value > 0) {
+        animatedHeightSV.value = withTiming(
+          measuredHeightSV.value,
+          KEYPAD_REVEAL_TIMING,
+        );
+      }
+      return;
+    }
+
+    opacitySV.value = withTiming(0, KEYPAD_REVEAL_TIMING);
+    animatedHeightSV.value = withTiming(0, KEYPAD_REVEAL_TIMING, (finished) => {
+      if (finished && unmountWhenCollapsed) {
+        runOnJS(setIsMounted)(false);
+      }
+    });
+  }, [
+    animatedHeightSV,
+    expanded,
+    isNatural,
+    measuredHeightSV,
+    opacitySV,
+    unmountWhenCollapsed,
+  ]);
+
+  const handleNaturalLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      if (nextHeight <= 0) {
+        return;
+      }
+      measuredHeightSV.value = nextHeight;
+      animatedHeightSV.value = nextHeight;
+      opacitySV.value = 1;
+      setLayoutMode('animated');
+    },
+    [animatedHeightSV, measuredHeightSV, opacitySV],
+  );
+
+  const handleAnimatedContentLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const nextHeight = event.nativeEvent.layout.height;
+      if (nextHeight <= 0) {
+        return;
+      }
+
+      const previousHeight = measuredHeightSV.value;
+      measuredHeightSV.value = nextHeight;
+
+      if (!expanded) {
+        return;
+      }
+
+      if (previousHeight === 0) {
+        animatedHeightSV.value = withTiming(nextHeight, KEYPAD_REVEAL_TIMING);
+        opacitySV.value = withTiming(1, KEYPAD_REVEAL_TIMING);
+        return;
+      }
+
+      if (Math.abs(previousHeight - nextHeight) > 1) {
+        animatedHeightSV.value = withTiming(nextHeight, KEYPAD_REVEAL_TIMING);
+      }
+    },
+    [animatedHeightSV, expanded, measuredHeightSV, opacitySV],
+  );
+
+  const revealStyle = useAnimatedStyle(() => {
+    if (isNatural) {
+      return { opacity: 1 };
+    }
+    return {
+      height: animatedHeightSV.value,
+      opacity: opacitySV.value,
+      overflow: 'hidden',
+    };
+  }, [isNatural]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      style={[revealStyle, style]}
+      onLayout={isNatural ? handleNaturalLayout : undefined}
+      testID={testID}
+    >
+      <View
+        style={isNatural ? undefined : styles.measuredContent}
+        onLayout={isNatural ? undefined : handleAnimatedContentLayout}
+        pointerEvents={expanded ? 'auto' : 'none'}
+      >
+        {children}
+      </View>
+    </Animated.View>
+  );
+};
+
+export default CollapsibleReveal;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
@@ -129,16 +129,22 @@ describe('QuickBuyActionFooter', () => {
     expect(screen.queryByTestId('quick-buy-slider')).toBeNull();
   });
 
-  it('hides pay-with and confirm while the keypad is open on the treatment', () => {
+  it('keeps footer mounted but non-interactive while the keypad is open on the treatment', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
       useKeyboard: true,
       isKeypadOpen: true,
       features: { payWithSheet: true, quickAmountPills: true },
     });
+
     render(<QuickBuyActionFooter />);
-    expect(screen.queryByTestId('quick-buy-pay-with-button')).toBeNull();
-    expect(screen.queryByTestId('quick-buy-confirm-button')).toBeNull();
-    expect(screen.queryByTestId('quick-buy-quick-amounts')).toBeNull();
+
+    expect(screen.getByTestId('quick-buy-footer-reveal')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-pay-with-button')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-quick-amounts')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('quick-buy-footer-reveal-content').props.pointerEvents,
+    ).toBe('none');
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -1,4 +1,3 @@
-import { AnimationDuration } from '@metamask/design-tokens';
 import {
   AvatarTokenSize,
   Box,
@@ -15,16 +14,14 @@ import {
 } from '@metamask/design-system-react-native';
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
-import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { strings } from '../../../../../../../../locales/i18n';
 import QuickBuyBanners from '../QuickBuyBanners';
 import QuickBuyConfirmButton from '../QuickBuyConfirmButton';
 import { useQuickBuyContext } from '../useQuickBuyContext';
+import CollapsibleReveal from './CollapsibleReveal';
 import { QuickBuyPercentageSlider } from './QuickBuyPercentageSlider';
 import QuickBuyQuickAmounts from './QuickBuyQuickAmounts';
 import QuickBuyTokenIcon from './QuickBuyTokenIcon';
-
-const FOOTER_ANIM_DURATION = AnimationDuration.Fast;
 
 const QuickBuyActionFooter: React.FC = () => {
   const {
@@ -53,7 +50,86 @@ const QuickBuyActionFooter: React.FC = () => {
   const pickerToken = tradeMode === 'sell' ? selectedDestStable : sourceToken;
   const pickerBalanceFiat =
     tradeMode === 'sell' ? destBalanceFiat : sourceBalanceFiat;
-  const isKeypadEditing = useKeyboard && isKeypadOpen;
+  // Collapse footer while the keypad expands (same CollapsibleReveal timing) so
+  // sheet height lerps closed→open instead of dipping then growing.
+  const isFooterExpanded = !(useKeyboard && isKeypadOpen);
+
+  const footerBody = (
+    <>
+      {features.quickAmountPills ? (
+        <Box twClassName="pb-3">
+          <QuickBuyQuickAmounts />
+        </Box>
+      ) : null}
+
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="pb-5"
+      >
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          {tradeMode === 'sell'
+            ? strings('social_leaderboard.quick_buy.receive')
+            : strings('social_leaderboard.quick_buy.pay_with')}
+        </Text>
+
+        <TouchableOpacity
+          disabled={!features.payWithSheet}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          testID="quick-buy-pay-with-button"
+          onPress={() => setActiveScreen('payWith')}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={2}
+          >
+            {pickerToken ? (
+              <QuickBuyTokenIcon
+                token={pickerToken}
+                size={AvatarTokenSize.Sm}
+              />
+            ) : null}
+            <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+              {pickerToken
+                ? pickerBalanceFiat
+                  ? `${pickerToken.symbol} (${pickerBalanceFiat})`
+                  : pickerToken.symbol
+                : '—'}
+            </Text>
+            {features.payWithSheet ? (
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Sm}
+                color={IconColor.IconDefault}
+              />
+            ) : null}
+          </Box>
+        </TouchableOpacity>
+      </Box>
+
+      <QuickBuyConfirmButton
+        state={confirmButtonState}
+        label={getButtonLabel()}
+        hasValidAmount={hasValidAmount}
+        isDisabled={isConfirmDisabled}
+        onPress={handleBuy}
+        testID="quick-buy-confirm-button"
+      />
+
+      {metamaskFeePercent > 0 ? (
+        <Box twClassName="mt-2 items-center">
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {strings('social_leaderboard.quick_buy.includes_mm_fee', {
+              fee: metamaskFeePercent,
+            })}
+          </Text>
+        </Box>
+      ) : null}
+    </>
+  );
 
   return (
     <Box twClassName="px-4">
@@ -70,102 +146,20 @@ const QuickBuyActionFooter: React.FC = () => {
         </Box>
       )}
 
-      {features.quickAmountPills && !isKeypadEditing ? (
-        <Animated.View
-          entering={FadeIn.duration(FOOTER_ANIM_DURATION)}
-          exiting={FadeOut.duration(FOOTER_ANIM_DURATION)}
-        >
-          <Box twClassName="pb-3">
-            <QuickBuyQuickAmounts />
-          </Box>
-        </Animated.View>
-      ) : null}
-
       <QuickBuyBanners isHardwareSolanaBlocked={isHardwareSolanaBlocked} />
 
-      {!isKeypadEditing ? (
-        <Animated.View
-          entering={FadeIn.duration(FOOTER_ANIM_DURATION)}
-          exiting={FadeOut.duration(FOOTER_ANIM_DURATION)}
+      {useKeyboard ? (
+        <CollapsibleReveal
+          expanded={isFooterExpanded}
+          snapExpandedOnMount
+          unmountWhenCollapsed={false}
+          testID="quick-buy-footer-reveal"
         >
-          {/* Pay with / Receive with row */}
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="pb-5"
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {tradeMode === 'sell'
-                ? strings('social_leaderboard.quick_buy.receive')
-                : strings('social_leaderboard.quick_buy.pay_with')}
-            </Text>
-
-            <TouchableOpacity
-              disabled={!features.payWithSheet}
-              activeOpacity={0.7}
-              accessibilityRole="button"
-              testID="quick-buy-pay-with-button"
-              onPress={() => setActiveScreen('payWith')}
-            >
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                gap={2}
-              >
-                {pickerToken ? (
-                  <QuickBuyTokenIcon
-                    token={pickerToken}
-                    size={AvatarTokenSize.Sm}
-                  />
-                ) : null}
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextDefault}
-                >
-                  {pickerToken
-                    ? pickerBalanceFiat
-                      ? `${pickerToken.symbol} (${pickerBalanceFiat})`
-                      : pickerToken.symbol
-                    : '—'}
-                </Text>
-                {features.payWithSheet ? (
-                  <Icon
-                    name={IconName.ArrowRight}
-                    size={IconSize.Sm}
-                    color={IconColor.IconDefault}
-                  />
-                ) : null}
-              </Box>
-            </TouchableOpacity>
-          </Box>
-
-          <QuickBuyConfirmButton
-            state={confirmButtonState}
-            label={getButtonLabel()}
-            hasValidAmount={hasValidAmount}
-            isDisabled={isConfirmDisabled}
-            onPress={handleBuy}
-            testID="quick-buy-confirm-button"
-          />
-
-          {metamaskFeePercent > 0 ? (
-            <Box twClassName="mt-2 items-center">
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('social_leaderboard.quick_buy.includes_mm_fee', {
-                  fee: metamaskFeePercent,
-                })}
-              </Text>
-            </Box>
-          ) : null}
-        </Animated.View>
-      ) : null}
+          {footerBody}
+        </CollapsibleReveal>
+      ) : (
+        footerBody
+      )}
     </Box>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyKeypad.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyKeypad.tsx
@@ -1,25 +1,24 @@
-import { AnimationDuration } from '@metamask/design-tokens';
 import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useCallback, useMemo } from 'react';
-import Animated, {
-  LinearTransition,
-  SlideInDown,
-  SlideOutDown,
-} from 'react-native-reanimated';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { View } from 'react-native';
 import Keypad, { type KeypadChangeData } from '../../../../../../Base/Keypad';
 import useCurrency from '../../../../../../Base/Keypad/useCurrency';
 import { useQuickBuyContext } from '../useQuickBuyContext';
+import CollapsibleReveal from './CollapsibleReveal';
 import QuickBuyQuickAmounts from './QuickBuyQuickAmounts';
 
 const UNPRICED_KEYPAD_CURRENCY = 'native';
-
-const KEYPAD_ANIM_DURATION = AnimationDuration.Fast;
 
 /**
  * Numeric keypad for the Quick Buy keyboard A/B treatment. When open, renders
  * quick-amount pills + Done above the shared `Base/Keypad`. Pay with / CTA are
  * collapsed in the footer while this is visible.
+ *
+ * Height is animated via CollapsibleReveal (same curve as the footer collapse)
+ * so the bottom-anchored sheet lerps between closed and open height — no dip.
+ * Mount is deferred until the first open so the sheet open animation isn't
+ * competing with keypad layout work.
  */
 const QuickBuyKeypad: React.FC = () => {
   const tw = useTailwind();
@@ -34,6 +33,15 @@ const QuickBuyKeypad: React.FC = () => {
     setIsKeypadOpen,
     features,
   } = useQuickBuyContext();
+
+  // Defer mounting until the first open so flash-icon sheet open stays smooth.
+  // After that, stay mounted (height 0) to keep expand/collapse in sync with footer.
+  const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
+  useEffect(() => {
+    if (isKeypadOpen) {
+      setHasOpenedOnce(true);
+    }
+  }, [isKeypadOpen]);
 
   const keypadCurrency = hasSourcePrice
     ? currentCurrency
@@ -72,22 +80,21 @@ const QuickBuyKeypad: React.FC = () => {
     sourceAmountTokens,
   ]);
 
-  if (!useKeyboard || !isKeypadOpen) {
+  if (!useKeyboard || (!hasOpenedOnce && !isKeypadOpen)) {
     return null;
   }
 
   return (
-    <Animated.View
-      entering={SlideInDown.duration(KEYPAD_ANIM_DURATION)}
-      exiting={SlideOutDown.duration(KEYPAD_ANIM_DURATION)}
+    <CollapsibleReveal
+      expanded={isKeypadOpen}
+      snapExpandedOnMount={false}
+      unmountWhenCollapsed={false}
+      testID="quick-buy-keypad-reveal"
     >
       {features.quickAmountPills ? (
-        <Animated.View
-          layout={LinearTransition.duration(KEYPAD_ANIM_DURATION)}
-          style={tw.style('px-4 pt-1')}
-        >
+        <View style={tw.style('px-4 pt-1')}>
           <QuickBuyQuickAmounts showDone onDonePress={handleDonePress} />
-        </Animated.View>
+        </View>
       ) : null}
       <Box twClassName="px-4 py-4" testID="quick-buy-keypad">
         <Keypad
@@ -96,7 +103,7 @@ const QuickBuyKeypad: React.FC = () => {
           currency={keypadCurrency}
         />
       </Box>
-    </Animated.View>
+    </CollapsibleReveal>
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/keypadAnimation.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/keypadAnimation.ts
@@ -1,0 +1,10 @@
+import { AnimationDuration } from '@metamask/design-tokens';
+import { Easing } from 'react-native-reanimated';
+
+/** Shared duration for keypad reveal and footer collapse on the amount screen. */
+export const KEYPAD_ANIM_DURATION = AnimationDuration.Fast;
+
+export const KEYPAD_REVEAL_TIMING = {
+  duration: KEYPAD_ANIM_DURATION,
+  easing: Easing.out(Easing.cubic),
+} as const;


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Stacked on #33605 (Quick Buy keypad A/B treatment).

https://github.com/user-attachments/assets/88239762-b6bb-4c12-b125-f6a904229704


**Reason:** On the keyboard treatment, tapping the amount opened the keypad with `SlideInDown` while the bottom sheet height jumped instantly. The sheet top border “teleported” up while the keypad slid in, which looked like clashing motion. Instant footer unmount then keypad grow also made the sheet dip down and bounce back up.

**Solution:** Introduce a shared `CollapsibleReveal` height+opacity animation for the keypad and the action footer so both panels animate on the same curve. The bottom-anchored sheet lerps between closed and open height instead of jumping, and opacity softens the hard clipped edge as the keypad reveals over the footer.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33605

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy keypad sheet motion (keyboard A/B treatment)

  Background:
    Given I am logged into MetaMask Mobile
    And I am in the Quick Buy keyboard A/B treatment
    And I can open Quick Buy from a social / asset entry point

  Scenario: user opens the keypad from the amount headline
    Given the Quick Buy sheet is open with the keypad closed
    And the pay-with row and confirm CTA are visible

    When user taps the amount headline
    Then the keypad and Done row reveal with a height animation
    And the sheet top border moves smoothly with the keypad (no instant jump)
    And the footer (pills / pay-with / CTA) collapses in sync (no dip-then-grow)

  Scenario: user dismisses the keypad with Done
    Given the Quick Buy keypad is open

    When user taps Done
    Then the keypad collapses with a height and fade animation
    And the footer restores without a hard cut or sheet bounce

  Scenario: control variant is unchanged
    Given I am in the Quick Buy slider (control) variant

    When user opens Quick Buy
    Then the percentage slider and footer behave as before
    And no keypad reveal chrome is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — see review recording on #33605 (sheet border jumps while keypad slides; sheet dips then grows on open).

### **After**

N/A — please attach a short sim recording of open/close keypad on this branch when available.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only animation and layout for the Quick Buy keyboard A/B treatment; no changes to trading, quotes, or payment flows.
> 
> **Overview**
> Replaces **slide/fade** keypad and footer transitions with a shared **`CollapsibleReveal`** height + opacity animation so the Quick Buy bottom sheet **lerps** between closed and open height instead of jumping or dipping.
> 
> **`CollapsibleReveal`** measures content height, supports natural layout on first paint (`snapExpandedOnMount`), optional stay-mounted-at-zero (`unmountWhenCollapsed={false}`), and uses **`KEYPAD_REVEAL_TIMING`** from new **`keypadAnimation.ts`**. The **keypad** defers mount until the first open, then stays mounted at height 0 for synced expand/collapse with the **footer**, which now **collapses** when the keypad is open but remains on-screen with **`pointerEvents: 'none'`** instead of unmounting. The slider/control variant is unchanged.
> 
> Adds **`CollapsibleReveal.test.tsx`** and updates **`QuickBuyActionFooter`** tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4608ba192f12f45478bff1d980829d8b0aa9a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->