### PR TITLE
fix: Polish Engagement toast for 8.6.0 release

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -3,7 +3,7 @@ import { DeepPartial } from '../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import { initialState as initialSecurityState } from '../../../reducers/security';
 import App from '.';
-import { cleanup, render, waitFor } from '@testing-library/react-native';
+import { act, cleanup, render, waitFor } from '@testing-library/react-native';
 import { RootState } from '../../../reducers';
 import Routes from '../../../constants/navigation/Routes';
 import {
@@ -761,6 +761,10 @@ describe('App', () => {
 
   describe('App version handling', () => {
     it('should handle version storage operations', async () => {
+      const getItemSpy = jest
+        .spyOn(StorageWrapper, 'getItem')
+        .mockResolvedValue(null);
+
       const mockStore = configureMockStore();
       const store = mockStore(initialState);
 
@@ -776,9 +780,15 @@ describe('App', () => {
 
       render(<App />, { wrapper: Providers });
 
-      await waitFor(() => {
-        expect(StorageWrapper.getItem).toHaveBeenCalled();
+      // Flush startApp's microtasks. Avoid waitFor here: this suite uses fake
+      // timers and testSetup freezes Date.now, so waitFor's timeout never
+      // elapses and a delayed getItem call hangs until Jest's test timeout.
+      await act(async () => {
+        await Promise.resolve();
       });
+
+      expect(getItemSpy).toHaveBeenCalledWith(CURRENT_APP_VERSION);
+      getItemSpy.mockRestore();
     });
   });
 
@@ -805,9 +815,11 @@ describe('App', () => {
 
       renderAppForVersionTest(initialState);
 
-      await waitFor(() => {
-        expect(getItemSpy).toHaveBeenCalled();
+      await act(async () => {
+        await Promise.resolve();
       });
+
+      expect(getItemSpy).toHaveBeenCalled();
 
       getItemSpy.mockRestore();
     });

--- a/app/components/Views/Notifications/Details/hooks/useCopyClipboard.test.ts
+++ b/app/components/Views/Notifications/Details/hooks/useCopyClipboard.test.ts
@@ -57,7 +57,7 @@ describe('useCopyClipboard', () => {
     expect(mockShowToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'Icon',
-        iconName: IconName.CheckBold,
+        iconName: IconName.Confirmation,
         hasNoTimeout: false,
       }),
     );

--- a/app/components/Views/Notifications/Details/hooks/useCopyClipboard.ts
+++ b/app/components/Views/Notifications/Details/hooks/useCopyClipboard.ts
@@ -33,9 +33,8 @@ function useCopyClipboard() {
       await ClipboardManager.setString(value);
       toastRef?.current?.showToast({
         variant: ToastVariants.Icon,
-        iconName: IconName.CheckBold,
-        iconColor: colors.accent03.dark,
-        backgroundColor: colors.accent03.normal,
+        iconName: IconName.Confirmation,
+        iconColor: colors.success.default,
         labelOptions: [
           { label: alertText ?? CopyClipboardAlertMessage.default() },
         ],
@@ -43,12 +42,7 @@ function useCopyClipboard() {
       });
       setTimeout(() => handleProtectWalletModalVisible(), 2000);
     },
-    [
-      colors.accent03.dark,
-      colors.accent03.normal,
-      toastRef,
-      handleProtectWalletModalVisible,
-    ],
+    [colors.success.default, toastRef, handleProtectWalletModalVisible],
   );
 
   return copyToClipboard;

--- a/app/components/Views/Notifications/PushNotificationOnboarding/index.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/index.tsx
@@ -32,7 +32,6 @@ interface PushNotificationOnboardingProps {
 const styles = StyleSheet.create({
   toastAccessory: {
     alignSelf: 'flex-start',
-    marginRight: 12,
     paddingTop: 4,
   },
 });
@@ -95,7 +94,7 @@ const PushNotificationOnboarding = ({
       title: string;
       description: string;
     }) => {
-      const iconColor = isEnabled ? IconColor.Success : IconColor.Alternative;
+      const iconColor = isEnabled ? IconColor.Success : IconColor.Default;
 
       toastRef?.current?.showToast({
         variant: ToastVariants.Plain,
@@ -111,7 +110,7 @@ const PushNotificationOnboarding = ({
         startAccessory: (
           <View style={styles.toastAccessory}>
             <Icon
-              name={isEnabled ? IconName.CheckBold : IconName.Info}
+              name={isEnabled ? IconName.Confirmation : IconName.Info}
               size={IconSize.Lg}
               color={iconColor}
             />


### PR DESCRIPTION
## **Description**

Polishes Engagement toast call sites for the 8.6.0 release so they align with the shared toast pattern (Confirmation icon, success/error icon colors, and default toast chrome instead of custom background colors).

Updates notification copy-clipboard and push-notification onboarding toasts to use Confirmation + success/default icon colors and shared accessory spacing.

## **Changelog**

CHANGELOG entry: Polished toast styling for consistency in the 8.6.0 release

## **Related issues**

Fixes:

Related toast polish PRs for 8.6.0:
- #33765 — Design System Engineers
- #33766 — Card
- #33767 — Predict
- #33769 — Money Movement
- #33770 — Metamask Assets
- #33771 — Mobile Core UX
- #33773 — Social AI
- #33774 — Web3Auth
- #33775 — Earn
- #33791 — Watchlist

## **Manual testing steps**

```gherkin
Feature: Notification toasts
  Scenario: copy from notification details
    Given the user copies a value from a notification detail
    When the toast appears
    Then it uses the Confirmation icon with the success color
```

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/6bc662e1-e36e-48ec-b093-62924433af77



### **After**


https://github.com/user-attachments/assets/eb9f5c07-546c-4165-ab61-84955173e096



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)