### PR TITLE
refactor: refactor NetworkSelector component and enhance tests

### DIFF
--- a/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
@@ -393,6 +393,37 @@ describe('Network Selector', () => {
     });
   });
 
+  it('omits non-matching network rows from virtualized search data', () => {
+    (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => true);
+    const { getByPlaceholderText, UNSAFE_getByType } =
+      renderComponent(initialState);
+
+    fireEvent.changeText(getByPlaceholderText('Search'), 'Polygon');
+
+    const list = UNSAFE_getByType(FlatList);
+    const listItems = list.props.data as {
+      type: string;
+      networkConfiguration?: { name: string };
+    }[];
+    const rpcNetworkItems = listItems.filter(
+      (item) => item.type === 'rpcNetwork',
+    );
+
+    expect(listItems).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'mainnet' }),
+        expect.objectContaining({ type: 'lineaMainnet' }),
+      ]),
+    );
+    expect(rpcNetworkItems).toEqual([
+      expect.objectContaining({
+        networkConfiguration: expect.objectContaining({
+          name: 'Polygon Mainnet',
+        }),
+      }),
+    ]);
+  });
+
   it('renders correctly', () => {
     (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => false);
     renderComponent(initialState);

--- a/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
@@ -78,11 +78,6 @@ import * as selectedNetworkControllerFcts from '../../../selectors/selectedNetwo
 
 const mockEngine = Engine;
 
-const setShowTestNetworksSpy = jest.spyOn(
-  Engine.context.PreferencesController,
-  'setShowTestNetworks',
-);
-
 // Mock the entire module
 jest.mock('../../../util/networks/isNetworkUiRedesignEnabled', () => ({
   isNetworkUiRedesignEnabled: jest.fn(),
@@ -360,6 +355,16 @@ const renderComponent = (state: any = {}) =>
   );
 
 describe('Network Selector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Engine.context.PreferencesController, 'setShowTestNetworks');
+    (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders heterogeneous network sections through a virtualized list', () => {
     (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => true);
     const { UNSAFE_getByType } = renderComponent(initialState);
@@ -424,7 +429,7 @@ describe('Network Selector', () => {
       expect(
         mockEngine.context.SelectedNetworkController
           .setNetworkClientIdForDomain,
-      ).toBeCalled();
+      ).toHaveBeenCalled();
     });
   });
 
@@ -445,7 +450,7 @@ describe('Network Selector', () => {
 
     expect(
       mockEngine.context.MultichainNetworkController.setActiveNetwork,
-    ).toBeCalled();
+    ).toHaveBeenCalled();
   });
 
   it('toggles the test networks switch correctly', () => {
@@ -457,7 +462,9 @@ describe('Network Selector', () => {
 
     fireEvent(testNetworksSwitch, 'onValueChange', true);
 
-    expect(setShowTestNetworksSpy).toBeCalled();
+    expect(
+      Engine.context.PreferencesController.setShowTestNetworks,
+    ).toHaveBeenCalled();
   });
 
   it('toggle test network is disabled and is on when a testnet is selected', () => {
@@ -528,7 +535,7 @@ describe('Network Selector', () => {
     fireEvent.press(gnosisCell);
     expect(
       mockEngine.context.MultichainNetworkController.setActiveNetwork,
-    ).toBeCalled();
+    ).toHaveBeenCalled();
   });
 
   it('changes to test network when another network cell is pressed', async () => {
@@ -601,7 +608,7 @@ describe('Network Selector', () => {
 
     expect(
       mockEngine.context.MultichainNetworkController.setActiveNetwork,
-    ).toBeCalled();
+    ).toHaveBeenCalled();
   });
 
   it('renders correctly with no network configurations', async () => {
@@ -652,10 +659,15 @@ describe('Network Selector', () => {
 
     fireEvent.press(polygonCell);
 
-    await waitFor(() => {
-      const rpcOption = getByText('polygon-mainnet.infura.io/v3');
-      fireEvent.press(rpcOption);
+    const rpcOption = await waitFor(() => {
+      const option = getByText('polygon-mainnet.infura.io/v3');
+
+      expect(option).toBeOnTheScreen();
+
+      return option;
     });
+
+    fireEvent.press(rpcOption);
   });
 
   it('filters networks correctly when searching', () => {
@@ -709,11 +721,15 @@ describe('Network Selector', () => {
 
     // Toggle the switch on
     fireEvent(testNetworksSwitch, 'onValueChange', true);
-    expect(setShowTestNetworksSpy).toBeCalledWith(true);
+    expect(
+      Engine.context.PreferencesController.setShowTestNetworks,
+    ).toHaveBeenCalledWith(true);
 
     // Toggle the switch off
     fireEvent(testNetworksSwitch, 'onValueChange', false);
-    expect(setShowTestNetworksSpy).toBeCalledWith(false);
+    expect(
+      Engine.context.PreferencesController.setShowTestNetworks,
+    ).toHaveBeenCalledWith(false);
   });
 
   describe('renderLineaMainnet', () => {

--- a/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { fireEvent, waitFor, screen } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
+import type { FlashListProps } from '@shopify/flash-list';
 
 // External dependencies
 import renderWithProvider from '../../../util/test/renderWithProvider';
@@ -14,6 +16,32 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { NetworkListModalSelectorsIDs } from './NetworkListModal.testIds';
 import { isNetworkUiRedesignEnabled } from '../../../util/networks/isNetworkUiRedesignEnabled';
 import { mockNetworkState } from '../../../util/test/network';
+
+jest.mock('@shopify/flash-list', () => {
+  const ReactMock = jest.requireActual<typeof import('react')>('react');
+  const { FlatList: MockFlashList } =
+    jest.requireActual<typeof import('react-native')>('react-native');
+
+  return {
+    FlashList: ReactMock.forwardRef(
+      (
+        {
+          renderScrollComponent: _renderScrollComponent,
+          ...props
+        }: FlashListProps<unknown>,
+        ref: React.ForwardedRef<FlatList<unknown>>,
+      ) => {
+        const mockProps = {
+          ...props,
+          initialNumToRender: props.data?.length,
+          ref,
+        } as unknown as React.ComponentPropsWithRef<typeof MockFlashList>;
+
+        return ReactMock.createElement(MockFlashList, mockProps);
+      },
+    ),
+  };
+});
 
 jest.mock('../../../util/metrics/MultichainAPI/networkMetricUtils', () => ({
   removeItemFromChainIdList: jest.fn().mockReturnValue({
@@ -332,6 +360,34 @@ const renderComponent = (state: any = {}) =>
   );
 
 describe('Network Selector', () => {
+  it('renders heterogeneous network sections through a virtualized list', () => {
+    (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => true);
+    const { UNSAFE_getByType } = renderComponent(initialState);
+
+    const list = UNSAFE_getByType(FlatList);
+    const itemTypes = list.props.data.map(
+      (item: { type: string }) => item.type,
+    );
+
+    expect(itemTypes).toEqual(
+      expect.arrayContaining([
+        'enabledNetworksHeader',
+        'mainnet',
+        'lineaMainnet',
+        'rpcNetwork',
+        'popularNetworksHeader',
+        'additionalNetworks',
+        'testNetworksSwitch',
+      ]),
+    );
+    expect(list.props.getItemType(list.props.data[0])).toBe(
+      'enabledNetworksHeader',
+    );
+    expect(list.props.maintainVisibleContentPosition).toEqual({
+      disabled: true,
+    });
+  });
+
   it('renders correctly', () => {
     (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => false);
     renderComponent(initialState);

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -1,25 +1,11 @@
 // Third party dependencies.
-import {
-  KeyboardAvoidingView,
-  Linking,
-  Switch,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { KeyboardAvoidingView, Linking, View } from 'react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
-import images from 'images/image-icons';
 import { useNavigation, type RouteProp } from '@react-navigation/native';
 import type { RootStackParamList } from '../../../core/NavigationService/types';
 
 // External dependencies.
-import Cell, {
-  CellVariant,
-} from '../../../component-library/components/Cells/Cell';
-import {
-  AvatarSize,
-  AvatarVariant,
-} from '../../../component-library/components/Avatars/Avatar';
+import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
 import { strings } from '../../../../locales/i18n';
 import BottomSheet, {
   BottomSheetRef,
@@ -34,19 +20,10 @@ import {
   selectShowTestNetworks,
   selectTokenNetworkFilter,
 } from '../../../selectors/preferencesController';
-import Networks, {
-  getAllNetworks,
-  isTestNet,
-  getNetworkImageSource,
-  isMainNet,
-  canDeleteNetwork,
-} from '../../../util/networks';
-import { LINEA_MAINNET, MAINNET } from '../../../constants/network';
 import {
   Button,
   ButtonVariant,
   ButtonSize,
-  Box,
 } from '@metamask/design-system-react-native';
 import { ButtonVariants } from '../../../component-library/components/Buttons/Button';
 import {
@@ -58,26 +35,18 @@ import Routes from '../../../constants/navigation/Routes';
 import { NetworkListModalSelectorsIDs } from './NetworkListModal.testIds';
 import { useTheme } from '../../../util/theme';
 import Text from '../../../component-library/components/Texts/Text/Text';
-import {
-  TextColor,
-  TextVariant,
-} from '../../../component-library/components/Texts/Text';
+import { TextVariant } from '../../../component-library/components/Texts/Text';
 
 // Internal dependencies
 import createStyles from './NetworkSelector.styles';
-import { ShowConfirmDeleteModalState, infuraNetwork } from './types';
+import { ShowConfirmDeleteModalState } from './types';
 import { getTokenNetworkFilterAfterNetworkDelete } from './utils/getTokenNetworkFilterAfterNetworkDelete';
-import { InfuraNetworkType } from '@metamask/controller-utils';
 import InfoModal from '../../Base/InfoModal';
 import hideKeyFromUrl from '../../../util/hideKeyFromUrl';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import CustomNetwork from '../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { NetworksSelectorSelectorsIDs } from '../Settings/NetworksSettings/NetworksView.testIds';
-import { PopularList } from '../../../util/networks/customNetworks';
 import NetworkSearchTextInput from './NetworkSearchTextInput';
 import { useAddPopularNetwork } from '../../hooks/useAddPopularNetwork';
-import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import AccountAction from '../AccountAction';
@@ -87,10 +56,10 @@ import BottomSheetFooter from '../../../component-library/components/BottomSheet
 import { ExtendedNetwork } from '../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import { isNetworkUiRedesignEnabled } from '../../../util/networks/isNetworkUiRedesignEnabled';
 import { CaipChainId, Hex } from '@metamask/utils';
-import hideProtocolFromUrl from '../../../util/hideProtocolFromUrl';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useNetworkInfo } from '../../../selectors/selectedNetworkController';
-import { NetworkConfiguration } from '@metamask/network-controller';
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import type { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import RpcSelectionModal from './RpcSelectionModal/RpcSelectionModal';
 import {
   TraceName,
@@ -110,7 +79,6 @@ import {
   selectSelectedNonEvmNetworkChainId,
 } from '../../../selectors/multichainNetworkController';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
-import { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import { useSwitchNetworks } from './useSwitchNetworks';
 import { removeItemFromChainIdList } from '../../../util/metrics/MultichainAPI/networkMetricUtils';
 import { analytics } from '../../../util/analytics/analytics';
@@ -118,9 +86,7 @@ import { NETWORK_SELECTOR_SOURCES } from '../../../constants/networkSelector';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../selectors/featureFlagController/gasFeesSponsored';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { isHardwareAccount } from '../../../util/address';
-import TagColored, {
-  TagColor,
-} from '../../../component-library/components-temp/TagColored';
+import NetworkSelectorList from './NetworkSelectorList';
 
 interface NetworkSelectorProps {
   route: RouteProp<RootStackParamList, 'NetworkSelector'>;
@@ -188,14 +154,15 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
   const isSendFlow =
     route?.params?.source === NETWORK_SELECTOR_SOURCES.SEND_FLOW;
 
-  const avatarSize = isNetworkUiRedesignEnabled() ? AvatarSize.Sm : undefined;
-  const modalTitle = isNetworkUiRedesignEnabled()
+  const isRedesignEnabled = isNetworkUiRedesignEnabled();
+  const avatarSize = isRedesignEnabled ? AvatarSize.Sm : undefined;
+  const modalTitle = isRedesignEnabled
     ? 'networks.additional_network_information_title'
     : 'networks.network_warning_title';
-  const modalDescription = isNetworkUiRedesignEnabled()
+  const modalDescription = isRedesignEnabled
     ? 'networks.additonial_network_information_desc'
     : 'networks.network_warning_desc';
-  const buttonLabelAddNetwork = isNetworkUiRedesignEnabled()
+  const buttonLabelAddNetwork = isRedesignEnabled
     ? 'app_settings.network_add_custom_network'
     : 'app_settings.network_add_network';
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] =
@@ -342,34 +309,6 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
     Linking.openURL(strings('networks.learn_more_url'));
   };
 
-  const filterNetworksByName = (
-    networks: ExtendedNetwork[],
-    networkName: string,
-  ) => {
-    const searchResult: ExtendedNetwork[] = networks.filter(({ name }) =>
-      name?.toLowerCase().includes(networkName.toLowerCase()),
-    );
-
-    return searchResult;
-  };
-
-  const isNoSearchResults = (networkIdenfier: string) => {
-    if (!searchString || !networkIdenfier) {
-      return false;
-    }
-
-    if (networkIdenfier === MAINNET || networkIdenfier === LINEA_MAINNET) {
-      const networkIdentified = Networks[
-        networkIdenfier
-      ] as unknown as ExtendedNetwork;
-      return (
-        filterNetworksByName([networkIdentified], searchString).length === 0
-      );
-    }
-
-    return !networkIdenfier.includes(searchString);
-  };
-
   const isNetworkSelected = (chainId: Hex | CaipChainId) => {
     if (browserChainId) {
       return chainId === browserChainId;
@@ -402,351 +341,6 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
     endTrace({ name: TraceName.NetworkSwitch });
   }, []);
 
-  const renderMainnet = () => {
-    const { name: mainnetName, chainId } = Networks.mainnet;
-    const rpcUrl =
-      networkConfigurations?.[chainId]?.rpcEndpoints?.[
-        networkConfigurations?.[chainId]?.defaultRpcEndpointIndex
-      ].url;
-    const name = networkConfigurations?.[chainId]?.name ?? mainnetName;
-
-    if (isNetworkUiRedesignEnabled() && isNoSearchResults(MAINNET)) return null;
-
-    if (isNetworkUiRedesignEnabled()) {
-      return (
-        <Cell
-          key={chainId}
-          variant={isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu}
-          title={name}
-          secondaryText={
-            showRpcSelector
-              ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
-              : undefined
-          }
-          avatarProps={{
-            variant: AvatarVariant.Network,
-            name: mainnetName,
-            imageSource: images.ETHEREUM,
-            size: AvatarSize.Sm,
-          }}
-          isSelected={isNetworkSelected(chainId)}
-          onPress={() => onNetworkChange(MAINNET)}
-          style={styles.networkCell}
-          buttonIcon={IconName.MoreVertical}
-          buttonProps={{
-            onButtonClick: () => {
-              openModal(chainId, false, MAINNET, true);
-            },
-          }}
-          onTextClick={() =>
-            openRpcModal({
-              chainId,
-              networkName: mainnetName,
-            })
-          }
-          onLongPress={() => {
-            openModal(chainId, false, MAINNET, true);
-          }}
-        />
-      );
-    }
-
-    return (
-      <Cell
-        variant={CellVariant.Select}
-        title={name}
-        avatarProps={{
-          variant: AvatarVariant.Network,
-          name: mainnetName,
-          imageSource: images.ETHEREUM,
-          size: avatarSize,
-        }}
-        isSelected={isNetworkSelected(chainId)}
-        onPress={() => onNetworkChange(MAINNET)}
-        style={styles.networkCell}
-      />
-    );
-  };
-
-  const renderLineaMainnet = () => {
-    const { name: lineaMainnetName, chainId } = Networks['linea-mainnet'];
-    const name = networkConfigurations?.[chainId]?.name ?? lineaMainnetName;
-    const rpcUrl =
-      networkConfigurations?.[chainId]?.rpcEndpoints?.[
-        networkConfigurations?.[chainId]?.defaultRpcEndpointIndex
-      ].url;
-
-    if (isNetworkUiRedesignEnabled() && isNoSearchResults('linea-mainnet'))
-      return null;
-
-    if (isNetworkUiRedesignEnabled()) {
-      return (
-        <Cell
-          key={chainId}
-          variant={isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu}
-          title={name}
-          avatarProps={{
-            variant: AvatarVariant.Network,
-            name: lineaMainnetName,
-            imageSource: images['LINEA-MAINNET'],
-            size: AvatarSize.Sm,
-          }}
-          isSelected={isNetworkSelected(chainId)}
-          onPress={() => onNetworkChange(LINEA_MAINNET)}
-          style={styles.networkCell}
-          buttonIcon={IconName.MoreVertical}
-          secondaryText={
-            showRpcSelector
-              ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
-              : undefined
-          }
-          buttonProps={{
-            onButtonClick: () => {
-              openModal(chainId, false, LINEA_MAINNET, true);
-            },
-          }}
-          onTextClick={() =>
-            openRpcModal({
-              chainId,
-              networkName: lineaMainnetName,
-            })
-          }
-          onLongPress={() => {
-            openModal(chainId, false, LINEA_MAINNET, true);
-          }}
-        />
-      );
-    }
-
-    return (
-      <Cell
-        variant={CellVariant.Select}
-        title={name}
-        avatarProps={{
-          variant: AvatarVariant.Network,
-          name: lineaMainnetName,
-          imageSource: images['LINEA-MAINNET'],
-          size: avatarSize,
-        }}
-        isSelected={isNetworkSelected(chainId)}
-        onPress={() => onNetworkChange(LINEA_MAINNET)}
-      />
-    );
-  };
-
-  const renderRpcNetworks = () =>
-    Object.values(networkConfigurations).map((networkConfiguration) => {
-      if (isNonEvmChainId(networkConfiguration.chainId)) return null;
-      const {
-        name: nickname,
-        rpcEndpoints,
-        chainId,
-        defaultRpcEndpointIndex,
-      } = networkConfiguration;
-      if (
-        !chainId ||
-        isTestNet(chainId) ||
-        isMainNet(chainId) ||
-        chainId === CHAIN_IDS.LINEA_MAINNET ||
-        chainId === CHAIN_IDS.GOERLI
-      ) {
-        return null;
-      }
-
-      const rpcUrl = rpcEndpoints[defaultRpcEndpointIndex].url;
-      const rpcName = rpcEndpoints[defaultRpcEndpointIndex].name ?? rpcUrl;
-
-      const name = nickname || rpcName;
-
-      if (isNetworkUiRedesignEnabled() && isNoSearchResults(name)) return null;
-
-      const image = getNetworkImageSource({ chainId: chainId?.toString() });
-
-      if (isNetworkUiRedesignEnabled()) {
-        return (
-          <Cell
-            key={chainId}
-            variant={
-              isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu
-            }
-            title={
-              isSendFlow ? (
-                name
-              ) : (
-                <Box twClassName="w-full flex-row gap-2 items-center self-stretch">
-                  <Text
-                    variant={TextVariant.BodyMD}
-                    numberOfLines={1}
-                    style={styles.networkNameText}
-                  >
-                    {name}
-                  </Text>
-                  {!isHardwareWallet &&
-                  isGasFeesSponsoredNetworkEnabled(chainId) ? (
-                    <TagColored
-                      color={TagColor.Success}
-                      style={styles.noNetworkFeeContainer}
-                      labelProps={{
-                        variant: TextVariant.BodySM,
-                        style: {
-                          textTransform: 'none',
-                          textAlign: 'center',
-                          bottom: 1,
-                          fontWeight: 'normal',
-                        },
-                      }}
-                    >
-                      {strings('networks.no_network_fee')}
-                    </TagColored>
-                  ) : undefined}
-                </Box>
-              )
-            }
-            tertiaryText={
-              isSendFlow &&
-              !isHardwareWallet &&
-              isGasFeesSponsoredNetworkEnabled(chainId)
-                ? strings('networks.no_network_fee')
-                : undefined
-            }
-            avatarProps={{
-              variant: AvatarVariant.Network,
-              name,
-              imageSource: image,
-              size: AvatarSize.Sm,
-            }}
-            isSelected={
-              !isEvmSelected ? false : Boolean(chainId === selectedChainId)
-            }
-            onPress={() => onSetRpcTarget(networkConfiguration)}
-            style={styles.networkCell}
-            buttonIcon={IconName.MoreVertical}
-            secondaryText={
-              showRpcSelector
-                ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
-                : undefined
-            }
-            buttonProps={{
-              onButtonClick: () => {
-                openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false);
-              },
-            }}
-            onTextClick={() =>
-              openRpcModal({
-                chainId,
-                networkName: name,
-              })
-            }
-            onLongPress={() => {
-              openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false);
-            }}
-          />
-        );
-      }
-
-      return (
-        <Cell
-          key={`${chainId}-${rpcUrl}`}
-          testID={NetworkListModalSelectorsIDs.CUSTOM_NETWORK_CELL(name)}
-          variant={CellVariant.Select}
-          title={name}
-          avatarProps={{
-            variant: AvatarVariant.Network,
-            name,
-            imageSource: image,
-            size: avatarSize,
-          }}
-          isSelected={
-            !isEvmSelected ? false : Boolean(chainId === selectedChainId)
-          }
-          onPress={() => onSetRpcTarget(networkConfiguration)}
-          style={styles.networkCell}
-        >
-          {Boolean(
-            chainId === selectedChainId && selectedRpcUrl === rpcUrl,
-          ) && <View testID={`${name}-selected`} />}
-        </Cell>
-      );
-    });
-
-  const renderOtherNetworks = () => {
-    const getAllNetworksTyped =
-      getAllNetworks() as unknown as InfuraNetworkType[];
-    const getOtherNetworks = () => getAllNetworksTyped.slice(3);
-    return getOtherNetworks().map((networkType: InfuraNetworkType) => {
-      const TypedNetworks = Networks as unknown as Record<
-        string,
-        infuraNetwork
-      >;
-      const { name, imageSource, chainId } = TypedNetworks[networkType];
-
-      const networkConfiguration = networkConfigurations[chainId];
-
-      const rpcEndpoints = networkConfiguration?.rpcEndpoints;
-
-      const rpcUrl =
-        rpcEndpoints?.[networkConfiguration?.defaultRpcEndpointIndex].url;
-
-      if (isNetworkUiRedesignEnabled() && isNoSearchResults(name)) return null;
-
-      if (isNetworkUiRedesignEnabled()) {
-        return (
-          <Cell
-            key={chainId}
-            variant={CellVariant.SelectWithMenu}
-            secondaryText={
-              showRpcSelector
-                ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
-                : undefined
-            }
-            title={name}
-            avatarProps={{
-              variant: AvatarVariant.Network,
-              name,
-              imageSource,
-              size: AvatarSize.Sm,
-            }}
-            isSelected={isNetworkSelected(chainId)}
-            onPress={() => onNetworkChange(networkType)}
-            style={styles.networkCell}
-            buttonIcon={IconName.MoreVertical}
-            buttonProps={{
-              onButtonClick: () => {
-                openModal(chainId, false, networkType, true);
-              },
-            }}
-            onTextClick={() =>
-              openRpcModal({
-                chainId,
-                networkName: name,
-              })
-            }
-            onLongPress={() => {
-              openModal(chainId, false, networkType, true);
-            }}
-          />
-        );
-      }
-
-      return (
-        <Cell
-          key={chainId}
-          variant={CellVariant.Select}
-          title={name}
-          avatarProps={{
-            variant: AvatarVariant.Network,
-            name,
-            imageSource,
-            size: avatarSize,
-          }}
-          isSelected={isNetworkSelected(chainId)}
-          onPress={() => onNetworkChange(networkType)}
-          style={styles.networkCell}
-        />
-      );
-    });
-  };
-
   const goToNetworkSettings = () => {
     sheetRef.current?.dismissModal(() => {
       navigate(Routes.ADD_NETWORK, {
@@ -755,119 +349,6 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
       });
     });
   };
-
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  const renderNonEvmNetworks = (onlyTestnets: boolean) => {
-    let networks = Object.values(nonEvmNetworkConfigurations);
-    if (onlyTestnets) {
-      networks = networks.filter((network) => network.isTestnet);
-    } else {
-      networks = networks.filter((network) => !network.isTestnet);
-    }
-
-    return networks.map((network) => {
-      const isSelected = isNetworkSelected(network.chainId);
-      return (
-        <Cell
-          key={network.chainId}
-          variant={CellVariant.Select}
-          title={network.name}
-          avatarProps={{
-            variant: AvatarVariant.Network,
-            name: network.name,
-            imageSource: network.imageSource,
-            size: avatarSize,
-          }}
-          isSelected={isSelected}
-          onPress={() => onNonEvmNetworkChange(network.chainId)}
-          style={styles.networkCell}
-        />
-      );
-    });
-  };
-
-  ///: END:ONLY_INCLUDE_IF
-  const renderTestNetworksSwitch = () => (
-    <View style={styles.switchContainer}>
-      <Text variant={TextVariant.BodyLGMedium} color={TextColor.Alternative}>
-        {strings('networks.show_test_networks')}
-      </Text>
-      <Switch
-        onValueChange={(value: boolean) => {
-          const { PreferencesController } = Engine.context;
-          PreferencesController.setShowTestNetworks(value);
-        }}
-        value={isTestNet(selectedChainId) || showTestNetworks}
-        trackColor={{
-          true: colors.primary.default,
-          false: colors.border.muted,
-        }}
-        thumbColor={theme.brandColors.white}
-        ios_backgroundColor={colors.border.muted}
-        testID={NetworkListModalSelectorsIDs.TEST_NET_TOGGLE}
-        disabled={isTestNet(selectedChainId)}
-      />
-    </View>
-  );
-
-  const renderAdditonalNetworks = () => {
-    let filteredNetworks;
-
-    if (isNetworkUiRedesignEnabled() && searchString.length > 0)
-      filteredNetworks = PopularList.filter(({ nickname }) =>
-        nickname.toLowerCase().includes(searchString.toLowerCase()),
-      );
-
-    return (
-      <View style={styles.addtionalNetworksContainer}>
-        <CustomNetwork
-          isNetworkModalVisible={showPopularNetworkModal}
-          closeNetworkModal={onCancel}
-          selectedNetwork={popularNetwork}
-          toggleWarningModal={toggleWarningModal}
-          showNetworkModal={showNetworkModal}
-          switchTab={undefined}
-          shouldNetworkSwitchPopToWallet={false}
-          customNetworksList={
-            searchString.length > 0 ? filteredNetworks : undefined
-          }
-          showCompletionMessage={false}
-          showPopularNetworkModal
-          hideWarningIcons
-          skipConfirmation
-          onNetworkAdd={handleAddPopularNetwork}
-        />
-      </View>
-    );
-  };
-
-  const renderPopularNetworksTitle = () => (
-    <View style={styles.popularNetworkTitleContainer}>
-      <Text variant={TextVariant.BodyLGMedium} color={TextColor.Alternative}>
-        {strings('networks.additional_networks')}
-      </Text>
-      <TouchableOpacity
-        testID={NetworkListModalSelectorsIDs.TOOLTIP}
-        style={styles.gasInfoContainer}
-        onPress={toggleWarningModal}
-        hitSlop={styles.hitSlop}
-      >
-        <MaterialCommunityIcons
-          name="information"
-          size={14}
-          style={styles.gasInfoIcon}
-        />
-      </TouchableOpacity>
-    </View>
-  );
-
-  const renderEnabledNetworksTitle = () => (
-    <View style={styles.switchContainer}>
-      <Text variant={TextVariant.BodyLGMedium} color={TextColor.Alternative}>
-        {strings('networks.enabled_networks')}
-      </Text>
-    </View>
-  );
 
   const handleSearchTextChange = (text: string) => {
     setSearchString(text);
@@ -933,30 +414,6 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
     onPress: () => confirmRemoveRpc(),
   };
 
-  const renderBottomSheetContent = () => (
-    <>
-      {isNetworkUiRedesignEnabled() &&
-        searchString.length === 0 &&
-        renderEnabledNetworksTitle()}
-      {renderMainnet()}
-      {renderLineaMainnet()}
-      {renderRpcNetworks()}
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-        !isSendFlow && renderNonEvmNetworks(false)
-        ///: END:ONLY_INCLUDE_IF
-      }
-      {!isSendFlow &&
-        isNetworkUiRedesignEnabled() &&
-        searchString.length === 0 &&
-        renderPopularNetworksTitle()}
-      {!isSendFlow && isNetworkUiRedesignEnabled() && renderAdditonalNetworks()}
-      {!isSendFlow && searchString.length === 0 && renderTestNetworksSwitch()}
-      {!isSendFlow && showTestNetworks && renderOtherNetworks()}
-      {!isSendFlow && showTestNetworks && renderNonEvmNetworks(true)}
-    </>
-  );
-
   return (
     <ReusableModal ref={sheetRef} style={styles.screen}>
       <View style={[styles.sheet, { paddingBottom: safeAreaInsets.bottom }]}>
@@ -980,13 +437,37 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
           style={styles.keyboardView}
           enabled
         >
-          <ScrollView
-            style={styles.scrollableDescription}
-            keyboardShouldPersistTaps="handled"
-            testID={NetworkListModalSelectorsIDs.SCROLL}
-          >
-            {renderBottomSheetContent()}
-          </ScrollView>
+          <NetworkSelectorList
+            networkConfigurations={networkConfigurations}
+            ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+            nonEvmNetworkConfigurations={nonEvmNetworkConfigurations}
+            ///: END:ONLY_INCLUDE_IF
+            searchString={searchString}
+            showTestNetworks={showTestNetworks}
+            isSendFlow={isSendFlow}
+            isRedesignEnabled={isRedesignEnabled}
+            showRpcSelector={showRpcSelector}
+            selectedChainId={selectedChainId}
+            selectedRpcUrl={selectedRpcUrl}
+            isEvmSelected={isEvmSelected}
+            isHardwareWallet={isHardwareWallet}
+            avatarSize={avatarSize}
+            showPopularNetworkModal={showPopularNetworkModal}
+            popularNetwork={popularNetwork}
+            isGasFeesSponsoredNetworkEnabled={isGasFeesSponsoredNetworkEnabled}
+            isNetworkSelected={isNetworkSelected}
+            onSetRpcTarget={onSetRpcTarget}
+            onNetworkChange={onNetworkChange}
+            ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+            onNonEvmNetworkChange={onNonEvmNetworkChange}
+            ///: END:ONLY_INCLUDE_IF
+            openModal={openModal}
+            openRpcModal={openRpcModal}
+            onCancel={onCancel}
+            toggleWarningModal={toggleWarningModal}
+            showNetworkModal={showNetworkModal}
+            handleAddPopularNetwork={handleAddPopularNetwork}
+          />
           {!isSendFlow ? (
             <Button
               variant={ButtonVariant.Secondary}

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
@@ -1,0 +1,648 @@
+import React, { useMemo } from 'react';
+import {
+  type ScrollViewProps,
+  Switch,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import { FlashList, type ListRenderItemInfo } from '@shopify/flash-list';
+import {
+  Box,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName as DesignSystemIconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { InfuraNetworkType } from '@metamask/controller-utils';
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import images from 'images/image-icons';
+
+import Cell, {
+  CellVariant,
+} from '../../../../component-library/components/Cells/Cell';
+import {
+  AvatarSize,
+  AvatarVariant,
+} from '../../../../component-library/components/Avatars/Avatar';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { TextVariant as LegacyTextVariant } from '../../../../component-library/components/Texts/Text';
+import TagColored, {
+  TagColor,
+} from '../../../../component-library/components-temp/TagColored';
+import Engine from '../../../../core/Engine';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  canDeleteNetwork,
+  getAllNetworks,
+  getNetworkImageSource,
+  isMainNet,
+  isTestNet,
+  default as Networks,
+} from '../../../../util/networks';
+import hideKeyFromUrl from '../../../../util/hideKeyFromUrl';
+import hideProtocolFromUrl from '../../../../util/hideProtocolFromUrl';
+import { strings } from '../../../../../locales/i18n';
+import { useTheme } from '../../../../util/theme';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import CustomNetwork from '../../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork';
+import { PopularList } from '../../../../util/networks/customNetworks';
+import { NetworkListModalSelectorsIDs } from '../NetworkListModal.testIds';
+import createStyles from '../NetworkSelector.styles';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { ExtendedNetwork } from '../../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
+import type { infuraNetwork } from '../types';
+import { isNonEvmChainId } from '../../../../core/Multichain/utils';
+import type {
+  NetworkSelectorListItem,
+  NetworkSelectorListProps,
+  NonEvmNetworkListConfiguration,
+} from './NetworkSelectorList.types';
+
+const keyExtractor = (item: NetworkSelectorListItem) => item.key;
+
+const getItemType = (item: NetworkSelectorListItem) => item.type;
+
+const NetworkSelectorList = ({
+  networkConfigurations,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  nonEvmNetworkConfigurations,
+  ///: END:ONLY_INCLUDE_IF
+  searchString,
+  showTestNetworks,
+  isSendFlow,
+  isRedesignEnabled,
+  showRpcSelector,
+  selectedChainId,
+  selectedRpcUrl,
+  isEvmSelected,
+  isHardwareWallet,
+  avatarSize,
+  showPopularNetworkModal,
+  popularNetwork,
+  isGasFeesSponsoredNetworkEnabled,
+  isNetworkSelected,
+  onSetRpcTarget,
+  onNetworkChange,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  onNonEvmNetworkChange,
+  ///: END:ONLY_INCLUDE_IF
+  openModal,
+  openRpcModal,
+  onCancel,
+  toggleWarningModal,
+  showNetworkModal,
+  handleAddPopularNetwork,
+}: NetworkSelectorListProps) => {
+  const theme = useTheme();
+  const { colors } = theme;
+  const styles = createStyles(colors);
+
+  const isNoSearchResults = (networkIdentifier: string) => {
+    if (!searchString || !networkIdentifier) {
+      return false;
+    }
+
+    if (
+      networkIdentifier === 'mainnet' ||
+      networkIdentifier === 'linea-mainnet'
+    ) {
+      const network = Networks[networkIdentifier] as unknown as ExtendedNetwork;
+      return !network.name?.toLowerCase().includes(searchString.toLowerCase());
+    }
+
+    return !networkIdentifier.includes(searchString);
+  };
+
+  const renderMainnet = () => {
+    const { name: mainnetName, chainId } = Networks.mainnet;
+    const networkConfiguration = networkConfigurations[chainId];
+    const rpcUrl =
+      networkConfiguration?.rpcEndpoints[
+        networkConfiguration.defaultRpcEndpointIndex
+      ].url;
+    const name = networkConfiguration?.name ?? mainnetName;
+
+    if (isRedesignEnabled && isNoSearchResults('mainnet')) return null;
+
+    if (!isRedesignEnabled) {
+      return (
+        <Cell
+          variant={CellVariant.Select}
+          title={name}
+          avatarProps={{
+            variant: AvatarVariant.Network,
+            name: mainnetName,
+            imageSource: images.ETHEREUM,
+            size: avatarSize,
+          }}
+          isSelected={isNetworkSelected(chainId)}
+          onPress={() => onNetworkChange(InfuraNetworkType.mainnet)}
+          style={styles.networkCell}
+        />
+      );
+    }
+
+    return (
+      <Cell
+        variant={isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu}
+        title={name}
+        secondaryText={
+          showRpcSelector
+            ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
+            : undefined
+        }
+        avatarProps={{
+          variant: AvatarVariant.Network,
+          name: mainnetName,
+          imageSource: images.ETHEREUM,
+          size: AvatarSize.Sm,
+        }}
+        isSelected={isNetworkSelected(chainId)}
+        onPress={() => onNetworkChange(InfuraNetworkType.mainnet)}
+        style={styles.networkCell}
+        buttonIcon={IconName.MoreVertical}
+        buttonProps={{
+          onButtonClick: () =>
+            openModal(chainId, false, InfuraNetworkType.mainnet, true),
+        }}
+        onTextClick={() => openRpcModal({ chainId, networkName: mainnetName })}
+        onLongPress={() =>
+          openModal(chainId, false, InfuraNetworkType.mainnet, true)
+        }
+      />
+    );
+  };
+
+  const renderLineaMainnet = () => {
+    const { name: networkName, chainId } = Networks['linea-mainnet'];
+    const networkConfiguration = networkConfigurations[chainId];
+    const rpcUrl =
+      networkConfiguration?.rpcEndpoints[
+        networkConfiguration.defaultRpcEndpointIndex
+      ].url;
+    const name = networkConfiguration?.name ?? networkName;
+
+    if (isRedesignEnabled && isNoSearchResults('linea-mainnet')) return null;
+
+    if (!isRedesignEnabled) {
+      return (
+        <Cell
+          variant={CellVariant.Select}
+          title={name}
+          avatarProps={{
+            variant: AvatarVariant.Network,
+            name: networkName,
+            imageSource: images['LINEA-MAINNET'],
+            size: avatarSize,
+          }}
+          isSelected={isNetworkSelected(chainId)}
+          onPress={() => onNetworkChange(InfuraNetworkType['linea-mainnet'])}
+        />
+      );
+    }
+
+    return (
+      <Cell
+        variant={isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu}
+        title={name}
+        secondaryText={
+          showRpcSelector
+            ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
+            : undefined
+        }
+        avatarProps={{
+          variant: AvatarVariant.Network,
+          name: networkName,
+          imageSource: images['LINEA-MAINNET'],
+          size: AvatarSize.Sm,
+        }}
+        isSelected={isNetworkSelected(chainId)}
+        onPress={() => onNetworkChange(InfuraNetworkType['linea-mainnet'])}
+        style={styles.networkCell}
+        buttonIcon={IconName.MoreVertical}
+        buttonProps={{
+          onButtonClick: () =>
+            openModal(chainId, false, InfuraNetworkType['linea-mainnet'], true),
+        }}
+        onTextClick={() => openRpcModal({ chainId, networkName })}
+        onLongPress={() =>
+          openModal(chainId, false, InfuraNetworkType['linea-mainnet'], true)
+        }
+      />
+    );
+  };
+
+  const renderRpcNetwork = (networkConfiguration: NetworkConfiguration) => {
+    const {
+      name: nickname,
+      rpcEndpoints,
+      chainId,
+      defaultRpcEndpointIndex,
+    } = networkConfiguration;
+    const rpcUrl = rpcEndpoints[defaultRpcEndpointIndex].url;
+    const name =
+      nickname || rpcEndpoints[defaultRpcEndpointIndex].name || rpcUrl;
+
+    if (isRedesignEnabled && isNoSearchResults(name)) return null;
+
+    const image = getNetworkImageSource({ chainId: chainId.toString() });
+    const isSelected = isEvmSelected && chainId === selectedChainId;
+
+    if (!isRedesignEnabled) {
+      return (
+        <Cell
+          testID={NetworkListModalSelectorsIDs.CUSTOM_NETWORK_CELL(name)}
+          variant={CellVariant.Select}
+          title={name}
+          avatarProps={{
+            variant: AvatarVariant.Network,
+            name,
+            imageSource: image,
+            size: avatarSize,
+          }}
+          isSelected={isSelected}
+          onPress={() => onSetRpcTarget(networkConfiguration)}
+          style={styles.networkCell}
+        >
+          {isSelected && selectedRpcUrl === rpcUrl ? (
+            <View testID={`${name}-selected`} />
+          ) : null}
+        </Cell>
+      );
+    }
+
+    return (
+      <Cell
+        variant={isSendFlow ? CellVariant.Select : CellVariant.SelectWithMenu}
+        title={
+          isSendFlow ? (
+            name
+          ) : (
+            <Box twClassName="w-full flex-row gap-2 items-center self-stretch">
+              <Text
+                variant={TextVariant.BodyMd}
+                numberOfLines={1}
+                style={styles.networkNameText}
+              >
+                {name}
+              </Text>
+              {!isHardwareWallet &&
+              isGasFeesSponsoredNetworkEnabled(chainId) ? (
+                <TagColored
+                  color={TagColor.Success}
+                  style={styles.noNetworkFeeContainer}
+                  labelProps={{
+                    variant: LegacyTextVariant.BodySM,
+                    style: {
+                      textTransform: 'none',
+                      textAlign: 'center',
+                      bottom: 1,
+                      fontWeight: 'normal',
+                    },
+                  }}
+                >
+                  {strings('networks.no_network_fee')}
+                </TagColored>
+              ) : null}
+            </Box>
+          )
+        }
+        tertiaryText={
+          isSendFlow &&
+          !isHardwareWallet &&
+          isGasFeesSponsoredNetworkEnabled(chainId)
+            ? strings('networks.no_network_fee')
+            : undefined
+        }
+        avatarProps={{
+          variant: AvatarVariant.Network,
+          name,
+          imageSource: image,
+          size: AvatarSize.Sm,
+        }}
+        isSelected={isSelected}
+        onPress={() => onSetRpcTarget(networkConfiguration)}
+        style={styles.networkCell}
+        buttonIcon={IconName.MoreVertical}
+        secondaryText={
+          showRpcSelector
+            ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
+            : undefined
+        }
+        buttonProps={{
+          onButtonClick: () =>
+            openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false),
+        }}
+        onTextClick={() => openRpcModal({ chainId, networkName: name })}
+        onLongPress={() =>
+          openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false)
+        }
+      />
+    );
+  };
+
+  const renderOtherNetwork = (networkType: InfuraNetworkType) => {
+    const typedNetworks = Networks as unknown as Record<string, infuraNetwork>;
+    const { name, imageSource, chainId } = typedNetworks[networkType];
+    const networkConfiguration = networkConfigurations[chainId];
+    const rpcUrl =
+      networkConfiguration?.rpcEndpoints[
+        networkConfiguration.defaultRpcEndpointIndex
+      ].url;
+
+    if (isRedesignEnabled && isNoSearchResults(name)) return null;
+
+    if (!isRedesignEnabled) {
+      return (
+        <Cell
+          variant={CellVariant.Select}
+          title={name}
+          avatarProps={{
+            variant: AvatarVariant.Network,
+            name,
+            imageSource,
+            size: avatarSize,
+          }}
+          isSelected={isNetworkSelected(chainId)}
+          onPress={() => onNetworkChange(networkType)}
+          style={styles.networkCell}
+        />
+      );
+    }
+
+    return (
+      <Cell
+        variant={CellVariant.SelectWithMenu}
+        secondaryText={
+          showRpcSelector
+            ? hideProtocolFromUrl(hideKeyFromUrl(rpcUrl))
+            : undefined
+        }
+        title={name}
+        avatarProps={{
+          variant: AvatarVariant.Network,
+          name,
+          imageSource,
+          size: AvatarSize.Sm,
+        }}
+        isSelected={isNetworkSelected(chainId)}
+        onPress={() => onNetworkChange(networkType)}
+        style={styles.networkCell}
+        buttonIcon={IconName.MoreVertical}
+        buttonProps={{
+          onButtonClick: () => openModal(chainId, false, networkType, true),
+        }}
+        onTextClick={() => openRpcModal({ chainId, networkName: name })}
+        onLongPress={() => openModal(chainId, false, networkType, true)}
+      />
+    );
+  };
+
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  const renderNonEvmNetwork = (network: NonEvmNetworkListConfiguration) => (
+    <Cell
+      variant={CellVariant.Select}
+      title={network.name}
+      avatarProps={{
+        variant: AvatarVariant.Network,
+        name: network.name,
+        imageSource: network.imageSource,
+        size: avatarSize,
+      }}
+      isSelected={isNetworkSelected(network.chainId)}
+      onPress={() => onNonEvmNetworkChange(network.chainId)}
+      style={styles.networkCell}
+    />
+  );
+  ///: END:ONLY_INCLUDE_IF
+
+  const renderAdditionalNetworks = () => {
+    const filteredNetworks =
+      searchString.length > 0
+        ? PopularList.filter(({ nickname }) =>
+            nickname.toLowerCase().includes(searchString.toLowerCase()),
+          )
+        : undefined;
+
+    return (
+      <View style={styles.addtionalNetworksContainer}>
+        <CustomNetwork
+          isNetworkModalVisible={showPopularNetworkModal}
+          closeNetworkModal={onCancel}
+          selectedNetwork={popularNetwork}
+          toggleWarningModal={toggleWarningModal}
+          showNetworkModal={showNetworkModal}
+          switchTab={undefined}
+          shouldNetworkSwitchPopToWallet={false}
+          customNetworksList={filteredNetworks}
+          showCompletionMessage={false}
+          showPopularNetworkModal
+          hideWarningIcons
+          skipConfirmation
+          onNetworkAdd={handleAddPopularNetwork}
+        />
+      </View>
+    );
+  };
+
+  const networkListData = useMemo(() => {
+    const items: NetworkSelectorListItem[] = [];
+
+    if (isRedesignEnabled && searchString.length === 0) {
+      items.push({
+        type: 'enabledNetworksHeader',
+        key: 'enabled-networks-header',
+      });
+    }
+
+    items.push({ type: 'mainnet', key: 'mainnet' });
+    items.push({ type: 'lineaMainnet', key: 'linea-mainnet' });
+
+    Object.values(networkConfigurations).forEach((networkConfiguration) => {
+      const { chainId } = networkConfiguration;
+      if (
+        isNonEvmChainId(chainId) ||
+        isTestNet(chainId) ||
+        isMainNet(chainId) ||
+        chainId === CHAIN_IDS.LINEA_MAINNET ||
+        chainId === CHAIN_IDS.GOERLI
+      ) {
+        return;
+      }
+
+      items.push({
+        type: 'rpcNetwork',
+        key: `rpc-network-${chainId}`,
+        networkConfiguration,
+      });
+    });
+
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    if (!isSendFlow) {
+      Object.values(nonEvmNetworkConfigurations)
+        .filter((network) => !network.isTestnet)
+        .forEach((networkConfiguration) => {
+          items.push({
+            type: 'nonEvmNetwork',
+            key: `non-evm-network-${networkConfiguration.chainId}`,
+            networkConfiguration,
+          });
+        });
+    }
+    ///: END:ONLY_INCLUDE_IF
+
+    if (!isSendFlow && isRedesignEnabled && searchString.length === 0) {
+      items.push({
+        type: 'popularNetworksHeader',
+        key: 'popular-networks-header',
+      });
+    }
+
+    if (!isSendFlow && isRedesignEnabled) {
+      items.push({ type: 'additionalNetworks', key: 'additional-networks' });
+    }
+
+    if (!isSendFlow && searchString.length === 0) {
+      items.push({ type: 'testNetworksSwitch', key: 'test-networks-switch' });
+    }
+
+    if (!isSendFlow && showTestNetworks) {
+      const networkTypes = getAllNetworks() as unknown as InfuraNetworkType[];
+      networkTypes.slice(3).forEach((networkType) => {
+        items.push({
+          type: 'otherNetwork',
+          key: `other-network-${networkType}`,
+          networkType,
+        });
+      });
+
+      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+      Object.values(nonEvmNetworkConfigurations)
+        .filter((network) => network.isTestnet)
+        .forEach((networkConfiguration) => {
+          items.push({
+            type: 'nonEvmNetwork',
+            key: `non-evm-test-network-${networkConfiguration.chainId}`,
+            networkConfiguration,
+          });
+        });
+      ///: END:ONLY_INCLUDE_IF
+    }
+
+    return items;
+  }, [
+    isRedesignEnabled,
+    isSendFlow,
+    networkConfigurations,
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    nonEvmNetworkConfigurations,
+    ///: END:ONLY_INCLUDE_IF
+    searchString,
+    showTestNetworks,
+  ]);
+
+  const renderItem = ({
+    item,
+  }: ListRenderItemInfo<NetworkSelectorListItem>) => {
+    switch (item.type) {
+      case 'enabledNetworksHeader':
+        return (
+          <View style={styles.switchContainer}>
+            <Text
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+            >
+              {strings('networks.enabled_networks')}
+            </Text>
+          </View>
+        );
+      case 'mainnet':
+        return renderMainnet();
+      case 'lineaMainnet':
+        return renderLineaMainnet();
+      case 'rpcNetwork':
+        return renderRpcNetwork(item.networkConfiguration);
+      case 'nonEvmNetwork':
+        return renderNonEvmNetwork(item.networkConfiguration);
+      case 'popularNetworksHeader':
+        return (
+          <View style={styles.popularNetworkTitleContainer}>
+            <Text
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+            >
+              {strings('networks.additional_networks')}
+            </Text>
+            <TouchableOpacity
+              testID={NetworkListModalSelectorsIDs.TOOLTIP}
+              style={styles.gasInfoContainer}
+              onPress={toggleWarningModal}
+              hitSlop={styles.hitSlop}
+            >
+              <Icon
+                name={DesignSystemIconName.Info}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </TouchableOpacity>
+          </View>
+        );
+      case 'additionalNetworks':
+        return renderAdditionalNetworks();
+      case 'testNetworksSwitch':
+        return (
+          <View style={styles.switchContainer}>
+            <Text
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+            >
+              {strings('networks.show_test_networks')}
+            </Text>
+            <Switch
+              onValueChange={(value) =>
+                Engine.context.PreferencesController.setShowTestNetworks(value)
+              }
+              value={isTestNet(selectedChainId) || showTestNetworks}
+              trackColor={{
+                true: colors.primary.default,
+                false: colors.border.muted,
+              }}
+              thumbColor={theme.brandColors.white}
+              ios_backgroundColor={colors.border.muted}
+              testID={NetworkListModalSelectorsIDs.TEST_NET_TOGGLE}
+              disabled={isTestNet(selectedChainId)}
+            />
+          </View>
+        );
+      case 'otherNetwork':
+        return renderOtherNetwork(item.networkType);
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <FlashList
+      data={networkListData}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      getItemType={getItemType}
+      style={styles.scrollableDescription}
+      keyboardShouldPersistTaps="handled"
+      testID={NetworkListModalSelectorsIDs.SCROLL}
+      renderScrollComponent={ScrollView as React.ComponentType<ScrollViewProps>}
+      maintainVisibleContentPosition={{ disabled: true }}
+      removeClippedSubviews
+    />
+  );
+};
+
+export default NetworkSelectorList;

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   type ScrollViewProps,
   Switch,
@@ -102,21 +102,28 @@ const NetworkSelectorList = ({
   const { colors } = theme;
   const styles = createStyles(colors);
 
-  const isNoSearchResults = (networkIdentifier: string) => {
-    if (!searchString || !networkIdentifier) {
-      return false;
-    }
+  const isNoSearchResults = useCallback(
+    (networkIdentifier: string) => {
+      if (!searchString || !networkIdentifier) {
+        return false;
+      }
 
-    if (
-      networkIdentifier === 'mainnet' ||
-      networkIdentifier === 'linea-mainnet'
-    ) {
-      const network = Networks[networkIdentifier] as unknown as ExtendedNetwork;
-      return !network.name?.toLowerCase().includes(searchString.toLowerCase());
-    }
+      if (
+        networkIdentifier === 'mainnet' ||
+        networkIdentifier === 'linea-mainnet'
+      ) {
+        const network = Networks[
+          networkIdentifier
+        ] as unknown as ExtendedNetwork;
+        return !network.name
+          ?.toLowerCase()
+          .includes(searchString.toLowerCase());
+      }
 
-    return !networkIdentifier.includes(searchString);
-  };
+      return !networkIdentifier.includes(searchString);
+    },
+    [searchString],
+  );
 
   const renderMainnet = () => {
     const { name: mainnetName, chainId } = Networks.mainnet;
@@ -126,8 +133,6 @@ const NetworkSelectorList = ({
         networkConfiguration.defaultRpcEndpointIndex
       ].url;
     const name = networkConfiguration?.name ?? mainnetName;
-
-    if (isRedesignEnabled && isNoSearchResults('mainnet')) return null;
 
     if (!isRedesignEnabled) {
       return (
@@ -187,8 +192,6 @@ const NetworkSelectorList = ({
       ].url;
     const name = networkConfiguration?.name ?? networkName;
 
-    if (isRedesignEnabled && isNoSearchResults('linea-mainnet')) return null;
-
     if (!isRedesignEnabled) {
       return (
         <Cell
@@ -247,8 +250,6 @@ const NetworkSelectorList = ({
     const rpcUrl = rpcEndpoints[defaultRpcEndpointIndex].url;
     const name =
       nickname || rpcEndpoints[defaultRpcEndpointIndex].name || rpcUrl;
-
-    if (isRedesignEnabled && isNoSearchResults(name)) return null;
 
     const image = getNetworkImageSource({ chainId: chainId.toString() });
     const isSelected = isEvmSelected && chainId === selectedChainId;
@@ -355,8 +356,6 @@ const NetworkSelectorList = ({
         networkConfiguration.defaultRpcEndpointIndex
       ].url;
 
-    if (isRedesignEnabled && isNoSearchResults(name)) return null;
-
     if (!isRedesignEnabled) {
       return (
         <Cell
@@ -460,11 +459,17 @@ const NetworkSelectorList = ({
       });
     }
 
-    items.push({ type: 'mainnet', key: 'mainnet' });
-    items.push({ type: 'lineaMainnet', key: 'linea-mainnet' });
+    if (!isRedesignEnabled || !isNoSearchResults('mainnet')) {
+      items.push({ type: 'mainnet', key: 'mainnet' });
+    }
+
+    if (!isRedesignEnabled || !isNoSearchResults('linea-mainnet')) {
+      items.push({ type: 'lineaMainnet', key: 'linea-mainnet' });
+    }
 
     Object.values(networkConfigurations).forEach((networkConfiguration) => {
-      const { chainId } = networkConfiguration;
+      const { chainId, defaultRpcEndpointIndex, name, rpcEndpoints } =
+        networkConfiguration;
       if (
         isNonEvmChainId(chainId) ||
         isTestNet(chainId) ||
@@ -472,6 +477,14 @@ const NetworkSelectorList = ({
         chainId === CHAIN_IDS.LINEA_MAINNET ||
         chainId === CHAIN_IDS.GOERLI
       ) {
+        return;
+      }
+
+      const rpcNetworkName =
+        name ||
+        rpcEndpoints[defaultRpcEndpointIndex].name ||
+        rpcEndpoints[defaultRpcEndpointIndex].url;
+      if (isRedesignEnabled && isNoSearchResults(rpcNetworkName)) {
         return;
       }
 
@@ -514,6 +527,17 @@ const NetworkSelectorList = ({
     if (!isSendFlow && showTestNetworks) {
       const networkTypes = getAllNetworks() as unknown as InfuraNetworkType[];
       networkTypes.slice(3).forEach((networkType) => {
+        const typedNetworks = Networks as unknown as Record<
+          string,
+          infuraNetwork
+        >;
+        if (
+          isRedesignEnabled &&
+          isNoSearchResults(typedNetworks[networkType].name)
+        ) {
+          return;
+        }
+
         items.push({
           type: 'otherNetwork',
           key: `other-network-${networkType}`,
@@ -542,6 +566,7 @@ const NetworkSelectorList = ({
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     nonEvmNetworkConfigurations,
     ///: END:ONLY_INCLUDE_IF
+    isNoSearchResults,
     searchString,
     showTestNetworks,
   ]);

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.types.ts
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.types.ts
@@ -1,0 +1,84 @@
+import type { ImageSourcePropType } from 'react-native';
+import type { InfuraNetworkType } from '@metamask/controller-utils';
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import type { MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import type { AvatarSize } from '../../../../component-library/components/Avatars/Avatar';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { ExtendedNetwork } from '../../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
+
+export type NonEvmNetworkListConfiguration = MultichainNetworkConfiguration & {
+  imageSource: ImageSourcePropType;
+  isTestnet: boolean;
+};
+
+export type NetworkSelectorListItem =
+  | { type: 'enabledNetworksHeader'; key: 'enabled-networks-header' }
+  | { type: 'mainnet'; key: 'mainnet' }
+  | { type: 'lineaMainnet'; key: 'linea-mainnet' }
+  | {
+      type: 'rpcNetwork';
+      key: string;
+      networkConfiguration: NetworkConfiguration;
+    }
+  | {
+      type: 'nonEvmNetwork';
+      key: string;
+      networkConfiguration: NonEvmNetworkListConfiguration;
+    }
+  | { type: 'popularNetworksHeader'; key: 'popular-networks-header' }
+  | { type: 'additionalNetworks'; key: 'additional-networks' }
+  | { type: 'testNetworksSwitch'; key: 'test-networks-switch' }
+  | {
+      type: 'otherNetwork';
+      key: string;
+      networkType: InfuraNetworkType;
+    };
+
+export interface NetworkSelectorListProps {
+  networkConfigurations: Record<Hex, NetworkConfiguration>;
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  nonEvmNetworkConfigurations: Record<
+    CaipChainId,
+    NonEvmNetworkListConfiguration
+  >;
+  ///: END:ONLY_INCLUDE_IF
+  searchString: string;
+  showTestNetworks: boolean;
+  isSendFlow: boolean;
+  isRedesignEnabled: boolean;
+  showRpcSelector: boolean;
+  selectedChainId: Hex;
+  selectedRpcUrl?: string;
+  isEvmSelected: boolean;
+  isHardwareWallet: boolean;
+  avatarSize?: AvatarSize;
+  showPopularNetworkModal: boolean;
+  popularNetwork?: ExtendedNetwork;
+  isGasFeesSponsoredNetworkEnabled: (chainId: Hex) => boolean;
+  isNetworkSelected: (chainId: Hex | CaipChainId) => boolean;
+  onSetRpcTarget: (networkConfiguration: NetworkConfiguration) => Promise<void>;
+  onNetworkChange: (networkType: InfuraNetworkType) => Promise<void>;
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  onNonEvmNetworkChange: (chainId: CaipChainId) => Promise<void>;
+  ///: END:ONLY_INCLUDE_IF
+  openModal: (
+    chainId: Hex,
+    displayEdit: boolean,
+    networkTypeOrRpcUrl: string,
+    isReadOnly: boolean,
+  ) => void;
+  openRpcModal: ({
+    chainId,
+    networkName,
+  }: {
+    chainId: Hex;
+    networkName: string;
+  }) => void;
+  onCancel: () => void;
+  toggleWarningModal: () => void;
+  showNetworkModal: (networkConfiguration: ExtendedNetwork) => void;
+  handleAddPopularNetwork: (
+    networkConfiguration: ExtendedNetwork,
+  ) => Promise<void>;
+}

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/index.ts
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/index.ts
@@ -1,0 +1,2 @@
+export { default } from './NetworkSelectorList';
+export type { NetworkSelectorListProps } from './NetworkSelectorList.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replaced the Network Selector's unbounded `ScrollView` with a virtualized `FlashList` so custom RPC networks, built-in networks, test networks, headers, and additional-network content no longer mount simultaneously.

Extracted the list presentation and typed heterogeneous list data into `NetworkSelectorList`, keeping the selector screen responsible for state, navigation, and modal orchestration. Existing search, selection, RPC actions, test-network controls, and test IDs are preserved.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1135

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Virtualized network selector

  Background:
    Given I am logged into MetaMask Mobile
    And I have configured at least 20 custom RPC networks

  Scenario: browse and select a custom RPC network
    Given I am on the Wallet home screen
    When I open the network selector
    Then the network list should scroll smoothly
    And the currently selected network should remain highlighted

    When I search for a custom network by name
    Then only matching networks should be displayed

    When I select a matching network
    Then the selected network should become active

  Scenario: access test and additional networks
    Given I am on the network selector
    When I enable test networks
    Then built-in test networks should be displayed
    And I can open the additional networks section and add a network
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core network-switching UI with a large structural refactor; behavior is intended to be preserved and is covered by expanded tests, but list virtualization and moved search logic could affect edge cases (search, test nets, send flow).
> 
> **Overview**
> **Replaces** the network selector’s unbounded `ScrollView` with a virtualized **`FlashList`** so headers, built-in networks, custom RPC rows, additional networks, and the test-network switch are driven from a single typed item list instead of mounting every section at once.
> 
> **Extracts** all list rendering and search filtering into **`NetworkSelectorList`** (with **`NetworkSelectorList.types`**), while **`NetworkSelector`** keeps modals, navigation, and switch handlers and passes callbacks/state as props. Section headers in the redesign path use design-system **`Text`** / **`Icon`** instead of the previous legacy text and vector icon.
> 
> **Tests** mock **`@shopify/flash-list`** as `FlatList`, add coverage for heterogeneous list data and search-filtered `data`, and tighten setup/assertions (`beforeEach`/`afterEach`, `toHaveBeenCalled`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c416bdb4c1e53911db0c3716d432717bfb3b348a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->