### PR TITLE
test: add Appium regression Playwright config and CI workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -373,6 +373,8 @@ tests/websocket/                                                @MetaMask/qa
 .github/workflows/run-appium-e2e-workflow.yml                   @MetaMask/qa
 .github/workflows/run-appium-smoke-tests-android.yml            @MetaMask/qa
 .github/workflows/run-appium-smoke-tests-ios.yml                @MetaMask/qa
+.github/workflows/run-appium-regression-tests-android.yml       @MetaMask/qa
+.github/workflows/run-appium-regression-tests-ios.yml           @MetaMask/qa
 .github/workflows/run-e2e-workflow.yml                          @MetaMask/qa
 .github/workflows/run-e2e-api-specs.yml                         @MetaMask/qa
 .github/workflows/run-e2e-regression-tests-android.yml          @MetaMask/qa

--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -52,6 +52,7 @@ e2e_test_files: &e2e_test_files
   - 'tests/regression/**'
   - 'tests/performance/**'
   - 'tests/smoke-appium/**'
+  - 'tests/regression-appium/**'
   - 'tests/flows/**'
   - 'tests/page-objects/**'
   - 'tests/selectors/**'

--- a/.github/scripts/e2e-split-tags-shards.mjs
+++ b/.github/scripts/e2e-split-tags-shards.mjs
@@ -129,12 +129,12 @@ async function shouldSkipFlakinessDetection() {
  *
  * Excludes:
  *   - `quarantine/` specs (skipped in CI)
- *   - `smoke-appium/` specs — these are Playwright + Appium specs run via
- *     tests/playwright.smoke-appium.config.ts, and are explicitly ignored by
- *     the Detox Jest config (jest.e2e.detox.config.js `testPathIgnorePatterns`).
- *     They still carry Smoke* tags, so without this exclusion the tag-based
- *     selection feeds them to the Detox runner, which then finds 0 matching
- *     tests and exits 1.
+ *   - `smoke-appium/` / `regression-appium/` specs — Playwright + Appium specs
+ *     run via tests/playwright.{smoke,regression}-appium.config.ts, and are
+ *     explicitly ignored by the Detox Jest config (jest.e2e.detox.config.js
+ *     `testPathIgnorePatterns`). They still carry Smoke*/Regression* tags, so
+ *     without this exclusion the tag-based selection feeds them to the Detox
+ *     runner, which then finds 0 matching tests and exits 1.
  * @param {*} filePath - The path to the file
  * @returns True if the file is a spec file, false otherwise
  */
@@ -142,7 +142,8 @@ function isSpecFile(filePath) {
   const segments = filePath.split(path.sep);
   return (filePath.endsWith('.spec.js') || filePath.endsWith('.spec.ts')) &&
     !segments.includes('quarantine') &&
-    !segments.includes('smoke-appium');
+    !segments.includes('smoke-appium') &&
+    !segments.includes('regression-appium');
 }
 
 /**
@@ -163,12 +164,14 @@ function* walk(dir) {
 }
 
 /**
- * Appium smoke specs live under tests/smoke-appium/ and are sharded by Playwright, not Detox.
- * This will be changed in the future when Detox is removed and all E2E tests are run by Playwright.
+ * Appium specs live under tests/smoke-appium/ and tests/regression-appium/ and
+ * are sharded by Playwright, not Detox. This will be changed in the future when
+ * Detox is removed and all E2E tests are run by Playwright.
  * @param {string} filePath
  */
 function isDetoxSpecFile(filePath) {
-  return !timingLookupKey(filePath).includes('smoke-appium/');
+  const key = timingLookupKey(filePath);
+  return !key.includes('smoke-appium/') && !key.includes('regression-appium/');
 }
 
 /**

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -1,5 +1,6 @@
-# Runs Appium smoke tests for one smoke tag on Android or iOS.
-# Called from run-appium-smoke-tests-{android,ios}.yml (one job per tag/split).
+# Runs Appium E2E tests for one tag on Android or iOS.
+# Called from run-appium-smoke-tests-{android,ios}.yml and
+# run-appium-regression-tests-{android,ios}.yml (one job per tag/split).
 
 name: Run Appium E2E
 
@@ -15,7 +16,7 @@ on:
         required: true
         type: string
       test_suite_tag:
-        description: 'Smoke tag id to filter tests (e.g. SmokeAccounts matches describe titles)'
+        description: 'Tag id to filter tests (e.g. SmokeAccounts or RegressionWalletUX)'
         required: true
         type: string
       split_number:
@@ -48,6 +49,26 @@ on:
         required: false
         type: string
         default: 'current'
+      playwright_config:
+        description: 'Playwright config path relative to repo root'
+        required: false
+        type: string
+        default: 'tests/playwright.smoke-appium.config.ts'
+      playwright_project_android:
+        description: 'Playwright project name for Android'
+        required: false
+        type: string
+        default: 'android-smoke'
+      playwright_project_ios:
+        description: 'Playwright project name for iOS'
+        required: false
+        type: string
+        default: 'ios-smoke'
+      report_name_prefix:
+        description: 'Prefix for report/video artifact paths (appium-smoke or appium-regression)'
+        required: false
+        type: string
+        default: 'appium-smoke'
 
 permissions:
   contents: read
@@ -277,22 +298,22 @@ jobs:
         env:
           IOS_SIMULATOR_UDID: ${{ steps.prepare-ios-appium.outputs.ios-simulator-udid }}
 
-      - name: Run Appium smoke tests (Android)
+      - name: Run Appium tests (Android)
         id: run-tests-android
         if: ${{ inputs.platform == 'android' }}
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: >-
           yarn playwright test
-          --config tests/playwright.smoke-appium.config.ts
-          --project android-smoke
+          --config ${{ inputs.playwright_config }}
+          --project ${{ inputs.playwright_project_android }}
           --grep "${{ steps.appium-grep.outputs.pattern }}"
           --shard=${{ inputs.split_number }}/${{ inputs.total_splits }}
           ${{ steps.appium-grep.outputs.pass_with_no_tests }}
         env:
           APPIUM_SMOKE_SUITE_NAME: ${{ inputs.test-suite-name }}
           APPIUM_SMOKE_JOB_TITLE: Appium ${{ inputs.test-suite-name }} (android)
-          APPIUM_SMOKE_ARTIFACT_NAME: appium-smoke-report-${{ inputs.test-suite-name }}
-          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: appium-smoke-videos-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_ARTIFACT_NAME: ${{ inputs.report_name_prefix }}-report-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: ${{ inputs.report_name_prefix }}-videos-${{ inputs.test-suite-name }}
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
@@ -307,22 +328,22 @@ jobs:
           # Required for Anvil mainnet forks (SmokeStake and other fork-based suites).
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
-      - name: Run Appium smoke tests (iOS)
+      - name: Run Appium tests (iOS)
         id: run-tests-ios
         if: ${{ inputs.platform == 'ios' }}
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: >-
           yarn playwright test
-          --config tests/playwright.smoke-appium.config.ts
-          --project ios-smoke
+          --config ${{ inputs.playwright_config }}
+          --project ${{ inputs.playwright_project_ios }}
           --grep "${{ steps.appium-grep.outputs.pattern }}"
           --shard=${{ inputs.split_number }}/${{ inputs.total_splits }}
           ${{ steps.appium-grep.outputs.pass_with_no_tests }}
         env:
           APPIUM_SMOKE_SUITE_NAME: ${{ inputs.test-suite-name }}
           APPIUM_SMOKE_JOB_TITLE: Appium ${{ inputs.test-suite-name }} (ios)
-          APPIUM_SMOKE_ARTIFACT_NAME: appium-smoke-report-${{ inputs.test-suite-name }}
-          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: appium-smoke-videos-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_ARTIFACT_NAME: ${{ inputs.report_name_prefix }}-report-${{ inputs.test-suite-name }}
+          APPIUM_SMOKE_VIDEOS_ARTIFACT_NAME: ${{ inputs.report_name_prefix }}-videos-${{ inputs.test-suite-name }}
           PLAYWRIGHT_JSON_OUTPUT_FILE: tests/test-reports/playwright-json/playwright-report.json
           APPIUM_RECORD_VIDEO_ON_FAILURE: 'true'
           SKIP_APPIUM_STOP: 'true'
@@ -343,16 +364,16 @@ jobs:
         if: ${{ always() && inputs.runner_provider == 'namespace' }}
         uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
         with:
-          name: appium-smoke-report-${{ inputs.test-suite-name }}
-          path: tests/test-reports/appium-smoke-report/${{ inputs.test-suite-name }}/
+          name: ${{ inputs.report_name_prefix }}-report-${{ inputs.test-suite-name }}
+          path: tests/test-reports/${{ inputs.report_name_prefix }}-report/${{ inputs.test-suite-name }}/
           if-no-files-found: ignore
           retention-days: 7
       - name: Upload Playwright HTML report (current)
         if: ${{ always() && inputs.runner_provider != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
-          name: appium-smoke-report-${{ inputs.test-suite-name }}
-          path: tests/test-reports/appium-smoke-report/${{ inputs.test-suite-name }}/
+          name: ${{ inputs.report_name_prefix }}-report-${{ inputs.test-suite-name }}
+          path: tests/test-reports/${{ inputs.report_name_prefix }}-report/${{ inputs.test-suite-name }}/
           if-no-files-found: ignore
           retention-days: 7
 
@@ -375,20 +396,38 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Upload JUnit report (Namespace)
+        if: ${{ always() && inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+        with:
+          name: ${{ inputs.report_name_prefix }}-junit-${{ inputs.test-suite-name }}
+          path: tests/test-reports/${{ inputs.report_name_prefix }}-junit/${{ inputs.test-suite-name }}.xml
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Upload JUnit report (current)
+        if: ${{ always() && inputs.runner_provider != 'namespace' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.report_name_prefix }}-junit-${{ inputs.test-suite-name }}
+          path: tests/test-reports/${{ inputs.report_name_prefix }}-junit/${{ inputs.test-suite-name }}.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload failure screen recordings (Namespace)
         if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider == 'namespace' }}
         uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
         with:
-          name: appium-smoke-videos-${{ inputs.test-suite-name }}
-          path: tests/test-reports/appium-smoke-videos/${{ inputs.test-suite-name }}/
+          name: ${{ inputs.report_name_prefix }}-videos-${{ inputs.test-suite-name }}
+          # ScreenRecording writes to this flat dir (no suite subdirectory).
+          path: tests/test-reports/appium-smoke-videos/
           if-no-files-found: ignore
           retention-days: 7
       - name: Upload failure screen recordings (current)
         if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
-          name: appium-smoke-videos-${{ inputs.test-suite-name }}
-          path: tests/test-reports/appium-smoke-videos/${{ inputs.test-suite-name }}/
+          name: ${{ inputs.report_name_prefix }}-videos-${{ inputs.test-suite-name }}
+          path: tests/test-reports/appium-smoke-videos/
           if-no-files-found: ignore
           retention-days: 7
 
@@ -397,7 +436,7 @@ jobs:
         uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
         with:
           name: Appium ${{ inputs.test-suite-name }} (${{ inputs.platform }})
-          path: tests/test-reports/appium-smoke-junit/${{ inputs.test-suite-name }}.xml
+          path: tests/test-reports/${{ inputs.report_name_prefix }}-junit/${{ inputs.test-suite-name }}.xml
           reporter: java-junit
           fail-on-error: false
           list-suites: all

--- a/.github/workflows/run-appium-regression-tests-android.yml
+++ b/.github/workflows/run-appium-regression-tests-android.yml
@@ -1,0 +1,138 @@
+# Appium Regression Tests — Android
+#
+# Manual workflow_dispatch (same model as Detox regression). Not PR-gating.
+# Fans out one reusable job per Appium regression tag. Add matching jobs below
+# as more tests/regression-appium specs land.
+#
+# Build: same main-e2e artifacts as Detox/Appium smoke (HAS_TEST_OVERRIDES=true).
+
+name: Android Appium Regression Tests
+
+on:
+  # schedule: # Currently disabled — mirror Detox regression until suites stabilize
+  #   - cron: '0 */3 * * *'
+  workflow_dispatch:
+    inputs:
+      notify_on_pass:
+        description: 'Send Slack notification even when all tests pass'
+        type: boolean
+        default: false
+      runner_provider:
+        description: Runner provider for this manual trial run
+        required: true
+        type: choice
+        options:
+          - current
+          - namespace
+        default: current
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+  checks: write
+
+jobs:
+  build-android-apks:
+    name: 'Build Android APKs'
+    if: ${{ github.event_name != 'merge_group' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-android-e2e.yml
+    with:
+      build_type: 'main'
+      metamask_environment: 'e2e'
+      runner_provider: ${{ inputs.runner_provider }}
+    secrets: inherit
+
+  appium-regression-ux-android:
+    name: 'Appium UX Regression (Android) - ${{ matrix.split }}'
+    needs: [build-android-apks]
+    strategy:
+      matrix:
+        split: [1]
+      fail-fast: false
+    uses: ./.github/workflows/run-appium-e2e-workflow.yml
+    with:
+      test-suite-name: appium-ux-android-regression-${{ matrix.split }}
+      platform: android
+      test_suite_tag: RegressionWalletUX
+      split_number: ${{ matrix.split }}
+      total_splits: 1
+      test-timeout-minutes: 60
+      build_type: main
+      metamask_environment: e2e
+      runner_provider: ${{ inputs.runner_provider }}
+      playwright_config: tests/playwright.regression-appium.config.ts
+      playwright_project_android: android-regression
+      playwright_project_ios: ios-regression
+      report_name_prefix: appium-regression
+    secrets: inherit
+
+  report-android-appium-regression-tests:
+    name: Report Android Appium Regression Tests
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    if: always()
+    needs:
+      - build-android-apks
+      - appium-regression-ux-android
+
+    steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
+
+      - name: Download JUnit artifacts (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+        continue-on-error: true
+        with:
+          path: all-test-artifacts/
+          pattern: 'appium-regression-junit-*'
+      - name: Download JUnit artifacts (current)
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: all-test-artifacts/
+          pattern: 'appium-regression-junit-*'
+
+      - name: Post Test Report
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
+        with:
+          name: 'Android Appium Regression Test Results'
+          path: 'all-test-artifacts/**/*.xml'
+          reporter: 'java-junit'
+          fail-on-error: false
+          list-suites: 'failed'
+          list-tests: 'failed'
+
+      - name: Upload all JUnit artifacts (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+        continue-on-error: true
+        with:
+          name: appium-regression-android-all-junit
+          path: all-test-artifacts/
+          retention-days: 7
+      - name: Upload all JUnit artifacts (current)
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: appium-regression-android-all-junit
+          path: all-test-artifacts/
+          retention-days: 7
+
+      - name: Fail if any Appium regression job failed
+        if: >-
+          ${{
+            needs.build-android-apks.result == 'failure' ||
+            needs.appium-regression-ux-android.result == 'failure'
+          }}
+        run: exit 1

--- a/.github/workflows/run-appium-regression-tests-ios.yml
+++ b/.github/workflows/run-appium-regression-tests-ios.yml
@@ -1,0 +1,136 @@
+# Appium Regression Tests — iOS
+#
+# Manual workflow_dispatch (same model as Detox regression). Not PR-gating.
+# Fans out one reusable job per Appium regression tag. Add matching jobs below
+# as more tests/regression-appium specs land.
+#
+# Build: same main-e2e artifacts as Detox/Appium smoke (HAS_TEST_OVERRIDES=true).
+
+name: iOS Appium Regression Tests
+
+on:
+  # schedule: # Currently disabled — mirror Detox regression until suites stabilize
+  #   - cron: '0 */3 * * *'
+  workflow_dispatch:
+    inputs:
+      notify_on_pass:
+        description: 'Send Slack notification even when all tests pass'
+        type: boolean
+        default: false
+      runner_provider:
+        description: Runner provider for this manual trial run
+        required: true
+        type: choice
+        options:
+          - current
+          - namespace
+        default: current
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+  checks: write
+
+jobs:
+  build-ios-apps:
+    name: 'Build iOS Apps'
+    if: ${{ github.event_name != 'merge_group' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-ios-e2e.yml
+    with:
+      runner_provider: ${{ inputs.runner_provider }}
+    secrets: inherit
+
+  appium-regression-ux-ios:
+    name: 'Appium UX Regression (iOS) - ${{ matrix.split }}'
+    needs: [build-ios-apps]
+    strategy:
+      matrix:
+        split: [1]
+      fail-fast: false
+    uses: ./.github/workflows/run-appium-e2e-workflow.yml
+    with:
+      test-suite-name: appium-ux-ios-regression-${{ matrix.split }}
+      platform: ios
+      test_suite_tag: RegressionWalletUX
+      split_number: ${{ matrix.split }}
+      total_splits: 1
+      test-timeout-minutes: 60
+      build_type: main
+      metamask_environment: e2e
+      runner_provider: ${{ inputs.runner_provider }}
+      playwright_config: tests/playwright.regression-appium.config.ts
+      playwright_project_android: android-regression
+      playwright_project_ios: ios-regression
+      report_name_prefix: appium-regression
+    secrets: inherit
+
+  report-ios-appium-regression-tests:
+    name: Report iOS Appium Regression Tests
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    if: always()
+    needs:
+      - build-ios-apps
+      - appium-regression-ux-ios
+
+    steps:
+      - name: Checkout (Namespace)
+        uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
+        if: ${{ inputs.runner_provider == 'namespace' }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ inputs.runner_provider != 'namespace' }}
+
+      - name: Download JUnit artifacts (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+        continue-on-error: true
+        with:
+          path: all-test-artifacts/
+          pattern: 'appium-regression-junit-*'
+      - name: Download JUnit artifacts (current)
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: all-test-artifacts/
+          pattern: 'appium-regression-junit-*'
+
+      - name: Post Test Report
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
+        with:
+          name: 'iOS Appium Regression Test Results'
+          path: 'all-test-artifacts/**/*.xml'
+          reporter: 'java-junit'
+          fail-on-error: false
+          list-suites: 'failed'
+          list-tests: 'failed'
+
+      - name: Upload all JUnit artifacts (Namespace)
+        if: ${{ inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+        continue-on-error: true
+        with:
+          name: appium-regression-ios-all-junit
+          path: all-test-artifacts/
+          retention-days: 7
+      - name: Upload all JUnit artifacts (current)
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: appium-regression-ios-all-junit
+          path: all-test-artifacts/
+          retention-days: 7
+
+      - name: Fail if any Appium regression job failed
+        if: >-
+          ${{
+            needs.build-ios-apps.result == 'failure' ||
+            needs.appium-regression-ux-ios.result == 'failure'
+          }}
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,13 +101,13 @@ scripts/                  # Build and automation scripts
 
 **Detailed guidelines are in `docs/testing/`** (canonical, in-repo) and the `mms-*` skill set installed via `yarn skills` (Cursor / Codex / Claude harnesses):
 
-| Guide                                                                                      | Scope                                                                        |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [`docs/testing/unit-testing.md`](docs/testing/unit-testing.md)                             | `*.test.*` files — test patterns, mocking, AAA                               |
-| [`docs/testing/e2e-testing.md`](docs/testing/e2e-testing.md)                               | Detox smoke/regression — Page Objects, gestures                              |
-| [`docs/testing/appium-smoke-testing.md`](docs/testing/appium-smoke-testing.md)             | Appium smoke — main-e2e builds, `yarn appium-smoke:*`                        |
-| [`docs/testing/component-view-tests.md`](docs/testing/component-view-tests.md)             | `*.view.test.tsx` — framework, presets, renderers                            |
-| [`docs/readme/version-gated-feature-flags.md`](docs/readme/version-gated-feature-flags.md) | Version-gated remote flags — `validatedVersionGatedFeatureFlag` in selectors |
+| Guide                                                                                      | Scope                                                                                         |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`docs/testing/unit-testing.md`](docs/testing/unit-testing.md)                             | `*.test.*` files — test patterns, mocking, AAA                                                |
+| [`docs/testing/e2e-testing.md`](docs/testing/e2e-testing.md)                               | Detox smoke/regression — Page Objects, gestures                                               |
+| [`docs/testing/appium-smoke-testing.md`](docs/testing/appium-smoke-testing.md)             | Appium smoke/regression — main-e2e builds, `yarn appium-smoke:*` / `yarn appium-regression:*` |
+| [`docs/testing/component-view-tests.md`](docs/testing/component-view-tests.md)             | `*.view.test.tsx` — framework, presets, renderers                                             |
+| [`docs/readme/version-gated-feature-flags.md`](docs/readme/version-gated-feature-flags.md) | Version-gated remote flags — `validatedVersionGatedFeatureFlag` in selectors                  |
 
 General coding, UI, deeplink-handler, and PR-creation guidance now lives in the centralized `mms-*` skill set installed via `yarn skills` (see `.agents/skills/mms-*` after sync).
 

--- a/docs/testing/appium-smoke-testing.md
+++ b/docs/testing/appium-smoke-testing.md
@@ -1,16 +1,16 @@
-# Appium Smoke E2E Tests
+# Appium Smoke & Regression E2E Tests
 
-Appium smoke tests are the **Playwright + Appium** counterpart to Detox smoke tests. They share page objects, fixtures, and assertions with Detox via the cross-framework layer in `tests/framework/`.
+Appium E2E tests are the **Playwright + Appium** counterpart to Detox. They share page objects, fixtures, and assertions with Detox via the cross-framework layer in `tests/framework/`.
 
-|                         | Detox smoke                     | Appium smoke                                           |
-| ----------------------- | ------------------------------- | ------------------------------------------------------ |
-| **Specs**               | `tests/smoke/`                  | `tests/smoke-appium/` (same folder layout)             |
-| **Runner**              | Detox + Jest                    | Playwright (`tests/playwright.smoke-appium.config.ts`) |
-| **CI workflows**        | `e2e-smoke-tests-{android,ios}` | `appium-smoke-tests-{android,ios}`                     |
-| **Build**               | Debug (Metro bundler required)  | **main-e2e release** (`HAS_TEST_OVERRIDES=true`)       |
-| **Local yarn commands** | `yarn test:e2e:*`               | `yarn appium-smoke:ios` / `yarn appium-smoke:android`  |
+|                         | Detox smoke                     | Appium smoke                                          | Detox regression             | Appium regression                                               |
+| ----------------------- | ------------------------------- | ----------------------------------------------------- | ---------------------------- | --------------------------------------------------------------- |
+| **Specs**               | `tests/smoke/`                  | `tests/smoke-appium/`                                 | `tests/regression/`          | `tests/regression-appium/`                                      |
+| **Runner**              | Detox + Jest                    | Playwright (`playwright.smoke-appium.config.ts`)      | Detox + Jest                 | Playwright (`playwright.regression-appium.config.ts`)           |
+| **CI workflows**        | `e2e-smoke-tests-{android,ios}` | `appium-smoke-tests-{android,ios}` (PR CI)            | `run-e2e-regression-tests-*` | `run-appium-regression-tests-*` (`workflow_dispatch`, not PR)   |
+| **Build**               | Debug (Metro bundler required)  | **main-e2e release** (`HAS_TEST_OVERRIDES=true`)      | Debug                        | **main-e2e release** (`HAS_TEST_OVERRIDES=true`)                |
+| **Local yarn commands** | `yarn test:e2e:*`               | `yarn appium-smoke:ios` / `yarn appium-smoke:android` | `yarn test:e2e:*`            | `yarn appium-regression:ios` / `yarn appium-regression:android` |
 
-Use Appium smoke when validating Appium framework changes, CI Appium jobs, or when adding smoke coverage that must run without Metro.
+Use Appium smoke when validating Appium framework changes, CI Appium jobs, or when adding smoke coverage that must run without Metro. Use Appium regression for deeper suites (e.g. `RegressionWalletUX`) that mirror Detox regression — manual / scheduled, not every PR.
 
 ## Architecture
 
@@ -190,9 +190,10 @@ CI uploads per-suite artifacts as `appium-smoke-report-<suite>` and `appium-smok
 
 ## CI
 
-- **Build:** `build` workflow produces `main-e2e-MetaMask.app` and `main-e2e-release.apk`.
-- **Tests:** `appium-smoke-tests-ios` / `appium-smoke-tests-android` in PR CI (see [E2E decision tree](../../.github/guidelines/E2E_DECISION_TREE.md)).
-- **Reusable job:** `.github/workflows/run-appium-e2e-workflow.yml` — downloads artifacts, runs `prepare-ios-appium-runner.mjs`, executes Playwright with `--grep` per smoke tag.
+- **Build:** `build` workflow / `build-*-e2e.yml` produce `main-e2e-MetaMask.app` and `main-e2e-release.apk`.
+- **Smoke tests:** `appium-smoke-tests-ios` / `appium-smoke-tests-android` in PR CI (see [E2E decision tree](../../.github/guidelines/E2E_DECISION_TREE.md)).
+- **Regression tests:** `run-appium-regression-tests-ios.yml` / `run-appium-regression-tests-android.yml` — `workflow_dispatch` only (same model as Detox regression). Currently fans out `RegressionWalletUX`; add jobs as more `tests/regression-appium/` tags land.
+- **Reusable job:** `.github/workflows/run-appium-e2e-workflow.yml` — downloads artifacts, runs `prepare-ios-appium-runner.mjs`, executes Playwright with `--grep` per tag. Smoke vs regression selects config/project via workflow inputs.
 
 ## Adding a new Appium smoke spec
 
@@ -202,6 +203,14 @@ CI uploads per-suite artifacts as `appium-smoke-report-<suite>` and `appium-smok
 4. Reuse existing page objects — avoid Detox-only `device.*` calls.
 5. Lint: `yarn lint tests/smoke-appium/<path> --fix` and `yarn lint:tsc`.
 6. Run locally with main-e2e build before opening a PR.
+
+## Adding a new Appium regression spec
+
+1. Place the spec under `tests/regression-appium/<feature>/` with a `Regression*` tag from `tests/tags.js`.
+2. Use the same Appium Playwright wrapper as smoke (`appiumTest`, `loginToAppPlaywright`, `currentDeviceDetails`).
+3. Run locally: `yarn appium-regression:ios --grep RegressionWalletUX` (or your tag).
+4. If the tag is new to Appium CI, add a job in `run-appium-regression-tests-{ios,android}.yml` (mirror the Detox regression tag split).
+5. Lint and run with a main-e2e build before opening a PR.
 
 ## Troubleshooting
 

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -193,9 +193,9 @@ Does the same Matchers.getElementByID/Text/Label call work for both?
 
 ## Test Organization — Detox vs Appium Specs
 
-Detox smoke tests live in `tests/smoke/`. Appium equivalents live in `tests/smoke-appium/` with the same folder structure. Because page objects are cross-framework, the test body is nearly identical — only the runner wrapper and login helper differ.
+Detox smoke tests live in `tests/smoke/`. Appium equivalents live in `tests/smoke-appium/` with the same folder structure. Detox regression lives in `tests/regression/`; Appium regression lives in `tests/regression-appium/`. Because page objects are cross-framework, the test body is nearly identical — only the runner wrapper and login helper differ.
 
-**Running Appium smoke locally:** see [Appium smoke testing](./appium-smoke-testing.md) for builds (`main-e2e-MetaMask.app`), commands (`yarn appium-smoke:ios`), and CI artifact download.
+**Running Appium locally:** see [Appium smoke testing](./appium-smoke-testing.md) for builds (`main-e2e-MetaMask.app`), smoke (`yarn appium-smoke:ios`), regression (`yarn appium-regression:ios`), and CI.
 
 ```typescript
 // Detox: tests/smoke/accounts/my-feature.spec.ts

--- a/package.json
+++ b/package.json
@@ -149,6 +149,8 @@
     "run-system-tests:ios-onboarding-sim": "yarn playwright test --project system-ios-onboarding-sim --config tests/playwright.system-emulator.config.ts",
     "appium-smoke:android": "yarn playwright test --config tests/playwright.smoke-appium.config.ts --project android-smoke",
     "appium-smoke:ios": "yarn playwright test --config tests/playwright.smoke-appium.config.ts --project ios-smoke",
+    "appium-regression:android": "yarn playwright test --config tests/playwright.regression-appium.config.ts --project android-regression",
+    "appium-regression:ios": "yarn playwright test --config tests/playwright.regression-appium.config.ts --project ios-regression",
     "capture-visual-baselines:android": "CAPTURE_BASELINES=true AI_VISUAL_TESTING_ENABLED=true yarn playwright test --project system-android-login-emu --config tests/playwright.system-emulator.config.ts",
     "capture-visual-baselines:ios": "CAPTURE_BASELINES=true AI_VISUAL_TESTING_ENABLED=true yarn playwright test --project system-ios-login-sim --config tests/playwright.system-emulator.config.ts",
     "test:depcheck": "yarn depcheck",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,15 +19,15 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 
 - [tests/integration/AGENTS.md](integration/AGENTS.md) — Agent index for integration tests: harnesses, layer boundaries, canonical skill, run commands, enforcement.
 
-### E2E Tests (Detox smoke/regression + Appium smoke)
+### E2E Tests (Detox smoke/regression + Appium smoke/regression)
 
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Canonical guide: patterns, Page Objects, assertions, gestures, prohibited patterns.
-- [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke: main-e2e builds, `yarn appium-smoke:*`, local setup, CI.
+- [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke + regression: main-e2e builds, `yarn appium-smoke:*` / `yarn appium-regression:*`, local setup, CI.
 
 ## Canonical Sources (read these, do not duplicate)
 
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Patterns, Page Objects, assertions, gestures, prohibited patterns.
-- [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke tests: builds, run commands, local/CI setup.
+- [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke + regression tests: builds, run commands, local/CI setup.
 - [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md) — Setup, run commands, build types, Metro, Detox, Flask; Appium smoke quick start.
 - [.github/guidelines/E2E_DECISION_TREE.md](../.github/guidelines/E2E_DECISION_TREE.md) — CI decision flow: when E2E runs, which labels gate it (pr-not-ready-for-e2e, skip-e2e, skip-smart-e2e-selection), AI test selection logic.
 - [tests/docs/README.md](docs/README.md) — Framework structure, withFixtures, FixtureBuilder, anti-patterns, checklist.

--- a/tests/jest.e2e.detox.config.js
+++ b/tests/jest.e2e.detox.config.js
@@ -13,8 +13,9 @@ module.exports = {
   rootDir: '..',
   testMatch: ['<rootDir>/tests/**/*.spec.{js,ts}'],
   testPathIgnorePatterns: [
-    // Playwright + Appium smoke specs — run via tests/playwright.smoke-appium.config.ts
+    // Playwright + Appium specs — run via tests/playwright.{smoke,regression}-appium.config.ts
     '<rootDir>/tests/smoke-appium/',
+    '<rootDir>/tests/regression-appium/',
   ],
   testTimeout: 300000,
   maxWorkers: 1,

--- a/tests/playwright.regression-appium.config.ts
+++ b/tests/playwright.regression-appium.config.ts
@@ -1,0 +1,113 @@
+import dotenv from 'dotenv';
+dotenv.config({ path: '.e2e.env' });
+
+import { Platform, ProviderName } from './framework/types';
+import { defineConfig } from './framework/config';
+
+// Requires HAS_TEST_OVERRIDES=true baked in at build time so the app activates
+// ReadOnlyNetworkStore and fetches fixture state from /state.json.
+//
+// Defaults match Detox local debug e2e output
+// Override with ANDROID_APK_PATH / IOS_APP_PATH for release/main-e2e artifacts
+// (e.g. build/ci-main-e2e/app-prod-release.apk) — launch helpers detect release
+// from the path and skip Metro deep-link automatically.
+const DEFAULT_ANDROID_APK =
+  process.env.ANDROID_APK_PATH?.trim() ||
+  process.env.PREBUILT_ANDROID_APK_PATH?.trim() ||
+  'android/app/build/outputs/apk/prod/debug/app-prod-debug.apk';
+const DEFAULT_IOS_APP =
+  process.env.IOS_APP_PATH?.trim() ||
+  process.env.PREBUILT_IOS_APP_PATH?.trim() ||
+  'ios/build/Build/Products/Debug-iphonesimulator/MetaMask.app';
+
+/**
+ * Playwright runner config for Appium regression tests.
+ *
+ * Runs Appium regression specs from tests/regression-appium. Tags live in
+ * describe titles via tags.js (same convention as Detox); --grep uses the tag
+ * id (e.g. RegressionWalletUX).
+ *
+ * Environment variables (all optional — defaults shown):
+ * - PREBUILT_ANDROID_APK_PATH — e2e APK from .e2e.env (overrides default debug path)
+ * - ANDROID_APK_PATH — path to the APK (overrides PREBUILT_ANDROID_APK_PATH)
+ * - PREBUILT_IOS_APP_PATH — e2e .app from .e2e.env (overrides default debug path)
+ * - IOS_APP_PATH — path to the .app (overrides PREBUILT_IOS_APP_PATH)
+ * - ANDROID_AVD_NAME — AVD name (default: 'Pixel_5_Pro_API_34')
+ * - IOS_SIMULATOR_NAME — simulator name (default: 'iPhone 16 Pro')
+ * - IOS_SIMULATOR_UDID — booted sim UDID (CI sets this from prepare-ios-appium-runner)
+ * - APPIUM_SMOKE_SUITE_NAME — CI suite id for per-job report/video paths
+ * - PLAYWRIGHT_JSON_OUTPUT_FILE — CI path for Playwright JSON report
+ *
+ * Usage:
+ * yarn appium-regression:android
+ * yarn appium-regression:ios
+ *
+ * Release CI artifact locally:
+ * ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk yarn appium-regression:android
+ */
+const suiteName = process.env.APPIUM_SMOKE_SUITE_NAME?.trim();
+const htmlReportDir = suiteName
+  ? `./test-reports/appium-regression-report/${suiteName}`
+  : './test-reports/appium-regression-report';
+const junitReportPath = suiteName
+  ? `./test-reports/appium-regression-junit/${suiteName}.xml`
+  : './test-reports/appium-regression-junit.xml';
+const jsonReportPath = process.env.PLAYWRIGHT_JSON_OUTPUT_FILE?.trim();
+
+export default defineConfig({
+  testDir: './regression-appium',
+  fullyParallel: false,
+  // Per-test timeout: cold WDA build on CI can take up to 10 min plus test time.
+  timeout: 15 * 60 * 1000,
+  retries: process.env.CI === 'true' ? 1 : 0,
+  reporter: [
+    ['html', { open: 'never', outputFolder: htmlReportDir }],
+    ['junit', { outputFile: junitReportPath }],
+    ['list'],
+    ...(jsonReportPath
+      ? ([['json', { outputFile: jsonReportPath }] as const] as const)
+      : []),
+    // CI: step summary + JUnit (dorny/test-reporter). Skip the `github` reporter —
+    // it emits error annotations for failed retry attempts even when the test
+    // eventually passes, which makes passing jobs look failed in the UI.
+    ...(process.env.CI === 'true'
+      ? ([['./reporters/github-step-summary-reporter.mjs'] as const] as const)
+      : []),
+  ],
+
+  projects: [
+    {
+      name: 'android-regression',
+      timeout: 8 * 60 * 1000,
+      use: {
+        platform: Platform.ANDROID,
+        device: {
+          provider: ProviderName.EMULATOR,
+          name: process.env.ANDROID_AVD_NAME || 'Pixel_5_Pro_API_34',
+        },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
+          buildPath: DEFAULT_ANDROID_APK,
+        },
+      },
+    },
+    {
+      name: 'ios-regression',
+      use: {
+        platform: Platform.IOS,
+        device: {
+          provider: ProviderName.SIMULATOR,
+          name: process.env.IOS_SIMULATOR_NAME || 'iPhone 16 Pro',
+          ...(process.env.IOS_SIMULATOR_UDID?.trim()
+            ? { udid: process.env.IOS_SIMULATOR_UDID.trim() }
+            : {}),
+        },
+        app: {
+          appId: 'io.metamask.MetaMask',
+          buildPath: DEFAULT_IOS_APP,
+        },
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds Appium regression runner (`tests/playwright.regression-appium.config.ts`) and `yarn appium-regression:{ios,android}` scripts, mirroring Detox regression.
- Extends `run-appium-e2e-workflow.yml` with config/project/`report_name_prefix` inputs (smoke defaults unchanged).
- Adds `workflow_dispatch` workflows `run-appium-regression-tests-{ios,android}.yml` for `RegressionWalletUX` (not PR-gating).
- Excludes `tests/regression-appium/` from Detox selection; updates docs/CODEOWNERS/filter-rules.

## Test plan
- [ ] Confirm smoke Appium jobs still use default config/project inputs
- [ ] Manually dispatch iOS/Android Appium regression workflows (expect 0 tests / pass-with-no-tests until follow-up PR)
- [ ] `yarn appium-regression:ios --list` / `yarn appium-regression:android --list` succeed


Made with [Cursor](https://cursor.com)