### PR TITLE
test: add Activity redesign empty-state Appium regression coverage

### DIFF
--- a/tests/helpers/activity/MockApiHelper.ts
+++ b/tests/helpers/activity/MockApiHelper.ts
@@ -1,0 +1,38 @@
+import type { Mockttp } from 'mockttp';
+import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
+
+const ACCOUNTS_TRANSACTIONS_URL =
+  /^https:\/\/accounts\.api\.cx\.metamask\.io\/v4\/multiaccount\/transactions(\?.*)?$/;
+
+/** Priority above default mocks so Activity specs own the accounts API. */
+const ACTIVITY_MOCK_PRIORITY = 1000;
+
+class MockApiHelper {
+  /**
+   * Intercepts the accounts API transaction history endpoint.
+   * Pass an empty array to simulate a wallet with no history (empty state).
+   */
+  async interceptTransactionHistory(
+    mockServer: Mockttp,
+    transactions: Record<string, unknown>[],
+  ): Promise<void> {
+    await setupMockRequest(
+      mockServer,
+      {
+        requestMethod: 'GET',
+        url: ACCOUNTS_TRANSACTIONS_URL,
+        response: {
+          data: transactions,
+          pageInfo: {
+            count: transactions.length,
+            hasNextPage: false,
+          },
+        },
+        responseCode: 200,
+      },
+      ACTIVITY_MOCK_PRIORITY,
+    );
+  }
+}
+
+export default new MockApiHelper();

--- a/tests/helpers/activity/activityMockFixtures.ts
+++ b/tests/helpers/activity/activityMockFixtures.ts
@@ -1,0 +1,58 @@
+import {
+  DEFAULT_FIXTURE_ACCOUNT,
+  DEFAULT_FIXTURE_ACCOUNT_2,
+} from '../../framework/fixtures/FixtureBuilder';
+
+export const ACTIVITY_COMPLETED_TX_HASH = '0xactivitycompletedsend001';
+
+export const ACTIVITY_EMPTY_STATE_COPY = {
+  transactionsUnfunded: {
+    description: 'Add funds to your wallet to get started.',
+    action: 'Add funds',
+  },
+  transactionsFunded: {
+    description: 'Swap your first token today.',
+    action: 'Swap tokens',
+  },
+  buySell: {
+    description: 'Add funds to your wallet to get started.',
+    action: 'Add funds',
+  },
+  predictions: {
+    description: 'Your first prediction could be your best.',
+    action: 'Make a prediction',
+  },
+  perps: {
+    description: 'Your first perps trade could be your best.',
+    action: 'Browse markets',
+  },
+  metamaskCard: {
+    description: 'Manage your MetaMask Card and spend crypto anywhere.',
+    action: 'Open MetaMask Card',
+  },
+} as const;
+
+export const ACTIVITY_MOCK_FIXTURES = {
+  completedTransactions: [
+    {
+      hash: ACTIVITY_COMPLETED_TX_HASH,
+      timestamp: new Date(Date.now() - 3_600_000).toISOString(),
+      chainId: 1,
+      blockNumber: 1,
+      blockHash: '0x2',
+      gas: 21_000,
+      gasUsed: 21_000,
+      gasPrice: '1',
+      effectiveGasPrice: '1',
+      nonce: 1,
+      cumulativeGasUsed: 21_000,
+      methodId: null,
+      value: '100000000000000000', // 0.1 ETH
+      to: DEFAULT_FIXTURE_ACCOUNT_2,
+      from: DEFAULT_FIXTURE_ACCOUNT,
+      isError: false,
+      valueTransfers: [],
+      transactionCategory: 'STANDARD',
+    },
+  ],
+};

--- a/tests/page-objects/Transactions/ActivityScreen.ts
+++ b/tests/page-objects/Transactions/ActivityScreen.ts
@@ -1,0 +1,217 @@
+import { ActivityScreenSelectorsIDs } from '../../../app/components/Views/ActivityScreen/ActivityScreen.testIds';
+import {
+  ActivityListSelectorsIDs,
+  activityListRowItemTestId,
+  activityListRowPendingSpinnerTestId,
+  activityListRowSubtitleTestId,
+  activityListRowTitleTestId,
+} from '../../../app/components/Views/ActivityList/ActivityList.testIds';
+import Matchers from '../../framework/Matchers';
+import Gestures from '../../framework/Gestures';
+import Assertions from '../../framework/Assertions';
+import type { EncapsulatedElementType } from '../../framework';
+import TabBarComponent from '../wallet/TabBarComponent';
+
+/**
+ * Mirrors app `ActivityTypeFilter` string values (testIDs use these suffixes).
+ * Defined here so E2E does not import app `types.ts` (pulls Engine via adapters).
+ */
+export enum ActivityTypeFilter {
+  All = 'all',
+  Transactions = 'transactions',
+  BuySell = 'buySell',
+  Perps = 'perps',
+  Predictions = 'predictions',
+  MetamaskCard = 'metamaskCard',
+}
+
+class ActivityScreen {
+  get screen(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.SAFE_AREA_VIEW);
+  }
+
+  get header(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.HEADER);
+  }
+
+  get backButton(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.BACK_BUTTON);
+  }
+
+  get networkFilterChip(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      ActivityScreenSelectorsIDs.NETWORK_FILTER_CHIP,
+    );
+  }
+
+  get typeFilterChip(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP);
+  }
+
+  get typeFilterSheet(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      ActivityScreenSelectorsIDs.TYPE_FILTER_SHEET,
+    );
+  }
+
+  get perpsFilterChip(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      ActivityScreenSelectorsIDs.PERPS_FILTER_CHIP,
+    );
+  }
+
+  get perpsFilterSheet(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      ActivityScreenSelectorsIDs.PERPS_FILTER_SHEET,
+    );
+  }
+
+  get emptyState(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.EMPTY_STATE);
+  }
+
+  get emptyStateListContainer(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityScreenSelectorsIDs.LIST);
+  }
+
+  emptyStateAction(label: string): EncapsulatedElementType {
+    return Matchers.getElementByText(label);
+  }
+
+  typeFilterOption(filter: ActivityTypeFilter): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      `${ActivityScreenSelectorsIDs.TYPE_FILTER_OPTION_PREFIX}${filter}`,
+    );
+  }
+
+  get transactionList(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityListSelectorsIDs.CONTAINER);
+  }
+
+  get loadingIndicator(): EncapsulatedElementType {
+    return Matchers.getElementByID(ActivityListSelectorsIDs.LOADING_INDICATOR);
+  }
+
+  transactionItem(index: number): EncapsulatedElementType {
+    return Matchers.getElementByID(activityListRowItemTestId(index));
+  }
+
+  transactionTitle(hashOrIndex: string | number): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      activityListRowTitleTestId(String(hashOrIndex)),
+    );
+  }
+
+  transactionSubtitle(hashOrIndex: string | number): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      activityListRowSubtitleTestId(String(hashOrIndex)),
+    );
+  }
+
+  transactionPrimaryAmount(
+    hashOrIndex: string | number,
+  ): EncapsulatedElementType {
+    return Matchers.getElementByID(`activity-primary-amount-${hashOrIndex}`);
+  }
+
+  transactionSecondaryAmount(
+    hashOrIndex: string | number,
+  ): EncapsulatedElementType {
+    return Matchers.getElementByID(`activity-secondary-amount-${hashOrIndex}`);
+  }
+
+  get pendingSectionHeader(): EncapsulatedElementType {
+    return Matchers.getElementByID('activity-list-date-header');
+  }
+
+  pendingSpinner(hashOrIndex: string | number): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      activityListRowPendingSpinnerTestId(String(hashOrIndex)),
+    );
+  }
+
+  async openFromTabBar(): Promise<void> {
+    await Gestures.waitAndTap(TabBarComponent.tabBarActivityButton, {
+      elemDescription: 'Activity tab',
+      timeout: 10_000,
+    });
+    await this.expectIsVisible();
+  }
+
+  async expectIsVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.screen, {
+      description: 'Activity redesign screen should be visible',
+      timeout: 20_000,
+    });
+  }
+
+  async expectEmptyStateVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.emptyState, {
+      description: 'Activity empty state should be visible',
+      timeout: 20_000,
+    });
+  }
+
+  async expectEmptyStateNotVisible(): Promise<void> {
+    await Assertions.expectElementToNotBeVisible(this.emptyState, {
+      description: 'Activity empty state should not be visible',
+      timeout: 20_000,
+    });
+  }
+
+  async expectEmptyStateContent(
+    description: string,
+    actionLabel: string,
+  ): Promise<void> {
+    await this.expectEmptyStateVisible();
+    await Assertions.expectTextDisplayed(description, {
+      description: `Empty state description "${description}"`,
+    });
+    await Assertions.expectElementToBeVisible(
+      this.emptyStateAction(actionLabel),
+      {
+        description: `Empty state CTA "${actionLabel}" should be visible`,
+      },
+    );
+  }
+
+  async selectTypeFilter(filter: ActivityTypeFilter): Promise<void> {
+    await Gestures.waitAndTap(this.typeFilterChip, {
+      elemDescription: 'Activity type filter chip',
+    });
+    await Assertions.expectElementToBeVisible(this.typeFilterSheet, {
+      description: 'Activity type filter sheet should open',
+    });
+    await Gestures.waitAndTap(this.typeFilterOption(filter), {
+      elemDescription: `Activity type filter option ${filter}`,
+    });
+  }
+
+  async tapEmptyStateAction(actionLabel: string): Promise<void> {
+    await Gestures.waitAndTap(this.emptyStateAction(actionLabel), {
+      elemDescription: `Activity empty state CTA "${actionLabel}"`,
+    });
+  }
+
+  async expectTransactionTitleVisible(hash: string): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.transactionTitle(hash), {
+      description: `Activity row title for ${hash} should be visible`,
+      timeout: 20_000,
+    });
+  }
+
+  async tapTransactionItem(index: number): Promise<void> {
+    await Gestures.waitAndTap(this.transactionItem(index), {
+      elemDescription: `Activity transaction item at index ${index}`,
+    });
+  }
+
+  async swipeDown(): Promise<void> {
+    await Gestures.swipe(this.transactionList, 'down', {
+      speed: 'slow',
+      percentage: 0.5,
+    });
+  }
+}
+
+export default new ActivityScreen();

--- a/tests/regression-appium/wallet/activity-redesign-empty-state.spec.ts
+++ b/tests/regression-appium/wallet/activity-redesign-empty-state.spec.ts
@@ -1,0 +1,400 @@
+import type { Mockttp } from 'mockttp';
+import { merge } from 'lodash';
+
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { RegressionWalletUX } from '../../tags.js';
+import { loginToAppPlaywright } from '../../flows/wallet.flow.js';
+import Assertions from '../../framework/Assertions.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import FixtureBuilder, {
+  DEFAULT_FIXTURE_ACCOUNT,
+  ENTROPY_WALLET_1_ID,
+} from '../../framework/fixtures/FixtureBuilder.js';
+import type {
+  AccountTreeControllerState,
+  Fixture,
+} from '../../framework/fixtures/types.js';
+import ActivityScreen, {
+  ActivityTypeFilter,
+} from '../../page-objects/Transactions/ActivityScreen.js';
+import QuoteView from '../../page-objects/swaps/QuoteView.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView.js';
+import CardHomeView from '../../page-objects/Card/CardHomeView.js';
+import BuildQuoteView from '../../page-objects/Ramps/BuildQuoteView.js';
+import MockApiHelper from '../../helpers/activity/MockApiHelper.js';
+import {
+  ACTIVITY_COMPLETED_TX_HASH,
+  ACTIVITY_EMPTY_STATE_COPY,
+  ACTIVITY_MOCK_FIXTURES,
+} from '../../helpers/activity/activityMockFixtures.js';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import { remoteFeatureFlagPredictEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import { POLYMARKET_COMPLETE_MOCKS } from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
+import {
+  PERPS_ARBITRUM_MOCKS,
+  mockPerpsGeolocation,
+} from '../../api-mocking/mock-responses/perps-arbitrum-mocks.js';
+import { setupBuyOnRampMocks } from '../../api-mocking/mock-responses/ramps/ramps-mocks.js';
+import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants.js';
+import { testSpecificMock as cardholderMocks } from '../../api-mocking/mock-responses/cardholder-mocks.js';
+
+const EVM_ONLY_ACCOUNT_TREE = {
+  accountTree: {
+    wallets: {
+      [ENTROPY_WALLET_1_ID]: {
+        id: ENTROPY_WALLET_1_ID,
+        type: 'Entropy',
+        metadata: { name: 'Secret Recovery Phrase 1' },
+        groups: {
+          [`${ENTROPY_WALLET_1_ID}/account-1`]: {
+            id: `${ENTROPY_WALLET_1_ID}/account-1`,
+            type: 'MultipleAccount',
+            accounts: ['4d7a5e0b-b261-4aed-8126-43972b0fa0a1'],
+            metadata: { name: 'Account 1' },
+          },
+        },
+      },
+    },
+    selectedAccountGroup: `${ENTROPY_WALLET_1_ID}/account-1`,
+  },
+};
+
+const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const SELECTED_RAMP_REGION = RampsRegions[RampsRegionsEnum.UNITED_STATES];
+
+function buildEmptyActivityFixture(options?: {
+  funded?: boolean;
+  withRampRegion?: boolean;
+  withCard?: boolean;
+  withPerps?: boolean;
+}): Fixture {
+  let builder = new FixtureBuilder()
+    .withAccountTreeController(
+      EVM_ONLY_ACCOUNT_TREE as unknown as Partial<AccountTreeControllerState>,
+    )
+    .withNetworkEnabledMap({ eip155: { '0x1': true } })
+    .withPrivacyModePreferences(false);
+
+  if (options?.withRampRegion) {
+    builder = builder.withRampsSelectedRegion(SELECTED_RAMP_REGION);
+  }
+  if (options?.withCard) {
+    builder = builder.withCardController();
+  }
+  if (options?.withPerps) {
+    builder = builder
+      .withPerpsProfile('no-positions')
+      .withPerpsFirstTimeUser(false);
+  }
+
+  const fixture = builder.build();
+
+  if (options?.funded) {
+    merge(fixture.state.engine.backgroundState.TokenBalancesController, {
+      tokenBalances: {
+        [DEFAULT_FIXTURE_ACCOUNT]: {
+          '0x1': {
+            [USDC_MAINNET]: '0x5f5e100', // 100 USDC
+          },
+        },
+      },
+    });
+  }
+
+  return fixture;
+}
+
+async function mockEmptyTransactionHistory(mockServer: Mockttp): Promise<void> {
+  await MockApiHelper.interceptTransactionHistory(mockServer, []);
+}
+
+appiumTest.describe(
+  RegressionWalletUX('Activity Redesign - Empty State'),
+  () => {
+    appiumTest.describe.configure({ timeout: 180_000 });
+
+    appiumTest(
+      'displays empty state when wallet has no transaction history',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture(),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: mockEmptyTransactionHistory,
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.transactionsUnfunded.description,
+              ACTIVITY_EMPTY_STATE_COPY.transactionsUnfunded.action,
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'does not display empty state when wallet has transactions',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture(),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await MockApiHelper.interceptTransactionHistory(
+                mockServer,
+                ACTIVITY_MOCK_FIXTURES.completedTransactions,
+              );
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+
+            await ActivityScreen.expectEmptyStateNotVisible();
+            await ActivityScreen.expectTransactionTitleVisible(
+              ACTIVITY_COMPLETED_TX_HASH,
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Add funds CTA from unfunded Transactions empty state opens buy flow',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture({ withRampRegion: true }),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await mockEmptyTransactionHistory(mockServer);
+              await setupBuyOnRampMocks(mockServer, SELECTED_RAMP_REGION);
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.transactionsUnfunded.description,
+              ACTIVITY_EMPTY_STATE_COPY.transactionsUnfunded.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.transactionsUnfunded.action,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              BuildQuoteView.amountToBuyLabel,
+              {
+                description: 'Buy quote amount label should be visible',
+                timeout: 20_000,
+              },
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Swap tokens CTA from funded Transactions empty state opens swap',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture({ funded: true }),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: mockEmptyTransactionHistory,
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.transactionsFunded.description,
+              ACTIVITY_EMPTY_STATE_COPY.transactionsFunded.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.transactionsFunded.action,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              QuoteView.sourceTokenArea,
+              {
+                description: 'Swap/bridge source token area should be visible',
+                timeout: 20_000,
+              },
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Buy/Sell empty state Add funds CTA opens buy flow',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture({ withRampRegion: true }),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await mockEmptyTransactionHistory(mockServer);
+              await setupBuyOnRampMocks(mockServer, SELECTED_RAMP_REGION);
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.selectTypeFilter(ActivityTypeFilter.BuySell);
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.buySell.description,
+              ACTIVITY_EMPTY_STATE_COPY.buySell.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.buySell.action,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              BuildQuoteView.amountToBuyLabel,
+              {
+                description: 'Buy quote amount label should be visible',
+                timeout: 20_000,
+              },
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Make a prediction CTA opens Predictions market list',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture(),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await mockEmptyTransactionHistory(mockServer);
+              await setupRemoteFeatureFlagsMock(mockServer, {
+                ...remoteFeatureFlagPredictEnabled(true),
+              });
+              await POLYMARKET_COMPLETE_MOCKS(mockServer);
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.selectTypeFilter(
+              ActivityTypeFilter.Predictions,
+            );
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.predictions.description,
+              ACTIVITY_EMPTY_STATE_COPY.predictions.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.predictions.action,
+            );
+
+            await PredictMarketList.waitForScreenToDisplay({
+              description: 'Predict market list should open from empty CTA',
+              timeout: 30_000,
+            });
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Browse markets CTA opens Perps market list',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture({ withPerps: true }),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await mockEmptyTransactionHistory(mockServer);
+              await setupRemoteFeatureFlagsMock(mockServer, {});
+              await PERPS_ARBITRUM_MOCKS(mockServer);
+              await mockPerpsGeolocation(
+                mockServer,
+                RampsRegions[RampsRegionsEnum.SPAIN],
+              );
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.selectTypeFilter(ActivityTypeFilter.Perps);
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.perps.description,
+              ACTIVITY_EMPTY_STATE_COPY.perps.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.perps.action,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              PerpsMarketListView.listHeader,
+              {
+                description: 'Perps market list header should be visible',
+                timeout: 30_000,
+              },
+            );
+          },
+        );
+      },
+    );
+
+    appiumTest(
+      'Open MetaMask Card CTA opens Card home',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: buildEmptyActivityFixture({ withCard: true }),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: async (mockServer: Mockttp) => {
+              await mockEmptyTransactionHistory(mockServer);
+              await cardholderMocks(mockServer);
+            },
+          },
+          async () => {
+            await loginToAppPlaywright({ scenarioType: 'e2e' });
+            await ActivityScreen.openFromTabBar();
+            await ActivityScreen.selectTypeFilter(
+              ActivityTypeFilter.MetamaskCard,
+            );
+            await ActivityScreen.expectEmptyStateContent(
+              ACTIVITY_EMPTY_STATE_COPY.metamaskCard.description,
+              ACTIVITY_EMPTY_STATE_COPY.metamaskCard.action,
+            );
+
+            await ActivityScreen.tapEmptyStateAction(
+              ACTIVITY_EMPTY_STATE_COPY.metamaskCard.action,
+            );
+
+            await Assertions.expectElementToBeVisible(
+              CardHomeView.cardViewTitle,
+              {
+                description: 'Card home title should be visible',
+                timeout: 30_000,
+              },
+            );
+          },
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- Adds Appium regression coverage for Activity redesign empty states under `RegressionWalletUX`.
- Includes Activity screen POM, accounts API mock helper, and empty-state fixtures/CTA scenarios (Transactions, Buy/Sell, Predictions, Perps, Card).

Depends on https://github.com/MetaMask/metamask-mobile/pull/33747 (Appium regression infra). Retarget to `main` after that merges.

## Test plan
- [ ] `yarn appium-regression:ios --grep RegressionWalletUX` against main-e2e build
- [ ] `yarn appium-regression:android --grep RegressionWalletUX` against main-e2e build
- [ ] Dispatch Appium regression workflows after infra PR is merged (or on this stack)