### PR TITLE
test: mock price alerts api to resolve e2e failures

### DIFF
--- a/tests/api-mocking/mock-responses/defaults/index.ts
+++ b/tests/api-mocking/mock-responses/defaults/index.ts
@@ -5,6 +5,7 @@
 
 import { DAPP_SCANNING_MOCKS } from './dapp-scanning.ts';
 import { PRICE_API_MOCKS } from './price-apis.ts';
+import { PRICE_ALERTS_API_MOCKS } from './price-alerts-api.ts';
 import { WEB_3_AUTH_MOCKS } from './web-3-auth.ts';
 import { DEFI_ADAPTERS_MOCKS } from './defi-adapter.ts';
 import { TOKEN_API_MOCKS } from './token-apis.ts';
@@ -44,6 +45,7 @@ export const DEFAULT_MOCKS = {
     ...(authMocks.GET || []),
     ...(DAPP_SCANNING_MOCKS.GET || []),
     ...(PRICE_API_MOCKS.GET || []),
+    ...(PRICE_ALERTS_API_MOCKS.GET || []),
     ...(WEB_3_AUTH_MOCKS.GET || []),
     ...(SWAP_API_MOCKS.GET || []),
     ...(STAKING_MOCKS.GET || []),

--- a/tests/api-mocking/mock-responses/defaults/price-alerts-api.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-alerts-api.ts
@@ -1,0 +1,21 @@
+import { MockEventsObject } from '../../../framework';
+
+/**
+ * Mock data for the Price Alerts API used in E2E testing.
+ *
+ * The token details screen calls GET /v1/alerts/supported-chains (via
+ * `useIsPriceAlertsChainSupported`) to decide whether to render the price
+ * alert bell icon. Any test that opens a token details page hits this
+ * endpoint, so it lives in the default mocks to avoid unmocked-request
+ * cleanup failures. Returns a stable list of CAIP-2 supported chains.
+ */
+export const PRICE_ALERTS_API_MOCKS: MockEventsObject = {
+  GET: [
+    {
+      urlEndpoint:
+        /^https:\/\/price-alerts\.(dev-api|uat-api|api)\.cx\.metamask\.io\/v1\/alerts\/supported-chains.*/,
+      responseCode: 200,
+      response: ['eip155:1'],
+    },
+  ],
+};


### PR DESCRIPTION
## **Description**

`SmokeSnaps: Name Lookup Snap Tests` (and any other E2E test that opens the token details / send screen) started failing test cleanup with:

```
Test made 1 unmocked request(s):
[GET] https://price-alerts.dev-api.cx.metamask.io/v1/alerts/supported-chains
```

This was caused by #33599 ("chore: remove price alerts FF"), which removed the `priceAlertsEnabled` remote feature flag gating and made `useIsPriceAlertsChainSupported` always call `fetchSupportedChains()` from the token details screen. Since the flag was also removed from `tests/feature-flags/feature-flag-registry.ts`, the request now fires unconditionally in every E2E run, but no default mock existed for it, so the framework's "no unmocked requests" cleanup check fails.

This PR adds `GET /v1/alerts/supported-chains` to the default E2E mocks (`tests/api-mocking/mock-responses/defaults/`), returning a stable `['eip155:1']` response, so any test that opens token details no longer trips the unmocked-request check.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #33599

## **Manual testing steps**

N/A — this is a test-infrastructure-only change (adds a default API mock); it does not touch app/runtime code or UI behavior.

```gherkin
Feature: Name Lookup Snap E2E test
  Scenario: Send flow resolves a domain via a name-lookup snap
    Given the Price Alerts supported-chains endpoint is mocked by default
    When any E2E test opens the token details / send screen
    Then no unmocked-request cleanup failure occurs
```

Verified locally by running:
```bash
yarn test:e2e:single tests/smoke/snaps/test-snap-name-lookup.spec.ts --browser=chrome
```

## **Screenshots/Recordings**

N/A — no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android — N/A, test-infra-only change, no runtime/app-code impact
- [ ] I've tested with a power user scenario — N/A
- [ ] I've instrumented key operations with Sentry traces for production performance metrics — N/A

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-infrastructure only; no app runtime or production behavior changes.
> 
> **Overview**
> Adds **default E2E API mocks** for `GET /v1/alerts/supported-chains` on the price-alerts service (dev/uat/prod host patterns), returning `['eip155:1']`, and wires them into `DEFAULT_MOCKS` alongside other default GET mocks.
> 
> This addresses **unmocked-request cleanup failures** after the price-alerts feature flag was removed and token details always calls `useIsPriceAlertsChainSupported` / `fetchSupportedChains()` when that screen opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046414a4da3f72d303aaf56048890e3266777993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->