### PR TITLE
fix(money): read vault config just-in-time and re-init on change (MUSD-951)

### DIFF
--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.test.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.test.ts
@@ -58,6 +58,24 @@ const VAULT_CONFIG: MoneyAccountVaultConfig = {
   lensAddress: '0x0000000000000000000000000000000000000003',
 };
 
+// A second config that differs only by its boring vault token. This mirrors
+// the real migration bug: same chain, live adapter, but a different vmUSD
+// token address arriving via a fresher flag payload.
+const OTHER_BORING_VAULT_ADDRESS =
+  '0x000000000000000000000000000000000000cafe' as Hex;
+
+const OTHER_VAULT_CONFIG: MoneyAccountVaultConfig = {
+  ...VAULT_CONFIG,
+  boringVault: OTHER_BORING_VAULT_ADDRESS,
+};
+
+const flagStateFor = (vaultConfig?: MoneyAccountVaultConfig) => ({
+  remoteFeatureFlags: vaultConfig
+    ? { moneyAccountVaultConfig: vaultConfig }
+    : {},
+  localOverrides: {},
+});
+
 function getInitRequestMock({
   isUnlocked,
   remoteFeatureFlagsState,
@@ -78,15 +96,16 @@ function getInitRequestMock({
     jest.fn().mockReturnValue({ isUnlocked }),
   );
 
+  const getStateMock = jest.fn().mockReturnValue(
+    remoteFeatureFlagsState ?? {
+      remoteFeatureFlags: {},
+      localOverrides: {},
+    },
+  );
   baseMessenger.registerActionHandler(
     // @ts-expect-error: Action not allowed on the mock messenger namespace.
     'RemoteFeatureFlagController:getState',
-    jest.fn().mockReturnValue(
-      remoteFeatureFlagsState ?? {
-        remoteFeatureFlags: {},
-        localOverrides: {},
-      },
-    ),
+    getStateMock,
   );
 
   const requestMock = {
@@ -96,22 +115,40 @@ function getInitRequestMock({
     initMessenger: getMoneyAccountUpgradeControllerInitMessenger(baseMessenger),
   };
 
-  return { requestMock, baseMessenger };
+  return { requestMock, baseMessenger, getStateMock };
 }
 
-const publishFlagOn = (
+/**
+ * Deliver a feature-flag state to the controller init. Because the just-in-time
+ * lifecycle reads `RemoteFeatureFlagController:getState` when the bootstrap
+ * runs, we keep `getState` and the `stateChange` event consistent — exactly as
+ * the real controller does when it publishes state changes.
+ */
+const deliverFlagState = (
   baseMessenger: ExtendedMessenger<MockAnyNamespace, never, never>,
-) =>
+  getStateMock: jest.Mock,
+  vaultConfig?: MoneyAccountVaultConfig,
+) => {
+  const state = flagStateFor(vaultConfig);
+  getStateMock.mockReturnValue(state);
   baseMessenger.publish(
     // @ts-expect-error: Event not allowed on the mock messenger namespace.
     'RemoteFeatureFlagController:stateChange',
-    {
-      remoteFeatureFlags: { moneyAccountVaultConfig: VAULT_CONFIG },
-      localOverrides: {},
-    },
+    state,
   );
+};
+
+const publishFlagOn = (
+  baseMessenger: ExtendedMessenger<MockAnyNamespace, never, never>,
+  getStateMock: jest.Mock,
+) => deliverFlagState(baseMessenger, getStateMock, VAULT_CONFIG);
 
 const flushAsync = () => new Promise(process.nextTick);
+
+// Wait for the current bootstrap (including any chained re-init) to settle,
+// swallowing rejections so failure paths can be asserted via mocks.
+const settleBootstrap = () =>
+  whenMoneyAccountUpgradeReady().catch(() => undefined);
 
 describe('moneyAccountUpgradeControllerInit', () => {
   let mockedController: jest.Mocked<MoneyAccountUpgradeController>;
@@ -178,12 +215,12 @@ describe('moneyAccountUpgradeControllerInit', () => {
     });
 
     it('resolves once bootstrap completes when keyring is already unlocked and the flag turns on', async () => {
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
-      publishFlagOn(baseMessenger);
+      publishFlagOn(baseMessenger, getStateMock);
 
       await expect(whenMoneyAccountUpgradeReady()).resolves.toBeUndefined();
       expect(mockedController.init).toHaveBeenCalledTimes(1);
@@ -191,12 +228,12 @@ describe('moneyAccountUpgradeControllerInit', () => {
   });
 
   it('initializes the controller with the chainId and boring vault address from the vault config when unlocked', async () => {
-    const { requestMock, baseMessenger } = getInitRequestMock({
+    const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
       isUnlocked: true,
     });
 
     moneyAccountUpgradeControllerInit(requestMock);
-    publishFlagOn(baseMessenger);
+    publishFlagOn(baseMessenger, getStateMock);
     await flushAsync();
 
     expect(mockedController.init).toHaveBeenCalledWith({
@@ -206,12 +243,12 @@ describe('moneyAccountUpgradeControllerInit', () => {
   });
 
   it('defers bootstrap until KeyringController:unlock fires when keyring is locked', async () => {
-    const { requestMock, baseMessenger } = getInitRequestMock({
+    const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
       isUnlocked: false,
     });
 
     moneyAccountUpgradeControllerInit(requestMock);
-    publishFlagOn(baseMessenger);
+    publishFlagOn(baseMessenger, getStateMock);
     await flushAsync();
 
     expect(mockedController.init).not.toHaveBeenCalled();
@@ -224,12 +261,12 @@ describe('moneyAccountUpgradeControllerInit', () => {
   });
 
   it('only bootstraps once even if KeyringController:unlock fires multiple times', async () => {
-    const { requestMock, baseMessenger } = getInitRequestMock({
+    const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
       isUnlocked: false,
     });
 
     moneyAccountUpgradeControllerInit(requestMock);
-    publishFlagOn(baseMessenger);
+    publishFlagOn(baseMessenger, getStateMock);
     // @ts-expect-error: Event not allowed on the mock messenger namespace.
     baseMessenger.publish('KeyringController:unlock');
     // @ts-expect-error: Event not allowed on the mock messenger namespace.
@@ -279,7 +316,7 @@ describe('moneyAccountUpgradeControllerInit', () => {
 
     it('bootstraps once the flag flips on via RemoteFeatureFlagController:stateChange', async () => {
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(false);
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
@@ -289,7 +326,7 @@ describe('moneyAccountUpgradeControllerInit', () => {
       expect(mockedController.init).not.toHaveBeenCalled();
 
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(true);
-      publishFlagOn(baseMessenger);
+      publishFlagOn(baseMessenger, getStateMock);
       await flushAsync();
 
       expect(mockedController.init).toHaveBeenCalledTimes(1);
@@ -297,15 +334,15 @@ describe('moneyAccountUpgradeControllerInit', () => {
 
     it('only bootstraps once even if the flag-on state change fires multiple times', async () => {
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(false);
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
 
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(true);
-      publishFlagOn(baseMessenger);
-      publishFlagOn(baseMessenger);
+      publishFlagOn(baseMessenger, getStateMock);
+      publishFlagOn(baseMessenger, getStateMock);
       await flushAsync();
 
       expect(mockedController.init).toHaveBeenCalledTimes(1);
@@ -331,14 +368,11 @@ describe('moneyAccountUpgradeControllerInit', () => {
     it('bootstraps from the cached RemoteFeatureFlagController state at init time, without waiting for a stateChange event', async () => {
       // Returning user: the cache is fresh, so `updateRemoteFeatureFlags`
       // early-returns and no stateChange ever fires. We must still init from
-      // the persisted state restored into the controller at construction.
+      // the persisted state exposed via `getState` at construction.
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(true);
       const { requestMock } = getInitRequestMock({
         isUnlocked: true,
-        remoteFeatureFlagsState: {
-          remoteFeatureFlags: { moneyAccountVaultConfig: VAULT_CONFIG },
-          localOverrides: {},
-        },
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
@@ -350,26 +384,21 @@ describe('moneyAccountUpgradeControllerInit', () => {
       });
     });
 
-    it('initializes from the stateChange event payload, not from Redux', async () => {
-      // The messenger publishes stateChange synchronously inside
-      // BaseController.update(), but the Redux store is updated up to 250ms
-      // later via EngineService.updateBatcher. Reading vaultConfig from
-      // Redux at this point would see stale (often undefined) data, so we
-      // must derive it from the event payload instead.
+    it('initializes from the RemoteFeatureFlagController state, not from Redux', async () => {
+      // The Redux store is updated up to 250ms later via
+      // EngineService.updateBatcher, so reading vaultConfig from Redux would
+      // see stale (often undefined) data. We derive it from the
+      // RemoteFeatureFlagController state instead.
       (
         ReduxService as unknown as { store: { getState: jest.Mock } }
       ).store.getState.mockReturnValue({});
       jest.mocked(isMoneyAccountEnabled).mockReturnValue(true);
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
-      // @ts-expect-error: Event not allowed on the mock messenger namespace.
-      baseMessenger.publish('RemoteFeatureFlagController:stateChange', {
-        remoteFeatureFlags: { moneyAccountVaultConfig: VAULT_CONFIG },
-        localOverrides: {},
-      });
+      deliverFlagState(baseMessenger, getStateMock, VAULT_CONFIG);
       await flushAsync();
 
       expect(mockedController.init).toHaveBeenCalledWith({
@@ -379,14 +408,151 @@ describe('moneyAccountUpgradeControllerInit', () => {
     });
   });
 
+  describe('just-in-time vault config', () => {
+    it('initializes with the vault config present at unlock time, not the one present when scheduled', async () => {
+      // Stale-then-fresh: config A is cached at engine init while locked, then
+      // a fresher config B arrives before the keyring is unlocked. The
+      // just-in-time read at unlock must use B.
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: false,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      deliverFlagState(baseMessenger, getStateMock, OTHER_VAULT_CONFIG);
+
+      // @ts-expect-error: Event not allowed on the mock messenger namespace.
+      baseMessenger.publish('KeyringController:unlock');
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+      expect(mockedController.init).toHaveBeenCalledWith({
+        chainId: VAULT_CHAIN_ID,
+        boringVaultAddress: OTHER_BORING_VAULT_ADDRESS,
+      });
+    });
+
+    it('falls back to the scheduled vault config when the flag has vanished by unlock time', async () => {
+      // Scheduled with config A while locked, but by the time we unlock the
+      // just-in-time read yields nothing. We must still init with A and report
+      // the missing config.
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: false,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      getStateMock.mockReturnValue(flagStateFor(undefined));
+
+      // @ts-expect-error: Event not allowed on the mock messenger namespace.
+      baseMessenger.publish('KeyringController:unlock');
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledWith({
+        chainId: VAULT_CHAIN_ID,
+        boringVaultAddress: BORING_VAULT_ADDRESS,
+      });
+      expect(Logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Missing Money Account vault config',
+        }),
+        expect.objectContaining({
+          tags: expect.objectContaining({ feature: 'money-account-upgrade' }),
+        }),
+      );
+    });
+  });
+
+  describe('re-init on vault-config change', () => {
+    it('re-runs init with the new vault config when it changes after bootstrap', async () => {
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: true,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+      expect(mockedController.init).toHaveBeenLastCalledWith({
+        chainId: VAULT_CHAIN_ID,
+        boringVaultAddress: BORING_VAULT_ADDRESS,
+      });
+
+      deliverFlagState(baseMessenger, getStateMock, OTHER_VAULT_CONFIG);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(2);
+      expect(mockedController.init).toHaveBeenLastCalledWith({
+        chainId: VAULT_CHAIN_ID,
+        boringVaultAddress: OTHER_BORING_VAULT_ADDRESS,
+      });
+    });
+
+    it('does not re-run init when a state change carries an identical vault config', async () => {
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: true,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+
+      deliverFlagState(baseMessenger, getStateMock, VAULT_CONFIG);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-init or log when the enable flag turns off after bootstrap', async () => {
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: true,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+      expect(Logger.error).not.toHaveBeenCalled();
+
+      jest.mocked(isMoneyAccountEnabled).mockReturnValue(false);
+      deliverFlagState(baseMessenger, getStateMock, undefined);
+      await settleBootstrap();
+
+      expect(mockedController.init).toHaveBeenCalledTimes(1);
+      expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('keeps whenMoneyAccountUpgradeReady tracking the latest re-init', async () => {
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
+        isUnlocked: true,
+        remoteFeatureFlagsState: flagStateFor(VAULT_CONFIG),
+      });
+
+      moneyAccountUpgradeControllerInit(requestMock);
+      await settleBootstrap();
+
+      deliverFlagState(baseMessenger, getStateMock, OTHER_VAULT_CONFIG);
+
+      await expect(whenMoneyAccountUpgradeReady()).resolves.toBeUndefined();
+      expect(mockedController.init).toHaveBeenLastCalledWith({
+        chainId: VAULT_CHAIN_ID,
+        boringVaultAddress: OTHER_BORING_VAULT_ADDRESS,
+      });
+    });
+  });
+
   describe('chain configuration', () => {
     it('does not add the chain if it is already configured', async () => {
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
-      publishFlagOn(baseMessenger);
+      publishFlagOn(baseMessenger, getStateMock);
       await flushAsync();
 
       expect(mockAddNetwork).not.toHaveBeenCalled();
@@ -396,12 +562,12 @@ describe('moneyAccountUpgradeControllerInit', () => {
     it('adds the chain from PopularList when it is not configured', async () => {
       jest.mocked(selectEvmNetworkConfigurationsByChainId).mockReturnValue({});
 
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
-      publishFlagOn(baseMessenger);
+      publishFlagOn(baseMessenger, getStateMock);
       await flushAsync();
 
       expect(mockAddNetwork).toHaveBeenCalledWith(
@@ -417,22 +583,16 @@ describe('moneyAccountUpgradeControllerInit', () => {
       const UNSUPPORTED_CHAIN_ID = '0xdeadbeef' as Hex;
       jest.mocked(selectEvmNetworkConfigurationsByChainId).mockReturnValue({});
 
-      const { requestMock, baseMessenger } = getInitRequestMock({
+      const { requestMock, baseMessenger, getStateMock } = getInitRequestMock({
         isUnlocked: true,
       });
 
       moneyAccountUpgradeControllerInit(requestMock);
-      // @ts-expect-error: Event not allowed on the mock messenger namespace.
-      baseMessenger.publish('RemoteFeatureFlagController:stateChange', {
-        remoteFeatureFlags: {
-          moneyAccountVaultConfig: {
-            ...VAULT_CONFIG,
-            chainId: UNSUPPORTED_CHAIN_ID,
-          },
-        },
-        localOverrides: {},
+      deliverFlagState(baseMessenger, getStateMock, {
+        ...VAULT_CONFIG,
+        chainId: UNSUPPORTED_CHAIN_ID,
       });
-      await flushAsync();
+      await settleBootstrap();
 
       expect(mockAddNetwork).not.toHaveBeenCalled();
       expect(mockedController.init).not.toHaveBeenCalled();

--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
@@ -73,10 +73,12 @@ const ensureChainConfigured = async (chainId: Hex): Promise<void> => {
 let bootstrapPromise: Promise<void> | null = null;
 
 /**
- * Promise that resolves once `MoneyAccountUpgradeController.init()` has run.
- * Rejects if bootstrap fails, or if it hasn't been scheduled yet (i.e. the
- * keyring is still locked). Callers that depend on the controller being
- * initialized — e.g. `upgradeAccount` — should `await` this first.
+ * Promise that resolves once the latest `MoneyAccountUpgradeController.init()`
+ * has run. Rejects if that bootstrap fails, or if none has been scheduled yet
+ * (i.e. the keyring is still locked). Because the controller can be re-inited
+ * when the vault config changes, this always tracks the most recent run in the
+ * bootstrap chain. Callers that depend on the controller being initialized —
+ * e.g. `upgradeAccount` — should `await` this first.
  */
 export const whenMoneyAccountUpgradeReady = (): Promise<void> => {
   if (!bootstrapPromise) {
@@ -101,11 +103,10 @@ export const __resetMoneyAccountUpgradeBootstrapForTesting = () => {
  * remote feature flag being on and the keyring being unlocked.
  *
  * The flag value and vault config are sourced from the
- * `RemoteFeatureFlagController` directly (via `getState` at startup and the
- * `stateChange` event for later updates). We deliberately avoid reading
- * vaultConfig from Redux at bootstrap time because Redux is updated via the
- * `EngineService` batcher (a 250ms-debounced dispatch) and would be stale
- * relative to the controller state we are reacting to.
+ * `RemoteFeatureFlagController` directly (via `getState` and the `stateChange`
+ * event). We deliberately avoid reading vaultConfig from Redux because Redux is
+ * updated via the `EngineService` batcher (a 250ms-debounced dispatch) and
+ * would be stale relative to the controller state we are reacting to.
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
@@ -123,6 +124,16 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
     state: persistedState.MoneyAccountUpgradeController,
   });
 
+  const reportBootstrapError = (error: Error) => {
+    Logger.error(error, {
+      tags: { feature: SENTRY_FEATURE_TAG },
+      context: {
+        name: 'money_account_upgrade',
+        data: { phase: 'bootstrap' },
+      },
+    });
+  };
+
   const bootstrap = async (vaultConfig: MoneyAccountVaultConfig) => {
     const chainId = vaultConfig.chainId as Hex;
 
@@ -134,78 +145,120 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
     });
   };
 
+  const mergedFlags = (state: RemoteFeatureFlagControllerState) => ({
+    ...state.remoteFeatureFlags,
+    ...(state.localOverrides ?? {}),
+  });
+
+  const readVaultConfig = (): MoneyAccountVaultConfig | undefined =>
+    getMoneyAccountVaultConfig(
+      mergedFlags(initMessenger.call('RemoteFeatureFlagController:getState')),
+    );
+
+  const configsEqual = (
+    a: MoneyAccountVaultConfig,
+    b: MoneyAccountVaultConfig,
+  ) =>
+    a.chainId === b.chainId &&
+    a.boringVault === b.boringVault &&
+    a.tellerAddress === b.tellerAddress &&
+    a.accountantAddress === b.accountantAddress &&
+    a.lensAddress === b.lensAddress;
+
+  // The vault config the most recent bootstrap run was given. Used to decide
+  // whether a later state change is a genuine change worth re-initing for.
+  let lastRunConfig: MoneyAccountVaultConfig | null = null;
+
+  // Run a single bootstrap for `vaultConfig`. Re-inits chain onto the previous
+  // run so they are serialized; the previous rejection is swallowed so one
+  // failure doesn't poison later re-inits, but each run still reports its own
+  // failure.
   const runBootstrap = (vaultConfig: MoneyAccountVaultConfig) => {
-    bootstrapPromise = bootstrap(vaultConfig);
-    bootstrapPromise.catch((error) => {
-      Logger.error(error as Error, {
-        tags: { feature: SENTRY_FEATURE_TAG },
-        context: {
-          name: 'money_account_upgrade',
-          data: { phase: 'bootstrap' },
-        },
-      });
-    });
+    lastRunConfig = vaultConfig;
+    const next = bootstrapPromise
+      ? bootstrapPromise
+          .catch(() => undefined)
+          .then(() => bootstrap(vaultConfig))
+      : bootstrap(vaultConfig);
+    bootstrapPromise = next;
+    next.catch(reportBootstrapError);
+  };
+
+  // Runs the first bootstrap using a just-in-time read of the flag state,
+  // falling back to the config that triggered scheduling if the flag has
+  // since vanished.
+  const runFirstBootstrap = (scheduledConfig: MoneyAccountVaultConfig) => {
+    const freshConfig = readVaultConfig();
+    if (!freshConfig) {
+      reportBootstrapError(new Error('Missing Money Account vault config'));
+    }
+    runBootstrap(freshConfig ?? scheduledConfig);
   };
 
   let bootstrapScheduled = false;
+  let bootstrapRan = false;
   const scheduleBootstrap = (vaultConfig: MoneyAccountVaultConfig) => {
     if (bootstrapScheduled) {
       return;
     }
     bootstrapScheduled = true;
 
+    const start = () => {
+      bootstrapRan = true;
+      runFirstBootstrap(vaultConfig);
+    };
+
     const { isUnlocked } = initMessenger.call('KeyringController:getState');
     if (isUnlocked) {
-      runBootstrap(vaultConfig);
+      start();
     } else {
       const onUnlock = () => {
         initMessenger.unsubscribe('KeyringController:unlock', onUnlock);
-        runBootstrap(vaultConfig);
+        start();
       };
       initMessenger.subscribe('KeyringController:unlock', onUnlock);
     }
   };
 
-  const mergedFlags = (state: RemoteFeatureFlagControllerState) => ({
-    ...state.remoteFeatureFlags,
-    ...(state.localOverrides ?? {}),
-  });
-
-  const tryStart = (state: RemoteFeatureFlagControllerState): boolean => {
+  const onFlagState = (state: RemoteFeatureFlagControllerState) => {
     const flags = mergedFlags(state);
     if (!isMoneyAccountEnabled(flags)) {
-      return false;
+      return;
     }
+
     const vaultConfig = getMoneyAccountVaultConfig(flags);
     if (!vaultConfig) {
-      Logger.error(new Error('Missing Money Account vault config'), {
-        tags: { feature: SENTRY_FEATURE_TAG },
-        context: {
-          name: 'money_account_upgrade',
-          data: { phase: 'bootstrap' },
-        },
-      });
-      return false;
+      // Only log before scheduling. We stay subscribed for the whole session,
+      // so logging on every unrelated flag change once we're already running
+      // would just be noise.
+      if (!bootstrapScheduled) {
+        reportBootstrapError(new Error('Missing Money Account vault config'));
+      }
+      return;
     }
-    scheduleBootstrap(vaultConfig);
-    return true;
+
+    if (!bootstrapScheduled) {
+      scheduleBootstrap(vaultConfig);
+      return;
+    }
+
+    // Scheduled but not yet run (awaiting unlock): the just-in-time read at run
+    // time will pick up the latest config, so nothing to do here. Once it has
+    // run, re-init if the vault config genuinely changed.
+    if (
+      bootstrapRan &&
+      lastRunConfig &&
+      !configsEqual(vaultConfig, lastRunConfig)
+    ) {
+      runBootstrap(vaultConfig);
+    }
   };
 
-  const onFlagChange = (state: RemoteFeatureFlagControllerState) => {
-    if (tryStart(state)) {
-      initMessenger.unsubscribe(
-        'RemoteFeatureFlagController:stateChange',
-        onFlagChange,
-      );
-    }
-  };
-
-  if (!tryStart(initMessenger.call('RemoteFeatureFlagController:getState'))) {
-    initMessenger.subscribe(
-      'RemoteFeatureFlagController:stateChange',
-      onFlagChange,
-    );
-  }
+  initMessenger.subscribe(
+    'RemoteFeatureFlagController:stateChange',
+    onFlagState,
+  );
+  onFlagState(initMessenger.call('RemoteFeatureFlagController:getState'));
 
   return { controller };
 };


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR fixes a lingering bug with the money account vault config. Previously we would capture the vault config on engine init from the persisted feature flags. This meant that the values used could be up to 24hrs old, and would be frozen for the duration of the session. This is generally fine, but caused some problems for internal accounts when we moved from dev to prod config. By fixing this we can prevent any future problems if we need to update the config again.

The new bootstrap lifecycle in money-account-upgrade-controller-init work as follows

- Read the vault config just-in-time when the bootstrap actually runs
  (immediately if unlocked, otherwise on KeyringController:unlock),
  falling back to the config that triggered scheduling if the flag has
  since vanished.
- Stay subscribed to RemoteFeatureFlagController:stateChange for the
  whole session; if the vault config changes after a bootstrap has run,
  re-run controller.init() with the new config. Re-runs are serialized
  on the previous bootstrap promise, and the controller's config
  fingerprint then triggers a clean re-upgrade.
- Subscribe before processing the initial state so a flag refresh
  landing in between cannot be missed.



<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: ensure that money upgrade controller won't use stale vault config

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-951

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches money account upgrade bootstrap timing and can re-run `controller.init()` mid-session when remote vault config changes, which affects upgrade readiness and vault addresses but stays within existing feature-flag and keyring gating.
> 
> **Overview**
> Fixes **stale Money Account vault config** by changing how `moneyAccountUpgradeControllerInit` bootstraps: the vault config is read **just-in-time** from `RemoteFeatureFlagController:getState` when bootstrap actually runs (on unlock or immediately if unlocked), with a fallback to the config that scheduled bootstrap if flags disappear.
> 
> The init path **stays subscribed** to `RemoteFeatureFlagController:stateChange` for the session. After the first successful bootstrap, a **genuine vault config change** (full fingerprint compare) triggers a **serialized re-run** of `controller.init()`; `whenMoneyAccountUpgradeReady()` tracks the **latest** promise in that chain. Re-inits chain after the prior bootstrap (failed runs are swallowed so later updates still apply).
> 
> Tests add helpers (`deliverFlagState`, `settleBootstrap`, alternate vault config) and cover JIT-at-unlock, fallback when config vanishes, re-init on change, no-op on identical config, and flag-off after bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7313a2d10e141ebddba2f53a8010e4e8e5dd4d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->