### PR TITLE
fix: guard Ramp toast navigation readiness

### DIFF
--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -13,6 +13,7 @@ import { strings } from '../../../../../locales/i18n';
 
 jest.mock('../../../../core/ToastService');
 jest.mock('../../../../core/NavigationService', () => ({
+  isReady: jest.fn(() => true),
   navigation: {
     navigate: jest.fn(),
   },
@@ -79,6 +80,26 @@ describe('v2OrderToast', () => {
         Routes.RAMP.RAMPS_ORDER_DETAILS,
         { orderId: 'test-order-id', showCloseButton: true },
       );
+    });
+
+    it('does not navigate when Track button is pressed before navigation is ready', () => {
+      (NavigationService.isReady as jest.Mock).mockReturnValue(false);
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Processing your purchase of ETH')
+        .mockReturnValueOnce('This should only take a few minutes...')
+        .mockReturnValueOnce('Track');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        status: RampsOrderStatus.Pending,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+      result?.linkButtonOptions?.onPress();
+
+      expect(mockToastService.closeToast).toHaveBeenCalled();
+      expect(NavigationService.navigation.navigate).not.toHaveBeenCalled();
     });
 
     it('returns toast options for COMPLETED state with success icon', () => {

--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -27,6 +27,11 @@ describe('v2OrderToast', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (NavigationService.isReady as jest.Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('buildV2OrderToastOptions', () => {

--- a/app/components/UI/Ramp/utils/v2OrderToast.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.ts
@@ -61,6 +61,10 @@ export function buildV2OrderToastOptions(
           label: strings('ramps_v2.notifications.track'),
           onPress: () => {
             ToastService.closeToast();
+            if (!NavigationService.isReady()) {
+              return;
+            }
+
             NavigationService.navigation.navigate(
               Routes.RAMP.RAMPS_ORDER_DETAILS,
               { orderId, showCloseButton: true },

--- a/app/core/NavigationService/NavigationService.test.ts
+++ b/app/core/NavigationService/NavigationService.test.ts
@@ -29,6 +29,7 @@ describe('NavigationService', () => {
       reset: jest.fn(),
       goBack: jest.fn(),
       dispatch: jest.fn(),
+      isReady: jest.fn(() => true),
       getState: jest.fn(() => ({
         routes: [{ name: 'Home' }],
         index: 0,
@@ -85,6 +86,28 @@ describe('NavigationService', () => {
 
       expect(navigation1).toBeDefined();
       expect(navigation2).toBeDefined();
+    });
+  });
+
+  describe('isReady', () => {
+    it('returns false when navigation has not been set', () => {
+      const isReady = (
+        NavigationService as unknown as { isReady: () => boolean }
+      ).isReady();
+
+      expect(isReady).toBe(false);
+      expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('returns navigation readiness when navigation has been set', () => {
+      NavigationService.navigation = mockNavigation;
+
+      const isReady = (
+        NavigationService as unknown as { isReady: () => boolean }
+      ).isReady();
+
+      expect(isReady).toBe(true);
+      expect(mockNavigation.isReady).toHaveBeenCalled();
     });
   });
 

--- a/app/core/NavigationService/NavigationService.ts
+++ b/app/core/NavigationService/NavigationService.ts
@@ -115,6 +115,13 @@ class NavigationService {
   }
 
   /**
+   * Checks whether the navigation container is mounted and ready.
+   */
+  static isReady() {
+    return Boolean(this.#navigation?.isReady?.());
+  }
+
+  /**
    * Resets the navigation reference. Only for testing purposes.
    * @internal
    */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Fixes a Sentry crash in the Ramp V2 pending-order toast Track action. The toast callback could run while the React Navigation container ref existed but the navigator was not mounted/ready yet, causing `NavigationService.navigation.navigate(...)` to throw React Navigation's "navigation object hasn't been initialized yet" error.

This change adds a non-throwing `NavigationService.isReady()` helper and uses it to skip the Ramp toast navigation action until the navigator is ready. The toast still closes when the user taps Track.

Also addressed flaky-test-detection feedback by resetting mock implementations between tests in `v2OrderToast.test.ts` and restoring the default `NavigationService.isReady()` return value in `beforeEach`.

## **Changelog**

CHANGELOG entry: Fixed a crash that could happen when tracking a pending buy order during app startup.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3581

## **Manual testing steps**

```gherkin
Feature: Ramp pending order toast navigation

  Scenario: user taps Track before app navigation is ready
    Given the app has not finished mounting the navigation container
    And a pending Ramp order toast is visible
    When the user taps Track
    Then the toast closes
    And the app does not navigate or crash
```

Automated regression coverage was added for this scenario.

## **Screenshots/Recordings**

N/A - no visual UI change.

### **Before**

N/A - crash-only behavior.

### **After**

N/A - crash-only behavior.

## Verification

- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/Ramp/utils/v2OrderToast.test.ts --runInBand --forceExit` reported all 10 Ramp toast tests PASS after the mock reset fix.
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/core/NavigationService/NavigationService.test.ts --runInBand --forceExit` reported all 28 NavigationService tests PASS.
- `yarn eslint app/core/NavigationService/NavigationService.ts app/core/NavigationService/NavigationService.test.ts app/components/UI/Ramp/utils/v2OrderToast.ts app/components/UI/Ramp/utils/v2OrderToast.test.ts` completed with 0 errors and 1 existing deprecation warning for `renderNumber` in `v2OrderToast.ts`.
- `yarn lint:tsc --pretty false` failed on pre-existing missing module errors outside this change: `app/util/termsOfUse/index.test.tsx(10,24)` and `app/util/termsOfUse/termsOfUse.ts(9,24)` cannot find `./termsOfUseContent`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors; labels were not changed by the agent.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A for this JS-only navigation guard; no manual Android run was performed.
- [x] I've tested with a power user scenario
  - N/A; this does not touch account/token rendering or power-user data paths.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A; this fixes an existing Sentry crash and does not add a new performance-sensitive operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40bf4aa7-641a-4beb-b6bb-146980c571be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40bf4aa7-641a-4beb-b6bb-146980c571be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

