### PR TITLE
ci: remove flaky FixtureValidation jobs from Appium smoke suites

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -292,27 +292,3 @@ jobs:
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
-
-  appium-fixture-validation-android-smoke:
-    if: >-
-      ${{
-        !cancelled() &&
-        (contains(fromJson(inputs.selected_tags), 'ALL') ||
-         contains(fromJson(inputs.selected_tags), 'FixtureValidation'))
-      }}
-    strategy:
-      matrix:
-        split: [1]
-      fail-fast: false
-    uses: ./.github/workflows/run-appium-e2e-workflow.yml
-    with:
-      test-suite-name: appium-fixture-validation-android-smoke
-      platform: android
-      test_suite_tag: FixtureValidation
-      split_number: ${{ matrix.split }}
-      total_splits: 1
-      test-timeout-minutes: 60
-      build_type: ${{ inputs.build_type }}
-      metamask_environment: ${{ inputs.metamask_environment }}
-      runner_provider: ${{ inputs.runner_provider }}
-    secrets: inherit

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -271,27 +271,3 @@ jobs:
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}
     secrets: inherit
-
-  appium-fixture-validation-ios-smoke:
-    if: >-
-      ${{
-        !cancelled() &&
-        (contains(fromJson(inputs.selected_tags || '["ALL"]'), 'ALL') ||
-         contains(fromJson(inputs.selected_tags || '["ALL"]'), 'FixtureValidation'))
-      }}
-    strategy:
-      matrix:
-        split: [1]
-      fail-fast: false
-    uses: ./.github/workflows/run-appium-e2e-workflow.yml
-    with:
-      test-suite-name: appium-fixture-validation-ios-smoke
-      platform: ios
-      test_suite_tag: FixtureValidation
-      split_number: ${{ matrix.split }}
-      total_splits: 1
-      test-timeout-minutes: 60
-      build_type: ${{ inputs.build_type || 'main' }}
-      metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
-    secrets: inherit


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Removes the dedicated `FixtureValidation` Appium smoke jobs from the Android and iOS Appium smoke workflows.

1. **Reason:** Running fixture validation as part of the Appium smoke suites was adding flake noise and redundant CI cost.
2. **Solution:** Drop `appium-fixture-validation-android-smoke` and `appium-fixture-validation-ios-smoke` from the smoke workflows. Fixture validation continues to run via the dedicated `validate-e2e-fixtures` job in `ci.yml` (and the update-fixtures workflow), so schema coverage is preserved without duplicating it in smoke.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — CI flake reduction; no product ticket

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Appium smoke FixtureValidation job removal

  Scenario: FixtureValidation is not scheduled in Appium smoke
    Given a PR triggers Appium smoke with selected_tags including ALL or FixtureValidation
    When the Android and iOS Appium smoke workflows run
    Then appium-fixture-validation-android-smoke and appium-fixture-validation-ios-smoke do not run

  Scenario: Fixture validation still runs via dedicated CI job
    Given a pull_request event reaches main CI after ios-tests-ready
    When validate-e2e-fixtures is scheduled
    Then FixtureValidation still executes through run-appium-e2e-workflow.yml
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow wiring only; no UI/product changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — CI workflow change only.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)