### PR TITLE
refactor(accounts): import hasTransactionType from @metamask/transaction-controller

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/useHandleHwSend.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHandleHwSend.ts
@@ -9,10 +9,10 @@ import {
 import { HardwareWalletsSwapsEventType } from './HardwareWalletsSwaps.state';
 import { Flow } from './flowStrategy';
 import { isHardwareAccount } from '../../../../util/address';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import { useSelectedGasFeeToken } from '../../../Views/confirmations/hooks/gas/useGasFeeToken';


### PR DESCRIPTION
## Summary

Part 2/4 of a stacked PR set. Updates `useHandleHwSend.ts` (HardwareWallet Swaps) to import `hasTransactionType` from `@metamask/transaction-controller` v69.2.0+ instead of the local confirmations utility.

## Stacked PRs
- PR 1 — confirmations + transaction-controller + utils → `@MetaMask/confirmations`
- **PR 2 (this)** — HardwareWallet → `@MetaMask/accounts-engineers`
- PR 3 — Perps → `@MetaMask/perps`
- PR 4 — Predict → `@MetaMask/predict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor on a single hook; predicate logic and HW send routing are unchanged.
> 
> **Overview**
> **`useHandleHwSend`** (hardware-wallet swaps send deferral) now sources **`hasTransactionType`** from **`@metamask/transaction-controller`** instead of **`confirmations/utils/transaction`**, alongside the existing **`TransactionMeta`** / **`TransactionType`** imports.
> 
> Runtime behavior is unchanged: **`shouldDefer`** still gates HW routing on **`simpleSend`** and **`tokenMethodTransfer`** via the same helper call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f83da49875e2823218fa41cfa76e5f12b11624c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->