### PR TITLE
refactor: simplify DOM in backup and social login screens

### DIFF
--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -164,30 +164,30 @@ const AccountBackupStep1 = (props) => {
               }
               style={tw.style('w-[250px] h-[250px] mx-auto')}
             />
-            <Box twClassName="mt-8 self-start gap-y-4">
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              twClassName="mt-8 self-start"
+            >
+              {strings('account_backup_step_1.info_text_1_1')}{' '}
               <Text
                 variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
+                color={TextColor.PrimaryDefault}
+                onPress={showWhatIsSeedphrase}
+                testID={ManualBackUpStepsSelectorsIDs.SEEDPHRASE_LINK}
               >
-                {strings('account_backup_step_1.info_text_1_1')}{' '}
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.PrimaryDefault}
-                  onPress={showWhatIsSeedphrase}
-                  testID={ManualBackUpStepsSelectorsIDs.SEEDPHRASE_LINK}
-                >
-                  {strings('account_backup_step_1.info_text_1_2')}
-                </Text>{' '}
-                {strings('account_backup_step_1.info_text_1_3')}{' '}
-              </Text>
+                {strings('account_backup_step_1.info_text_1_2')}
+              </Text>{' '}
+              {strings('account_backup_step_1.info_text_1_3')}{' '}
+            </Text>
 
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {strings('account_backup_step_1.info_text_1_4')}
-              </Text>
-            </Box>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              twClassName="self-start mt-4"
+            >
+              {strings('account_backup_step_1.info_text_1_4')}
+            </Text>
           </Box>
 
           <Box

--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -442,32 +442,24 @@ const ManualBackupStep2 = ({
         >
           <Box
             justifyContent={BoxJustifyContent.SpaceBetween}
-            twClassName="flex-1 h-full gap-y-4"
+            twClassName="flex-1 gap-y-4"
+            style={{ height: windowHeight - 290 }}
             testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
           >
-            <Box
-              justifyContent={BoxJustifyContent.SpaceBetween}
-              twClassName="flex-1 gap-y-4"
-              style={{ height: windowHeight - 290 }}
+            <Text variant={TextVariant.DisplayMd} color={TextColor.TextDefault}>
+              {strings('manual_backup_step_2.action')}
+            </Text>
+
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
             >
-              <Text
-                variant={TextVariant.DisplayMd}
-                color={TextColor.TextDefault}
-              >
-                {strings('manual_backup_step_2.action')}
-              </Text>
+              {strings('manual_backup_step_2.info')}
+            </Text>
 
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {strings('manual_backup_step_2.info')}
-              </Text>
-
-              <Box twClassName="flex-1 gap-1">
-                {renderGrid()}
-                {renderMissingWords()}
-              </Box>
+            <Box twClassName="flex-1 gap-1">
+              {renderGrid()}
+              {renderMissingWords()}
             </Box>
           </Box>
         </ActionView>

--- a/app/components/Views/ManualBackupStep3/index.js
+++ b/app/components/Views/ManualBackupStep3/index.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import { Alert, BackHandler, Keyboard } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Box } from '@metamask/design-system-react-native';
 import StorageWrapper from '../../../store/storage-wrapper';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
 import { strings } from '../../../../locales/i18n';
@@ -126,7 +125,7 @@ class ManualBackupStep3 extends PureComponent {
 
   render() {
     return (
-      <Box twClassName="flex-1 bg-default mt-4">
+      <>
         <OnboardingSuccessComponent
           onDone={this.done}
           successFlow={ONBOARDING_SUCCESS_FLOW.BACKED_UP_SRP}
@@ -135,7 +134,7 @@ class ManualBackupStep3 extends PureComponent {
           <AndroidBackHandler customBackPress={this.props.navigation.pop} />
         )}
         {this.renderHint()}
-      </Box>
+      </>
     );
   }
 }

--- a/app/components/Views/OnboardingSheet/index.tsx
+++ b/app/components/Views/OnboardingSheet/index.tsx
@@ -127,21 +127,71 @@ const OnboardingSheet = () => {
         twClassName="p-4 gap-y-4"
         testID={OnboardingSheetSelectorIDs.CONTAINER_ID}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          justifyContent={BoxJustifyContent.End}
-          twClassName="gap-4 w-full"
+        <Button
+          variant={ButtonVariant.Secondary}
+          onPress={onPressContinueWithGoogleAction}
+          testID={OnboardingSheetSelectorIDs.GOOGLE_LOGIN_BUTTON}
+          startAccessory={
+            <GoogleIcon
+              fill="currentColor"
+              width={24}
+              height={24}
+              name={'google'}
+            />
+          }
+          isFullWidth
+          size={ButtonSize.Lg}
+          style={tw.style('border border-muted', {
+            backgroundColor: colors.text.default,
+          })}
+          textProps={{ style: { color: colors.background.default } }}
         >
-          <Button
-            variant={ButtonVariant.Secondary}
-            onPress={onPressContinueWithGoogleAction}
-            testID={OnboardingSheetSelectorIDs.GOOGLE_LOGIN_BUTTON}
-            startAccessory={
-              <GoogleIcon
+          {createWallet
+            ? strings('onboarding.continue_with_google')
+            : strings('onboarding.sign_in_with_google')}
+        </Button>
+        <Button
+          variant={ButtonVariant.Secondary}
+          onPress={onPressContinueWithAppleAction}
+          testID={OnboardingSheetSelectorIDs.APPLE_LOGIN_BUTTON}
+          startAccessory={
+            isDark ? (
+              <AppleIcon
                 fill="currentColor"
                 width={24}
                 height={24}
-                name={'google'}
+                name={'apple'}
+              />
+            ) : (
+              <AppleWhiteIcon
+                fill="currentColor"
+                width={24}
+                height={24}
+                name={'apple-white'}
+              />
+            )
+          }
+          isFullWidth
+          size={ButtonSize.Lg}
+          style={tw.style('border border-muted', {
+            backgroundColor: colors.text.default,
+          })}
+          textProps={{ style: { color: colors.background.default } }}
+        >
+          {createWallet
+            ? strings('onboarding.continue_with_apple')
+            : strings('onboarding.sign_in_with_apple')}
+        </Button>
+        {onPressContinueWithTelegram ? (
+          <Button
+            variant={ButtonVariant.Secondary}
+            onPress={onPressContinueWithTelegramAction}
+            testID={OnboardingSheetSelectorIDs.TELEGRAM_LOGIN_BUTTON}
+            startAccessory={
+              <Icon
+                name={IconName.Telegram}
+                size={IconSize.Lg}
+                style={tw.style({ color: commonColors.telegramBlue })}
               />
             }
             isFullWidth
@@ -152,66 +202,10 @@ const OnboardingSheet = () => {
             textProps={{ style: { color: colors.background.default } }}
           >
             {createWallet
-              ? strings('onboarding.continue_with_google')
-              : strings('onboarding.sign_in_with_google')}
+              ? strings('onboarding.continue_with_telegram')
+              : strings('onboarding.sign_in_with_telegram')}
           </Button>
-          <Button
-            variant={ButtonVariant.Secondary}
-            onPress={onPressContinueWithAppleAction}
-            testID={OnboardingSheetSelectorIDs.APPLE_LOGIN_BUTTON}
-            startAccessory={
-              isDark ? (
-                <AppleIcon
-                  fill="currentColor"
-                  width={24}
-                  height={24}
-                  name={'apple'}
-                />
-              ) : (
-                <AppleWhiteIcon
-                  fill="currentColor"
-                  width={24}
-                  height={24}
-                  name={'apple-white'}
-                />
-              )
-            }
-            isFullWidth
-            size={ButtonSize.Lg}
-            style={tw.style('border border-muted', {
-              backgroundColor: colors.text.default,
-            })}
-            textProps={{ style: { color: colors.background.default } }}
-          >
-            {createWallet
-              ? strings('onboarding.continue_with_apple')
-              : strings('onboarding.sign_in_with_apple')}
-          </Button>
-          {onPressContinueWithTelegram ? (
-            <Button
-              variant={ButtonVariant.Secondary}
-              onPress={onPressContinueWithTelegramAction}
-              testID={OnboardingSheetSelectorIDs.TELEGRAM_LOGIN_BUTTON}
-              startAccessory={
-                <Icon
-                  name={IconName.Telegram}
-                  size={IconSize.Lg}
-                  style={tw.style({ color: commonColors.telegramBlue })}
-                />
-              }
-              isFullWidth
-              size={ButtonSize.Lg}
-              style={tw.style('border border-muted', {
-                backgroundColor: colors.text.default,
-              })}
-              textProps={{ style: { color: colors.background.default } }}
-            >
-              {createWallet
-                ? strings('onboarding.continue_with_telegram')
-                : strings('onboarding.sign_in_with_telegram')}
-            </Button>
-          ) : null}
-        </Box>
+        ) : null}
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
@@ -229,52 +223,44 @@ const OnboardingSheet = () => {
           </Text>
           <Box twClassName="flex-1 h-px bg-border-muted" />
         </Box>
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          justifyContent={BoxJustifyContent.End}
-          twClassName="gap-4 w-full"
+        <Button
+          variant={ButtonVariant.Secondary}
+          onPress={createWallet ? onPressCreateAction : onPressImportAction}
+          testID={OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON}
+          isFullWidth
+          size={ButtonSize.Lg}
         >
-          <Button
-            variant={ButtonVariant.Secondary}
-            onPress={createWallet ? onPressCreateAction : onPressImportAction}
-            testID={OnboardingSheetSelectorIDs.IMPORT_SEED_BUTTON}
-            isFullWidth
-            size={ButtonSize.Lg}
-          >
-            {createWallet
-              ? strings('onboarding.continue_with_srp')
-              : strings('onboarding.import_srp')}
-          </Button>
-        </Box>
-        <Box alignItems={BoxAlignItems.Center} twClassName="mt-6">
+          {createWallet
+            ? strings('onboarding.continue_with_srp')
+            : strings('onboarding.import_srp')}
+        </Button>
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+          twClassName="mt-6 text-center"
+        >
+          {strings('onboarding.by_continuing')}{' '}
           <Text
             variant={TextVariant.BodyXs}
             fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-            style={tw.style('text-center')}
+            color={TextColor.PrimaryDefault}
+            onPress={onPressTermsOfUse}
+            testID="terms-of-use-link"
           >
-            {strings('onboarding.by_continuing')}{' '}
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.PrimaryDefault}
-              onPress={onPressTermsOfUse}
-              testID="terms-of-use-link"
-            >
-              {strings('onboarding.terms_of_use')}
-            </Text>{' '}
-            {strings('onboarding.and')}{' '}
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.PrimaryDefault}
-              onPress={onPressPrivacyNotice}
-              testID="privacy-notice-link"
-            >
-              {strings('onboarding.privacy_notice')}
-            </Text>
+            {strings('onboarding.terms_of_use')}
+          </Text>{' '}
+          {strings('onboarding.and')}{' '}
+          <Text
+            variant={TextVariant.BodyXs}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.PrimaryDefault}
+            onPress={onPressPrivacyNotice}
+            testID="privacy-notice-link"
+          >
+            {strings('onboarding.privacy_notice')}
           </Text>
-        </Box>
+        </Text>
       </Box>
     </BottomSheet>
   );

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -167,30 +167,25 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
           </Text>
         </Box>
 
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          gap={isMedium ? 3 : 4}
+        <Button
+          variant={ButtonVariant.Primary}
+          testID={
+            isUserTypeNew
+              ? OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_BUTTON
+              : OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_EXISTING_USER_BUTTON
+          }
+          isFullWidth
+          size={isMedium ? ButtonSize.Md : ButtonSize.Lg}
+          onPress={isUserTypeNew ? handleSetMetaMaskPin : handleSecureWallet}
           marginBottom={4}
           twClassName="w-full"
         >
-          <Button
-            variant={ButtonVariant.Primary}
-            testID={
-              isUserTypeNew
-                ? OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_NEW_USER_BUTTON
-                : OnboardingSelectorIDs.SOCIAL_LOGIN_IOS_EXISTING_USER_BUTTON
-            }
-            isFullWidth
-            size={isMedium ? ButtonSize.Md : ButtonSize.Lg}
-            onPress={isUserTypeNew ? handleSetMetaMaskPin : handleSecureWallet}
-          >
-            {strings(
-              isUserTypeNew
-                ? 'social_login_ios_user.new_user_button'
-                : 'social_login_ios_user.existing_user_button',
-            )}
-          </Button>
-        </Box>
+          {strings(
+            isUserTypeNew
+              ? 'social_login_ios_user.new_user_button'
+              : 'social_login_ios_user.existing_user_button',
+          )}
+        </Button>
       </Box>
     </SafeAreaView>
   );

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -177,8 +177,7 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
           isFullWidth
           size={isMedium ? ButtonSize.Md : ButtonSize.Lg}
           onPress={isUserTypeNew ? handleSetMetaMaskPin : handleSecureWallet}
-          marginBottom={4}
-          twClassName="w-full"
+          twClassName="w-full mb-4"
         >
           {strings(
             isUserTypeNew

--- a/app/components/Views/WalletCreationError/SocialLoginErrorSheet.tsx
+++ b/app/components/Views/WalletCreationError/SocialLoginErrorSheet.tsx
@@ -91,14 +91,12 @@ const SocialLoginErrorSheet = ({
   }, [trackEvent, createEventBuilder, accountType]);
 
   return (
-    <SafeAreaView style={tw.style('flex-1 bg-alternative justify-end')}>
-      <Box twClassName="flex-1 justify-center items-center">
-        <Image
-          source={FOX_LOGO}
-          style={tw.style('w-[120px] h-[120px]')}
-          resizeMode="contain"
-        />
-      </Box>
+    <SafeAreaView style={tw.style('flex-1 bg-alternative')}>
+      <Image
+        source={FOX_LOGO}
+        style={tw.style('flex-1 w-[120px] h-[120px] self-center')}
+        resizeMode="contain"
+      />
 
       <Box twClassName="bg-default rounded-t-2xl p-4 pb-10 items-center">
         <Box twClassName="w-10 h-1 bg-border-muted rounded-full self-center mb-4" />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Onboarding DOM simplification. Removes redundant layout wrappers without changing UI, copy, handlers, or testIDs.

Why: Deeply nested Box/View wrappers make onboarding screens harder to maintain and more brittle for E2E/component tests.

What changed (layout-only):

* ManualBackupStep2 — Merged nested flex-1 / SpaceBetween Box wrappers into one container; kept PROTECT_CONTAINER testID and height constraint
* AccountBackupStep1 — Removed info-text wrapper Box; preserved spacing with mt-8 / mt-4 on the text nodes
* ManualBackupStep3 — Removed outer Box that duplicated OnboardingSuccessComponent layout
* SocialLoginErrorSheet — Removed fox-logo wrapper Box
* OnboardingSheet — Flattened button column wrappers around Google/Apple actions
* SocialLoginIosUser — Removed redundant layout-only wrappers

No logic, copy, styling tokens, or testIDs were intentionally changed.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-913

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Onboarding DOM simplification

  Scenario: user completes SRP backup confirm step
    Given the user is creating a new wallet and reaches Manual Backup Step 2
    When the user views the confirm seed phrase screen
    Then layout and copy match main (no visual regressions)
    And the protect container and word grid remain interactive

  Scenario: user views account backup intro
    Given the user is on Account Backup Step 1
    When the user views the info text and seed phrase link
    Then spacing and link behavior match main
    And tapping the seed phrase link still opens the explanation

  Scenario: user finishes SRP backup success
    Given the user completed Manual Backup Step 2 successfully
    When Manual Backup Step 3 / success is shown
    Then the success screen renders without layout breakage
    And Done / back behavior still works

  Scenario: user opens social login onboarding sheet
    Given seedless onboarding is enabled
    When the user opens the Google/Apple onboarding sheet
    Then Google and Apple buttons render and remain tappable
    And testIDs for the sheet and buttons still resolve
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/c243a92f-063e-4de6-bdcf-af144fd61457


https://github.com/user-attachments/assets/23eac5c2-afe7-4162-85bc-205b6ffdbe54


https://github.com/user-attachments/assets/f0c4ff29-6dd9-45c4-95dd-a32c2fdc224d


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only JSX structure changes on non-critical onboarding flows; main risk is subtle layout regressions on different screen sizes.
> 
> **Overview**
> **Layout-only refactor** across SRP backup, onboarding sheet, and social-login screens: redundant `Box` wrappers are removed or merged so the tree is flatter, without intended changes to copy, handlers, or `testID`s.
> 
> On **Account Backup Step 1**, the info-text `Box` is dropped; spacing moves to `mt-8` / `mt-4` on the text nodes while the nested seed-phrase link and `SEEDPHRASE_LINK` testID stay the same.
> 
> **Manual Backup Step 2** collapses two nested flex containers into one `PROTECT_CONTAINER` `Box` that still uses the `windowHeight - 290` height constraint; title, info, grid, and missing-word UI are direct children.
> 
> **Manual Backup Step 3** drops an outer `Box` and a `Box` import in favor of a fragment around `OnboardingSuccessComponent`. **OnboardingSheet** removes column wrappers so Google/Apple/Telegram, the “or” divider, SRP import, and legal text sit as siblings under the sheet container. **SocialLoginIosUser** removes a wrapper around the primary CTA (button props unchanged). **SocialLoginErrorSheet** removes the centered fox `Box` and uses `flex-1` on the `Image` instead of `justify-end` on the safe area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31deb2b9c915c12abe5f7214403524033ed80b63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->