### PR TITLE
refactor(homepage): simplify Perps section rendering and enhance scroll event handling

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { act, render, fireEvent } from '@testing-library/react-native';
 import PerpsHomeView from './PerpsHomeView';
 import { PERPS_EVENT_VALUE } from '@metamask/perps-controller';
 import {
@@ -26,9 +26,20 @@ import Routes from '../../../../../constants/navigation/Routes';
 // Mock react-native-reanimated
 jest.mock('react-native-reanimated', () => {
   const Reanimated = jest.requireActual('react-native-reanimated/mock');
+  const mockUseAnimatedScrollHandler = jest.fn(
+    (handlers: { onScroll: (event: unknown) => void }) => handlers.onScroll,
+  );
   Reanimated.default.ScrollView = jest.requireActual('react-native').ScrollView;
+  Reanimated.useAnimatedScrollHandler = mockUseAnimatedScrollHandler;
   return Reanimated;
 });
+
+jest.mock('react-native-worklets', () => ({
+  scheduleOnRN: jest.fn(
+    (callback: (...args: number[]) => void, ...args: number[]) =>
+      callback(...args),
+  ),
+}));
 
 // Mock navigation
 const mockNavigate = jest.fn();
@@ -106,6 +117,7 @@ const mockHandleAddFunds = jest.fn();
 const mockHandleWithdraw = jest.fn();
 const mockCloseEligibilityModal = jest.fn();
 const mockSetPerpsMode = jest.fn();
+const mockUsePerpsHomeSectionTracking = jest.fn();
 jest.mock('../../hooks', () => ({
   usePerpsHomeData: jest.fn(),
   usePerpsMeasurement: jest.fn(),
@@ -126,11 +138,7 @@ jest.mock('../../hooks', () => ({
     isProcessing: false,
     error: null,
   })),
-  usePerpsHomeSectionTracking: jest.fn(() => ({
-    handleSectionLayout: jest.fn(() => jest.fn()),
-    handleScroll: jest.fn(),
-    resetTracking: jest.fn(),
-  })),
+  usePerpsHomeSectionTracking: () => mockUsePerpsHomeSectionTracking(),
   usePerpsMode: jest.fn(() => ({
     mode: 'lite',
     setMode: mockSetPerpsMode,
@@ -482,6 +490,13 @@ jest.mock(
 
 const mockUsePerpsHomeData = jest.requireMock('../../hooks')
   .usePerpsHomeData as jest.Mock;
+const mockUseAnimatedScrollHandler = jest.requireMock('react-native-reanimated')
+  .useAnimatedScrollHandler as jest.Mock;
+const mockScrollTracking = () => ({
+  handleSectionLayout: jest.fn(() => jest.fn()),
+  handleScroll: jest.fn(),
+  resetTracking: jest.fn(),
+});
 
 const mockUsePerpsLiveAccount = jest.requireMock('../../hooks/stream')
   .usePerpsLiveAccount as jest.Mock;
@@ -514,6 +529,7 @@ describe('PerpsHomeView', () => {
     mockNavigateToMarketList.mockClear();
     mockRouteParams = { source: 'main_action_button' };
     mockUsePerpsHomeData.mockReturnValue(mockDefaultData);
+    mockUsePerpsHomeSectionTracking.mockReturnValue(mockScrollTracking());
     mockUsePerpsTopMovers.mockReturnValue({
       data: [],
       isLoading: false,
@@ -651,6 +667,43 @@ describe('PerpsHomeView', () => {
     });
     // Search bar should still not be visible in HomeView (navigation happens, component doesn't toggle search)
     expect(queryByTestId('perps-home-search-bar')).toBeNull();
+  });
+
+  it('forwards scroll events to the latest section tracking callback', async () => {
+    const initialTracking = mockScrollTracking();
+    const latestTracking = mockScrollTracking();
+    mockUsePerpsHomeSectionTracking.mockReturnValue(initialTracking);
+
+    const { rerender } = render(<PerpsHomeView />);
+    const scrollHandlers = mockUseAnimatedScrollHandler.mock.calls.map(
+      ([handlers]) =>
+        handlers as {
+          onScroll: (event: {
+            contentOffset: { x: number; y: number };
+            layoutMeasurement: { width: number; height: number };
+          }) => void;
+        },
+    );
+    const event = {
+      contentOffset: { x: 0, y: 240 },
+      layoutMeasurement: { width: 390, height: 844 },
+    };
+
+    mockUsePerpsHomeSectionTracking.mockReturnValue(latestTracking);
+    rerender(<PerpsHomeView />);
+
+    await act(async () => {
+      scrollHandlers.forEach(({ onScroll }) => onScroll(event));
+      await Promise.resolve();
+    });
+
+    expect(initialTracking.handleScroll).not.toHaveBeenCalled();
+    expect(latestTracking.handleScroll).toHaveBeenCalledWith({
+      nativeEvent: {
+        contentOffset: { x: 0, y: 240 },
+        layoutMeasurement: { width: 0, height: 844 },
+      },
+    });
   });
 
   it('carries route transactionActiveAbTests when search opens market list', () => {

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -706,32 +706,4 @@ describe('Homepage', () => {
       });
     });
   });
-
-  describe('perpsProvidersHoisted + Perps feature flag', () => {
-    it('does not render PerpsSection when perpsProvidersHoisted=true and Perps flag is disabled', () => {
-      jest
-        .requireMock('../../UI/Perps')
-        .selectPerpsEnabledFlag.mockReturnValue(false);
-
-      renderWithProvider(<Homepage perpsProvidersHoisted />, {
-        state: stateWithPreferences,
-      });
-
-      const calls = getUseHomeViewedEventCalls();
-      expect(calls.some((c) => c[0]?.sectionName === 'perps')).toBe(false);
-    });
-
-    it('renders PerpsSection when perpsProvidersHoisted=true and Perps flag is enabled', () => {
-      jest
-        .requireMock('../../UI/Perps')
-        .selectPerpsEnabledFlag.mockReturnValue(true);
-
-      renderWithProvider(<Homepage perpsProvidersHoisted />, {
-        state: stateWithPreferences,
-      });
-
-      const calls = getUseHomeViewedEventCalls();
-      expect(calls.some((c) => c[0]?.sectionName === 'perps')).toBe(true);
-    });
-  });
 });

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -39,177 +39,175 @@ import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager
  * This component orchestrates all homepage sections and coordinates
  * their refresh functionality via refs.
  */
-const Homepage = forwardRef<SectionRefreshHandle, Record<string, never>>(
-  (_props, ref) => {
-    const tokensSectionRef = useRef<SectionRefreshHandle>(null);
-    const perpsSectionRef = useRef<SectionRefreshHandle>(null);
-    const predictionsSectionRef = useRef<SectionRefreshHandle>(null);
-    const topTradersSectionRef = useRef<SectionRefreshHandle>(null);
-    const defiSectionRef = useRef<SectionRefreshHandle>(null);
-    const nftsSectionRef = useRef<SectionRefreshHandle>(null);
-    const watchlistSectionRef = useRef<SectionRefreshHandle>(null);
+const Homepage = forwardRef<SectionRefreshHandle, object>((_props, ref) => {
+  const tokensSectionRef = useRef<SectionRefreshHandle>(null);
+  const perpsSectionRef = useRef<SectionRefreshHandle>(null);
+  const predictionsSectionRef = useRef<SectionRefreshHandle>(null);
+  const topTradersSectionRef = useRef<SectionRefreshHandle>(null);
+  const defiSectionRef = useRef<SectionRefreshHandle>(null);
+  const nftsSectionRef = useRef<SectionRefreshHandle>(null);
+  const watchlistSectionRef = useRef<SectionRefreshHandle>(null);
 
-    const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
-    const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-    const isDeFiEnabled = useSelector(selectDeFiPositionsSectionEnabled);
-    const isTopTradersEnabled = useSelector(selectSocialLeaderboardEnabled);
-    const isWatchlistEnabled = useSelector(selectTokenWatchlistEnabled);
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const isDeFiEnabled = useSelector(selectDeFiPositionsSectionEnabled);
+  const isTopTradersEnabled = useSelector(selectSocialLeaderboardEnabled);
+  const isWatchlistEnabled = useSelector(selectTokenWatchlistEnabled);
 
-    const ownedNfts = useOwnedNfts();
-    const hasNfts = ownedNfts.length > 0;
+  const ownedNfts = useOwnedNfts();
+  const hasNfts = ownedNfts.length > 0;
 
-    const { enableAllPopularNetworks, isNetworkEnabled, popularNetworks } =
-      useNetworkEnablement();
-    const { detectNfts, abortDetection } = useNftDetection();
-    const popularNetworksKey = popularNetworks.join(',');
-    const areAllPopularNetworksEnabled = useMemo(() => {
-      if (popularNetworksKey === '') {
-        return true;
+  const { enableAllPopularNetworks, isNetworkEnabled, popularNetworks } =
+    useNetworkEnablement();
+  const { detectNfts, abortDetection } = useNftDetection();
+  const popularNetworksKey = popularNetworks.join(',');
+  const areAllPopularNetworksEnabled = useMemo(() => {
+    if (popularNetworksKey === '') {
+      return true;
+    }
+    return popularNetworksKey
+      .split(',')
+      .every((chainId) =>
+        isNetworkEnabled(chainId as Parameters<typeof isNetworkEnabled>[0]),
+      );
+  }, [isNetworkEnabled, popularNetworksKey]);
+
+  // useFocusEffect (not useEffect) so we run every time the user focuses this screen
+  // (e.g. switches to Wallet tab or returns from a section). With useEffect we would
+  // only run on first mount, so "all popular networks" would not be re-applied when
+  // they come back to the homepage.
+  useFocusEffect(
+    useCallback(() => {
+      if (!areAllPopularNetworksEnabled) {
+        enableAllPopularNetworks();
       }
-      return popularNetworksKey
-        .split(',')
-        .every((chainId) =>
-          isNetworkEnabled(chainId as Parameters<typeof isNetworkEnabled>[0]),
-        );
-    }, [isNetworkEnabled, popularNetworksKey]);
+    }, [areAllPopularNetworksEnabled, enableAllPopularNetworks]),
+  );
 
-    // useFocusEffect (not useEffect) so we run every time the user focuses this screen
-    // (e.g. switches to Wallet tab or returns from a section). With useEffect we would
-    // only run on first mount, so "all popular networks" would not be re-applied when
-    // they come back to the homepage.
-    useFocusEffect(
-      useCallback(() => {
-        if (!areAllPopularNetworksEnabled) {
-          enableAllPopularNetworks();
-        }
-      }, [areAllPopularNetworksEnabled, enableAllPopularNetworks]),
-    );
+  // TODO(ASSETS-3660): Replace with a proper polling mechanism in NftDetectionController.
+  useThrottledFocusEffect(
+    useCallback(() => {
+      detectNfts(true, false).catch(() => {
+        // AbortError is expected when detection is cancelled on blur
+      });
 
-    // TODO(ASSETS-3660): Replace with a proper polling mechanism in NftDetectionController.
-    useThrottledFocusEffect(
-      useCallback(() => {
-        detectNfts(true, false).catch(() => {
-          // AbortError is expected when detection is cancelled on blur
-        });
+      return () => {
+        abortDetection();
+      };
+    }, [detectNfts, abortDetection]),
+    300_000, // 5 minutes
+  );
 
-        return () => {
-          abortDetection();
-        };
-      }, [detectNfts, abortDetection]),
-      300_000, // 5 minutes
-    );
-
-    /**
-     * Compute the ordered list of enabled sections. Tokens are always present;
-     * NFTs, Perps, Predictions, and DeFi are conditional.
-     */
-    const enabledSections = useMemo(
-      () =>
-        [
-          { name: HomeSectionNames.TOKENS, enabled: true },
-          { name: HomeSectionNames.PERPS, enabled: isPerpsEnabled },
-          { name: HomeSectionNames.PREDICT, enabled: isPredictEnabled },
-          { name: HomeSectionNames.WATCHLIST, enabled: isWatchlistEnabled },
-          {
-            name: HomeSectionNames.TOP_TRADERS,
-            enabled: isTopTradersEnabled,
-          },
-          { name: HomeSectionNames.DEFI, enabled: isDeFiEnabled },
-          { name: HomeSectionNames.NFTS, enabled: hasNfts },
-        ].filter((section) => section.enabled),
+  /**
+   * Compute the ordered list of enabled sections. Tokens are always present;
+   * NFTs, Perps, Predictions, and DeFi are conditional.
+   */
+  const enabledSections = useMemo(
+    () =>
       [
-        isPerpsEnabled,
-        isPredictEnabled,
-        isDeFiEnabled,
-        hasNfts,
-        isTopTradersEnabled,
-        isWatchlistEnabled,
-      ],
-    );
+        { name: HomeSectionNames.TOKENS, enabled: true },
+        { name: HomeSectionNames.PERPS, enabled: isPerpsEnabled },
+        { name: HomeSectionNames.PREDICT, enabled: isPredictEnabled },
+        { name: HomeSectionNames.WATCHLIST, enabled: isWatchlistEnabled },
+        {
+          name: HomeSectionNames.TOP_TRADERS,
+          enabled: isTopTradersEnabled,
+        },
+        { name: HomeSectionNames.DEFI, enabled: isDeFiEnabled },
+        { name: HomeSectionNames.NFTS, enabled: hasNfts },
+      ].filter((section) => section.enabled),
+    [
+      isPerpsEnabled,
+      isPredictEnabled,
+      isDeFiEnabled,
+      hasNfts,
+      isTopTradersEnabled,
+      isWatchlistEnabled,
+    ],
+  );
 
-    const totalSectionsLoaded = enabledSections.length;
+  const totalSectionsLoaded = enabledSections.length;
 
-    useHomeSessionSummary({ totalSectionsLoaded });
+  useHomeSessionSummary({ totalSectionsLoaded });
 
-    const getSectionIndex = useCallback(
-      (name: HomeSectionName) =>
-        enabledSections.findIndex((s) => s.name === name),
-      [enabledSections],
-    );
+  const getSectionIndex = useCallback(
+    (name: HomeSectionName) =>
+      enabledSections.findIndex((s) => s.name === name),
+    [enabledSections],
+  );
 
-    const refresh = useCallback(async () => {
-      await Promise.allSettled([
-        tokensSectionRef.current?.refresh(),
-        perpsSectionRef.current?.refresh(),
-        predictionsSectionRef.current?.refresh(),
-        watchlistSectionRef.current?.refresh(),
-        topTradersSectionRef.current?.refresh(),
-        defiSectionRef.current?.refresh(),
-        nftsSectionRef.current?.refresh(),
-      ]);
-    }, []);
+  const refresh = useCallback(async () => {
+    await Promise.allSettled([
+      tokensSectionRef.current?.refresh(),
+      perpsSectionRef.current?.refresh(),
+      predictionsSectionRef.current?.refresh(),
+      watchlistSectionRef.current?.refresh(),
+      topTradersSectionRef.current?.refresh(),
+      defiSectionRef.current?.refresh(),
+      nftsSectionRef.current?.refresh(),
+    ]);
+  }, []);
 
-    useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+  useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
-    return (
-      <Box
-        marginBottom={8}
-        testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
-        accessible={false}
-      >
-        <TokensSection
-          ref={tokensSectionRef}
-          sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}
+  return (
+    <Box
+      marginBottom={8}
+      testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
+      accessible={false}
+    >
+      <TokensSection
+        ref={tokensSectionRef}
+        sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}
+        totalSectionsLoaded={totalSectionsLoaded}
+      />
+      {isPerpsEnabled && (
+        <PerpsConnectionProvider suppressErrorView>
+          <PerpsStreamProvider>
+            <HomepagePerpsHomeSlot
+              ref={perpsSectionRef}
+              sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
+              totalSectionsLoaded={totalSectionsLoaded}
+            />
+          </PerpsStreamProvider>
+        </PerpsConnectionProvider>
+      )}
+      <PredictionsSection
+        ref={predictionsSectionRef}
+        sectionIndex={getSectionIndex(HomeSectionNames.PREDICT)}
+        totalSectionsLoaded={totalSectionsLoaded}
+      />
+      {isWatchlistEnabled && (
+        <WatchlistSection
+          ref={watchlistSectionRef}
+          sectionIndex={getSectionIndex(HomeSectionNames.WATCHLIST)}
           totalSectionsLoaded={totalSectionsLoaded}
         />
-        {isPerpsEnabled && (
-          <PerpsConnectionProvider suppressErrorView>
-            <PerpsStreamProvider>
-              <HomepagePerpsHomeSlot
-                ref={perpsSectionRef}
-                sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
-                totalSectionsLoaded={totalSectionsLoaded}
-              />
-            </PerpsStreamProvider>
-          </PerpsConnectionProvider>
-        )}
-        <PredictionsSection
-          ref={predictionsSectionRef}
-          sectionIndex={getSectionIndex(HomeSectionNames.PREDICT)}
+      )}
+      {isTopTradersEnabled && (
+        <TopTradersSection
+          ref={topTradersSectionRef}
+          sectionIndex={getSectionIndex(HomeSectionNames.TOP_TRADERS)}
           totalSectionsLoaded={totalSectionsLoaded}
         />
-        {isWatchlistEnabled && (
-          <WatchlistSection
-            ref={watchlistSectionRef}
-            sectionIndex={getSectionIndex(HomeSectionNames.WATCHLIST)}
-            totalSectionsLoaded={totalSectionsLoaded}
-          />
-        )}
-        {isTopTradersEnabled && (
-          <TopTradersSection
-            ref={topTradersSectionRef}
-            sectionIndex={getSectionIndex(HomeSectionNames.TOP_TRADERS)}
-            totalSectionsLoaded={totalSectionsLoaded}
-          />
-        )}
-        {isDeFiEnabled && (
-          <DeFiSection
-            ref={defiSectionRef}
-            sectionIndex={getSectionIndex(HomeSectionNames.DEFI)}
-            totalSectionsLoaded={totalSectionsLoaded}
-          />
-        )}
-        {hasNfts && (
-          <NFTsSection
-            ref={nftsSectionRef}
-            sectionIndex={getSectionIndex(HomeSectionNames.NFTS)}
-            totalSectionsLoaded={totalSectionsLoaded}
-          />
-        )}
-        <MoreSection />
-      </Box>
-    );
-  },
-);
+      )}
+      {isDeFiEnabled && (
+        <DeFiSection
+          ref={defiSectionRef}
+          sectionIndex={getSectionIndex(HomeSectionNames.DEFI)}
+          totalSectionsLoaded={totalSectionsLoaded}
+        />
+      )}
+      {hasNfts && (
+        <NFTsSection
+          ref={nftsSectionRef}
+          sectionIndex={getSectionIndex(HomeSectionNames.NFTS)}
+          totalSectionsLoaded={totalSectionsLoaded}
+        />
+      )}
+      <MoreSection />
+    </Box>
+  );
+});
 
 export default Homepage;

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -33,22 +33,14 @@ import { useThrottledFocusEffect } from '../../hooks/useThrottledFocusEffect';
 import { PerpsConnectionProvider } from '../../UI/Perps/providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager';
 
-interface HomepageProps {
-  /**
-   * When true, skips rendering PerpsConnectionProvider + PerpsStreamProvider
-   * because a parent (e.g. HomepageDiscoveryTabs) already provides them.
-   */
-  perpsProvidersHoisted?: boolean;
-}
-
 /**
  * Homepage component - Main view for the redesigned wallet homepage.
  *
  * This component orchestrates all homepage sections and coordinates
  * their refresh functionality via refs.
  */
-const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
-  ({ perpsProvidersHoisted = false }, ref) => {
+const Homepage = forwardRef<SectionRefreshHandle, Record<string, never>>(
+  (_props, ref) => {
     const tokensSectionRef = useRef<SectionRefreshHandle>(null);
     const perpsSectionRef = useRef<SectionRefreshHandle>(null);
     const predictionsSectionRef = useRef<SectionRefreshHandle>(null);
@@ -170,24 +162,17 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
           sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}
           totalSectionsLoaded={totalSectionsLoaded}
         />
-        {isPerpsEnabled &&
-          (perpsProvidersHoisted ? (
-            <HomepagePerpsHomeSlot
-              ref={perpsSectionRef}
-              sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
-              totalSectionsLoaded={totalSectionsLoaded}
-            />
-          ) : (
-            <PerpsConnectionProvider suppressErrorView>
-              <PerpsStreamProvider>
-                <HomepagePerpsHomeSlot
-                  ref={perpsSectionRef}
-                  sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
-                  totalSectionsLoaded={totalSectionsLoaded}
-                />
-              </PerpsStreamProvider>
-            </PerpsConnectionProvider>
-          ))}
+        {isPerpsEnabled && (
+          <PerpsConnectionProvider suppressErrorView>
+            <PerpsStreamProvider>
+              <HomepagePerpsHomeSlot
+                ref={perpsSectionRef}
+                sectionIndex={getSectionIndex(HomeSectionNames.PERPS)}
+                totalSectionsLoaded={totalSectionsLoaded}
+              />
+            </PerpsStreamProvider>
+          </PerpsConnectionProvider>
+        )}
         <PredictionsSection
           ref={predictionsSectionRef}
           sectionIndex={getSectionIndex(HomeSectionNames.PREDICT)}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Completes the Hub Page Discovery Tabs A/B test removal by deleting Homepage's now-unreachable `perpsProvidersHoisted` API and its conditional Perps provider branch. Homepage now consistently owns the Perps connection and stream providers.

Adds a regression test for the Perps home scroll bridge. It verifies that a Reanimated worklet retained across renders dispatches scroll offsets and viewport height to the latest section-tracking callback, preventing stale-closure analytics.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-975

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps home scroll tracking

  Scenario: Scroll Perps home
    Given I am on the Perps home screen
    When I scroll the market sections
    Then the header animation should respond to the scroll position
    And section view tracking should continue to record the current scroll position
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simplifies Homepage Perps wiring and adds test coverage; no auth, payments, or data-model changes.
> 
> **Overview**
> Removes the **`perpsProvidersHoisted`** prop and the branch that skipped **`PerpsConnectionProvider`** / **`PerpsStreamProvider`** on Homepage. When Perps is enabled, Homepage **always** wraps the Perps home slot with those providers, matching cleanup after the Hub Page Discovery Tabs A/B test.
> 
> Adds a **`PerpsHomeView`** regression test so Reanimated scroll handlers still call the **latest** **`usePerpsHomeSectionTracking`** **`handleScroll`** after rerender (avoids stale-closure section analytics). Drops Homepage tests that only covered the removed hoisted-provider behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58560dfe57252f6b65b035cc7cafe9a1031c83cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->