### PR TITLE
perf(predict): cut crypto up/down cpu in ws parsing and re-renders

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownChart/PredictCryptoUpDownChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownChart/PredictCryptoUpDownChart.test.tsx
@@ -279,9 +279,14 @@ describe('PredictCryptoUpDownChart', () => {
       window: 300,
     });
 
+    // The component is memoized, so a same-props rerender would bail out
+    // before reading the updated hook mock. In production the hook's own
+    // state update re-renders the component; simulate that here by changing
+    // a prop alongside the mocked hook value.
     rerender(
       <PredictCryptoUpDownChart
         market={market}
+        targetPrice={100}
         onCurrentPriceChange={onCurrentPriceChange}
       />,
     );

--- a/app/components/UI/Predict/components/PredictCryptoUpDownChart/PredictCryptoUpDownChart.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownChart/PredictCryptoUpDownChart.tsx
@@ -158,4 +158,8 @@ const PredictCryptoUpDownChart: React.FC<PredictCryptoUpDownChartProps> = ({
   );
 };
 
-export default PredictCryptoUpDownChart;
+// Memoized: the parent details screen re-renders on every live price tick
+// (which this chart itself triggers via `onCurrentPriceChange`). The chart
+// re-renders from its own hook state; parent-driven re-renders with unchanged
+// props would only re-serialize chart props for the WebView.
+export default React.memo(PredictCryptoUpDownChart);

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -348,6 +348,15 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
     [market.series],
   );
 
+  // Stable reference so the memoized TimeSlotPicker doesn't re-render on
+  // every live price tick of this screen.
+  const handleMarketSelected = useCallback(
+    (nextMarket: PredictMarket) => {
+      setSelectedMarket(attachSeries(nextMarket));
+    },
+    [attachSeries],
+  );
+
   const getNextSelectedMarket = useCallback(
     (currentMarket: PredictMarketWithSeries): PredictMarketWithSeries => {
       if (!currentSeriesMarkets?.length) {
@@ -523,7 +532,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
         <TimeSlotPicker
           markets={visibleSlotMarkets}
           selectedMarketId={selectedMarket.id}
-          onMarketSelected={(m) => setSelectedMarket(attachSeries(m))}
+          onMarketSelected={handleMarketSelected}
         />
 
         <Box

--- a/app/components/UI/Predict/components/PredictCryptoUpDownPositions/PredictCryptoUpDownPositions.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownPositions/PredictCryptoUpDownPositions.tsx
@@ -64,4 +64,7 @@ const PredictCryptoUpDownPositions: React.FC<
 
 PredictCryptoUpDownPositions.displayName = 'PredictCryptoUpDownPositions';
 
-export default PredictCryptoUpDownPositions;
+// Memoized: the parent details screen re-renders on every live price tick;
+// `rows` is memoized upstream (usePredictSeriesPositions), so position rows
+// only re-render when positions actually change.
+export default React.memo(PredictCryptoUpDownPositions);

--- a/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
+++ b/app/components/UI/Predict/components/TimeSlotPicker/TimeSlotPicker.tsx
@@ -294,4 +294,8 @@ const TimeSlotPicker: React.FC<TimeSlotPickerProps> = ({
   );
 };
 
-export default TimeSlotPicker;
+// Memoized: the parent details screen re-renders on every live price tick,
+// and this component's own render (pill styles, countdowns, scroll anchoring)
+// is comparatively expensive. Callers must pass stable `markets` /
+// `onMarketSelected` references for the memo to be effective.
+export default React.memo(TimeSlotPicker);

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -72,6 +72,16 @@ const trimLivePoints = (
   latestTime: number,
 ): LivelinePoint[] => {
   const cutoff = latestTime - LIVE_CHART_RETENTION_SECS;
+
+  // Fast path: nothing to trim — return the same reference to avoid an O(n)
+  // copy on every live tick.
+  if (
+    points.length <= LIVE_CHART_MAX_POINTS &&
+    (points.length === 0 || points[0].time >= cutoff)
+  ) {
+    return points;
+  }
+
   const retainedPoints = points.filter((point) => point.time >= cutoff);
 
   if (retainedPoints.length <= LIVE_CHART_MAX_POINTS) {
@@ -258,15 +268,18 @@ export const useCryptoUpDownChartData = (
       markLiveStreamFresh();
       setLiveValue(update.price);
       setLivePoints((points) => {
-        const timeSecs = getLivePointTime(
-          update.timestamp,
-          points.at(-1)?.time,
-        );
+        const lastPoint = points.at(-1);
+        const timeSecs = getLivePointTime(update.timestamp, lastPoint?.time);
         const point: LivelinePoint = {
           time: timeSecs,
           value: update.price,
         };
-        const nextPoints = mergeLivelinePoints(points, [point]);
+        // Fast path: live ticks almost always arrive in order, so append
+        // instead of re-building (Map + sort) the whole array on every tick.
+        const nextPoints =
+          !lastPoint || timeSecs > lastPoint.time
+            ? [...points, point]
+            : mergeLivelinePoints(points, [point]);
         return trimLivePoints(nextPoints, timeSecs);
       });
       if (liveLoadingRef.current) {

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -461,7 +461,7 @@ describe('WebSocketManager', () => {
         payload: { symbol: 'eth/usd', timestamp: 1700000001, value: 3500 },
       });
 
-      expect(() => jest.advanceTimersByTime(16)).not.toThrow();
+      expect(() => jest.advanceTimersByTime(250)).not.toThrow();
       expect(endTrace).toHaveBeenCalledWith({
         name: TraceName.CryptoUpDownBufferFlush,
       });
@@ -479,7 +479,7 @@ describe('WebSocketManager', () => {
         timestamp: 1700000001,
         payload: { symbol: 'eth/usd', timestamp: 1700000001, value: 3500 },
       });
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith({
@@ -511,7 +511,7 @@ describe('WebSocketManager', () => {
       (endTrace as jest.Mock).mockClear();
 
       try {
-        expect(() => jest.advanceTimersByTime(16)).toThrow(traceError);
+        expect(() => jest.advanceTimersByTime(250)).toThrow(traceError);
       } finally {
         WebSocketManager.resetInstance();
       }
@@ -1326,7 +1326,7 @@ describe('WebSocketManager', () => {
       });
 
       // Throttled - advance timer to trigger flush
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).toHaveBeenCalledWith({
         symbol: 'btc/usd',
@@ -1354,7 +1354,7 @@ describe('WebSocketManager', () => {
       // Send pong as raw string (not JSON)
       rtdsInstance.onmessage?.({ data: 'pong' } as MessageEvent);
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -1378,7 +1378,7 @@ describe('WebSocketManager', () => {
         },
       });
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -1451,7 +1451,7 @@ describe('WebSocketManager', () => {
         timestamp: 1700000000,
         payload: { symbol: 'eth/usd', timestamp: 1700000000, value: 3500 },
       });
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(btcCallback).not.toHaveBeenCalled();
       expect(ethCallback).toHaveBeenCalledWith({
@@ -1521,7 +1521,7 @@ describe('WebSocketManager', () => {
       expect(callback).not.toHaveBeenCalled();
 
       // Advance past throttle interval
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       // Only latest value delivered (buffer overwrites per symbol)
       expect(callback).toHaveBeenCalledTimes(1);
@@ -1544,7 +1544,7 @@ describe('WebSocketManager', () => {
         data: 'not valid json',
       } as MessageEvent);
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -1954,7 +1954,7 @@ describe('WebSocketManager', () => {
         payload: { symbol: 'btc/usd', timestamp: 1700000000, value: 67234.5 },
       });
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback1).toHaveBeenCalled();
       expect(callback2).toHaveBeenCalled();
@@ -1977,7 +1977,7 @@ describe('WebSocketManager', () => {
         timestamp: 1700000000,
         payload: { symbol: 'btc/usd', timestamp: 1700000000, value: 67234.5 },
       });
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callbackA).toHaveBeenCalledTimes(1);
       expect(callbackB).toHaveBeenCalledTimes(1);
@@ -1991,7 +1991,7 @@ describe('WebSocketManager', () => {
         timestamp: 1700000001,
         payload: { symbol: 'eth/usd', timestamp: 1700000001, value: 3500.0 },
       });
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callbackA).not.toHaveBeenCalled();
       expect(callbackB).toHaveBeenCalledTimes(1);
@@ -2012,7 +2012,7 @@ describe('WebSocketManager', () => {
         payload: { symbol: 'btc/usd', timestamp: 1700000000, value: 67234.5 },
       });
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
       expect(trace).not.toHaveBeenCalledWith({
@@ -2035,7 +2035,7 @@ describe('WebSocketManager', () => {
         timestamp: 1700000000,
       });
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -2169,11 +2169,11 @@ describe('WebSocketManager', () => {
         payload: { symbol: 'btc/usd', timestamp: 1700000000, value: 67234.5 },
       });
 
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
       expect(callback).toHaveBeenCalledTimes(1);
 
       callback.mockClear();
-      jest.advanceTimersByTime(16);
+      jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
     });

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -1,13 +1,5 @@
 import { AppState, AppStateStatus } from 'react-native';
 import {
-  array,
-  create,
-  optional,
-  string,
-  type as structType,
-  type Infer,
-} from '@metamask/superstruct';
-import {
   ConnectionStatus,
   ConnectionStatusCallback,
   CryptoPriceUpdate,
@@ -40,7 +32,12 @@ const PING_INTERVAL_MS = 50000;
 const RTDS_WS_URL = 'wss://ws-live-data.polymarket.com';
 const RTDS_CRYPTO_PRICES_CHAINLINK_TOPIC = 'crypto_prices_chainlink';
 const RTDS_PING_INTERVAL_MS = 5000;
-const DEFAULT_THROTTLE_INTERVAL_MS = 16;
+// Crypto price ticks (RTDS chainlink) can arrive many times per second per
+// symbol, while the UI only needs a few updates per second. Each flush fans
+// out through React state updates (chart data rebuild, screen re-render,
+// WebView postMessage), so this is deliberately aligned with
+// MARKET_PRICE_EMIT_THROTTLE_MS instead of a per-frame 16ms interval.
+const CRYPTO_PRICE_EMIT_THROTTLE_MS = 250;
 const ORDERBOOK_EMIT_THROTTLE_MS = 250;
 const MARKET_PRICE_EMIT_THROTTLE_MS = 250;
 
@@ -62,29 +59,64 @@ interface SportsWebSocketEvent {
   ended: boolean;
 }
 
-const MarketOrderbookLevelSchema = structType({
-  price: string(),
-  size: string(),
-});
+interface MarketOrderbookLevel {
+  price: string;
+  size: string;
+}
 
-const MarketPriceChangeSchema = structType({
-  asset_id: string(),
-  price: string(),
-  best_bid: string(),
-  best_ask: string(),
-});
+interface MarketPriceChange {
+  asset_id: string;
+  price: string;
+  best_bid: string;
+  best_ask: string;
+}
 
-const MarketWebSocketEventSchema = structType({
-  event_type: string(),
-  market: optional(string()),
-  asset_id: optional(string()),
-  bids: optional(array(MarketOrderbookLevelSchema)),
-  asks: optional(array(MarketOrderbookLevelSchema)),
-  price_changes: optional(array(MarketPriceChangeSchema)),
-  timestamp: optional(string()),
-});
+interface MarketWebSocketEvent {
+  event_type: string;
+  market?: string;
+  asset_id?: string;
+  bids?: MarketOrderbookLevel[];
+  asks?: MarketOrderbookLevel[];
+  price_changes?: MarketPriceChange[];
+  timestamp?: string;
+}
 
-type MarketWebSocketEvent = Infer<typeof MarketWebSocketEventSchema>;
+/**
+ * Lightweight structural guard for market WebSocket messages.
+ *
+ * This runs on EVERY message of a very chatty socket (order book snapshots
+ * can carry hundreds of levels), so schema-library validation (superstruct
+ * `create`) is deliberately avoided here — per-element validation of
+ * `bids`/`asks`/`price_changes` dominated JS CPU profiles of the Crypto
+ * Up/Down flow. Only top-level field shapes are checked; array elements are
+ * validated defensively at their single consumption sites
+ * (`handleBookEvent` and the price-change mapping in `handleMarketMessage`).
+ */
+const toMarketWebSocketEvent = (
+  parsed: unknown,
+): MarketWebSocketEvent | undefined => {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.event_type !== 'string') {
+    return undefined;
+  }
+  if (
+    (candidate.market !== undefined && typeof candidate.market !== 'string') ||
+    (candidate.asset_id !== undefined &&
+      typeof candidate.asset_id !== 'string') ||
+    (candidate.timestamp !== undefined &&
+      typeof candidate.timestamp !== 'string') ||
+    (candidate.bids !== undefined && !Array.isArray(candidate.bids)) ||
+    (candidate.asks !== undefined && !Array.isArray(candidate.asks)) ||
+    (candidate.price_changes !== undefined &&
+      !Array.isArray(candidate.price_changes))
+  ) {
+    return undefined;
+  }
+  return candidate as unknown as MarketWebSocketEvent;
+};
 
 interface RtdsWebSocketEvent {
   topic: string;
@@ -879,15 +911,13 @@ export class WebSocketManager {
       return undefined;
     }
 
-    try {
-      return create(parsedMessage, MarketWebSocketEventSchema);
-    } catch (error) {
+    const data = toMarketWebSocketEvent(parsedMessage);
+    if (!data) {
       DevLogger.log('WebSocketManager: Ignoring invalid market message', {
-        error,
         bodySnippet: message.slice(0, 200),
       });
-      return undefined;
     }
+    return data;
   }
 
   private handleMarketMessage = (event: WebSocketMessageEvent): void => {
@@ -909,12 +939,20 @@ export class WebSocketManager {
         return;
       }
 
-      const updates: PriceUpdate[] = data.price_changes.map((change) => ({
-        tokenId: change.asset_id,
-        price: parseFloat(change.price) || 0,
-        bestBid: parseFloat(change.best_bid) || 0,
-        bestAsk: parseFloat(change.best_ask) || 0,
-      }));
+      const updates: PriceUpdate[] = [];
+      for (const change of data.price_changes) {
+        // Elements are not schema-validated in the hot parse path (see
+        // `toMarketWebSocketEvent`) — guard here instead.
+        if (!change || typeof change.asset_id !== 'string') {
+          continue;
+        }
+        updates.push({
+          tokenId: change.asset_id,
+          price: parseFloat(change.price) || 0,
+          bestBid: parseFloat(change.best_bid) || 0,
+          bestAsk: parseFloat(change.best_ask) || 0,
+        });
+      }
 
       updates.forEach((update) => {
         this.marketPriceCache.set(update.tokenId, update);
@@ -951,8 +989,13 @@ export class WebSocketManager {
       return;
     }
 
+    // Levels are not schema-validated in the hot parse path (see
+    // `toMarketWebSocketEvent`) — guard each level here instead.
     const bids = new Map<string, number>();
     data.bids?.forEach((level) => {
+      if (!level || typeof level.price !== 'string') {
+        return;
+      }
       const size = parseFloat(level.size);
       if (Number.isFinite(size) && size > 0) {
         bids.set(level.price, size);
@@ -960,6 +1003,9 @@ export class WebSocketManager {
     });
     const asks = new Map<string, number>();
     data.asks?.forEach((level) => {
+      if (!level || typeof level.price !== 'string') {
+        return;
+      }
       const size = parseFloat(level.size);
       if (Number.isFinite(size) && size > 0) {
         asks.set(level.price, size);
@@ -1274,7 +1320,7 @@ export class WebSocketManager {
 
     this.throttleTimer = setInterval(() => {
       this.flushCryptoPriceBuffer();
-    }, DEFAULT_THROTTLE_INTERVAL_MS);
+    }, CRYPTO_PRICE_EMIT_THROTTLE_MS);
   }
 
   private flushCryptoPriceBuffer(): void {


### PR DESCRIPTION
## **Description**

Users reported their phones heating up while using Predict, especially on the **Crypto Up/Down markets**. A React Native Release Profiler CPU trace (27s idling on the Crypto Up/Down details screen) showed the Hermes JS thread busy **~29% of wall time with zero idle windows**, dominated by two costs:

1. **46% of busy time — WebSocket message validation.** Every message on the Polymarket CLOB market socket was validated with superstruct `create()`. Order book snapshots (hundreds of levels) were validated element-by-element and then mostly **dropped**, since the Crypto Up/Down chart's orderbook overlay is disabled and there are no orderbook subscribers.
2. **39% of busy time — React render/commit.** Every live crypto price tick (RTDS flush throttle was 16ms) rebuilt the chart's point array (Map + sort of up to 3,600 points), then bubbled the price to the root of the 652-line `PredictCryptoUpDownDetails` screen, re-rendering the entire subtree (header, time slot picker, positions, actions) per tick.

**Solution:**

- `WebSocketManager`: replace superstruct validation in the market-message hot path with a lightweight structural guard (same pattern the RTDS handler already used); array elements are validated defensively at their single consumption sites instead.
- `WebSocketManager`: raise the RTDS crypto price flush throttle **16ms → 250ms**, aligned with the existing market/orderbook emit throttles (caps the whole downstream cascade: chart rebuild → screen re-render → WebView postMessage).
- `useCryptoUpDownChartData`: append + trim in-order live ticks instead of rebuilding (Map + sort) the whole array per tick; skip the O(n) copy in `trimLivePoints` when nothing needs trimming.
- Memoize the heavy children of `PredictCryptoUpDownDetails` (`PredictCryptoUpDownChart`, `TimeSlotPicker`, `PredictCryptoUpDownPositions`) and stabilize the `TimeSlotPicker` callback, so the unavoidable per-tick root re-render only touches the price text.

No behavior changes: malformed WS messages are still silently ignored (covered by existing tests), and price/orderbook data flow is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Improved performance and reduced device heat when viewing Predict Crypto Up/Down markets

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: PRED-1135

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict Crypto Up/Down performance

  Scenario: user idles on a Crypto Up/Down market details screen
    Given the user opens Predict and navigates to a live Crypto Up/Down market (e.g. BTC 5-minute)

    When the user stays on the details screen for ~60 seconds
    Then the live price, chart, time slots, and Up/Down buttons keep updating as before
    And the device does not become noticeably warm
    And a Release Profiler capture shows the JS thread mostly idle
    (previously ~29% busy: parseMarketMessageData/superstruct ~13.5% of wall time)

  Scenario: user interacts with the details screen
    Given the user is on a Crypto Up/Down market details screen

    When the user switches time slots, pulls to refresh, and places a bet
    Then all interactions behave the same as before the change
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no visual changes. Evidence is CPU-profile based:

### **Before**

Release Profiler trace (27s, Crypto Up/Down details screen): JS thread busy 29.1% of wall time, no idle seconds; `parseMarketMessageData` → superstruct `_validate` = 46.4% of busy time; React render/commit = 38.6% of busy time.

### **After**

Release Profiler re-trace on this branch (46.5s, same flow):

- `parseMarketMessageData`: **13.5% → 0.4% of wall time** (46.4% → 1.8% of busy; superstruct frames eliminated, remaining slice is `JSON.parse` + the cheap guard)
- JS thread busy: **29.1% → 17.6%** steady-state, with idle seconds restored (previously zero idle windows)
- Of the remaining busy time, ~17% is non-Predict wallet background work (multicall balance polling) present in this capture; Predict-attributable JS load dropped roughly in half
- Largest remaining React frame is `propagateParentContextChanges` during child bailouts — i.e. the new memoization is taking effect (children bail out instead of re-rendering)

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Existing `TraceName.CryptoUpDownWsMessage` / `TraceName.CryptoUpDownBufferFlush` traces cover the changed paths

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches high-frequency WebSocket parsing and live price → React update paths; behavior is intended to stay the same with defensive checks at consumption sites, but regressions could affect chart freshness or silently dropped malformed messages.
> 
> **Overview**
> Targets **device heat and JS thread load** on Predict Crypto Up/Down by cutting work on the Polymarket market WebSocket hot path and on each live price tick.
> 
> **`WebSocketManager`** drops superstruct `create()` on every CLOB market message in favor of a **lightweight structural guard** (`toMarketWebSocketEvent`); `bids`/`asks`/`price_changes` elements are checked only in `handleBookEvent` and price-change mapping. RTDS chainlink flushes move from **16ms → 250ms** (`CRYPTO_PRICE_EMIT_THROTTLE_MS`), aligned with other emit throttles.
> 
> **`useCryptoUpDownChartData`** appends in-order live ticks instead of Map+sort each tick, and **`trimLivePoints`** returns the same array reference when nothing needs trimming.
> 
> **`PredictCryptoUpDownDetails`** wraps **`PredictCryptoUpDownChart`**, **`TimeSlotPicker`**, and **`PredictCryptoUpDownPositions`** in **`React.memo`**, with a stable **`handleMarketSelected`** for the picker. Chart tests account for memo by changing a prop on rerender.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e30975dc94ce5dc6a9af35c1f2e666bd45505d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->