### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (Perps, Predict)

### DIFF
--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
@@ -531,7 +531,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           {overlaySeries.map((series, index) => (
             <LineChart
               key={`${series.label}-${index}`}
-              style={StyleSheet.absoluteFillObject}
+              style={StyleSheet.absoluteFill}
               data={series.data.map((point) => point.value)}
               svg={{ stroke: series.color, strokeWidth: 2 }}
               contentInset={CHART_CONTENT_INSET}
@@ -543,7 +543,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           ))}
           {/* Tooltip overlay - rendered last to appear on top */}
           <LineChart
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             data={primaryChartData}
             svg={{ stroke: 'transparent', strokeWidth: 0 }}
             contentInset={CHART_CONTENT_INSET}

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -38,7 +38,7 @@ const styleSheet = (params: {
       marginBottom: 16,
     },
     shimmerOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: CARD_BORDER_RADIUS,
     },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 3 usages in Perps and Predict components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers:

- `app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts` (`@MetaMask/perps`)
- `app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx` (`@MetaMask/predict`)

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for both touched component folders pass locally (132/132).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user views Perps and Predict surfaces that use absolute-fill overlays
    Given the app is built from this branch
    When user views the Perpetuals section on the homepage
    Then market tile card overlays render full-size as before
    When user opens a Predict market's details chart
    Then the chart loading/gradient overlay fills the chart area as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic API rename only; no logic, auth, or data changes, and behavior is identical on the current React Native version.
> 
> **Overview**
> **Perps and Predict** swap the deprecated `StyleSheet.absoluteFillObject` for `StyleSheet.absoluteFill` in three overlay styles, as prep for React Native 0.85 where the old name is removed.
> 
> In **PredictDetailsChart**, stacked `LineChart` layers (overlay series and the transparent tooltip chart) still use full-bleed positioning. **PerpsMarketTileCard**’s `shimmerOverlay` still spreads the same absolute-fill box into its style object.
> 
> On the current RN release this is a no-op alias change; layout and visuals should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5ba8ea4fa5bb9e1b2dee5fb4a91b58a9969b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->