### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (assets)

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -55,7 +55,7 @@ const styleSheet = (params: { theme: Theme }) =>
       alignSelf: 'stretch',
     } as ViewStyle,
     noDataOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       zIndex: 2,

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -30,12 +30,12 @@ const styleSheet = (params: {
     },
     /** Same pattern as AdvancedChart: overlay does not participate in flex layout with AreaChart. */
     loadingOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },
     noDataOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
@@ -28,7 +28,7 @@ const styleSheet = (params: {
       paddingVertical: 16,
     },
     skeletonOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       paddingHorizontal: 16,
       backgroundColor: theme.colors.background.default,
     },

--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -66,7 +66,7 @@ const styleSheet = (params: {
     mediaPlayer: {
       minHeight: 10,
     },
-    imageFallBackTextContainer: StyleSheet.absoluteFillObject,
+    imageFallBackTextContainer: StyleSheet.absoluteFill,
     imageFallBackShowContainer: {
       bottom: 32,
     },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 5 usages in Assets-owned components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs a single owning team's approval (the original touched 10+ teams' code). This slice covers only `@MetaMask/metamask-assets`-owned files:

- `app/components/UI/AssetOverview/Price/Price.styles.tsx`
- `app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx`
- `app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts`
- `app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts`

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for all touched components pass locally (206/206).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user opens asset surfaces that use absolute-fill overlays
    Given the app is built from this branch
    When user opens a token details page with the price chart loading
    Then the chart loading overlay renders full-size as before
    When user opens the watchlist full-screen search
    Then the search content overlay covers the view as before
    When user views an NFT with media loading
    Then the collectible media placeholder fills its container as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical API rename with identical runtime behavior on current RN; no logic, auth, or data changes.
> 
> **Overview**
> Prepares Assets-owned UI for React Native 0.85 by swapping deprecated `StyleSheet.absoluteFillObject` for `StyleSheet.absoluteFill` in four style files.
> 
> **Price** (`noDataOverlay`), **PriceChart** (`loadingOverlayContainer`, `noDataOverlayContainer`), **WatchlistSearchContent** (`skeletonOverlay`), and **CollectibleMedia** (`imageFallBackTextContainer`) keep the same spread or direct assignment pattern; on current RN builds the two APIs are aliases, so layout and overlays should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0952b55b43e57776bb0705126f90bc2dce60ca4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->