### PR TITLE
refactor(predict): import hasTransactionType from @metamask/transaction-controller

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { AssetType } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
+import { hasTransactionType } from '@metamask/transaction-controller';
 import { usePredictBalanceTokenFilter } from './usePredictBalanceTokenFilter';
 
 let mockTransactionMeta: { type?: string } | null = null;
@@ -12,7 +12,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../Views/confirmations/utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: jest.fn(),
 }));
 

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
@@ -1,11 +1,13 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { useCallback } from 'react';
 import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import {
   AssetType,
   TokenListItem,
 } from '../../../Views/confirmations/types/token';
-import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 
 export function usePredictBalanceTokenFilter(
   forceEnabled = false,

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
@@ -62,7 +62,8 @@ jest.mock('../../../../../../../util/address', () => ({
 }));
 
 let mockHasTransactionType = true;
-jest.mock('../../../../../../Views/confirmations/utils/transaction', () => ({
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
   hasTransactionType: (transactionMeta: unknown) => {
     if (!transactionMeta) return false;
     return mockHasTransactionType;

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
@@ -12,7 +12,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
 import { strings } from '../../../../../../../../locales/i18n';
 import Icon, {
   IconColor,
@@ -22,7 +25,6 @@ import Icon, {
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { useTransactionPayToken } from '../../../../../../Views/confirmations/hooks/pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../../../../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
-import { hasTransactionType } from '../../../../../../Views/confirmations/utils/transaction';
 import {
   TokenIcon,
   TokenIconVariant,


### PR DESCRIPTION
## Summary

Part 4/4 of a stacked PR set. Updates 4 Predict files (hooks + views + tests) to import `hasTransactionType` from `@metamask/transaction-controller` v69.2.0+ instead of the local confirmations utility. Also updates test mocks to target the controller package.

## Stacked PRs
- PR 1 — confirmations + transaction-controller + utils → `@MetaMask/confirmations`
- PR 2 — HardwareWallet → `@MetaMask/accounts-engineers`
- PR 3 — Perps → `@MetaMask/perps`
- **PR 4 (this)** — Predict → `@MetaMask/predict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path refactor with no logic changes; tests updated to mock the same symbol from the package.
> 
> **Overview**
> Predict hooks and **PredictPayWithRow** now import **`hasTransactionType`** from **`@metamask/transaction-controller`** (alongside **`TransactionType`**) instead of **`confirmations/utils/transaction`**, aligning with the shared controller API in v69.2.0+.
> 
> Unit tests mock **`@metamask/transaction-controller`** with **`jest.requireActual`** and stub **`hasTransactionType`** there; runtime behavior for predict deposit-and-order checks is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60493a1c3031efc019639ff342c366aad2250671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->