### PR TITLE
feat(performance): add performance tests for Homepage, PopularTokensList, MultichainTransactionsView, and UnifiedTransactionsView

### DIFF
--- a/app/components/Views/Homepage/Homepage.perf-test.tsx
+++ b/app/components/Views/Homepage/Homepage.perf-test.tsx
@@ -1,96 +1,43 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Provider } from 'react-redux';
 import { measureRenders } from 'reassure';
+import configureStore from '../../../util/test/configureStore';
+import initialRootState from '../../../util/test/initial-root-state';
+import { mockTheme, ThemeContext } from '../../../util/theme';
 import Homepage from './Homepage';
 
-jest.mock('react-redux', () => ({
-  useSelector: () => false,
-}));
+jest.mock(
+  '@metamask/sentinel-api-service',
+  () => ({
+    SentinelApiService: class SentinelApiService {},
+  }),
+  { virtual: true },
+);
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+  }),
   useFocusEffect: jest.fn(),
+  useIsFocused: () => true,
 }));
 
-jest.mock('../../UI/Perps', () => ({
-  selectPerpsEnabledFlag: () => false,
+jest.mock('./Sections/Tokens/hooks/usePopularTokens', () => ({
+  usePopularTokens: () => ({
+    tokens: [],
+    isInitialLoading: false,
+    isRefreshing: false,
+    error: null,
+    refetch: jest.fn().mockResolvedValue(undefined),
+  }),
 }));
 
-jest.mock('./Sections/Tokens', () => ({
+jest.mock('../../UI/Money/hooks/useMoneyAccountBalance', () => ({
   __esModule: true,
-  default: () => {
-    const ReactActual = jest.requireActual('react');
-    const { Text, View } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      null,
-      ReactActual.createElement(Text, null, 'Tokens'),
-    );
-  },
-}));
-
-jest.mock('./Sections/Predictions', () => ({
-  __esModule: true,
-  default: () => {
-    const ReactActual = jest.requireActual('react');
-    const { Text, View } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      null,
-      ReactActual.createElement(Text, null, 'Predictions'),
-    );
-  },
-}));
-
-jest.mock('./Sections/More', () => ({
-  __esModule: true,
-  default: () => {
-    const ReactActual = jest.requireActual('react');
-    const { Text, View } = jest.requireActual('react-native');
-
-    return ReactActual.createElement(
-      View,
-      null,
-      ReactActual.createElement(Text, null, 'More'),
-    );
-  },
-}));
-
-jest.mock('./Sections/Perpetuals/HomepagePerpsHomeSlot', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-jest.mock('./Sections/TopTraders', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-jest.mock('./Sections/DeFi', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-jest.mock('./Sections/NFTs', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-jest.mock('./Sections/Watchlist', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
-jest.mock('./Sections/NFTs/hooks', () => ({
-  useOwnedNfts: () => [],
-}));
-
-jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
-  useNetworkEnablement: () => ({
-    enableAllPopularNetworks: jest.fn(),
-    isNetworkEnabled: () => true,
-    popularNetworks: [],
+  default: () => ({
+    apyPercent: undefined,
   }),
 }));
 
@@ -110,6 +57,35 @@ jest.mock('./hooks/useHomeSessionSummary', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn(() => ({})),
+    })),
+  }),
+}));
+
+const store = configureStore(initialRootState);
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: 0,
+    },
+  },
+});
+const ProvidersWrapper = ({ children }: { children: React.ReactElement }) => (
+  <Provider store={store}>
+    <ThemeContext.Provider value={mockTheme}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeContext.Provider>
+  </Provider>
+);
+
 test('Homepage top-level mount performance', async () => {
-  await measureRenders(<Homepage />);
+  await measureRenders(<Homepage />, {
+    wrapper: ProvidersWrapper,
+  });
 });

--- a/app/components/Views/Homepage/Homepage.perf-test.tsx
+++ b/app/components/Views/Homepage/Homepage.perf-test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { measureRenders } from 'reassure';
+import Homepage from './Homepage';
+
+jest.mock('react-redux', () => ({
+  useSelector: () => false,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock('../../UI/Perps', () => ({
+  selectPerpsEnabledFlag: () => false,
+}));
+
+jest.mock('./Sections/Tokens', () => ({
+  __esModule: true,
+  default: () => {
+    const ReactActual = jest.requireActual('react');
+    const { Text, View } = jest.requireActual('react-native');
+
+    return ReactActual.createElement(
+      View,
+      null,
+      ReactActual.createElement(Text, null, 'Tokens'),
+    );
+  },
+}));
+
+jest.mock('./Sections/Predictions', () => ({
+  __esModule: true,
+  default: () => {
+    const ReactActual = jest.requireActual('react');
+    const { Text, View } = jest.requireActual('react-native');
+
+    return ReactActual.createElement(
+      View,
+      null,
+      ReactActual.createElement(Text, null, 'Predictions'),
+    );
+  },
+}));
+
+jest.mock('./Sections/More', () => ({
+  __esModule: true,
+  default: () => {
+    const ReactActual = jest.requireActual('react');
+    const { Text, View } = jest.requireActual('react-native');
+
+    return ReactActual.createElement(
+      View,
+      null,
+      ReactActual.createElement(Text, null, 'More'),
+    );
+  },
+}));
+
+jest.mock('./Sections/Perpetuals/HomepagePerpsHomeSlot', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./Sections/TopTraders', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./Sections/DeFi', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./Sections/NFTs', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./Sections/Watchlist', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('./Sections/NFTs/hooks', () => ({
+  useOwnedNfts: () => [],
+}));
+
+jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
+  useNetworkEnablement: () => ({
+    enableAllPopularNetworks: jest.fn(),
+    isNetworkEnabled: () => true,
+    popularNetworks: [],
+  }),
+}));
+
+jest.mock('../../hooks/useNftDetection', () => ({
+  useNftDetection: () => ({
+    detectNfts: jest.fn().mockResolvedValue(undefined),
+    abortDetection: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useThrottledFocusEffect', () => ({
+  useThrottledFocusEffect: jest.fn(),
+}));
+
+jest.mock('./hooks/useHomeSessionSummary', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+test('Homepage top-level mount performance', async () => {
+  await measureRenders(<Homepage />);
+});

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokensList.perf-test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokensList.perf-test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { measureRenders } from 'reassure';
+import configureStore from '../../../../../../util/test/configureStore';
+import initialRootState from '../../../../../../util/test/initial-root-state';
+import { mockTheme, ThemeContext } from '../../../../../../util/theme';
 import type { PopularToken } from '../hooks/usePopularTokens';
 import PopularTokensList from './PopularTokensList';
 
@@ -28,10 +32,6 @@ jest.mock('../hooks', () => ({
   }),
 }));
 
-jest.mock('react-redux', () => ({
-  useSelector: () => 'usd',
-}));
-
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: jest.fn(),
@@ -44,12 +44,15 @@ jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   }),
 }));
 
-jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({
-    style: () => ({}),
-  }),
-}));
+const store = configureStore(initialRootState);
+const ProvidersWrapper = ({ children }: { children: React.ReactElement }) => (
+  <Provider store={store}>
+    <ThemeContext.Provider value={mockTheme}>{children}</ThemeContext.Provider>
+  </Provider>
+);
 
 test('PopularTokensList mount performance with 20 tokens', async () => {
-  await measureRenders(<PopularTokensList />);
+  await measureRenders(<PopularTokensList />, {
+    wrapper: ProvidersWrapper,
+  });
 });

--- a/app/components/Views/Homepage/Sections/Tokens/components/PopularTokensList.perf-test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/components/PopularTokensList.perf-test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { measureRenders } from 'reassure';
+import type { PopularToken } from '../hooks/usePopularTokens';
+import PopularTokensList from './PopularTokensList';
+
+const mockTokens: PopularToken[] = Array.from(
+  { length: 20 },
+  (_value, index) => ({
+    assetId: `eip155:1/erc20:0x${(index + 1).toString(16).padStart(40, '0')}`,
+    name: `Popular Token ${index + 1}`,
+    symbol: `TOK${index + 1}`,
+    iconUrl: `https://example.com/token-${index + 1}.png`,
+    price: index + 1.25,
+    priceChange1d: index % 2 === 0 ? 2.5 : -1.5,
+  }),
+);
+
+jest.mock('../hooks', () => ({
+  usePopularTokens: () => ({
+    tokens: mockTokens,
+    isInitialLoading: false,
+    isRefreshing: false,
+    error: null,
+    refetch: jest.fn().mockResolvedValue(undefined),
+  }),
+  useRampsButtonClickedEvent: () => ({
+    trackBuyButtonClicked: jest.fn(),
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: () => 'usd',
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
+  useRampNavigation: () => ({
+    goToBuy: jest.fn(),
+  }),
+}));
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: () => ({}),
+  }),
+}));
+
+test('PopularTokensList mount performance with 20 tokens', async () => {
+  await measureRenders(<PopularTokensList />);
+});

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
@@ -20,7 +20,7 @@ const nativeAsset = {
   unit: 'SOL',
   fungible: true,
   type: `${SolScope.Mainnet}/slip44:501`,
-};
+} satisfies Extract<Transaction['from'][number]['asset'], { fungible: true }>;
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => mockNavigation,

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   SolScope,
   Transaction,
@@ -6,27 +7,23 @@ import {
   TransactionType,
 } from '@metamask/keyring-api';
 import { measureRenders } from 'reassure';
+import configureStore from '../../../util/test/configureStore';
+import initialRootState from '../../../util/test/initial-root-state';
+import { mockTheme, ThemeContext } from '../../../util/theme';
 import MultichainTransactionsView from './MultichainTransactionsView';
 
 const mockNavigation = {
   navigate: jest.fn(),
 };
+const nativeAsset = {
+  amount: '1',
+  unit: 'SOL',
+  fungible: true,
+  type: `${SolScope.Mainnet}/slip44:501`,
+};
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => mockNavigation,
-}));
-
-jest.mock('react-redux', () => ({
-  useSelector: () => false,
-}));
-
-jest.mock('../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      icon: { default: 'icon-default' },
-      primary: { default: 'primary-default' },
-    },
-  }),
 }));
 
 jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
@@ -45,33 +42,14 @@ jest.mock(
   }),
 );
 
-jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
-  useBridgeHistoryItemBySrcTxHash: () => ({
-    bridgeHistoryItemsBySrcTxHash: {},
-  }),
-}));
-
-jest.mock('../../UI/MultichainTransactionListItem', () => {
-  const ReactActual = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-
-  return ({ transaction }: { transaction: Transaction }) =>
-    ReactActual.createElement(Text, null, transaction.id);
-});
-
-jest.mock('../MultichainTransactionsView/MultichainTransactionsFooter', () => ({
-  __esModule: true,
-  default: () => null,
-}));
-
 const transactions: Transaction[] = Array.from(
   { length: 100 },
   (_value, index) => ({
     id: `solana-transaction-${index}`,
     chain: SolScope.Mainnet,
     account: 'selected-address',
-    from: [{ address: `sender-${index}`, asset: null }],
-    to: [{ address: `recipient-${index}`, asset: null }],
+    from: [{ address: `sender-${index}`, asset: nativeAsset }],
+    to: [{ address: `recipient-${index}`, asset: nativeAsset }],
     events: [],
     fees: [],
     value: String(index + 1),
@@ -81,6 +59,13 @@ const transactions: Transaction[] = Array.from(
   }),
 );
 
+const store = configureStore(initialRootState);
+const ProvidersWrapper = ({ children }: { children: React.ReactElement }) => (
+  <Provider store={store}>
+    <ThemeContext.Provider value={mockTheme}>{children}</ThemeContext.Provider>
+  </Provider>
+);
+
 test('MultichainTransactionsView mount performance with 100 transactions', async () => {
   await measureRenders(
     <MultichainTransactionsView
@@ -88,5 +73,6 @@ test('MultichainTransactionsView mount performance with 100 transactions', async
       selectedAddress="selected-address"
       chainId={SolScope.Mainnet}
     />,
+    { wrapper: ProvidersWrapper },
   );
 });

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.perf-test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {
+  SolScope,
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/keyring-api';
+import { measureRenders } from 'reassure';
+import MultichainTransactionsView from './MultichainTransactionsView';
+
+const mockNavigation = {
+  navigate: jest.fn(),
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: () => false,
+}));
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      icon: { default: 'icon-default' },
+      primary: { default: 'primary-default' },
+    },
+  }),
+}));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(),
+  }),
+}));
+
+jest.mock(
+  '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys',
+  () => ({
+    useMultichainActivityMaliciousTokenKeys: () => ({
+      maliciousTokenKeys: new Set(),
+    }),
+  }),
+);
+
+jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
+  useBridgeHistoryItemBySrcTxHash: () => ({
+    bridgeHistoryItemsBySrcTxHash: {},
+  }),
+}));
+
+jest.mock('../../UI/MultichainTransactionListItem', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+
+  return ({ transaction }: { transaction: Transaction }) =>
+    ReactActual.createElement(Text, null, transaction.id);
+});
+
+jest.mock('../MultichainTransactionsView/MultichainTransactionsFooter', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const transactions: Transaction[] = Array.from(
+  { length: 100 },
+  (_value, index) => ({
+    id: `solana-transaction-${index}`,
+    chain: SolScope.Mainnet,
+    account: 'selected-address',
+    from: [{ address: `sender-${index}`, asset: null }],
+    to: [{ address: `recipient-${index}`, asset: null }],
+    events: [],
+    fees: [],
+    value: String(index + 1),
+    type: index % 2 === 0 ? TransactionType.Send : TransactionType.Receive,
+    status: TransactionStatus.Confirmed,
+    timestamp: 1_750_000_000 - index,
+  }),
+);
+
+test('MultichainTransactionsView mount performance with 100 transactions', async () => {
+  await measureRenders(
+    <MultichainTransactionsView
+      transactions={transactions}
+      selectedAddress="selected-address"
+      chainId={SolScope.Mainnet}
+    />,
+  );
+});

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
@@ -27,7 +27,10 @@ const nativeAsset = {
   unit: 'SOL',
   fungible: true,
   type: `${SolScope.Mainnet}/slip44:501`,
-};
+} satisfies Extract<
+  NonEvmTransaction['from'][number]['asset'],
+  { fungible: true }
+>;
 
 jest.mock(
   '@metamask/sentinel-api-service',

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import {
   SolScope,
   Transaction as NonEvmTransaction,
@@ -11,11 +12,30 @@ import {
   TransactionType as EvmTransactionType,
 } from '@metamask/transaction-controller';
 import { measureRenders } from 'reassure';
+import configureStore from '../../../util/test/configureStore';
+import initialRootState, {
+  backgroundState,
+} from '../../../util/test/initial-root-state';
+import { mockTheme, ThemeContext } from '../../../util/theme';
 import type { TransactionViewModel } from './types';
 import UnifiedTransactionsView from './UnifiedTransactionsView';
 
 const mockSelectedAddress = '0x0000000000000000000000000000000000000abc';
 const mockNavigate = jest.fn();
+const nativeAsset = {
+  amount: '1',
+  unit: 'SOL',
+  fungible: true,
+  type: `${SolScope.Mainnet}/slip44:501`,
+};
+
+jest.mock(
+  '@metamask/sentinel-api-service',
+  () => ({
+    SentinelApiService: class SentinelApiService {},
+  }),
+  { virtual: true },
+);
 
 const mockPendingTransactions: TransactionMeta[] = Array.from(
   { length: 10 },
@@ -92,8 +112,8 @@ const mockNonEvmTransactions: NonEvmTransaction[] = Array.from(
     id: `solana-${index}`,
     chain: SolScope.Mainnet,
     account: 'solana-account-address',
-    from: [{ address: `sender-${index}`, asset: null }],
-    to: [{ address: `recipient-${index}`, asset: null }],
+    from: [{ address: `sender-${index}`, asset: nativeAsset }],
+    to: [{ address: `recipient-${index}`, asset: nativeAsset }],
     events: [],
     fees: [],
     value: String(index + 1),
@@ -107,65 +127,6 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
   }),
-}));
-
-jest.mock('react-redux', () => ({
-  useSelector: (selector: (state: unknown) => unknown) => selector({}),
-}));
-
-jest.mock('../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccount: () => ({
-    address: mockSelectedAddress,
-  }),
-}));
-
-jest.mock('../../../selectors/currencyRateController', () => ({
-  selectCurrentCurrency: () => 'usd',
-}));
-
-jest.mock('../../../selectors/multichain/multichain', () => ({
-  selectNonEvmTransactionsForSelectedAccountGroup: () => ({
-    transactions: mockNonEvmTransactions,
-  }),
-}));
-
-jest.mock(
-  '../../../selectors/multichainAccounts/accountTreeController',
-  () => ({
-    selectSelectedAccountGroupInternalAccounts: () => [
-      {
-        id: 'evm-account',
-        address: mockSelectedAddress,
-        type: 'eip155:eoa',
-      },
-      {
-        id: 'solana-account',
-        address: 'solana-account-address',
-        type: 'solana:data-account',
-      },
-    ],
-  }),
-);
-
-jest.mock('../../../selectors/networkController', () => ({
-  selectEvmNetworkConfigurationsByChainId: () => ({}),
-  selectProviderType: () => undefined,
-}));
-
-jest.mock('../../../selectors/networkEnablementController', () => ({
-  selectEVMEnabledNetworks: () => ['0x1'],
-  selectNonEVMEnabledNetworks: () => [
-    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-  ],
-}));
-
-jest.mock('../../../selectors/transactionController', () => ({
-  selectLocalTransactions: () => mockPendingTransactions,
-  selectRelatedChainIdsByTransactionId: () => new Map(),
-}));
-
-jest.mock('../../../selectors/bridgeStatusController', () => ({
-  selectBridgeHistoryForAccount: () => ({}),
 }));
 
 jest.mock('./useTransactionsQuery', () => ({
@@ -205,6 +166,12 @@ jest.mock('./useTransactionAutoScroll', () => ({
   }),
 }));
 
+jest.mock('../confirmations/hooks/gas/useGasFeeEstimates', () => ({
+  useGasFeeEstimates: () => ({
+    gasFeeEstimates: undefined,
+  }),
+}));
+
 jest.mock('../../hooks/useBlockExplorer', () => ({
   __esModule: true,
   default: () => ({
@@ -220,30 +187,6 @@ jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
-jest.mock('../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      icon: { default: 'icon-default' },
-      primary: { default: 'primary-default' },
-    },
-  }),
-}));
-
-jest.mock('../../hooks/useStyles', () => ({
-  useStyles: () => ({
-    styles: {
-      container: {},
-      emptyList: {},
-    },
-  }),
-}));
-
-jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({
-    style: () => ({}),
-  }),
-}));
-
 jest.mock(
   '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys',
   () => ({
@@ -253,50 +196,114 @@ jest.mock(
   }),
 );
 
-jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
-  useBridgeHistoryItemBySrcTxHash: () => ({
-    bridgeHistoryItemsBySrcTxHash: {},
-  }),
-}));
-
-jest.mock('../../UI/AssetOverview/PriceChart/PriceChart.context', () => ({
-  __esModule: true,
-  default: {
-    Consumer: ({
-      children,
-    }: {
-      children: (value: { isChartBeingTouched: boolean }) => React.ReactNode;
-    }) => children({ isChartBeingTouched: false }),
+const evmAccount = {
+  id: 'evm-account',
+  address: mockSelectedAddress,
+  type: 'eip155:eoa' as const,
+  scopes: ['eip155:0' as const],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'EVM Account',
+    keyring: { type: 'HD Key Tree' },
   },
-  PriceChartProvider: ({ children }: { children: React.ReactNode }) => children,
-}));
+};
 
-jest.mock('../../UI/TransactionElement', () => {
-  const ReactActual = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
+const solanaAccount = {
+  id: 'solana-account',
+  address: 'solana-account-address',
+  type: 'solana:data-account' as const,
+  scopes: [SolScope.Mainnet],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Solana Account',
+    keyring: { type: 'Snap Keyring' },
+  },
+};
 
-  return ({ tx }: { tx: TransactionMeta }) =>
-    ReactActual.createElement(Text, null, tx.id);
+const accountGroupId = 'entropy:wallet/0';
+const store = configureStore({
+  ...initialRootState,
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      AccountsController: {
+        ...backgroundState.AccountsController,
+        internalAccounts: {
+          accounts: {
+            [evmAccount.id]: evmAccount,
+            [solanaAccount.id]: solanaAccount,
+          },
+          selectedAccount: evmAccount.id,
+        },
+      },
+      AccountTreeController: {
+        ...backgroundState.AccountTreeController,
+        accountTree: {
+          wallets: {
+            'entropy:wallet': {
+              id: 'entropy:wallet',
+              type: 'entropy',
+              status: 'ready',
+              metadata: { name: 'Test Wallet' },
+              groups: {
+                [accountGroupId]: {
+                  id: accountGroupId,
+                  type: 'multichain-account',
+                  accounts: [evmAccount.id, solanaAccount.id],
+                  metadata: {
+                    name: 'Account 1',
+                    pinned: false,
+                    hidden: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+        selectedAccountGroup: accountGroupId,
+      },
+      TransactionController: {
+        ...backgroundState.TransactionController,
+        transactions: mockPendingTransactions,
+      },
+      MultichainTransactionsController: {
+        nonEvmTransactions: {
+          [solanaAccount.id]: {
+            [SolScope.Mainnet]: {
+              transactions: mockNonEvmTransactions,
+              next: null,
+              lastUpdated: 1_750_000_000,
+            },
+          },
+        },
+      },
+      NetworkEnablementController: {
+        ...backgroundState.NetworkEnablementController,
+        enabledNetworkMap: {
+          eip155: { '0x1': true },
+          solana: { [SolScope.Mainnet]: true },
+          bip122: {},
+          tron: {},
+        },
+      },
+      BridgeStatusController: {
+        ...backgroundState.BridgeStatusController,
+        txHistory: {},
+      },
+    },
+  },
 });
 
-jest.mock('../../UI/MultichainTransactionListItem', () => {
-  const ReactActual = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-
-  return ({ transaction }: { transaction: NonEvmTransaction }) =>
-    ReactActual.createElement(Text, null, transaction.id);
-});
-
-jest.mock('../../UI/MultichainBridgeTransactionListItem', () => () => null);
-jest.mock('../../UI/Transactions/TransactionsFooter', () => () => null);
-jest.mock(
-  '../MultichainTransactionsView/MultichainTransactionsFooter',
-  () => () => null,
+const ProvidersWrapper = ({ children }: { children: React.ReactElement }) => (
+  <Provider store={store}>
+    <ThemeContext.Provider value={mockTheme}>{children}</ThemeContext.Provider>
+  </Provider>
 );
-jest.mock('../confirmations/components/modals/cancel-speedup-modal', () => ({
-  CancelSpeedupModal: () => null,
-}));
 
 test('UnifiedTransactionsView mount performance with mixed item kinds', async () => {
-  await measureRenders(<UnifiedTransactionsView />);
+  await measureRenders(<UnifiedTransactionsView />, {
+    wrapper: ProvidersWrapper,
+  });
 });

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.perf-test.tsx
@@ -1,0 +1,302 @@
+import React from 'react';
+import {
+  SolScope,
+  Transaction as NonEvmTransaction,
+  TransactionStatus as NonEvmTransactionStatus,
+  TransactionType,
+} from '@metamask/keyring-api';
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType as EvmTransactionType,
+} from '@metamask/transaction-controller';
+import { measureRenders } from 'reassure';
+import type { TransactionViewModel } from './types';
+import UnifiedTransactionsView from './UnifiedTransactionsView';
+
+const mockSelectedAddress = '0x0000000000000000000000000000000000000abc';
+const mockNavigate = jest.fn();
+
+const mockPendingTransactions: TransactionMeta[] = Array.from(
+  { length: 10 },
+  (_value, index) => ({
+    id: `pending-${index}`,
+    chainId: '0x1',
+    hash: `0x${(index + 1).toString(16).padStart(64, '0')}`,
+    networkClientId: 'mainnet',
+    status: TransactionStatus.submitted,
+    time: 1_750_000_000_000 - index * 3,
+    type: EvmTransactionType.simpleSend,
+    txParams: {
+      from: mockSelectedAddress,
+      to: '0x0000000000000000000000000000000000000def',
+      value: '0x1',
+      nonce: `0x${index.toString(16)}`,
+    },
+  }),
+);
+
+const mockConfirmedTransactions: TransactionViewModel[] = Array.from(
+  { length: 10 },
+  (_value, index) => {
+    const transactionMeta: TransactionMeta = {
+      id: `confirmed-${index}`,
+      chainId: '0x1',
+      hash: `0x${(index + 101).toString(16).padStart(64, '0')}`,
+      networkClientId: 'mainnet',
+      status: TransactionStatus.confirmed,
+      time: 1_750_000_000_000 - index * 3 - 1,
+      type: EvmTransactionType.simpleSend,
+      txParams: {
+        from: mockSelectedAddress,
+        to: '0x0000000000000000000000000000000000000def',
+        value: '0x1',
+        nonce: `0x${(index + 100).toString(16)}`,
+      },
+    };
+
+    return {
+      accountId: `eip155:1:${mockSelectedAddress}`,
+      blockHash: `0xblock-${index}`,
+      blockNumber: index + 1,
+      chainId: 1,
+      cumulativeGasUsed: 21000,
+      effectiveGasPrice: '1',
+      from: mockSelectedAddress,
+      gas: 21000,
+      gasPrice: '1',
+      gasUsed: 21000,
+      hash: transactionMeta.hash as string,
+      id: transactionMeta.id,
+      isError: false,
+      logs: [],
+      methodId: '0x',
+      nonce: index + 100,
+      readable: 'Transfer',
+      timestamp: '2025-06-15T15:06:40.000Z',
+      time: transactionMeta.time,
+      to: transactionMeta.txParams.to as string,
+      transactionCategory: 'TRANSFER',
+      transactionType: 'SIMPLE_SEND',
+      value: '1',
+      valueTransfers: [],
+      hexChainId: '0x1',
+      transactionMeta,
+    };
+  },
+);
+
+const mockNonEvmTransactions: NonEvmTransaction[] = Array.from(
+  { length: 10 },
+  (_value, index) => ({
+    id: `solana-${index}`,
+    chain: SolScope.Mainnet,
+    account: 'solana-account-address',
+    from: [{ address: `sender-${index}`, asset: null }],
+    to: [{ address: `recipient-${index}`, asset: null }],
+    events: [],
+    fees: [],
+    value: String(index + 1),
+    type: index % 2 === 0 ? TransactionType.Send : TransactionType.Receive,
+    status: NonEvmTransactionStatus.Confirmed,
+    timestamp: 1_750_000_000 - index * 3 - 2,
+  }),
+);
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccount: () => ({
+    address: mockSelectedAddress,
+  }),
+}));
+
+jest.mock('../../../selectors/currencyRateController', () => ({
+  selectCurrentCurrency: () => 'usd',
+}));
+
+jest.mock('../../../selectors/multichain/multichain', () => ({
+  selectNonEvmTransactionsForSelectedAccountGroup: () => ({
+    transactions: mockNonEvmTransactions,
+  }),
+}));
+
+jest.mock(
+  '../../../selectors/multichainAccounts/accountTreeController',
+  () => ({
+    selectSelectedAccountGroupInternalAccounts: () => [
+      {
+        id: 'evm-account',
+        address: mockSelectedAddress,
+        type: 'eip155:eoa',
+      },
+      {
+        id: 'solana-account',
+        address: 'solana-account-address',
+        type: 'solana:data-account',
+      },
+    ],
+  }),
+);
+
+jest.mock('../../../selectors/networkController', () => ({
+  selectEvmNetworkConfigurationsByChainId: () => ({}),
+  selectProviderType: () => undefined,
+}));
+
+jest.mock('../../../selectors/networkEnablementController', () => ({
+  selectEVMEnabledNetworks: () => ['0x1'],
+  selectNonEVMEnabledNetworks: () => [
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  ],
+}));
+
+jest.mock('../../../selectors/transactionController', () => ({
+  selectLocalTransactions: () => mockPendingTransactions,
+  selectRelatedChainIdsByTransactionId: () => new Map(),
+}));
+
+jest.mock('../../../selectors/bridgeStatusController', () => ({
+  selectBridgeHistoryForAccount: () => ({}),
+}));
+
+jest.mock('./useTransactionsQuery', () => ({
+  useTransactionsQuery: () => ({
+    data: {
+      pageParams: [undefined],
+      pages: [{ data: mockConfirmedTransactions }],
+    },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isInitialLoading: false,
+    isFetchingNextPage: false,
+    refetch: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('./useUnifiedTxActions', () => ({
+  useUnifiedTxActions: () => ({
+    speedUpIsOpen: false,
+    cancelIsOpen: false,
+    confirmDisabled: false,
+    existingTx: null,
+    onSpeedUpAction: jest.fn(),
+    onCancelAction: jest.fn(),
+    onSpeedUpCancelCompleted: jest.fn(),
+    speedUpTransaction: jest.fn(),
+    cancelTransaction: jest.fn(),
+    signQRTransaction: jest.fn(),
+    signLedgerTransaction: jest.fn(),
+    cancelUnsignedQRTransaction: jest.fn(),
+  }),
+}));
+
+jest.mock('./useTransactionAutoScroll', () => ({
+  useTransactionAutoScroll: () => ({
+    handleScroll: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useBlockExplorer', () => ({
+  __esModule: true,
+  default: () => ({
+    getBlockExplorerUrl: jest.fn(),
+    getBlockExplorerName: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      icon: { default: 'icon-default' },
+      primary: { default: 'primary-default' },
+    },
+  }),
+}));
+
+jest.mock('../../hooks/useStyles', () => ({
+  useStyles: () => ({
+    styles: {
+      container: {},
+      emptyList: {},
+    },
+  }),
+}));
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({
+    style: () => ({}),
+  }),
+}));
+
+jest.mock(
+  '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys',
+  () => ({
+    useMultichainActivityMaliciousTokenKeys: () => ({
+      maliciousTokenKeys: new Set(),
+    }),
+  }),
+);
+
+jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
+  useBridgeHistoryItemBySrcTxHash: () => ({
+    bridgeHistoryItemsBySrcTxHash: {},
+  }),
+}));
+
+jest.mock('../../UI/AssetOverview/PriceChart/PriceChart.context', () => ({
+  __esModule: true,
+  default: {
+    Consumer: ({
+      children,
+    }: {
+      children: (value: { isChartBeingTouched: boolean }) => React.ReactNode;
+    }) => children({ isChartBeingTouched: false }),
+  },
+  PriceChartProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('../../UI/TransactionElement', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+
+  return ({ tx }: { tx: TransactionMeta }) =>
+    ReactActual.createElement(Text, null, tx.id);
+});
+
+jest.mock('../../UI/MultichainTransactionListItem', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+
+  return ({ transaction }: { transaction: NonEvmTransaction }) =>
+    ReactActual.createElement(Text, null, transaction.id);
+});
+
+jest.mock('../../UI/MultichainBridgeTransactionListItem', () => () => null);
+jest.mock('../../UI/Transactions/TransactionsFooter', () => () => null);
+jest.mock(
+  '../MultichainTransactionsView/MultichainTransactionsFooter',
+  () => () => null,
+);
+jest.mock('../confirmations/components/modals/cancel-speedup-modal', () => ({
+  CancelSpeedupModal: () => null,
+}));
+
+test('UnifiedTransactionsView mount performance with mixed item kinds', async () => {
+  await measureRenders(<UnifiedTransactionsView />);
+});


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds Reassure render-performance coverage for high-traffic wallet surfaces that previously had no component-level perf safety net:

- Homepage top-level render
- PopularTokensList with 20 populated tokens
- MultichainTransactionsView with 100 transactions
- UnifiedTransactionsView with mixed pending EVM, confirmed EVM, and non-EVM transactions

The tests seed representative data volumes and use `measureRenders` so regressions can be detected by the existing Reassure baseline/branch workflow.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TMCU-1137

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Reassure render-performance coverage

  Scenario: Execute the component performance test suite
    Given the repository dependencies are installed

    When the Reassure performance tests are run
    Then Homepage, PopularTokensList, MultichainTransactionsView, and UnifiedTransactionsView each produce render measurements
    And the test run completes without errors
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production or runtime behavior changes.
> 
> **Overview**
> Adds **Reassure** `measureRenders` coverage for four high-traffic wallet UI surfaces that previously had no component-level render perf baselines.
> 
> New `*.perf-test.tsx` files mount **`Homepage`** (Redux, theme, React Query, with navigation/analytics/token hooks stubbed), **`PopularTokensList`** with 20 mocked tokens, **`MultichainTransactionsView`** with 100 Solana transactions, and **`UnifiedTransactionsView`** with a seeded Redux state mixing pending EVM txs, confirmed EVM view models, and non-EVM Solana activity plus mocked data hooks.
> 
> These tests follow the same pattern as existing perf tests (e.g. `DeepLinkModal`, `BatchSellTokenSelect`) so CI/Reassure can track render regressions on mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee0c7c4115ebb6deab8c1d9de3823f2c83fa87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->