### PR TITLE
refactor: import hasTransactionType from @metamask/transaction-controller

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/useHandleHwSend.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHandleHwSend.ts
@@ -9,10 +9,10 @@ import {
 import { HardwareWalletsSwapsEventType } from './HardwareWalletsSwaps.state';
 import { Flow } from './flowStrategy';
 import { isHardwareAccount } from '../../../../util/address';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import { useSelectedGasFeeToken } from '../../../Views/confirmations/hooks/gas/useGasFeeToken';

--- a/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
@@ -1,4 +1,7 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import perpsPayTokenIcon from 'images/perps-pay-token-icon.png';
 import { useCallback } from 'react';
 import { Image } from 'react-native';
@@ -8,7 +11,6 @@ import {
   AssetType,
   type TokenListItem,
 } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { selectPerpsPayWithAnyTokenAllowlistAssets } from '../selectors/featureFlags';
 import { useIsPerpsBalanceSelected } from './useIsPerpsBalanceSelected';
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -5,6 +5,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import {
   PERPS_TRANSACTIONS_HISTORY_CONSTANTS,
@@ -33,7 +34,6 @@ import {
   PerpsTransaction,
   PerpsTransactionType,
 } from '../types/transactionHistory';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream/usePerpsLiveFills';
 import {

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
@@ -7,6 +7,7 @@ import {
   TransactionMeta,
   TransactionStatus,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../locales/i18n';
@@ -15,7 +16,6 @@ import { ToastVariants } from '../../../../component-library/components/Toast';
 import type { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import type { ToastRegistration } from '../../../Nav/App/ControllerEventToastBridge';
 import { useAppThemeFromContext } from '../../../../util/theme';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { resolveWithdrawTokenInfo } from '../../../Views/confirmations/utils/withdraw-token-resolution';
 import { isPerpsPredictMoneyWithdraw } from '../../Money/utils/moneyTransactionGuards';
 import { store } from '../../../../store';

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { AssetType } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
+import { hasTransactionType } from '@metamask/transaction-controller';
 import { usePredictBalanceTokenFilter } from './usePredictBalanceTokenFilter';
 
 let mockTransactionMeta: { type?: string } | null = null;
@@ -12,7 +12,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../Views/confirmations/utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: jest.fn(),
 }));
 

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
@@ -1,11 +1,13 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useCallback } from 'react';
 import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import {
   AssetType,
   TokenListItem,
 } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 
 export function usePredictBalanceTokenFilter(
   forceEnabled = false,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
@@ -62,7 +62,8 @@ jest.mock('../../../../../../../util/address', () => ({
 }));
 
 let mockHasTransactionType = true;
-jest.mock('../../../../../../Views/confirmations/utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: (transactionMeta: unknown) => {
     if (!transactionMeta) return false;
     return mockHasTransactionType;

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
@@ -12,7 +12,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { strings } from '../../../../../../../../locales/i18n';
 import Icon, {
   IconColor,
@@ -22,7 +25,6 @@ import Icon, {
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { useTransactionPayToken } from '../../../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../../../../../Views/confirmations/utils/transaction';
 import {
   TokenIcon,
   TokenIconVariant,

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -1,5 +1,8 @@
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { numberToHex, type CaipChainId } from '@metamask/utils';
 import { useNavigation } from '@react-navigation/native';
 import type {
@@ -86,7 +89,6 @@ import { getAddressUrl } from '../../../core/Multichain/utils';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { CancelSpeedupModal } from '../confirmations/components/modals/cancel-speedup-modal';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { hasTransactionType } from '../confirmations/utils/transaction';
 import styleSheet from './ActivityList.styles';
 import { useUnifiedTxActions } from './useUnifiedTxActions';
 import { useTransactionAutoScroll } from './useTransactionAutoScroll';

--- a/app/components/Views/confirmations/components/PayAccountSelector/PayAccountSelector.tsx
+++ b/app/components/Views/confirmations/components/PayAccountSelector/PayAccountSelector.tsx
@@ -1,13 +1,15 @@
 import React, { useCallback } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
 import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { useTransactionAccountOverride } from '../../hooks/transactions/useTransactionAccountOverride';
-import { hasTransactionType } from '../../utils/transaction';
 import { replaceAccountInNestedTransactions } from '../../utils/transaction-pay';
 import AccountSelector from '../AccountSelector';
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { type Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
@@ -22,7 +25,6 @@ import { strings } from '../../../../../../../locales/i18n';
 import { selectPrimaryMoneyAccount } from '../../../../../../selectors/moneyAccountController';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { useIsMoneyAccountContext } from '../../../hooks/activity/useIsMoneyAccountContext';
-import { hasTransactionType } from '../../../utils/transaction';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import MoneyIcon from '../../../../../../images/money.png';

--- a/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { hasTransactionType } from '../../../utils/transaction';
 import { strings } from '../../../../../../../locales/i18n';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';

--- a/app/components/Views/confirmations/components/activity/transaction-details-fiat-order-id-row/transaction-details-fiat-order-id-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-fiat-order-id-row/transaction-details-fiat-order-id-row.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import {
   Box,
   BoxAlignItems,
@@ -12,7 +15,6 @@ import { IconColor } from '../../../../../../component-library/components/Icons/
 import { strings } from '../../../../../../../locales/i18n';
 import { shortenString } from '../../../../../../util/notifications/methods/common';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { hasTransactionType } from '../../../utils/transaction';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import CopyButton from '../../UI/copy-button/copy-button';
 import { TransactionDetailsFiatOrderIdRowTestIds } from './transaction-details-fiat-order-id-row.testIds';

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -14,11 +14,9 @@ import {
   CHAIN_IDS,
   TransactionMeta,
   TransactionType,
-} from '@metamask/transaction-controller';
-import {
   hasTransactionType,
-  parseStandardTokenTransactionData,
-} from '../../../utils/transaction';
+} from '@metamask/transaction-controller';
+import { parseStandardTokenTransactionData } from '../../../utils/transaction';
 import { Result } from '@ethersproject/abi';
 import { calcTokenAmount } from '../../../../../../util/transactions';
 import { useStyles } from '../../../../../../component-library/hooks';

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -3,8 +3,10 @@ import { TransactionDetailsRow } from '../transaction-details-row/transaction-de
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { strings } from '../../../../../../../locales/i18n';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useFeeCalculations } from '../../../hooks/gas/useFeeCalculations';
 import { BigNumber } from 'bignumber.js';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -9,8 +9,10 @@ import { useIsMoneyAccountContext } from '../../../hooks/activity/useIsMoneyAcco
 import { strings } from '../../../../../../../locales/i18n';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useFiatOrderStatus } from '../../../hooks/activity/useFiatOrderStatus';
 import PaymentMethodIcon from '../../../../../UI/Ramp/Aggregator/components/PaymentMethodIcon';
 import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { strings } from '../../../../../../../locales/i18n';
-import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -3,10 +3,10 @@ import {
   CHAIN_IDS,
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
-import { hasTransactionType } from '../../../utils/transaction';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { POLYGON_PUSD } from '../../../constants/predict';
 import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionSummaryLine } from './transaction-summary-line';
-import { hasTransactionType } from '../../../utils/transaction';
 import { POLYGON_PUSD } from '../../../constants/predict';
 import { ARBITRUM_USDC } from '../../../constants/perps';
 import { getTokenDisplaySymbol } from '../../../../../UI/Earn/constants/musd';

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -14,8 +14,8 @@ import {
   TransactionMeta,
   TransactionStatus,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
 import { RELAY_DEPOSIT_TYPES } from '../../../constants/confirmations';
 import { ProgressList } from '../../progress-list';
 import { SourceHashSummaryLine } from './source-hash-summary-line';

--- a/app/components/Views/confirmations/components/activity/transaction-details-to-row/transaction-details-to-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-to-row/transaction-details-to-row.tsx
@@ -1,7 +1,10 @@
 import React, { useMemo } from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { type Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
 import AvatarAccount from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
@@ -12,10 +15,7 @@ import { NameType } from '../../../../../UI/Name/Name.types';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { useIsMoneyAccountContext } from '../../../hooks/activity/useIsMoneyAccountContext';
-import {
-  hasTransactionType,
-  parseStandardTokenTransactionData,
-} from '../../../utils/transaction';
+import { parseStandardTokenTransactionData } from '../../../utils/transaction';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import { getTokenTransferData } from '../../../utils/transaction-pay';
 import MoneyIcon from '../../../../../../images/money.png';

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -4,8 +4,10 @@ import Text from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';
 import { usePayFiatFormatter } from '../../../hooks/pay/usePayFiatFormatter';

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -15,12 +15,12 @@ import { TransactionDetailsTotalRow } from '../transaction-details-total-row';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { useIsMoneyAccountContext } from '../../../hooks/activity/useIsMoneyAccountContext';
 import { strings } from '../../../../../../../locales/i18n';
 import { TransactionDetailsFeeSection } from '../transaction-details-fee-section';
-import { hasTransactionType } from '../../../utils/transaction';
 import { TransactionDetailsRetry } from '../transaction-details-retry';
 import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
 import { TransactionDetailsToRow } from '../transaction-details-to-row';

--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
@@ -4,10 +4,12 @@ import BannerAlert from '../../../../../component-library/components/Banners/Ban
 import styleSheet from './alert-banner.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 import { getBannerAlertSeverity } from '../../utils/alert-system';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { AlertKeys } from '../../constants/alerts';
-import { hasTransactionType } from '../../utils/transaction';
 export interface AlertBannerProps {
   blockingOnly?: boolean;
   excludeKeys?: AlertKeys[];

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -27,7 +27,10 @@ import Info from '../info-root';
 import Title from '../title';
 import { Footer, FooterSkeleton } from '../footer';
 import styleSheet from './confirm-component.styles';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import AnimatedSpinner, { SpinnerSize } from '../../../../UI/AnimatedSpinner';
@@ -37,7 +40,6 @@ import {
 } from '../info/custom-amount-info';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
 import { TransferInfoSkeleton } from '../info/transfer/transfer';
 

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -31,12 +31,14 @@ import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { isStakingConfirmation } from '../../utils/confirm';
 import styleSheet from './footer.styles';
 import Routes from '../../../../../constants/navigation/Routes';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import {
   MMM_ORIGIN,
   TRANSFER_TRANSACTION_TYPES,
 } from '../../constants/confirmations';
-import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimFooter } from '../predict-confirmations/predict-claim-footer/predict-claim-footer';
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.tsx
@@ -5,7 +5,10 @@ import {
   ButtonIconVariant,
 } from '../../../../../../component-library/components/Toast';
 import { strings } from '../../../../../../../locales/i18n';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
 import {
@@ -16,7 +19,6 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { getNetworkImageSource } from '../../../../../../util/networks';
-import { hasTransactionType } from '../../../utils/transaction';
 
 const IGNORED_TRANSACTION_TYPES = [TransactionType.musdConversion];
 

--- a/app/components/Views/confirmations/components/info-root/info-root.tsx
+++ b/app/components/Views/confirmations/components/info-root/info-root.tsx
@@ -1,5 +1,8 @@
 import { ApprovalType } from '@metamask/controller-utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import React from 'react';
 import { UnstakeConfirmationViewProps } from '../../../../UI/Stake/Views/UnstakeConfirmationView/UnstakeConfirmationView.types';
 import { useQRHardwareContext } from '../../context/qr-hardware-context';
@@ -21,7 +24,6 @@ import QRInfo from '../qr-info';
 import ContractDeployment from '../info/contract-deployment';
 import { PerpsDepositInfo } from '../info/perps-deposit-info';
 import { PredictDepositInfo } from '../info/predict-deposit-info';
-import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfo } from '../info/predict-claim-info';
 import { PredictWithdrawInfo } from '../info/predict-withdraw-info';
 import { PerpsWithdrawInfo } from '../info/perps-withdraw-info';

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -9,7 +9,10 @@ import React, {
 } from 'react';
 import { View } from 'react-native';
 import { toCaipAssetType } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { PayTokenAmount, PayTokenAmountSkeleton } from '../../pay-token-amount';
 import { BalanceProjection } from '../../../../../UI/Money/components/BalanceProjection';
 import { PayWithRow, PayWithRowSkeleton } from '../../rows/pay-with-row';
@@ -60,10 +63,7 @@ import { useRampNavigation } from '../../../../../UI/Ramp/hooks/useRampNavigatio
 import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { AlignItems } from '../../../../../UI/Box/box.types';
 import { strings } from '../../../../../../../locales/i18n';
-import {
-  hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../../utils/transaction';
+import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import {
   ConfirmationParams,

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -25,11 +25,11 @@ import {
 import { getAvailableTokens } from '../../../utils/transaction-pay';
 import { useTransactionPayBlockedTokens } from '../../../hooks/pay/useTransactionPayBlockedTokens';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
 import {
+  TransactionType,
   hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../../utils/transaction';
+} from '@metamask/transaction-controller';
+import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import { useMusdConversionTokens } from '../../../../../UI/Earn/hooks/useMusdConversionTokens';
 import { HIDE_NETWORK_FILTER_TYPES } from '../../../constants/confirmations';
 import { useMusdPaymentToken } from '../../../../../UI/Earn/hooks/useMusdPaymentToken';

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -17,11 +17,11 @@ import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
 } from '../../hooks/pay/useTransactionPayData';
+import { isTransactionPayWithdraw } from '../../utils/transaction';
 import {
+  TransactionType,
   hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../utils/transaction';
-import { TransactionType } from '@metamask/transaction-controller';
+} from '@metamask/transaction-controller';
 
 export interface PayTokenAmountProps {
   amountHuman: string;

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -13,8 +13,10 @@ import {
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { InfoRowSkeleton, InfoRowVariant } from '../../UI/info-row/info-row';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { ConfirmationRowComponentIDs } from '../../../ConfirmationView.testIds';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 

--- a/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
+++ b/app/components/Views/confirmations/components/rows/percentage-row/percentage-row.tsx
@@ -12,8 +12,10 @@ import { strings } from '../../../../../../../locales/i18n';
 import { IconColor } from '../../../../../../component-library/components/Icons/Icon';
 import AppConstants from '../../../../../../core/AppConstants';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../../utils/transaction';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { MUSD_EVENTS_CONSTANTS } from '../../../../../UI/Earn/constants/events';

--- a/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.test.tsx
@@ -95,7 +95,8 @@ jest.mock(
   },
 );
 
-jest.mock('../../../utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: (meta: { type?: string } | undefined, types: string[]) =>
     meta?.type ? types.includes(meta.type) : false,
 }));

--- a/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.tsx
+++ b/app/components/Views/confirmations/components/rows/perps-account-picker-row/perps-account-picker-row.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from 'react';
 
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import { updateTransaction } from '../../../../../../util/transaction-controller';
@@ -16,7 +19,6 @@ import {
   PayWithOption,
 } from '../../confirm/confirm-component';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../../utils/transaction';
 import { AccountPickerRowContent } from '../account-picker-row';
 
 const formatBalance = (account: SubAccountInfo): string =>

--- a/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.test.tsx
@@ -99,7 +99,8 @@ jest.mock(
   },
 );
 
-jest.mock('../../../utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: (meta: { type?: string } | undefined, types: string[]) =>
     meta?.type ? types.includes(meta.type) : false,
 }));

--- a/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.tsx
+++ b/app/components/Views/confirmations/components/rows/predict-account-picker-row/predict-account-picker-row.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback } from 'react';
 
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import { updateTransaction } from '../../../../../../util/transaction-controller';
@@ -16,7 +19,6 @@ import {
   PayWithOption,
 } from '../../confirm/confirm-component';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../../utils/transaction';
 import { replaceAccountInNestedTransactions } from '../../../utils/transaction-pay';
 import { AccountPickerRowContent } from '../account-picker-row';
 

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -7,7 +7,10 @@ import InfoRow from '../../UI/info-row';
 import { strings } from '../../../../../../../locales/i18n';
 import { View } from 'react-native';
 import { BigNumber } from 'bignumber.js';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import {
   useIsTransactionPayLoading,
   useTransactionPayTotals,
@@ -17,7 +20,6 @@ import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/us
 import { ConfirmationRowComponentIDs } from '../../../ConfirmationView.testIds';
 import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../../utils/transaction';
 
 const HIDE_TYPES = [TransactionType.musdConversion];
 

--- a/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useAccountNoFundsAlert.ts
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { AlertKeys } from '../../constants/alerts';
 import { Alert, Severity } from '../../types/alerts';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayAvailableTokens } from '../pay/useTransactionPayAvailableTokens';
-import { hasTransactionType } from '../../utils/transaction';
 import { useIsFiatPaymentAvailable } from '../pay/useIsFiatPaymentAvailable';
 import { useIsTransactionPayLoading } from '../pay/useTransactionPayData';
 

--- a/app/components/Views/confirmations/hooks/alerts/useBatchedUnusedApprovalsAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useBatchedUnusedApprovalsAlert.ts
@@ -3,6 +3,7 @@ import {
   NestedTransactionMetadata,
   SimulationTokenBalanceChange,
   SimulationErrorCode,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -20,7 +21,6 @@ import {
   parseApprovalTransactionData,
   ParsedApprovalTransactionData,
 } from '../../utils/approvals';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { selectNonZeroUnusedApprovalsAllowList } from '../../../../../selectors/featureFlagController/confirmations';

--- a/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.ts
@@ -4,8 +4,10 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { TransactionMeta } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../utils/transaction';
+import {
+  TransactionMeta,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useTransactionPayFiatPayment } from '../pay/useTransactionPayData';
 import { useRampsBuyLimits } from '../../../../UI/Ramp/hooks/useRampsBuyLimits';
 import { MONEY_ACCOUNT_CURRENCY } from '../../components/info/money-account-withdraw-info/money-account-withdraw-info';

--- a/app/components/Views/confirmations/hooks/alerts/useFirstTimeInteractionAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useFirstTimeInteractionAlert.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -8,7 +11,6 @@ import { AlertKeys } from '../../constants/alerts';
 import { MM_PAY_TRANSACTION_TYPES } from '../../constants/confirmations';
 import { Alert, Severity } from '../../types/alerts';
 import { TrustSignalDisplayState } from '../../types/trustSignals';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransferRecipient } from '../transactions/useTransferRecipient';
 import { useAddressTrustSignal } from '../useAddressTrustSignals';

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -9,11 +9,11 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { useConfirmActions } from '../useConfirmActions';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
-import { TransactionType } from '@metamask/transaction-controller';
 import {
+  TransactionType,
   hasTransactionType,
-  shouldApplyGasFeeSponsorship,
-} from '../../utils/transaction';
+} from '@metamask/transaction-controller';
+import { shouldApplyGasFeeSponsorship } from '../../utils/transaction';
 import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSourceAmount';
 import { selectUseTransactionSimulations } from '../../../../../selectors/preferencesController';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientMoneyAccountBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientMoneyAccountBalanceAlert.ts
@@ -7,8 +7,8 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../utils/transaction';
 import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
 import { useTokenAmount } from '../useTokenAmount';
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPerpsBalanceAlert.ts
@@ -9,9 +9,9 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useTokenAmount } from '../useTokenAmount';
-import { hasTransactionType } from '../../utils/transaction';
 import {
   useTransactionPayQuotes,
   useTransactionPayTotals,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
@@ -8,9 +8,9 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useTokenAmount } from '../useTokenAmount';
-import { hasTransactionType } from '../../utils/transaction';
 import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalance';
 import {
   useTransactionPayQuotes,

--- a/app/components/Views/confirmations/hooks/alerts/useMMPayHardwareAccountAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useMMPayHardwareAccountAlert.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { AlertKeys } from '../../constants/alerts';
 import { Alert, Severity } from '../../types/alerts';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useTransactionPayFiatPayment } from '../pay/useTransactionPayData';
-import {
-  hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../utils/transaction';
+import { isTransactionPayWithdraw } from '../../utils/transaction';
 import {
   isHardwareAccount,
   isQRHardwareAccount,

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -1,3 +1,5 @@
+import { hasTransactionType } from '@metamask/transaction-controller';
+
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useMemo } from 'react';
 import { AlertKeys } from '../../constants/alerts';
@@ -18,7 +20,6 @@ import {
   PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
   QUOTE_REQUIRED_TRANSACTION_TYPES,
 } from '../../constants/confirmations';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
 
 export function useNoPayTokenQuotesAlert() {

--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import {
   TransactionStatus,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { AlertKeys } from '../../constants/alerts';
 import { Severity } from '../../types/alerts';
@@ -10,7 +11,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import { selectTransactions } from '../../../../../selectors/transactionController';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { isHardwareAccount } from '../../../../../util/address';
 import { selectMetaMaskPayHardwareFlags } from '../../../../../selectors/featureFlagController/confirmations';

--- a/app/components/Views/confirmations/hooks/alerts/useTransactionDepositLimitAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useTransactionDepositLimitAlert.ts
@@ -3,13 +3,13 @@ import { useSelector } from 'react-redux';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { Alert, Severity } from '../../types/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { selectDepositLimits } from '../../../../../selectors/featureFlagController/confirmations';
 
 function formatUsdAmount(value: number): string {

--- a/app/components/Views/confirmations/hooks/earn/useCustomAmount.tsx
+++ b/app/components/Views/confirmations/hooks/earn/useCustomAmount.tsx
@@ -1,9 +1,11 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { limitToMaximumDecimalPlaces } from '../../../../../util/number';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../../../UI/Earn/selectors/featureFlags';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useMusdConversionEligibility } from '../../../../UI/Earn/hooks/useMusdConversionEligibility';
 

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -2,7 +2,11 @@ import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
-import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import {
+  CHAIN_IDS,
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 
@@ -27,10 +31,7 @@ import { useIsPerpsBalanceSelected } from '../../../../../UI/Perps/hooks/useIsPe
 import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaymentToken';
 import { markPerpsPaymentTokenSelection } from '../../../../../UI/Perps/utils/perpsPaymentTokenSelection';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
-import {
-  hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../../utils/transaction';
+import { isTransactionPayWithdraw } from '../../../utils/transaction';
 import {
   isMatchingPayToken,
   resolvePreferredPayToken,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPerpsSection.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import {
   Button,
@@ -26,7 +29,6 @@ import {
   PayWithRowConfig,
   PayWithSectionConfig,
 } from '../../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
-import { hasTransactionType } from '../../../utils/transaction';
 import { useClearPaymentOverride } from './useClearPaymentOverride';
 
 export const PAY_WITH_PERPS_SECTION_TEST_ID = 'pay-with-section-perps';

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithPredictSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithPredictSection.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 import {
   Button,
@@ -21,7 +24,6 @@ import {
   PayWithRowConfig,
   PayWithSectionConfig,
 } from '../../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
-import { hasTransactionType } from '../../../utils/transaction';
 import { dismissActivePreviewSheet } from '../../../../../UI/Predict/contexts';
 import useApprovalRequest from '../../useApprovalRequest';
 

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -12,6 +12,7 @@ import {
   CHAIN_IDS,
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import {
@@ -22,7 +23,6 @@ import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTo
 import { AssetType } from '../../types/token';
 import {
   getPostQuoteTransactionType,
-  hasTransactionType,
   isTransactionPayWithdraw,
 } from '../../utils/transaction';
 import { useSelector } from 'react-redux';

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
@@ -1,6 +1,7 @@
+import { hasTransactionType } from '@metamask/transaction-controller';
+
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
 import { useHasNativeFiatProvider } from '../../../../UI/Ramp/hooks/useHasNativeFiatProvider';
-import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 

--- a/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsMoneyAccountFlagDefault.ts
@@ -1,14 +1,14 @@
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
 import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { ConfirmationParams } from '../../components/confirm/confirm-component';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import {
-  getTransactionType,
-  hasTransactionType,
-} from '../../utils/transaction';
+import { getTransactionType } from '../../utils/transaction';
 
 const PERPS_PREDICT_TRANSACTION_TYPES: TransactionType[] = [
   TransactionType.perpsDeposit,

--- a/app/components/Views/confirmations/hooks/pay/useMoneyNoFeeTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useMoneyNoFeeTokens.ts
@@ -1,8 +1,10 @@
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { selectRelayFixedSpread } from '../../../../../selectors/featureFlagController/confirmations';
 import { isSubsidizedSource } from '../../utils/relayFixedSpread';
 

--- a/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
@@ -1,5 +1,6 @@
+import { hasTransactionType } from '@metamask/transaction-controller';
+
 import { useTransactionDetails } from '../activity/useTransactionDetails';
-import { hasTransactionType } from '../../utils/transaction';
 import { USER_CURRENCY_TYPES } from '../../constants/confirmations';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 

--- a/app/components/Views/confirmations/hooks/pay/usePaySectionRecipientMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePaySectionRecipientMetrics.ts
@@ -1,9 +1,9 @@
-import { TransactionType } from '@metamask/transaction-controller';
-import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import {
+  TransactionType,
   hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../utils/transaction';
+} from '@metamask/transaction-controller';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { isTransactionPayWithdraw } from '../../utils/transaction';
 import { PayWithSectionId } from '../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
 import { useSectionTracking } from './useSectionTracking';
 

--- a/app/components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts
@@ -1,6 +1,9 @@
 import { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { RootState } from '../../../../../reducers';
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
@@ -9,7 +12,6 @@ import { selectPredictSelectedPaymentToken } from '../../../../UI/Predict/select
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { useTransactionPayFiatPayment } from './useTransactionPayData';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { PayWithSectionId } from '../../components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types';
 import { useSectionTracking } from './useSectionTracking';
 

--- a/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
@@ -1,13 +1,16 @@
 import React, { ReactNode, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
-import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import {
+  CHAIN_IDS,
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { selectRelayFixedSpread } from '../../../../../selectors/featureFlagController/confirmations';
 import {
   isSubsidizedRoute,
   isSubsidizedSource,
 } from '../../utils/relayFixedSpread';
-import { hasTransactionType } from '../../utils/transaction';
 import { safeFormatChainIdToHex } from '../../../../UI/Card/util/safeFormatChainIdToHex';
 import { MUSD_TOKEN_ADDRESS } from '../../../../UI/Earn/constants/musd';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayCurrency.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayCurrency.ts
@@ -2,7 +2,8 @@ import {
   PAY_TRANSACTION_TYPES,
   USER_CURRENCY_TYPES,
 } from '../../constants/confirmations';
-import { hasTransactionType } from '../../utils/transaction';
+import { hasTransactionType } from '@metamask/transaction-controller';
+
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 
 const PAY_CURRENCY = 'USD';

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -9,10 +9,12 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { useDeepMemo } from '../useDeepMemo';
 import { Hex, Json, isCaipChainId, isHexString } from '@metamask/utils';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { BridgeToken } from '../../../../UI/Bridge/types';
-import { hasTransactionType } from '../../utils/transaction';
 import {
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,11 +1,13 @@
 import { useEffect, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import { createProjectLogger, type Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useTransactionPayWithdraw } from './useTransactionPayWithdraw';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { computeProxyAddress } from '../../../../UI/Predict/providers/polymarket/safe/utils';
-import { hasTransactionType } from '../../utils/transaction';
 import { usePredictAccountState } from '../../../../UI/Predict/hooks/usePredictAccountState';
 
 const log = createProjectLogger('transaction-pay-post-quote');

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -2,6 +2,7 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
@@ -15,7 +16,6 @@ import { selectTransactionPaymentTokenByTransactionId } from '../../../../../sel
 import { updateTransaction } from '../../../../../util/transaction-controller';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
-import { hasTransactionType } from '../../utils/transaction';
 import Logger from '../../../../../util/Logger';
 
 export function useTransactionPayToken(): {

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
@@ -4,6 +4,7 @@ import { toHex } from '@metamask/controller-utils';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
@@ -18,7 +19,6 @@ import {
   updateMoneyAccountWithdrawTokenAmount,
 } from '../../../../UI/Money/utils/moneyAccountTransactions';
 import { UpdateTransactionPayAmountCall } from '../../types/transactions';
-import { hasTransactionType } from '../../utils/transaction';
 import { prefixError } from '../../../../../util/transactions/error-prefix';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 

--- a/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useDepositPrefillAmount.ts
@@ -3,6 +3,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import {
@@ -13,7 +14,6 @@ import {
 } from '../../../../../selectors/featureFlagController/confirmations';
 import { selectAccountOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
 import { RootState } from '../../../../../reducers';
-import { hasTransactionType } from '../../utils/transaction';
 import { isRouteToken } from '../../utils/relayFixedSpread';
 import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -7,6 +7,7 @@ import { useFullScreenConfirmation } from '../ui/useFullScreenConfirmation';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { isHardwareAccount } from '../../../../../util/address';
@@ -17,10 +18,7 @@ import {
 } from '../../components/confirm/confirm-component';
 import { createProjectLogger } from '@metamask/utils';
 import { useSelectedGasFeeToken } from '../gas/useGasFeeToken';
-import {
-  hasTransactionType,
-  shouldApplyGasFeeSponsorship,
-} from '../../utils/transaction';
+import { shouldApplyGasFeeSponsorship } from '../../utils/transaction';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
 import { cloneDeep } from 'lodash';

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -5,6 +5,7 @@ import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
@@ -12,10 +13,7 @@ import { useUpdateTransactionPayAmount } from '../pay/useUpdateTransactionPayAmo
 import { getTokenAddress } from '../../utils/transaction-pay';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
-import {
-  hasTransactionType,
-  isTransactionPayWithdraw,
-} from '../../utils/transaction';
+import { isTransactionPayWithdraw } from '../../utils/transaction';
 import { usePredictBalance } from '../../../../UI/Predict/hooks/usePredictBalance';
 import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
 import {

--- a/app/components/Views/confirmations/hooks/ui/useFullScreenConfirmation.ts
+++ b/app/components/Views/confirmations/hooks/ui/useFullScreenConfirmation.ts
@@ -1,11 +1,14 @@
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  hasTransactionType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+
 import { FULL_SCREEN_CONFIRMATIONS } from '../../constants/confirmations';
 import { useIsInternalConfirmation } from '../transactions/useIsInternalConfirmation';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import useApprovalRequest from '../useApprovalRequest';
-import { hasTransactionType } from '../../utils/transaction';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import type { ConfirmationParams } from '../../components/confirm/confirm-component';
 

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -3,6 +3,7 @@ import {
   NestedTransactionMetadata,
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import {
   PaymentOverride,
@@ -11,7 +12,6 @@ import {
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
 import { PREDICT_MINIMUM_DEPOSIT } from '../constants/predict';
-import { hasTransactionType } from './transaction';
 import { Hex } from '@metamask/utils';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
 import { AssetType, TokenStandard } from '../types/token';

--- a/app/components/Views/confirmations/utils/transaction.test.ts
+++ b/app/components/Views/confirmations/utils/transaction.test.ts
@@ -11,7 +11,6 @@ import {
   getSeverity,
   hasGasFeeTokenSelected,
   getTransactionType,
-  hasTransactionType,
   isRevokeDelegationTransaction,
   isTransactionMarkedAsGasFeeSponsored,
   isTransactionPayWithdraw,
@@ -232,49 +231,6 @@ describe('getTransactionType', () => {
     } as unknown as TransactionMeta;
 
     expect(getTransactionType(txMeta)).toBe(TransactionType.perpsDeposit);
-  });
-});
-
-describe('hasTransactionType', () => {
-  it('returns true if transaction type matches', () => {
-    const txMeta = {
-      type: TransactionType.simpleSend,
-    } as TransactionMeta;
-
-    expect(
-      hasTransactionType(txMeta, [
-        TransactionType.bridge,
-        TransactionType.simpleSend,
-      ]),
-    ).toBe(true);
-  });
-
-  it('returns true if nested transaction type matches', () => {
-    const txMeta = {
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.simpleSend }],
-    } as TransactionMeta;
-
-    expect(
-      hasTransactionType(txMeta, [
-        TransactionType.bridge,
-        TransactionType.simpleSend,
-      ]),
-    ).toBe(true);
-  });
-
-  it('returns false if neither transaction type nor nested transaction types match', () => {
-    const txMeta = {
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.bridge }],
-    } as TransactionMeta;
-
-    expect(
-      hasTransactionType(txMeta, [
-        TransactionType.simpleSend,
-        TransactionType.cancel,
-      ]),
-    ).toBe(false);
   });
 });
 

--- a/app/components/Views/confirmations/utils/transaction.ts
+++ b/app/components/Views/confirmations/utils/transaction.ts
@@ -1,6 +1,7 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { Interface } from '@ethersproject/abi';
 import {
+  hasTransactionType,
   TransactionMeta,
   TransactionParams,
   TransactionStatus,
@@ -143,23 +144,6 @@ export function getTransactionType(
     if (nestedType) return nestedType;
   }
   return type;
-}
-
-export function hasTransactionType(
-  transactionMeta: TransactionMeta | undefined,
-  types: readonly TransactionType[],
-) {
-  const { nestedTransactions, type } = transactionMeta ?? {};
-
-  if (types.includes(type as TransactionType)) {
-    return true;
-  }
-
-  return (
-    nestedTransactions?.some((tx) =>
-      types.includes(tx.type as TransactionType),
-    ) ?? false
-  );
 }
 
 /**

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/money-account-override.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/money-account-override.ts
@@ -1,6 +1,7 @@
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
@@ -11,7 +12,6 @@ import type { RootState } from '../../../../../reducers';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
 import TransactionTypes from '../../../../TransactionTypes';
 import { replaceAccountInNestedTransactions } from '../../../../../components/Views/confirmations/utils/transaction-pay';
-import { hasTransactionType } from '../../../../../components/Views/confirmations/utils/transaction';
 
 /**
  * Eagerly refresh native and token balances across all configured chains

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
@@ -2,6 +2,7 @@ import { merge } from 'lodash';
 import {
   TransactionType,
   type TransactionMeta,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 
 import type {
@@ -15,7 +16,6 @@ import {
   isValidHexAddress,
 } from '../../../../../util/address';
 import { getMethodData } from '../../../../../util/transactions';
-import { hasTransactionType } from '../../../../../components/Views/confirmations/utils/transaction';
 
 export async function getBaseMetricsProperties({
   transactionMeta,

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -1,11 +1,11 @@
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { TransactionMetrics, TransactionMetricsBuilder } from '../types';
 import { JsonMap } from '../../../../../util/analytics/analytics.types';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../components/Views/confirmations/constants/tokens';
-import { hasTransactionType } from '../../../../../components/Views/confirmations/utils/transaction';
 import {
   getMetaMaskPayFiatChainTarget,
   normalizeMetaMaskPayPaymentMethod,

--- a/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
+++ b/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
@@ -6,6 +6,7 @@ import {
   type SavedGasFees,
   type TransactionMeta,
   type TransactionControllerOptions,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import type { SmartTransactionsController } from '@metamask/smart-transactions-controller';
 import type { WalletOptions } from '@metamask/wallet';
@@ -16,7 +17,6 @@ import {
   REDESIGNED_TRANSACTION_TYPES,
   RELAY_DEPOSIT_TYPES,
 } from '../../../../components/Views/confirmations/constants/confirmations';
-import { hasTransactionType } from '../../../../components/Views/confirmations/utils/transaction';
 import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import AppConstants from '../../../../core/AppConstants';
 import { store } from '../../../../store';

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -3,10 +3,10 @@ import { TX_UNAPPROVED } from '../../constants/transaction';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import { uniq } from 'lodash';
 import { Hex } from '@metamask/utils';
-import { hasTransactionType } from '../../components/Views/confirmations/utils/transaction';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { AddressBookControllerState } from '@metamask/address-book-controller';
 

--- a/app/util/transactions/hooks/index.ts
+++ b/app/util/transactions/hooks/index.ts
@@ -9,6 +9,7 @@ import {
   type TransactionControllerOptions,
   type TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import {
   type TransactionData,
@@ -43,10 +44,7 @@ import {
   PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
   QUOTE_REQUIRED_TRANSACTION_TYPES,
 } from '../../../components/Views/confirmations/constants/confirmations';
-import {
-  getPostQuoteTransactionType,
-  hasTransactionType,
-} from '../../../components/Views/confirmations/utils/transaction';
+import { getPostQuoteTransactionType } from '../../../components/Views/confirmations/utils/transaction';
 
 const TRANSACTION_SUBMISSION_METHOD_METRIC_NAME =
   'transaction_submission_method';


### PR DESCRIPTION
## Summary

`hasTransactionType` was extracted into `@metamask/transaction-controller` and released in v69.2.0 (currently on v69.2.1 in this repo).

This PR removes the local duplicate from `app/components/Views/confirmations/utils/transaction.ts` and updates all 80 import sites to use the upstream package directly.

## Changes

- **Removed** `hasTransactionType` export from `confirmations/utils/transaction.ts`
- **Added** `import { hasTransactionType } from '@metamask/transaction-controller'` to `transaction.ts` itself (used by `isTransactionPayWithdraw` and `getPostQuoteTransactionType`)
- **Updated** all 78 other files that imported `hasTransactionType` from the local utility to import from `@metamask/transaction-controller` instead
- **Removed** the `hasTransactionType` test block from `transaction.test.ts` (behaviour is tested upstream)
- **Updated** test mocks in 4 test files to target `@metamask/transaction-controller` instead of the local module path

## Testing

- `yarn lint:tsc` passes with zero errors
- Lint + Prettier ran cleanly via pre-commit hook (80 files, 223 insertions, 214 deletions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; behavior should match the upstream helper already shipped in the transaction-controller version pinned by the app.
> 
> **Overview**
> **Deduplicates `hasTransactionType`** by dropping the app-local copy in `confirmations/utils/transaction.ts` and wiring every caller to **`@metamask/transaction-controller`** (v69.2+), including confirmations UI, Perps/Predict, activity, Engine metrics, and transaction hooks.
> 
> The local utility still imports the package helper for **`isTransactionPayWithdraw`** / **`getPostQuoteTransactionType`**. Tests that mocked the confirmations path now mock **`@metamask/transaction-controller`**, and the in-repo **`hasTransactionType`** unit tests were removed in favor of upstream coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce2f84da86977e5d0915b7f0180917926ab83eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->