### PR TITLE
feat: add Perps Pro chart panel

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -374,6 +374,7 @@ export const getPerpsCandlePeriodBottomSheetSelector = {
 
 // Helper functions for PerpsCandlePeriodSelector dynamic selectors
 export const getPerpsCandlePeriodSelector = {
+  group: (baseTestID: string) => `${baseTestID}-group`,
   periodButton: (baseTestID: string, period: string) =>
     `${baseTestID}-period-${period}`,
   moreButton: (baseTestID: string) => `${baseTestID}-more-button`,
@@ -452,8 +453,20 @@ export const PerpsProMarketViewSelectorsIDs = {
   HEADER: 'perps-pro-market-header',
   HEADER_SYMBOL: 'perps-pro-market-header-symbol',
   MARKET_SUMMARY: 'perps-pro-market-summary',
+  MARKET_PRICE: 'perps-pro-market-price',
+  MARKET_PRICE_CHANGE: 'perps-pro-market-price-change',
   CHART_PANEL: 'perps-pro-market-chart-panel',
   CHART_CONTENT: 'perps-pro-market-chart-content',
+  CHART_OHLCV: 'perps-pro-market-chart-ohlcv',
+  CHART_SKELETON: 'perps-pro-market-chart-skeleton',
+  CHART_LIGHTWEIGHT: 'perps-pro-market-chart-lightweight',
+  CHART_PERIOD_SELECTOR: 'perps-pro-market-chart-period-selector',
+  CHART_MORE_PERIODS_SHEET: 'perps-pro-market-chart-more-periods-sheet',
+  CHART_FULLSCREEN_BUTTON: 'perps-pro-market-chart-fullscreen-button',
+  CHART_PRICE_DEVIATION_WARNING:
+    'perps-pro-market-chart-price-deviation-warning',
+  CHART_SERVICE_INTERRUPTION_BANNER:
+    'perps-pro-market-chart-service-interruption-banner',
   STATS_BAR: 'perps-pro-market-stats-bar',
   LAYOUT: 'perps-pro-market-layout',
   LEFT_COLUMN: 'perps-pro-market-left-column',

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -48,7 +48,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
-import { setPerpsChartPreferredCandlePeriod } from '../../../../../actions/settings';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -130,6 +129,7 @@ import {
   type DataMonitorParams,
 } from '../../hooks/usePerpsDataMonitor';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import { usePerpsChartInteractions } from '../../hooks/usePerpsChartInteractions';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import { usePerpsMarketStats } from '../../hooks/usePerpsMarketStats';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
@@ -139,6 +139,10 @@ import { usePerpsOICap } from '../../hooks/usePerpsOICap';
 import { usePerpsTPSLUpdate } from '../../hooks/usePerpsTPSLUpdate';
 import { useStopLossPrompt } from '../../hooks/useStopLossPrompt';
 import usePerpsToasts from '../../hooks/usePerpsToasts';
+import {
+  getPerpsChartAnalyticsProperties,
+  getPerpsChartLibrary,
+} from '../../utils/chartAnalytics';
 import { WATCHLIST_LIMIT } from '../../utils/marketUtils';
 import {
   getRelatedMarketsForMarket,
@@ -185,16 +189,6 @@ interface MarketDetailsRouteParams {
   source_section?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
 }
-
-const getChartLibrary = (isAdvancedChartEnabled: boolean) =>
-  isAdvancedChartEnabled
-    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
-    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
-
-const getChartAnalyticsPropertiesForLibrary = (chartLibrary: string) => ({
-  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
-  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
-});
 
 const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Use centralized navigation hook for all Perps navigation
@@ -303,7 +297,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     selectPerpsAdvancedChartEnabledFlag,
   );
   const configuredChartLibrary = useMemo(
-    () => getChartLibrary(isAdvancedChartEnabled),
+    () => getPerpsChartLibrary(isAdvancedChartEnabled),
     [isAdvancedChartEnabled],
   );
   const [effectiveChartLibrary, setEffectiveChartLibrary] = useState(
@@ -316,7 +310,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     ? effectiveChartLibrary
     : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
   const chartAnalyticsProperties = useMemo(
-    () => getChartAnalyticsPropertiesForLibrary(chartLibrary),
+    () => getPerpsChartAnalyticsProperties(chartLibrary),
     [chartLibrary],
   );
   const isServiceInterruptionBannerEnabled = useSelector(
@@ -779,24 +773,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     properties: marketDetailsScreenViewedProperties,
   });
 
-  const handleCandlePeriodChange = useCallback(
-    (newPeriod: CandlePeriod) => {
-      // Persist the preference to Redux store
-      dispatch(setPerpsChartPreferredCandlePeriod(newPeriod));
+  const handleAdvancedChartError = useCallback(() => {
+    setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);
+  }, []);
 
-      // Track chart interaction
-      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-        ...chartAnalyticsProperties,
-        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-          PERPS_EVENT_VALUE.INTERACTION_TYPE.CANDLE_PERIOD_CHANGED,
-        [PERPS_EVENT_PROPERTY.CANDLE_PERIOD]: newPeriod,
-      });
-
-      // Note: Chart will auto-zoom to latest candle when new data arrives (see useEffect below)
-    },
-    [chartAnalyticsProperties, market, track, dispatch],
-  );
+  const { handleCandlePeriodChange, handleChartError } =
+    usePerpsChartInteractions({
+      asset: market?.symbol,
+      chartAnalyticsProperties,
+      chartErrorMessage: 'Chart rendering error in market details view',
+      isAdvancedChartEnabled,
+      onAdvancedChartError: handleAdvancedChartError,
+    });
 
   const handleMorePress = useCallback(() => {
     setIsMoreCandlePeriodsVisible(true);
@@ -1357,33 +1345,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const handleFullscreenChartClose = useCallback(() => {
     setIsFullscreenChartVisible(false);
   }, []);
-
-  const handleChartError = useCallback(
-    (error?: Error | string) => {
-      const errorMessage =
-        typeof error === 'string'
-          ? error
-          : (error?.message ?? 'Chart rendering error in market details view');
-      // Log the error but don't block the UI
-      Logger.error(new Error(errorMessage), {
-        tags: { feature: PERPS_CONSTANTS.FeatureName },
-      });
-      track(MetaMetricsEvents.PERPS_ERROR, {
-        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.WARNING,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
-        [PERPS_EVENT_PROPERTY.SCREEN_NAME]:
-          PERPS_EVENT_VALUE.SCREEN_NAME.PERPS_MARKET_DETAILS,
-        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
-          PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
-        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-        ...chartAnalyticsProperties,
-      });
-      if (isAdvancedChartEnabled) {
-        setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);
-      }
-    },
-    [isAdvancedChartEnabled, market?.symbol, chartAnalyticsProperties, track],
-  );
 
   // Determine market hours content key based on current status - recalculated on each render to stay current
   const marketHoursContentKey = (() => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -150,6 +150,7 @@ import {
 import { willFlipPosition } from '../../utils/orderUtils';
 import { derivePerpsTradeAction } from '../../utils/deriveTradeAction';
 import { toPerpsEntryAttribution } from '../../utils/perpsAnalyticsAttribution';
+import { getPerpsChartLibrary } from '../../utils/chartAnalytics';
 import {
   calculateRoEForPrice,
   isStopLossSafeFromLiquidation,
@@ -195,11 +196,6 @@ interface OrderRouteParams {
   defaultMaxLeverage?: number;
 }
 
-const getChartLibrary = (isAdvancedChartEnabled: boolean) =>
-  isAdvancedChartEnabled
-    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
-    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
-
 interface PerpsOrderViewContentProps {
   hideTPSL?: boolean;
   defaultSzDecimals?: number;
@@ -235,7 +231,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     selectPerpsAdvancedChartEnabledFlag,
   );
   const chartLibrary =
-    route.params?.chartLibrary ?? getChartLibrary(isAdvancedChartEnabled);
+    route.params?.chartLibrary ?? getPerpsChartLibrary(isAdvancedChartEnabled);
   const fromTokenDetails = route.params?.fromTokenDetails ?? false;
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { fireEvent, within } from '@testing-library/react-native';
+import { Box, ButtonBase } from '@metamask/design-system-react-native';
+import { CandlePeriod } from '@metamask/perps-controller';
 import PerpsProMarketView from './';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
@@ -13,9 +15,84 @@ interface MockRouteParams {
   market?: { symbol: string; price?: string };
 }
 
+interface MockChartPanelProps {
+  symbol: string;
+  selectedCandlePeriod: CandlePeriod;
+  onMorePress: () => void;
+}
+
+interface MockCandlePeriodBottomSheetProps {
+  isVisible: boolean;
+  selectedPeriod: CandlePeriod;
+  onClose: () => void;
+  onPeriodChange: (period: CandlePeriod) => void;
+  testID?: string;
+}
+
 let mockRouteParams: MockRouteParams | undefined = {
   market: { symbol: 'BTC', price: '$90,000.00' },
 };
+const mockTrack = jest.fn();
+
+const mockPerpsProChartPanel = jest.fn(
+  ({ symbol, onMorePress }: MockChartPanelProps) => (
+    <>
+      <Box
+        testID={PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY}
+        twClassName="h-[76px]"
+      />
+      <Box
+        testID={PerpsProMarketViewSelectorsIDs.CHART_PANEL}
+        accessibilityLabel={symbol}
+      >
+        <Box
+          testID={PerpsProMarketViewSelectorsIDs.CHART_CONTENT}
+          twClassName="h-[344px]"
+        />
+        <ButtonBase testID="mock-pro-chart-more-button" onPress={onMorePress}>
+          <Box />
+        </ButtonBase>
+      </Box>
+    </>
+  ),
+);
+
+const mockCandlePeriodBottomSheet = jest.fn(
+  ({
+    isVisible,
+    onClose,
+    onPeriodChange,
+    testID,
+  }: MockCandlePeriodBottomSheetProps) =>
+    isVisible ? (
+      <Box testID={testID}>
+        <ButtonBase
+          testID="mock-more-period-option"
+          onPress={() => onPeriodChange(CandlePeriod.FourHours)}
+        >
+          <Box />
+        </ButtonBase>
+        <ButtonBase testID="mock-more-period-close" onPress={onClose}>
+          <Box />
+        </ButtonBase>
+      </Box>
+    ) : null,
+);
+
+jest.mock('./components/PerpsProChartPanel', () => ({
+  __esModule: true,
+  default: (props: MockChartPanelProps) => mockPerpsProChartPanel(props),
+}));
+
+jest.mock('../../components/PerpsCandlePeriodBottomSheet', () => ({
+  __esModule: true,
+  default: (props: MockCandlePeriodBottomSheetProps) =>
+    mockCandlePeriodBottomSheet(props),
+}));
+
+jest.mock('../../hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -49,6 +126,7 @@ const renderView = () =>
 
 describe('PerpsProMarketView', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockRouteParams = { market: { symbol: 'BTC', price: '$90,000.00' } };
   });
 
@@ -147,6 +225,52 @@ describe('PerpsProMarketView', () => {
     expect(
       getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  it('opens the More candle periods sheet from the chart', () => {
+    const { getByTestId } = renderView();
+
+    fireEvent.press(getByTestId('mock-pro-chart-more-button'));
+
+    expect(
+      getByTestId(PerpsProMarketViewSelectorsIDs.CHART_MORE_PERIODS_SHEET),
+    ).toBeOnTheScreen();
+  });
+
+  it('mounts the More candle periods sheet outside the scroll view', () => {
+    const { getByTestId } = renderView();
+    fireEvent.press(getByTestId('mock-pro-chart-more-button'));
+    const scrollView = getByTestId(PerpsProMarketViewSelectorsIDs.SCROLL_VIEW);
+
+    const nestedSheet = within(scrollView).queryByTestId(
+      PerpsProMarketViewSelectorsIDs.CHART_MORE_PERIODS_SHEET,
+    );
+
+    expect(nestedSheet).not.toBeOnTheScreen();
+  });
+
+  it('updates the chart period from the More candle periods sheet', () => {
+    const { getByTestId } = renderView();
+    fireEvent.press(getByTestId('mock-pro-chart-more-button'));
+
+    fireEvent.press(getByTestId('mock-more-period-option'));
+
+    expect(mockPerpsProChartPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectedCandlePeriod: CandlePeriod.FourHours,
+      }),
+    );
+  });
+
+  it('closes the More candle periods sheet', () => {
+    const { getByTestId, queryByTestId } = renderView();
+    fireEvent.press(getByTestId('mock-pro-chart-more-button'));
+
+    fireEvent.press(getByTestId('mock-more-period-close'));
+
+    expect(
+      queryByTestId(PerpsProMarketViewSelectorsIDs.CHART_MORE_PERIODS_SHEET),
+    ).not.toBeOnTheScreen();
   });
 
   it('updates the form to Market and closes the order type sheet', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { fireEvent, within } from '@testing-library/react-native';
 import { Box, ButtonBase } from '@metamask/design-system-react-native';
 import { CandlePeriod } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import PerpsProMarketView from './';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
@@ -13,6 +18,8 @@ import {
 
 interface MockRouteParams {
   market?: { symbol: string; price?: string };
+  source?: string;
+  source_section?: string;
 }
 
 interface MockChartPanelProps {
@@ -33,6 +40,9 @@ let mockRouteParams: MockRouteParams | undefined = {
   market: { symbol: 'BTC', price: '$90,000.00' },
 };
 const mockTrack = jest.fn();
+const mockUsePerpsEventTracking = jest.fn((_options?: unknown) => ({
+  track: mockTrack,
+}));
 
 const mockPerpsProChartPanel = jest.fn(
   ({ symbol, onMorePress }: MockChartPanelProps) => (
@@ -91,7 +101,8 @@ jest.mock('../../components/PerpsCandlePeriodBottomSheet', () => ({
 }));
 
 jest.mock('../../hooks/usePerpsEventTracking', () => ({
-  usePerpsEventTracking: () => ({ track: mockTrack }),
+  usePerpsEventTracking: (options?: unknown) =>
+    mockUsePerpsEventTracking(options),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -160,6 +171,24 @@ describe('PerpsProMarketView', () => {
       'edges',
       ['top', 'bottom', 'left', 'right'],
     );
+  });
+
+  it('tracks an attributed Pro market screen view', () => {
+    renderView();
+
+    expect(mockUsePerpsEventTracking).toHaveBeenCalledWith({
+      eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+      resetKey: expect.stringMatching(/^BTC:/),
+      conditions: [true],
+      properties: expect.objectContaining({
+        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+          PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
+        [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
+        [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+        [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: expect.any(String),
+        [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
+      }),
+    });
   });
 
   it('renders every top-level scaffold slot', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -6,33 +6,29 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import {
-  CandlePeriod,
-  PERPS_CONSTANTS,
   TimeDuration,
   getPerpsDisplaySymbol,
   type OrderType,
 } from '@metamask/perps-controller';
-import {
-  PERPS_EVENT_PROPERTY,
-  PERPS_EVENT_VALUE,
-} from '@metamask/perps-controller/constants';
+import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
-import { setPerpsChartPreferredCandlePeriod } from '../../../../../actions/settings';
 import { useStyles } from '../../../../../component-library/hooks';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import Logger from '../../../../../util/Logger';
 import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
 import PerpsCandlePeriodBottomSheet from '../../components/PerpsCandlePeriodBottomSheet';
 import PerpsOrderTypeBottomSheetView from '../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
-import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import { usePerpsChartInteractions } from '../../hooks/usePerpsChartInteractions';
 import { selectPerpsChartPreferredCandlePeriod } from '../../selectors/chartPreferences';
 import { selectPerpsAdvancedChartEnabledFlag } from '../../selectors/featureFlags';
 import type { PerpsStackParamList } from '../../types/navigation';
+import {
+  getPerpsChartAnalyticsProperties,
+  getPerpsChartLibrary,
+} from '../../utils/chartAnalytics';
 import PerpsProChartPanel from './components/PerpsProChartPanel';
 import PerpsProMarketHeader from './components/PerpsProMarketHeader';
 import PerpsProMarketLayout from './components/PerpsProMarketLayout';
@@ -41,16 +37,6 @@ import PerpsProOrderFormPanel from './components/PerpsProOrderFormPanel';
 import PerpsProPositionsPanel from './components/PerpsProPositionsPanel';
 import PerpsProStatsBar from './components/PerpsProStatsBar';
 import { createStyles } from './PerpsProMarketView.styles';
-
-const getChartLibrary = (isAdvancedChartEnabled: boolean) =>
-  isAdvancedChartEnabled
-    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
-    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
-
-const getChartAnalyticsProperties = (chartLibrary: string) => ({
-  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
-  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
-});
 
 /**
  * Pro-mode replacement for `PerpsMarketDetailsView`.
@@ -63,8 +49,6 @@ const getChartAnalyticsProperties = (chartLibrary: string) => ({
  */
 const PerpsProMarketView = () => {
   const { styles } = useStyles(createStyles, {});
-  const dispatch = useDispatch();
-  const { track } = usePerpsEventTracking();
   const route =
     useRoute<RouteProp<PerpsStackParamList, 'PerpsMarketDetails'>>();
   const market = route.params?.market;
@@ -84,7 +68,7 @@ const PerpsProMarketView = () => {
   const isAdvancedChartEnabled = useSelector(
     selectPerpsAdvancedChartEnabledFlag,
   );
-  const configuredChartLibrary = getChartLibrary(isAdvancedChartEnabled);
+  const configuredChartLibrary = getPerpsChartLibrary(isAdvancedChartEnabled);
   const [effectiveChartLibrary, setEffectiveChartLibrary] = useState(
     configuredChartLibrary,
   );
@@ -112,51 +96,22 @@ const PerpsProMarketView = () => {
   }, [configuredChartLibrary, market?.symbol]);
 
   const chartAnalyticsProperties = useMemo(
-    () => getChartAnalyticsProperties(effectiveChartLibrary),
+    () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
     [effectiveChartLibrary],
   );
 
-  const handleCandlePeriodChange = useCallback(
-    (newPeriod: CandlePeriod) => {
-      dispatch(setPerpsChartPreferredCandlePeriod(newPeriod));
-      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-        ...chartAnalyticsProperties,
-        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-          PERPS_EVENT_VALUE.INTERACTION_TYPE.CANDLE_PERIOD_CHANGED,
-        [PERPS_EVENT_PROPERTY.CANDLE_PERIOD]: newPeriod,
-      });
-    },
-    [chartAnalyticsProperties, dispatch, market?.symbol, track],
-  );
+  const handleAdvancedChartError = useCallback(() => {
+    setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);
+  }, []);
 
-  const handleChartError = useCallback(
-    (error?: Error | string) => {
-      const errorMessage =
-        typeof error === 'string'
-          ? error
-          : (error?.message ?? 'Chart rendering error in Pro market view');
-
-      Logger.error(new Error(errorMessage), {
-        tags: { feature: PERPS_CONSTANTS.FeatureName },
-      });
-      track(MetaMetricsEvents.PERPS_ERROR, {
-        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.WARNING,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
-        [PERPS_EVENT_PROPERTY.SCREEN_NAME]:
-          PERPS_EVENT_VALUE.SCREEN_NAME.PERPS_MARKET_DETAILS,
-        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
-          PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
-        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-        ...chartAnalyticsProperties,
-      });
-
-      if (isAdvancedChartEnabled) {
-        setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);
-      }
-    },
-    [chartAnalyticsProperties, isAdvancedChartEnabled, market?.symbol, track],
-  );
+  const { handleCandlePeriodChange, handleChartError } =
+    usePerpsChartInteractions({
+      asset: market?.symbol,
+      chartAnalyticsProperties,
+      chartErrorMessage: 'Chart rendering error in Pro market view',
+      isAdvancedChartEnabled,
+      onAdvancedChartError: handleAdvancedChartError,
+    });
 
   if (!market?.symbol) {
     return (

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -10,7 +10,10 @@ import {
   getPerpsDisplaySymbol,
   type OrderType,
 } from '@metamask/perps-controller';
-import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView } from 'react-native';
@@ -18,10 +21,12 @@ import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
 import PerpsCandlePeriodBottomSheet from '../../components/PerpsCandlePeriodBottomSheet';
 import PerpsOrderTypeBottomSheetView from '../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
 import { usePerpsChartInteractions } from '../../hooks/usePerpsChartInteractions';
+import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { selectPerpsChartPreferredCandlePeriod } from '../../selectors/chartPreferences';
 import { selectPerpsAdvancedChartEnabledFlag } from '../../selectors/featureFlags';
 import type { PerpsStackParamList } from '../../types/navigation';
@@ -52,6 +57,8 @@ const PerpsProMarketView = () => {
   const route =
     useRoute<RouteProp<PerpsStackParamList, 'PerpsMarketDetails'>>();
   const market = route.params?.market;
+  const source = route.params?.source;
+  const sourceSection = route.params?.source_section;
   const [isOrderBookCollapsed, setIsOrderBookCollapsed] = useState(false);
 
   const handleCollapseOrderBook = useCallback(() => {
@@ -99,6 +106,28 @@ const PerpsProMarketView = () => {
     () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
     [effectiveChartLibrary],
   );
+
+  const screenViewedProperties = useMemo(
+    () => ({
+      [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+        PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
+      [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
+      [PERPS_EVENT_PROPERTY.SOURCE]:
+        source || PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+      ...chartAnalyticsProperties,
+      ...(sourceSection && {
+        [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: sourceSection,
+      }),
+    }),
+    [chartAnalyticsProperties, market?.symbol, source, sourceSection],
+  );
+
+  usePerpsEventTracking({
+    eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+    resetKey: `${market?.symbol || ''}:${effectiveChartLibrary}`,
+    conditions: [Boolean(market?.symbol)],
+    properties: screenViewedProperties,
+  });
 
   const handleAdvancedChartError = useCallback(() => {
     setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -6,27 +6,51 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import {
+  CandlePeriod,
+  PERPS_CONSTANTS,
+  TimeDuration,
   getPerpsDisplaySymbol,
   type OrderType,
 } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
 import { useRoute, type RouteProp } from '@react-navigation/native';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
+import { setPerpsChartPreferredCandlePeriod } from '../../../../../actions/settings';
 import { useStyles } from '../../../../../component-library/hooks';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import Logger from '../../../../../util/Logger';
 import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
+import PerpsCandlePeriodBottomSheet from '../../components/PerpsCandlePeriodBottomSheet';
 import PerpsOrderTypeBottomSheetView from '../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
+import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import { selectPerpsChartPreferredCandlePeriod } from '../../selectors/chartPreferences';
+import { selectPerpsAdvancedChartEnabledFlag } from '../../selectors/featureFlags';
 import type { PerpsStackParamList } from '../../types/navigation';
 import PerpsProChartPanel from './components/PerpsProChartPanel';
 import PerpsProMarketHeader from './components/PerpsProMarketHeader';
 import PerpsProMarketLayout from './components/PerpsProMarketLayout';
-import PerpsProMarketSummary from './components/PerpsProMarketSummary';
 import PerpsProOrderBookPanel from './components/PerpsProOrderBookPanel';
 import PerpsProOrderFormPanel from './components/PerpsProOrderFormPanel';
 import PerpsProPositionsPanel from './components/PerpsProPositionsPanel';
 import PerpsProStatsBar from './components/PerpsProStatsBar';
 import { createStyles } from './PerpsProMarketView.styles';
+
+const getChartLibrary = (isAdvancedChartEnabled: boolean) =>
+  isAdvancedChartEnabled
+    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
+    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
+
+const getChartAnalyticsProperties = (chartLibrary: string) => ({
+  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
+  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
+});
 
 /**
  * Pro-mode replacement for `PerpsMarketDetailsView`.
@@ -39,6 +63,8 @@ import { createStyles } from './PerpsProMarketView.styles';
  */
 const PerpsProMarketView = () => {
   const { styles } = useStyles(createStyles, {});
+  const dispatch = useDispatch();
+  const { track } = usePerpsEventTracking();
   const route =
     useRoute<RouteProp<PerpsStackParamList, 'PerpsMarketDetails'>>();
   const market = route.params?.market;
@@ -51,6 +77,19 @@ const PerpsProMarketView = () => {
   const handleExpandOrderBook = useCallback(() => {
     setIsOrderBookCollapsed(false);
   }, []);
+
+  const selectedCandlePeriod = useSelector(
+    selectPerpsChartPreferredCandlePeriod,
+  );
+  const isAdvancedChartEnabled = useSelector(
+    selectPerpsAdvancedChartEnabledFlag,
+  );
+  const configuredChartLibrary = getChartLibrary(isAdvancedChartEnabled);
+  const [effectiveChartLibrary, setEffectiveChartLibrary] = useState(
+    configuredChartLibrary,
+  );
+  const [isMoreCandlePeriodsVisible, setIsMoreCandlePeriodsVisible] =
+    useState(false);
 
   const [orderType, setOrderType] = useState<OrderType>('limit');
   const [isOrderTypeSheetVisible, setIsOrderTypeSheetVisible] = useState(false);
@@ -67,6 +106,57 @@ const PerpsProMarketView = () => {
     setOrderType(newOrderType);
     setIsOrderTypeSheetVisible(false);
   }, []);
+
+  useEffect(() => {
+    setEffectiveChartLibrary(configuredChartLibrary);
+  }, [configuredChartLibrary, market?.symbol]);
+
+  const chartAnalyticsProperties = useMemo(
+    () => getChartAnalyticsProperties(effectiveChartLibrary),
+    [effectiveChartLibrary],
+  );
+
+  const handleCandlePeriodChange = useCallback(
+    (newPeriod: CandlePeriod) => {
+      dispatch(setPerpsChartPreferredCandlePeriod(newPeriod));
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
+        ...chartAnalyticsProperties,
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.CANDLE_PERIOD_CHANGED,
+        [PERPS_EVENT_PROPERTY.CANDLE_PERIOD]: newPeriod,
+      });
+    },
+    [chartAnalyticsProperties, dispatch, market?.symbol, track],
+  );
+
+  const handleChartError = useCallback(
+    (error?: Error | string) => {
+      const errorMessage =
+        typeof error === 'string'
+          ? error
+          : (error?.message ?? 'Chart rendering error in Pro market view');
+
+      Logger.error(new Error(errorMessage), {
+        tags: { feature: PERPS_CONSTANTS.FeatureName },
+      });
+      track(MetaMetricsEvents.PERPS_ERROR, {
+        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.WARNING,
+        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
+        [PERPS_EVENT_PROPERTY.SCREEN_NAME]:
+          PERPS_EVENT_VALUE.SCREEN_NAME.PERPS_MARKET_DETAILS,
+        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+          PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
+        [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
+        ...chartAnalyticsProperties,
+      });
+
+      if (isAdvancedChartEnabled) {
+        setEffectiveChartLibrary(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT);
+      }
+    },
+    [chartAnalyticsProperties, isAdvancedChartEnabled, market?.symbol, track],
+  );
 
   if (!market?.symbol) {
     return (
@@ -111,8 +201,15 @@ const PerpsProMarketView = () => {
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
       >
-        <PerpsProMarketSummary />
-        <PerpsProChartPanel />
+        <PerpsProChartPanel
+          symbol={market.symbol}
+          selectedCandlePeriod={selectedCandlePeriod}
+          isAdvancedChartEnabled={isAdvancedChartEnabled}
+          effectiveChartLibrary={effectiveChartLibrary}
+          onCandlePeriodChange={handleCandlePeriodChange}
+          onMorePress={() => setIsMoreCandlePeriodsVisible(true)}
+          onChartError={handleChartError}
+        />
         <PerpsProStatsBar />
         <PerpsProMarketLayout
           isOrderBookCollapsed={isOrderBookCollapsed}
@@ -134,6 +231,16 @@ const PerpsProMarketView = () => {
         <SectionDivider />
         <PerpsProPositionsPanel />
       </ScrollView>
+      <PerpsCandlePeriodBottomSheet
+        isVisible={isMoreCandlePeriodsVisible}
+        onClose={() => setIsMoreCandlePeriodsVisible(false)}
+        selectedPeriod={selectedCandlePeriod}
+        selectedDuration={TimeDuration.YearToDate}
+        onPeriodChange={handleCandlePeriodChange}
+        showAllPeriods
+        asset={market.symbol}
+        testID={PerpsProMarketViewSelectorsIDs.CHART_MORE_PERIODS_SHEET}
+      />
       <PerpsOrderTypeBottomSheetView
         isVisible={isOrderTypeSheetVisible}
         onClose={handleOrderTypeSheetClose}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -1,0 +1,439 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  Box,
+  FilterButtonVariant,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import {
+  CandlePeriod,
+  type CandleData,
+  type Position,
+} from '@metamask/perps-controller';
+import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
+import type { PerpsAdvancedChartProps } from '../../../components/PerpsAdvancedChart/PerpsAdvancedChart';
+import PerpsCandlePeriodSelector from '../../../components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector';
+import type { PerpsChartFullscreenModalProps } from '../../../components/PerpsChartFullscreenModal/PerpsChartFullscreenModal';
+import type { OhlcData } from '../../../components/TradingViewChart';
+import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import PerpsProChartPanel from './PerpsProChartPanel';
+
+interface MockLivePriceHeaderProps {
+  currentPrice: number;
+  testIDPrice?: string;
+  testIDChange?: string;
+}
+
+interface MockTradingViewChartProps {
+  candleData?: CandleData | null;
+  tpslLines?: {
+    currentPrice?: string;
+  };
+  onOhlcDataChange?: (data: OhlcData | null) => void;
+  testID?: string;
+}
+
+const MOCK_CANDLE_DATA: CandleData = {
+  symbol: 'BTC',
+  interval: CandlePeriod.FifteenMinutes,
+  candles: [
+    {
+      time: 1700000000000,
+      open: '50000',
+      high: '51000',
+      low: '49000',
+      close: '50500',
+      volume: '100',
+    },
+  ],
+};
+
+const MOCK_POSITION: Position = {
+  symbol: 'BTC',
+  size: '1',
+  entryPrice: '50000',
+  positionValue: '50000',
+  unrealizedPnl: '500',
+  marginUsed: '5000',
+  leverage: { type: 'isolated', value: 10 },
+  liquidationPrice: '45000',
+  maxLeverage: 40,
+  returnOnEquity: '10',
+  cumulativeFunding: { allTime: '0', sinceChange: '0', sinceOpen: '0' },
+  takeProfitPrice: '55000',
+  stopLossPrice: '47000',
+  takeProfitCount: 1,
+  stopLossCount: 1,
+};
+
+const mockTrack = jest.fn();
+const mockOnCandlePeriodChange = jest.fn();
+const mockOnMorePress = jest.fn();
+const mockOnChartError = jest.fn();
+const mockFetchMoreHistory = jest.fn();
+const mockPerpsAdvancedChart = jest.fn((_props: PerpsAdvancedChartProps) => (
+  <Box testID="mock-perps-advanced-chart" />
+));
+const mockTradingViewChart = jest.fn((props: MockTradingViewChartProps) => (
+  <Box testID={props.testID ?? 'mock-trading-view-chart'} />
+));
+const mockLivePriceHeader = jest.fn(
+  ({ currentPrice, testIDPrice, testIDChange }: MockLivePriceHeaderProps) => (
+    <>
+      <Box testID={testIDPrice} accessibilityLabel={String(currentPrice)} />
+      <Box testID={testIDChange} />
+    </>
+  ),
+);
+const mockFullscreenModal = jest.fn(
+  ({ isVisible }: PerpsChartFullscreenModalProps) =>
+    isVisible ? <Box testID="mock-perps-fullscreen-chart" /> : null,
+);
+const mockPerpsOHLCVBar = ({ testID }: { testID?: string }) => (
+  <Box testID={testID} />
+);
+const mockPerpsPriceDeviationWarning = ({ testID }: { testID?: string }) => (
+  <Box testID={testID} />
+);
+const mockPerpsServiceInterruptionBanner = ({
+  testID,
+}: {
+  testID?: string;
+}) => <Box testID={testID} />;
+const mockUsePerpsLiveCandles = jest.fn();
+const mockUseHasExistingPosition = jest.fn();
+const mockUsePerpsMarketData = jest.fn();
+const mockUsePriceDeviation = jest.fn();
+
+jest.mock('../../../hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+jest.mock('../../../hooks/stream/usePerpsLiveCandles', () => ({
+  usePerpsLiveCandles: (params: unknown) => mockUsePerpsLiveCandles(params),
+}));
+
+jest.mock('../../../hooks/useHasExistingPosition', () => ({
+  useHasExistingPosition: (params: unknown) =>
+    mockUseHasExistingPosition(params),
+}));
+
+jest.mock('../../../hooks/useIsPriceDeviatedAboveThreshold', () => ({
+  useIsPriceDeviatedAboveThreshold: (symbol: string) =>
+    mockUsePriceDeviation(symbol),
+}));
+
+jest.mock('../../../hooks', () => ({
+  usePerpsMarketData: (params: unknown) => mockUsePerpsMarketData(params),
+}));
+
+jest.mock('../../../components/PerpsAdvancedChart/PerpsAdvancedChart', () => ({
+  __esModule: true,
+  default: (props: PerpsAdvancedChartProps) => mockPerpsAdvancedChart(props),
+}));
+
+jest.mock('../../../components/TradingViewChart', () => ({
+  __esModule: true,
+  default: (props: MockTradingViewChartProps) => mockTradingViewChart(props),
+}));
+
+jest.mock('../../../components/LivePriceDisplay/LivePriceHeader', () => ({
+  __esModule: true,
+  default: (props: MockLivePriceHeaderProps) => mockLivePriceHeader(props),
+}));
+
+jest.mock(
+  '../../../components/PerpsChartFullscreenModal/PerpsChartFullscreenModal',
+  () => ({
+    __esModule: true,
+    default: (props: PerpsChartFullscreenModalProps) =>
+      mockFullscreenModal(props),
+  }),
+);
+
+jest.mock('../../../components/PerpsOHLCVBar', () => ({
+  __esModule: true,
+  default: (props: { testID?: string }) => mockPerpsOHLCVBar(props),
+}));
+
+jest.mock('../../../components/PerpsPriceDeviationWarning', () => ({
+  __esModule: true,
+  default: (props: { testID?: string }) =>
+    mockPerpsPriceDeviationWarning(props),
+}));
+
+jest.mock('../../../components/PerpsServiceInterruptionBanner', () => ({
+  __esModule: true,
+  default: (props: { testID?: string }) =>
+    mockPerpsServiceInterruptionBanner(props),
+}));
+
+const getLastAdvancedChartProps = () => {
+  const lastCall = mockPerpsAdvancedChart.mock.calls.at(-1);
+  if (!lastCall) {
+    throw new Error('PerpsAdvancedChart was not rendered');
+  }
+  return lastCall[0];
+};
+
+const getLastFullscreenModalProps = () => {
+  const lastCall = mockFullscreenModal.mock.calls.at(-1);
+  if (!lastCall) {
+    throw new Error('PerpsChartFullscreenModal was not rendered');
+  }
+  return lastCall[0];
+};
+
+type PerpsProChartPanelProps = React.ComponentProps<typeof PerpsProChartPanel>;
+
+const renderChartPanel = (overrides: Partial<PerpsProChartPanelProps> = {}) =>
+  render(
+    <PerpsProChartPanel
+      symbol="BTC"
+      selectedCandlePeriod={CandlePeriod.FifteenMinutes}
+      isAdvancedChartEnabled
+      effectiveChartLibrary={PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED}
+      onCandlePeriodChange={mockOnCandlePeriodChange}
+      onMorePress={mockOnMorePress}
+      onChartError={mockOnChartError}
+      {...overrides}
+    />,
+  );
+
+describe('PerpsProChartPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsLiveCandles.mockReturnValue({
+      candleData: MOCK_CANDLE_DATA,
+      isLoading: false,
+      hasHistoricalData: true,
+      fetchMoreHistory: mockFetchMoreHistory,
+    });
+    mockUseHasExistingPosition.mockReturnValue({
+      existingPosition: null,
+    });
+    mockUsePerpsMarketData.mockReturnValue({
+      marketData: { szDecimals: 2 },
+    });
+    mockUsePriceDeviation.mockReturnValue({
+      isDeviatedAboveThreshold: false,
+      isLoading: false,
+    });
+  });
+
+  it('renders the Advanced Chart path when its feature flag is enabled', () => {
+    renderChartPanel();
+
+    expect(screen.getByTestId('mock-perps-advanced-chart')).toBeOnTheScreen();
+    expect(mockPerpsAdvancedChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: 'BTC',
+        interval: CandlePeriod.FifteenMinutes,
+        fallbackCandleData: MOCK_CANDLE_DATA,
+      }),
+    );
+  });
+
+  it('uses the 344px Figma chart height', () => {
+    renderChartPanel();
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_PANEL),
+    ).toHaveStyle({ height: 344 });
+  });
+
+  it('uses the 76px Figma market-summary height', () => {
+    renderChartPanel();
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY),
+    ).toHaveStyle({ height: 76 });
+  });
+
+  it('renders the Lightweight Chart path when its feature flag is disabled', () => {
+    renderChartPanel({ isAdvancedChartEnabled: false });
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_LIGHTWEIGHT),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a skeleton while Lightweight candle history is unavailable', () => {
+    mockUsePerpsLiveCandles.mockReturnValue({
+      candleData: null,
+      isLoading: true,
+      hasHistoricalData: false,
+      fetchMoreHistory: mockFetchMoreHistory,
+    });
+
+    renderChartPanel({ isAdvancedChartEnabled: false });
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_SKELETON),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the configured Pro candle periods', () => {
+    renderChartPanel();
+
+    expect(screen.getByText('1m')).toBeOnTheScreen();
+    expect(screen.getByText('5m')).toBeOnTheScreen();
+    expect(screen.getByText('15m')).toBeOnTheScreen();
+    expect(screen.getByText('1h')).toBeOnTheScreen();
+    expect(screen.getByText('1d')).toBeOnTheScreen();
+  });
+
+  it('left-aligns the configured Pro candle periods', () => {
+    renderChartPanel();
+
+    expect(
+      screen.UNSAFE_getByType(PerpsCandlePeriodSelector).props.groupTwClassName,
+    ).toBe('gap-2 justify-start');
+  });
+
+  it('uses the Figma compact candle-period appearance', () => {
+    renderChartPanel();
+
+    const selector = screen.UNSAFE_getByType(PerpsCandlePeriodSelector);
+
+    expect(selector.props.filterVariant).toBe(FilterButtonVariant.Secondary);
+    expect(selector.props.periodButtonTwClassName).toBe('h-7 rounded px-1');
+    expect(selector.props.moreButtonTwClassName).toBe('h-7 rounded px-1');
+    expect(selector.props.textVariant).toBe(TextVariant.BodyXs);
+  });
+
+  it('forwards a selected Pro candle period', () => {
+    renderChartPanel();
+
+    fireEvent.press(screen.getByText('1h'));
+
+    expect(mockOnCandlePeriodChange).toHaveBeenCalledWith(CandlePeriod.OneHour);
+  });
+
+  it('requests the More candle periods sheet', () => {
+    renderChartPanel();
+
+    fireEvent.press(
+      screen.getByTestId(
+        `${PerpsProMarketViewSelectorsIDs.CHART_PERIOD_SELECTOR}-more-button`,
+      ),
+    );
+
+    expect(mockOnMorePress).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the existing fullscreen chart modal', () => {
+    renderChartPanel();
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON,
+      ),
+    );
+
+    expect(screen.getByTestId('mock-perps-fullscreen-chart')).toBeOnTheScreen();
+  });
+
+  it('closes the existing fullscreen chart modal', () => {
+    renderChartPanel();
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON,
+      ),
+    );
+    const fullscreenModalProps = getLastFullscreenModalProps();
+
+    act(() => {
+      fullscreenModalProps.onClose();
+    });
+
+    expect(
+      screen.queryByTestId('mock-perps-fullscreen-chart'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders the latest candle price in the market summary', () => {
+    renderChartPanel();
+
+    expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
+      expect.objectContaining({ currentPrice: 50500 }),
+    );
+  });
+
+  it('synchronizes the market summary with the Advanced Chart price', () => {
+    renderChartPanel();
+
+    act(() => {
+      getLastAdvancedChartProps().onLatestPriceChange?.(51000);
+    });
+
+    expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
+      expect.objectContaining({ currentPrice: 51000 }),
+    );
+  });
+
+  it('renders OHLCV values reported by the active chart', () => {
+    const ohlcData: OhlcData = {
+      time: 1700000000000,
+      open: '50000',
+      high: '51000',
+      low: '49000',
+      close: '50500',
+      volume: '100',
+    };
+    renderChartPanel();
+
+    act(() => {
+      getLastAdvancedChartProps().onCrosshairDataChange?.(ohlcData);
+    });
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_OHLCV),
+    ).toBeOnTheScreen();
+  });
+
+  it('passes position overlays to the active chart', () => {
+    mockUseHasExistingPosition.mockReturnValue({
+      existingPosition: MOCK_POSITION,
+    });
+
+    renderChartPanel();
+
+    expect(mockPerpsAdvancedChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        positionSize: '1',
+        tpslLines: expect.objectContaining({
+          entryPrice: '50000',
+          takeProfitPrice: '55000',
+          stopLossPrice: '47000',
+          liquidationPrice: '45000',
+        }),
+      }),
+    );
+  });
+
+  it('renders the price-deviation warning for a halted market', () => {
+    mockUsePriceDeviation.mockReturnValue({
+      isDeviatedAboveThreshold: true,
+      isLoading: false,
+    });
+
+    renderChartPanel();
+
+    expect(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_PRICE_DEVIATION_WARNING,
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('forwards an Advanced Chart rendering error', () => {
+    renderChartPanel();
+
+    act(() => {
+      getLastAdvancedChartProps().onError?.('WebView failed');
+    });
+
+    expect(mockOnChartError).toHaveBeenCalledWith('WebView failed');
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -1,31 +1,295 @@
-import { Box } from '@metamask/design-system-react-native';
-import React from 'react';
-import { StyleSheet } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  FilterButtonVariant,
+  IconName,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { CandlePeriod, TimeDuration } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
+import ComponentErrorBoundary from '../../../../ComponentErrorBoundary';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import { PERPS_CHART_CONFIG } from '../../../constants/chartConfig';
+import { usePerpsMarketData } from '../../../hooks';
+import { usePerpsEventTracking } from '../../../hooks/usePerpsEventTracking';
+import { useHasExistingPosition } from '../../../hooks/useHasExistingPosition';
+import { useIsPriceDeviatedAboveThreshold } from '../../../hooks/useIsPriceDeviatedAboveThreshold';
+import { usePerpsLiveCandles } from '../../../hooks/stream/usePerpsLiveCandles';
+import PerpsAdvancedChart from '../../../components/PerpsAdvancedChart/PerpsAdvancedChart';
+import PerpsCandlePeriodSelector, {
+  type PerpsCandlePeriodOption,
+} from '../../../components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector';
+import PerpsChartFullscreenModal from '../../../components/PerpsChartFullscreenModal/PerpsChartFullscreenModal';
+import PerpsOHLCVBar from '../../../components/PerpsOHLCVBar';
+import PerpsPriceDeviationWarning from '../../../components/PerpsPriceDeviationWarning';
+import PerpsServiceInterruptionBanner from '../../../components/PerpsServiceInterruptionBanner';
+import TradingViewChart, {
+  type OhlcData,
+  type TradingViewChartRef,
+} from '../../../components/TradingViewChart';
+import PerpsProMarketSummary from './PerpsProMarketSummary';
 
-const styles = StyleSheet.create({
-  chart: {
-    height: 344,
-  },
+const PRO_CHART_HEIGHT = 288;
+const PRO_CANDLE_PERIODS = [
+  { label: '1m', value: CandlePeriod.OneMinute },
+  { label: '5m', value: CandlePeriod.FiveMinutes },
+  { label: '15m', value: CandlePeriod.FifteenMinutes },
+  { label: '1h', value: CandlePeriod.OneHour },
+  { label: '1d', value: CandlePeriod.OneDay },
+] as const satisfies readonly PerpsCandlePeriodOption[];
+
+const getChartAnalyticsProperties = (chartLibrary: string) => ({
+  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
+  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
 });
 
+interface PerpsProChartPanelProps {
+  symbol: string;
+  selectedCandlePeriod: CandlePeriod;
+  isAdvancedChartEnabled: boolean;
+  effectiveChartLibrary: string;
+  onCandlePeriodChange: (period: CandlePeriod) => void;
+  onMorePress: () => void;
+  onChartError: (error?: Error | string) => void;
+}
+
 /**
- * Pro-mode chart area placeholder.
- *
- * Scaffold only: empty container sized to the Figma chart height. Real chart
- * content is added by the chart capability.
+ * Pro Token + Chart section composed from the existing Lite chart stack.
  */
-const PerpsProChartPanel = () => (
-  <Box
-    testID={PerpsProMarketViewSelectorsIDs.CHART_PANEL}
-    twClassName="px-4 py-2"
-  >
-    <Box
-      testID={PerpsProMarketViewSelectorsIDs.CHART_CONTENT}
-      twClassName="rounded-xl bg-muted"
-      style={styles.chart}
-    />
-  </Box>
-);
+const PerpsProChartPanel = ({
+  symbol,
+  selectedCandlePeriod,
+  isAdvancedChartEnabled,
+  effectiveChartLibrary,
+  onCandlePeriodChange,
+  onMorePress,
+  onChartError,
+}: PerpsProChartPanelProps) => {
+  const { track } = usePerpsEventTracking();
+  const [isFullscreenChartVisible, setIsFullscreenChartVisible] =
+    useState(false);
+  const [ohlcData, setOhlcData] = useState<OhlcData | null>(null);
+  const [advancedChartCurrentPrice, setAdvancedChartCurrentPrice] = useState<
+    number | undefined
+  >(undefined);
+  const chartRef = useRef<TradingViewChartRef>(null);
+  const previousIntervalRef = useRef<CandlePeriod | null>(null);
+  const visibleCandleCount = PERPS_CHART_CONFIG.CANDLE_COUNT.DEFAULT;
+
+  useEffect(() => {
+    setAdvancedChartCurrentPrice(undefined);
+  }, [isAdvancedChartEnabled, selectedCandlePeriod, symbol]);
+
+  const chartAnalyticsProperties = useMemo(
+    () => getChartAnalyticsProperties(effectiveChartLibrary),
+    [effectiveChartLibrary],
+  );
+
+  const { candleData, hasHistoricalData, fetchMoreHistory } =
+    usePerpsLiveCandles({
+      symbol,
+      interval: selectedCandlePeriod,
+      duration: TimeDuration.YearToDate,
+      throttleMs: 1000,
+    });
+  const { existingPosition } = useHasExistingPosition({
+    asset: symbol,
+    loadOnMount: true,
+  });
+  const { marketData } = usePerpsMarketData({ asset: symbol });
+  const {
+    isDeviatedAboveThreshold: isTradingHalted,
+    isLoading: isLoadingTradingHalted,
+  } = useIsPriceDeviatedAboveThreshold(symbol);
+
+  const chartCurrentPrice = useMemo(() => {
+    const lastCandle = candleData?.candles.at(-1);
+    return lastCandle?.close ? Number.parseFloat(lastCandle.close) : 0;
+  }, [candleData]);
+  const syncedChartCurrentPrice =
+    isAdvancedChartEnabled && advancedChartCurrentPrice !== undefined
+      ? advancedChartCurrentPrice
+      : chartCurrentPrice;
+
+  const tpslLines = useMemo(() => {
+    const currentPrice =
+      syncedChartCurrentPrice > 0
+        ? syncedChartCurrentPrice.toString()
+        : undefined;
+
+    if (!existingPosition) {
+      return currentPrice ? { currentPrice } : undefined;
+    }
+
+    return {
+      entryPrice: existingPosition.entryPrice,
+      takeProfitPrice: existingPosition.takeProfitPrice,
+      stopLossPrice: existingPosition.stopLossPrice,
+      liquidationPrice: existingPosition.liquidationPrice || undefined,
+      currentPrice,
+    };
+  }, [existingPosition, syncedChartCurrentPrice]);
+
+  useEffect(() => {
+    const hasIntervalChanged =
+      previousIntervalRef.current !== selectedCandlePeriod;
+
+    if (hasIntervalChanged && candleData?.interval === selectedCandlePeriod) {
+      chartRef.current?.zoomToLatestCandle(visibleCandleCount);
+      previousIntervalRef.current = selectedCandlePeriod;
+    }
+  }, [candleData, selectedCandlePeriod, visibleCandleCount]);
+
+  const handleFullscreenChartOpen = useCallback(() => {
+    setIsFullscreenChartVisible(true);
+    track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+        PERPS_EVENT_VALUE.INTERACTION_TYPE.FULL_SCREEN_CHART,
+      [PERPS_EVENT_PROPERTY.ASSET]: symbol,
+      ...chartAnalyticsProperties,
+    });
+  }, [chartAnalyticsProperties, symbol, track]);
+
+  return (
+    <>
+      <PerpsProMarketSummary
+        symbol={symbol}
+        currentPrice={syncedChartCurrentPrice}
+      />
+      <Box
+        testID={PerpsProMarketViewSelectorsIDs.CHART_PANEL}
+        twClassName="my-2 h-[344px] px-4 py-2"
+      >
+        <Box
+          testID={PerpsProMarketViewSelectorsIDs.CHART_CONTENT}
+          twClassName="flex-1 gap-2"
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+          >
+            <PerpsCandlePeriodSelector
+              selectedPeriod={selectedCandlePeriod}
+              onPeriodChange={onCandlePeriodChange}
+              onMorePress={onMorePress}
+              visiblePeriods={PRO_CANDLE_PERIODS}
+              twClassName="flex-1 py-0"
+              groupTwClassName="gap-2 justify-start"
+              filterVariant={FilterButtonVariant.Secondary}
+              periodButtonTwClassName="h-7 rounded px-1"
+              moreButtonTwClassName="h-7 rounded px-1"
+              textVariant={TextVariant.BodyXs}
+              testID={PerpsProMarketViewSelectorsIDs.CHART_PERIOD_SELECTOR}
+            />
+            <ButtonIcon
+              iconName={IconName.Expand}
+              size={ButtonIconSize.Sm}
+              onPress={handleFullscreenChartOpen}
+              testID={PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON}
+              accessibilityLabel={strings(
+                'perps.market_details.fullscreen_chart',
+              )}
+            />
+          </Box>
+          <ComponentErrorBoundary
+            componentLabel="PerpsProMarketChart"
+            onError={onChartError}
+          >
+            <Box twClassName="relative flex-1">
+              {ohlcData ? (
+                <Box twClassName="absolute left-0 right-0 top-0 z-10">
+                  <PerpsOHLCVBar
+                    open={ohlcData.open}
+                    high={ohlcData.high}
+                    low={ohlcData.low}
+                    close={ohlcData.close}
+                    volume={ohlcData.volume}
+                    testID={PerpsProMarketViewSelectorsIDs.CHART_OHLCV}
+                  />
+                </Box>
+              ) : null}
+              {isAdvancedChartEnabled ? (
+                <PerpsAdvancedChart
+                  symbol={symbol}
+                  interval={selectedCandlePeriod}
+                  visibleCandleCount={visibleCandleCount}
+                  height={PRO_CHART_HEIGHT}
+                  tpslLines={tpslLines}
+                  positionSize={existingPosition?.size}
+                  szDecimals={marketData?.szDecimals}
+                  onCrosshairDataChange={setOhlcData}
+                  onLatestPriceChange={setAdvancedChartCurrentPrice}
+                  onError={onChartError}
+                  fallbackCandleData={candleData}
+                  fallbackFetchMoreHistory={fetchMoreHistory}
+                  paginationDuration={TimeDuration.YearToDate}
+                />
+              ) : hasHistoricalData ? (
+                <TradingViewChart
+                  ref={chartRef}
+                  candleData={candleData}
+                  height={PRO_CHART_HEIGHT}
+                  visibleCandleCount={visibleCandleCount}
+                  tpslLines={tpslLines}
+                  symbol={symbol}
+                  showOverlay={false}
+                  coloredVolume
+                  onOhlcDataChange={setOhlcData}
+                  onNeedMoreHistory={fetchMoreHistory}
+                  testID={PerpsProMarketViewSelectorsIDs.CHART_LIGHTWEIGHT}
+                />
+              ) : (
+                <Skeleton
+                  height={PRO_CHART_HEIGHT}
+                  width="100%"
+                  testID={PerpsProMarketViewSelectorsIDs.CHART_SKELETON}
+                />
+              )}
+            </Box>
+          </ComponentErrorBoundary>
+        </Box>
+      </Box>
+      {isTradingHalted && !isLoadingTradingHalted ? (
+        <PerpsPriceDeviationWarning
+          testID={PerpsProMarketViewSelectorsIDs.CHART_PRICE_DEVIATION_WARNING}
+        />
+      ) : null}
+      <PerpsServiceInterruptionBanner
+        testID={
+          PerpsProMarketViewSelectorsIDs.CHART_SERVICE_INTERRUPTION_BANNER
+        }
+      />
+      <PerpsChartFullscreenModal
+        isVisible={isFullscreenChartVisible}
+        candleData={candleData}
+        tpslLines={tpslLines}
+        selectedInterval={selectedCandlePeriod}
+        visibleCandleCount={visibleCandleCount}
+        onClose={() => setIsFullscreenChartVisible(false)}
+        onIntervalChange={onCandlePeriodChange}
+        isAdvancedChartEnabled={isAdvancedChartEnabled}
+        symbol={symbol}
+        positionSize={existingPosition?.size}
+        szDecimals={marketData?.szDecimals}
+      />
+    </>
+  );
+};
 
 export default PerpsProChartPanel;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -31,6 +31,7 @@ import { usePerpsEventTracking } from '../../../hooks/usePerpsEventTracking';
 import { useHasExistingPosition } from '../../../hooks/useHasExistingPosition';
 import { useIsPriceDeviatedAboveThreshold } from '../../../hooks/useIsPriceDeviatedAboveThreshold';
 import { usePerpsLiveCandles } from '../../../hooks/stream/usePerpsLiveCandles';
+import { getPerpsChartAnalyticsProperties } from '../../../utils/chartAnalytics';
 import PerpsAdvancedChart from '../../../components/PerpsAdvancedChart/PerpsAdvancedChart';
 import PerpsCandlePeriodSelector, {
   type PerpsCandlePeriodOption,
@@ -53,11 +54,6 @@ const PRO_CANDLE_PERIODS = [
   { label: '1h', value: CandlePeriod.OneHour },
   { label: '1d', value: CandlePeriod.OneDay },
 ] as const satisfies readonly PerpsCandlePeriodOption[];
-
-const getChartAnalyticsProperties = (chartLibrary: string) => ({
-  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
-  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
-});
 
 interface PerpsProChartPanelProps {
   symbol: string;
@@ -97,7 +93,7 @@ const PerpsProChartPanel = ({
   }, [isAdvancedChartEnabled, selectedCandlePeriod, symbol]);
 
   const chartAnalyticsProperties = useMemo(
-    () => getChartAnalyticsProperties(effectiveChartLibrary),
+    () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
     [effectiveChartLibrary],
   );
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketSummary.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketSummary.tsx
@@ -2,36 +2,38 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
-  BoxJustifyContent,
 } from '@metamask/design-system-react-native';
 import React from 'react';
-import { StyleSheet } from 'react-native';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import LivePriceHeader from '../../../components/LivePriceDisplay/LivePriceHeader';
 
-const styles = StyleSheet.create({
-  container: {
-    height: 76,
-  },
-});
+interface PerpsProMarketSummaryProps {
+  symbol: string;
+  currentPrice: number;
+}
 
 /**
- * Scroll-contained market price and 24-hour change placeholder.
- *
- * The fixed app header remains outside the scroll view. Price content and the
- * compact chart action are populated by the panel implementation that owns
- * live market data.
+ * Scroll-contained live market price and 24-hour change.
  */
-const PerpsProMarketSummary = () => (
+const PerpsProMarketSummary = ({
+  symbol,
+  currentPrice,
+}: PerpsProMarketSummaryProps) => (
   <Box
     testID={PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY}
     flexDirection={BoxFlexDirection.Row}
     alignItems={BoxAlignItems.Center}
-    justifyContent={BoxJustifyContent.Between}
-    twClassName="px-4"
-    style={styles.container}
+    twClassName="h-[76px] px-4"
   >
-    <Box twClassName="h-12 w-40 rounded-lg bg-muted" />
-    <Box twClassName="h-8 w-8 rounded-full bg-muted" />
+    <Box twClassName="flex-1">
+      <LivePriceHeader
+        symbol={symbol}
+        currentPrice={currentPrice}
+        size="large"
+        testIDPrice={PerpsProMarketViewSelectorsIDs.MARKET_PRICE}
+        testIDChange={PerpsProMarketViewSelectorsIDs.MARKET_PRICE_CHANGE}
+      />
+    </Box>
   </Box>
 );
 

--- a/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.test.tsx
@@ -1,11 +1,25 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
-import PerpsCandlePeriodSelector from './PerpsCandlePeriodSelector';
+import {
+  FilterButton,
+  FilterButtonGroup,
+  FilterButtonVariant,
+  SelectButton,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import PerpsCandlePeriodSelector, {
+  type PerpsCandlePeriodOption,
+} from './PerpsCandlePeriodSelector';
 import { CandlePeriod } from '@metamask/perps-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 
 const mockOnPeriodChange = jest.fn();
 const mockOnMorePress = jest.fn();
+const CUSTOM_CANDLE_PERIODS = [
+  { label: '1m', value: CandlePeriod.OneMinute },
+  { label: '1h', value: CandlePeriod.OneHour },
+  { label: '1d', value: CandlePeriod.OneDay },
+] as const satisfies readonly PerpsCandlePeriodOption[];
 
 describe('PerpsCandlePeriodSelector', () => {
   beforeEach(() => {
@@ -84,5 +98,96 @@ describe('PerpsCandlePeriodSelector', () => {
 
     // Assert - Should show the custom period label instead of "show more"
     expect(getByText('1h')).toBeOnTheScreen();
+  });
+
+  it('renders the configured visible periods', () => {
+    const { getByText, queryByText } = renderWithProvider(
+      <PerpsCandlePeriodSelector
+        selectedPeriod={CandlePeriod.OneMinute}
+        onPeriodChange={mockOnPeriodChange}
+        onMorePress={mockOnMorePress}
+        visiblePeriods={CUSTOM_CANDLE_PERIODS}
+      />,
+      { state: { engine: { backgroundState: {} } } },
+    );
+
+    expect(getByText('1m')).toBeOnTheScreen();
+    expect(getByText('1h')).toBeOnTheScreen();
+    expect(getByText('1d')).toBeOnTheScreen();
+    expect(queryByText('3min')).not.toBeOnTheScreen();
+  });
+
+  it('routes configured period presses through onPeriodChange', () => {
+    const { getByText } = renderWithProvider(
+      <PerpsCandlePeriodSelector
+        selectedPeriod={CandlePeriod.OneMinute}
+        onPeriodChange={mockOnPeriodChange}
+        onMorePress={mockOnMorePress}
+        visiblePeriods={CUSTOM_CANDLE_PERIODS}
+      />,
+      { state: { engine: { backgroundState: {} } } },
+    );
+
+    fireEvent.press(getByText('1h'));
+
+    expect(mockOnPeriodChange).toHaveBeenCalledWith(CandlePeriod.OneHour);
+  });
+
+  it('centers the default candle period group', () => {
+    const testID = 'test-candle-selector';
+    const { UNSAFE_getByType } = renderWithProvider(
+      <PerpsCandlePeriodSelector
+        selectedPeriod={CandlePeriod.OneMinute}
+        testID={testID}
+      />,
+      { state: { engine: { backgroundState: {} } } },
+    );
+
+    expect(UNSAFE_getByType(FilterButtonGroup).props.twClassName).toBe(
+      'gap-1 grow justify-center',
+    );
+  });
+
+  it('applies a configured candle period group alignment', () => {
+    const testID = 'test-candle-selector';
+    const { UNSAFE_getByType } = renderWithProvider(
+      <PerpsCandlePeriodSelector
+        selectedPeriod={CandlePeriod.OneMinute}
+        groupTwClassName="gap-1 grow justify-start"
+        testID={testID}
+      />,
+      { state: { engine: { backgroundState: {} } } },
+    );
+
+    expect(UNSAFE_getByType(FilterButtonGroup).props.twClassName).toBe(
+      'gap-1 grow justify-start',
+    );
+  });
+
+  it('applies configured compact period-button styling', () => {
+    const { UNSAFE_getAllByType, UNSAFE_getByType } = renderWithProvider(
+      <PerpsCandlePeriodSelector
+        selectedPeriod={CandlePeriod.OneMinute}
+        filterVariant={FilterButtonVariant.Secondary}
+        periodButtonTwClassName="h-7 rounded px-1"
+        moreButtonTwClassName="h-7 rounded px-1"
+        textVariant={TextVariant.BodyXs}
+      />,
+      { state: { engine: { backgroundState: {} } } },
+    );
+
+    const periodButton = UNSAFE_getAllByType(FilterButton)[0];
+    const periodGroup = UNSAFE_getByType(FilterButtonGroup);
+    const moreButton = UNSAFE_getByType(SelectButton);
+
+    expect(periodGroup.props.variant).toBe(FilterButtonVariant.Secondary);
+    expect(periodButton.props.twClassName).toBe('h-7 rounded px-1');
+    expect(periodButton.props.textProps).toEqual({
+      variant: TextVariant.BodyXs,
+    });
+    expect(moreButton.props.twClassName).toBe('h-7 rounded px-1');
+    expect(moreButton.props.textProps).toEqual({
+      variant: TextVariant.BodyXs,
+    });
   });
 });

--- a/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
@@ -8,17 +8,23 @@ import {
   SelectButton,
   SelectButtonSize,
   SelectButtonVariant,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { CandlePeriod, CANDLE_PERIODS } from '@metamask/perps-controller';
 import { getPerpsCandlePeriodSelector } from '../../Perps.testIds';
 
-const DEFAULT_CANDLE_PERIODS = [
+export interface PerpsCandlePeriodOption {
+  label: string;
+  value: CandlePeriod;
+}
+
+export const DEFAULT_CANDLE_PERIODS = [
   { label: '1min', value: CandlePeriod.OneMinute },
   { label: '3min', value: CandlePeriod.ThreeMinutes },
   { label: '5min', value: CandlePeriod.FiveMinutes },
   { label: '15min', value: CandlePeriod.FifteenMinutes },
-] as const;
+] as const satisfies readonly PerpsCandlePeriodOption[];
 
 const getCandlePeriodLabel = (period: CandlePeriod | string): string => {
   const candlePeriod = CANDLE_PERIODS.find(
@@ -31,6 +37,13 @@ interface PerpsCandlePeriodSelectorProps {
   selectedPeriod: CandlePeriod | string;
   onPeriodChange?: (period: CandlePeriod) => void;
   onMorePress?: () => void;
+  visiblePeriods?: readonly PerpsCandlePeriodOption[];
+  twClassName?: string;
+  groupTwClassName?: string;
+  filterVariant?: FilterButtonVariant;
+  periodButtonTwClassName?: string;
+  moreButtonTwClassName?: string;
+  textVariant?: TextVariant;
   testID?: string;
 }
 
@@ -38,11 +51,18 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
   selectedPeriod,
   onPeriodChange,
   onMorePress,
+  visiblePeriods = DEFAULT_CANDLE_PERIODS,
+  twClassName = 'w-full items-center py-3',
+  groupTwClassName = 'gap-1 grow justify-center',
+  filterVariant = FilterButtonVariant.Primary,
+  periodButtonTwClassName,
+  moreButtonTwClassName,
+  textVariant,
   testID,
 }) => {
   const normalizedSelectedPeriod = selectedPeriod?.toLowerCase();
 
-  const isMorePeriodSelected = !DEFAULT_CANDLE_PERIODS.some(
+  const isMorePeriodSelected = !visiblePeriods.some(
     (period) => period.value?.toLowerCase() === normalizedSelectedPeriod,
   );
 
@@ -52,11 +72,11 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
     }
 
     return (
-      DEFAULT_CANDLE_PERIODS.find(
+      visiblePeriods.find(
         (period) => period.value?.toLowerCase() === normalizedSelectedPeriod,
       )?.value ?? ''
     );
-  }, [isMorePeriodSelected, normalizedSelectedPeriod]);
+  }, [isMorePeriodSelected, normalizedSelectedPeriod, visiblePeriods]);
 
   const handleFilterChange = useCallback(
     (value: string) => {
@@ -70,18 +90,21 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
     : null;
 
   return (
-    <Box twClassName="w-full items-center py-3" testID={testID}>
+    <Box twClassName={twClassName} testID={testID}>
       <FilterButtonGroup
         value={groupValue}
         onChange={handleFilterChange}
-        variant={FilterButtonVariant.Primary}
-        twClassName="gap-1 grow justify-center"
+        variant={filterVariant}
+        twClassName={groupTwClassName}
+        testID={testID ? getPerpsCandlePeriodSelector.group(testID) : undefined}
       >
-        {DEFAULT_CANDLE_PERIODS.map((period) => (
+        {visiblePeriods.map((period) => (
           <FilterButton
             key={period.value}
             value={period.value}
             size={FilterButtonSize.Sm}
+            twClassName={periodButtonTwClassName}
+            textProps={textVariant ? { variant: textVariant } : undefined}
             testID={
               testID
                 ? getPerpsCandlePeriodSelector.periodButton(
@@ -103,6 +126,8 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
               : SelectButtonVariant.Tertiary
           }
           size={SelectButtonSize.Sm}
+          twClassName={moreButtonTwClassName}
+          textProps={textVariant ? { variant: textVariant } : undefined}
           onPress={onMorePress}
           testID={
             testID ? getPerpsCandlePeriodSelector.moreButton(testID) : undefined

--- a/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.styles.ts
+++ b/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.styles.ts
@@ -22,19 +22,13 @@ export const selectorStyleSheet = (params: { theme: Theme }) => {
       alignItems: 'center',
     },
     intervalTabActive: {
-      backgroundColor: colors.primary.muted,
+      backgroundColor: colors.background.muted,
     },
     intervalTabInactive: {
       backgroundColor: importedColors.transparent,
     },
     intervalTabText: {
       fontSize: 12,
-    },
-    intervalTabTextActive: {
-      color: colors.primary.inverse,
-    },
-    intervalTabTextInactive: {
-      color: colors.text.muted,
     },
   });
 };

--- a/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import ThemeProvider from '../../../../../component-library/providers/ThemeProvider/ThemeProvider';
+import { lightTheme } from '@metamask/design-tokens';
 import { getCandlestickChartSelector } from '../../Perps.testIds';
 import PerpsCandlestickChartIntervalSelector from './PerpsCandlestickChartIntervalSelector';
 
@@ -124,6 +125,21 @@ describe('PerpsCandlestickChartIntervalSelector', () => {
 
     // Assert - Now 5m should be selected
     expect(getByTestId(testIDs.interval5m)).toBeOnTheScreen();
+  });
+
+  it('uses muted background and default text for the selected interval', () => {
+    const { getByTestId, getByText } = render(
+      <TestWrapper>
+        <PerpsCandlestickChartIntervalSelector {...defaultProps} />
+      </TestWrapper>,
+    );
+
+    expect(getByTestId(testIDs.interval1h)).toHaveStyle({
+      backgroundColor: lightTheme.colors.background.muted,
+    });
+    expect(getByText('1h')).toHaveStyle({
+      color: lightTheme.colors.text.default,
+    });
   });
 
   it('renders correct testID structure for each interval', () => {

--- a/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
@@ -50,12 +50,7 @@ const PerpsCandlestickChartIntervalSelector: React.FC<
                 ? TextColor.TextDefault
                 : TextColor.TextMuted
             }
-            style={[
-              styles.intervalTabText,
-              selectedInterval === interval.value
-                ? styles.intervalTabTextActive
-                : styles.intervalTabTextInactive,
-            ]}
+            style={styles.intervalTabText}
           >
             {interval.label}
           </Text>

--- a/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
@@ -20,7 +20,7 @@ interface PerpsCandlestickChartIntervalSelectorProps {
 const PerpsCandlestickChartIntervalSelector: React.FC<
   PerpsCandlestickChartIntervalSelectorProps
 > = ({ selectedInterval, onIntervalChange, testID, style }) => {
-  const { styles } = useStyles(selectorStyleSheet, {});
+  const { styles } = useStyles(selectorStyleSheet);
 
   return (
     <ScrollView

--- a/app/components/UI/Perps/components/PerpsChartFullscreenModal/PerpsChartFullscreenModal.test.tsx
+++ b/app/components/UI/Perps/components/PerpsChartFullscreenModal/PerpsChartFullscreenModal.test.tsx
@@ -161,8 +161,9 @@ jest.mock('../PerpsAdvancedChart/PerpsAdvancedChart', () => {
 
 jest.mock(
   '../PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector',
-  () =>
-    jest.fn(
+  () => ({
+    __esModule: true,
+    default: jest.fn(
       ({
         onIntervalChange,
         testID,
@@ -182,6 +183,7 @@ jest.mock(
         );
       },
     ),
+  }),
 );
 
 jest.mock('../PerpsOHLCVBar', () =>

--- a/app/components/UI/Perps/components/PerpsChartFullscreenModal/PerpsChartFullscreenModal.tsx
+++ b/app/components/UI/Perps/components/PerpsChartFullscreenModal/PerpsChartFullscreenModal.tsx
@@ -35,6 +35,10 @@ import PerpsOHLCVBar from '../PerpsOHLCVBar';
 import ComponentErrorBoundary from '../../../ComponentErrorBoundary';
 import { useScreenOrientation } from '../../../../../core/ScreenOrientation';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import {
+  getPerpsChartAnalyticsProperties,
+  getPerpsChartLibrary,
+} from '../../utils/chartAnalytics';
 
 export interface PerpsChartFullscreenModalProps {
   isVisible: boolean;
@@ -53,16 +57,6 @@ export interface PerpsChartFullscreenModalProps {
   /** Hyperliquid size decimals; forwarded so fullscreen advanced chart matches market precision. */
   szDecimals?: number | null;
 }
-
-const getChartLibrary = (isAdvancedChartEnabled: boolean) =>
-  isAdvancedChartEnabled
-    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
-    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
-
-const getChartAnalyticsPropertiesForLibrary = (chartLibrary: string) => ({
-  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
-  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
-});
 
 const PerpsChartFullscreenModal: React.FC<PerpsChartFullscreenModalProps> = ({
   isVisible,
@@ -93,7 +87,7 @@ const PerpsChartFullscreenModal: React.FC<PerpsChartFullscreenModalProps> = ({
   const [ohlcvHeight, setOhlcvHeight] = useState<number>(0);
   const { track } = usePerpsEventTracking();
   const configuredChartLibrary = useMemo(
-    () => getChartLibrary(Boolean(isAdvancedChartEnabled)),
+    () => getPerpsChartLibrary(Boolean(isAdvancedChartEnabled)),
     [isAdvancedChartEnabled],
   );
   const [effectiveChartLibrary, setEffectiveChartLibrary] = useState(
@@ -103,7 +97,7 @@ const PerpsChartFullscreenModal: React.FC<PerpsChartFullscreenModalProps> = ({
     setEffectiveChartLibrary(configuredChartLibrary);
   }, [configuredChartLibrary, isVisible, symbol]);
   const chartAnalyticsProperties = useMemo(
-    () => getChartAnalyticsPropertiesForLibrary(effectiveChartLibrary),
+    () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
     [effectiveChartLibrary],
   );
 
@@ -141,7 +135,7 @@ const PerpsChartFullscreenModal: React.FC<PerpsChartFullscreenModalProps> = ({
         `${symbol}:${trackedChartLibrary}`,
       );
       const screenViewChartAnalyticsProperties = chartLibrary
-        ? getChartAnalyticsPropertiesForLibrary(chartLibrary)
+        ? getPerpsChartAnalyticsProperties(chartLibrary)
         : chartAnalyticsProperties;
       track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
         [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:

--- a/app/components/UI/Perps/hooks/usePerpsChartInteractions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsChartInteractions.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { CandlePeriod, PERPS_CONSTANTS } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
+import { setPerpsChartPreferredCandlePeriod } from '../../../../actions/settings';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import {
+  getPerpsChartAnalyticsProperties,
+  getPerpsChartLibrary,
+} from '../utils/chartAnalytics';
+import { usePerpsChartInteractions } from './usePerpsChartInteractions';
+
+const mockDispatch = jest.fn();
+const mockTrack = jest.fn();
+const mockLoggerError = jest.fn();
+const mockOnAdvancedChartError = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('./usePerpsEventTracking', () => ({
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}));
+
+const chartAnalyticsProperties = getPerpsChartAnalyticsProperties(
+  getPerpsChartLibrary(true),
+);
+
+const renderInteractions = (isAdvancedChartEnabled = true) =>
+  renderHook(() =>
+    usePerpsChartInteractions({
+      asset: 'BTC',
+      chartAnalyticsProperties,
+      chartErrorMessage: 'Chart failed',
+      isAdvancedChartEnabled,
+      onAdvancedChartError: mockOnAdvancedChartError,
+    }),
+  );
+
+describe('usePerpsChartInteractions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists a selected candle period', () => {
+    const { result } = renderInteractions();
+
+    act(() => {
+      result.current.handleCandlePeriodChange(CandlePeriod.OneHour);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setPerpsChartPreferredCandlePeriod(CandlePeriod.OneHour),
+    );
+  });
+
+  it('tracks a selected candle period', () => {
+    const { result } = renderInteractions();
+
+    act(() => {
+      result.current.handleCandlePeriodChange(CandlePeriod.OneHour);
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.PERPS_UI_INTERACTION,
+      expect.objectContaining({
+        [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.CANDLE_PERIOD_CHANGED,
+        [PERPS_EVENT_PROPERTY.CANDLE_PERIOD]: CandlePeriod.OneHour,
+      }),
+    );
+  });
+
+  it('logs a chart error', () => {
+    const { result } = renderInteractions();
+
+    act(() => {
+      result.current.handleChartError('WebView failed');
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'WebView failed' }),
+      { tags: { feature: PERPS_CONSTANTS.FeatureName } },
+    );
+  });
+
+  it('tracks a chart error', () => {
+    const { result } = renderInteractions();
+
+    act(() => {
+      result.current.handleChartError('WebView failed');
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.PERPS_ERROR,
+      expect.objectContaining({
+        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: 'WebView failed',
+        [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
+      }),
+    );
+  });
+
+  it('falls back after an Advanced Chart error', () => {
+    const { result } = renderInteractions();
+
+    act(() => {
+      result.current.handleChartError('WebView failed');
+    });
+
+    expect(mockOnAdvancedChartError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not request fallback after a Lightweight Chart error', () => {
+    const { result } = renderInteractions(false);
+
+    act(() => {
+      result.current.handleChartError('WebView failed');
+    });
+
+    expect(mockOnAdvancedChartError).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsChartInteractions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsChartInteractions.ts
@@ -1,0 +1,85 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { CandlePeriod, PERPS_CONSTANTS } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
+import { setPerpsChartPreferredCandlePeriod } from '../../../../actions/settings';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import Logger from '../../../../util/Logger';
+import type { PerpsChartAnalyticsProperties } from '../utils/chartAnalytics';
+import { usePerpsEventTracking } from './usePerpsEventTracking';
+
+interface UsePerpsChartInteractionsOptions {
+  asset?: string;
+  chartAnalyticsProperties: PerpsChartAnalyticsProperties;
+  chartErrorMessage: string;
+  isAdvancedChartEnabled: boolean;
+  onAdvancedChartError: () => void;
+}
+
+export const usePerpsChartInteractions = ({
+  asset,
+  chartAnalyticsProperties,
+  chartErrorMessage,
+  isAdvancedChartEnabled,
+  onAdvancedChartError,
+}: UsePerpsChartInteractionsOptions) => {
+  const dispatch = useDispatch();
+  const { track } = usePerpsEventTracking();
+
+  const handleCandlePeriodChange = useCallback(
+    (newPeriod: CandlePeriod) => {
+      dispatch(setPerpsChartPreferredCandlePeriod(newPeriod));
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.ASSET]: asset || '',
+        ...chartAnalyticsProperties,
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.CANDLE_PERIOD_CHANGED,
+        [PERPS_EVENT_PROPERTY.CANDLE_PERIOD]: newPeriod,
+      });
+    },
+    [asset, chartAnalyticsProperties, dispatch, track],
+  );
+
+  const handleChartError = useCallback(
+    (error?: Error | string) => {
+      const errorMessage =
+        typeof error === 'string'
+          ? error
+          : (error?.message ?? chartErrorMessage);
+
+      Logger.error(new Error(errorMessage), {
+        tags: { feature: PERPS_CONSTANTS.FeatureName },
+      });
+      track(MetaMetricsEvents.PERPS_ERROR, {
+        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.WARNING,
+        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
+        [PERPS_EVENT_PROPERTY.SCREEN_NAME]:
+          PERPS_EVENT_VALUE.SCREEN_NAME.PERPS_MARKET_DETAILS,
+        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+          PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
+        [PERPS_EVENT_PROPERTY.ASSET]: asset || '',
+        ...chartAnalyticsProperties,
+      });
+
+      if (isAdvancedChartEnabled) {
+        onAdvancedChartError();
+      }
+    },
+    [
+      asset,
+      chartAnalyticsProperties,
+      chartErrorMessage,
+      isAdvancedChartEnabled,
+      onAdvancedChartError,
+      track,
+    ],
+  );
+
+  return {
+    handleCandlePeriodChange,
+    handleChartError,
+  };
+};

--- a/app/components/UI/Perps/utils/chartAnalytics.ts
+++ b/app/components/UI/Perps/utils/chartAnalytics.ts
@@ -1,0 +1,18 @@
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
+
+export const getPerpsChartLibrary = (isAdvancedChartEnabled: boolean) =>
+  isAdvancedChartEnabled
+    ? PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED
+    : PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT;
+
+export const getPerpsChartAnalyticsProperties = (chartLibrary: string) => ({
+  [PERPS_EVENT_PROPERTY.CHART_LIBRARY]: chartLibrary,
+  [PERPS_EVENT_PROPERTY.ASSET_TYPE]: PERPS_EVENT_VALUE.ASSET_TYPE.PERP,
+});
+
+export type PerpsChartAnalyticsProperties = ReturnType<
+  typeof getPerpsChartAnalyticsProperties
+>;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the functional Token + Chart region to the Perps Pro market view, replacing the existing scaffold.

The Pro chart reuses the Lite chart architecture, including live candle data, Advanced Chart with lightweight fallback, overlays, OHLCV data, warnings, analytics, fullscreen mode, and persisted timeframe selection. It also adds the Pro-specific timeframe controls and live price summary, styled to match Figma.

Motivation
Perps Pro needs a functional chart before the market view can support inline trading. Reusing the existing chart stack preserves established behavior while providing a Pro-specific presentation without introducing another chart engine or changing Lite mode.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added the functional chart to the Perps Pro market view

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3556

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/de46290a-9dc0-4fa2-b464-1432789f3c27


https://github.com/user-attachments/assets/9c673875-3110-45b0-ab60-dffa67903dd4





## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large trading-UI change with live data and chart fallbacks, but it reuses established Perps chart paths and is covered by new unit tests rather than touching auth or payments.
> 
> **Overview**
> Replaces the **Perps Pro** market view chart scaffold with a full **Token + Chart** region that reuses the existing Lite chart stack (live candles, Advanced Chart with lightweight fallback, position overlays, OHLCV, fullscreen, deviation/service banners, and persisted timeframe).
> 
> **`PerpsProMarketView`** now drives the chart from Redux preferred period and feature flags, tracks **`PERPS_SCREEN_VIEWED`** with chart attribution, and mounts the **More periods** bottom sheet outside the scroll view. Shared behavior is extracted into **`usePerpsChartInteractions`** and **`chartAnalytics`** helpers, which **Lite** market details, order flow, and fullscreen chart also adopt.
> 
> **`PerpsCandlePeriodSelector`** gains configurable visible periods and compact styling for Pro; **`PerpsProMarketSummary`** shows live price via **`LivePriceHeader`**. Test IDs and unit tests cover the Pro chart panel, screen wiring, and the new hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16cba4e99c4af8e9a8604b0e53a16f0d0c487c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->