### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (component-library)

### DIFF
--- a/app/component-library/components-temp/Loader/Loader.styles.ts
+++ b/app/component-library/components-temp/Loader/Loader.styles.ts
@@ -18,7 +18,7 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     base: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       backgroundColor: colors.background.default,

--- a/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/BottomSheet.styles.ts
@@ -12,7 +12,7 @@ import { StyleSheet } from 'react-native';
 const styleSheet = () =>
   StyleSheet.create({
     base: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'flex-end',
     },
   });

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
@@ -35,7 +35,7 @@ const styleSheet = (params: {
       padding: 0,
     },
     underlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       flexDirection: 'row',
       backgroundColor: colors.background.muted,
     },

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
@@ -32,7 +32,7 @@ const styleSheet = (params: {
       style,
     ) as ViewStyle,
     underlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       flexDirection: 'row',
       backgroundColor: colors.background.muted,
     },

--- a/app/component-library/components/Overlay/Overlay.styles.ts
+++ b/app/component-library/components/Overlay/Overlay.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: { theme: Theme; vars: OverlayStyleSheetVars }) => {
   return StyleSheet.create({
     base: Object.assign(
       {
-        ...StyleSheet.absoluteFillObject,
+        ...StyleSheet.absoluteFill,
         backgroundColor: color || theme.colors.overlay.default,
       } as ViewStyle,
       style,

--- a/app/component-library/components/Skeleton/Skeleton.styles.ts
+++ b/app/component-library/components/Skeleton/Skeleton.styles.ts
@@ -31,7 +31,7 @@ const styleSheet = (params: { theme: Theme; vars: SkeletonStyleSheetVars }) => {
       style,
     ) as ViewStyle,
     background: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: 4,
     } as ViewStyle,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 6 usages in `app/component-library/` with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs a single owning team's approval (the original touched 10+ teams' code). This slice covers only Design System-owned files:

- `components-temp/Loader/Loader.styles.ts`
- `components/BottomSheets/BottomSheet/BottomSheet.styles.ts`
- `components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts`
- `components/List/ListItemSelect/ListItemSelect.styles.ts`
- `components/Overlay/Overlay.styles.ts`
- `components/Skeleton/Skeleton.styles.ts`

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Component unit tests for all 6 touched components pass locally (55/55).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user opens surfaces that use component-library overlays
    Given the app is built from this branch
    When user opens a bottom sheet (e.g. account selector)
    Then the backdrop overlay covers the full screen behind the sheet
    When user views a screen with Skeleton loading placeholders
    Then the skeleton shimmer background renders full-size as before
    When user selects an item in a select list
    Then the selected-item underlay highlights the full row as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API rename with no intended behavior change; only affects styling spreads in component-library overlays and underlays.
> 
> **Overview**
> Prepares Design System component-library styles for React Native 0.85 by swapping deprecated `StyleSheet.absoluteFillObject` for `StyleSheet.absoluteFill` in six style sheets (Loader, BottomSheet, list select underlays, Overlay, Skeleton).
> 
> Each change is the same one-line spread replacement for full-screen / underlay positioning; on the current RN version the two APIs are equivalent, so layout and visuals should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2a60d3e55fd57f6e257c33b1efbde83d777dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->