### PR TITLE
fix: Polish Earn toast for 8.6.0 release

### DIFF
--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -103,7 +103,7 @@ const CashGetMusdEmptyState = ({
     lastMerklClaimErrorToastRef.current = merklClaimError;
     toastRef?.current?.showToast({
       variant: ToastVariants.Plain,
-      labelOptions: [{ label: merklClaimError, isBold: false }],
+      labelOptions: [{ label: merklClaimError, isBold: true }],
       hasNoTimeout: false,
     });
   }, [merklClaimError, toastRef]);


### PR DESCRIPTION
## **Description**

Polishes Earn toast call sites for the 8.6.0 release so they align with the shared toast pattern (Confirmation icon, success/error icon colors, and default toast chrome instead of custom background colors).

Updates the Cash mUSD empty-state Merkl claim error toast label to bold for consistency with other plain toasts.

## **Changelog**

CHANGELOG entry: Polished toast styling for consistency in the 8.6.0 release

## **Related issues**

Fixes:

Related toast polish PRs for 8.6.0:
- #33765 — Design System Engineers
- #33766 — Card
- #33767 — Predict
- #33769 — Money Movement
- #33770 — Metamask Assets
- #33771 — Mobile Core UX
- #33772 — Engagement
- #33773 — Social AI
- #33774 — Web3Auth
- #33791 — Watchlist

## **Manual testing steps**

```gherkin
Feature: Cash claim error toast
  Scenario: Merkl claim error
    Given a Merkl claim error occurs on the Cash empty state
    When the toast appears
    Then the error label is bold
```

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/18dbc467-9ee9-418a-9b64-3e051a0d10ca



### **After**


https://github.com/user-attachments/assets/eb07041e-f01b-4822-817f-d1e6e3bbe58e



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)