### PR TITLE
fix: keep amount entry visible before quote loading

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -480,9 +480,33 @@ describe('CustomAmountInfo', () => {
     expect(getByText('Test Alert Message')).toBeDefined();
   });
 
-  it('renders keyboard', () => {
-    const { getByTestId } = render();
-    expect(getByTestId('deposit-keyboard')).toBeDefined();
+  it('renders keyboard instead of the loading review while an empty perps deposit is loading', () => {
+    useTransactionCustomAmountMock.mockReturnValue({
+      amountFiat: '0',
+      amountHuman: '0',
+      amountHumanDebounced: '0',
+      amountFiatDebounced: '0',
+      hasInput: false,
+      isDepositPrefillEnabled: false,
+      isDepositPrefilled: false,
+      isInputChanged: false,
+      isPrefillPending: false,
+      isDepositPrefillLoading: false,
+      updatePendingAmount: noop,
+      updatePendingAmountPercentage: noop,
+      updateTokenAmount: jest.fn(),
+    });
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
+
+    const { getByTestId, queryByTestId } = render({
+      transactionType: TransactionType.perpsDeposit,
+    });
+
+    expect(getByTestId('deposit-keyboard')).toBeOnTheScreen();
+    expect(queryByTestId('bridge-fee-row-skeleton')).not.toBeOnTheScreen();
+    expect(queryByTestId('bridge-time-row-skeleton')).not.toBeOnTheScreen();
+    expect(queryByTestId('total-row-skeleton')).not.toBeOnTheScreen();
   });
 
   describe('bottomBlock', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -111,6 +111,21 @@ type QuoteHandoff =
       quotesLastUpdated: number;
     };
 
+function getLatestQuotesLastUpdated(
+  controllerQuotesLastUpdated: number | undefined,
+  reduxQuotesLastUpdated: number | undefined,
+) {
+  if (controllerQuotesLastUpdated === undefined) {
+    return reduxQuotesLastUpdated;
+  }
+
+  if (reduxQuotesLastUpdated === undefined) {
+    return controllerQuotesLastUpdated;
+  }
+
+  return Math.max(controllerQuotesLastUpdated, reduxQuotesLastUpdated);
+}
+
 export interface CustomAmountInfoProps {
   autoSelectFiatPayment?: boolean;
   children?: ReactNode;
@@ -324,13 +339,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             ]
           : undefined;
         const controllerQuotesLastUpdated = transactionData?.quotesLastUpdated;
-        const reduxQuotesLastUpdated = quotesLastUpdatedRef.current;
-        const latestQuotesLastUpdated =
-          controllerQuotesLastUpdated === undefined
-            ? reduxQuotesLastUpdated
-            : reduxQuotesLastUpdated === undefined
-              ? controllerQuotesLastUpdated
-              : Math.max(controllerQuotesLastUpdated, reduxQuotesLastUpdated);
+        const latestQuotesLastUpdated = getLatestQuotesLastUpdated(
+          controllerQuotesLastUpdated,
+          quotesLastUpdatedRef.current,
+        );
 
         if (transactionData?.isLoading) {
           setQuoteHandoff({
@@ -522,7 +534,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             </>
           )}
           {isResultReady && (
-            <Box
+            <View
               pointerEvents={showLoadingReview ? 'none' : 'auto'}
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
@@ -545,7 +557,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 />
               )}
               <PercentageRow />
-            </Box>
+            </View>
           )}
           {footerText && (
             <Text

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -216,6 +216,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const isKeyboardVisibleRef = useRef(isKeyboardVisible);
     isKeyboardVisibleRef.current = isKeyboardVisible;
     const [isAmountUpdating, setIsAmountUpdating] = useState(false);
+    const [hasCommittedAmount, setHasCommittedAmount] = useState(false);
     const [quoteHandoff, setQuoteHandoff] = useState<QuoteHandoff>();
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
@@ -258,12 +259,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
     quotesLastUpdatedRef.current = quotesLastUpdated;
     const isQuotesLoading = useIsTransactionPayLoading();
-    const showLoadingReview = isAmountUpdating || isQuotesLoading;
+    const hasSourceAmount = useTransactionPayHasSourceAmount();
+    const showLoadingReview =
+      isAmountUpdating || (isQuotesLoading && hasCommittedAmount);
     const isResultReady =
       showLoadingReview ||
       isTransactionResultReady ||
       (isAddMusdIntent && !isKeyboardVisible);
-    const hasSourceAmount = useTransactionPayHasSourceAmount();
     const { alerts } = useAlerts();
     const accountNoFundsAlert = useAccountNoFundsAlert();
     const hasAccountNoFunds = accountNoFundsAlert.length > 0;
@@ -303,6 +305,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
       try {
         await updateTokenAmount();
+        setHasCommittedAmount(true);
         if (selectedFiatPaymentMethodId && transactionId) {
           Engine.context.TransactionPayController.updateFiatPayment({
             transactionId,
@@ -361,6 +364,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           ),
         );
         setIsKeyboardVisible(true);
+        setHasCommittedAmount(false);
         setQuoteHandoff(undefined);
         setIsAmountUpdating(false);
         // Keep keyboard visible so the user can retry; do not advance the flow.


### PR DESCRIPTION
## Description

When a Perps deposit confirmation opened, TransactionPayController could report quote loading before the user had entered or committed an amount. The shared confirmation UI interpreted that initial state as a review-loading state and replaced the amount-entry keypad with quote skeletons.

This change keeps the amount-entry keypad visible until an amount update is in progress or an amount has been committed. It preserves the existing Money Account preparation and quote-handoff behavior after Continue.

## Related issues

Refs: https://github.com/MetaMask/metamask-mobile/pull/33726

## Testing

- Reproduced the initial loading issue from Money Account → Send → Perps Account.
- Confirmed the pre-fix behavior on the cherry-pick comparison worktree.
- Targeted CustomAmountInfo suite: 87 passed.
- Amount/update/controller suites: 159 passed.
- Prettier and git diff --check passed.

## Screenshots/Recordings

N/A — behavior was verified manually in the iOS development build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized confirmation UI gating in CustomAmountInfo; post-commit quote handoff and Money Account preparation behavior are preserved per existing tests.
> 
> **Overview**
> Fixes **Perps deposit** (and similar flows) opening with quote loading already true, which previously triggered the **review loading** state and hid the deposit keypad behind fee/total skeletons.
> 
> **`showLoadingReview`** now requires a committed amount: quote loading alone no longer shows skeletons—only **`isAmountUpdating`** or **`isQuotesLoading && hasCommittedAmount`**. **`hasCommittedAmount`** is set after a successful **`updateTokenAmount`** on Done and cleared if the update fails (keyboard restored for retry).
> 
> Quote handoff after Continue is unchanged; **`getLatestQuotesLastUpdated`** is a small extract of the controller vs Redux timestamp merge. Review rows wrapper switches from **`Box`** to **`View`**. Tests cover empty **perps deposit** while pay is loading: keypad visible, skeletons absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d482d807a11ddbea8132ae0ffaaffd454b336fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->