### PR TITLE
refactor(selectors): replace direct state access with selector functions

### DIFF
--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -16,7 +16,6 @@ import { strings } from '../../../../locales/i18n';
 import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
 import styles from './MultichainTransactionListItem.styles';
 import { useSelector } from 'react-redux';
-import { RootState } from '../../../reducers';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
 import Badge, {
@@ -30,6 +29,7 @@ import {
   TRANSACTION_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
+import { selectAppTheme } from '../../../selectors/user';
 
 const MultichainTransactionListItem = ({
   transaction,
@@ -46,7 +46,7 @@ const MultichainTransactionListItem = ({
 }) => {
   const { colors, typography } = useTheme();
   const osColorScheme = useColorScheme();
-  const appTheme = useSelector((state: RootState) => state.user.appTheme);
+  const appTheme = useSelector(selectAppTheme);
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const displayData = useMultichainTransactionDisplay(transaction, chainId);

--- a/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.tsx
@@ -13,8 +13,7 @@ import { TextColor } from '../../../../component-library/components/Texts/Text/T
 
 import TransactionDetails from '../TransactionDetails';
 import { toDateFormat } from '../../../../util/date';
-import { selectTransactionMetadataById } from '../../../../selectors/transactionController';
-import { RootState } from '../../../../reducers';
+import { makeSelectTransactionMetadataById } from '../../../../selectors/transactionController';
 
 interface TransactionDetailsSheetParams {
   tx: {
@@ -58,9 +57,11 @@ const TransactionDetailsSheet: React.FC = () => {
 
   const { tx, transactionElement, transactionDetails } = route.params;
 
-  const liveTransaction = useSelector((state: RootState) =>
-    selectTransactionMetadataById(state, tx.id),
+  const selectLiveTransaction = useMemo(
+    () => makeSelectTransactionMetadataById(tx.id),
+    [tx.id],
   );
+  const liveTransaction = useSelector(selectLiveTransaction);
   const currentTx = useMemo(
     () =>
       liveTransaction

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -39,11 +39,10 @@ import { useMerklBonusClaim } from '../../../../UI/Earn/components/MerklRewards/
 import { useNetworkName } from '../../../../Views/confirmations/hooks/useNetworkName';
 import I18n, { strings } from '../../../../../../locales/i18n';
 import Logger from '../../../../../util/Logger';
-import { RootState } from '../../../../../reducers';
 import {
-  selectConversionRateByChainId,
+  makeSelectConversionRateByChainId,
+  makeSelectUSDConversionRateByChainId,
   selectCurrentCurrency,
-  selectUSDConversionRateByChainId,
 } from '../../../../../selectors/currencyRateController';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { formatWithThreshold } from '../../../../../util/assets';
@@ -60,6 +59,13 @@ interface CashGetMusdEmptyStateProps {
   isFullView?: boolean;
   hideClaimButton?: boolean;
 }
+
+const selectMainnetConversionRate = makeSelectConversionRateByChainId(
+  MUSD_CONVERSION_DEFAULT_CHAIN_ID,
+);
+const selectMainnetUsdConversionRate = makeSelectUSDConversionRateByChainId(
+  MUSD_CONVERSION_DEFAULT_CHAIN_ID,
+);
 
 /**
  * Empty state for the Cash (mUSD) full view when the user has no mUSD.
@@ -119,12 +125,8 @@ const CashGetMusdEmptyState = ({
   const networkName = useNetworkName(MUSD_CONVERSION_DEFAULT_CHAIN_ID);
 
   const currentCurrency = useSelector(selectCurrentCurrency);
-  const mainnetConversionRate = useSelector((state: RootState) =>
-    selectConversionRateByChainId(state, MUSD_CONVERSION_DEFAULT_CHAIN_ID),
-  );
-  const mainnetUsdConversionRate = useSelector((state: RootState) =>
-    selectUSDConversionRateByChainId(state, MUSD_CONVERSION_DEFAULT_CHAIN_ID),
-  );
+  const mainnetConversionRate = useSelector(selectMainnetConversionRate);
+  const mainnetUsdConversionRate = useSelector(selectMainnetUsdConversionRate);
   const { navigateToCash } = useCashNavigation();
 
   /** USD → selected fiat (same basis as aggregated mUSD balance / price row). */

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
@@ -4,7 +4,7 @@ import { useDeFiPositionsForHomepage } from './useDeFiPositionsForHomepage';
 const mockSelectDefiPositionsByChainIds = jest.fn();
 
 jest.mock('../../../../../../selectors/defiPositionsController', () => ({
-  selectDefiPositionsByChainIds: (_state: unknown, _chainIds: unknown) =>
+  makeSelectDefiPositionsByChainIds: (_chainIds: unknown) => () =>
     mockSelectDefiPositionsByChainIds(),
 }));
 

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
@@ -3,9 +3,8 @@ import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { GroupedDeFiPositions } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
-import { selectDefiPositionsByChainIds } from '../../../../../../selectors/defiPositionsController';
+import { makeSelectDefiPositionsByChainIds } from '../../../../../../selectors/defiPositionsController';
 import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
-import { RootState } from '../../../../../../reducers';
 
 import { sortAssets } from '../../../../../UI/Tokens/util';
 
@@ -53,11 +52,21 @@ const MAX_POSITIONS_DEFAULT = 5;
 export const useDeFiPositionsForHomepage = (
   maxPositions: number = MAX_POSITIONS_DEFAULT,
 ): UseDeFiPositionsForHomepageResult => {
-  const { popularEvmNetworks } = useNetworkEnablement();
-
-  const defiPositionsByChainIds = useSelector((state: RootState) =>
-    selectDefiPositionsByChainIds(state, popularEvmNetworks),
+  const { popularEvmNetworks: rawPopularEvmNetworks } = useNetworkEnablement();
+  const popularEvmNetworksKey = (rawPopularEvmNetworks ?? []).join(',');
+  const popularEvmNetworks = useMemo(
+    () =>
+      popularEvmNetworksKey
+        ? (popularEvmNetworksKey.split(',') as Hex[])
+        : undefined,
+    [popularEvmNetworksKey],
   );
+
+  const selectHomepageDeFiPositions = useMemo(
+    () => makeSelectDefiPositionsByChainIds(popularEvmNetworks),
+    [popularEvmNetworks],
+  );
+  const defiPositionsByChainIds = useSelector(selectHomepageDeFiPositions);
 
   const result = useMemo((): UseDeFiPositionsForHomepageResult => {
     // Loading state - data not yet available

--- a/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Nft } from '@metamask/assets-controllers';
-import { RootState } from '../../../../../../reducers';
-import { multichainCollectiblesByEnabledNetworksSelector } from '../../../../../../reducers/collectibles';
 import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../../../selectors/multichainAccounts/accountTreeController';
+import { makeSelectMultichainCollectiblesByEnabledNetworks } from '../../../../../../selectors/nftController';
 
 /**
  * Hook to get all owned NFTs for the currently selected account.
@@ -29,20 +28,21 @@ const useOwnedNfts = (): Nft[] => {
         : undefined,
     [selectedGroupAccounts],
   );
+  const popularChainIdsKey = (popularNetworks ?? []).join(',');
   const popularChainIds = useMemo(
-    () => (popularNetworks?.length > 0 ? popularNetworks : undefined),
-    [popularNetworks],
+    () => (popularChainIdsKey ? popularChainIdsKey.split(',') : undefined),
+    [popularChainIdsKey],
   );
 
-  const nftsByChain = useSelector((state: RootState) =>
-    (
-      multichainCollectiblesByEnabledNetworksSelector as (
-        s: RootState,
-        preferredChainIds?: string[],
-        addressesOverride?: string[],
-      ) => Record<string, Nft[]>
-    )(state, popularChainIds, addressesOverride),
-  ) as Record<string, Nft[]>;
+  const selectNftsByChain = useMemo(
+    () =>
+      makeSelectMultichainCollectiblesByEnabledNetworks(
+        popularChainIds,
+        addressesOverride,
+      ),
+    [popularChainIds, addressesOverride],
+  );
+  const nftsByChain = useSelector(selectNftsByChain);
 
   return useMemo(() => {
     const allNfts = Object.values(nftsByChain ?? {}).flat();

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -49,10 +49,9 @@ jest.mock(
 );
 
 jest.mock('../../../../../selectors/assets/assets-list', () => ({
-  selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance: (
-    state: unknown,
-    chainIds: string[],
-  ) => mockSortedTokenKeys(state, chainIds),
+  makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance:
+    (chainIds: string[]) => (state: unknown) =>
+      mockSortedTokenKeys(state, chainIds),
 }));
 
 jest.mock('../../../../../selectors/assets/balances', () => ({

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -20,7 +20,7 @@ import ErrorState from '../../components/ErrorState';
 import Routes from '../../../../../constants/navigation/Routes';
 import SectionRow from '../../components/SectionRow';
 import { useIsZeroBalanceAccount } from './hooks';
-import { selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance } from '../../../../../selectors/assets/assets-list';
+import { makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance } from '../../../../../selectors/assets/assets-list';
 import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
 import { TokenListItem } from '../../../../UI/Tokens/TokenList/TokenListItem/TokenListItem';
@@ -28,7 +28,6 @@ import RemoveTokenBottomSheet from '../../../../UI/Tokens/TokenList/RemoveTokenB
 import { ScamWarningModal } from '../../../../UI/Tokens/TokenList/ScamWarningModal/ScamWarningModal';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
-import { RootState } from '../../../../../reducers';
 import { SectionRefreshHandle } from '../../types';
 import { strings } from '../../../../../../locales/i18n';
 import { PopularTokensList } from './components';
@@ -68,13 +67,20 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     const sectionViewRef = useRef<View>(null);
     const navigation = useNavigation<AppNavigationProp>();
     const isZeroBalanceAccount = useIsZeroBalanceAccount();
-    const { popularNetworks: popularChainIds } = useNetworkEnablement();
-    const sortedTokenKeys = useSelector((state: RootState) =>
-      selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
-        state,
-        popularChainIds,
-      ),
+    const { popularNetworks } = useNetworkEnablement();
+    const popularChainIdsKey = (popularNetworks ?? []).join(',');
+    const popularChainIds = useMemo(
+      () => (popularChainIdsKey ? popularChainIdsKey.split(',') : []),
+      [popularChainIdsKey],
     );
+    const selectSortedTokenKeys = useMemo(
+      () =>
+        makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+          popularChainIds,
+        ),
+      [popularChainIds],
+    );
+    const sortedTokenKeys = useSelector(selectSortedTokenKeys);
     const accountGroupBalance = useSelector(
       selectAccountGroupBalanceForEmptyState,
     );

--- a/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/BatchSwapButton.tsx
+++ b/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/BatchSwapButton.tsx
@@ -8,7 +8,6 @@ import { strings } from '../../../../../../../locales/i18n';
 import AppConstants from '../../../../../../core/AppConstants';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { selectIsSwapsEnabled } from '../../../../../../core/redux/slices/bridge';
-import type { RootState } from '../../../../../../reducers';
 import { selectBatchSellEnabled } from '../../../../../../selectors/featureFlagController/batchSell';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import {
@@ -31,9 +30,7 @@ const BatchSwapButton = ({
   const navigation = useNavigation<AppNavigationProp>();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const isBatchSellEnabled = useSelector(selectBatchSellEnabled);
-  const isSwapsEnabled = useSelector((state: RootState) =>
-    selectIsSwapsEnabled(state),
-  );
+  const isSwapsEnabled = useSelector(selectIsSwapsEnabled);
   const label = strings('homepage.action_buttons.batch_swap');
   const isDisabled =
     !isBatchSellEnabled || !AppConstants.SWAPS.ACTIVE || !isSwapsEnabled;

--- a/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/SwapButton.tsx
+++ b/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/SwapButton.tsx
@@ -4,7 +4,6 @@ import { IconName } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import AppConstants from '../../../../../../core/AppConstants';
 import { selectIsSwapsEnabled } from '../../../../../../core/redux/slices/bridge';
-import type { RootState } from '../../../../../../reducers';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import {
   SwapBridgeNavigationLocation,
@@ -24,9 +23,7 @@ const SwapButton = ({
   allowTwoLineLabel,
 }: HomepageActionButtonSlotProps) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const isSwapsEnabled = useSelector((state: RootState) =>
-    selectIsSwapsEnabled(state),
-  );
+  const isSwapsEnabled = useSelector(selectIsSwapsEnabled);
   const { goToSwaps } = useSwapBridgeNavigation({
     location: SwapBridgeNavigationLocation.MainView,
     sourcePage: 'MainView',

--- a/app/components/Views/Settings/SecuritySettings/Sections/AutoLock/AutoLock.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/AutoLock/AutoLock.tsx
@@ -13,16 +13,15 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import styleSheet from './styles';
+import { selectLockTime } from '../../../../../../selectors/settings';
 
 const AutoLock = () => {
   const { styles } = useStyles(styleSheet, {});
   const dispatch = useDispatch();
 
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const lockTime = useSelector((state: any) => state.settings.lockTime);
+  const lockTime = useSelector(selectLockTime);
 
-  const selectLockTime = (time: string): void => {
+  const handleSelectLockTime = (time: string): void => {
     dispatch(setLockTime(parseInt(time, 10)));
   };
 
@@ -42,7 +41,7 @@ const AutoLock = () => {
       <View style={styles.picker}>
         <SelectComponent
           selectedValue={lockTime.toString()}
-          onValueChange={selectLockTime}
+          onValueChange={handleSelectLockTime}
           label={strings('app_settings.auto_lock')}
           options={AUTO_LOCK_OPTIONS}
         />

--- a/app/reducers/collectibles/index.js
+++ b/app/reducers/collectibles/index.js
@@ -1,31 +1,13 @@
-import { toHex } from '@metamask/controller-utils';
 import { createSelector } from 'reselect';
 import { selectChainId } from '../../selectors/networkController';
 import {
   selectAllNftContracts,
   selectAllNfts,
+  selectMultichainCollectiblesByEnabledNetworks,
 } from '../../selectors/nftController';
 import { selectSelectedInternalAccountAddress } from '../../selectors/accountsController';
 import { compareTokenIds } from '../../util/tokens';
 import { createDeepEqualSelector } from '../../selectors/util';
-import { selectEnabledNetworksByNamespace } from '../../selectors/networkEnablementController';
-
-/**
- * Builds a set of chain IDs for filtering. When chainIds include CAIP-2 (e.g. from listPopularNetworks),
- * adds Hex form for eip155:* so we match NFT keys which are Hex.
- * @param {string[]} chainIds - CAIP-2 or Hex chain IDs
- * @returns {Set<string>}
- */
-function buildAllowedChainIdSet(chainIds) {
-  const set = new Set(chainIds);
-  for (const id of chainIds) {
-    if (id.startsWith('eip155:')) {
-      const reference = id.slice(7);
-      if (reference) set.add(toHex(reference));
-    }
-  }
-  return set;
-}
 
 const favoritesSelector = (state) => state.collectibles.favorites;
 
@@ -61,69 +43,7 @@ export const collectiblesSelector = createDeepEqualSelector(
  * @param {string[]} [addressesOverride] - Optional list of addresses to aggregate NFTs from; when omitted, uses selected account address only
  */
 export const multichainCollectiblesByEnabledNetworksSelector =
-  createDeepEqualSelector(
-    [
-      selectSelectedInternalAccountAddress,
-      selectAllNfts,
-      selectEnabledNetworksByNamespace,
-      (state, preferredChainIds) => preferredChainIds,
-      (state, _preferredChainIds, addressesOverride) => addressesOverride,
-    ],
-    (
-      selectedAddress,
-      allNfts,
-      enabledNetworks,
-      preferredChainIds,
-      addressesOverride,
-    ) => {
-      const addresses =
-        addressesOverride != null &&
-        Array.isArray(addressesOverride) &&
-        addressesOverride.length > 0
-          ? addressesOverride
-          : selectedAddress
-            ? [selectedAddress]
-            : [];
-
-      let allowedChainIdsSet;
-
-      if (
-        preferredChainIds != null &&
-        Array.isArray(preferredChainIds) &&
-        preferredChainIds.length > 0
-      ) {
-        allowedChainIdsSet = buildAllowedChainIdSet(preferredChainIds);
-      } else {
-        const enabledChainIds = [];
-        for (const namespace of Object.keys(enabledNetworks || {})) {
-          const networkMap = enabledNetworks[namespace] || {};
-          for (const chainId of Object.keys(networkMap)) {
-            if (networkMap[chainId]) enabledChainIds.push(chainId);
-          }
-        }
-
-        if (enabledChainIds.length === 0) {
-          return {};
-        }
-
-        allowedChainIdsSet = new Set(enabledChainIds);
-      }
-
-      const result = {};
-      for (const address of addresses) {
-        const addressNfts = allNfts?.[address];
-        if (!addressNfts) continue;
-        for (const chainId of Object.keys(addressNfts)) {
-          if (!allowedChainIdsSet.has(chainId)) continue;
-          const nfts = addressNfts[chainId];
-          if (!Array.isArray(nfts)) continue;
-          result[chainId] = (result[chainId] || []).concat(nfts);
-        }
-      }
-
-      return result;
-    },
-  );
+  selectMultichainCollectiblesByEnabledNetworks;
 
 export const favoritesCollectiblesSelector = createSelector(
   selectSelectedInternalAccountAddress,

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -18,6 +18,7 @@ import {
   selectAssetsByAccountGroupId,
   selectAssetsBySelectedAccountGroup,
   selectHasEligibleSwapSource,
+  makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance,
   selectSortedAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroupForChainIds,
   selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance,
@@ -1324,6 +1325,24 @@ describe('selectSortedAssetsBySelectedAccountGroupForChainIds', () => {
 });
 
 describe('selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance', () => {
+  it('returns assets for the chain IDs bound to the selector factory', () => {
+    const state = mockState();
+    const chainIds = ['eip155:1', '0xa'];
+    const selectSortedAssets =
+      makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+        chainIds,
+      );
+
+    const result = selectSortedAssets(state);
+
+    expect(result).toEqual(
+      selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+        state,
+        chainIds,
+      ),
+    );
+  });
+
   it('filters assets by explicit chain IDs (same as ForChainIds)', () => {
     const state = mockState();
     const chainIds = ['eip155:1', '0xa'];

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -510,6 +510,13 @@ export const selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance =
     },
   );
 
+export const makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance =
+  (chainIds: string[]) => (state: RootState) =>
+    selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+      state,
+      chainIds,
+    );
+
 // TODO BIP44 - Remove this selector and instead pass down the asset from the token list to the list item to avoid unnecessary re-renders
 export const selectAsset = createSelector(
   [

--- a/app/selectors/currencyRateController.test.ts
+++ b/app/selectors/currencyRateController.test.ts
@@ -1,4 +1,6 @@
 import {
+  makeSelectConversionRateByChainId,
+  makeSelectUSDConversionRateByChainId,
   selectConversionRate,
   selectConversionRateByChainId,
   selectCurrencyRateForChainId,
@@ -287,6 +289,63 @@ describe('CurrencyRateController Selectors', () => {
         chainId,
       );
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('conversion rate selector factories', () => {
+    const chainId = '0x1';
+
+    beforeEach(() => {
+      (isTestNet as jest.Mock).mockReturnValue(false);
+      jest
+        .spyOn(
+          NetworkControllerSelectors,
+          'selectNetworkConfigurationByChainId',
+        )
+        .mockReturnValue({
+          nativeCurrency: 'ETH',
+        } as MultichainNetworkConfiguration);
+    });
+
+    const createMockState = (): RootState =>
+      ({
+        engine: {
+          backgroundState: {
+            CurrencyRateController: {
+              currencyRates: mockCurrencyRateState.currencyRates,
+            },
+            NetworkController: {
+              networkConfigurationsByChainId: {
+                [chainId]: {
+                  nativeCurrency: 'ETH',
+                },
+              },
+            },
+          },
+        },
+        settings: {
+          showFiatOnTestnets: true,
+        },
+      }) as unknown as RootState;
+
+    it('returns the conversion rate for the chain ID bound to the factory', () => {
+      const state = createMockState();
+      const selectConversionRateForChain =
+        makeSelectConversionRateByChainId(chainId);
+
+      const result = selectConversionRateForChain(state);
+
+      expect(result).toBe(3000);
+    });
+
+    it('returns the USD conversion rate for the chain ID bound to the factory', () => {
+      const state = createMockState();
+      const selectUSDConversionRateForChain =
+        makeSelectUSDConversionRateByChainId(chainId);
+
+      const result = selectUSDConversionRateForChain(state);
+
+      expect(result).toBe(3000);
     });
   });
 });

--- a/app/selectors/currencyRateController.ts
+++ b/app/selectors/currencyRateController.ts
@@ -84,6 +84,10 @@ export const selectConversionRateByChainId = createSelector(
   },
 );
 
+export const makeSelectConversionRateByChainId =
+  (chainId: string) => (state: RootState) =>
+    selectConversionRateByChainId(state, chainId);
+
 export const selectUsdConversionRate = createSelector(
   getCurrencyRateControllerCurrencyRates,
   getCurrencyRateControllerCurrentCurrency,
@@ -106,3 +110,7 @@ export const selectUSDConversionRateByChainId = createSelector(
     return currencyRates?.[nativeCurrency]?.usdConversionRate;
   },
 );
+
+export const makeSelectUSDConversionRateByChainId =
+  (chainId: string) => (state: RootState) =>
+    selectUSDConversionRateByChainId(state, chainId);

--- a/app/selectors/defiPositionsController.ts
+++ b/app/selectors/defiPositionsController.ts
@@ -154,3 +154,7 @@ export const selectDefiPositionsByChainIds = createDeepEqualSelector(
     return filtered;
   },
 );
+
+export const makeSelectDefiPositionsByChainIds =
+  (chainIds: Hex[] | undefined) => (state: RootState) =>
+    selectDefiPositionsByChainIds(state, chainIds);

--- a/app/selectors/nftController.ts
+++ b/app/selectors/nftController.ts
@@ -6,10 +6,12 @@ import {
 } from '@metamask/assets-controllers';
 import { Hex, KnownCaipNamespace } from '@metamask/utils';
 import { EthScope } from '@metamask/keyring-api';
+import { toHex } from '@metamask/controller-utils';
 import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectEnabledNetworksByNamespace } from './networkEnablementController';
 import { selectSelectedInternalAccountByScope } from './multichainAccounts/accounts';
+import { selectSelectedInternalAccountAddress } from './accountsController';
 
 const selectNftControllerState = (state: RootState) =>
   state.engine.backgroundState.NftController;
@@ -118,3 +120,84 @@ export const multichainCollectibleForEvmAccount = createDeepEqualSelector(
     return result;
   },
 );
+
+const buildAllowedNftChainIdSet = (chainIds: string[]): Set<string> => {
+  const allowedChainIds = new Set(chainIds);
+  for (const chainId of chainIds) {
+    if (chainId.startsWith('eip155:')) {
+      const reference = chainId.slice(7);
+      if (reference) {
+        allowedChainIds.add(toHex(reference));
+      }
+    }
+  }
+  return allowedChainIds;
+};
+
+export const selectMultichainCollectiblesByEnabledNetworks =
+  createDeepEqualSelector(
+    [
+      selectSelectedInternalAccountAddress,
+      selectAllNfts,
+      selectEnabledNetworksByNamespace,
+      (_state: RootState, preferredChainIds?: string[]) => preferredChainIds,
+      (
+        _state: RootState,
+        _preferredChainIds?: string[],
+        addressesOverride?: string[],
+      ) => addressesOverride,
+    ],
+    (
+      selectedAddress,
+      allNfts,
+      enabledNetworks,
+      preferredChainIds,
+      addressesOverride,
+    ): Record<string, Nft[]> => {
+      const addresses =
+        addressesOverride?.length && addressesOverride.length > 0
+          ? addressesOverride
+          : selectedAddress
+            ? [selectedAddress]
+            : [];
+
+      let allowedChainIds: Set<string>;
+      if (preferredChainIds?.length && preferredChainIds.length > 0) {
+        allowedChainIds = buildAllowedNftChainIdSet(preferredChainIds);
+      } else {
+        const enabledChainIds = Object.values(enabledNetworks ?? {}).flatMap(
+          (networkMap) =>
+            Object.entries(networkMap)
+              .filter(([, enabled]) => enabled)
+              .map(([chainId]) => chainId),
+        );
+        if (enabledChainIds.length === 0) {
+          return {};
+        }
+        allowedChainIds = new Set(enabledChainIds);
+      }
+
+      const result: Record<string, Nft[]> = {};
+      for (const address of addresses) {
+        const addressNfts = allNfts?.[address as Hex];
+        if (!addressNfts) {
+          continue;
+        }
+        for (const [chainId, nfts] of Object.entries(addressNfts)) {
+          if (allowedChainIds.has(chainId) && Array.isArray(nfts)) {
+            result[chainId] = (result[chainId] ?? []).concat(nfts);
+          }
+        }
+      }
+      return result;
+    },
+  );
+
+export const makeSelectMultichainCollectiblesByEnabledNetworks =
+  (preferredChainIds?: string[], addressesOverride?: string[]) =>
+  (state: RootState) =>
+    selectMultichainCollectiblesByEnabledNetworks(
+      state,
+      preferredChainIds,
+      addressesOverride,
+    );

--- a/app/selectors/settings.ts
+++ b/app/selectors/settings.ts
@@ -4,6 +4,8 @@ import { AvatarAccountType } from '../component-library/components/Avatars/Avata
 
 const selectSettings = (state: RootState) => state.settings;
 
+export const selectLockTime = (state: RootState) => state.settings.lockTime;
+
 export const selectShowFiatInTestnets = createSelector(
   selectSettings,
   (settingsState: Record<string, unknown>) =>

--- a/app/selectors/transactionController.ts
+++ b/app/selectors/transactionController.ts
@@ -464,6 +464,10 @@ export const selectTransactionMetadataById = createDeepEqualSelector(
   (transactions, id) => transactions.find((tx) => tx.id === id),
 );
 
+export const makeSelectTransactionMetadataById =
+  (id: string) => (state: RootState) =>
+    selectTransactionMetadataById(state, id);
+
 export const selectTransactionBatchMetadataById = createDeepEqualSelector(
   selectTransactionBatchesStrict,
   (_: RootState, id: string) => id,

--- a/app/selectors/user.ts
+++ b/app/selectors/user.ts
@@ -1,0 +1,3 @@
+import type { RootState } from '../reducers';
+
+export const selectAppTheme = (state: RootState) => state.user.appTheme;

--- a/tests/api-mocking/mock-responses/defaults/index.ts
+++ b/tests/api-mocking/mock-responses/defaults/index.ts
@@ -36,6 +36,7 @@ import { STATIC_ASSETS_MOCKS } from './static-assets.ts';
 import { SIGNATURE_INSIGHTS_MOCKS } from './signature-insights.ts';
 import { NFT_API_MOCKS } from './nft-api.ts';
 import { SOCIAL_API_MOCKS } from './social-api.ts';
+import { PRICE_ALERTS_API_MOCKS } from './price-alerts.ts';
 
 // Get auth mocks
 const authMocks = getAuthMocks();
@@ -68,6 +69,7 @@ export const DEFAULT_MOCKS = {
     ...(STATIC_ASSETS_MOCKS.GET || []),
     ...(NFT_API_MOCKS.GET || []),
     ...(SOCIAL_API_MOCKS.GET || []),
+    ...(PRICE_ALERTS_API_MOCKS.GET || []),
     ...(PERPS_HYPERLIQUID_MOCKS.GET || []),
     // Chains Network Mock - Provides blockchain network data
     {

--- a/tests/api-mocking/mock-responses/defaults/index.ts
+++ b/tests/api-mocking/mock-responses/defaults/index.ts
@@ -36,7 +36,6 @@ import { STATIC_ASSETS_MOCKS } from './static-assets.ts';
 import { SIGNATURE_INSIGHTS_MOCKS } from './signature-insights.ts';
 import { NFT_API_MOCKS } from './nft-api.ts';
 import { SOCIAL_API_MOCKS } from './social-api.ts';
-import { PRICE_ALERTS_API_MOCKS } from './price-alerts.ts';
 
 // Get auth mocks
 const authMocks = getAuthMocks();
@@ -69,7 +68,6 @@ export const DEFAULT_MOCKS = {
     ...(STATIC_ASSETS_MOCKS.GET || []),
     ...(NFT_API_MOCKS.GET || []),
     ...(SOCIAL_API_MOCKS.GET || []),
-    ...(PRICE_ALERTS_API_MOCKS.GET || []),
     ...(PERPS_HYPERLIQUID_MOCKS.GET || []),
     // Chains Network Mock - Provides blockchain network data
     {

--- a/tests/api-mocking/mock-responses/defaults/price-alerts.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-alerts.ts
@@ -1,18 +1,18 @@
 import { MockEventsObject } from '../../../framework';
 
 /**
- * Mock data for Price Alerts API endpoints used in E2E testing.
- * Blocks actual requests to the price-alerts supported-chains endpoint,
- * which is fetched whenever the Token Details page is opened.
+ * Default Price Alerts API mocks for E2E tests.
+ *
+ * An empty supported-chains response keeps Price Alerts disabled unless a test
+ * explicitly overrides this mock to exercise the feature.
  */
-
 export const PRICE_ALERTS_API_MOCKS: MockEventsObject = {
   GET: [
     {
       urlEndpoint:
         /^https:\/\/price-alerts\.(api|dev-api)\.cx\.metamask\.io\/v1\/alerts\/supported-chains$/,
       responseCode: 200,
-      response: ['eip155:1'],
+      response: [],
     },
   ],
 };

--- a/tests/api-mocking/mock-responses/defaults/price-alerts.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-alerts.ts
@@ -1,10 +1,9 @@
 import { MockEventsObject } from '../../../framework';
 
 /**
- * Default Price Alerts API mocks for E2E tests.
- *
- * An empty supported-chains response keeps Price Alerts disabled unless a test
- * explicitly overrides this mock to exercise the feature.
+ * Mock data for Price Alerts API endpoints used in E2E testing.
+ * Blocks actual requests to the price-alerts supported-chains endpoint,
+ * which is fetched whenever the Token Details page is opened.
  */
 export const PRICE_ALERTS_API_MOCKS: MockEventsObject = {
   GET: [
@@ -12,7 +11,7 @@ export const PRICE_ALERTS_API_MOCKS: MockEventsObject = {
       urlEndpoint:
         /^https:\/\/price-alerts\.(api|dev-api)\.cx\.metamask\.io\/v1\/alerts\/supported-chains$/,
       responseCode: 200,
-      response: [],
+      response: ['eip155:1'],
     },
   ],
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Replaces the 10 audited inline `useSelector` accessors in mobile-core-ux paths with named selectors. Adds typed selectors for lock time and app theme, selector factories for parameterized state, and relocates the multichain collectible selector into `app/selectors/` while retaining the legacy reducer export.

Homepage token, NFT, and DeFi selectors now receive network lists that are memoized by content, preserving selector identity when `useNetworkEnablement` returns a new array reference. This prevents avoidable selector recomputation and consumer re-renders without changing user-visible behavior.

Validation:
- Passed targeted unit tests: 15 suites, 267 tests.
- Passed ESLint for changed files (existing deprecation warnings only).
- `yarn lint:tsc` remains blocked by the unrelated `app/components/hooks/useBluetoothPermissions.ts:22` reference to `PERMISSIONS.IOS.BLUETOOTH`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1136

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Named Redux selector subscriptions

  Background:
    Given I am logged into MetaMask Mobile with token, NFT, and DeFi portfolio data

  Scenario: Homepage renders portfolio sections
    Given I am on the Wallet home screen
    When the Tokens, NFTs, and DeFi sections finish loading
    Then the same token, NFT, and DeFi data should be displayed
    And opening the screen should not produce a render regression in React DevTools Profiler

  Scenario: Settings and transaction details retain their selected state
    Given I am on Security & Privacy settings
    When I change the Auto-Lock duration
    Then the selected Auto-Lock duration should remain displayed

    When I open a transaction details sheet
    Then the transaction details should reflect the latest Redux transaction state
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with equivalent selector behavior and added tests; main risk is subtle memoization bugs on homepage sections, not security or data handling.
> 
> **Overview**
> Replaces inline `useSelector` / `RootState` access across homepage, settings, and transaction UI with **named selectors** and **`makeSelect*` factories** so parameterized subscriptions stay stable.
> 
> **Selector layer:** Adds `selectAppTheme`, `selectLockTime`, and factories for transaction metadata, currency rates by chain, DeFi positions, sorted tokens, and multichain NFTs. **Moves** multichain collectible filtering from `app/reducers/collectibles` into `app/selectors/nftController`, with the reducer re-exporting the canonical selector.
> 
> **Consumers:** Homepage **Tokens**, **NFTs**, and **DeFi** hooks now memoize popular network lists (string key → stable array) and bind chain/address args via `useMemo` + factory selectors to avoid extra re-renders when `useNetworkEnablement` returns new array references. **Cash** mUSD empty state uses module-level chain-bound rate selectors; **Auto-lock** uses `selectLockTime`; swap buttons use `selectIsSwapsEnabled` directly.
> 
> Tests updated for factory mocks; unit tests added for conversion-rate and sorted-asset factories. Minor whitespace-only change in E2E price-alerts mock file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c8c96d303cf14b24014797118a598b4fe01711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->