### PR TITLE
[DO NOT MERGE] feat(perps): ADR58 POC ETH position debug banner (TAT-3215)

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -268,6 +268,11 @@ export const PerpsHomeViewSelectorsIDs = {
   WITHDRAW_BUTTON: 'perps-home-withdraw-button',
   ADD_FUNDS_BUTTON: 'perps-home-add-funds-button',
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',
+  /**
+   * ADR58 POC (DO NOT MERGE) — debug banner when an open ETH Perps position exists.
+   * testID used by recipe proof; remove with the POC.
+   */
+  ADR58_ETH_POSITION_BANNER: 'perps-home-adr58-eth-position-banner',
   /** Per-position card; suffixed with the list index, e.g. `perps-home-position-card-0` */
   POSITION_CARD: 'perps-home-position-card',
   /** Per-order card; suffixed with the list index, e.g. `perps-home-order-card-0` */

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
@@ -113,6 +113,17 @@ const styleSheet = (params: { theme: Theme }) => {
     sectionContent: {
       paddingHorizontal: 16,
     },
+    // ADR58 POC (DO NOT MERGE): red debug banner + white text (error tokens).
+    adr58EthPositionBanner: {
+      backgroundColor: colors.error.default,
+      marginHorizontal: 16,
+      marginBottom: 12,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+    },
+    adr58EthPositionBannerText: {
+      color: colors.error.inverse,
+    },
   });
 };
 

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -777,6 +777,86 @@ describe('PerpsHomeView', () => {
     expect(queryByText('perps.home.positions')).toBeNull();
   });
 
+  // ADR58 POC (DO NOT MERGE) — debug banner for open ETH position.
+  it('shows the ADR58 ETH position banner with exact copy when an ETH position is open', () => {
+    mockUsePerpsHomeData.mockReturnValue({
+      ...mockDefaultData,
+      positions: [
+        {
+          symbol: 'ETH',
+          size: '1.0',
+          entryPrice: '2000',
+          positionValue: '2000',
+          unrealizedPnl: '0',
+          marginUsed: '200',
+          leverage: { type: 'cross' as const, value: 10 },
+          liquidationPrice: '1500',
+          maxLeverage: 50,
+          returnOnEquity: '0',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+          takeProfitCount: 0,
+          stopLossCount: 0,
+        },
+      ],
+    });
+
+    const { getByTestId } = render(<PerpsHomeView />);
+
+    expect(
+      getByTestId(PerpsHomeViewSelectorsIDs.ADR58_ETH_POSITION_BANNER),
+    ).toHaveTextContent('ADR58 POC: ETH POSITION DETECTED');
+  });
+
+  it('hides the ADR58 ETH position banner when there is no open ETH position', () => {
+    mockUsePerpsHomeData.mockReturnValue({
+      ...mockDefaultData,
+      positions: [],
+    });
+
+    const { queryByTestId } = render(<PerpsHomeView />);
+
+    expect(
+      queryByTestId(PerpsHomeViewSelectorsIDs.ADR58_ETH_POSITION_BANNER),
+    ).toBeNull();
+  });
+
+  it('hides the ADR58 banner for a non-ETH open position', () => {
+    mockUsePerpsHomeData.mockReturnValue({
+      ...mockDefaultData,
+      positions: [
+        {
+          symbol: 'BTC',
+          size: '0.5',
+          entryPrice: '50000',
+          positionValue: '25000',
+          unrealizedPnl: '100',
+          marginUsed: '1000',
+          leverage: { type: 'cross' as const, value: 25 },
+          liquidationPrice: '48000',
+          maxLeverage: 50,
+          returnOnEquity: '10',
+          cumulativeFunding: {
+            allTime: '0',
+            sinceOpen: '0',
+            sinceChange: '0',
+          },
+          takeProfitCount: 0,
+          stopLossCount: 0,
+        },
+      ],
+    });
+
+    const { queryByTestId } = render(<PerpsHomeView />);
+
+    expect(
+      queryByTestId(PerpsHomeViewSelectorsIDs.ADR58_ETH_POSITION_BANNER),
+    ).toBeNull();
+  });
+
   it('hides orders section when no orders', () => {
     // Arrange
     mockUsePerpsHomeData.mockReturnValue({

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -359,6 +359,12 @@ const PerpsHomeView = ({
 
   // Calculate positions subtitle with P&L
   const hasPositions = positions.length > 0;
+  // ADR58 POC (DO NOT MERGE): show debug banner only for an open ETH position.
+  // Matches domain equality used by useHasExistingPosition (position.symbol === asset).
+  const hasOpenEthPosition = useMemo(
+    () => positions.some((position) => position.symbol === 'ETH'),
+    [positions],
+  );
   const { positionsSubtitle, positionsSubtitleColor, positionsSubtitleSuffix } =
     useMemo(() => {
       const pnlNum = parseFloat(unrealizedPnl);
@@ -723,6 +729,25 @@ const PerpsHomeView = ({
   const homeSections = useMemo(
     () => [
       {
+        // ADR58 POC (DO NOT MERGE) — debug banner above the open positions list.
+        key: 'adr58-eth-position-banner',
+        visible: hasOpenEthPosition,
+        content: (
+          <View
+            testID={PerpsHomeViewSelectorsIDs.ADR58_ETH_POSITION_BANNER}
+            // ADR58 POC: theme error tokens = red bg / white text (easy to delete).
+            style={styles.adr58EthPositionBanner}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              style={styles.adr58EthPositionBannerText}
+            >
+              ADR58 POC: ETH POSITION DETECTED
+            </Text>
+          </View>
+        ),
+      },
+      {
         key: 'positions',
         visible: isLoading.positions || positions.length > 0,
         onLayout: handleSectionLayout(PERPS_EVENT_VALUE.SECTION_NAME.POSITIONS),
@@ -949,6 +974,7 @@ const PerpsHomeView = ({
     ],
     [
       isLoading,
+      hasOpenEthPosition,
       positions,
       orders,
       privacyMode,
@@ -979,6 +1005,8 @@ const PerpsHomeView = ({
       recentActivity,
       handleSectionLayout,
       moreItems,
+      styles.adr58EthPositionBanner,
+      styles.adr58EthPositionBannerText,
     ],
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

DO NOT MERGE — ADR58 POC only.
-->

## **Description**

**DO NOT MERGE.** ADR58 debug POC for TAT-3215.

On MetaMask Mobile Perps home, show a red debug banner with exact text `ADR58 POC: ETH POSITION DETECTED` above the open positions list **only** when the account has an open ETH Perps position. Minimal surface area for easy revert.

<!-- mms-check: type=text required=true -->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Jira: https://consensyssoftware.atlassian.net/browse/TAT-3215

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Recipe-backed proof (iOS simulator `mm-1`, testnet Perps, wallet fixture unlocked):

```gherkin
Feature: ADR58 POC ETH position banner on Perps home

  Scenario: No open ETH position hides the banner
    Given the wallet is unlocked on the fixture account
    And ETH Perps testnet position state is clean
    When the user opens Perps home
    Then the ADR58 banner testID is absent

  Scenario: Open ETH position shows the red banner with exact copy
    Given a small open ETH testnet long position
    When the user opens Perps home
    Then a red banner appears above the open positions list
    And the banner text is exactly "ADR58 POC: ETH POSITION DETECTED"
```

Recipe: task `artifacts/recipe.json` · run PASS under `pr-package/runs/artifacts-recipe-run/`  
Quality: pass · Unit tests in `PerpsHomeView.test.tsx` · `mm-harness check diff` PASS

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>ui.screenshot screenshot</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3215-dev-do-not-merge-adr58-eth-position-banner-0632/01-ui-screenshot-screenshot.png" alt="ui.screenshot screenshot" width="400" /></td>
<td align="center" width="50%"><strong>ui.screenshot screenshot</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3215-dev-do-not-merge-adr58-eth-position-banner-0632/02-ui-screenshot-screenshot.png" alt="ui.screenshot screenshot" width="400" /></td>
</tr>
</table>

### **Before**
No open ETH position — banner absent (recipe AC1).

### **After**
Open ETH 3x long — red banner above positions with exact ADR58 copy (recipe AC2/AC3).

### **Recipe evidence**

| AC | Proof |
|----|--------|
| AC1 banner absent when flat | `wait_for` absent + screenshot 01 |
| AC2/AC3 banner present + exact text | `wait_for` present + text + screenshot 02 |
| Cleanup | `teardown_state` ETH positions/orders none |

Image slots filled after public evidence upload (or drag/drop from `pr-package/images/`).

## **Recipe artifact package**

- Task: `temp/tasks/recipe-cook/20260727T042853Z-adr58-poc-do-not-merge-eth-position-banner`
- Package: `pr-package/` (runs, images, checklist, final-report)
- Platform: iOS · build: Expo dev client · Perps testnet enabled

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and Mobile Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable (POC — testIDs/comments mark DO NOT MERGE)
- [x] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android — N/A for this DO-NOT-MERGE POC (iOS recipe proof only)
- [ ] I've tested with a power user scenario — N/A
- [ ] I've instrumented key operations with Sentry traces — N/A (debug POC)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
