### PR TITLE
feat(Rewards): Update text of money card in Rewards banner carousel

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsView.constants.ts
+++ b/app/components/UI/Rewards/Views/RewardsView.constants.ts
@@ -63,6 +63,8 @@ export const REWARDS_VIEW_SELECTORS = {
   // Earn rewards section
   EARN_REWARDS_PREVIEW: 'rewards-view-earn-rewards-preview',
   EARN_REWARDS_MUSD_CARD: 'rewards-view-earn-rewards-musd-card',
+  EARN_REWARDS_MUSD_DISCLAIMER_LINK:
+    'rewards-view-earn-rewards-musd-disclaimer-link',
   EARN_REWARDS_CARD_CARD: 'rewards-view-earn-rewards-card-card',
   // Campaigns
   CAMPAIGNS_PREVIEW: 'rewards-view-campaigns-preview',

--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.test.tsx
@@ -5,6 +5,13 @@ import EarnRewardsPreview from './EarnRewardsPreview';
 import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants';
 import { handleDeeplink } from '../../../../../core/DeeplinkManager';
 import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
+import Routes from '../../../../../constants/navigation/Routes';
+import { MONEY_DISCLAIMER_URL } from '../../../../../constants/urls';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -41,7 +48,9 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string, params?: Record<string, string | number>) => {
     const map: Record<string, string> = {
       'rewards.earn_rewards.title': 'Earn rewards',
-      'rewards.earn_rewards.musd_title': 'Up to {{percentage}}% bonus on mUSD',
+      'rewards.earn_rewards.musd_money_title': 'Earn up to {{percentage}}% APY',
+      'rewards.earn_rewards.musd_disclaimer_accessibility_label':
+        'mUSD APY disclaimer',
       'rewards.earn_rewards.musd_subtitle': 'Money accounts are here',
       'rewards.earn_rewards.card_title': 'Up to 3% back on spend',
       'rewards.earn_rewards.card_subtitle': 'Get your MetaMask Card now',
@@ -225,7 +234,8 @@ describe('EarnRewardsPreview', () => {
     it('renders correct text for mUSD card', () => {
       setupSelectors({ geoLocation: 'US' });
       const { getByText } = render(<EarnRewardsPreview />);
-      expect(getByText('Up to 3.8% bonus on mUSD')).toBeOnTheScreen();
+      expect(getByText(/Earn up to 3\.8% APY/)).toBeOnTheScreen();
+      expect(getByText('*')).toBeOnTheScreen();
       expect(getByText('Money accounts are here')).toBeOnTheScreen();
     });
 
@@ -235,7 +245,7 @@ describe('EarnRewardsPreview', () => {
       } as ReturnType<typeof useMoneyAccountBalance>);
       setupSelectors({ geoLocation: 'US' });
       const { getByText } = render(<EarnRewardsPreview />);
-      expect(getByText('Up to 3% bonus on mUSD')).toBeOnTheScreen();
+      expect(getByText(/Earn up to 3% APY/)).toBeOnTheScreen();
     });
 
     it('renders correct text for MetaMask card', () => {
@@ -305,6 +315,24 @@ describe('EarnRewardsPreview', () => {
       expect(mockHandleDeeplink).toHaveBeenCalledWith({
         uri: 'metamask://money',
       });
+    });
+
+    it('opens the APY disclaimer in the in-app browser when the asterisk is pressed', () => {
+      setupSelectors({ geoLocation: 'US' });
+      const { getByTestId } = render(<EarnRewardsPreview />);
+
+      fireEvent.press(
+        getByTestId(REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_DISCLAIMER_LINK),
+        { stopPropagation: jest.fn() },
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+        params: expect.objectContaining({
+          newTabUrl: MONEY_DISCLAIMER_URL,
+        }),
+      });
+      expect(mockHandleDeeplink).not.toHaveBeenCalled();
     });
 
     it('triggers card-home deeplink when card card is pressed', () => {

--- a/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
+++ b/app/components/UI/Rewards/components/EarnRewards/EarnRewardsPreview.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  GestureResponderEvent,
   Image,
   ImageSourcePropType,
   Pressable,
@@ -9,6 +10,7 @@ import {
   useWindowDimensions,
   View,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -36,6 +38,9 @@ import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance'
 import { selectMoneyEnableMoneyAccountFlag } from '../../../Money/selectors/featureFlags';
 import musdImage from '../../../../../images/rewards/rewards-musd-earn.png';
 import cardImage from '../../../../../images/rewards/rewards-card-earn.png';
+import Routes from '../../../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import { MONEY_DISCLAIMER_URL } from '../../../../../constants/urls';
 
 const AVATAR_SIZE = 78;
 const UK_COUNTRY_CODE = 'GB';
@@ -58,7 +63,7 @@ const styles = StyleSheet.create({
 
 interface EarnCardProps {
   image: ImageSourcePropType;
-  title: string;
+  title: ReactNode;
   subtitle: string;
   onPress: () => void;
   testID: string;
@@ -100,9 +105,7 @@ const EarnCard: React.FC<EarnCardProps> = ({
         />
       </Box>
       <Box twClassName="flex-1">
-        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-          {title}
-        </Text>
+        {title}
         <Text variant={TextVariant.BodySm} twClassName="text-alternative">
           {subtitle}
         </Text>
@@ -130,6 +133,7 @@ type CarouselSlotKey = 'musd-skeleton' | 'musd' | 'card';
  */
 const EarnRewardsPreview: React.FC = () => {
   const tw = useTailwind();
+  const navigation = useNavigation<AppNavigationProp>();
   const { colors } = useTheme();
   const { width: screenWidth } = useWindowDimensions();
   // Only the left padding consumes viewport space at scroll position 0.
@@ -160,6 +164,20 @@ const EarnRewardsPreview: React.FC = () => {
   const handleMusdPress = useCallback(() => {
     handleDeeplink({ uri: MUSD_MONEY_URL });
   }, []);
+
+  const handleMusdDisclaimerPress = useCallback(
+    (event: GestureResponderEvent) => {
+      event.stopPropagation();
+      navigation.navigate(Routes.BROWSER.HOME, {
+        screen: Routes.BROWSER.VIEW,
+        params: {
+          newTabUrl: MONEY_DISCLAIMER_URL,
+          timestamp: Date.now(),
+        },
+      });
+    },
+    [navigation],
+  );
 
   const handleCardPress = useCallback(() => {
     handleDeeplink({ uri: 'metamask://card-home' });
@@ -243,9 +261,29 @@ const EarnRewardsPreview: React.FC = () => {
               <EarnCard
                 testID={REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_CARD}
                 image={musdImage}
-                title={strings('rewards.earn_rewards.musd_title', {
-                  percentage: apyPercent ?? 3,
-                })}
+                title={
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                  >
+                    {strings('rewards.earn_rewards.musd_money_title', {
+                      percentage: apyPercent ?? 3,
+                    })}
+                    <Text
+                      accessibilityRole="link"
+                      accessibilityLabel={strings(
+                        'rewards.earn_rewards.musd_disclaimer_accessibility_label',
+                      )}
+                      testID={
+                        REWARDS_VIEW_SELECTORS.EARN_REWARDS_MUSD_DISCLAIMER_LINK
+                      }
+                      twClassName="text-primary"
+                      onPress={handleMusdDisclaimerPress}
+                    >
+                      *
+                    </Text>
+                  </Text>
+                }
                 subtitle={strings('rewards.earn_rewards.musd_subtitle')}
                 onPress={handleMusdPress}
                 disabled={isDragging}
@@ -255,7 +293,14 @@ const EarnRewardsPreview: React.FC = () => {
               <EarnCard
                 testID={REWARDS_VIEW_SELECTORS.EARN_REWARDS_CARD_CARD}
                 image={cardImage}
-                title={strings('rewards.earn_rewards.card_title')}
+                title={
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                  >
+                    {strings('rewards.earn_rewards.card_title')}
+                  </Text>
+                }
                 subtitle={cardSubtitle}
                 onPress={handleCardPress}
                 disabled={isDragging}

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -45,6 +45,7 @@ export const MULTICHAIN_ACCOUNTS_URL = `https://support.metamask.io/configure/ac
 // Tokens & Swaps
 export const MUSD_LEARN_MORE_URL = `https://support.metamask.io/manage-crypto/tokens/musd/${MOBILE_UTM}`;
 export const MONEY_LANDING_URL = `https://metamask.io/money${MOBILE_UTM}`;
+export const MONEY_DISCLAIMER_URL = 'https://metamask.io/money#disclaimer';
 export const MUSD_PRICE_URL = `https://metamask.io/price/metamask-usd${MOBILE_UTM}`;
 export const MISSING_TOKENS_URL = `https://support.metamask.io/managing-my-tokens/custom-tokens/how-to-display-tokens-in-metamask/${MOBILE_UTM}`;
 export const SWAP_ISSUES_URL = `https://support.metamask.io/token-swaps/error-fetching-quote/${MOBILE_UTM}`;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10024,7 +10024,8 @@
     },
     "earn_rewards": {
       "title": "Earn rewards",
-      "musd_title": "Up to {{percentage}}% bonus on mUSD",
+      "musd_money_title": "Earn up to {{percentage}}% APY",
+      "musd_disclaimer_accessibility_label": "mUSD APY disclaimer",
       "musd_subtitle": "Money accounts are here",
       "card_title": "Up to 3% back on spend",
       "card_subtitle": "Get your MetaMask Card now",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Updates text in the money banner shown in the Rewards tab. The previous text was not aligned with the launch of money accounts. 

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-1483

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user visits Rewards tab
    Given money banner is displayed in user's jurisdiction

    When user observes the money banner
    Then it says "Up to X% APY*" 
    
    When user taps on the *
    Then user is taken to the money webpage disclaimer section
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

n/a

### **After**

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-07-24 at 15 42 47" src="https://github.com/user-attachments/assets/c7856c49-ee71-4ab5-925b-d416ff40fbcf" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Rewards UI and external disclaimer URL only; behavior is covered by unit tests and does not change money deeplink or account logic.
> 
> **Overview**
> Updates the Rewards **Earn rewards** carousel mUSD card copy from “bonus on mUSD” to **“Earn up to X% APY”** with a tappable **\*** that opens the Money disclaimer on `metamask.io/money#disclaimer` in the in-app browser (card tap still deeplinks to Money).
> 
> `EarnCard` titles are now `ReactNode` so the APY line can embed a link with `stopPropagation`, plus a new test ID and `MONEY_DISCLAIMER_URL` constant; unit tests cover the new strings and navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9605a1e42b385da25b6fa6633cb9a7b7f1407f43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->