### PR TITLE
chore: centralize custom hex colors into app/styles/colors.ts

### DIFF
--- a/app/styles/colors.ts
+++ b/app/styles/colors.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @metamask/design-tokens/color-no-hex */
+
+/**
+ * ============================================================
+ * CUSTOM COLOR REGISTRY — READ BEFORE ADDING ANYTHING HERE
+ * ============================================================
+ *
+ * This file is the ONE permitted home for custom hex colors in the app.
+ * The eslint-disable above exists ONLY for this file.
+ *
+ * 🚨 IF YOU ARE ABOUT TO ADD A COLOR HERE, TREAT IT AS A RED FLAG.
+ *
+ * Stop. Push back on the designer. If a custom color is showing up in
+ * a design spec, that is a signal the design system may have a gap —
+ * raise it in Slack at #metamask-design-system before merging.
+ *
+ * ⚠️ Custom hex colors MUST be a last resort. Before adding a new value:
+ *
+ * 1. DESIGN TOKENS first — `useTheme().colors.*` covers almost all UI.
+ * See @metamask/design-tokens for the full token catalogue.
+ *
+ * 2. BRAND COLORS second — `brandColor.*` from @metamask/design-tokens
+ * provides the MetaMask brand palette and is already theme-aware.
+ * Reach for these before inventing a new hex value.
+ *
+ * 3. ONLY add a raw hex here when no token or brand color exists AND
+ * the value is dictated by a third-party spec (Apple HIG, a provider's
+ * iframe chrome, a partner's brand mark, chart indicator series, etc.).
+ * Add a comment on the entry explaining exactly why no token applies.
+ *
+ * Adding a hex color to bypass design-system constraints is NOT acceptable.
+ *
+ * Note: `eslint-disable @metamask/design-tokens/color-no-hex` is also
+ * legitimate in SVG and image asset files where hex values are part of
+ * the asset definition, not UI styling. It must NOT appear in component,
+ * style, or utility files — add the color here and import it instead.
+ * ============================================================
+ */
+
+/**
+ * Theme-invariant brand/product colors.
+ *
+ * Use for third-party brand marks, payment buttons, and provider iframe
+ * backgrounds — values that must not change with the user's color scheme.
+ * Do not add semantic UI colors here; use design-system tokens instead.
+ */
+export const staticColors = {
+  white: '#FFFFFF',
+  // Apple Pay — do not change unless noted by Apple HIG:
+  // https://developer.apple.com/design/human-interface-guidelines/apple-pay
+  applePayBlack: '#000000',
+  applePayWhite: '#FFFFFF',
+  telegramBlue: '#29B6F6',
+  btnBlack: '#1C1E21',
+  btnBlackText: '#FFFFFF',
+  modalScrollButton: '#ECEEFF',
+  // Provider iframe chrome backgrounds — these colors are set by each
+  // provider and outside our control. We match them so the native chrome
+  // feels seamless with the embedded webview. Update only if a provider
+  // changes their iframe theme colors.
+  transakCheckoutDark: '#1a1a1a',
+  moonpayCheckoutDark: '#131416',
+  banxaCheckoutDark: '#0D0D0F',
+  // Onboarding carousel — brand accent pairs per slide (theme-invariant)
+  onboardingCarousel: {
+    one: { color: '#190066', background: '#E5FFC3' },
+    two: { color: '#3D065F', background: '#FFA680' },
+    three: { color: '#190066', background: '#CCE7FF' },
+  },
+} as const;
+
+/**
+ * Theme-variant custom colors.
+ *
+ * Keyed by `'light'` and `'dark'` (matching `AppThemeKey`). When a
+ * design-system token is sufficient for one mode, set that entry to `null`
+ * and fall back to the token at the callsite.
+ *
+ * Access via `useCustomColors()` in functional components, or index directly
+ * with `themeAppearance` for class components and non-hook contexts.
+ */
+export const customColors = {
+  light: {
+    // design-token success.default (#457a39) is too faint on a light
+    // background for charts and price indicators — use this darker green.
+    successGreen: '#00881A',
+    gettingStartedBackground: '#FFF2EB',
+    gettingStartedText: '#3D065F',
+  },
+  dark: {
+    successGreen: null as null, // fall back to colors.success.default
+    gettingStartedBackground: '#EAC2FF',
+    gettingStartedText: '#3D065F',
+  },
+} as const;
+
+export type CustomColorSet =
+  | typeof customColors.light
+  | typeof customColors.dark;

--- a/app/styles/common.ts
+++ b/app/styles/common.ts
@@ -1,57 +1,34 @@
-/* eslint-disable @metamask/design-tokens/color-no-hex*/
-
 /**
  * Common styles and variables
  */
 
 import { TextStyle, ViewStyle } from 'react-native';
+import { customColors, staticColors } from './colors';
 
 /**
- * Map of color names to HEX values
+ * Map of color names — sources hex values from `app/styles/colors.ts`.
+ * Add new custom colors there, not here.
  */
 export const colors = {
   blackTransparent: 'rgba(0, 0, 0, 0.5)',
   whiteTransparent: 'rgba(255, 255, 255, 0.7)',
-  white: '#FFFFFF',
+  white: staticColors.white,
   transparent: 'transparent',
   overlay: 'rgba(242, 244, 246, 0.33)',
-  // Do not change the values of applePay tokens unless noted by
-  // https://developer.apple.com/design/human-interface-guidelines/apple-pay
-  applePayBlack: '#000000',
-  applePayWhite: '#FFFFFF',
-  telegramBlue: '#29B6F6',
-  btnBlack: '#1C1E21',
-  btnBlackText: '#FFFFFF',
+  applePayBlack: staticColors.applePayBlack,
+  applePayWhite: staticColors.applePayWhite,
+  telegramBlue: staticColors.telegramBlue,
+  btnBlack: staticColors.btnBlack,
+  btnBlackText: staticColors.btnBlackText,
   btnBlackInverse: 'rgba(60, 77, 157, 0.1)',
-  modalScrollButton: '#ECEEFF',
-  gettingStartedPageBackgroundColor: '#EAC2FF',
-  gettingStartedTextColor: '#3D065F',
-  gettingStartedPageBackgroundColorLightMode: '#FFF2EB',
-  // Provider iframe backgrounds — these colors are set by each provider and
-  // outside our control. We match them in the checkout BottomSheet so the
-  // native chrome feels seamless with the embedded webview. Update only if
-  // a provider changes their iframe theme colors.
-  transakCheckoutDark: '#1a1a1a',
-  moonpayCheckoutDark: '#131416',
-  banxaCheckoutDark: '#0D0D0F',
-};
-
-export const onboardingCarouselColors: Record<
-  string,
-  { color: string; background: string }
-> = {
-  one: {
-    color: '#190066',
-    background: '#E5FFC3',
-  },
-  two: {
-    color: '#3D065F',
-    background: '#FFA680',
-  },
-  three: {
-    color: '#190066',
-    background: '#CCE7FF',
-  },
+  modalScrollButton: staticColors.modalScrollButton,
+  gettingStartedPageBackgroundColor: customColors.dark.gettingStartedBackground,
+  gettingStartedTextColor: customColors.light.gettingStartedText,
+  gettingStartedPageBackgroundColorLightMode:
+    customColors.light.gettingStartedBackground,
+  transakCheckoutDark: staticColors.transakCheckoutDark,
+  moonpayCheckoutDark: staticColors.moonpayCheckoutDark,
+  banxaCheckoutDark: staticColors.banxaCheckoutDark,
 };
 
 /**

--- a/app/util/theme/index.ts
+++ b/app/util/theme/index.ts
@@ -14,18 +14,18 @@ import {
   resolveDarkTheme,
   brandColor,
 } from '@metamask/design-tokens';
+import { customColors, CustomColorSet } from '../../styles/colors';
 import Device from '../device';
 import { isPureBlackEnabled } from './pureBlackPreview';
 
 const resolvedDarkTheme = resolveDarkTheme(isPureBlackEnabled);
 
 /**
- * Darker success green used in light mode for better contrast on charts,
- * price indicators, and action buttons. The design-system token
- * `success.default` is too faint against a light background.
+ * Darker success green for light mode — sourced from the central custom
+ * color registry (`app/styles/colors.ts`). No hex literal lives here.
  */
-// eslint-disable-next-line @metamask/design-tokens/color-no-hex
-export const LIGHT_MODE_SUCCESS_GREEN = '#00881A';
+export const LIGHT_MODE_SUCCESS_GREEN =
+  customColors[AppThemeKey.light].successGreen;
 
 /**
  * This is needed to make our unit tests pass since Enzyme doesn't support contextType
@@ -227,3 +227,20 @@ export const useAssetFromTheme = (light: any, dark: any) => {
 
   return asset;
 };
+
+/**
+ * Returns the custom color set for the active theme.
+ *
+ * Prefer design-system tokens (`useTheme().colors`) over these values.
+ * Only reach for `useCustomColors()` when no token exists — see
+ * `app/styles/colors.ts` for the full registry and rationale per entry.
+ *
+ * For class components or non-hook contexts, index `customColors` directly:
+ * `customColors[theme.themeAppearance]`
+ */
+export const useCustomColors = (): CustomColorSet => {
+  const { themeAppearance } = useTheme();
+  return customColors[themeAppearance];
+};
+
+export { customColors } from '../../styles/colors';

--- a/app/util/theme/index.ts
+++ b/app/util/theme/index.ts
@@ -14,17 +14,17 @@ import {
   resolveDarkTheme,
   brandColor,
 } from '@metamask/design-tokens';
+import { customColors, CustomColorSet } from '../../styles/colors';
 import Device from '../device';
 
 const resolvedDarkTheme = resolveDarkTheme(true);
 
 /**
- * Darker success green used in light mode for better contrast on charts,
- * price indicators, and action buttons. The design-system token
- * `success.default` is too faint against a light background.
+ * Darker success green for light mode — sourced from the central custom
+ * color registry (`app/styles/colors.ts`). No hex literal lives here.
  */
-// eslint-disable-next-line @metamask/design-tokens/color-no-hex
-export const LIGHT_MODE_SUCCESS_GREEN = '#00881A';
+export const LIGHT_MODE_SUCCESS_GREEN =
+  customColors[AppThemeKey.light].successGreen;
 
 /**
  * This is needed to make our unit tests pass since Enzyme doesn't support contextType
@@ -226,3 +226,20 @@ export const useAssetFromTheme = (light: any, dark: any) => {
 
   return asset;
 };
+
+/**
+ * Returns the custom color set for the active theme.
+ *
+ * Prefer design-system tokens (`useTheme().colors`) over these values.
+ * Only reach for `useCustomColors()` when no token exists — see
+ * `app/styles/colors.ts` for the full registry and rationale per entry.
+ *
+ * For class components or non-hook contexts, index `customColors` directly:
+ * `customColors[theme.themeAppearance]`
+ */
+export const useCustomColors = (): CustomColorSet => {
+  const { themeAppearance } = useTheme();
+  return customColors[themeAppearance];
+};
+
+export { customColors } from '../../styles/colors';


### PR DESCRIPTION
## Summary

- Creates `app/styles/colors.ts` as the **single permitted home** for custom hex colors — one `eslint-disable @metamask/design-tokens/color-no-hex` at the top of that file only
- Exports `staticColors` (theme-invariant brand/third-party values) and `customColors` (light/dark keyed variants), plus a `useCustomColors()` hook
- Removes the file-level `eslint-disable` and all hex literals from `app/styles/common.ts` — the `colors` export shape is unchanged so all existing consumers are unaffected
- Removes the `LIGHT_MODE_SUCCESS_GREEN` hex literal from `app/util/theme/index.ts`; it now sources from `customColors`

## Motivation

81+ files currently use `eslint-disable @metamask/design-tokens/color-no-hex` to silence the rule that enforces design-token usage. Custom colors are scattered with no central audit point, no light/dark strategy, and no guidance on when they're acceptable.

This PR establishes the pattern. The `colors.ts` header comment explicitly tells contributors:

> 🚨 If you are about to add a color here, treat it as a red flag. Push back on the designer. If a custom color is showing up in a design spec, that is a signal the design system may have a gap — raise it in Slack at #metamask-design-system before merging.

The 81 remaining files can migrate incrementally — teams remove their own `eslint-disable`s as they touch those files and move values here.

## Test plan

- [ ] `yarn lint` passes with no `color-no-hex` violations outside `app/styles/colors.ts`
- [ ] `yarn lint:tsc` passes with no type errors
- [ ] Existing components that import `colors` from `app/styles/common` render correctly (shape unchanged)
- [ ] `LIGHT_MODE_SUCCESS_GREEN` still resolves to `'#00881A'` (sourced from `customColors.light.successGreen`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that preserves the `colors` export shape and success-green value; no auth, data, or runtime logic changes beyond import paths.
> 
> **Overview**
> Introduces **`app/styles/colors.ts`** as the only allowed place for raw hex colors (single `color-no-hex` eslint disable), with **`staticColors`** for theme-invariant third-party/brand values and **`customColors`** keyed by light/dark, plus contributor guidance to prefer design tokens first.
> 
> **`app/styles/common.ts`** drops its file-level hex disable and inline literals; the exported **`colors`** map keeps the same keys and now pulls values from the registry so existing imports stay valid. Onboarding carousel hex pairs move into **`staticColors.onboardingCarousel`** (the separate **`onboardingCarouselColors`** export is removed). **`app/util/theme/index.ts`** sources **`LIGHT_MODE_SUCCESS_GREEN`** from **`customColors`** instead of a local hex, and adds **`useCustomColors()`** (and re-exports **`customColors`**) for theme-aware custom colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091dbb246d95a1ac010d16691703610d667b7df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->