### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (Notifications, SocialLeaderboard)

### DIFF
--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -45,7 +45,7 @@ const createStyles = (theme) => {
 
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     titleWrapper: {
       borderBottomWidth: StyleSheet.hairlineWidth,

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -101,7 +101,7 @@ const NotifCard = ({
 
       {/* Border overlay — MaskedView fades the border top-to-transparent */}
       <MaskedView
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         maskElement={
           <LinearGradient
             colors={['black', 'black', 'transparent']}
@@ -112,7 +112,7 @@ const NotifCard = ({
       >
         <View
           style={[
-            StyleSheet.absoluteFillObject,
+            StyleSheet.absoluteFill,
             styles.border,
             { borderColor: mutedBorderColor },
           ]}

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   labelActive: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
@@ -37,7 +37,7 @@ export const OVERLAY_TOP_OFFSET = 80;
  * visual (background, trader cards, buttons). In the v4 ("hybrid") artboard the
  * step title + description are NOT baked into the Rive, so React Native renders
  * them as a non-interactive overlay pinned to the top of the screen, above the
- * Rive element which fills the container via `StyleSheet.absoluteFillObject`.
+ * Rive element which fills the container via `StyleSheet.absoluteFill`.
  */
 const createStyles = () =>
   StyleSheet.create({
@@ -45,7 +45,7 @@ const createStyles = () =>
       flex: 1,
     },
     gradient: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     textOverlay: {
       position: 'absolute',

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
@@ -850,7 +850,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
           shows. */}
       {referencedAssets && (
         <Animated.View
-          style={[StyleSheet.absoluteFillObject, { opacity: riveOpacity }]}
+          style={[StyleSheet.absoluteFill, { opacity: riveOpacity }]}
         >
           <Rive
             ref={ref}
@@ -863,7 +863,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
             layoutScaleFactor={PixelRatio.get()}
             onPlay={revealRive}
             onError={handleError}
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             testID={SocialLeaderboardOnboardingSelectorsIDs.RIVE_ANIMATION}
           />
         </Animated.View>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   layer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 9 usages in Notifications (Engagement team) and SocialLeaderboard (Social & AI team) components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers:

- `app/components/UI/Notification/TransactionNotification/index.js` (`@MetaMask/engagement`)
- `app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx` (`@MetaMask/engagement`)
- `app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx` (`@MetaMask/social-ai`)
- `app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts` (`@MetaMask/social-ai`)
- `app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx` (`@MetaMask/social-ai`)
- `app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx` (`@MetaMask/social-ai`)

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for all touched component folders pass locally (781/781).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user views Notifications and SocialLeaderboard surfaces
    Given the app is built from this branch
    When an in-app transaction notification is shown
    Then the notification backdrop covers the screen as before
    When user goes through push notification onboarding
    Then the notification card art layers render stacked as before
    When user opens the Social Leaderboard onboarding, feed toggle, or a trader position view
    Then background/overlay layers fill their containers as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identical StyleSheet constant on current RN; styling-only touch with no logic, auth, or data changes.
> 
> **Overview**
> Replaces deprecated **`StyleSheet.absoluteFillObject`** with **`StyleSheet.absoluteFill`** across Notifications and Social Leaderboard UI (transaction notification styles, push onboarding card overlays, feed audience toggle, onboarding Rive layers, trader position header). This is pre-work for React Native 0.85, where the old name is removed; on current RN it is an alias swap with no layout or behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35674661e26ac076a07f20809cc57013a271ef94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->