### PR TITLE
refactor: flatten Import SRP step 0 spacing without gap/margin stacking

### DIFF
--- a/app/components/UI/SrpInputGrid/SrpInputGrid.types.ts
+++ b/app/components/UI/SrpInputGrid/SrpInputGrid.types.ts
@@ -54,4 +54,11 @@ export interface SrpInputGridProps {
    * @default true
    */
   autoFocus?: boolean;
+
+  /**
+   * Whether to include the default top margin (`mt-2`) on the root container.
+   * Set to `false` when the parent owns spacing above the grid (avoids gap/margin stacking).
+   * @default true
+   */
+  includeTopMargin?: boolean;
 }

--- a/app/components/UI/SrpInputGrid/index.test.tsx
+++ b/app/components/UI/SrpInputGrid/index.test.tsx
@@ -73,6 +73,21 @@ describe('SrpInputGrid', () => {
     expect(toJSON()).not.toBeNull();
   });
 
+  it('omits top margin when includeTopMargin is false', () => {
+    const { toJSON: withTopMargin } = renderWithProvider(
+      <SrpInputGrid {...defaultProps} />,
+    );
+    const { toJSON: withoutTopMargin } = renderWithProvider(
+      <SrpInputGrid {...defaultProps} includeTopMargin={false} />,
+    );
+
+    expect(withTopMargin()).not.toBeNull();
+    expect(withoutTopMargin()).not.toBeNull();
+    expect(JSON.stringify(withTopMargin())).not.toEqual(
+      JSON.stringify(withoutTopMargin()),
+    );
+  });
+
   it('renders with custom uniqueId', () => {
     const { toJSON } = renderWithProvider(
       <SrpInputGrid {...defaultProps} uniqueId="custom-id" />,

--- a/app/components/UI/SrpInputGrid/index.tsx
+++ b/app/components/UI/SrpInputGrid/index.tsx
@@ -90,6 +90,7 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
       disabled = false,
       onCurrentWordChange,
       autoFocus: autoFocusProp = true,
+      includeTopMargin = true,
     },
     ref,
   ) => {
@@ -355,7 +356,11 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
     }, [trimmedSeedPhraseLength, handleClear, handlePaste]);
 
     return (
-      <Box twClassName="flex-col gap-1 mt-2 mb-6">
+      <Box
+        twClassName={
+          includeTopMargin ? 'flex-col gap-1 mt-2 mb-6' : 'flex-col gap-1 mb-6'
+        }
+      >
         <Box
           backgroundColor={BoxBackgroundColor.BackgroundSection}
           twClassName={`rounded-[10px] min-h-[210px] flex-row flex-wrap w-full px-4 ${!isFirstInput ? 'pt-4 pb-2' : ''}`}

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -621,15 +621,15 @@ const ImportFromSecretRecoveryPhrase = ({
           ]}
         >
           {currentStep === 0 && (
-            <>
-              <Text
-                variant={TextVariant.DisplayMd}
-                color={TextColor.TextDefault}
-                testID={ImportFromSeedSelectorsIDs.SCREEN_TITLE_ID}
-              >
-                {strings('import_from_seed.title')}
-              </Text>
-              <Box twClassName="mt-1.5">
+            <Box twClassName="gap-y-2">
+              <Box twClassName="gap-y-1.5">
+                <Text
+                  variant={TextVariant.DisplayMd}
+                  color={TextColor.TextDefault}
+                  testID={ImportFromSeedSelectorsIDs.SCREEN_TITLE_ID}
+                >
+                  {strings('import_from_seed.title')}
+                </Text>
                 {isAddDeviceSyncEnabled ? (
                   <Text
                     variant={TextVariant.BodyMd}
@@ -683,20 +683,21 @@ const ImportFromSecretRecoveryPhrase = ({
                     </TouchableOpacity>
                   </Box>
                 )}
-                <SrpInputGrid
-                  ref={srpInputGridRef}
-                  seedPhrase={seedPhrase}
-                  onSeedPhraseChange={setSeedPhrase}
-                  onError={setError}
-                  externalError={error}
-                  testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
-                  placeholderText={strings('import_from_seed.srp_placeholder')}
-                  uniqueId={uniqueId}
-                  onCurrentWordChange={setCurrentInputWord}
-                  autoFocus={false}
-                />
               </Box>
-            </>
+              <SrpInputGrid
+                ref={srpInputGridRef}
+                seedPhrase={seedPhrase}
+                onSeedPhraseChange={setSeedPhrase}
+                onError={setError}
+                externalError={error}
+                testIdPrefix={ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}
+                placeholderText={strings('import_from_seed.srp_placeholder')}
+                uniqueId={uniqueId}
+                onCurrentWordChange={setCurrentInputWord}
+                autoFocus={false}
+                includeTopMargin={false}
+              />
+            </Box>
           )}
 
           {currentStep === 1 && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Flattens `ImportFromSecretRecoveryPhrase` step 0 layout and fixes the gap/margin stacking that blocked this DOM simplification in onboarding flatten PR.

**What changed:**
- Added optional `includeTopMargin` on `SrpInputGrid` (default `true` so other callers stay unchanged)
- Import step 0: title + description grouped with `gap-y-1.5`; parent `gap-y-2` owns space above the grid; grid uses `includeTopMargin={false}`
- Spacing maps to the previous `mt-1.5` + `mt-2` (6px / 8px) without stacking

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [TO-912](https://consensyssoftware.atlassian.net/browse/TO-912)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Import wallet SRP layout

  Scenario: user opens import SRP and spacing matches main
    Given the user is on the Onboarding screen
    When the user chooses Import using Secret Recovery Phrase
    Then the Import wallet title, description, and SrpInputGrid are shown
    And spacing between title and description matches main (no extra gap)
    And spacing between description and SrpInputGrid matches main (no stacked gap/margin)

  Scenario: user continues past step 0
    Given the user is on ImportFromSecretRecoveryPhrase step 0
    When the user enters a valid Secret Recovery Phrase and continues
    Then step 1 (password) still works as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/bc9e05b7-2930-42e6-86ea-8dd06cab2a3f

<img width="282" height="599" alt="Screenshot 2026-07-27 at 9 32 06 AM" src="https://github.com/user-attachments/assets/7d365145-f0f7-4ca7-9fe1-092ff9ed6638" />
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TO-912]: https://consensyssoftware.atlassian.net/browse/TO-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual spacing and layout-only changes on onboarding import; default `SrpInputGrid` behavior is unchanged for other screens.
> 
> **Overview**
> Adds optional **`includeTopMargin`** on `SrpInputGrid` (default **`true`**) so the root container can skip **`mt-2`** when the parent controls vertical spacing; other callers keep the previous layout.
> 
> **Import from SRP step 0** is restructured: title and description sit in a **`gap-y-1.5`** group inside a parent **`gap-y-2`**, and the grid is passed **`includeTopMargin={false}`** so spacing matches the prior **`mt-1.5` + `mt-2`** without stacked gap and margin.
> 
> A unit test asserts the tree differs when **`includeTopMargin`** is **`false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c2b524b3d4498c2837ffb71c77dba5e95ab4fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->