### PR TITLE
refactor(perps): import hasTransactionType from @metamask/transaction-controller

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
@@ -1,4 +1,7 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import perpsPayTokenIcon from 'images/perps-pay-token-icon.png';
 import { useCallback } from 'react';
 import { Image } from 'react-native';
@@ -8,7 +11,6 @@ import {
   AssetType,
   type TokenListItem,
 } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { selectPerpsPayWithAnyTokenAllowlistAssets } from '../selectors/featureFlags';
 import { useIsPerpsBalanceSelected } from './useIsPerpsBalanceSelected';
 

--- a/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTransactionHistory.ts
@@ -5,6 +5,7 @@ import { BigNumber } from 'bignumber.js';
 import {
   TransactionMeta,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import {
   PERPS_TRANSACTIONS_HISTORY_CONSTANTS,
@@ -33,7 +34,6 @@ import {
   PerpsTransaction,
   PerpsTransactionType,
 } from '../types/transactionHistory';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream/usePerpsLiveFills';
 import {

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
@@ -7,6 +7,7 @@ import {
   TransactionMeta,
   TransactionStatus,
   TransactionType,
+  hasTransactionType,
 } from '@metamask/transaction-controller';
 import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../locales/i18n';
@@ -15,7 +16,6 @@ import { ToastVariants } from '../../../../component-library/components/Toast';
 import type { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import type { ToastRegistration } from '../../../Nav/App/ControllerEventToastBridge';
 import { useAppThemeFromContext } from '../../../../util/theme';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { resolveWithdrawTokenInfo } from '../../../Views/confirmations/utils/withdraw-token-resolution';
 import { isPerpsPredictMoneyWithdraw } from '../../Money/utils/moneyTransactionGuards';
 import { store } from '../../../../store';


### PR DESCRIPTION
## Summary

Part 3/4 of a stacked PR set. Updates 3 Perps hooks to import `hasTransactionType` from `@metamask/transaction-controller` v69.2.0+ instead of the local confirmations utility.

## Stacked PRs
- PR 1 — confirmations + transaction-controller + utils → `@MetaMask/confirmations`
- PR 2 — HardwareWallet → `@MetaMask/accounts-engineers`
- **PR 3 (this)** — Perps → `@MetaMask/perps`
- PR 4 — Predict → `@MetaMask/predict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; behavior depends on the controller export matching the former local helper.
> 
> **Overview**
> **Perps hooks now source `hasTransactionType` from `@metamask/transaction-controller`** instead of the confirmations `utils/transaction` helper, aligning with transaction-controller v69.2.0+.
> 
> The import path changes in **`usePerpsBalanceTokenFilter`**, **`usePerpsTransactionHistory`**, and **`usePerpsWithdrawToastRegistrations`** only; call sites and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f0c4efb1bb33444276bf28a7f4b4ea3df51668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->