### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (Card, Money)

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
 });

--- a/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
+++ b/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
@@ -54,7 +54,7 @@ export interface DaimoPayModalParams {
 
 const baseStyles = StyleSheet.create({
   absoluteFill: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
   },
 });
 

--- a/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
+++ b/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
@@ -111,7 +111,7 @@ const MoneyFirstTimeDepositView = () => {
         dataBinding={AutoBind(true)}
         fit={Fit.Layout}
         layoutScaleFactor={PixelRatio.get()}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         onError={handleError}
         testID={MoneyFirstTimeDepositViewTestIds.RIVE_ANIMATION}
       />

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -493,7 +493,7 @@ const MoneyOnboardingView = () => {
         layoutScaleFactor={PixelRatio.get()}
         onStateChanged={handleStateChanged}
         onError={handleError}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
       />
       <MoneyOnboardingTextOverlay


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 4 usages in Card and Money components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers:

- `app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx` (`@MetaMask/card`)
- `app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx` (`@MetaMask/card`)
- `app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx` (`@MetaMask/earn`)
- `app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx` (`@MetaMask/earn`)

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for all touched component folders pass locally (200/200).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user views Card and Money surfaces that use absolute-fill overlays
    Given the app is built from this branch
    When user opens the Card spending limit view while data is loading
    Then the shimmer overlay covers the content area as before
    When user opens the Daimo Pay modal
    Then the modal backdrop/webview overlay renders full-screen as before
    When user goes through the Money onboarding / first-time deposit views
    Then background layers fill the screen as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style API rename only; no logic, navigation, or payment flow changes.
> 
> **Overview**
> Swaps deprecated **`StyleSheet.absoluteFillObject`** for **`StyleSheet.absoluteFill`** in four Card and Money UI files (shimmer overlay, Daimo Pay modal full-screen layout, and two Rive full-bleed backgrounds). This is RN 0.85 pre-upgrade cleanup with no intended layout or behavior change on current RN versions where the two APIs are equivalent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939b8cf50ca12016f0b71adf2c59ffe2701aa8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->