### PR TITLE
fix(agentic-cli): open settings on any Android deny after Turn on

### DIFF
--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { renderHook, act } from '@testing-library/react-native';
 import { ToastContext } from '../../../component-library/components/Toast';
 import type {
@@ -11,6 +11,7 @@ import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 const mockEnableNotifications = jest.fn();
 const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
+const mockRequestPushPermissions = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockIsNotificationsFeatureEnabled = jest.fn();
 
@@ -31,6 +32,7 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   },
   isPushPermissionPromptable: () => mockIsPushPermissionPromptable(),
   isPushPermissionGranted: () => mockIsPushPermissionGranted(),
+  requestPushPermissions: () => mockRequestPushPermissions(),
 }));
 
 jest.mock('../../../../locales/i18n', () => ({
@@ -74,6 +76,8 @@ describe('useCliLoginPushNudge', () => {
     mockEnableNotifications.mockResolvedValue(undefined);
     mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
+    mockRequestPushPermissions.mockResolvedValue(false);
+    Platform.OS = 'ios';
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
       handler: (state: string) => void,
@@ -266,5 +270,61 @@ describe('useCliLoginPushNudge', () => {
 
     expect(mockIsPushPermissionGranted).not.toHaveBeenCalled();
     expect(mockEnableNotifications).not.toHaveBeenCalled();
+  });
+
+  describe('android', () => {
+    beforeEach(() => {
+      Platform.OS = 'android';
+    });
+
+    it('opens settings when the OS dialog is skipped after permanent denial', async () => {
+      const dateNow = jest.spyOn(Date, 'now');
+      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(100);
+      mockRequestPushPermissions.mockResolvedValue(false);
+      const { result } = renderNudge();
+
+      act(() => {
+        result.current.showNudge();
+      });
+      await tapTurnOn();
+
+      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
+      expect(mockEnableNotifications).not.toHaveBeenCalled();
+      expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+      dateNow.mockRestore();
+    });
+
+    it('closes without settings when the user denies the OS dialog', async () => {
+      const dateNow = jest.spyOn(Date, 'now');
+      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(1500);
+      mockRequestPushPermissions.mockResolvedValue(false);
+      const { result } = renderNudge();
+
+      act(() => {
+        result.current.showNudge();
+      });
+      await tapTurnOn();
+
+      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
+      expect(mockEnableNotifications).not.toHaveBeenCalled();
+      expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+      expect(closeToast).toHaveBeenCalled();
+      dateNow.mockRestore();
+    });
+
+    it('enables notifications when the OS grants push permission', async () => {
+      mockRequestPushPermissions.mockResolvedValue(true);
+      const { result } = renderNudge();
+
+      act(() => {
+        result.current.showNudge();
+      });
+      await tapTurnOn();
+
+      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
+      expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
+      expect(mockOpenSystemSettings).not.toHaveBeenCalled();
+      expect(closeToast).toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { AppState, Platform } from 'react-native';
+// eslint-disable-next-line react-native/split-platform-components
+import { AppState, PermissionsAndroid, Platform } from 'react-native';
 import { renderHook, act } from '@testing-library/react-native';
 import { ToastContext } from '../../../component-library/components/Toast';
 import type {
@@ -11,7 +12,6 @@ import { useCliLoginPushNudge } from './useCliLoginPushNudge';
 const mockEnableNotifications = jest.fn();
 const mockIsPushPermissionPromptable = jest.fn();
 const mockIsPushPermissionGranted = jest.fn();
-const mockRequestPushPermissions = jest.fn();
 const mockOpenSystemSettings = jest.fn();
 const mockIsNotificationsFeatureEnabled = jest.fn();
 
@@ -32,7 +32,6 @@ jest.mock('../../../util/notifications/services/NotificationService', () => ({
   },
   isPushPermissionPromptable: () => mockIsPushPermissionPromptable(),
   isPushPermissionGranted: () => mockIsPushPermissionGranted(),
-  requestPushPermissions: () => mockRequestPushPermissions(),
 }));
 
 jest.mock('../../../../locales/i18n', () => ({
@@ -76,7 +75,9 @@ describe('useCliLoginPushNudge', () => {
     mockEnableNotifications.mockResolvedValue(undefined);
     mockIsPushPermissionPromptable.mockResolvedValue(true);
     mockIsPushPermissionGranted.mockResolvedValue(false);
-    mockRequestPushPermissions.mockResolvedValue(false);
+    jest
+      .spyOn(PermissionsAndroid, 'request')
+      .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
     Platform.OS = 'ios';
     jest.spyOn(AppState, 'addEventListener').mockImplementation(((
       _event: string,
@@ -272,15 +273,16 @@ describe('useCliLoginPushNudge', () => {
     expect(mockEnableNotifications).not.toHaveBeenCalled();
   });
 
-  describe('android', () => {
+  describe('android 13+', () => {
     beforeEach(() => {
       Platform.OS = 'android';
+      jest.spyOn(Platform, 'Version', 'get').mockReturnValue(33);
     });
 
-    it('opens settings when the OS dialog is skipped after permanent denial', async () => {
-      const dateNow = jest.spyOn(Date, 'now');
-      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(100);
-      mockRequestPushPermissions.mockResolvedValue(false);
+    it('opens settings when the OS permanently denied the permission', async () => {
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
       const { result } = renderNudge();
 
       act(() => {
@@ -288,16 +290,17 @@ describe('useCliLoginPushNudge', () => {
       });
       await tapTurnOn();
 
-      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
+      expect(PermissionsAndroid.request).toHaveBeenCalledWith(
+        PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+      );
       expect(mockEnableNotifications).not.toHaveBeenCalled();
       expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
-      dateNow.mockRestore();
     });
 
-    it('closes without settings when the user denies the OS dialog', async () => {
-      const dateNow = jest.spyOn(Date, 'now');
-      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(1500);
-      mockRequestPushPermissions.mockResolvedValue(false);
+    it('closes without settings when the user dismisses the OS dialog', async () => {
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
       const { result } = renderNudge();
 
       act(() => {
@@ -305,15 +308,16 @@ describe('useCliLoginPushNudge', () => {
       });
       await tapTurnOn();
 
-      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
+      expect(PermissionsAndroid.request).toHaveBeenCalledTimes(1);
       expect(mockEnableNotifications).not.toHaveBeenCalled();
       expect(mockOpenSystemSettings).not.toHaveBeenCalled();
       expect(closeToast).toHaveBeenCalled();
-      dateNow.mockRestore();
     });
 
     it('enables notifications when the OS grants push permission', async () => {
-      mockRequestPushPermissions.mockResolvedValue(true);
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
       const { result } = renderNudge();
 
       act(() => {
@@ -321,10 +325,29 @@ describe('useCliLoginPushNudge', () => {
       });
       await tapTurnOn();
 
-      expect(mockRequestPushPermissions).toHaveBeenCalledTimes(1);
       expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
       expect(mockOpenSystemSettings).not.toHaveBeenCalled();
       expect(closeToast).toHaveBeenCalled();
+    });
+  });
+
+  describe('android < 13', () => {
+    beforeEach(() => {
+      Platform.OS = 'android';
+      jest.spyOn(Platform, 'Version', 'get').mockReturnValue(31);
+    });
+
+    it('opens settings without a runtime dialog when push is not granted', async () => {
+      const { result } = renderNudge();
+
+      act(() => {
+        result.current.showNudge();
+      });
+      await tapTurnOn();
+
+      expect(PermissionsAndroid.request).not.toHaveBeenCalled();
+      expect(mockEnableNotifications).not.toHaveBeenCalled();
+      expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -297,7 +297,27 @@ describe('useCliLoginPushNudge', () => {
       expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     });
 
+    it('opens settings when DENIED is returned without showing the OS dialog', async () => {
+      const dateNow = jest.spyOn(Date, 'now');
+      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(50);
+      jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
+      const { result } = renderNudge();
+
+      act(() => {
+        result.current.showNudge();
+      });
+      await tapTurnOn();
+
+      expect(mockEnableNotifications).not.toHaveBeenCalled();
+      expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
+      dateNow.mockRestore();
+    });
+
     it('closes without settings when the user dismisses the OS dialog', async () => {
+      const dateNow = jest.spyOn(Date, 'now');
+      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(1500);
       jest
         .spyOn(PermissionsAndroid, 'request')
         .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
@@ -312,6 +332,7 @@ describe('useCliLoginPushNudge', () => {
       expect(mockEnableNotifications).not.toHaveBeenCalled();
       expect(mockOpenSystemSettings).not.toHaveBeenCalled();
       expect(closeToast).toHaveBeenCalled();
+      dateNow.mockRestore();
     });
 
     it('enables notifications when the OS grants push permission', async () => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -274,27 +274,18 @@ describe('useCliLoginPushNudge', () => {
   });
 
   describe('android 13+', () => {
-    let mockShouldShowRationale: jest.Mock;
+    let requestMock: jest.Mock;
 
     beforeEach(() => {
       Platform.OS = 'android';
       jest.spyOn(Platform, 'Version', 'get').mockReturnValue(33);
-      mockShouldShowRationale = jest.fn().mockResolvedValue(true);
-      Object.defineProperty(
-        PermissionsAndroid,
-        'shouldShowRequestPermissionRationale',
-        {
-          value: mockShouldShowRationale,
-          configurable: true,
-          writable: true,
-        },
-      );
+      requestMock = jest
+        .spyOn(PermissionsAndroid, 'request')
+        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
     });
 
     it('opens settings when the OS permanently denied the permission', async () => {
-      jest
-        .spyOn(PermissionsAndroid, 'request')
-        .mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
+      requestMock.mockResolvedValue(PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN);
       const { result } = renderNudge();
 
       act(() => {
@@ -309,27 +300,7 @@ describe('useCliLoginPushNudge', () => {
       expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     });
 
-    it('opens settings when DENIED and the OS will not show rationale again', async () => {
-      jest
-        .spyOn(PermissionsAndroid, 'request')
-        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
-      mockShouldShowRationale.mockResolvedValue(false);
-      const { result } = renderNudge();
-
-      act(() => {
-        result.current.showNudge();
-      });
-      await tapTurnOn();
-
-      expect(mockEnableNotifications).not.toHaveBeenCalled();
-      expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
-    });
-
-    it('closes without settings when the user dismisses the OS dialog', async () => {
-      jest
-        .spyOn(PermissionsAndroid, 'request')
-        .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
-      mockShouldShowRationale.mockResolvedValue(true);
+    it('opens settings when the user denies the OS dialog', async () => {
       const { result } = renderNudge();
 
       act(() => {
@@ -339,14 +310,11 @@ describe('useCliLoginPushNudge', () => {
 
       expect(PermissionsAndroid.request).toHaveBeenCalledTimes(1);
       expect(mockEnableNotifications).not.toHaveBeenCalled();
-      expect(mockOpenSystemSettings).not.toHaveBeenCalled();
-      expect(closeToast).toHaveBeenCalled();
+      expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     });
 
     it('enables notifications when the OS grants push permission', async () => {
-      jest
-        .spyOn(PermissionsAndroid, 'request')
-        .mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
+      requestMock.mockResolvedValue(PermissionsAndroid.RESULTS.GRANTED);
       const { result } = renderNudge();
 
       act(() => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -274,7 +274,7 @@ describe('useCliLoginPushNudge', () => {
   });
 
   describe('android 13+', () => {
-    let requestMock: jest.Mock;
+    let requestMock: jest.SpyInstance;
 
     beforeEach(() => {
       Platform.OS = 'android';

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -274,9 +274,21 @@ describe('useCliLoginPushNudge', () => {
   });
 
   describe('android 13+', () => {
+    let mockShouldShowRationale: jest.Mock;
+
     beforeEach(() => {
       Platform.OS = 'android';
       jest.spyOn(Platform, 'Version', 'get').mockReturnValue(33);
+      mockShouldShowRationale = jest.fn().mockResolvedValue(true);
+      Object.defineProperty(
+        PermissionsAndroid,
+        'shouldShowRequestPermissionRationale',
+        {
+          value: mockShouldShowRationale,
+          configurable: true,
+          writable: true,
+        },
+      );
     });
 
     it('opens settings when the OS permanently denied the permission', async () => {
@@ -297,12 +309,11 @@ describe('useCliLoginPushNudge', () => {
       expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     });
 
-    it('opens settings when DENIED is returned without showing the OS dialog', async () => {
-      const dateNow = jest.spyOn(Date, 'now');
-      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(50);
+    it('opens settings when DENIED and the OS will not show rationale again', async () => {
       jest
         .spyOn(PermissionsAndroid, 'request')
         .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
+      mockShouldShowRationale.mockResolvedValue(false);
       const { result } = renderNudge();
 
       act(() => {
@@ -312,15 +323,13 @@ describe('useCliLoginPushNudge', () => {
 
       expect(mockEnableNotifications).not.toHaveBeenCalled();
       expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
-      dateNow.mockRestore();
     });
 
     it('closes without settings when the user dismisses the OS dialog', async () => {
-      const dateNow = jest.spyOn(Date, 'now');
-      dateNow.mockReturnValueOnce(0).mockReturnValueOnce(1500);
       jest
         .spyOn(PermissionsAndroid, 'request')
         .mockResolvedValue(PermissionsAndroid.RESULTS.DENIED);
+      mockShouldShowRationale.mockResolvedValue(true);
       const { result } = renderNudge();
 
       act(() => {
@@ -332,7 +341,6 @@ describe('useCliLoginPushNudge', () => {
       expect(mockEnableNotifications).not.toHaveBeenCalled();
       expect(mockOpenSystemSettings).not.toHaveBeenCalled();
       expect(closeToast).toHaveBeenCalled();
-      dateNow.mockRestore();
     });
 
     it('enables notifications when the OS grants push permission', async () => {

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -19,6 +19,26 @@ import NotificationService, {
 /** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
 const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
+/**
+ * Below this threshold, `PermissionsAndroid.request(POST_NOTIFICATIONS)` likely
+ * returned without showing the OS dialog (permanent deny). Only applies to the
+ * direct PermissionsAndroid call — not Notifee channel setup.
+ */
+const ANDROID_OS_DIALOG_MIN_ELAPSED_MS = 300;
+
+function shouldOpenAndroidNotificationSettings(
+  result: string,
+  requestElapsedMs: number,
+): boolean {
+  if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+    return true;
+  }
+  return (
+    result === PermissionsAndroid.RESULTS.DENIED &&
+    requestElapsedMs < ANDROID_OS_DIALOG_MIN_ELAPSED_MS
+  );
+}
+
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
 ];
@@ -183,9 +203,11 @@ export function useCliLoginPushNudge(): {
         // denied it, which is the authoritative signal that the OS dialog can
         // no longer be shown.
         if (Number(Platform.Version) >= ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
+          const requestStartedAt = Date.now();
           const result = await PermissionsAndroid.request(
             PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
           );
+          const requestElapsedMs = Date.now() - requestStartedAt;
           if (!isCurrent()) {
             return;
           }
@@ -193,11 +215,11 @@ export function useCliLoginPushNudge(): {
             await runEnableFlow(isCurrent);
             return;
           }
-          if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+          if (shouldOpenAndroidNotificationSettings(result, requestElapsedMs)) {
             openSettingsAndScheduleRetry(isCurrent);
             return;
           }
-          // RESULTS.DENIED: the OS dialog was shown and dismissed.
+          // DENIED after the OS dialog was shown and dismissed.
           if (isCurrent()) {
             toastRef?.current?.closeToast();
           }

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useRef } from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { ToastContext } from '../../../component-library/components/Toast';
 import {
   ToastVariants,
@@ -12,7 +12,11 @@ import { useEnableNotifications } from '../../../util/notifications/hooks/useNot
 import NotificationService, {
   isPushPermissionGranted,
   isPushPermissionPromptable,
+  requestPushPermissions,
 } from '../../../util/notifications/services/NotificationService';
+
+/** Below this threshold, Android likely skipped the OS dialog (permanent deny). */
+const ANDROID_OS_DIALOG_MIN_ELAPSED_MS = 800;
 
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
@@ -33,6 +37,10 @@ const ERROR_LABELS = () => [
  * Denying that dialog closes the toast without opening Settings. When the OS can
  * no longer show its dialog (e.g. iOS after a prior denial), it deep-links to
  * device notification settings and retries once the app returns to foreground.
+ *
+ * Android: Notifee reports DENIED for both "never asked" and "permanently
+ * denied", so we request OS permission first and treat a fast denial (no dialog)
+ * as a signal to open device notification settings.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -112,6 +120,36 @@ export function useCliLoginPushNudge(): {
     [clearForegroundRetry],
   );
 
+  const openSettingsAndScheduleRetry = useCallback(
+    (isCurrent: () => boolean) => {
+      toastRef?.current?.closeToast();
+      NotificationService.openSystemSettings();
+      scheduleForegroundRetry(async () => {
+        if (!isCurrent()) {
+          return;
+        }
+        inFlightRef.current = true;
+        try {
+          if (!(await isPushPermissionGranted())) {
+            if (isCurrent()) {
+              toastRef?.current?.closeToast();
+            }
+            return;
+          }
+          if (!isCurrent()) {
+            return;
+          }
+          showLoadingToast();
+          await runEnableFlow(isCurrent);
+        } finally {
+          inFlightRef.current = false;
+        }
+      });
+      inFlightRef.current = false;
+    },
+    [runEnableFlow, scheduleForegroundRetry, showLoadingToast, toastRef],
+  );
+
   const onTapTurnOn = useCallback(async () => {
     if (inFlightRef.current) {
       return;
@@ -137,45 +175,43 @@ export function useCliLoginPushNudge(): {
         return;
       }
 
+      if (Platform.OS === 'android') {
+        showLoadingToast();
+        const requestStartedAt = Date.now();
+        const osGranted = await requestPushPermissions();
+        const requestElapsedMs = Date.now() - requestStartedAt;
+
+        if (!isCurrent()) {
+          return;
+        }
+
+        if (osGranted) {
+          await runEnableFlow(isCurrent);
+          return;
+        }
+
+        if (requestElapsedMs < ANDROID_OS_DIALOG_MIN_ELAPSED_MS) {
+          openSettingsAndScheduleRetry(isCurrent);
+          return;
+        }
+
+        if (isCurrent()) {
+          toastRef?.current?.closeToast();
+        }
+        return;
+      }
+
       const promptable = await isPushPermissionPromptable();
       if (!isCurrent()) {
         return;
       }
 
       if (!promptable) {
-        // OS dialog cannot be shown again (e.g. iOS after a prior denial).
-        // Deep-link to device settings and retry on return to foreground.
-        toastRef?.current?.closeToast();
-        NotificationService.openSystemSettings();
-        scheduleForegroundRetry(async () => {
-          if (!isCurrent()) {
-            return;
-          }
-          inFlightRef.current = true;
-          try {
-            if (!(await isPushPermissionGranted())) {
-              if (isCurrent()) {
-                toastRef?.current?.closeToast();
-              }
-              return;
-            }
-            if (!isCurrent()) {
-              return;
-            }
-            showLoadingToast();
-            await runEnableFlow(isCurrent);
-          } finally {
-            inFlightRef.current = false;
-          }
-        });
-        // The enable work is deferred to the foreground retry, which manages
-        // its own in-flight guard. Release the guard now so a later tap is not
-        // permanently blocked if the user never returns from device settings.
-        inFlightRef.current = false;
+        openSettingsAndScheduleRetry(isCurrent);
         return;
       }
 
-      // OS can still show its dialog — request permission via enableNotifications().
+      // iOS: OS can still show its dialog — request permission via enableNotifications().
       // If the user denies, dismiss the toast without opening Settings (matches
       // PushNotificationOnboarding).
       showLoadingToast();
@@ -195,8 +231,8 @@ export function useCliLoginPushNudge(): {
     }
   }, [
     enableNotifications,
+    openSettingsAndScheduleRetry,
     runEnableFlow,
-    scheduleForegroundRetry,
     showErrorToast,
     showLoadingToast,
     toastRef,

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -1,5 +1,7 @@
 import { useCallback, useContext, useEffect, useRef } from 'react';
-import { AppState, Platform } from 'react-native';
+// PermissionsAndroid usage below is gated behind `Platform.OS === 'android'`.
+// eslint-disable-next-line react-native/split-platform-components
+import { AppState, PermissionsAndroid, Platform } from 'react-native';
 import { ToastContext } from '../../../component-library/components/Toast';
 import {
   ToastVariants,
@@ -12,11 +14,10 @@ import { useEnableNotifications } from '../../../util/notifications/hooks/useNot
 import NotificationService, {
   isPushPermissionGranted,
   isPushPermissionPromptable,
-  requestPushPermissions,
 } from '../../../util/notifications/services/NotificationService';
 
-/** Below this threshold, Android likely skipped the OS dialog (permanent deny). */
-const ANDROID_OS_DIALOG_MIN_ELAPSED_MS = 800;
+/** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
+const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
@@ -39,8 +40,8 @@ const ERROR_LABELS = () => [
  * device notification settings and retries once the app returns to foreground.
  *
  * Android: Notifee reports DENIED for both "never asked" and "permanently
- * denied", so we request OS permission first and treat a fast denial (no dialog)
- * as a signal to open device notification settings.
+ * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS) and
+ * treat NEVER_ASK_AGAIN as the signal to open device notification settings.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -177,27 +178,35 @@ export function useCliLoginPushNudge(): {
 
       if (Platform.OS === 'android') {
         showLoadingToast();
-        const requestStartedAt = Date.now();
-        const osGranted = await requestPushPermissions();
-        const requestElapsedMs = Date.now() - requestStartedAt;
-
-        if (!isCurrent()) {
+        // Android 13+ requires the POST_NOTIFICATIONS runtime permission. The
+        // request resolves to NEVER_ASK_AGAIN once the user has permanently
+        // denied it, which is the authoritative signal that the OS dialog can
+        // no longer be shown.
+        if (Number(Platform.Version) >= ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
+          const result = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+          );
+          if (!isCurrent()) {
+            return;
+          }
+          if (result === PermissionsAndroid.RESULTS.GRANTED) {
+            await runEnableFlow(isCurrent);
+            return;
+          }
+          if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+            openSettingsAndScheduleRetry(isCurrent);
+            return;
+          }
+          // RESULTS.DENIED: the OS dialog was shown and dismissed.
+          if (isCurrent()) {
+            toastRef?.current?.closeToast();
+          }
           return;
         }
 
-        if (osGranted) {
-          await runEnableFlow(isCurrent);
-          return;
-        }
-
-        if (requestElapsedMs < ANDROID_OS_DIALOG_MIN_ELAPSED_MS) {
-          openSettingsAndScheduleRetry(isCurrent);
-          return;
-        }
-
-        if (isCurrent()) {
-          toastRef?.current?.closeToast();
-        }
+        // Android < 13 has no runtime dialog; when notifications are not
+        // already granted they can only be enabled from system settings.
+        openSettingsAndScheduleRetry(isCurrent);
         return;
       }
 

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -157,6 +157,73 @@ export function useCliLoginPushNudge(): {
     [runEnableFlow, scheduleForegroundRetry, showLoadingToast, toastRef],
   );
 
+  const runGrantedFlow = useCallback(
+    async (isCurrent: () => boolean) => {
+      if (!isCurrent()) {
+        return;
+      }
+      showLoadingToast();
+      await enableNotifications();
+      if (isCurrent()) {
+        toastRef?.current?.closeToast();
+      }
+    },
+    [enableNotifications, showLoadingToast, toastRef],
+  );
+
+  const runAndroidPermissionFlow = useCallback(
+    async (isCurrent: () => boolean) => {
+      showLoadingToast();
+      // Android < 13 has no runtime dialog; when notifications are not already
+      // granted they can only be enabled from system settings.
+      if (Number(Platform.Version) < ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
+        openSettingsAndScheduleRetry(isCurrent);
+        return;
+      }
+      // Android 13+ requires the POST_NOTIFICATIONS runtime permission.
+      const result = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+      );
+      if (!isCurrent()) {
+        return;
+      }
+      if (result === PermissionsAndroid.RESULTS.GRANTED) {
+        await runEnableFlow(isCurrent);
+        return;
+      }
+      // User tapped Turn on — any deny opens settings.
+      openSettingsAndScheduleRetry(isCurrent);
+    },
+    [openSettingsAndScheduleRetry, runEnableFlow, showLoadingToast],
+  );
+
+  const runIosPermissionFlow = useCallback(
+    async (isCurrent: () => boolean) => {
+      const promptable = await isPushPermissionPromptable();
+      if (!isCurrent()) {
+        return;
+      }
+      if (!promptable) {
+        openSettingsAndScheduleRetry(isCurrent);
+        return;
+      }
+      // OS can still show its dialog — request permission via enableNotifications().
+      // If the user denies, dismiss the toast without opening Settings (matches
+      // PushNotificationOnboarding).
+      showLoadingToast();
+      await enableNotifications();
+      if (isCurrent()) {
+        toastRef?.current?.closeToast();
+      }
+    },
+    [
+      enableNotifications,
+      openSettingsAndScheduleRetry,
+      showLoadingToast,
+      toastRef,
+    ],
+  );
+
   const onTapTurnOn = useCallback(async () => {
     if (inFlightRef.current) {
       return;
@@ -168,66 +235,17 @@ export function useCliLoginPushNudge(): {
 
     try {
       if (await isPushPermissionGranted()) {
-        if (!isCurrent()) {
-          return;
-        }
-        showLoadingToast();
-        await enableNotifications();
-        if (isCurrent()) {
-          toastRef?.current?.closeToast();
-        }
+        await runGrantedFlow(isCurrent);
         return;
       }
       if (!isCurrent()) {
         return;
       }
-
       if (Platform.OS === 'android') {
-        showLoadingToast();
-        // Android 13+ requires the POST_NOTIFICATIONS runtime permission. The
-        // request resolves to NEVER_ASK_AGAIN once the user has permanently
-        // denied it, which is the authoritative signal that the OS dialog can
-        // no longer be shown.
-        if (Number(Platform.Version) >= ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
-          const result = await PermissionsAndroid.request(
-            PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-          );
-          if (!isCurrent()) {
-            return;
-          }
-          if (result === PermissionsAndroid.RESULTS.GRANTED) {
-            await runEnableFlow(isCurrent);
-            return;
-          }
-          // User tapped Turn on — any deny opens settings.
-          openSettingsAndScheduleRetry(isCurrent);
-          return;
-        }
-
-        // Android < 13 has no runtime dialog; when notifications are not
-        // already granted they can only be enabled from system settings.
-        openSettingsAndScheduleRetry(isCurrent);
+        await runAndroidPermissionFlow(isCurrent);
         return;
       }
-
-      const promptable = await isPushPermissionPromptable();
-      if (!isCurrent()) {
-        return;
-      }
-
-      if (!promptable) {
-        openSettingsAndScheduleRetry(isCurrent);
-        return;
-      }
-
-      // iOS: OS can still show its dialog — request permission via enableNotifications().
-      // If the user denies, dismiss the toast without opening Settings (matches
-      // PushNotificationOnboarding).
-      showLoadingToast();
-      await enableNotifications();
-      if (isCurrent()) {
-        toastRef?.current?.closeToast();
-      }
+      await runIosPermissionFlow(isCurrent);
     } catch {
       if (isCurrent()) {
         toastRef?.current?.closeToast();
@@ -239,11 +257,10 @@ export function useCliLoginPushNudge(): {
       }
     }
   }, [
-    enableNotifications,
-    openSettingsAndScheduleRetry,
-    runEnableFlow,
+    runGrantedFlow,
+    runAndroidPermissionFlow,
+    runIosPermissionFlow,
     showErrorToast,
-    showLoadingToast,
     toastRef,
   ]);
 

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -130,6 +130,11 @@ export function useCliLoginPushNudge(): {
   const openSettingsAndScheduleRetry = useCallback(
     (isCurrent: () => boolean) => {
       toastRef?.current?.closeToast();
+      // Release the in-flight guard before opening system settings so that a
+      // throw from openSystemSettings() can't leave "Turn on" permanently
+      // locked. Both iOS and Android reach this helper, so releasing here keeps
+      // them consistent. The scheduled foreground retry owns its own guard.
+      inFlightRef.current = false;
       NotificationService.openSystemSettings();
       scheduleForegroundRetry(async () => {
         if (!isCurrent()) {
@@ -152,7 +157,6 @@ export function useCliLoginPushNudge(): {
           inFlightRef.current = false;
         }
       });
-      inFlightRef.current = false;
     },
     [runEnableFlow, scheduleForegroundRetry, showLoadingToast, toastRef],
   );
@@ -173,14 +177,17 @@ export function useCliLoginPushNudge(): {
 
   const runAndroidPermissionFlow = useCallback(
     async (isCurrent: () => boolean) => {
-      showLoadingToast();
       // Android < 13 has no runtime dialog; when notifications are not already
       // granted they can only be enabled from system settings.
+      // openSettingsAndScheduleRetry closes the toast and opens settings, so no
+      // loading toast is needed here.
       if (Number(Platform.Version) < ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
         openSettingsAndScheduleRetry(isCurrent);
         return;
       }
-      // Android 13+ requires the POST_NOTIFICATIONS runtime permission.
+      // Android 13+ requires the POST_NOTIFICATIONS runtime permission. Don't
+      // show the loading toast before the request — it would sit behind the OS
+      // permission dialog.
       const result = await PermissionsAndroid.request(
         PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
       );
@@ -188,10 +195,13 @@ export function useCliLoginPushNudge(): {
         return;
       }
       if (result === PermissionsAndroid.RESULTS.GRANTED) {
+        // Show the loading toast only while the enable work runs, after the OS
+        // dialog is dismissed.
+        showLoadingToast();
         await runEnableFlow(isCurrent);
         return;
       }
-      // User tapped Turn on — any deny opens settings.
+      // User tapped Turn on — any deny opens settings (no loading toast).
       openSettingsAndScheduleRetry(isCurrent);
     },
     [openSettingsAndScheduleRetry, runEnableFlow, showLoadingToast],

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -19,19 +19,6 @@ import NotificationService, {
 /** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
 const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
-/** RN runtime exposes this; PermissionsAndroidStatic typings omit it. */
-async function shouldShowAndroidPermissionRationale(
-  permission: (typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS],
-): Promise<boolean> {
-  return (
-    PermissionsAndroid as typeof PermissionsAndroid & {
-      shouldShowRequestPermissionRationale: (
-        permission: (typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS],
-      ) => Promise<boolean>;
-    }
-  ).shouldShowRequestPermissionRationale(permission);
-}
-
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
 ];
@@ -46,15 +33,19 @@ const ERROR_LABELS = () => [
 
 /**
  * Shared toast-based push-permission nudge shown after a successful Agentic CLI
- * QR login (MMAI-925). On "Turn on": when the OS can still show its permission
- * dialog it calls enableNotifications() (in-app notifications + OS prompt).
- * Denying that dialog closes the toast without opening Settings. When the OS can
- * no longer show its dialog (e.g. iOS after a prior denial), it deep-links to
- * device notification settings and retries once the app returns to foreground.
+ * QR login (MMAI-925). On "Turn on", tapping the nudge signals intent to enable
+ * notifications.
+ *
+ * iOS: when the OS can still show its permission dialog, enableNotifications()
+ * requests permission; denying that dialog closes the toast without opening
+ * Settings. When the OS can no longer show its dialog (e.g. after a prior
+ * denial), it deep-links to device notification settings and retries once the
+ * app returns to foreground.
  *
  * Android: Notifee reports DENIED for both "never asked" and "permanently
- * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS) and
- * shouldShowRequestPermissionRationale to detect when settings must be opened.
+ * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS). Any deny
+ * after "Turn on" opens notification settings because the user already signaled
+ * intent to enable.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -208,24 +199,8 @@ export function useCliLoginPushNudge(): {
             await runEnableFlow(isCurrent);
             return;
           }
-          if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-            openSettingsAndScheduleRetry(isCurrent);
-            return;
-          }
-          const shouldShowRationale =
-            await shouldShowAndroidPermissionRationale(
-              PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
-            );
-          if (!isCurrent()) {
-            return;
-          }
-          if (!shouldShowRationale) {
-            openSettingsAndScheduleRetry(isCurrent);
-            return;
-          }
-          if (isCurrent()) {
-            toastRef?.current?.closeToast();
-          }
+          // User tapped Turn on — any deny opens settings.
+          openSettingsAndScheduleRetry(isCurrent);
           return;
         }
 

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -19,26 +19,6 @@ import NotificationService, {
 /** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
 const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
-/**
- * Below this threshold, `PermissionsAndroid.request(POST_NOTIFICATIONS)` likely
- * returned without showing the OS dialog (permanent deny). Only applies to the
- * direct PermissionsAndroid call — not Notifee channel setup.
- */
-const ANDROID_OS_DIALOG_MIN_ELAPSED_MS = 300;
-
-function shouldOpenAndroidNotificationSettings(
-  result: string,
-  requestElapsedMs: number,
-): boolean {
-  if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-    return true;
-  }
-  return (
-    result === PermissionsAndroid.RESULTS.DENIED &&
-    requestElapsedMs < ANDROID_OS_DIALOG_MIN_ELAPSED_MS
-  );
-}
-
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
 ];
@@ -61,7 +41,7 @@ const ERROR_LABELS = () => [
  *
  * Android: Notifee reports DENIED for both "never asked" and "permanently
  * denied", so we use PermissionsAndroid.request(POST_NOTIFICATIONS) and
- * treat NEVER_ASK_AGAIN as the signal to open device notification settings.
+ * shouldShowRequestPermissionRationale to detect when settings must be opened.
  */
 export function useCliLoginPushNudge(): {
   showNudge: () => boolean;
@@ -203,11 +183,9 @@ export function useCliLoginPushNudge(): {
         // denied it, which is the authoritative signal that the OS dialog can
         // no longer be shown.
         if (Number(Platform.Version) >= ANDROID_POST_NOTIFICATIONS_API_LEVEL) {
-          const requestStartedAt = Date.now();
           const result = await PermissionsAndroid.request(
             PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
           );
-          const requestElapsedMs = Date.now() - requestStartedAt;
           if (!isCurrent()) {
             return;
           }
@@ -215,11 +193,21 @@ export function useCliLoginPushNudge(): {
             await runEnableFlow(isCurrent);
             return;
           }
-          if (shouldOpenAndroidNotificationSettings(result, requestElapsedMs)) {
+          if (result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
             openSettingsAndScheduleRetry(isCurrent);
             return;
           }
-          // DENIED after the OS dialog was shown and dismissed.
+          const shouldShowRationale =
+            await PermissionsAndroid.shouldShowRequestPermissionRationale(
+              PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+            );
+          if (!isCurrent()) {
+            return;
+          }
+          if (!shouldShowRationale) {
+            openSettingsAndScheduleRetry(isCurrent);
+            return;
+          }
           if (isCurrent()) {
             toastRef?.current?.closeToast();
           }

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts
@@ -19,6 +19,19 @@ import NotificationService, {
 /** Android API level (13) that introduced the POST_NOTIFICATIONS runtime permission. */
 const ANDROID_POST_NOTIFICATIONS_API_LEVEL = 33;
 
+/** RN runtime exposes this; PermissionsAndroidStatic typings omit it. */
+async function shouldShowAndroidPermissionRationale(
+  permission: (typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS],
+): Promise<boolean> {
+  return (
+    PermissionsAndroid as typeof PermissionsAndroid & {
+      shouldShowRequestPermissionRationale: (
+        permission: (typeof PermissionsAndroid.PERMISSIONS)[keyof typeof PermissionsAndroid.PERMISSIONS],
+      ) => Promise<boolean>;
+    }
+  ).shouldShowRequestPermissionRationale(permission);
+}
+
 const NUDGE_LABELS = () => [
   { label: strings('sdk_connect_v2.push_nudge.title'), isBold: true },
 ];
@@ -114,7 +127,9 @@ export function useCliLoginPushNudge(): {
             return;
           }
           clearForegroundRetry();
-          void retry();
+          retry().catch(() => {
+            /* enable flow logs its own failures */
+          });
         },
       );
     },
@@ -198,7 +213,7 @@ export function useCliLoginPushNudge(): {
             return;
           }
           const shouldShowRationale =
-            await PermissionsAndroid.shouldShowRequestPermissionRationale(
+            await shouldShowAndroidPermissionRationale(
               PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
             );
           if (!isCurrent()) {


### PR DESCRIPTION
## **Description**

Follow-up to #33688 (MMAI-925: Agentic CLI login push-permission nudge, toast variant).

On Android 13+, tapping **Turn on** on the nudge calls `PermissionsAndroid.request(POST_NOTIFICATIONS)` instead of relying on Notifee's `isPushPermissionPromptable()`, which reports `DENIED` for both first-time and permanently blocked states and can leave the nudge in a no-op path.

- **Granted** → `enableNotifications()` and close the toast
- **Denied or never ask again** → open device notification settings (the user already signaled intent by tapping Turn on), then retry enabling on foreground return if OS permission is granted

Android < 13 has no runtime permission dialog; tapping Turn on opens notification settings directly.

**iOS is unchanged:** when the OS can still show its dialog, `enableNotifications()` runs and a denial closes the toast without opening Settings; when the OS can no longer prompt, MetaMask deep-links to notification settings.

This simplifies earlier iterations by removing denial counters, elapsed-time heuristics, and `shouldShowRequestPermissionRationale` branching.


## Video


https://github.com/user-attachments/assets/f8a3b35e-aca0-41b6-9823-fa27d29bbcad



## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMAI-925

## **Manual testing steps**

```gherkin
Feature: CLI login push nudge (toast variant, MMAI-925)

  Scenario: Android 13+ grants notification permission
    Given MetaMask is installed on Android 13+ with push permission not granted
    And the CLI login push nudge toast is visible after Agentic CLI QR login

    When the user taps Turn on and grants the OS notification prompt
    Then in-app notifications are enabled
    And the nudge toast closes

  Scenario: Android 13+ denies notification permission
    Given MetaMask is installed on Android 13+ with push permission not granted
    And the CLI login push nudge toast is visible

    When the user taps Turn on and denies the OS notification prompt
    Then MetaMask opens device notification settings
    And in-app notifications remain disabled until OS permission is granted

  Scenario: Android 13+ permanently denies notification permission
    Given MetaMask is installed on Android 13+ with push permission permanently denied
    And the CLI login push nudge toast is visible

    When the user taps Turn on
    Then MetaMask opens device notification settings

  Scenario: iOS still prompts when promptable
    Given MetaMask is installed on iOS with push permission not yet granted
    And the CLI login push nudge toast is visible

    When the user taps Turn on and denies the OS prompt
    Then the nudge toast closes
    And MetaMask does not open notification settings

  Scenario: iOS opens settings when no longer promptable
    Given MetaMask is installed on iOS with push permission permanently denied
    And the CLI login push nudge toast is visible

    When the user taps Turn on
    Then MetaMask opens device notification settings
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified manually on physical Android device (SM_A336E).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-login notification permission UX on Android (runtime permission + settings deep link) with moderate refactor of async flow guards; iOS path is mostly extracted, not redesigned.
> 
> **Overview**
> **Android “Turn on”** on the CLI login push nudge no longer relies on Notifee promptability (which couldn’t distinguish first ask vs blocked). The hook now branches by platform after checking whether push is already granted.
> 
> On **Android 13+**, it calls `PermissionsAndroid.request(POST_NOTIFICATIONS)`: **granted** runs the existing enable flow and closes the toast; **denied or never ask again** closes the toast, opens notification settings, and retries enable when the app returns to foreground if OS permission was granted. On **Android &lt; 13**, **Turn on** skips a runtime dialog and goes straight to settings with the same foreground retry.
> 
> **iOS** behavior is unchanged but shares a new `openSettingsAndScheduleRetry` helper with Android. The **Turn on** handler is refactored into smaller flows, the in-flight guard is released before opening settings, and foreground retry handlers swallow promise rejections.
> 
> Tests add Android 13+ and pre-13 cases with `PermissionsAndroid` / `Platform` mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a355708fe3e8b0b4920ace0d27a88689b0dd31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->