### PR TITLE
prototype: Refine QuickBuy bottom sheet UI and animations

### DIFF
--- a/app/components/Base/Keypad/components.tsx
+++ b/app/components/Base/Keypad/components.tsx
@@ -15,9 +15,6 @@ import {
   TextVariant,
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
-import { useTheme } from '../../../util/theme';
-import { Colors } from '../../../util/theme/models';
-
 // TODO: @MetaMask/design-system-engineers
 // Use the concrete Box component props here instead of BoxProps.
 // In MetaMask Mobile, extending BoxProps in forwarding wrappers can fail TS checks
@@ -28,31 +25,33 @@ import { Colors } from '../../../util/theme/models';
 // https://github.com/MetaMask/metamask-design-system/issues/1115
 type BoxComponentProps = React.ComponentProps<typeof Box>;
 
-const createStyles = (colors: Colors) =>
-  StyleSheet.create({
-    keypadButton: {
-      backgroundColor: colors.background.muted,
-      borderRadius: 12,
-      paddingHorizontal: 16,
-      height: 48,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    keypadDeleteButton: {
-      borderRadius: 12,
-      paddingHorizontal: 16,
-      height: 48,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-  });
+// TEMP: Quick Buy keypad look — transparent keys + 24px digits. Revert when settled.
+const styles = StyleSheet.create({
+  keypadButton: {
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    height: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  keypadButtonText: {
+    fontSize: 24,
+  },
+  keypadDeleteButton: {
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    height: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
 interface KeypadContainerProps extends BoxComponentProps {
   children?: React.ReactNode;
 }
 
 const KeypadContainer: React.FC<KeypadContainerProps> = (props) => (
-  <Box gap={3} {...props} />
+  <Box gap={5} {...props} />
 );
 
 interface KeypadRowProps extends BoxComponentProps {
@@ -63,7 +62,7 @@ const KeypadRow: React.FC<KeypadRowProps> = (props) => (
   <Box
     flexDirection={BoxFlexDirection.Row}
     justifyContent={BoxJustifyContent.Between}
-    gap={3}
+    gap={5}
     {...props}
   />
 );
@@ -83,31 +82,27 @@ const KeypadButton: React.FC<KeypadButtonProps> = ({
   isDisabled,
   boxWrapperProps,
   ...props
-}) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
-
-  return (
-    // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
-    <Box twClassName="flex-1" {...boxWrapperProps}>
-      <TouchableOpacity
-        style={[styles.keypadButton, style]}
-        disabled={isDisabled}
-        accessibilityRole="button"
-        accessible
-        {...props}
+}) => (
+  // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
+  <Box twClassName="flex-1" {...boxWrapperProps}>
+    <TouchableOpacity
+      style={[styles.keypadButton, style]}
+      disabled={isDisabled}
+      accessibilityRole="button"
+      accessible
+      {...props}
+    >
+      <Text
+        twClassName="font-medium text-center"
+        variant={TextVariant.DisplayMd}
+        style={styles.keypadButtonText}
+        accessibilityRole="none"
       >
-        <Text
-          twClassName="font-medium text-center"
-          variant={TextVariant.DisplayMd}
-          accessibilityRole="none"
-        >
-          {children}
-        </Text>
-      </TouchableOpacity>
-    </Box>
-  );
-};
+        {children}
+      </Text>
+    </TouchableOpacity>
+  </Box>
+);
 
 interface KeypadDeleteButtonProps {
   style?: StyleProp<ViewStyle>;
@@ -122,24 +117,19 @@ const KeypadDeleteButton: React.FC<KeypadDeleteButtonProps> = ({
   style,
   boxWrapperProps,
   ...props
-}) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
-
-  return (
-    // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
-    <Box twClassName="flex-1" {...boxWrapperProps}>
-      <TouchableOpacity
-        style={[styles.keypadDeleteButton, style]}
-        accessibilityRole="button"
-        accessible
-        {...props}
-      >
-        <Icon name={IconName.Backspace} size={IconSize.Xl} />
-      </TouchableOpacity>
-    </Box>
-  );
-};
+}) => (
+  // Required wrapper to ensure the KeypadButton takes up space available in KeypadRow
+  <Box twClassName="flex-1" {...boxWrapperProps}>
+    <TouchableOpacity
+      style={[styles.keypadDeleteButton, style]}
+      accessibilityRole="button"
+      accessible
+      {...props}
+    >
+      <Icon name={IconName.Backspace} size={IconSize.Xl} />
+    </TouchableOpacity>
+  </Box>
+);
 
 type KeypadType = React.FC<KeypadContainerProps> & {
   Row: React.FC<KeypadRowProps>;

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
-import { FullWindowOverlay } from 'react-native-screens';
 import { useRoute } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
@@ -44,8 +43,8 @@ import ModalConfirmation from '../../../component-library/components/Modals/Moda
 import Toast, {
   ToastContext,
 } from '../../../component-library/components/Toast';
-import { Toaster } from '@metamask/design-system-react-native';
 import AgentStepHud from '../../../dev-tools/AgenticService/AgentStepHud';
+import { ToasterOverlay } from './ToasterOverlay';
 import PerpsWebSocketHealthToast, {
   WebSocketHealthToastProvider,
 } from '../../UI/Perps/components/PerpsWebSocketHealthToast';
@@ -1416,19 +1415,11 @@ const App: React.FC = () => {
         <AppFlow />
         <Toast ref={toastRef} />
         {/*
-          FullWindowOverlay (iOS) renders <Toaster /> in a UIWindow above every native
-          layer — including native-stack card screens — which a plain absolute View as a
-          sibling of <AppFlow /> cannot reach. Without this wrapper some Toasts render
-          behind the native stack card screens and are not visible.
-          unstable_accessibilityContainerViewIsModal={false} prevents react-native-screens
-          from marking the native container as accessibilityViewIsModal=YES, which would
-          otherwise hide the entire app's AX tree from VoiceOver/XCUITest/Appium whenever
-          no toast is active. Toasts are non-blocking so non-modal AX behaviour is correct.
-          See: https://consensyssoftware.atlassian.net/browse/DSYS-931
+          ToasterOverlay mounts FullWindowOverlay only while a toast is active
+          on iOS so idle RNSFullWindowOverlay / UIWindow is not left in the
+          native hierarchy. See ToasterOverlay.tsx and DSYS-931 / #32973.
         */}
-        <FullWindowOverlay unstable_accessibilityContainerViewIsModal={false}>
-          <Toaster />
-        </FullWindowOverlay>
+        <ToasterOverlay />
         <PerpsWebSocketHealthToast />
         {__DEV__ && <AgentStepHud />}
         <ControllerEventToastBridge registrations={toastRegistrations} />

--- a/app/components/Nav/App/ToasterOverlay/ToasterOverlay.constants.ts
+++ b/app/components/Nav/App/ToasterOverlay/ToasterOverlay.constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Must stay aligned with `TOAST_VISIBILITY_DURATION` from
+ * `@metamask/design-system-shared` (Toaster auto-dismiss delay after enter spring).
+ */
+export const TOAST_VISIBILITY_DURATION_MS = 2750;
+
+/**
+ * Buffer for Toaster enter/exit springs before unmounting FullWindowOverlay.
+ * Slightly late unmount is safe; early unmount would clip the toast.
+ */
+export const TOAST_OVERLAY_ANIMATION_BUFFER_MS = 1500;
+
+/**
+ * Time from showToast (auto-dismiss) until the overlay can unmount.
+ * Matches Toaster: spring in → visibility delay → spring out → resetState.
+ */
+export const TOAST_OVERLAY_AUTO_DISMISS_MS =
+  TOAST_VISIBILITY_DURATION_MS + TOAST_OVERLAY_ANIMATION_BUFFER_MS;
+
+export const TOASTER_FULL_WINDOW_OVERLAY_TEST_ID =
+  'toaster-full-window-overlay';

--- a/app/components/Nav/App/ToasterOverlay/ToasterOverlay.test.tsx
+++ b/app/components/Nav/App/ToasterOverlay/ToasterOverlay.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { Platform, View } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+
+import ToasterOverlay from './ToasterOverlay';
+import {
+  TOAST_OVERLAY_ANIMATION_BUFFER_MS,
+  TOAST_OVERLAY_AUTO_DISMISS_MS,
+  TOASTER_FULL_WINDOW_OVERLAY_TEST_ID,
+} from './ToasterOverlay.constants';
+
+interface ToasterRef {
+  showToast: (options: { title?: string; hasNoTimeout?: boolean }) => void;
+  closeToast: () => void;
+}
+
+const mockShowToast = jest.fn();
+const mockCloseToast = jest.fn();
+const mockOverlayTestId = 'toaster-full-window-overlay';
+let latestToasterRef: { current: ToasterRef | null } | null = null;
+
+jest.mock('react-native-screens', () => {
+  const { View: MockView } = jest.requireActual<{
+    View: typeof View;
+  }>('react-native');
+
+  return {
+    FullWindowOverlay: ({
+      children,
+      unstable_accessibilityContainerViewIsModal,
+    }: {
+      children: React.ReactNode;
+      unstable_accessibilityContainerViewIsModal?: boolean;
+    }) => (
+      <MockView
+        testID={mockOverlayTestId}
+        accessibilityContainerViewIsModal={
+          unstable_accessibilityContainerViewIsModal
+        }
+      >
+        {children}
+      </MockView>
+    ),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactMock = jest.requireActual<typeof React>('react');
+  const { View: MockView } = jest.requireActual<{
+    View: typeof View;
+  }>('react-native');
+
+  const MockToaster = ReactMock.forwardRef<ToasterRef, Record<string, never>>(
+    (_props, ref) => {
+      const api: ToasterRef = {
+        showToast: (...args) => mockShowToast(...args),
+        closeToast: (...args) => mockCloseToast(...args),
+      };
+
+      ReactMock.useImperativeHandle(ref, () => api);
+      ReactMock.useLayoutEffect(() => {
+        if (ref && typeof ref !== 'function') {
+          latestToasterRef = ref;
+        }
+      });
+
+      return <MockView testID="toaster" />;
+    },
+  );
+  MockToaster.displayName = 'MockToaster';
+
+  return {
+    Toaster: MockToaster,
+  };
+});
+
+describe('ToasterOverlay', () => {
+  const originalPlatform = Platform.OS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    latestToasterRef = null;
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => 'ios',
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => originalPlatform,
+    });
+  });
+
+  it('does not mount FullWindowOverlay while idle on iOS', () => {
+    const { queryByTestId, getByTestId } = render(<ToasterOverlay />);
+
+    expect(getByTestId('toaster')).toBeOnTheScreen();
+    expect(queryByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID)).toBeNull();
+  });
+
+  it('mounts FullWindowOverlay when showToast is called on iOS', async () => {
+    const { getByTestId, queryByTestId } = render(<ToasterOverlay />);
+
+    expect(queryByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID)).toBeNull();
+
+    act(() => {
+      latestToasterRef?.current?.showToast({ title: 'Copied' });
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID),
+      ).toBeOnTheScreen();
+    });
+    expect(getByTestId('toaster')).toBeOnTheScreen();
+    expect(mockShowToast).toHaveBeenCalledWith({ title: 'Copied' });
+  });
+
+  it('sets accessibilityContainerViewIsModal to false on the overlay', async () => {
+    const { getByTestId } = render(<ToasterOverlay />);
+
+    act(() => {
+      latestToasterRef?.current?.showToast({ title: 'Copied' });
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID),
+      ).toBeOnTheScreen();
+    });
+
+    expect(
+      getByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID).props
+        .accessibilityContainerViewIsModal,
+    ).toBe(false);
+  });
+
+  it('unmounts FullWindowOverlay after auto-dismiss timeout', async () => {
+    const { getByTestId, queryByTestId } = render(<ToasterOverlay />);
+
+    act(() => {
+      latestToasterRef?.current?.showToast({ title: 'Copied' });
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID),
+      ).toBeOnTheScreen();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_OVERLAY_AUTO_DISMISS_MS);
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID)).toBeNull();
+    });
+  });
+
+  it('unmounts FullWindowOverlay after closeToast exit buffer', async () => {
+    const { getByTestId, queryByTestId } = render(<ToasterOverlay />);
+
+    act(() => {
+      latestToasterRef?.current?.showToast({
+        title: 'Pinned',
+        hasNoTimeout: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        getByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID),
+      ).toBeOnTheScreen();
+    });
+
+    act(() => {
+      latestToasterRef?.current?.closeToast();
+    });
+
+    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(TOAST_OVERLAY_ANIMATION_BUFFER_MS);
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID)).toBeNull();
+    });
+  });
+
+  it('does not mount FullWindowOverlay on Android', () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      get: () => 'android',
+    });
+
+    const { queryByTestId, getByTestId } = render(<ToasterOverlay />);
+
+    expect(getByTestId('toaster')).toBeOnTheScreen();
+    expect(queryByTestId(TOASTER_FULL_WINDOW_OVERLAY_TEST_ID)).toBeNull();
+  });
+});

--- a/app/components/Nav/App/ToasterOverlay/ToasterOverlay.tsx
+++ b/app/components/Nav/App/ToasterOverlay/ToasterOverlay.tsx
@@ -1,0 +1,130 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+import {
+  Toaster,
+  type ToastOptions,
+  type ToasterRef,
+} from '@metamask/design-system-react-native';
+import { FullWindowOverlay } from 'react-native-screens';
+
+import {
+  TOAST_OVERLAY_ANIMATION_BUFFER_MS,
+  TOAST_OVERLAY_AUTO_DISMISS_MS,
+} from './ToasterOverlay.constants';
+
+/**
+ * Hosts design-system `<Toaster />` and mounts iOS `FullWindowOverlay` only
+ * while a toast is active.
+ *
+ * Idle `FullWindowOverlay` still creates a native `RNSFullWindowOverlay` /
+ * `UIWindow` even when Toaster returns null. Conditional mounting removes that
+ * idle window (same pattern as HardwareWalletProvider / #32973).
+ *
+ * Toaster must remount when the overlay wrapper appears, so the first
+ * `showToast` is deferred until after overlay mount. The global `toast()` API
+ * keeps working because Toaster re-registers on mount.
+ *
+ * `unstable_accessibilityContainerViewIsModal={false}` retains the DSYS-931
+ * fix so an active overlay does not hide the app AX tree.
+ */
+const ToasterOverlay = () => {
+  const toasterRef = useRef<ToasterRef>(null);
+  const pendingToastRef = useRef<ToastOptions | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shouldShowOverlayRef = useRef(false);
+  const [shouldShowOverlay, setShouldShowOverlay] = useState(false);
+
+  shouldShowOverlayRef.current = shouldShowOverlay;
+
+  const clearHideTimer = () => {
+    if (hideTimerRef.current !== null) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  };
+
+  const scheduleOverlayHide = (delayMs: number) => {
+    clearHideTimer();
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      setShouldShowOverlay(false);
+    }, delayMs);
+  };
+
+  // Re-wrap every commit: Toaster replaces imperative methods each render.
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+
+    const api = toasterRef.current;
+    if (!api) {
+      return;
+    }
+
+    const originalShowToast = api.showToast;
+    const originalCloseToast = api.closeToast;
+
+    api.showToast = (options: ToastOptions) => {
+      clearHideTimer();
+
+      if (!shouldShowOverlayRef.current) {
+        pendingToastRef.current = options;
+        setShouldShowOverlay(true);
+        return;
+      }
+
+      originalShowToast(options);
+
+      if (!options.hasNoTimeout) {
+        scheduleOverlayHide(TOAST_OVERLAY_AUTO_DISMISS_MS);
+      }
+    };
+
+    api.closeToast = () => {
+      clearHideTimer();
+      originalCloseToast();
+      scheduleOverlayHide(TOAST_OVERLAY_ANIMATION_BUFFER_MS);
+    };
+  });
+
+  // After overlay + Toaster remount, flush the deferred toast.
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios' || !shouldShowOverlay) {
+      return;
+    }
+
+    const pending = pendingToastRef.current;
+    if (!pending || !toasterRef.current) {
+      return;
+    }
+
+    pendingToastRef.current = null;
+    toasterRef.current.showToast(pending);
+  }, [shouldShowOverlay]);
+
+  useLayoutEffect(
+    () => () => {
+      clearHideTimer();
+    },
+    [],
+  );
+
+  if (Platform.OS !== 'ios') {
+    return <Toaster />;
+  }
+
+  const toaster = <Toaster ref={toasterRef} />;
+
+  if (!shouldShowOverlay) {
+    return toaster;
+  }
+
+  return (
+    <FullWindowOverlay unstable_accessibilityContainerViewIsModal={false}>
+      {toaster}
+    </FullWindowOverlay>
+  );
+};
+
+export default ToasterOverlay;

--- a/app/components/Nav/App/ToasterOverlay/index.ts
+++ b/app/components/Nav/App/ToasterOverlay/index.ts
@@ -1,0 +1,6 @@
+export { default as ToasterOverlay } from './ToasterOverlay';
+export {
+  TOASTER_FULL_WINDOW_OVERLAY_TEST_ID,
+  TOAST_OVERLAY_ANIMATION_BUFFER_MS,
+  TOAST_OVERLAY_AUTO_DISMISS_MS,
+} from './ToasterOverlay.constants';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetDialog.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetDialog.test.tsx
@@ -1,0 +1,96 @@
+import { act, render } from '@testing-library/react-native';
+import React, { useEffect, useRef } from 'react';
+import { AccessibilityInfo, Text } from 'react-native';
+import {
+  QuickBuyBottomSheetDialog,
+  type QuickBuyBottomSheetDialogRef,
+} from './QuickBuyBottomSheetDialog';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  Theme: { Light: 'light', Dark: 'dark' },
+  useTailwind: () => ({
+    style: (...args: unknown[]) => args,
+  }),
+  useTheme: () => 'light',
+  usePureBlack: () => false,
+}));
+
+jest.mock('@metamask/design-tokens', () => ({
+  lightTheme: { shadows: { size: { lg: {} } } },
+  resolveDarkTheme: () => ({ shadows: { size: { lg: {} } } }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {
+    // no-op
+  };
+  return Reanimated;
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const ReactMock = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    Gesture: {
+      Pan: () => ({
+        enabled: () => ({
+          onStart: () => ({
+            onUpdate: () => ({
+              onEnd: () => ({}),
+            }),
+          }),
+        }),
+      }),
+    },
+    GestureDetector: ({ children }: { children: React.ReactNode }) =>
+      ReactMock.createElement(View, null, children),
+  };
+});
+
+describe('QuickBuyBottomSheetDialog', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(AccessibilityInfo, 'isReduceMotionEnabled')
+      .mockResolvedValue(false);
+    jest.spyOn(AccessibilityInfo, 'addEventListener').mockReturnValue({
+      remove: jest.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the drag handle when interactable', () => {
+    const { getByTestId } = render(
+      <QuickBuyBottomSheetDialog>
+        <Text>content</Text>
+      </QuickBuyBottomSheetDialog>,
+    );
+
+    expect(getByTestId('quick-buy-drag-handle')).toBeTruthy();
+  });
+
+  it('calls onCloseStart when onCloseDialog is invoked', () => {
+    const onCloseStart = jest.fn();
+    const TestComponent = () => {
+      const ref = useRef<QuickBuyBottomSheetDialogRef>(null);
+      useEffect(() => {
+        act(() => {
+          ref.current?.onCloseDialog();
+        });
+      }, []);
+      return (
+        <QuickBuyBottomSheetDialog ref={ref} onCloseStart={onCloseStart}>
+          <Text>content</Text>
+        </QuickBuyBottomSheetDialog>
+      );
+    };
+
+    render(<TestComponent />);
+
+    expect(onCloseStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetDialog.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetDialog.tsx
@@ -1,0 +1,397 @@
+import {
+  Theme,
+  usePureBlack,
+  useTailwind,
+  useTheme,
+} from '@metamask/design-system-twrnc-preset';
+import { lightTheme, resolveDarkTheme } from '@metamask/design-tokens';
+import { debounce } from 'lodash';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react';
+import {
+  AccessibilityInfo,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  type LayoutChangeEvent,
+  type ViewProps,
+} from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  Easing,
+  ReduceMotion,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import {
+  SHEET_DIALOG_CLOSE_DURATION,
+  SHEET_DIALOG_CLOSE_EASING,
+  SHEET_DIALOG_DRAG_DISMISS_OFFSET,
+  SHEET_DIALOG_DRAG_DISMISS_VELOCITY,
+  SHEET_DIALOG_DRAG_ELASTIC_DOWN,
+  SHEET_DIALOG_OFFSCREEN_FACTOR,
+  SHEET_DIALOG_SPRING,
+} from './sheetStackMotion';
+
+const sheetCloseEasing = Easing.bezier(
+  SHEET_DIALOG_CLOSE_EASING[0],
+  SHEET_DIALOG_CLOSE_EASING[1],
+  SHEET_DIALOG_CLOSE_EASING[2],
+  SHEET_DIALOG_CLOSE_EASING[3],
+);
+
+export type QuickBuyBottomSheetDialogProps = {
+  children?: React.ReactNode;
+  isFullscreen?: boolean;
+  isInteractable?: boolean;
+  keyboardAvoidingViewEnabled?: boolean;
+  onClose?: (hasPendingAction?: boolean) => void;
+  /** Fired when dismiss starts (programmatic or drag) — fade backdrop in parallel. */
+  onCloseStart?: () => void;
+  onOpen?: (hasPendingAction?: boolean) => void;
+  twClassName?: string;
+} & ViewProps;
+
+export interface QuickBuyBottomSheetDialogRef {
+  onCloseDialog: (callback?: () => void) => void;
+  onOpenDialog: (callback?: () => void) => void;
+}
+
+/**
+ * Quick Buy sheet surface — mirrored from DS BottomSheetDialog (PR #1411)
+ * until the package ships spring open, tween dismiss, and handle-only drag.
+ */
+export const QuickBuyBottomSheetDialog = forwardRef<
+  QuickBuyBottomSheetDialogRef,
+  QuickBuyBottomSheetDialogProps
+>(
+  (
+    {
+      children,
+      isFullscreen = false,
+      isInteractable = true,
+      keyboardAvoidingViewEnabled = true,
+      onClose,
+      onCloseStart,
+      onOpen,
+      style,
+      twClassName,
+      ...props
+    },
+    ref,
+  ) => {
+    const tw = useTailwind();
+    const currentTheme = useTheme();
+    const isPureBlack = usePureBlack();
+    const shadowLg =
+      currentTheme === Theme.Light
+        ? lightTheme.shadows.size.lg
+        : resolveDarkTheme(isPureBlack).shadows.size.lg;
+
+    const { top: screenTopPadding, bottom: screenBottomPadding } =
+      useSafeAreaInsets();
+    const { y: frameY, height: screenHeight } = useSafeAreaFrame();
+
+    const maxSheetHeight = screenHeight - screenTopPadding;
+    const currentYOffset = useSharedValue(screenHeight);
+    const topOfDialogYValue = useSharedValue(0);
+    const bottomOfDialogYValue = useSharedValue(screenHeight);
+    const gestureStartYOffset = useSharedValue(0);
+    const reduceMotion = useSharedValue(false);
+    const isMounted = useRef(false);
+
+    useEffect(() => {
+      let isActive = true;
+
+      void Promise.resolve(AccessibilityInfo.isReduceMotionEnabled())
+        .then((enabled) => {
+          if (isActive) {
+            reduceMotion.value = Boolean(enabled);
+          }
+        })
+        .catch(() => {
+          // AccessibilityInfo can reject in non-native test environments.
+        });
+
+      const subscription = AccessibilityInfo.addEventListener(
+        'reduceMotionChanged',
+        (enabled) => {
+          reduceMotion.value = enabled;
+        },
+      );
+
+      return () => {
+        isActive = false;
+        subscription?.remove?.();
+      };
+    }, [reduceMotion]);
+
+    const onOpenCB = useCallback(() => {
+      onOpen?.();
+    }, [onOpen]);
+    const onCloseCB = useCallback(() => {
+      onClose?.();
+    }, [onClose]);
+    const onCloseStartCB = useCallback(() => {
+      onCloseStart?.();
+    }, [onCloseStart]);
+
+    const onCloseDialog = useCallback(
+      (callback?: () => void) => {
+        onCloseStartCB();
+
+        const closeConfig = reduceMotion.value
+          ? { duration: 0 }
+          : {
+              duration: SHEET_DIALOG_CLOSE_DURATION,
+              easing: sheetCloseEasing,
+            };
+
+        currentYOffset.value = withTiming(
+          bottomOfDialogYValue.value,
+          closeConfig,
+          (finished) => {
+            if (!finished) {
+              return;
+            }
+            // Reanimated v3 — scheduleOnRN is v4-only.
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+            runOnJS(onCloseCB)();
+            if (callback) {
+              // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+              runOnJS(callback)();
+            }
+          },
+        );
+      },
+      [
+        onCloseCB,
+        onCloseStartCB,
+        currentYOffset,
+        bottomOfDialogYValue,
+        reduceMotion,
+      ],
+    );
+
+    const gestureHandler = useMemo(() => {
+      const gesture = Gesture.Pan()
+        .enabled(isInteractable)
+        .onStart(() => {
+          'worklet';
+          gestureStartYOffset.value = currentYOffset.value;
+        })
+        .onUpdate((event) => {
+          'worklet';
+          const { translationY } = event;
+          // Top hard-stop. Downward tracks the finger 1:1.
+          if (translationY <= 0) {
+            currentYOffset.value = topOfDialogYValue.value;
+          } else {
+            currentYOffset.value =
+              gestureStartYOffset.value +
+              translationY * SHEET_DIALOG_DRAG_ELASTIC_DOWN;
+          }
+        })
+        .onEnd((event) => {
+          'worklet';
+          const { velocityY } = event;
+          const dragOffset = currentYOffset.value - topOfDialogYValue.value;
+          const shouldDismiss =
+            dragOffset > SHEET_DIALOG_DRAG_DISMISS_OFFSET ||
+            velocityY > SHEET_DIALOG_DRAG_DISMISS_VELOCITY;
+
+          if (shouldDismiss) {
+            // Keep dismiss on the UI thread — avoid a frame stall before tween.
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+            runOnJS(onCloseStartCB)();
+            const closeConfig = reduceMotion.value
+              ? { duration: 0 }
+              : {
+                  duration: SHEET_DIALOG_CLOSE_DURATION,
+                  easing: sheetCloseEasing,
+                };
+            currentYOffset.value = withTiming(
+              bottomOfDialogYValue.value,
+              closeConfig,
+              (finished) => {
+                if (finished) {
+                  // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+                  runOnJS(onCloseCB)();
+                }
+              },
+            );
+          } else if (reduceMotion.value) {
+            currentYOffset.value = withTiming(topOfDialogYValue.value, {
+              duration: 0,
+            });
+          } else {
+            currentYOffset.value = withSpring(topOfDialogYValue.value, {
+              ...SHEET_DIALOG_SPRING,
+              velocity: velocityY,
+              reduceMotion: ReduceMotion.System,
+            });
+          }
+        });
+
+      return gesture;
+    }, [
+      isInteractable,
+      currentYOffset,
+      gestureStartYOffset,
+      topOfDialogYValue,
+      bottomOfDialogYValue,
+      reduceMotion,
+      onCloseStartCB,
+      onCloseCB,
+    ]);
+
+    const onOpenDialog = (callback?: () => void) => {
+      currentYOffset.value = bottomOfDialogYValue.value;
+
+      const onOpened = (finished?: boolean) => {
+        if (finished === false) {
+          return;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+        runOnJS(onOpenCB)();
+        if (callback) {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated -- runOnJS is the v3 bridge
+          runOnJS(callback)();
+        }
+      };
+
+      if (reduceMotion.value) {
+        currentYOffset.value = withTiming(
+          topOfDialogYValue.value,
+          { duration: 0 },
+          onOpened,
+        );
+      } else {
+        currentYOffset.value = withSpring(
+          topOfDialogYValue.value,
+          {
+            ...SHEET_DIALOG_SPRING,
+            reduceMotion: ReduceMotion.System,
+          },
+          onOpened,
+        );
+      }
+    };
+
+    const onDebouncedCloseDialog = useMemo(
+      () => debounce(onCloseDialog, 2000, { leading: true }),
+      [onCloseDialog],
+    );
+
+    useEffect(
+      () => onDebouncedCloseDialog.cancel(),
+      [children, onDebouncedCloseDialog],
+    );
+
+    const updateSheetHeight = (e: LayoutChangeEvent) => {
+      const { height } = e.nativeEvent.layout;
+      bottomOfDialogYValue.value = height * SHEET_DIALOG_OFFSCREEN_FACTOR;
+
+      if (!isMounted.current) {
+        isMounted.current = true;
+        onOpenDialog();
+      }
+    };
+
+    const animatedSheetStyle = useAnimatedStyle(
+      () => ({
+        transform: [
+          {
+            translateY: currentYOffset.value,
+          },
+        ],
+      }),
+      [],
+    );
+
+    const sheetStyle = useMemo(
+      () => [
+        tw.style(
+          isPureBlack ? 'bg-alternative' : 'bg-default',
+          'rounded-t-3xl overflow-hidden border border-muted',
+          twClassName,
+        ),
+        {
+          maxHeight: maxSheetHeight,
+          paddingBottom: Platform.select({
+            ios: screenBottomPadding,
+            macos: screenBottomPadding,
+            default: screenBottomPadding + 16,
+          }),
+          ...(isFullscreen && { height: maxSheetHeight }),
+          ...shadowLg,
+        },
+        style,
+      ],
+      [
+        tw,
+        isPureBlack,
+        maxSheetHeight,
+        screenBottomPadding,
+        isFullscreen,
+        shadowLg,
+        style,
+        twClassName,
+      ],
+    );
+
+    const combinedSheetStyle = useMemo(
+      () => [...sheetStyle, animatedSheetStyle],
+      [sheetStyle, animatedSheetStyle],
+    );
+
+    useImperativeHandle(ref, () => ({
+      onOpenDialog,
+      onCloseDialog,
+    }));
+
+    return (
+      <KeyboardAvoidingView
+        style={tw.style('absolute bottom-0 inset-x-0')}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={
+          Platform.OS === 'ios' ? -screenBottomPadding : frameY
+        }
+        enabled={keyboardAvoidingViewEnabled}
+        {...props}
+      >
+        <Animated.View onLayout={updateSheetHeight} style={combinedSheetStyle}>
+          {isInteractable ? (
+            <GestureDetector gesture={gestureHandler}>
+              {/* Handle-only drag (PR #1411). 6px pill matches Quick Buy design. */}
+              <View
+                style={tw.style('self-stretch items-center pt-2 pb-2')}
+                testID="quick-buy-drag-handle"
+              >
+                <View
+                  style={tw.style('h-[6px] w-10 rounded-full bg-border-muted')}
+                />
+              </View>
+            </GestureDetector>
+          ) : null}
+          {children}
+        </Animated.View>
+      </KeyboardAvoidingView>
+    );
+  },
+);
+
+QuickBuyBottomSheetDialog.displayName = 'QuickBuyBottomSheetDialog';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetOverlay.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetOverlay.test.tsx
@@ -1,0 +1,95 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React, { useEffect, useRef } from 'react';
+import { AccessibilityInfo } from 'react-native';
+import {
+  QuickBuyBottomSheetOverlay,
+  type QuickBuyBottomSheetOverlayRef,
+} from './QuickBuyBottomSheetOverlay';
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: () => ({}),
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Reanimated = require('react-native-reanimated/mock');
+  Reanimated.default.call = () => {
+    // no-op
+  };
+  return Reanimated;
+});
+
+describe('QuickBuyBottomSheetOverlay', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(AccessibilityInfo, 'isReduceMotionEnabled')
+      .mockResolvedValue(false);
+    jest.spyOn(AccessibilityInfo, 'addEventListener').mockReturnValue({
+      remove: jest.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders with testID', () => {
+    const { getByTestId } = render(
+      <QuickBuyBottomSheetOverlay testID="overlay" />,
+    );
+
+    expect(getByTestId('overlay')).toBeTruthy();
+  });
+
+  it('calls onPress when overlay is pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <QuickBuyBottomSheetOverlay
+        testID="overlay"
+        onPress={onPress}
+        touchableOpacityProps={{ testID: 'overlay-press' }}
+      />,
+    );
+
+    fireEvent.press(getByTestId('overlay-press'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes onCloseOverlay via ref', () => {
+    const overlayRef: { current: QuickBuyBottomSheetOverlayRef | null } = {
+      current: null,
+    };
+    const TestComponent = () => {
+      const ref = useRef<QuickBuyBottomSheetOverlayRef>(null);
+      useEffect(() => {
+        overlayRef.current = ref.current;
+      }, []);
+      return <QuickBuyBottomSheetOverlay ref={ref} testID="overlay" />;
+    };
+
+    render(<TestComponent />);
+
+    expect(overlayRef.current).not.toBeNull();
+    expect(typeof overlayRef.current?.onCloseOverlay).toBe('function');
+  });
+
+  it('calls callback after onCloseOverlay', () => {
+    const callback = jest.fn();
+    const TestComponent = () => {
+      const ref = useRef<QuickBuyBottomSheetOverlayRef>(null);
+      useEffect(() => {
+        act(() => {
+          ref.current?.onCloseOverlay(callback);
+        });
+      }, []);
+      return <QuickBuyBottomSheetOverlay ref={ref} />;
+    };
+
+    render(<TestComponent />);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetOverlay.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetOverlay.tsx
@@ -1,0 +1,148 @@
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+} from 'react';
+import {
+  AccessibilityInfo,
+  TouchableOpacity,
+  type TouchableOpacityProps,
+  type ViewProps,
+} from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  OVERLAY_CLOSE_DURATION,
+  OVERLAY_OPEN_DURATION,
+  OVERLAY_OPEN_EASING,
+} from './sheetStackMotion';
+
+const overlayOpenEasing = Easing.bezier(
+  OVERLAY_OPEN_EASING[0],
+  OVERLAY_OPEN_EASING[1],
+  OVERLAY_OPEN_EASING[2],
+  OVERLAY_OPEN_EASING[3],
+);
+
+export type QuickBuyBottomSheetOverlayProps = {
+  twClassName?: string;
+  onPress?: () => void;
+  touchableOpacityProps?: Omit<TouchableOpacityProps, 'onPress' | 'style'>;
+} & ViewProps;
+
+export interface QuickBuyBottomSheetOverlayRef {
+  /** Fade the overlay out. Optional callback runs after the fade completes. */
+  onCloseOverlay: (callback?: () => void) => void;
+}
+
+/**
+ * Quick Buy backdrop — mirrored from DS BottomSheetOverlay (PR #1411) until
+ * the package ships the reanimated open/close motion + imperative fade-out.
+ */
+export const QuickBuyBottomSheetOverlay = forwardRef<
+  QuickBuyBottomSheetOverlayRef,
+  QuickBuyBottomSheetOverlayProps
+>(({ style, twClassName, onPress, touchableOpacityProps, ...props }, ref) => {
+  const tw = useTailwind();
+  const opacityVal = useSharedValue(0);
+  const reduceMotion = useSharedValue(false);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const openOverlay = (instant: boolean) => {
+      opacityVal.value = withTiming(1, {
+        duration: instant ? 0 : OVERLAY_OPEN_DURATION,
+        easing: overlayOpenEasing,
+      });
+    };
+
+    // Start open animation immediately; snap to instant if reduce-motion is on.
+    openOverlay(false);
+
+    // Promise.resolve: RN test mocks may return a bare boolean / undefined.
+    void Promise.resolve(AccessibilityInfo.isReduceMotionEnabled())
+      .then((enabled) => {
+        if (!isActive) {
+          return;
+        }
+        reduceMotion.value = Boolean(enabled);
+        if (enabled) {
+          openOverlay(true);
+        }
+      })
+      .catch(() => {
+        // AccessibilityInfo can reject in non-native test environments.
+      });
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      (enabled) => {
+        reduceMotion.value = enabled;
+      },
+    );
+
+    return () => {
+      isActive = false;
+      subscription?.remove?.();
+    };
+  }, [opacityVal, reduceMotion]);
+
+  const onCloseOverlay = useCallback(
+    (callback?: () => void) => {
+      opacityVal.value = withTiming(
+        0,
+        {
+          duration: reduceMotion.value ? 0 : OVERLAY_CLOSE_DURATION,
+          // Matches web BACKDROP_CLOSE ease: 'easeIn'
+          easing: Easing.in(Easing.ease),
+        },
+        (finished) => {
+          if (finished && callback) {
+            runOnJS(callback)();
+          }
+        },
+      );
+    },
+    [opacityVal, reduceMotion],
+  );
+
+  useImperativeHandle(ref, () => ({
+    onCloseOverlay,
+  }));
+
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      opacity: opacityVal.value,
+    }),
+    [],
+  );
+
+  return (
+    <Animated.View
+      style={[
+        tw.style('absolute inset-0 bg-overlay-default', twClassName),
+        style,
+        animatedStyle,
+      ]}
+      {...props}
+    >
+      {onPress ? (
+        <TouchableOpacity
+          onPress={onPress}
+          {...touchableOpacityProps}
+          style={tw.style('flex-1')}
+        />
+      ) : null}
+    </Animated.View>
+  );
+});
+
+QuickBuyBottomSheetOverlay.displayName = 'QuickBuyBottomSheetOverlay';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetSkeleton.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetSkeleton.test.tsx
@@ -10,7 +10,9 @@ describe('QuickBuyBottomSheetSkeleton', () => {
 
   it('renders the toolbar rate-tag skeleton', () => {
     render(<QuickBuyBottomSheetSkeleton />);
-    expect(screen.getByTestId('quick-buy-skeleton-rate-tag')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('quick-buy-skeleton-close-button'),
+    ).toBeOnTheScreen();
   });
 
   it('renders the slider skeleton', () => {
@@ -21,6 +23,11 @@ describe('QuickBuyBottomSheetSkeleton', () => {
   it('renders the pay-with pill skeleton', () => {
     render(<QuickBuyBottomSheetSkeleton />);
     expect(screen.getByTestId('quick-buy-skeleton-pay-with')).toBeOnTheScreen();
+  });
+
+  it('renders the total row skeleton', () => {
+    render(<QuickBuyBottomSheetSkeleton />);
+    expect(screen.getByTestId('quick-buy-skeleton-total')).toBeOnTheScreen();
   });
 
   it('renders the confirm-button skeleton', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetSkeleton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyBottomSheetSkeleton.tsx
@@ -24,20 +24,25 @@ const QuickBuyBottomSheetSkeleton: React.FC<
 
   return (
     <Box testID="quick-buy-content-loading">
-      {/* Toolbar — mirrors QuickBuyToolbar px-4 pt-2 pb-3 */}
+      {/* Toolbar — mirrors QuickBuyToolbar: settings | toggle | close */}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Between}
         twClassName="px-4 pt-2 pb-3"
       >
-        <Skeleton width={56} height={28} style={tw.style('rounded-full')} />
-        <Skeleton
-          width={140}
-          height={28}
-          style={tw.style('rounded-full')}
-          testID="quick-buy-skeleton-rate-tag"
-        />
+        <Box twClassName="flex-1" alignItems={BoxAlignItems.Start}>
+          <Skeleton width={40} height={40} style={tw.style('rounded-full')} />
+        </Box>
+        <Skeleton width={120} height={32} style={tw.style('rounded-full')} />
+        <Box twClassName="flex-1" alignItems={BoxAlignItems.End}>
+          <Skeleton
+            width={40}
+            height={40}
+            style={tw.style('rounded-full')}
+            testID="quick-buy-skeleton-close-button"
+          />
+        </Box>
       </Box>
 
       {/* Amount area — mirrors QuickBuyAmountSection pt-6 pb-4 */}
@@ -97,11 +102,29 @@ const QuickBuyBottomSheetSkeleton: React.FC<
           />
         </Box>
 
+        {/* Total row */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="pb-5"
+        >
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {strings('social_leaderboard.quick_buy.total')}
+          </Text>
+          <Skeleton
+            width={56}
+            height={16}
+            style={tw.style('rounded-md')}
+            testID="quick-buy-skeleton-total"
+          />
+        </Box>
+
         {/* Confirm button */}
         <Skeleton
           width="100%"
           height={48}
-          style={tw.style('rounded-xl')}
+          style={tw.style('rounded-[99px]')}
           testID="quick-buy-skeleton-confirm-button"
         />
       </Box>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.test.tsx
@@ -8,6 +8,7 @@ const defaultProps = {
   hasValidAmount: false,
   isDisabled: false,
   onPress: jest.fn(),
+  tradeMode: 'buy' as const,
   testID: 'confirm-button',
 };
 
@@ -66,5 +67,25 @@ describe('QuickBuyConfirmButton', () => {
     );
     fireEvent.press(screen.getByTestId('confirm-button'));
     expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('applies the success color in buy mode', () => {
+    render(<QuickBuyConfirmButton {...defaultProps} tradeMode="buy" />);
+
+    expect(screen.getByTestId('confirm-button').props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ backgroundColor: expect.any(String) }),
+      ]),
+    );
+  });
+
+  it('applies the orange sell color in sell mode', () => {
+    render(<QuickBuyConfirmButton {...defaultProps} tradeMode="sell" />);
+
+    expect(screen.getByTestId('confirm-button').props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ backgroundColor: expect.any(String) }),
+      ]),
+    );
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.tsx
@@ -11,11 +11,14 @@ import {
   ButtonBaseSize,
   ButtonVariant,
 } from '@metamask/design-system-react-native';
+import { brandColor } from '@metamask/design-tokens';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Icon, {
   IconName,
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
+import { useTheme } from '../../../../../../util/theme';
+import type { QuickBuyTradeMode } from './types';
 
 export type ConfirmButtonState = 'idle' | 'loading' | 'success';
 
@@ -23,7 +26,8 @@ const styles = StyleSheet.create({
   successContainer: {
     height: 48,
     width: '100%',
-    borderRadius: 12,
+    // Temporary override — match primary button pill until DS default updates.
+    borderRadius: 99,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
@@ -36,6 +40,7 @@ interface QuickBuyConfirmButtonProps {
   hasValidAmount: boolean;
   isDisabled: boolean;
   onPress: () => void;
+  tradeMode: QuickBuyTradeMode;
   testID?: string;
 }
 
@@ -44,9 +49,13 @@ const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
   label,
   isDisabled,
   onPress,
+  tradeMode,
   testID,
 }) => {
   const tw = useTailwind();
+  const { colors } = useTheme();
+  const actionColor =
+    tradeMode === 'sell' ? brandColor.orange400 : colors.success.default;
   const checkScale = useSharedValue(0);
 
   useEffect(() => {
@@ -61,7 +70,7 @@ const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
   if (state === 'success') {
     return (
       <Box
-        style={[styles.successContainer, tw.style('bg-icon-default')]}
+        style={[styles.successContainer, { backgroundColor: actionColor }]}
         testID={testID}
       >
         <Animated.View style={checkmarkStyle}>
@@ -84,6 +93,9 @@ const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
       isFullWidth
       testID={testID}
       isDisabled={state !== 'idle' || isDisabled}
+      // Temporary override — pill radius + buy/sell action colors.
+      twClassName="rounded-[99px]"
+      style={{ backgroundColor: actionColor }}
     >
       {label}
     </Button>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
@@ -77,7 +77,11 @@ const QuickBuyQuoteDetailsScreen: React.FC = () => {
 
       {!hasQuoteDetails ? (
         <Box twClassName="px-4 py-8" alignItems={BoxAlignItems.Center}>
-          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
+            twClassName="text-center"
+          >
             {strings(
               hasValidAmount
                 ? 'social_leaderboard.quick_buy.quote_details_empty_no_quote'

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -39,23 +39,23 @@ const mockOnCloseDialog = jest.fn((cb?: () => void) => cb?.());
 
 const mockOnCloseOverlay = jest.fn((cb?: () => void) => cb?.());
 
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
+jest.mock('./QuickBuyBottomSheetDialog', () => {
   const ReactMock = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
 
   return {
-    ...actual,
-    BottomSheetDialog: ReactMock.forwardRef(
+    QuickBuyBottomSheetDialog: ReactMock.forwardRef(
       (
         {
           children,
           onClose,
           onOpen,
+          onCloseStart,
         }: {
           children: unknown;
           onClose?: () => void;
           onOpen?: () => void;
+          onCloseStart?: () => void;
         },
         ref: unknown,
       ) => {
@@ -64,7 +64,10 @@ jest.mock('@metamask/design-system-react-native', () => {
           onOpenDialog: (cb?: () => void) => {
             cb?.();
           },
-          onCloseDialog: mockOnCloseDialog,
+          onCloseDialog: (cb?: () => void) => {
+            onCloseStart?.();
+            mockOnCloseDialog(cb);
+          },
         }));
         return ReactMock.createElement(
           View,
@@ -250,20 +253,6 @@ jest.mock('./QuickBuyPriceImpactConfirmScreen', () => {
   };
 });
 
-jest.mock('./QuickBuyBottomSheetSkeleton', () => {
-  const ReactMock = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      ReactMock.createElement(
-        Text,
-        { testID: 'mock-skeleton' },
-        'quick-buy-content-loading',
-      ),
-  };
-});
-
 jest.mock('../../../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../../../util/theme');
   return {
@@ -404,10 +393,6 @@ describe('QuickBuyRoot', () => {
         onClose={jest.fn()}
       />,
     );
-
-    act(() => {
-      storedOnOpenCallback?.();
-    });
 
     expect(screen.getByTestId('mock-toolbar')).toBeOnTheScreen();
     expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react-native';
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, Text } from 'react-native';
 import { TextColor } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import QuickBuyRoot from './QuickBuyRoot';
@@ -115,11 +115,86 @@ jest.mock('./QuickBuyAmount', () => {
 
 jest.mock('./components/QuickBuyActionFooter', () => {
   const ReactMock = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
+  const { Text, Pressable: PressableMock } = jest.requireActual('react-native');
+  const { useQuickBuyContext: useCtx } = jest.requireActual(
+    './useQuickBuyContext',
+  );
   return {
     __esModule: true,
-    default: () =>
-      ReactMock.createElement(Text, { testID: 'mock-action-footer' }, 'footer'),
+    default: () => {
+      const { setActiveScreen } = useCtx();
+      return ReactMock.createElement(
+        ReactMock.Fragment,
+        null,
+        ReactMock.createElement(
+          Text,
+          { testID: 'mock-action-footer' },
+          'footer',
+        ),
+        ReactMock.createElement(PressableMock, {
+          testID: 'nav-to-payWith',
+          onPress: () => setActiveScreen('payWith'),
+        }),
+        ReactMock.createElement(PressableMock, {
+          testID: 'nav-to-quoteDetails',
+          onPress: () => setActiveScreen('quoteDetails'),
+        }),
+      );
+    },
+  };
+});
+
+jest.mock('./QuickBuyTokenSelectScreen', () => {
+  const ReactMock = jest.requireActual('react');
+  const { Text, Pressable: PressableMock } = jest.requireActual('react-native');
+  const { useQuickBuyContext: useCtx } = jest.requireActual(
+    './useQuickBuyContext',
+  );
+  return {
+    __esModule: true,
+    default: () => {
+      const { setActiveScreen } = useCtx();
+      return ReactMock.createElement(
+        ReactMock.Fragment,
+        null,
+        ReactMock.createElement(
+          Text,
+          { testID: 'mock-pay-with-screen' },
+          'pay-with',
+        ),
+        ReactMock.createElement(PressableMock, {
+          testID: 'nav-back-from-payWith',
+          onPress: () => setActiveScreen('amount'),
+        }),
+      );
+    },
+  };
+});
+
+jest.mock('./QuickBuyQuoteDetailsScreen', () => {
+  const ReactMock = jest.requireActual('react');
+  const { Text, Pressable: PressableMock } = jest.requireActual('react-native');
+  const { useQuickBuyContext: useCtx } = jest.requireActual(
+    './useQuickBuyContext',
+  );
+  return {
+    __esModule: true,
+    default: () => {
+      const { setActiveScreen } = useCtx();
+      return ReactMock.createElement(
+        ReactMock.Fragment,
+        null,
+        ReactMock.createElement(
+          Text,
+          { testID: 'mock-quote-details-screen' },
+          'quote-details',
+        ),
+        ReactMock.createElement(PressableMock, {
+          testID: 'nav-back-from-quoteDetails',
+          onPress: () => setActiveScreen('amount'),
+        }),
+      );
+    },
   };
 });
 
@@ -452,7 +527,7 @@ describe('QuickBuyRoot', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('applies the measured locked height after the first layout', () => {
+  it('renders the in-sheet stack root layer for the amount screen', () => {
     renderWithProvider(
       <QuickBuyRoot
         isVisible
@@ -465,46 +540,9 @@ describe('QuickBuyRoot', () => {
       storedOnOpenCallback?.();
     });
 
-    const container = screen.getByTestId('quick-buy-content-container');
-    act(() => {
-      fireEvent(container, 'layout', {
-        nativeEvent: { layout: { height: 480 } },
-      });
-    });
-
-    expect(StyleSheet.flatten(container.props.style)).toMatchObject({
-      height: 480,
-    });
-  });
-
-  it('keeps the initial locked height when a later layout reports a different height', () => {
-    renderWithProvider(
-      <QuickBuyRoot
-        isVisible
-        target={positionToQuickBuyTarget(createPosition())}
-        features={TOP_TRADERS_QUICK_BUY_FEATURES}
-        onClose={jest.fn()}
-      />,
-    );
-    act(() => {
-      storedOnOpenCallback?.();
-    });
-
-    const container = screen.getByTestId('quick-buy-content-container');
-    act(() => {
-      fireEvent(container, 'layout', {
-        nativeEvent: { layout: { height: 480 } },
-      });
-    });
-    act(() => {
-      fireEvent(container, 'layout', {
-        nativeEvent: { layout: { height: 300 } },
-      });
-    });
-
-    expect(StyleSheet.flatten(container.props.style)).toMatchObject({
-      height: 480,
-    });
+    expect(screen.getByTestId('quick-buy-stack-root')).toBeOnTheScreen();
+    expect(screen.queryByTestId('quick-buy-stack-detail')).toBeNull();
+    expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
   });
 
   describe('close behavior', () => {
@@ -536,37 +574,62 @@ describe('QuickBuyRoot', () => {
       expect(mockOnCloseDialog).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+  });
 
-    it('suppresses the content exit transition while closing', () => {
+  describe('in-sheet stack', () => {
+    const openSheet = () => {
       renderWithProvider(
         <QuickBuyRoot
           isVisible
           target={positionToQuickBuyTarget(createPosition())}
           features={TOP_TRADERS_QUICK_BUY_FEATURES}
           onClose={jest.fn()}
-        >
-          <CloseProbe />
-        </QuickBuyRoot>,
+        />,
       );
       act(() => {
         storedOnOpenCallback?.();
       });
+    };
 
-      const beforeContainer = screen.getByTestId('quick-buy-content-container');
-      const animatedBefore = beforeContainer.children[0] as {
-        props: { exiting?: unknown };
-      };
-      expect(animatedBefore.props.exiting).toBeDefined();
+    it('pushes pay with as a detail layer while keeping the amount root mounted', () => {
+      openSheet();
 
       act(() => {
-        fireEvent.press(screen.getByTestId('probe-close'));
+        fireEvent.press(screen.getByTestId('nav-to-payWith'));
       });
 
-      const afterContainer = screen.getByTestId('quick-buy-content-container');
-      const animatedAfter = afterContainer.children[0] as {
-        props: { exiting?: unknown };
-      };
-      expect(animatedAfter.props.exiting).toBeUndefined();
+      expect(screen.getByTestId('quick-buy-stack-root')).toBeOnTheScreen();
+      expect(screen.getByTestId('quick-buy-stack-detail')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-pay-with-screen')).toBeOnTheScreen();
+    });
+
+    it('pushes quote details as a detail layer', () => {
+      openSheet();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-to-quoteDetails'));
+      });
+
+      expect(screen.getByTestId('quick-buy-stack-detail')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-quote-details-screen')).toBeOnTheScreen();
+    });
+
+    it('keeps the detail mounted through the pop so the slide-out can play', () => {
+      openSheet();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-to-payWith'));
+      });
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-back-from-payWith'));
+      });
+
+      // Detail stays mounted immediately after pop so the outgoing screen can
+      // slide away; it unmounts after SHEET_STACK_PUSH_DURATION.
+      expect(screen.getByTestId('quick-buy-stack-detail')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-pay-with-screen')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -37,6 +37,8 @@ jest.mock('../../../analytics', () => {
 let storedOnOpenCallback: (() => void) | undefined;
 const mockOnCloseDialog = jest.fn((cb?: () => void) => cb?.());
 
+const mockOnCloseOverlay = jest.fn((cb?: () => void) => cb?.());
+
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   const ReactMock = jest.requireActual('react');
@@ -49,15 +51,18 @@ jest.mock('@metamask/design-system-react-native', () => {
         {
           children,
           onClose,
+          onOpen,
         }: {
           children: unknown;
           onClose?: () => void;
+          onOpen?: () => void;
         },
         ref: unknown,
       ) => {
+        storedOnOpenCallback = onOpen;
         ReactMock.useImperativeHandle(ref, () => ({
-          onOpenDialog: (cb: () => void) => {
-            storedOnOpenCallback = cb;
+          onOpenDialog: (cb?: () => void) => {
+            cb?.();
           },
           onCloseDialog: mockOnCloseDialog,
         }));
@@ -65,6 +70,39 @@ jest.mock('@metamask/design-system-react-native', () => {
           View,
           { testID: 'mock-bottom-sheet-dialog', onTouchEnd: onClose },
           children,
+        );
+      },
+    ),
+  };
+});
+
+jest.mock('./QuickBuyBottomSheetOverlay', () => {
+  const ReactMock = jest.requireActual('react');
+  const { View, Pressable: PressableMock } = jest.requireActual('react-native');
+  return {
+    QuickBuyBottomSheetOverlay: ReactMock.forwardRef(
+      (
+        {
+          onPress,
+          testID,
+        }: {
+          onPress?: () => void;
+          testID?: string;
+        },
+        ref: unknown,
+      ) => {
+        ReactMock.useImperativeHandle(ref, () => ({
+          onCloseOverlay: mockOnCloseOverlay,
+        }));
+        return ReactMock.createElement(
+          View,
+          { testID: testID ?? 'quick-buy-overlay' },
+          onPress
+            ? ReactMock.createElement(PressableMock, {
+                testID: 'quick-buy-overlay-press',
+                onPress,
+              })
+            : null,
         );
       },
     ),
@@ -347,6 +385,7 @@ describe('QuickBuyRoot', () => {
     jest.clearAllMocks();
     storedOnOpenCallback = undefined;
     mockOnCloseDialog.mockImplementation((cb?: () => void) => cb?.());
+    mockOnCloseOverlay.mockImplementation((cb?: () => void) => cb?.());
     (useQuickBuyController as jest.Mock).mockReturnValue(buildHookResult());
     (useQuickBuySetup as jest.Mock).mockReturnValue({
       chainId: '0x1',
@@ -373,6 +412,37 @@ describe('QuickBuyRoot', () => {
     expect(screen.getByTestId('mock-toolbar')).toBeOnTheScreen();
     expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
     expect(screen.getByTestId('mock-action-footer')).toBeOnTheScreen();
+  });
+
+  it('renders the backdrop overlay behind the sheet', () => {
+    renderWithProvider(
+      <QuickBuyRoot
+        isVisible
+        target={positionToQuickBuyTarget(createPosition())}
+        features={TOP_TRADERS_QUICK_BUY_FEATURES}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('quick-buy-sheet-host')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-overlay')).toBeOnTheScreen();
+  });
+
+  it('fades the overlay and closes the dialog when the backdrop is pressed', () => {
+    const onClose = jest.fn();
+    renderWithProvider(
+      <QuickBuyRoot
+        isVisible
+        target={positionToQuickBuyTarget(createPosition())}
+        features={TOP_TRADERS_QUICK_BUY_FEATURES}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('quick-buy-overlay-press'));
+
+    expect(mockOnCloseOverlay).toHaveBeenCalledTimes(1);
+    expect(mockOnCloseDialog).toHaveBeenCalledWith(onClose);
   });
 
   it('fires SOCIAL_QUICK_BUY_SHEET_VIEWED when the sheet opens with a source', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -4,19 +4,9 @@ import {
   type BottomSheetDialogRef,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import type { LayoutChangeEvent } from 'react-native';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useSelector } from 'react-redux';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
-import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
 import { useABTest } from '../../../../../../hooks/useABTest';
 import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import {
@@ -38,11 +28,9 @@ import QuickBuyPriceImpactConfirmScreen from './QuickBuyPriceImpactConfirmScreen
 import QuickBuyQuoteDetailsScreen from './QuickBuyQuoteDetailsScreen';
 import QuickBuySelectQuoteScreen from './QuickBuySelectQuoteScreen';
 import QuickBuyTokenSelectScreen from './QuickBuyTokenSelectScreen';
-import {
-  makeScreenTransitions,
-  SCREEN_DEPTH,
-  type ScreenDirection,
-} from './transitions';
+import { SHEET_STACK_PUSH_DURATION } from './sheetStackMotion';
+import { isSheetStackScreen } from './transitions';
+import { Animated, useSheetStackTransition } from './useSheetStackTransition';
 import type {
   QuickBuyAnalyticsContext,
   QuickBuyFeatures,
@@ -53,15 +41,8 @@ import type {
 
 export type { QuickBuyRootProps } from './types';
 
-function renderActiveScreen(
-  activeScreen: QuickBuyScreen,
-  children: React.ReactNode | undefined,
-): React.ReactNode {
-  if (children !== undefined && children !== null) {
-    return children;
-  }
-
-  switch (activeScreen) {
+function renderScreen(screen: QuickBuyScreen): React.ReactNode {
+  switch (screen) {
     case 'payWith':
       return <QuickBuyTokenSelectScreen />;
     case 'quoteDetails':
@@ -97,15 +78,41 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
   const [isContentReady, setIsContentReady] = useState(false);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
-  // Measured once from the first screen and reused as a fixed height for every
-  // screen so the sheet keeps a constant size during navigation (no layout
-  // shift between screens).
-  const [lockedHeight, setLockedHeight] = useState<number | null>(null);
-  // True once a dismissal is requested via the CTA/Cancel so the content drops
-  // with the sheet instead of running its horizontal screen-exit transition.
+  // Keep the last pushed screen mounted through the pop animation so the
+  // outgoing detail stays visible while it slides off.
+  const [renderedDetail, setRenderedDetail] = useState<QuickBuyScreen | null>(
+    null,
+  );
+  // True once a dismissal is requested via the CTA/Cancel so we don't also
+  // run a horizontal pop while the sheet is sliding down.
   const [isClosing, setIsClosing] = useState(false);
-  const isSubmittingTx = useSelector(selectIsSubmittingTx);
+  // Last screen we already drove stack motion for — ignores Strict Mode's
+  // double effect invoke so we don't skip pop/unmount or re-snap mid-push.
+  const lastAnimatedScreenRef = useRef<QuickBuyScreen>('amount');
+  const unmountDetailTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const surfaceClass = useElevatedSurface();
+
+  const {
+    isPushed,
+    requestPush,
+    pop,
+    snapToPushed,
+    onStackLayout,
+    onRootLayout,
+    onDetailLayout,
+    heightStyle,
+    rootScreenStyle,
+    detailScreenStyle,
+  } = useSheetStackTransition();
+
+  const popRef = useRef(pop);
+  popRef.current = pop;
+  const requestPushRef = useRef(requestPush);
+  requestPushRef.current = requestPush;
+  const snapToPushedRef = useRef(snapToPushed);
+  snapToPushedRef.current = snapToPushed;
 
   // Keyboard vs slider A/B test. Resolved here so `Experiment Viewed` fires
   // once the sheet is actually shown (this component only mounts when visible).
@@ -116,26 +123,9 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   );
   const useKeyboard = variant.useKeyboard;
 
-  const directionSV = useSharedValue<ScreenDirection>(1);
-  // Suppresses the enter animation on the initial screen when the sheet opens;
-  // transitions only kick in once the user navigates between screens.
-  const [hasNavigated, setHasNavigated] = useState(false);
-  const { entering, exiting } = useMemo(
-    () => makeScreenTransitions(directionSV),
-    [directionSV],
-  );
-
-  const navigateToScreen = useCallback(
-    (next: QuickBuyScreen) => {
-      setHasNavigated(true);
-      setActiveScreen((current) => {
-        directionSV.value =
-          SCREEN_DEPTH[next] >= SCREEN_DEPTH[current] ? 1 : -1;
-        return next;
-      });
-    },
-    [directionSV],
-  );
+  const navigateToScreen = useCallback((next: QuickBuyScreen) => {
+    setActiveScreen(next);
+  }, []);
 
   const trackSheetViewed = useCallback(() => {
     const source = analyticsContext?.source;
@@ -157,6 +147,50 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     });
   }, [trackSheetViewed]);
 
+  // Drive in-sheet stack push/pop from activeScreen. Skip while the whole
+  // sheet is dismissing so content doesn't also slide horizontally.
+  // Push is deferred via requestPush → detail onLayout so we never animate
+  // with an unmeasured (0-height) detail, which collapsed the sheet.
+  useEffect(() => {
+    if (isClosing) {
+      lastAnimatedScreenRef.current = activeScreen;
+      return;
+    }
+
+    const from = lastAnimatedScreenRef.current;
+    if (from === activeScreen) {
+      return;
+    }
+    lastAnimatedScreenRef.current = activeScreen;
+
+    if (isSheetStackScreen(activeScreen)) {
+      if (unmountDetailTimeoutRef.current !== null) {
+        clearTimeout(unmountDetailTimeoutRef.current);
+        unmountDetailTimeoutRef.current = null;
+      }
+      setRenderedDetail(activeScreen);
+      if (isSheetStackScreen(from)) {
+        // Already drilled in (e.g. quoteDetails ↔ selectQuote) — swap detail
+        // content without replaying the push from amount.
+        snapToPushedRef.current();
+      } else {
+        requestPushRef.current();
+      }
+      return;
+    }
+
+    // Returning to amount: pop, then unmount detail after the slide finishes.
+    if (isSheetStackScreen(from)) {
+      popRef.current();
+      if (unmountDetailTimeoutRef.current === null) {
+        unmountDetailTimeoutRef.current = setTimeout(() => {
+          unmountDetailTimeoutRef.current = null;
+          setRenderedDetail(null);
+        }, SHEET_STACK_PUSH_DURATION);
+      }
+    }
+  }, [activeScreen, isClosing]);
+
   // Animate the sheet down (then run the parent's onClose) and flag the content
   // as closing so it doesn't slide horizontally on the way out. Falls back to a
   // direct onClose when the imperative handle isn't available.
@@ -170,35 +204,13 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     }
   }, [onClose]);
 
-  const handleContentLayout = useCallback(
-    (event: LayoutChangeEvent) => {
-      // Capture the first (amount) screen height once so every sub-screen shares
-      // it and doesn't collapse to its own (often short) content height. In the
-      // keyboard treatment the amount screen stays dynamic below, but its
-      // initial (keypad-open) height is still the baseline for the others.
-      if (lockedHeight !== null) {
-        return;
-      }
-      const { height } = event.nativeEvent.layout;
-      if (height > 0) {
-        setLockedHeight(height);
-      }
-    },
-    [lockedHeight],
-  );
-
   // Keep the bottom safe-area inset only on screens that pin a CTA at the
-  // bottom; the scroll-only screens (quote details / select quote / pay with /
-  // receive) sit flush to the edge instead of leaving dead space below.
-  const hasBottomCta =
-    activeScreen === 'amount' || activeScreen === 'priceImpactConfirm';
+  // bottom; scroll-only detail screens sit flush to the edge.
+  const detailHasBottomCta = renderedDetail === 'priceImpactConfirm';
 
-  // The amount screen in the keyboard treatment stays dynamic so it can grow and
-  // shrink with the keypad; every other screen (and the whole control variant)
-  // uses the locked height so sub-screens like "Pay with" don't collapse to
-  // their own short content height.
-  const isDynamicAmountScreen = useKeyboard && activeScreen === 'amount';
-  const shouldLockHeight = lockedHeight !== null && !isDynamicAmountScreen;
+  // Custom children (tests / compound overrides) use a single layer — the
+  // in-sheet stack is for the real amount ↔ payWith / quoteDetails flow.
+  const useCustomChildren = children !== undefined && children !== null;
 
   return (
     <BottomSheetDialog
@@ -230,33 +242,46 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           setActiveScreen={navigateToScreen}
           useKeyboard={useKeyboard}
         >
-          <Box
-            testID="quick-buy-content-container"
-            onLayout={handleContentLayout}
-            style={
-              shouldLockHeight && lockedHeight !== null
-                ? {
-                    // Scroll-only screens reclaim the bottom safe-area inset
-                    // that BottomSheetDialog adds, so they sit flush to the
-                    // edge while keeping the same overall sheet height as the
-                    // CTA screens (no layout shift between screens).
-                    height: hasBottomCta
-                      ? lockedHeight
-                      : lockedHeight + bottomInset,
-                    ...(hasBottomCta ? {} : { marginBottom: -bottomInset }),
-                  }
-                : undefined
-            }
-          >
+          {useCustomChildren ? (
+            <Box testID="quick-buy-content-container">{children}</Box>
+          ) : (
             <Animated.View
-              key={activeScreen}
-              entering={hasNavigated ? entering : undefined}
-              exiting={isClosing ? undefined : exiting}
-              style={shouldLockHeight ? tw.style('flex-1') : undefined}
+              testID="quick-buy-content-container"
+              onLayout={onStackLayout}
+              style={[tw.style('w-full overflow-hidden'), heightStyle]}
             >
-              {renderActiveScreen(activeScreen, children)}
+              <Animated.View
+                testID="quick-buy-stack-root"
+                onLayout={onRootLayout}
+                pointerEvents={isPushed ? 'none' : 'auto'}
+                style={[
+                  tw.style(`absolute left-0 right-0 top-0 ${surfaceClass}`),
+                  rootScreenStyle,
+                ]}
+              >
+                {renderScreen('amount')}
+              </Animated.View>
+
+              {renderedDetail !== null && (
+                <Animated.View
+                  testID="quick-buy-stack-detail"
+                  onLayout={onDetailLayout}
+                  pointerEvents={isPushed ? 'auto' : 'none'}
+                  style={[
+                    tw.style(
+                      `absolute left-0 right-0 top-0 overflow-hidden ${surfaceClass}`,
+                    ),
+                    detailHasBottomCta
+                      ? undefined
+                      : { marginBottom: -bottomInset },
+                    detailScreenStyle,
+                  ]}
+                >
+                  <Box twClassName="flex-1">{renderScreen(renderedDetail)}</Box>
+                </Animated.View>
+              )}
             </Animated.View>
-          </Box>
+          )}
         </QuickBuyProvider>
       ) : (
         <QuickBuyBottomSheetSkeleton useKeyboard={useKeyboard} />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -22,7 +22,10 @@ import {
 import { useSocialLeaderboardAnalytics } from '../../../analytics';
 import { TOP_TRADERS_QUICK_BUY_FEATURES } from './features';
 import QuickBuyAmountScreen from './QuickBuyAmountScreen';
-import QuickBuyBottomSheetSkeleton from './QuickBuyBottomSheetSkeleton';
+import {
+  QuickBuyBottomSheetOverlay,
+  type QuickBuyBottomSheetOverlayRef,
+} from './QuickBuyBottomSheetOverlay';
 import { QuickBuyProvider } from './QuickBuyContext';
 import QuickBuyPriceImpactConfirmScreen from './QuickBuyPriceImpactConfirmScreen';
 import QuickBuyQuoteDetailsScreen from './QuickBuyQuoteDetailsScreen';
@@ -76,7 +79,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const { bottom: bottomInset } = useSafeAreaInsets();
   const { track } = useSocialLeaderboardAnalytics();
   const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
-  const [isContentReady, setIsContentReady] = useState(false);
+  const overlayRef = useRef<QuickBuyBottomSheetOverlayRef>(null);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
   // Keep the last pushed screen mounted through the pop animation so the
   // outgoing detail stays visible while it slides off.
@@ -96,6 +99,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
 
   const {
     isPushed,
+    isHeightReady,
     requestPush,
     pop,
     snapToPushed,
@@ -139,13 +143,6 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
         analyticsContext.traderTradeType ?? QuickBuyEventValues.TRADE_TYPE.BUY,
     });
   }, [analyticsContext, target.tokenSymbol, track]);
-
-  useEffect(() => {
-    bottomSheetRef.current?.onOpenDialog(() => {
-      setIsContentReady(true);
-      trackSheetViewed();
-    });
-  }, [trackSheetViewed]);
 
   // Drive in-sheet stack push/pop from activeScreen. Skip while the whole
   // sheet is dismissing so content doesn't also slide horizontally.
@@ -194,8 +191,10 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   // Animate the sheet down (then run the parent's onClose) and flag the content
   // as closing so it doesn't slide horizontally on the way out. Falls back to a
   // direct onClose when the imperative handle isn't available.
+  // Fade the backdrop in parallel with dismiss (DS onCloseStart → overlay fade).
   const requestClose = useCallback(() => {
     setIsClosing(true);
+    overlayRef.current?.onCloseOverlay();
     const sheet = bottomSheetRef.current;
     if (sheet?.onCloseDialog) {
       sheet.onCloseDialog(onClose);
@@ -212,26 +211,38 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   // in-sheet stack is for the real amount ↔ payWith / quoteDetails flow.
   const useCustomChildren = children !== undefined && children !== null;
 
+  // Host fills the window like DS BottomSheet so the backdrop can cover the
+  // chart behind the dialog. Backdrop / sheet Y stay put during in-sheet stack.
+  //
+  // Content mounts immediately (no post-open skeleton swap). Until the amount
+  // root is measured, keep it in document flow so BottomSheetDialog opens at
+  // the real height; absolute + heightStyle only after measure (stack push).
   return (
-    <BottomSheetDialog
-      ref={bottomSheetRef}
-      onClose={onClose}
-      twClassName={`${surfaceClass} rounded-t-[40px]`}
-    >
-      {/* Temporary override: DS BottomSheetDialog ships h-1 (4px); cover with a
-          thicker pill to match design until the DS default is updated.
-          Keep this wrapper transparent — a full-bleed surface bg here clips
-          against large top radii and leaves a gap at the corners. */}
-      <Box
-        twClassName="-mt-3 items-center pt-2 pb-2"
-        pointerEvents="none"
-        testID="quick-buy-drag-handle"
+    <Box twClassName="absolute inset-0" testID="quick-buy-sheet-host">
+      <QuickBuyBottomSheetOverlay
+        ref={overlayRef}
+        onPress={requestClose}
+        testID="quick-buy-overlay"
+      />
+      <BottomSheetDialog
+        ref={bottomSheetRef}
+        onOpen={trackSheetViewed}
+        onClose={onClose}
+        twClassName={`${surfaceClass} rounded-t-[40px]`}
       >
-        {/* Mask the thin DS handle only under the pill */}
-        <Box twClassName={`absolute h-3 w-12 rounded-full ${surfaceClass}`} />
-        <Box twClassName="h-[6px] w-10 rounded-full bg-border-muted" />
-      </Box>
-      {isContentReady ? (
+        {/* Temporary override: DS BottomSheetDialog ships h-1 (4px); cover with a
+            thicker pill to match design until the DS default is updated.
+            Keep this wrapper transparent — a full-bleed surface bg here clips
+            against large top radii and leaves a gap at the corners. */}
+        <Box
+          twClassName="-mt-3 items-center pt-2 pb-2"
+          pointerEvents="none"
+          testID="quick-buy-drag-handle"
+        >
+          {/* Mask the thin DS handle only under the pill */}
+          <Box twClassName={`absolute h-3 w-12 rounded-full ${surfaceClass}`} />
+          <Box twClassName="h-[6px] w-10 rounded-full bg-border-muted" />
+        </Box>
         <QuickBuyProvider
           key={variantName}
           target={target}
@@ -248,14 +259,19 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
             <Animated.View
               testID="quick-buy-content-container"
               onLayout={onStackLayout}
-              style={[tw.style('w-full overflow-hidden'), heightStyle]}
+              style={[
+                tw.style('w-full overflow-hidden'),
+                isHeightReady ? heightStyle : undefined,
+              ]}
             >
               <Animated.View
                 testID="quick-buy-stack-root"
                 onLayout={onRootLayout}
                 pointerEvents={isPushed ? 'none' : 'auto'}
                 style={[
-                  tw.style('absolute left-0 right-0 top-0'),
+                  isHeightReady
+                    ? tw.style('absolute left-0 right-0 top-0')
+                    : tw.style('w-full'),
                   rootScreenStyle,
                 ]}
               >
@@ -275,16 +291,16 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
                     detailScreenStyle,
                   ]}
                 >
-                  <Box twClassName="flex-1">{renderScreen(renderedDetail)}</Box>
+                  <Box twClassName="flex-1">
+                    {renderScreen(renderedDetail)}
+                  </Box>
                 </Animated.View>
               )}
             </Animated.View>
           )}
         </QuickBuyProvider>
-      ) : (
-        <QuickBuyBottomSheetSkeleton useKeyboard={useKeyboard} />
-      )}
-    </BottomSheetDialog>
+      </BottomSheetDialog>
+    </Box>
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -204,8 +204,21 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     <BottomSheetDialog
       ref={bottomSheetRef}
       onClose={onClose}
-      twClassName={surfaceClass}
+      twClassName={`${surfaceClass} rounded-t-[40px]`}
     >
+      {/* Temporary override: DS BottomSheetDialog ships h-1 (4px); cover with a
+          thicker pill to match design until the DS default is updated.
+          Keep this wrapper transparent — a full-bleed surface bg here clips
+          against large top radii and leaves a gap at the corners. */}
+      <Box
+        twClassName="-mt-3 items-center pt-2 pb-2"
+        pointerEvents="none"
+        testID="quick-buy-drag-handle"
+      >
+        {/* Mask the thin DS handle only under the pill */}
+        <Box twClassName={`absolute h-3 w-12 rounded-full ${surfaceClass}`} />
+        <Box twClassName="h-[6px] w-10 rounded-full bg-border-muted" />
+      </Box>
       {isContentReady ? (
         <QuickBuyProvider
           key={variantName}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -255,7 +255,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
                 onLayout={onRootLayout}
                 pointerEvents={isPushed ? 'none' : 'auto'}
                 style={[
-                  tw.style(`absolute left-0 right-0 top-0 ${surfaceClass}`),
+                  tw.style('absolute left-0 right-0 top-0'),
                   rootScreenStyle,
                 ]}
               >
@@ -268,9 +268,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
                   onLayout={onDetailLayout}
                   pointerEvents={isPushed ? 'auto' : 'none'}
                   style={[
-                    tw.style(
-                      `absolute left-0 right-0 top-0 overflow-hidden ${surfaceClass}`,
-                    ),
+                    tw.style('absolute left-0 right-0 top-0 overflow-hidden'),
                     detailHasBottomCta
                       ? undefined
                       : { marginBottom: -bottomInset },

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -1,8 +1,4 @@
-import {
-  BottomSheetDialog,
-  Box,
-  type BottomSheetDialogRef,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -22,6 +18,10 @@ import {
 import { useSocialLeaderboardAnalytics } from '../../../analytics';
 import { TOP_TRADERS_QUICK_BUY_FEATURES } from './features';
 import QuickBuyAmountScreen from './QuickBuyAmountScreen';
+import {
+  QuickBuyBottomSheetDialog,
+  type QuickBuyBottomSheetDialogRef,
+} from './QuickBuyBottomSheetDialog';
 import {
   QuickBuyBottomSheetOverlay,
   type QuickBuyBottomSheetOverlayRef,
@@ -78,7 +78,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const tw = useTailwind();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const { track } = useSocialLeaderboardAnalytics();
-  const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
+  const bottomSheetRef = useRef<QuickBuyBottomSheetDialogRef>(null);
   const overlayRef = useRef<QuickBuyBottomSheetOverlayRef>(null);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
   // Keep the last pushed screen mounted through the pop animation so the
@@ -188,20 +188,24 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     }
   }, [activeScreen, isClosing]);
 
-  // Animate the sheet down (then run the parent's onClose) and flag the content
-  // as closing so it doesn't slide horizontally on the way out. Falls back to a
-  // direct onClose when the imperative handle isn't available.
-  // Fade the backdrop in parallel with dismiss (DS onCloseStart → overlay fade).
-  const requestClose = useCallback(() => {
+  // Fade backdrop + flag content closing when dismiss starts (CTA, overlay, or
+  // drag) so in-sheet stack doesn't also slide while the sheet tweens down.
+  const handleCloseStart = useCallback(() => {
     setIsClosing(true);
     overlayRef.current?.onCloseOverlay();
+  }, []);
+
+  // Animate the sheet down (then run the parent's onClose). Falls back to a
+  // direct onClose when the imperative handle isn't available.
+  const requestClose = useCallback(() => {
     const sheet = bottomSheetRef.current;
     if (sheet?.onCloseDialog) {
       sheet.onCloseDialog(onClose);
     } else {
+      handleCloseStart();
       onClose();
     }
-  }, [onClose]);
+  }, [handleCloseStart, onClose]);
 
   // Keep the bottom safe-area inset only on screens that pin a CTA at the
   // bottom; scroll-only detail screens sit flush to the edge.
@@ -224,25 +228,13 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
         onPress={requestClose}
         testID="quick-buy-overlay"
       />
-      <BottomSheetDialog
+      <QuickBuyBottomSheetDialog
         ref={bottomSheetRef}
         onOpen={trackSheetViewed}
+        onCloseStart={handleCloseStart}
         onClose={onClose}
         twClassName={`${surfaceClass} rounded-t-[40px]`}
       >
-        {/* Temporary override: DS BottomSheetDialog ships h-1 (4px); cover with a
-            thicker pill to match design until the DS default is updated.
-            Keep this wrapper transparent — a full-bleed surface bg here clips
-            against large top radii and leaves a gap at the corners. */}
-        <Box
-          twClassName="-mt-3 items-center pt-2 pb-2"
-          pointerEvents="none"
-          testID="quick-buy-drag-handle"
-        >
-          {/* Mask the thin DS handle only under the pill */}
-          <Box twClassName={`absolute h-3 w-12 rounded-full ${surfaceClass}`} />
-          <Box twClassName="h-[6px] w-10 rounded-full bg-border-muted" />
-        </Box>
         <QuickBuyProvider
           key={variantName}
           target={target}
@@ -291,15 +283,13 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
                     detailScreenStyle,
                   ]}
                 >
-                  <Box twClassName="flex-1">
-                    {renderScreen(renderedDetail)}
-                  </Box>
+                  <Box twClassName="flex-1">{renderScreen(renderedDetail)}</Box>
                 </Animated.View>
               )}
             </Animated.View>
           )}
         </QuickBuyProvider>
-      </BottomSheetDialog>
+      </QuickBuyBottomSheetDialog>
     </Box>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, screen } from '@testing-library/react-native';
+import { fireEvent, screen } from '@testing-library/react-native';
 import { TextColor } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import type { Position } from '@metamask/social-controllers';
@@ -49,20 +49,13 @@ jest.mock('../../../../../../hooks/useABTest', () => ({
   }),
 }));
 
-// Captures the onOpenDialog callback registered by QuickBuyRootInner.
-// Call storedOnOpenCallback() inside act() after render to simulate the sheet
-// finishing its open animation and make isContentReady become true.
-let storedOnOpenCallback: (() => void) | undefined;
-
 // Render children directly so inner component content is visible
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
+jest.mock('./QuickBuyBottomSheetDialog', () => {
   const ReactMock = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
 
   return {
-    ...actual,
-    BottomSheetDialog: ReactMock.forwardRef(
+    QuickBuyBottomSheetDialog: ReactMock.forwardRef(
       (
         {
           children,
@@ -74,8 +67,8 @@ jest.mock('@metamask/design-system-react-native', () => {
         ref: unknown,
       ) => {
         ReactMock.useImperativeHandle(ref, () => ({
-          onOpenDialog: (cb: () => void) => {
-            storedOnOpenCallback = cb;
+          onOpenDialog: (cb?: () => void) => {
+            cb?.();
           },
           onCloseDialog: (cb?: () => void) => cb?.(),
         }));
@@ -177,20 +170,6 @@ jest.mock('./QuickBuyBanners', () => {
     __esModule: true,
     default: () =>
       ReactMock.createElement(Text, { testID: 'mock-banners' }, 'banners'),
-  };
-});
-
-jest.mock('./QuickBuyBottomSheetSkeleton', () => {
-  const ReactMock = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      ReactMock.createElement(
-        Text,
-        { testID: 'mock-skeleton' },
-        'quick-buy-content-loading',
-      ),
   };
 });
 
@@ -322,7 +301,6 @@ const setMockQuickBuyController = (
 describe('QuickBuy.Root', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    storedOnOpenCallback = undefined;
     mockUseKeyboard = false;
     setMockQuickBuyController();
     (useQuickBuySetup as jest.Mock).mockReturnValue({
@@ -368,7 +346,7 @@ describe('QuickBuy.Root', () => {
   });
 
   describe('inner sheet', () => {
-    it('renders the toolbar after deferred content becomes ready', () => {
+    it('renders amount content as soon as the sheet mounts', () => {
       renderWithProvider(
         <QuickBuy.Root
           isVisible
@@ -380,26 +358,8 @@ describe('QuickBuy.Root', () => {
         />,
       );
 
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       expect(screen.getByTestId('mock-toolbar')).toBeOnTheScreen();
-    });
-
-    it('renders the skeleton body before deferred content becomes ready', () => {
-      renderWithProvider(
-        <QuickBuy.Root
-          isVisible
-          target={positionToQuickBuyTarget(createPosition())}
-          features={TOP_TRADERS_QUICK_BUY_FEATURES}
-          onClose={jest.fn()}
-        />,
-      );
-
-      expect(screen.getByTestId('mock-skeleton')).toBeOnTheScreen();
-      expect(screen.queryByTestId('mock-toolbar')).not.toBeOnTheScreen();
-      expect(screen.queryByTestId('mock-amount-section')).not.toBeOnTheScreen();
+      expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
     });
 
     it('shows an unsupported chain message instead of the buy flow', () => {
@@ -413,9 +373,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
 
       expect(
         screen.getByText('social_leaderboard.quick_buy.unsupported_chain'),
@@ -438,10 +395,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       expect(screen.getByTestId('mock-amount-section')).toBeOnTheScreen();
       expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
     });
@@ -458,10 +411,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       expect(screen.queryByTestId('quick-buy-keypad')).not.toBeOnTheScreen();
     });
 
@@ -477,10 +426,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       expect(screen.queryByTestId('quick-buy-keypad')).not.toBeOnTheScreen();
     });
 
@@ -496,10 +441,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       fireEvent.press(screen.getByTestId('quick-buy-amount-area-pressable'));
 
       expect(screen.getByTestId('quick-buy-keypad')).toBeOnTheScreen();
@@ -534,10 +475,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       expect(screen.queryByTestId('quick-buy-keypad')).not.toBeOnTheScreen();
       expect((useQuickBuyController as jest.Mock).mock.calls[0]?.[3]).toBe(
         false,
@@ -572,10 +509,6 @@ describe('QuickBuy.Root', () => {
           onClose={jest.fn()}
         />,
       );
-      act(() => {
-        storedOnOpenCallback?.();
-      });
-
       fireEvent.press(screen.getByTestId('quick-buy-confirm-button'));
 
       expect(handleConfirm).toHaveBeenCalledTimes(1);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyTokenSelectList.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyTokenSelectList.tsx
@@ -3,6 +3,9 @@ import {
   Box,
   BoxAlignItems,
   BoxJustifyContent,
+  ButtonIconSize,
+  ButtonIconVariant,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -113,8 +116,14 @@ const QuickBuyTokenSelectList: React.FC<QuickBuyTokenSelectListProps> = ({
     <>
       <BottomSheetHeader
         onBack={onBack}
-        backButtonProps={{ testID: 'quick-buy-pay-with-back' }}
+        backButtonProps={{
+          testID: 'quick-buy-pay-with-back',
+          variant: ButtonIconVariant.Filled,
+          size: ButtonIconSize.Lg,
+          iconProps: { size: IconSize.Md },
+        }}
         testID="quick-buy-pay-with-header"
+        twClassName="h-12 px-4 pt-0 mb-3"
       >
         <Text variant={TextVariant.HeadingSm}>{title}</Text>
       </BottomSheetHeader>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
 import QuickBuyActionFooter from './QuickBuyActionFooter';
 import { useQuickBuyContext } from '../useQuickBuyContext';
 
@@ -50,6 +50,18 @@ jest.mock('../QuickBuyConfirmButton', () => {
   };
 });
 
+jest.mock(
+  '../../../../../../../component-library/components-temp/Skeleton',
+  () => {
+    const ReactMock = jest.requireActual('react');
+    const { Text } = jest.requireActual('react-native');
+    return {
+      Skeleton: ({ testID }: { testID?: string }) =>
+        ReactMock.createElement(Text, { testID }, 'skeleton'),
+    };
+  },
+);
+
 const baseContext = {
   sliderPercent: 0,
   isSliderDisabled: false,
@@ -72,6 +84,8 @@ const baseContext = {
   setActiveScreen: jest.fn(),
   useKeyboard: false,
   isKeypadOpen: false,
+  totalAmountFiat: '$0.00',
+  isTotalLoading: false,
 };
 
 describe('QuickBuyActionFooter', () => {
@@ -141,10 +155,50 @@ describe('QuickBuyActionFooter', () => {
 
     expect(screen.getByTestId('quick-buy-footer-reveal')).toBeOnTheScreen();
     expect(screen.getByTestId('quick-buy-pay-with-button')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-total-row')).toBeOnTheScreen();
     expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
     expect(screen.getByTestId('quick-buy-quick-amounts')).toBeOnTheScreen();
     expect(
       screen.getByTestId('quick-buy-footer-reveal-content').props.pointerEvents,
     ).toBe('none');
+  });
+
+  it('renders the total amount beneath pay with', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      totalAmountFiat: '$20.18',
+    });
+
+    render(<QuickBuyActionFooter />);
+
+    expect(screen.getByTestId('quick-buy-total-row')).toBeOnTheScreen();
+    expect(screen.getByText('$20.18')).toBeOnTheScreen();
+    expect(
+      screen.getByText('social_leaderboard.quick_buy.total'),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows a loading skeleton while the total is loading', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      isTotalLoading: true,
+    });
+
+    render(<QuickBuyActionFooter />);
+
+    expect(screen.getByTestId('quick-buy-total-loading')).toBeOnTheScreen();
+  });
+
+  it('navigates to quote details when the total row is pressed', () => {
+    const setActiveScreen = jest.fn();
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      setActiveScreen,
+    });
+
+    render(<QuickBuyActionFooter />);
+    fireEvent.press(screen.getByTestId('quick-buy-total-row'));
+
+    expect(setActiveScreen).toHaveBeenCalledWith('quoteDetails');
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -172,7 +172,7 @@ const QuickBuyActionFooter: React.FC = () => {
               {features.payWithSheet ? (
                 <Icon
                   name={IconName.ArrowRight}
-                  size={IconSize.Sm}
+                  size={IconSize.Xs}
                   color={IconColor.IconDefault}
                 />
               ) : null}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -12,9 +12,12 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, { useState } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
+import { Skeleton } from '../../../../../../../component-library/components-temp/Skeleton';
+import { useTheme } from '../../../../../../../util/theme';
 import QuickBuyBanners from '../QuickBuyBanners';
 import QuickBuyConfirmButton from '../QuickBuyConfirmButton';
 import { useQuickBuyContext } from '../useQuickBuyContext';
@@ -23,7 +26,67 @@ import { QuickBuyPercentageSlider } from './QuickBuyPercentageSlider';
 import QuickBuyQuickAmounts from './QuickBuyQuickAmounts';
 import QuickBuyTokenIcon from './QuickBuyTokenIcon';
 
+/** Fine dotted underline — RN's textDecorationStyle can't control dash size. */
+const DOTTED_DASH = 2;
+const DOTTED_GAP = 2;
+
+const dottedStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    marginTop: 1,
+    height: 1,
+    overflow: 'hidden',
+  },
+  dash: {
+    width: DOTTED_DASH,
+    height: 1,
+  },
+  dashGap: {
+    marginRight: DOTTED_GAP,
+  },
+});
+
+const DottedUnderlineLabel: React.FC<{
+  children: string;
+}> = ({ children }) => {
+  const { colors } = useTheme();
+  const [width, setWidth] = useState(0);
+  const dashCount =
+    width > 0
+      ? Math.floor((width + DOTTED_GAP) / (DOTTED_DASH + DOTTED_GAP))
+      : 0;
+
+  return (
+    <View>
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        onLayout={(event) => {
+          setWidth(event.nativeEvent.layout.width);
+        }}
+      >
+        {children}
+      </Text>
+      {dashCount > 0 ? (
+        <View style={[dottedStyles.row, { width }]}>
+          {Array.from({ length: dashCount }, (_, index) => (
+            <View
+              key={index}
+              style={[
+                dottedStyles.dash,
+                { backgroundColor: colors.text.alternative },
+                index === dashCount - 1 ? null : dottedStyles.dashGap,
+              ]}
+            />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
 const QuickBuyActionFooter: React.FC = () => {
+  const tw = useTailwind();
   const {
     sliderPercent,
     isSliderDisabled,
@@ -34,7 +97,6 @@ const QuickBuyActionFooter: React.FC = () => {
     hasValidAmount,
     isConfirmDisabled,
     handleBuy,
-    metamaskFeePercent,
     isHardwareSolanaBlocked,
     tradeMode,
     sourceToken,
@@ -45,6 +107,8 @@ const QuickBuyActionFooter: React.FC = () => {
     setActiveScreen,
     useKeyboard,
     isKeypadOpen,
+    totalAmountFiat,
+    isTotalLoading,
   } = useQuickBuyContext();
 
   const pickerToken = tradeMode === 'sell' ? selectedDestStable : sourceToken;
@@ -66,9 +130,9 @@ const QuickBuyActionFooter: React.FC = () => {
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Between}
-        twClassName="pb-5"
+        twClassName="pb-3"
       >
-        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {tradeMode === 'sell'
             ? strings('social_leaderboard.quick_buy.receive')
             : strings('social_leaderboard.quick_buy.pay_with')}
@@ -84,31 +148,68 @@ const QuickBuyActionFooter: React.FC = () => {
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            gap={2}
+            gap={3}
           >
             {pickerToken ? (
               <QuickBuyTokenIcon
                 token={pickerToken}
                 size={AvatarTokenSize.Sm}
+                twClassName="h-[20px] w-[20px]"
               />
             ) : null}
-            <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
-              {pickerToken
-                ? pickerBalanceFiat
-                  ? `${pickerToken.symbol} (${pickerBalanceFiat})`
-                  : pickerToken.symbol
-                : '—'}
-            </Text>
-            {features.payWithSheet ? (
-              <Icon
-                name={IconName.ArrowRight}
-                size={IconSize.Sm}
-                color={IconColor.IconDefault}
-              />
-            ) : null}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+                {pickerToken
+                  ? pickerBalanceFiat
+                    ? `${pickerToken.symbol} (${pickerBalanceFiat})`
+                    : pickerToken.symbol
+                  : '—'}
+              </Text>
+              {features.payWithSheet ? (
+                <Icon
+                  name={IconName.ArrowRight}
+                  size={IconSize.Sm}
+                  color={IconColor.IconDefault}
+                />
+              ) : null}
+            </Box>
           </Box>
         </TouchableOpacity>
       </Box>
+
+      <TouchableOpacity
+        onPress={() => setActiveScreen('quoteDetails')}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        testID="quick-buy-total-row"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="pb-5"
+        >
+          <DottedUnderlineLabel>
+            {strings('social_leaderboard.quick_buy.total')}
+          </DottedUnderlineLabel>
+          {isTotalLoading ? (
+            <Skeleton
+              width={56}
+              height={16}
+              style={tw.style('rounded-md')}
+              testID="quick-buy-total-loading"
+            />
+          ) : (
+            <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+              {totalAmountFiat}
+            </Text>
+          )}
+        </Box>
+      </TouchableOpacity>
 
       <QuickBuyConfirmButton
         state={confirmButtonState}
@@ -116,18 +217,9 @@ const QuickBuyActionFooter: React.FC = () => {
         hasValidAmount={hasValidAmount}
         isDisabled={isConfirmDisabled}
         onPress={handleBuy}
+        tradeMode={tradeMode}
         testID="quick-buy-confirm-button"
       />
-
-      {metamaskFeePercent > 0 ? (
-        <Box twClassName="mt-2 items-center">
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {strings('social_leaderboard.quick_buy.includes_mm_fee', {
-              fee: metamaskFeePercent,
-            })}
-          </Text>
-        </Box>
-      ) : null}
     </>
   );
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
@@ -15,7 +15,7 @@ describe('QuickBuyAmountSection', () => {
     render(<QuickBuyAmountSection {...baseProps} />);
 
     expect(screen.getByText('$2.55')).toBeOnTheScreen();
-    expect(screen.getByText('56.52037 GIGA')).toBeOnTheScreen();
+    expect(screen.getByText('≈ 56.52037 GIGA')).toBeOnTheScreen();
     expect(
       screen.queryByTestId('quick-buy-amount-loading'),
     ).not.toBeOnTheScreen();
@@ -35,7 +35,7 @@ describe('QuickBuyAmountSection', () => {
     expect(
       screen.queryByTestId('quick-buy-amount-loading-icon'),
     ).not.toBeOnTheScreen();
-    expect(screen.queryByText('56.52037 GIGA')).not.toBeOnTheScreen();
+    expect(screen.queryByText('≈ 56.52037 GIGA')).not.toBeOnTheScreen();
   });
 
   it('is not pressable when no onAmountAreaPress is provided (control)', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
@@ -73,7 +73,9 @@ const QuickBuyAmountSection: React.FC<QuickBuyAmountSectionProps> = ({
   } else {
     const isCryptoPrimary = amountDisplayMode === 'crypto';
     primaryLabel = isCryptoPrimary ? cryptoAmountLabel : fiatAmountLabel;
-    secondaryLabel = isCryptoPrimary ? fiatAmountLabel : cryptoAmountLabel;
+    secondaryLabel = isCryptoPrimary
+      ? `≈ ${fiatAmountLabel}`
+      : `≈ ${cryptoAmountLabel}`;
   }
 
   const content = (
@@ -85,7 +87,7 @@ const QuickBuyAmountSection: React.FC<QuickBuyAmountSectionProps> = ({
       testID="quick-buy-amount-area"
     >
       <Text
-        variant={TextVariant.DisplayMd}
+        variant={TextVariant.DisplayLg}
         fontWeight={FontWeight.Bold}
         color={TextColor.TextDefault}
       >

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPayWithChainFilter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPayWithChainFilter.tsx
@@ -36,8 +36,9 @@ const QuickBuyPayWithChainFilter: React.FC<QuickBuyPayWithChainFilterProps> = ({
       activeChipKey={getChainChipKey(selectedChainId)}
       onChipSelect={(key) => onSelect(key === 'all' ? null : key)}
       testID={testID}
-      containerTwClassName="pb-3"
-      chipTwClassName="rounded-lg px-3 py-1.5"
+      containerTwClassName="pb-4"
+      // TEMP: pill shape for Quick Buy polish — revert when settled.
+      chipTwClassName="rounded-[99px] px-3 py-1.5"
       getChipTestId={getChainFilterTestId}
       useGestureHandlerScrollView
     />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
@@ -4,6 +4,8 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
+  FontWeight,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import React, { useCallback } from 'react';
 import { strings } from '../../../../../../../../locales/i18n';
@@ -18,13 +20,18 @@ import {
  * Shared pill chrome.
  * ButtonSize.Md (40px) matches the Figma height; px-2 overrides the default
  * 16px horizontal padding so all four labels fit on one row without clipping.
+ * Label is BodySm Medium (Md buttons default to BodyMd).
  */
 const QUICK_AMOUNT_PILL_PROPS = {
   variant: ButtonVariant.Secondary,
   size: ButtonSize.Md,
+  textProps: {
+    variant: TextVariant.BodySm,
+    fontWeight: FontWeight.Medium,
+  },
 } as const;
 
-const QUICK_AMOUNT_PILL_TW_CLASS = 'min-w-0 flex-1 px-2';
+const QUICK_AMOUNT_PILL_TW_CLASS = 'min-w-0 flex-1 rounded-[99px] px-2';
 
 export interface QuickBuyQuickAmountsProps {
   /** When true, appends a primary Done pill (keyboard-open row above the keypad). */
@@ -74,6 +81,7 @@ const QuickBuyQuickAmounts: React.FC<QuickBuyQuickAmountsProps> = ({
       <Button
         variant={ButtonVariant.Primary}
         size={ButtonSize.Md}
+        textProps={QUICK_AMOUNT_PILL_PROPS.textProps}
         onPress={onDonePress}
         twClassName={QUICK_AMOUNT_PILL_TW_CLASS}
         testID="quick-buy-keypad-done"

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuySubScreenHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuySubScreenHeader.tsx
@@ -6,8 +6,10 @@ import {
   BoxJustifyContent,
   ButtonIcon,
   ButtonIconSize,
+  ButtonIconVariant,
   FontWeight,
   IconName as DsIconName,
+  IconSize,
   Text,
   TextColor,
   TextVariant,
@@ -28,11 +30,13 @@ const QuickBuySubScreenHeader: React.FC<QuickBuySubScreenHeaderProps> = ({
     flexDirection={BoxFlexDirection.Row}
     alignItems={BoxAlignItems.Center}
     justifyContent={BoxJustifyContent.Between}
-    twClassName="h-14 px-2"
+    twClassName="h-12 px-4 pt-0 mb-3"
   >
     <ButtonIcon
       iconName={DsIconName.ArrowLeft}
-      size={ButtonIconSize.Md}
+      size={ButtonIconSize.Lg}
+      variant={ButtonIconVariant.Filled}
+      iconProps={{ size: IconSize.Md }}
       onPress={onBack}
       testID="quick-buy-sub-screen-back-button"
     />
@@ -45,7 +49,9 @@ const QuickBuySubScreenHeader: React.FC<QuickBuySubScreenHeaderProps> = ({
     </Text>
     <ButtonIcon
       iconName={DsIconName.Close}
-      size={ButtonIconSize.Md}
+      size={ButtonIconSize.Lg}
+      variant={ButtonIconVariant.Filled}
+      iconProps={{ size: IconSize.Md }}
       onPress={onClose}
       testID="quick-buy-sub-screen-close-button"
     />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTokenIcon.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTokenIcon.tsx
@@ -30,6 +30,11 @@ const styles = StyleSheet.create({
 interface QuickBuyTokenIconProps {
   token: BridgeToken;
   size?: AvatarTokenSize;
+  /**
+   * Optional Tailwind override for the avatar dimensions (e.g. `h-[20px] w-[20px]`).
+   * Applied after the size preset so custom pixel sizes can be used.
+   */
+  twClassName?: string;
 }
 
 /**
@@ -45,6 +50,7 @@ interface QuickBuyTokenIconProps {
 const QuickBuyTokenIcon: React.FC<QuickBuyTokenIconProps> = ({
   token,
   size = AvatarTokenSize.Md,
+  twClassName,
 }) => {
   const networkImageSource = getNetworkImageSource({
     chainId: token.chainId,
@@ -73,6 +79,7 @@ const QuickBuyTokenIcon: React.FC<QuickBuyTokenIconProps> = ({
       name={token.symbol}
       src={source}
       size={size}
+      twClassName={twClassName}
       imageOrSvgProps={{
         imageProps: { onError, testID: QUICK_BUY_TOKEN_ICON_AVATAR_TEST_ID },
       }}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
@@ -12,9 +12,8 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
 }));
 
 const baseContext = {
-  formattedRate: undefined,
-  formattedExchangeRate: '1 ETH = 1000 USDC',
   setActiveScreen: jest.fn(),
+  onClose: jest.fn(),
   features: { tradeModes: ['buy'] as ('buy' | 'sell')[] },
   tradeMode: 'buy' as const,
   setTradeMode: jest.fn(),
@@ -22,14 +21,14 @@ const baseContext = {
 
 describe('QuickBuyToolbar', () => {
   const setActiveScreen = jest.fn();
+  const onClose = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
-      formattedRate: undefined,
-      formattedExchangeRate: '1 ETH = 1000 USDC',
       setActiveScreen,
+      onClose,
     });
   });
 
@@ -51,6 +50,7 @@ describe('QuickBuyToolbar', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
       setActiveScreen,
+      onClose,
       features: { tradeModes: ['buy', 'sell'] },
       hasSellableBalance: true,
     });
@@ -65,6 +65,7 @@ describe('QuickBuyToolbar', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
       setActiveScreen,
+      onClose,
       features: { tradeModes: ['buy', 'sell'] },
       hasSellableBalance: false,
     });
@@ -78,53 +79,21 @@ describe('QuickBuyToolbar', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('shows formattedExchangeRate when no quote is available', () => {
+  it('renders settings and close buttons with muted circular backgrounds', () => {
     render(<QuickBuyToolbar />);
-    expect(screen.getByTestId('quick-buy-rate-tag')).toBeOnTheScreen();
-    expect(screen.getByText('1 ETH = 1000 USDC')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-settings-button')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-close-button')).toBeOnTheScreen();
   });
 
-  it('prefers formattedRate (quote-based) over formattedExchangeRate when a quote is available', () => {
-    (useQuickBuyContext as jest.Mock).mockReturnValue({
-      ...baseContext,
-      formattedRate: '1 SOL = 25,738.44 GIGA',
-      formattedExchangeRate: '1 SOL = 23,529 GIGA',
-      setActiveScreen,
-    });
-
+  it('navigates to quoteDetails when the settings button is pressed', () => {
     render(<QuickBuyToolbar />);
-    expect(screen.getByText('1 SOL = 25,738.44 GIGA')).toBeOnTheScreen();
-    expect(screen.queryByText('1 SOL = 23,529 GIGA')).not.toBeOnTheScreen();
-  });
-
-  it('shows formattedRate even when formattedExchangeRate is undefined', () => {
-    (useQuickBuyContext as jest.Mock).mockReturnValue({
-      ...baseContext,
-      formattedRate: '1 ETH = 4381.23 REPPO',
-      formattedExchangeRate: undefined,
-      setActiveScreen,
-    });
-
-    render(<QuickBuyToolbar />);
-    expect(screen.getByTestId('quick-buy-rate-tag')).toBeOnTheScreen();
-    expect(screen.getByText('1 ETH = 4381.23 REPPO')).toBeOnTheScreen();
-  });
-
-  it('hides the rate tag when both rates are undefined', () => {
-    (useQuickBuyContext as jest.Mock).mockReturnValue({
-      ...baseContext,
-      formattedRate: undefined,
-      formattedExchangeRate: undefined,
-      setActiveScreen,
-    });
-
-    render(<QuickBuyToolbar />);
-    expect(screen.queryByTestId('quick-buy-rate-tag')).not.toBeOnTheScreen();
-  });
-
-  it('navigates to quoteDetails screen when the rate tag is pressed', () => {
-    render(<QuickBuyToolbar />);
-    fireEvent.press(screen.getByTestId('quick-buy-rate-tag-pressable'));
+    fireEvent.press(screen.getByTestId('quick-buy-settings-button'));
     expect(setActiveScreen).toHaveBeenCalledWith('quoteDetails');
+  });
+
+  it('calls onClose when the close button is pressed', () => {
+    render(<QuickBuyToolbar />);
+    fireEvent.press(screen.getByTestId('quick-buy-close-button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
@@ -1,27 +1,43 @@
 import React from 'react';
+import { TouchableOpacity } from 'react-native';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react-native';
-import QuickBuyRateTag from './QuickBuyRateTag';
 import QuickBuyTradeModeToggle from './QuickBuyTradeModeToggle';
 import { useQuickBuyContext } from '../useQuickBuyContext';
 
-const QuickBuyToolbar: React.FC = () => {
-  const {
-    formattedRate,
-    formattedExchangeRate,
-    setActiveScreen,
-    features,
-    isPriceImpactError,
-    hasSellableBalance,
-  } = useQuickBuyContext();
+const ToolbarIconButton: React.FC<{
+  iconName: IconName;
+  onPress: () => void;
+  testID: string;
+}> = ({ iconName, onPress, testID }) => (
+  <TouchableOpacity
+    onPress={onPress}
+    accessibilityRole="button"
+    activeOpacity={0.7}
+    testID={testID}
+  >
+    <Box
+      twClassName="h-10 w-10 items-center justify-center rounded-full bg-muted"
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+    >
+      <Icon name={iconName} size={IconSize.Md} color={IconColor.IconDefault} />
+    </Box>
+  </TouchableOpacity>
+);
 
-  // Prefer the quote-derived rate (available once a quote is fetched),
-  // fall back to the price-metadata rate for the pre-quote state.
-  const rateLabel = formattedRate ?? formattedExchangeRate;
+const QuickBuyToolbar: React.FC = () => {
+  const { setActiveScreen, features, hasSellableBalance, onClose } =
+    useQuickBuyContext();
+
   const showFullToggle = features.tradeModes.length > 1 && hasSellableBalance;
 
   return (
@@ -31,13 +47,33 @@ const QuickBuyToolbar: React.FC = () => {
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
     >
+      <Box
+        twClassName="flex-1"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Start}
+      >
+        <ToolbarIconButton
+          iconName={IconName.Setting}
+          onPress={() => setActiveScreen('quoteDetails')}
+          testID="quick-buy-settings-button"
+        />
+      </Box>
+
       <QuickBuyTradeModeToggle buyOnly={!showFullToggle} />
 
-      <QuickBuyRateTag
-        label={rateLabel}
-        onPress={() => setActiveScreen('quoteDetails')}
-        isHighPriceImpact={isPriceImpactError}
-      />
+      <Box
+        twClassName="flex-1"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.End}
+      >
+        <ToolbarIconButton
+          iconName={IconName.Close}
+          onPress={onClose}
+          testID="quick-buy-close-button"
+        />
+      </Box>
     </Box>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
@@ -6,7 +6,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { brandColor } from '@metamask/design-tokens';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   StyleSheet,
@@ -15,7 +14,6 @@ import {
 } from 'react-native';
 import Animated, {
   interpolate,
-  interpolateColor,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -38,8 +36,8 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     bottom: 0,
-    // Matches the buttons' rounded-lg (8px) so the fill tucks neatly behind them.
-    borderRadius: 8,
+    // Matches the buttons' 99px radius so the fill tucks neatly behind them.
+    borderRadius: 99,
   },
 });
 
@@ -54,8 +52,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
 }) => {
   const { tradeMode, setTradeMode, hasSellableBalance } = useQuickBuyContext();
   const { colors } = useTheme();
-  const buyColor = colors.success.default;
-  const sellColor = brandColor.orange400;
+  const activeColor = colors.icon.default;
 
   const slideProgress = useSharedValue(tradeMode === 'sell' ? 1 : 0);
   const buyWidthSV = useSharedValue(0);
@@ -103,14 +100,10 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
     return {
       left: buyXSV.value,
       width,
-      backgroundColor: interpolateColor(
-        progress,
-        [0, 1],
-        [buyColor, sellColor],
-      ),
+      backgroundColor: activeColor,
       transform: [{ translateX: progress * buyWidthSV.value }],
     };
-  }, [buyColor, sellColor]);
+  }, [activeColor]);
 
   const sliderWidth = tradeMode === 'buy' ? (buyLayout?.width ?? 0) : sellWidth;
 
@@ -118,16 +111,16 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
     return (
       <Box
         flexDirection={BoxFlexDirection.Row}
-        twClassName="border border-muted rounded-xl p-1"
+        twClassName="bg-muted rounded-[99px] p-1"
         testID={testID}
       >
         <Box
-          twClassName="rounded-lg px-4 py-1"
-          style={{ backgroundColor: buyColor }}
+          twClassName="rounded-[99px] px-4 py-1"
+          style={{ backgroundColor: activeColor }}
         >
           <Text
             variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
+            fontWeight={FontWeight.Bold}
             color={TextColor.PrimaryInverse}
           >
             {strings('social_leaderboard.quick_buy.buy_label')}
@@ -140,7 +133,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
-      twClassName="border border-muted rounded-xl p-1"
+      twClassName="bg-muted rounded-[99px] p-1"
       testID={testID}
     >
       <Box flexDirection={BoxFlexDirection.Row} style={styles.row}>
@@ -160,12 +153,10 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
           accessibilityState={{ selected: tradeMode === 'buy' }}
           testID="quick-buy-trade-mode-buy"
         >
-          <Box twClassName="rounded-lg px-4 py-1">
+          <Box twClassName="rounded-[99px] px-4 py-1">
             <Text
               variant={TextVariant.BodyMd}
-              fontWeight={
-                tradeMode === 'buy' ? FontWeight.Medium : FontWeight.Regular
-              }
+              fontWeight={FontWeight.Bold}
               color={
                 tradeMode === 'buy'
                   ? TextColor.PrimaryInverse
@@ -193,13 +184,11 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
           testID="quick-buy-trade-mode-sell"
         >
           <Box
-            twClassName={`rounded-lg px-4 py-1 ${!hasSellableBalance ? 'opacity-40' : ''}`}
+            twClassName={`rounded-[99px] px-4 py-1 ${!hasSellableBalance ? 'opacity-40' : ''}`}
           >
             <Text
               variant={TextVariant.BodyMd}
-              fontWeight={
-                tradeMode === 'sell' ? FontWeight.Medium : FontWeight.Regular
-              }
+              fontWeight={FontWeight.Bold}
               color={
                 tradeMode === 'sell'
                   ? TextColor.PrimaryInverse

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
@@ -2,6 +2,13 @@ import {
   OVERLAY_CLOSE_DURATION,
   OVERLAY_OPEN_DURATION,
   OVERLAY_OPEN_EASING,
+  SHEET_DIALOG_CLOSE_DURATION,
+  SHEET_DIALOG_CLOSE_EASING,
+  SHEET_DIALOG_DRAG_DISMISS_OFFSET,
+  SHEET_DIALOG_DRAG_DISMISS_VELOCITY,
+  SHEET_DIALOG_DRAG_ELASTIC_DOWN,
+  SHEET_DIALOG_OFFSCREEN_FACTOR,
+  SHEET_DIALOG_SPRING,
   SHEET_STACK_CONTENT_EASING,
   SHEET_STACK_HEIGHT_DURATION,
   SHEET_STACK_HEIGHT_EASING,
@@ -13,6 +20,26 @@ import {
 } from './sheetStackMotion';
 
 describe('sheetStackMotion', () => {
+  it('matches DS sheet open spring (critically damped)', () => {
+    expect(SHEET_DIALOG_SPRING).toEqual({
+      stiffness: 540,
+      damping: 55,
+      mass: 1,
+    });
+  });
+
+  it('matches DS sheet dismiss tween and offscreen factor', () => {
+    expect(SHEET_DIALOG_CLOSE_DURATION).toBe(280);
+    expect(SHEET_DIALOG_CLOSE_EASING).toEqual([0.32, 0.72, 0, 1]);
+    expect(SHEET_DIALOG_OFFSCREEN_FACTOR).toBe(1.05);
+  });
+
+  it('matches DS drag dismiss thresholds', () => {
+    expect(SHEET_DIALOG_DRAG_DISMISS_OFFSET).toBe(120);
+    expect(SHEET_DIALOG_DRAG_DISMISS_VELOCITY).toBe(800);
+    expect(SHEET_DIALOG_DRAG_ELASTIC_DOWN).toBe(1);
+  });
+
   it('matches DS in-sheet stack durations (0.45s slide / height)', () => {
     expect(SHEET_STACK_PUSH_DURATION).toBe(450);
     expect(SHEET_STACK_HEIGHT_DURATION).toBe(450);
@@ -30,8 +57,8 @@ describe('sheetStackMotion', () => {
     expect(SHEET_STACK_HEIGHT_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
   });
 
-  it('matches installed BottomSheetDialog open (Fast) and DS close', () => {
-    expect(OVERLAY_OPEN_DURATION).toBe(150);
+  it('matches DS backdrop open / close durations', () => {
+    expect(OVERLAY_OPEN_DURATION).toBe(400);
     expect(OVERLAY_CLOSE_DURATION).toBe(200);
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
@@ -1,4 +1,7 @@
 import {
+  OVERLAY_CLOSE_DURATION,
+  OVERLAY_OPEN_DURATION,
+  OVERLAY_OPEN_EASING,
   SHEET_STACK_CONTENT_EASING,
   SHEET_STACK_HEIGHT_DURATION,
   SHEET_STACK_HEIGHT_EASING,
@@ -25,5 +28,14 @@ describe('sheetStackMotion', () => {
     expect(SHEET_STACK_CONTENT_EASING).toEqual([0.16, 1, 0.3, 1]);
     expect(SHEET_STACK_PUSH_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
     expect(SHEET_STACK_HEIGHT_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
+  });
+
+  it('matches installed BottomSheetDialog open (Fast) and DS close', () => {
+    expect(OVERLAY_OPEN_DURATION).toBe(150);
+    expect(OVERLAY_CLOSE_DURATION).toBe(200);
+  });
+
+  it('uses the content ease curve for backdrop open', () => {
+    expect(OVERLAY_OPEN_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.test.ts
@@ -1,0 +1,29 @@
+import {
+  SHEET_STACK_CONTENT_EASING,
+  SHEET_STACK_HEIGHT_DURATION,
+  SHEET_STACK_HEIGHT_EASING,
+  SHEET_STACK_OPACITY_IN_DELAY,
+  SHEET_STACK_OPACITY_IN_DURATION,
+  SHEET_STACK_OPACITY_OUT_DURATION,
+  SHEET_STACK_PUSH_DURATION,
+  SHEET_STACK_PUSH_EASING,
+} from './sheetStackMotion';
+
+describe('sheetStackMotion', () => {
+  it('matches DS in-sheet stack durations (0.45s slide / height)', () => {
+    expect(SHEET_STACK_PUSH_DURATION).toBe(450);
+    expect(SHEET_STACK_HEIGHT_DURATION).toBe(450);
+  });
+
+  it('matches DS opacity crossfade timings', () => {
+    expect(SHEET_STACK_OPACITY_IN_DURATION).toBe(220);
+    expect(SHEET_STACK_OPACITY_IN_DELAY).toBe(50);
+    expect(SHEET_STACK_OPACITY_OUT_DURATION).toBe(80);
+  });
+
+  it('uses the content ease curve for push and height', () => {
+    expect(SHEET_STACK_CONTENT_EASING).toEqual([0.16, 1, 0.3, 1]);
+    expect(SHEET_STACK_PUSH_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
+    expect(SHEET_STACK_HEIGHT_EASING).toEqual(SHEET_STACK_CONTENT_EASING);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
@@ -8,16 +8,54 @@
  */
 
 /**
+ * Sheet open / snap-back spring — critically damped, no bounce.
+ * Matches Framer `stiffness: 540, damping: 55` (mass 1).
+ */
+export const SHEET_DIALOG_SPRING = {
+  stiffness: 540,
+  damping: 55,
+  mass: 1,
+} as const;
+
+/**
+ * Offscreen start/end multiplier for open/close (y: 105%).
+ */
+export const SHEET_DIALOG_OFFSCREEN_FACTOR = 1.05;
+
+/**
+ * Sheet dismiss tween duration in ms (0.28s).
+ */
+export const SHEET_DIALOG_CLOSE_DURATION = 280;
+
+/**
+ * iOS sheet curve — fast start, soft landing: [0.32, 0.72, 0, 1].
+ */
+export const SHEET_DIALOG_CLOSE_EASING = [0.32, 0.72, 0, 1] as const;
+
+/**
+ * Drag dismiss distance threshold in px.
+ */
+export const SHEET_DIALOG_DRAG_DISMISS_OFFSET = 120;
+
+/**
+ * Drag dismiss velocity threshold in px/s.
+ */
+export const SHEET_DIALOG_DRAG_DISMISS_VELOCITY = 800;
+
+/**
+ * Downward drag follow factor (1 = 1:1 with the finger).
+ */
+export const SHEET_DIALOG_DRAG_ELASTIC_DOWN = 1;
+
+/**
  * Content / surface ease — easeOutExpo-style: [0.16, 1, 0.3, 1].
  */
 export const SHEET_STACK_CONTENT_EASING = [0.16, 1, 0.3, 1] as const;
 
 /**
- * Backdrop open duration in ms — match installed BottomSheetDialog open
- * (`AnimationDuration.Fast` = 150). Keeps scrim and sheet Y in sync; bump
- * with the DS sheet when PR #1411 ships a longer open.
+ * Backdrop open duration in ms (0.4s).
  */
-export const OVERLAY_OPEN_DURATION = 150;
+export const OVERLAY_OPEN_DURATION = 400;
 
 /**
  * Backdrop open curve — same content ease as in-sheet nav.

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
@@ -1,0 +1,45 @@
+/**
+ * In-sheet stack motion tokens — mirrored from design-system BottomSheetDialog
+ * (replit/bottom-sheet / PR #1411) for Quick Buy only until the package ships them.
+ *
+ * Springs are only for interactive settle (open, snap-back).
+ * Surface exits and content nav use tweens on the two iOS curves.
+ */
+
+/**
+ * Content / surface ease — easeOutExpo-style: [0.16, 1, 0.3, 1].
+ */
+export const SHEET_STACK_CONTENT_EASING = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * In-sheet stack push / pop duration in ms (0.45s).
+ * Full-width slide; drill deeper left, back right.
+ */
+export const SHEET_STACK_PUSH_DURATION = 450;
+
+/**
+ * In-sheet stack push curve — content ease, not the sheet dismiss curve.
+ */
+export const SHEET_STACK_PUSH_EASING = SHEET_STACK_CONTENT_EASING;
+
+/**
+ * Incoming screen opacity: 0.22s easeOut, delayed 0.05s.
+ */
+export const SHEET_STACK_OPACITY_IN_DURATION = 220;
+export const SHEET_STACK_OPACITY_IN_DELAY = 50;
+
+/**
+ * Outgoing screen opacity: 0.08s easeIn (vanishes before the new screen lands).
+ */
+export const SHEET_STACK_OPACITY_OUT_DURATION = 80;
+
+/**
+ * In-sheet content height resize — same 0.45s content ease as the slide
+ * so height and X move as one gesture (no layout-spring bounce).
+ */
+export const SHEET_STACK_HEIGHT_DURATION = 450;
+
+/**
+ * Height resize expo-out curve: [0.16, 1, 0.3, 1].
+ */
+export const SHEET_STACK_HEIGHT_EASING = SHEET_STACK_CONTENT_EASING;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/sheetStackMotion.ts
@@ -1,6 +1,7 @@
 /**
- * In-sheet stack motion tokens — mirrored from design-system BottomSheetDialog
- * (replit/bottom-sheet / PR #1411) for Quick Buy only until the package ships them.
+ * Sheet / stack / backdrop motion tokens — mirrored from design-system
+ * BottomSheetDialog + BottomSheetOverlay (replit/bottom-sheet / PR #1411)
+ * for Quick Buy only until the package ships them.
  *
  * Springs are only for interactive settle (open, snap-back).
  * Surface exits and content nav use tweens on the two iOS curves.
@@ -10,6 +11,23 @@
  * Content / surface ease — easeOutExpo-style: [0.16, 1, 0.3, 1].
  */
 export const SHEET_STACK_CONTENT_EASING = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * Backdrop open duration in ms — match installed BottomSheetDialog open
+ * (`AnimationDuration.Fast` = 150). Keeps scrim and sheet Y in sync; bump
+ * with the DS sheet when PR #1411 ships a longer open.
+ */
+export const OVERLAY_OPEN_DURATION = 150;
+
+/**
+ * Backdrop open curve — same content ease as in-sheet nav.
+ */
+export const OVERLAY_OPEN_EASING = SHEET_STACK_CONTENT_EASING;
+
+/**
+ * Backdrop close duration in ms (0.2s).
+ */
+export const OVERLAY_CLOSE_DURATION = 200;
 
 /**
  * In-sheet stack push / pop duration in ms (0.45s).

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.test.ts
@@ -1,31 +1,8 @@
-import type { SharedValue } from 'react-native-reanimated';
 import {
-  makeScreenTransitions,
+  isSheetStackScreen,
   SCREEN_DEPTH,
-  SCREEN_SLIDE_OFFSET,
-  type ScreenDirection,
+  SHEET_STACK_SCREENS,
 } from './transitions';
-
-jest.mock('react-native-reanimated', () => ({
-  withTiming: (toValue: number) => toValue,
-}));
-
-interface ResolvedAnimation {
-  initialValues: {
-    opacity: number;
-    transform: [{ translateX: number }];
-  };
-  animations: {
-    opacity: number;
-    transform: [{ translateX: number }];
-  };
-}
-
-const directionSV = (value: ScreenDirection): SharedValue<ScreenDirection> =>
-  ({ value }) as SharedValue<ScreenDirection>;
-
-const resolve = (fn: () => unknown): ResolvedAnimation =>
-  fn() as ResolvedAnimation;
 
 describe('SCREEN_DEPTH', () => {
   it('maps every screen to its navigation depth', () => {
@@ -39,70 +16,18 @@ describe('SCREEN_DEPTH', () => {
   });
 });
 
-describe('SCREEN_SLIDE_OFFSET', () => {
-  it('is a positive horizontal distance', () => {
-    expect(SCREEN_SLIDE_OFFSET).toBeGreaterThan(0);
-  });
-});
-
-describe('makeScreenTransitions', () => {
-  describe('forward direction (deeper)', () => {
-    const { entering, exiting } = makeScreenTransitions(directionSV(1));
-
-    it('enters from the right and fades in', () => {
-      const { initialValues, animations } = resolve(entering as () => unknown);
-
-      expect(initialValues.opacity).toBe(0);
-      expect(initialValues.transform[0].translateX).toBe(SCREEN_SLIDE_OFFSET);
-      expect(animations.opacity).toBe(1);
-      expect(animations.transform[0].translateX).toBe(0);
-    });
-
-    it('exits to the left and fades out', () => {
-      const { initialValues, animations } = resolve(exiting as () => unknown);
-
-      expect(initialValues.opacity).toBe(1);
-      expect(initialValues.transform[0].translateX).toBe(0);
-      expect(animations.opacity).toBe(0);
-      expect(animations.transform[0].translateX).toBe(-SCREEN_SLIDE_OFFSET);
-    });
+describe('SHEET_STACK_SCREENS', () => {
+  it('includes pay with and quote details for in-sheet push/pop', () => {
+    expect(SHEET_STACK_SCREENS.has('payWith')).toBe(true);
+    expect(SHEET_STACK_SCREENS.has('quoteDetails')).toBe(true);
   });
 
-  describe('back direction (shallower)', () => {
-    const { entering, exiting } = makeScreenTransitions(directionSV(-1));
-
-    it('enters from the left and fades in', () => {
-      const { initialValues, animations } = resolve(entering as () => unknown);
-
-      expect(initialValues.opacity).toBe(0);
-      expect(initialValues.transform[0].translateX).toBe(-SCREEN_SLIDE_OFFSET);
-      expect(animations.opacity).toBe(1);
-      expect(animations.transform[0].translateX).toBe(0);
-    });
-
-    it('exits to the right and fades out', () => {
-      const { initialValues, animations } = resolve(exiting as () => unknown);
-
-      expect(initialValues.opacity).toBe(1);
-      expect(initialValues.transform[0].translateX).toBe(0);
-      expect(animations.opacity).toBe(0);
-      expect(animations.transform[0].translateX).toBe(SCREEN_SLIDE_OFFSET);
-    });
+  it('does not treat the amount root as a stacked screen', () => {
+    expect(isSheetStackScreen('amount')).toBe(false);
   });
 
-  it('reads the direction lazily so a shared-value change flips the animation', () => {
-    const sv = directionSV(1);
-    const { entering } = makeScreenTransitions(sv);
-
-    const forward = resolve(entering as () => unknown);
-    expect(forward.initialValues.transform[0].translateX).toBe(
-      SCREEN_SLIDE_OFFSET,
-    );
-
-    sv.value = -1;
-    const back = resolve(entering as () => unknown);
-    expect(back.initialValues.transform[0].translateX).toBe(
-      -SCREEN_SLIDE_OFFSET,
-    );
+  it('treats nested quote and confirm screens as stacked details', () => {
+    expect(isSheetStackScreen('selectQuote')).toBe(true);
+    expect(isSheetStackScreen('priceImpactConfirm')).toBe(true);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.ts
@@ -1,73 +1,24 @@
-import { AnimationDuration } from '@metamask/design-tokens';
-import {
-  withTiming,
-  type EntryExitAnimationFunction,
-  type SharedValue,
-} from 'react-native-reanimated';
 import type { QuickBuyScreen } from './types';
 
-/** Horizontal slide distance (px) for screen enter/exit. */
-export const SCREEN_SLIDE_OFFSET = 24;
+/**
+ * Screens that push onto the in-sheet stack from the amount root.
+ * Backdrop / sheet Y / handle stay put; contents slide full-width.
+ */
+export const SHEET_STACK_SCREENS: ReadonlySet<QuickBuyScreen> = new Set([
+  'payWith',
+  'quoteDetails',
+  'selectQuote',
+  'priceImpactConfirm',
+]);
 
-/** Navigation depth per screen; sign of the delta gives transition direction. */
+export const isSheetStackScreen = (screen: QuickBuyScreen): boolean =>
+  SHEET_STACK_SCREENS.has(screen);
+
+/** Navigation depth per screen; used for analytics / ordering only. */
 export const SCREEN_DEPTH: Record<QuickBuyScreen, number> = {
   amount: 0,
   payWith: 1,
   quoteDetails: 1,
   selectQuote: 2,
   priceImpactConfirm: 1,
-};
-
-/** +1 = forward (deeper), -1 = back (shallower). */
-export type ScreenDirection = 1 | -1;
-
-const DURATION = AnimationDuration.Fast;
-
-/**
- * Build direction-aware enter/exit animations bound to a shared direction value.
- *
- * Forward (dir=1): new screen enters from the right (+offset -> 0), old screen
- * exits to the left (0 -> -offset). Back (dir=-1): mirrored. Both fade.
- *
- * Direction is read from `directionSV` when the animation starts (the next UI
- * frame), so both the entering and exiting views see the up-to-date direction
- * computed at navigation time.
- */
-export const makeScreenTransitions = (
-  directionSV: SharedValue<ScreenDirection>,
-) => {
-  const entering: EntryExitAnimationFunction = () => {
-    'worklet';
-    const dir = directionSV.value;
-    return {
-      initialValues: {
-        opacity: 0,
-        transform: [{ translateX: dir * SCREEN_SLIDE_OFFSET }],
-      },
-      animations: {
-        opacity: withTiming(1, { duration: DURATION }),
-        transform: [{ translateX: withTiming(0, { duration: DURATION }) }],
-      },
-    };
-  };
-
-  const exiting: EntryExitAnimationFunction = () => {
-    'worklet';
-    const dir = directionSV.value;
-    return {
-      initialValues: { opacity: 1, transform: [{ translateX: 0 }] },
-      animations: {
-        opacity: withTiming(0, { duration: DURATION }),
-        transform: [
-          {
-            translateX: withTiming(-dir * SCREEN_SLIDE_OFFSET, {
-              duration: DURATION,
-            }),
-          },
-        ],
-      },
-    };
-  };
-
-  return { entering, exiting };
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useSheetStackTransition.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useSheetStackTransition.ts
@@ -297,6 +297,7 @@ export const useSheetStackTransition = () => {
 
   return {
     isPushed,
+    isHeightReady,
     push,
     requestPush,
     pop,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useSheetStackTransition.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useSheetStackTransition.ts
@@ -1,0 +1,315 @@
+import { useCallback, useRef, useState } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
+import Animated, {
+  Easing,
+  ReduceMotion,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  SHEET_STACK_HEIGHT_DURATION,
+  SHEET_STACK_HEIGHT_EASING,
+  SHEET_STACK_OPACITY_IN_DELAY,
+  SHEET_STACK_OPACITY_IN_DURATION,
+  SHEET_STACK_OPACITY_OUT_DURATION,
+  SHEET_STACK_PUSH_DURATION,
+  SHEET_STACK_PUSH_EASING,
+} from './sheetStackMotion';
+
+const stackPushEasing = Easing.bezier(
+  SHEET_STACK_PUSH_EASING[0],
+  SHEET_STACK_PUSH_EASING[1],
+  SHEET_STACK_PUSH_EASING[2],
+  SHEET_STACK_PUSH_EASING[3],
+);
+
+const stackHeightEasing = Easing.bezier(
+  SHEET_STACK_HEIGHT_EASING[0],
+  SHEET_STACK_HEIGHT_EASING[1],
+  SHEET_STACK_HEIGHT_EASING[2],
+  SHEET_STACK_HEIGHT_EASING[3],
+);
+
+const stackOpacityInEasing = Easing.out(Easing.ease);
+const stackOpacityOutEasing = Easing.in(Easing.ease);
+
+/**
+ * In-sheet push/pop matching web SheetStack / DS BottomSheet stories:
+ * full-width slide + opacity crossfade (0.45s content ease) and synced height tween.
+ * Backdrop / sheet Y / handle stay put.
+ *
+ * Detail screens are often scrollable (`flex-1`). Those need a bounded height, so
+ * push never shrinks below the measured root (amount) height — the sheet stays
+ * put or grows, and the detail layer fills the tweening box.
+ */
+export const useSheetStackTransition = () => {
+  const [stackWidth, setStackWidth] = useState(0);
+  const [isPushed, setIsPushed] = useState(false);
+  const [isHeightReady, setIsHeightReady] = useState(false);
+  const isAnimatingRef = useRef(false);
+  const isPushedRef = useRef(false);
+  /** When true, the next detail onLayout should kick off push (detail just mounted). */
+  const pendingPushRef = useRef(false);
+
+  const progress = useSharedValue(0);
+  const contentHeight = useSharedValue(0);
+  const rootHeight = useSharedValue(0);
+  const detailHeight = useSharedValue(0);
+  const widthSv = useSharedValue(0);
+  const rootOpacity = useSharedValue(1);
+  const detailOpacity = useSharedValue(0);
+
+  const animateTo = useCallback(
+    (next: 0 | 1) => {
+      // Never tween height to 0 — if detail hasn't measured yet (or is a
+      // flex-fill scroller whose intrinsic height is just the header), keep at
+      // least the amount-screen height so the sheet doesn't collapse.
+      const measuredDetail = detailHeight.value;
+      const measuredRoot = rootHeight.value;
+      const targetHeight =
+        next === 1
+          ? Math.max(measuredDetail, measuredRoot)
+          : measuredRoot > 0
+            ? measuredRoot
+            : contentHeight.value;
+
+      if (targetHeight <= 0 && next === 1) {
+        // Root also unmeasured — bail; caller should retry after layout.
+        return false;
+      }
+
+      isAnimatingRef.current = true;
+      isPushedRef.current = next === 1;
+      setIsPushed(next === 1);
+      if (next === 1) {
+        pendingPushRef.current = false;
+      }
+
+      progress.value = withTiming(next, {
+        duration: SHEET_STACK_PUSH_DURATION,
+        easing: stackPushEasing,
+        reduceMotion: ReduceMotion.System,
+      });
+
+      if (targetHeight > 0) {
+        contentHeight.value = withTiming(targetHeight, {
+          duration: SHEET_STACK_HEIGHT_DURATION,
+          easing: stackHeightEasing,
+          reduceMotion: ReduceMotion.System,
+        });
+      }
+
+      if (next === 1) {
+        rootOpacity.value = withTiming(0, {
+          duration: SHEET_STACK_OPACITY_OUT_DURATION,
+          easing: stackOpacityOutEasing,
+          reduceMotion: ReduceMotion.System,
+        });
+        detailOpacity.value = withDelay(
+          SHEET_STACK_OPACITY_IN_DELAY,
+          withTiming(1, {
+            duration: SHEET_STACK_OPACITY_IN_DURATION,
+            easing: stackOpacityInEasing,
+            reduceMotion: ReduceMotion.System,
+          }),
+        );
+      } else {
+        detailOpacity.value = withTiming(0, {
+          duration: SHEET_STACK_OPACITY_OUT_DURATION,
+          easing: stackOpacityOutEasing,
+          reduceMotion: ReduceMotion.System,
+        });
+        rootOpacity.value = withDelay(
+          SHEET_STACK_OPACITY_IN_DELAY,
+          withTiming(1, {
+            duration: SHEET_STACK_OPACITY_IN_DURATION,
+            easing: stackOpacityInEasing,
+            reduceMotion: ReduceMotion.System,
+          }),
+        );
+      }
+
+      const clearMs = Math.max(
+        SHEET_STACK_PUSH_DURATION,
+        SHEET_STACK_HEIGHT_DURATION,
+      );
+      setTimeout(() => {
+        isAnimatingRef.current = false;
+      }, clearMs);
+
+      return true;
+    },
+    [
+      contentHeight,
+      detailHeight,
+      detailOpacity,
+      progress,
+      rootHeight,
+      rootOpacity,
+    ],
+  );
+
+  // Stable identities — callers sync from activeScreen in an effect and must
+  // not re-fire when isPushed flips mid-animation.
+  const push = useCallback(() => {
+    if (isPushedRef.current) {
+      pendingPushRef.current = false;
+      return true;
+    }
+    const started = animateTo(1);
+    if (started) {
+      pendingPushRef.current = false;
+    }
+    return started;
+  }, [animateTo]);
+
+  /**
+   * Mount detail first, then call this. Push runs after detail layout when
+   * heights are unknown; if the amount root is already measured, push starts
+   * immediately using that height as a floor (avoids collapsing the sheet).
+   */
+  const requestPush = useCallback(() => {
+    if (isPushedRef.current) {
+      pendingPushRef.current = false;
+      return;
+    }
+    // Always arm pending so a late detail layout can still sync height, but
+    // start the slide as soon as we have a root height floor.
+    pendingPushRef.current = true;
+    if (rootHeight.value > 0 || detailHeight.value > 0) {
+      animateTo(1);
+    }
+  }, [animateTo, detailHeight, rootHeight]);
+
+  const pop = useCallback(() => {
+    pendingPushRef.current = false;
+    if (isPushedRef.current) {
+      animateTo(0);
+    }
+  }, [animateTo]);
+
+  /**
+   * Jump to a pushed state without animating from root — used when entering a
+   * stack screen from another non-root screen (e.g. selectQuote → quoteDetails)
+   * where the sheet is already drilled in.
+   */
+  const snapToPushed = useCallback(() => {
+    pendingPushRef.current = false;
+    isAnimatingRef.current = false;
+    isPushedRef.current = true;
+    progress.value = 1;
+    rootOpacity.value = 0;
+    detailOpacity.value = 1;
+    const nextHeight = Math.max(detailHeight.value, rootHeight.value);
+    if (nextHeight > 0) {
+      contentHeight.value = nextHeight;
+    }
+    setIsPushed(true);
+  }, [
+    contentHeight,
+    detailHeight,
+    detailOpacity,
+    progress,
+    rootHeight,
+    rootOpacity,
+  ]);
+
+  const onStackLayout = (e: LayoutChangeEvent) => {
+    const { width } = e.nativeEvent.layout;
+    if (width > 0 && width !== stackWidth) {
+      setStackWidth(width);
+      widthSv.value = width;
+    }
+  };
+
+  const onRootLayout = (e: LayoutChangeEvent) => {
+    const { height } = e.nativeEvent.layout;
+    if (height <= 0) {
+      return;
+    }
+    rootHeight.value = height;
+    if (!isHeightReady) {
+      contentHeight.value = height;
+      setIsHeightReady(true);
+    } else if (!isPushedRef.current && !isAnimatingRef.current) {
+      // Sync only at rest — never cancel an in-flight height tween.
+      contentHeight.value = height;
+    }
+  };
+
+  const onDetailLayout = (e: LayoutChangeEvent) => {
+    const { height } = e.nativeEvent.layout;
+    if (height <= 0) {
+      return;
+    }
+    detailHeight.value = height;
+
+    if (pendingPushRef.current) {
+      pendingPushRef.current = false;
+      // If push already started from requestPush (root height floor), this is
+      // a no-op for progress; animateTo still refreshes height if taller.
+      if (!isPushedRef.current) {
+        animateTo(1);
+      } else if (!isAnimatingRef.current) {
+        contentHeight.value = Math.max(height, rootHeight.value);
+      }
+      return;
+    }
+
+    if (isPushedRef.current && !isAnimatingRef.current) {
+      // Grow with taller detail content; never shrink below the amount root
+      // (scrollable pay-with fills the root height via flex).
+      contentHeight.value = Math.max(height, rootHeight.value);
+    }
+  };
+
+  const heightStyle = useAnimatedStyle(() => ({
+    height: contentHeight.value > 0 ? contentHeight.value : undefined,
+  }));
+
+  const rootScreenStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX: interpolate(progress.value, [0, 1], [0, -widthSv.value]),
+      },
+    ],
+    opacity: rootOpacity.value,
+  }));
+
+  const detailScreenStyle = useAnimatedStyle(() => {
+    // Until width is measured, keep detail off-screen so it doesn't cover root.
+    const x =
+      widthSv.value > 0
+        ? interpolate(progress.value, [0, 1], [widthSv.value, 0])
+        : 9999;
+    // Bound the detail box to the tweening sheet height so `flex-1` scroll
+    // children (pay with) actually fill and scroll instead of collapsing.
+    const height = contentHeight.value > 0 ? contentHeight.value : undefined;
+    return {
+      transform: [{ translateX: x }],
+      opacity: detailOpacity.value,
+      height,
+    };
+  });
+
+  return {
+    isPushed,
+    push,
+    requestPush,
+    pop,
+    snapToPushed,
+    onStackLayout,
+    onRootLayout,
+    onDetailLayout,
+    heightStyle,
+    rootScreenStyle,
+    detailScreenStyle,
+  };
+};
+
+export type SheetStackTransition = ReturnType<typeof useSheetStackTransition>;
+
+export { Animated };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1256,7 +1256,7 @@
       "est_points": "Est. points",
       "no_quotes": "No quotes available for this token",
       "quote_details_empty_no_amount": "Enter an amount to see quote details.",
-      "quote_details_empty_no_quote": "No quote available right now. Try a different amount.",
+      "quote_details_empty_no_quote": "Quotes are not available now. Please try a different amount.",
       "loading": "Loading...",
       "unavailable": "Swap unavailable",
       "unsupported_chain": "This chain is not supported for Quick Buy yet",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Quick Buy’s nested bottom sheets needed design polish and motion that matches the design-system `BottomSheetDialog` prototype (until that package ships).

This PR:
- Polishes Quick Buy sheet UI (headers, spacing, icons, empty-state copy, action footer/toolbar)
- Adds stacked sheet transitions plus overlay effects for nested sheets
- Ports DS-style dialog motion locally (`QuickBuyBottomSheetDialog`: spring open, tween dismiss, handle-only drag)
- Fixes toaster rendering above overlays via a dedicated `ToasterOverlay`
- Temporarily adjusts shared Keypad styling for Quick Buy look (transparent keys, larger digits)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-design-system/pull/1411

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy bottom sheet motion and polish

  Scenario: open Quick Buy and navigate nested sheets
    Given the user is on a trader position view with Quick Buy available
    When the user opens Quick Buy
    Then the sheet opens with spring motion matching the DS bottom sheet dialog
    And the UI headers, spacing, and keypad look polished

  Scenario: stack Pay With / Quote Details over the root sheet
    Given Quick Buy is open
    When the user opens Pay With or Quote Details
    Then the nested sheet animates in with overlay effects on the sheet below
    And dismissing the nested sheet restores the root sheet smoothly

  Scenario: dismiss via handle drag
    Given Quick Buy is open
    When the user drags the sheet handle downward past the dismiss threshold
    Then the sheet dismisses with tween motion
    And only the handle initiates drag (content scroll does not dismiss)

  Scenario: toaster above overlay
    Given a Quick Buy sheet (or nested sheet) is open
    When a toast is shown
    Then the toast appears above the sheet overlay
```


Field | Value
-- | --
Source branch | prototype/quick-buy
Build name | main-rc
Build commit SHA | 2f293446cdb210c910956b7968fbdeea3c555ce1
Build version | 8.6.0
Build number | 6189
TestFlight group | MetaMask BETA & Release Candidates
Workflow branch ref | main



## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/bd532214-8a7d-4792-b98b-7c1a2064388b



### **After**

https://github.com/user-attachments/assets/e591c9e4-be1c-4a44-bf4c-f4f298914cb1




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
