### PR TITLE
feat: show slippage button on swaps screen before quote

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -31,6 +31,7 @@ import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/test/keyringControllerTestUtils';
 import { RootState } from '../../../../../reducers';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
+import Engine from '../../../../../core/Engine';
 import { BridgeTrendingTokensSectionTestIds } from '../../components/BridgeTrendingTokensSection/BridgeTrendingTokensSection.testIds';
 import { SwapDiscoveryFeedTestIds } from '../../components/SwapDiscoveryFeed/SwapDiscoveryFeed.testIds';
 import {
@@ -430,6 +431,73 @@ describe('BridgeView', () => {
     expect(
       getByTestId(BridgeViewSelectorsIDs.DESTINATION_TOKEN_AREA),
     ).toBeTruthy();
+  });
+
+  it('renders the slippage settings button without an active quote', () => {
+    jest
+      .mocked(useBridgeQuoteData as unknown as jest.Mock)
+      .mockImplementationOnce(() => ({
+        ...mockUseBridgeQuoteData,
+        activeQuote: null,
+        formattedQuoteData: undefined,
+      }));
+
+    const { getByTestId } = renderScreen(
+      BridgeView,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: mockState },
+    );
+
+    expect(
+      getByTestId(BridgeViewSelectorsIDs.SLIPPAGE_SETTINGS_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('opens the swap slippage modal from the settings button', () => {
+    const testState = createBridgeTestState();
+    const { getByTestId } = renderScreen(
+      BridgeView,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: testState },
+    );
+
+    fireEvent.press(
+      getByTestId(BridgeViewSelectorsIDs.SLIPPAGE_SETTINGS_BUTTON),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: testState.bridge.sourceToken?.chainId,
+        destChainId: testState.bridge.destToken?.chainId,
+      },
+    });
+  });
+
+  it('resets slippage and controller quote state when leaving the screen', () => {
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides: {
+        slippage: '3.5',
+        isSlippageUserOverride: true,
+      },
+    });
+    const { store, unmount } = renderScreen(
+      BridgeView,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: testState },
+    );
+
+    unmount();
+
+    expect(store.getState().bridge.slippage).toBeUndefined();
+    expect(store.getState().bridge.isSlippageUserOverride).toBe(false);
+    expect(Engine.context.BridgeController.resetState).toHaveBeenCalled();
   });
 
   it('scrolls to top and clears the route param when requested on focus', () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -4,6 +4,7 @@ export const BridgeViewSelectorsIDs = {
   SOURCE_TOKEN_INPUT: 'source-token-area-input',
   SOURCE_AMOUNT_TYPE_TOGGLE: 'source-token-area-amount-type-toggle',
   DESTINATION_TOKEN_INPUT: 'dest-token-area-input',
+  SLIPPAGE_SETTINGS_BUTTON: 'bridge-slippage-settings-button',
   CONFIRM_BUTTON: 'bridge-confirm-button',
   CONFIRM_BUTTON_KEYPAD: 'bridge-confirm-button-keypad',
   BRIDGE_VIEW_SCROLL: 'bridge-view-scroll',

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -317,12 +317,6 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
   const slippage = useSelector(selectSlippage);
   const isSlippageUserOverride = useSelector(selectIsSlippageUserOverride);
-
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log('[SWAPS-4815] BridgeView slippage:', slippage);
-  }, [slippage]);
-
   const previousSlippageRef = useRef(slippage);
   const nonSlippageQuoteRequestKey = JSON.stringify([
     sourceAmount,

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -317,6 +317,12 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   const { quotesLastFetched } = useSelector(selectBridgeControllerState);
   const slippage = useSelector(selectSlippage);
   const isSlippageUserOverride = useSelector(selectIsSlippageUserOverride);
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('[SWAPS-4815] BridgeView slippage:', slippage);
+  }, [slippage]);
+
   const previousSlippageRef = useRef(slippage);
   const nonSlippageQuoteRequestKey = JSON.stringify([
     sourceAmount,
@@ -480,6 +486,16 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     headerTitle = `${strings('swaps.title')}/${strings('bridge.title')}`;
   }
 
+  const handleSlippageSettingsPress = useCallback(() => {
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.SWAP_DEFAULT_SLIPPAGE_MODAL,
+      params: {
+        sourceChainId: sourceToken?.chainId,
+        destChainId: destToken?.chainId,
+      },
+    });
+  }, [destToken?.chainId, navigation, sourceToken?.chainId]);
+
   useTrackSwapPageViewed(location);
 
   const handleSourceMaxPress = () => {
@@ -564,6 +580,14 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
       <HeaderStandard
         title={headerTitle}
         onBack={() => navigation.goBack()}
+        endButtonIconProps={[
+          {
+            iconName: IconName.Setting,
+            onPress: handleSlippageSettingsPress,
+            testID: BridgeViewSelectorsIDs.SLIPPAGE_SETTINGS_BUTTON,
+            accessibilityLabel: strings('bridge.slippage'),
+          },
+        ]}
         includesTopInset
       />
       <ScreenView safeAreaEdges={[]} contentContainerStyle={styles.screen}>

--- a/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.test.tsx
@@ -273,6 +273,33 @@ describe('DefaultSlippageModal', () => {
   });
 
   describe('handleSubmit', () => {
+    it('disables submit when EVM slippage is undefined', () => {
+      mockSelector.mockReturnValue(undefined);
+      mockUseSlippageConfig.mockReturnValue({
+        ...mockSlippageConfig,
+        default_slippage_options: ['0.5', '2', '3'],
+      });
+      const { getByRole } = render(<DefaultSlippageModal />);
+
+      const submitButton = getByRole('button', { name: 'Submit' });
+
+      expect(submitButton.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    it('does not dispatch when EVM slippage is undefined', () => {
+      mockSelector.mockReturnValue(undefined);
+      mockUseSlippageConfig.mockReturnValue({
+        ...mockSlippageConfig,
+        default_slippage_options: ['0.5', '2', '3'],
+      });
+      const { getByRole } = render(<DefaultSlippageModal />);
+      const submitButton = getByRole('button', { name: 'Submit' });
+
+      fireEvent.press(submitButton);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
     it('dispatches undefined when auto is selected', () => {
       mockSelector.mockReturnValue(undefined);
 

--- a/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.test.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.test.tsx
@@ -141,6 +141,22 @@ describe('DefaultSlippageModal', () => {
       );
     });
 
+    it('keeps slippage undefined for EVM options without auto', () => {
+      mockSelector.mockReturnValue(undefined);
+      mockUseSlippageConfig.mockReturnValue({
+        ...mockSlippageConfig,
+        default_slippage_options: ['0.5', '2', '3'],
+      });
+
+      render(<DefaultSlippageModal />);
+
+      expect(mockUseGetSlippageOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          slippage: undefined,
+        }),
+      );
+    });
+
     it('uses redux slippage value when defined', () => {
       mockSelector.mockReturnValue('2');
 

--- a/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.tsx
@@ -54,8 +54,10 @@ export const DefaultSlippageModalContent = ({
   }, [onOpenCustomSlippage]);
 
   const handleSubmit = useCallback(() => {
+    if (selectedSlippage === undefined) return;
+
     const nextSlippage =
-      selectedSlippage === undefined || selectedSlippage === AUTO_SLIPPAGE_VALUE
+      selectedSlippage === AUTO_SLIPPAGE_VALUE
         ? undefined
         : String(selectedSlippage);
 
@@ -100,6 +102,7 @@ export const DefaultSlippageModalContent = ({
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           onPress={handleSubmit}
+          isDisabled={selectedSlippage === undefined}
           isFullWidth
         >
           {strings('bridge.submit')}

--- a/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.tsx
+++ b/app/components/UI/Bridge/components/SlippageModal/DefaultSlippageModal.tsx
@@ -35,10 +35,15 @@ export const DefaultSlippageModalContent = ({
   onOpenCustomSlippage,
 }: DefaultSlippageModalContentProps) => {
   const sheetRef = useRef<BottomSheetRef>(null);
-  const [selectedSlippage, setSelectedSlippage] = useState<SlippageType>(
-    initialSlippage ?? AUTO_SLIPPAGE_VALUE,
-  );
   const slippageConfig = useSlippageConfig({ sourceChainId, destChainId });
+  const [selectedSlippage, setSelectedSlippage] = useState<
+    SlippageType | undefined
+  >(
+    initialSlippage ??
+      (slippageConfig.default_slippage_options.includes(AUTO_SLIPPAGE_VALUE)
+        ? AUTO_SLIPPAGE_VALUE
+        : undefined),
+  );
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -20,7 +20,11 @@ import { RootState } from '../../../../../reducers';
 import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/test/keyringControllerTestUtils';
 import { BigNumber } from 'ethers';
 import Engine from '../../../../../core/Engine';
-import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
+import {
+  setSlippage,
+  setSlippageUserOverride,
+  setSourceAmount,
+} from '../../../../../core/redux/slices/bridge';
 import {
   ChainId,
   MetaMetricsSwapsEventSource,
@@ -917,6 +921,107 @@ describe('SwapsConfirmButton', () => {
       const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
       expect(button.props.accessibilityState?.disabled).toBe(false);
       expect(getByText(strings('bridge.confirm_swap'))).toBeTruthy();
+    });
+
+    it('shows loading when user slippage changes before quote refresh starts', () => {
+      const { getByTestId, store } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: mockState,
+        },
+      );
+
+      act(() => {
+        store.dispatch(setSlippageUserOverride('3.5'));
+      });
+
+      const button = getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON);
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      expect(button.props.accessibilityState?.busy).toBe(true);
+    });
+
+    it('enables confirmation after the custom-slippage quote settles', () => {
+      const customSlippageQuote = {
+        ...mockActiveQuote,
+        quote: {
+          ...mockActiveQuote.quote,
+          slippage: 3.5,
+        },
+      };
+      let quoteData = {
+        ...mockUseBridgeQuoteData,
+        activeQuote: mockActiveQuote,
+        isLoading: false,
+      };
+      jest
+        .mocked(useBridgeQuoteData as unknown as jest.Mock)
+        .mockImplementation(() => quoteData);
+      const state = {
+        ...mockState,
+        bridge: {
+          ...mockState.bridge,
+          slippage: '3.5',
+          isSlippageUserOverride: true,
+        },
+      };
+      const { getByTestId, rerender } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        { state },
+      );
+      quoteData = {
+        ...quoteData,
+        isLoading: true,
+      };
+      rerender(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+      );
+      quoteData = {
+        ...quoteData,
+        activeQuote: customSlippageQuote,
+        isLoading: false,
+      };
+
+      rerender(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+      );
+
+      expect(
+        getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+          .accessibilityState?.disabled,
+      ).toBe(false);
+    });
+
+    it('keeps confirmation enabled when the backend hydrates slippage', () => {
+      const { getByTestId, store } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: mockState,
+        },
+      );
+
+      act(() => {
+        store.dispatch(setSlippage('0.5'));
+      });
+
+      expect(
+        getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON).props
+          .accessibilityState?.disabled,
+      ).toBe(false);
     });
   });
 

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -11,6 +11,8 @@ import {
   selectBridgeFeatureFlags,
   selectIsSolanaSourced,
   selectIsSubmittingTx,
+  selectIsSlippageUserOverride,
+  selectSlippage,
   selectSourceAmount,
   selectSourceToken,
   selectDestToken,
@@ -64,6 +66,8 @@ export const SwapsConfirmButton = ({
   const updateQuoteParams = useBridgeQuoteRequest();
   const sourceAmount = useSelector(selectSourceAmount);
   const sourceToken = useSelector(selectSourceToken);
+  const slippage = useSelector(selectSlippage);
+  const isSlippageUserOverride = useSelector(selectIsSlippageUserOverride);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
   const walletAddress = useSelector(selectSourceWalletAddress);
   const selectedAddress = useSelector(
@@ -140,6 +144,7 @@ export const SwapsConfirmButton = ({
   // The ref only updates when loading finishes (quote arrived / error)
   // so it stays stale during the debounce window after the user edits.
   const settledAmountRef = useRef(sourceAmount);
+  const settledSlippageRef = useRef(slippage);
   const wasLoadingRef = useRef(isLoading);
 
   const hasError = !!blockaidError || !!quoteFetchError || isNoQuotesAvailable;
@@ -148,11 +153,16 @@ export const SwapsConfirmButton = ({
     const loadingJustFinished = wasLoadingRef.current && !isLoading;
     if (loadingJustFinished || hasError || needsNewQuote) {
       settledAmountRef.current = sourceAmount;
+      settledSlippageRef.current = slippage;
     }
     wasLoadingRef.current = isLoading;
-  }, [isLoading, sourceAmount, hasError, needsNewQuote]);
+  }, [isLoading, sourceAmount, slippage, hasError, needsNewQuote]);
 
   const isSourceAmountChanged = sourceAmount !== settledAmountRef.current;
+  const isActiveQuoteSlippageMismatch =
+    slippage !== undefined &&
+    activeQuote != null &&
+    Number(slippage) !== Number(activeQuote.quote.slippage);
 
   // True when user has entered a valid amount but the quote fetch hasn't
   // started yet (e.g. during the debounce window after typing).
@@ -162,12 +172,16 @@ export const SwapsConfirmButton = ({
   // True when the sourceAmount changed from what the current quote was
   // fetched for (stale quote during debounce window).
   const isPendingQuoteRefresh = isSourceAmountChanged && hasNonZeroSourceAmount;
+  const isPendingSlippageRefresh =
+    Boolean(isSlippageUserOverride) &&
+    (slippage !== settledSlippageRef.current || isActiveQuoteSlippageMismatch);
 
   const isSubmitDisabled =
     !hasNonZeroSourceAmount ||
     isAwaitingQuote ||
     (activeQuote && !isActiveQuoteForCurrentTokenPair) ||
     isPendingQuoteRefresh ||
+    isPendingSlippageRefresh ||
     (isLoading && !activeQuote) ||
     hasInsufficientBalance ||
     hasInsufficientNativeReserveError ||
@@ -242,7 +256,11 @@ export const SwapsConfirmButton = ({
   const buttonIsInLoadingState =
     !needsNewQuote &&
     !hasError &&
-    (isLoading || isSubmittingTx || isAwaitingQuote || isPendingQuoteRefresh) &&
+    (isLoading ||
+      isSubmittingTx ||
+      isAwaitingQuote ||
+      isPendingQuoteRefresh ||
+      isPendingSlippageRefresh) &&
     isSubmitDisabled;
 
   const label = useMemo(() => {

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
@@ -102,6 +102,29 @@ describe('useBridgeConfirm', () => {
       });
     });
 
+    it('forwards the quote fetched with custom slippage unchanged', async () => {
+      const customSlippageQuote = {
+        ...mockQuoteWithMetadata,
+        quote: {
+          ...mockQuoteWithMetadata.quote,
+          slippage: 3.5,
+        },
+      };
+      const { result } = renderHook({
+        ...defaultParams,
+        activeQuote: customSlippageQuote,
+      });
+
+      await act(async () => {
+        await result.current();
+      });
+
+      expect(mockSubmitBridgeTx).toHaveBeenCalledWith({
+        quoteResponse: customSlippageQuote,
+        location: MetaMetricsSwapsEventSource.MainView,
+      });
+    });
+
     it('passes the location prop through to submitBridgeTx', async () => {
       const { result } = renderHook({
         ...defaultParams,
@@ -175,6 +198,26 @@ describe('useBridgeConfirm', () => {
       });
 
       expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    it('keeps the slippage override after successful submission', async () => {
+      const state = {
+        bridge: {
+          ...mockBridgeReducerState,
+          slippage: '3.5',
+          isSlippageUserOverride: true,
+        },
+      };
+      const { result, store } = renderHook(defaultParams, state);
+
+      await act(async () => {
+        await result.current();
+      });
+
+      expect((store.getState() as RootState).bridge.slippage).toBe('3.5');
+      expect(
+        (store.getState() as RootState).bridge.isSlippageUserOverride,
+      ).toBe(true);
     });
   });
 

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -126,9 +126,6 @@ export const useBridgeQuoteRequest = (
       insufficientBal,
     };
 
-    // eslint-disable-next-line no-console
-    console.log('[SWAPS-4815] Quote request slippage:', params.slippage);
-
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
       params,
       context,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -126,6 +126,9 @@ export const useBridgeQuoteRequest = (
       insufficientBal,
     };
 
+    // eslint-disable-next-line no-console
+    console.log('[SWAPS-4815] Quote request slippage:', params.slippage);
+
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
       params,
       context,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -152,6 +152,58 @@ describe('useBridgeQuoteRequest', () => {
     expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalled();
   });
 
+  it('includes the custom slippage in quote parameters', async () => {
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides: {
+        slippage: '3.5',
+        isSlippageUserOverride: true,
+      },
+    });
+    const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+      state: testState,
+    });
+
+    await act(async () => {
+      await result.current();
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
+    });
+
+    expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slippage: 3.5,
+      }),
+      undefined,
+      0,
+      1,
+    );
+  });
+
+  it('omits slippage from quote parameters for Auto', async () => {
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides: {
+        slippage: undefined,
+        isSlippageUserOverride: true,
+      },
+    });
+    const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+      state: testState,
+    });
+
+    await act(async () => {
+      await result.current();
+      jest.advanceTimersByTime(DEBOUNCE_WAIT);
+    });
+
+    expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slippage: undefined,
+      }),
+      undefined,
+      0,
+      1,
+    );
+  });
+
   it('skips update when source token is missing', async () => {
     const testState = createBridgeTestState({
       bridgeReducerOverrides: {

--- a/app/components/UI/Bridge/hooks/useGetSlippageOptions/index.test.tsx
+++ b/app/components/UI/Bridge/hooks/useGetSlippageOptions/index.test.tsx
@@ -116,6 +116,21 @@ describe('useGetSlippageOptions', () => {
     expect(result.current[3].selected).toBe(false); // 3
   });
 
+  it('does not select an option when slippage is undefined', () => {
+    const { result } = renderHook(() =>
+      useGetSlippageOptions({
+        ...defaultProps,
+        allowCustomSlippage: true,
+        slippageOptions: ['0.5', '2', '3'],
+        slippage: undefined,
+      }),
+    );
+
+    result.current.forEach((option) => {
+      expect(option.selected).toBe(false);
+    });
+  });
+
   it('set custom slippage option if slippage value does not exist on slippageOptions array', () => {
     const { result } = renderHook(() =>
       useGetSlippageOptions({

--- a/app/components/UI/Bridge/hooks/useGetSlippageOptions/index.ts
+++ b/app/components/UI/Bridge/hooks/useGetSlippageOptions/index.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 interface Props {
   allowCustomSlippage?: boolean;
   slippageOptions: readonly string[];
-  slippage: string;
+  slippage?: string;
   onDefaultOptionPress: (value: SlippageType) => () => void;
   onCustomOptionPress?: () => void;
 }
@@ -31,9 +31,9 @@ export const useGetSlippageOptions = ({
         id: 'custom-slippage',
         label: strings('bridge.custom'),
         onPress: onCustomOptionPress,
-        selected: !slippageOptions.some(
-          (value) => String(value) === String(slippage),
-        ),
+        selected:
+          slippage !== undefined &&
+          !slippageOptions.some((value) => String(value) === String(slippage)),
       });
     }
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -303,6 +303,49 @@ describe('bridge slice', () => {
         '0x0000000000000000000000000000000000000000',
       );
     });
+
+    it('clears slippage when the source token changes', () => {
+      const state = reducer(
+        { ...initialState, slippage: '2', isSlippageUserOverride: true },
+        setSourceToken(mockToken),
+      );
+
+      expect(state.slippage).toBeUndefined();
+      expect(state.isSlippageUserOverride).toBe(false);
+    });
+
+    it('keeps slippage when the source token identity is unchanged', () => {
+      const state = reducer(
+        {
+          ...initialState,
+          sourceToken: mockToken,
+          slippage: '2',
+          isSlippageUserOverride: true,
+        },
+        setSourceToken({ ...mockToken }),
+      );
+
+      expect(state.slippage).toBe('2');
+      expect(state.isSlippageUserOverride).toBe(true);
+    });
+
+    it('clears slippage when the token address is unchanged on another network', () => {
+      const state = reducer(
+        {
+          ...initialState,
+          sourceToken: mockToken,
+          slippage: '2',
+          isSlippageUserOverride: true,
+        },
+        setSourceToken({
+          ...mockToken,
+          chainId: '0x89',
+        }),
+      );
+
+      expect(state.slippage).toBeUndefined();
+      expect(state.isSlippageUserOverride).toBe(false);
+    });
   });
 
   describe('batch sell state', () => {
@@ -518,6 +561,8 @@ describe('bridge slice', () => {
         destAmount: '100',
         sourceToken: mockToken,
         destToken: mockDestToken,
+        slippage: '3.5',
+        isSlippageUserOverride: true,
         bridgeViewMode: BridgeViewMode.Bridge,
       };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a persistent slippage settings button to the Unified Swaps header so users can configure slippage before a quote is available. The selected threshold is retained for the current token pair and session, included in subsequent quote requests, and reset when the pair changes or the user leaves the Swaps screen.

The confirmation button remains disabled while a quote using the selected slippage is pending, preventing submission of a stale quote. EVM pairs with undefined slippage show no selected option, while Solana retains the existing Auto selection.

Automated coverage was added for settings navigation, quote propagation, stale-quote blocking, submission forwarding, session reset boundaries, and EVM undefined-slippage selection.

We explicitly highlight nothing in EVM when the slippage is `undefined` (matches Extension `main` behavior). Backend has a default slippage of 2% which will be returned with the quote.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added slippage settings to Swaps before a quote is available

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: SWAPS-4815

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Configure slippage from Unified Swaps

  Scenario: Set custom slippage before a quote is available
    Given the user is on the Swaps screen with an EVM token pair and no active quote

    When the user opens the header slippage settings, enters a custom threshold, and submits it
    Then a new quote is requested with the custom threshold
    And confirmation remains unavailable until the matching quote settles

  Scenario: Retain slippage for the current pair
    Given the user selected a custom slippage threshold

    When subsequent quotes are fetched for the same source and destination tokens
    Then the custom threshold remains selected and is included in each quote request

  Scenario: Reset slippage outside the current pair or session
    Given the user selected a custom slippage threshold

    When the user changes either token or network, or leaves and re-enters Swaps
    Then slippage returns to its default behavior

  Scenario: Display undefined slippage correctly
    Given slippage is undefined

    When the user opens slippage settings for an EVM pair
    Then no slippage option is highlighted
    And Auto remains highlighted when the source chain is Solana
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — not provided.

### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/10c62f82-038d-4a64-994a-ab35915c965d





## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swap confirmation gating and quote request parameters; incorrect stale-quote or slippage-reset behavior could block swaps or submit wrong slippage, but changes are scoped to bridge UI/state with broad test coverage.
> 
> **Overview**
> Adds a **header settings control** on Unified Swaps/Bridge so users can open slippage configuration **before any quote exists**, navigating to the existing swap default slippage modal with source/destination chain context.
> 
> **Slippage selection and quotes:** Custom slippage is sent on quote requests when set; **Auto** omits `slippage` from params. The confirm button **stays disabled/loading** while a user override is waiting for a quote that matches the chosen slippage (including mismatch with `activeQuote.quote.slippage`). Backend-only slippage hydration does not block confirm or force an extra quote when other inputs are unchanged.
> 
> **EVM vs Solana UI:** When config has no Auto option, initial selection can be **undefined** (no preset highlighted); submit is disabled until the user picks a value. Solana-style configs still default to Auto.
> 
> **Session boundaries:** Leaving the screen resets bridge Redux (including slippage override) and `BridgeController.resetState`; changing source token identity (including chain) clears slippage per reducer tests. Override is retained through successful swap submission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2b6b5f8a2dba556353234e34a93d445044eba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[SWAPS-4815]: https://consensyssoftware.atlassian.net/browse/SWAPS-4815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ