### PR TITLE
fix: Polish Web3Auth toast for 8.6.0 release

### DIFF
--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../component-library/components/Toast';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import { Alert } from 'react-native';
+import { mockTheme } from '../../../util/theme';
 
 // Mock for keyboard state visibility
 const mockUseKeyboardState = jest.fn();
@@ -475,7 +476,8 @@ describe('ImportNewSecretRecoveryPhrase', () => {
           label: 'Wallet 2 imported',
         },
       ],
-      iconName: IconName.Check,
+      iconName: IconName.Confirmation,
+      iconColor: mockTheme.colors.success.default,
       hasNoTimeout: false,
     });
   });

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
@@ -48,6 +48,7 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useAccountsWithNetworkActivitySync } from '../../hooks/useAccountsWithNetworkActivitySync';
 import { Authentication } from '../../../core';
 import Routes from '../../../constants/navigation/Routes';
+import { useTheme } from '../../../util/theme';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { QRTabSwitcherScreens } from '../QRTabSwitcher';
 import Logger from '../../../util/Logger';
@@ -103,6 +104,7 @@ const ImportNewSecretRecoveryPhrase = () => {
     [insets, tw],
   );
   const { toastRef } = useContext(ToastContext);
+  const { colors } = useTheme();
   const srpInputGridRef = useRef<SrpInputGridRef>(null);
 
   // State
@@ -250,7 +252,8 @@ const ImportNewSecretRecoveryPhrase = () => {
           } ${strings('import_new_secret_recovery_phrase.success_2')}`,
         },
       ],
-      iconName: ComponentIconName.Check,
+      iconName: ComponentIconName.Confirmation,
+      iconColor: colors.success.default,
       hasNoTimeout: false,
     });
 
@@ -261,6 +264,7 @@ const ImportNewSecretRecoveryPhrase = () => {
     seedPhrase,
     trackDiscoveryEvent,
     toastRef,
+    colors.success.default,
     hdKeyrings.length,
     fetchAccountsWithActivity,
     navigation,


### PR DESCRIPTION
## **Description**

Polishes Web3Auth toast call sites for the 8.6.0 release so they align with the shared toast pattern (Confirmation icon, success/error icon colors, and default toast chrome instead of custom background colors).

Updates the import-SRP success toast to use the Confirmation icon with the theme success color.

## **Changelog**

CHANGELOG entry: Polished toast styling for consistency in the 8.6.0 release

## **Related issues**

Fixes:

Related toast polish PRs for 8.6.0:
- #33765 — Design System Engineers
- #33766 — Card
- #33767 — Predict
- #33769 — Money Movement
- #33770 — Metamask Assets
- #33771 — Mobile Core UX
- #33772 — Engagement
- #33773 — Social AI
- #33775 — Earn
- #33791 — Watchlist

## **Manual testing steps**

```gherkin
Feature: Import SRP toast
  Scenario: SRP imported successfully
    Given the user successfully imports a secret recovery phrase
    When the success toast appears
    Then it uses the Confirmation icon with the success color
```

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/3b4e9009-bf86-4df0-b012-faf210ebaa40



### **After**

https://github.com/user-attachments/assets/09487e6e-4e41-4d68-8f86-a155bf7a1c63




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)