### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (Bridge, Ramp)

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
@@ -32,7 +32,7 @@ const styleSheet = (params: { theme: Theme }) =>
       borderRadius: 8,
     },
     hollowCircleContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
@@ -77,7 +77,7 @@ const createStyles = (
       zIndex: 2,
     },
     backgroundShapes: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       zIndex: 1,
       justifyContent: 'center',
       alignItems: 'center',


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 2 usages in Bridge (Swaps team) and Ramp (Money Movement team) components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers:

- `app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx` (`@MetaMask/swaps-engineers`)
- `app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx` (`@MetaMask/money-movement`)

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for both touched component folders pass locally (66/66).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user views bridge transaction details and ramp loading states
    Given the app is built from this branch
    When user opens a bridge transaction's details while it is pending
    Then the pulsing status circle animates centered in its container as before
    When user starts a buy flow and the aggregator quotes are loading
    Then the loading animation renders full-size as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line style alias swaps with no logic or layout API changes; equivalent to current RN behavior.
> 
> **Overview**
> **Replaces** the deprecated `StyleSheet.absoluteFillObject` spread with `StyleSheet.absoluteFill` in two Ramp/Money Movement and Bridge/Swaps UI components ahead of React Native 0.85, where the old name is removed.
> 
> The change is limited to `PulsingCircle` (bridge transaction details pulsing overlay) and Ramp aggregator `LoadingAnimation` (background shapes overlay). Layout and styling behavior are unchanged on current RN versions because the two APIs are equivalent aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fffe18b3e5ea69d2695bd985544c628118c1475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->