### PR TITLE
feat: make watchlist row draggable cp-8.5.0

### DIFF
--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistEditableRow.test.tsx
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistEditableRow.test.tsx
@@ -73,7 +73,7 @@ describe('WatchlistEditableRow', () => {
     expect(getByText('Ethereum')).toBeDefined();
   });
 
-  it('renders drag handle in edit mode', () => {
+  it('renders drag area in edit mode', () => {
     const { getByTestId } = render(
       <WatchlistEditableRow token={createToken()} position={0} isEditMode />,
     );
@@ -83,7 +83,7 @@ describe('WatchlistEditableRow', () => {
     ).toBeDefined();
   });
 
-  it('calls reorderable drag on long press of drag handle in edit mode', () => {
+  it('calls reorderable drag on long press of the row in edit mode', () => {
     const { getByTestId } = render(
       <WatchlistEditableRow token={createToken()} position={0} isEditMode />,
     );
@@ -94,6 +94,20 @@ describe('WatchlistEditableRow', () => {
     );
 
     expect(mockDrag).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not expose a drag area outside edit mode', () => {
+    const { queryByTestId } = render(
+      <WatchlistEditableRow
+        token={createToken()}
+        position={0}
+        isEditMode={false}
+      />,
+    );
+
+    expect(
+      queryByTestId(WatchlistFullScreenViewSelectorsIDs.DRAG_HANDLE),
+    ).toBeNull();
   });
 
   it('calls onRemoveFromDraft when unwatch star is pressed in edit mode', () => {

--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistEditableRow.tsx
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistEditableRow.tsx
@@ -25,6 +25,11 @@ interface WatchlistEditableRowProps {
   onRemoveFromDraft?: (assetId: string) => void;
 }
 
+/**
+ * In edit mode the whole row (except the trash control) long-presses to drag.
+ * The drag-grid icon is a visual affordance only — a small left-edge hit target
+ * conflicts with Android's system back gesture.
+ */
 const WatchlistEditableRow = ({
   token,
   position,
@@ -38,26 +43,17 @@ const WatchlistEditableRow = ({
     onRemoveFromDraft?.(String(token.assetId));
   }, [onRemoveFromDraft, token.assetId]);
 
-  return (
-    <View
-      style={styles.editableRow}
-      testID={WatchlistFullScreenViewSelectorsIDs.EDITABLE_ROW}
-    >
+  const rowBody = (
+    <>
       <View
         style={isEditMode ? styles.dragHandle : styles.editControlHidden}
-        pointerEvents={isEditMode ? 'auto' : 'none'}
+        pointerEvents="none"
       >
-        <Pressable
-          onLongPress={drag}
-          disabled={!isEditMode}
-          testID={WatchlistFullScreenViewSelectorsIDs.DRAG_HANDLE}
-        >
-          <Icon
-            name={LocalIconName.DragGrid}
-            size={IconSize.Md}
-            color={IconColor.Muted}
-          />
-        </Pressable>
+        <Icon
+          name={LocalIconName.DragGrid}
+          size={IconSize.Md}
+          color={IconColor.Muted}
+        />
       </View>
 
       <View
@@ -70,6 +66,28 @@ const WatchlistEditableRow = ({
           tokenDetailsSource={TokenDetailsSource.WatchlistFullscreen}
         />
       </View>
+    </>
+  );
+
+  return (
+    <View
+      style={styles.editableRow}
+      testID={WatchlistFullScreenViewSelectorsIDs.EDITABLE_ROW}
+    >
+      {isEditMode ? (
+        <Pressable
+          style={styles.dragArea}
+          onLongPress={drag}
+          delayLongPress={300}
+          testID={WatchlistFullScreenViewSelectorsIDs.DRAG_HANDLE}
+          accessibilityRole="button"
+          accessibilityLabel="Drag to reorder"
+        >
+          {rowBody}
+        </Pressable>
+      ) : (
+        <View style={styles.dragArea}>{rowBody}</View>
+      )}
 
       <View
         style={isEditMode ? styles.unwatchStar : styles.editControlHidden}

--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistFullScreenView.styles.ts
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistFullScreenView.styles.ts
@@ -34,6 +34,12 @@ const styleSheet = (params: { theme: Theme }) => {
       flexDirection: 'row',
       alignItems: 'flex-start',
     },
+    dragArea: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      minWidth: 0,
+    },
     dragHandle: {
       height: 40,
       marginTop: 8,

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
@@ -598,6 +598,40 @@ describe('shared tokenWatchlistBatcher cross-mutation coalescing', () => {
     });
   });
 
+  it('does not invalidate hydrated when add is unwatched before add settles', async () => {
+    const { Wrapper, queryClient } = createWrapper();
+    seedCache(queryClient, { assets: [ASSET_A], version: 1 });
+    seedHydratedCache(queryClient, hydratedFor([ASSET_A]));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result: add } = renderHook(
+      () => useTokenWatchlistAddItemMutation(),
+      { wrapper: Wrapper },
+    );
+    const { result: remove } = renderHook(
+      () => useTokenWatchlistRemoveItemMutation(),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      const pendingAdd = add.current.mutateAsync(ASSET_B);
+      const pendingRemove = remove.current.mutateAsync(ASSET_B);
+      await drainBatcher();
+      await Promise.all([pendingAdd, pendingRemove]);
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: tokenWatchlistQueryKeys.hydrated,
+    });
+    expect(readCache(queryClient)).toStrictEqual({
+      assets: [ASSET_A],
+      version: 1,
+    });
+    expect(readHydratedCache(queryClient)).toStrictEqual(
+      hydratedFor([ASSET_A]),
+    );
+  });
+
   it('lets a replace op overwrite any add/remove ops submitted before it in the same batch', async () => {
     const { Wrapper, queryClient } = createWrapper();
     seedCache(queryClient, { assets: [ASSET_A], version: 1 });

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
@@ -129,10 +129,18 @@ const useWatchlistMutation = <TInput>({
   applyOptimistic,
   toOp,
   invalidateOnSettled = { blob: true, hydrated: true },
+  shouldInvalidateHydrated,
 }: {
   applyOptimistic: (current: readonly string[], input: TInput) => string[];
   toOp: (input: TInput) => WatchlistOp;
   invalidateOnSettled?: InvalidateOnSettledOptions;
+  /**
+   * Optional gate for hydrated invalidation. Used by add to skip refetch when
+   * the added IDs were already removed before the mutation settled (quick
+   * watch→unwatch), which would otherwise race a late getTokens result back
+   * into the list.
+   */
+  shouldInvalidateHydrated?: (input: TInput) => boolean;
 }) => {
   const queryClient = useQueryClient();
 
@@ -182,13 +190,16 @@ const useWatchlistMutation = <TInput>({
         );
       }
     },
-    onSettled: () => {
+    onSettled: (_data, _error, input) => {
       if (invalidateOnSettled.blob !== false) {
         queryClient.invalidateQueries({
           queryKey: tokenWatchlistQueryKeys.blob,
         });
       }
-      if (invalidateOnSettled.hydrated !== false) {
+      const shouldInvalidate =
+        invalidateOnSettled.hydrated !== false &&
+        (shouldInvalidateHydrated?.(input) ?? true);
+      if (shouldInvalidate) {
         queryClient.invalidateQueries({
           queryKey: tokenWatchlistQueryKeys.hydrated,
         });
@@ -202,14 +213,31 @@ const useWatchlistMutation = <TInput>({
  * optimistic cache updates with rollback and enqueues an `add` op into
  * the shared {@link tokenWatchlistBatcher}.
  */
-export const useTokenWatchlistAddItemMutation = () =>
-  useWatchlistMutation<WatchlistAddInput>({
+export const useTokenWatchlistAddItemMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useWatchlistMutation<WatchlistAddInput>({
     applyOptimistic: (current, input) =>
       mergeAssets(current, toStrings(asArray(input))),
     toOp: (input) => ({ kind: 'add', ids: toStrings(asArray(input)) }),
     // Blob is already correct after onMutate; hydrated needs getTokens for metadata.
     invalidateOnSettled: { blob: false, hydrated: true },
+    shouldInvalidateHydrated: (input) => {
+      const blob = queryClient.getQueryData<WatchlistBlob>(
+        tokenWatchlistQueryKeys.blob,
+      );
+      // Cold blob cache: still refetch so newly added metadata can load.
+      if (blob === undefined) {
+        return true;
+      }
+      const addedIds = toStrings(asArray(input));
+      // Skip refetch if every added id was already removed (quick toggle).
+      return addedIds.some((id) =>
+        blob.assets.some((asset) => asset.toLowerCase() === id.toLowerCase()),
+      );
+    },
   });
+};
 
 /**
  * Remove one or more `CaipAssetType` ids from the watchlist. Mirrors

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.test.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.test.ts
@@ -151,6 +151,72 @@ describe('useTokenWatchlistQuery', () => {
     ]);
   });
 
+  it('drops tokens removed from the optimistic blob while getTokens is in flight', async () => {
+    const { Wrapper, queryClient } = createWrapper();
+    mockedReadFromTokenWatchList.mockResolvedValue({
+      assets: ['eip155:1/slip44:60', 'eip155:1/erc20:0xbbb'],
+      version: 1,
+    });
+
+    let resolveGetTokens:
+      | ((
+          value: {
+            assetId: string;
+            symbol: string;
+            name: string;
+            decimals: number;
+          }[],
+        ) => void)
+      | null = null;
+    mockedGetTokens.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGetTokens = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useTokenWatchlistQuery(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(mockedGetTokens).toHaveBeenCalled();
+    });
+
+    // Simulate remove winning while Token API hydration is still pending.
+    queryClient.setQueryData(tokenWatchlistQueryKeys.blob, {
+      assets: ['eip155:1/slip44:60'],
+      version: 1,
+    });
+
+    await waitFor(() => {
+      expect(resolveGetTokens).not.toBeNull();
+    });
+
+    resolveGetTokens?.([
+      {
+        assetId: 'eip155:1/slip44:60',
+        symbol: 'ETH',
+        name: 'Ethereum',
+        decimals: 18,
+      },
+      {
+        assetId: 'eip155:1/erc20:0xbbb',
+        symbol: 'BBB',
+        name: 'Token BBB',
+        decimals: 18,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toStrictEqual(true);
+    });
+
+    expect(result.current.data?.map((token) => token.assetId)).toStrictEqual([
+      'eip155:1/slip44:60',
+    ]);
+  });
+
   it('hydrates the user balance from controller state for watched tokens held by the wallet', async () => {
     mockAssetsByChain = {
       'eip155:1': [

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.test.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.test.ts
@@ -158,19 +158,16 @@ describe('useTokenWatchlistQuery', () => {
       version: 1,
     });
 
-    let resolveGetTokens:
-      | ((
-          value: {
-            assetId: string;
-            symbol: string;
-            name: string;
-            decimals: number;
-          }[],
-        ) => void)
-      | null = null;
+    interface TokenFixture {
+      assetId: string;
+      symbol: string;
+      name: string;
+      decimals: number;
+    }
+    let resolveGetTokens!: (value: TokenFixture[]) => void;
     mockedGetTokens.mockImplementation(
       () =>
-        new Promise((resolve) => {
+        new Promise<TokenFixture[]>((resolve) => {
           resolveGetTokens = resolve;
         }),
     );
@@ -189,11 +186,7 @@ describe('useTokenWatchlistQuery', () => {
       version: 1,
     });
 
-    await waitFor(() => {
-      expect(resolveGetTokens).not.toBeNull();
-    });
-
-    resolveGetTokens?.([
+    resolveGetTokens([
       {
         assetId: 'eip155:1/slip44:60',
         symbol: 'ETH',

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistQuery.ts
@@ -1,10 +1,14 @@
 import { useMemo } from 'react';
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 
 import { selectAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { selectTokenWatchlistEnabled } from '../../../Assets/selectors/featureFlags';
-import { readFromTokenWatchList } from '../storage';
+import { readFromTokenWatchList, type WatchlistBlob } from '../storage';
 import {
   addBalanceToTokens,
   buildAssetsByAssetId,
@@ -44,6 +48,8 @@ export const useTokenWatchlistQuery = (
     [assetsByChain],
   );
 
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: suggestedTokens
       ? tokenWatchlistQueryKeys.suggested(suggestedIncludeSpaceX)
@@ -58,7 +64,28 @@ export const useTokenWatchlistQuery = (
       if (!blob.assets.length) {
         return [];
       }
-      return getTokens(blob.assets);
+      const tokens = await getTokens(blob.assets);
+
+      // Reconcile against the latest optimistic blob (preferred) or storage.
+      // A slow getTokens started by add can otherwise finish after remove and
+      // resurrect a token the user already unwatched.
+      const cachedBlob = queryClient.getQueryData<WatchlistBlob>(
+        tokenWatchlistQueryKeys.blob,
+      );
+      const latestAssets =
+        cachedBlob?.assets ?? (await readFromTokenWatchList()).assets;
+      if (!latestAssets.length) {
+        return [];
+      }
+
+      const byId = new Map(
+        tokens.map((token) => [String(token.assetId).toLowerCase(), token]),
+      );
+      return latestAssets
+        .map((id) => byId.get(id.toLowerCase()))
+        .filter(
+          (token): token is WatchlistTokenMetadata => token !== undefined,
+        );
     },
     select: (tokens: WatchlistTokenMetadata[]) =>
       addBalanceToTokens(tokens, assetsByAssetId),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes two watchlist interaction issues:

1. **Unreliable drag activation on Android** — makes the whole watchlist row (except the trash control) long-pressable to start a drag instead of requiring users to press the small left-edge drag-grid icon.
2. **Quick watch→unwatch race** — prevents a token from reappearing in the full-screen watchlist when a user quickly watches and unwatches it in search, then returns to the list.

### Why
After shipping drag-and-drop in #33677, Android users sometimes could not start a drag from the handle icon because the left-edge hit target conflicts with Android's system back gesture. Reducing the long-press delay from the React Native default (500ms) to **300ms** also makes drag activation more responsive.

The quick watch→unwatch flow exposed a separate React Query race: the add mutation could start a slow hydrated-token refetch, the remove mutation would optimistically remove the token, and then the late add refetch could write stale token metadata back into the hydrated list.

### What changed

#### Drag reliability
- Wraps the editable row body in a `Pressable` with `onLongPress={drag}` and `delayLongPress={300}`
- Keeps the drag-grid icon as a visual affordance only (`pointerEvents="none"`)
- Keeps the trash button independently tappable
- Preserves normal token-row navigation outside edit mode

#### Quick watch→unwatch consistency
- Skips the add mutation's hydrated-query invalidation when its added IDs have already been removed before the mutation settles
- Reconciles Token API hydration results against the latest optimistic watchlist blob before updating the hydrated query
- Prevents an in-flight add refetch from resurrecting a token the user already unwatched
- Adds regression tests for both the mutation invalidation race and late hydration result

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Improved watchlist drag-and-drop and fixed tokens reappearing after being quickly watched and unwatched

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3775
Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3778
Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3776

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Watchlist interaction reliability

  Scenario: User reorders a token by long-pressing the row on Android
    Given the user has at least 3 tokens on their watchlist
    And the user opens the full-screen watchlist
    And the user taps Edit

    When the user long-presses the middle of a token row (not just the drag icon)
    And moves the row to a new position
    And releases

    Then the row reorders successfully
    And the Android system back gesture is not triggered by the long-press

  Scenario: Drag activates faster than before
    Given the user is in full-screen watchlist Edit mode

    When the user long-presses a token row for about 300ms
    Then drag mode starts without needing a ~500ms press

  Scenario: Quick watch and unwatch does not leave a stale token
    Given the user opens search from the full-screen watchlist
    And the searched token is not currently watched

    When the user quickly watches and then unwatches the token
    And the user returns to the full-screen watchlist
    Then the token is not shown in the watchlist
    And the token does not reappear after the Token API request completes

  Scenario: Trash and non-edit behavior remain unchanged
    Given the user is in full-screen watchlist Edit mode
    When the user taps the trash icon on a row
    Then the token is removed from the edit draft

    Given the user is not in edit mode
    When the user taps a token row
    Then token details open as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — interaction and cache-consistency fixes with no visual design changes. Manual verification on Android is recommended.

### **Before**

<!-- [screenshots/recordings] -->

- Drag only started from the small left-edge drag-grid icon and could conflict with Android's system back gesture.
- Quickly watching and unwatching a token in search could allow a late add refetch to show the token in the watchlist.

### **After**

<!-- [screenshots/recordings] -->

- Long-pressing anywhere on the row (except trash) starts drag with a 300ms delay.
- Quick watch→unwatch remains removed even when an earlier hydration request finishes later.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches optimistic watchlist mutations and hydrated query reconciliation; wrong gating could skip needed refetches or leave list drift, but scope is limited to watchlist UI/cache with regression tests.
> 
> **Overview**
> Improves full-screen watchlist **edit-mode reordering** and fixes **stale tokens** after a fast watch then unwatch.
> 
> **Drag:** In edit mode, long-press on the **whole row** (except trash) starts reorder, with `delayLongPress={300}`. The drag-grid icon is display-only (`pointerEvents="none"`) so Android’s edge back gesture no longer fights a tiny handle. Outside edit mode there is no drag hit target; trash and normal row navigation stay as before.
> 
> **Cache race:** Add mutations can skip **hydrated** query invalidation when added IDs are already gone from the optimistic blob before settle. `useTokenWatchlistQuery` also **re-filters** `getTokens` results against the latest blob so a slow in-flight hydration cannot bring back unwatched tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58d431e14211401924c71287e1f549820f88e310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->