### PR TITLE
fix(token-details): reorder header icons [ASSETS-3772]

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import type { TokenSecurityData } from '@metamask/assets-controllers';
 import Routes from '../../../../constants/navigation/Routes';
@@ -301,6 +302,27 @@ describe('TokenDetailsInlineHeader', () => {
       const { queryByTestId } = renderHeader();
 
       expect(queryByTestId('share-button')).toBeNull();
+    });
+
+    it('renders end-accessory icons left-to-right as price alert, share, then star', () => {
+      const { getByTestId, toJSON } = renderHeader({
+        onPriceAlertPress: jest.fn(),
+        onSharePress: jest.fn(),
+        starButton: <Text testID="watchlist-star-button">★</Text>,
+      });
+
+      expect(getByTestId('token-price-alert-button')).toBeOnTheScreen();
+      expect(getByTestId('share-button')).toBeOnTheScreen();
+      expect(getByTestId('watchlist-star-button')).toBeOnTheScreen();
+
+      const serialized = JSON.stringify(toJSON());
+      const alertIndex = serialized.indexOf('token-price-alert-button');
+      const shareIndex = serialized.indexOf('share-button');
+      const starIndex = serialized.indexOf('watchlist-star-button');
+
+      expect(alertIndex).toBeGreaterThanOrEqual(0);
+      expect(shareIndex).toBeGreaterThan(alertIndex);
+      expect(starIndex).toBeGreaterThan(shareIndex);
     });
   });
 });

--- a/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsInlineHeader.tsx
@@ -124,11 +124,23 @@ export const TokenDetailsInlineHeader = ({
     isStockToken,
   ]);
 
+  // Left → right: price alert, share, watchlist star.
+  // Matches design (ASSETS-3772) and the visual order HeaderSubpage used to
+  // produce via endButtonIconProps (which reverses before render).
   const endAccessory = useMemo(() => {
     const buttons: ReactNode[] = [];
 
-    if (starButton) {
-      buttons.push(<React.Fragment key="star">{starButton}</React.Fragment>);
+    if (onPriceAlertPress) {
+      buttons.push(
+        <ButtonIcon
+          key="alert"
+          iconName={IconName.Notification}
+          size={ButtonIconSize.Md}
+          onPress={onPriceAlertPress}
+          testID={TokenOverviewSelectorsIDs.PRICE_ALERT_BUTTON}
+          accessibilityLabel="Create price alert"
+        />,
+      );
     }
     if (onSharePress) {
       buttons.push(
@@ -142,17 +154,8 @@ export const TokenDetailsInlineHeader = ({
         />,
       );
     }
-    if (onPriceAlertPress) {
-      buttons.push(
-        <ButtonIcon
-          key="alert"
-          iconName={IconName.Notification}
-          size={ButtonIconSize.Md}
-          onPress={onPriceAlertPress}
-          testID={TokenOverviewSelectorsIDs.PRICE_ALERT_BUTTON}
-          accessibilityLabel="Create price alert"
-        />,
-      );
+    if (starButton) {
+      buttons.push(<React.Fragment key="star">{starButton}</React.Fragment>);
     }
 
     if (buttons.length === 0) return undefined;
@@ -161,7 +164,7 @@ export const TokenDetailsInlineHeader = ({
         {buttons}
       </Box>
     );
-  }, [starButton, onSharePress, onPriceAlertPress]);
+  }, [onPriceAlertPress, onSharePress, starButton]);
 
   const inlineDescription = useMemo(() => {
     if (!contractAddress) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Reorders the Token Details page header end-accessory icons to match ASSETS-3772 design specs.

**Why:** When the header migrated from `endButtonIconProps` to a custom `endAccessory`, icon order no longer matched design. `HeaderSubpage` reverses `endButtonIconProps` before render, so the previous array order `[star, share, alert]` visually rendered as alert → share → star. The custom `endAccessory` row did not reverse, so the UI incorrectly showed star → share → alert.

**What changed:** `TokenDetailsInlineHeader` now builds the end-accessory buttons left → right as:
1. Price alert / notification
2. Share
3. Watchlist star

Unit test coverage asserts this order when all three actions are present.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Reordered Token Details header icons to price alert, share, then watchlist star

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3772

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token Details header icon order

  Scenario: header shows icons in design order
    Given the watchlist feature flag is enabled
    And price alerts and share are available for the token
    When I open the Token Details page
    Then the header end icons appear left-to-right as price alert, share, then watchlist star

  Scenario: optional icons omit correctly
    Given the watchlist feature flag is disabled
    When I open the Token Details page
    Then the header still shows price alert then share without a star
    And relative order of remaining icons is unchanged
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — icon reorder only; no visual redesign. Verify order on device/simulator against ASSETS-3772 design.

### **Before**

Left → right: watchlist star, share, price alert

### **After**

Left → right: price alert, share, watchlist star

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0839f8fe-ab65-409e-8aa5-eaf0805f5bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0839f8fe-ab65-409e-8aa5-eaf0805f5bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

