### PR TITLE
ci: pass AI analyzer gate for medium Runway cherry-picks into release branches

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -48,3 +48,8 @@ jobs:
           add-label: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           litellm-api-key: ${{ secrets.AI_ANALYZER_LITELLM_KEY }}
+          # Gate override for Runway release-branch cherry-picks
+          gate-override-risk-threshold: medium
+          gate-override-base-pattern: '^release/'
+          gate-override-author: 'runway-github[bot]'
+          gate-override-title-pattern: 'cherry.?pick'


### PR DESCRIPTION
## **Description**

Passes four `gate-override-*` inputs so the `AI PR Analyzer / Gate` check concludes `success` for medium-risk Runway cherry-picks into release branches. Fail-closed: trusted same-repo PRs only (forks excluded), author `runway-github[bot]`, base `^release/`, title `cherry.?pick`, risk within `medium`. Off for every other PR. Does not change merge automation by itself.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. A `runway-github[bot]` cherry-pick PR into `release/*` scored `medium` concludes the gate `success` (`Risk gate passed via override: medium ≤ medium`).
2. A `medium` PR into `main`, or from another author, stays `neutral`.

## **Screenshots/Recordings**

N/A. CI config change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A. CI config change, no runtime impact.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
