### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (HardwareWallet, Onboarding)

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   overlayCenter: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -370,7 +370,7 @@ export function HwQrScanner() {
     return (
       <>
         <Camera
-          style={StyleSheet.absoluteFillObject}
+          style={StyleSheet.absoluteFill}
           device={cameraDevice}
           isActive={isFocused && hasPermission}
           codeScanner={codeScanner}

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -180,7 +180,7 @@ async function isDeviceOffline(): Promise<boolean> {
 
 const styles = StyleSheet.create({
   androidNotificationOverlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     zIndex: 999,
     elevation: 999,
   },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 3 usages in HardwareWallet (Accounts team) and Onboarding (Web3Auth team) components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers:

- `app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx` (`@MetaMask/accounts-engineers`)
- `app/components/Views/Onboarding/index.tsx` (`@MetaMask/web3auth`)

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for both touched areas pass locally (547 tests; the one pre-existing `Onboarding/index.test.tsx` suite-import failure also reproduces on a pristine `main` checkout locally — environment-related, unaffected by this change).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user views hardware wallet QR scanner and onboarding
    Given the app is built from this branch
    When user connects a QR hardware wallet during a swap and the scanner opens
    Then the camera scanner overlay covers the screen as before
    When user opens the app onboarding flow
    Then the onboarding background layer fills the screen as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only API rename with no logic changes; current RN treats both symbols as the same fill style.
> 
> **Overview**
> Replaces deprecated **`StyleSheet.absoluteFillObject`** with **`StyleSheet.absoluteFill`** in three places as pre-work for the React Native 0.85 upgrade (the alias is removed in 0.85).
> 
> **Hardware wallet QR scanner** (`HwQrScanner.tsx`): the scan-frame overlay style spread and the `Camera` full-bleed style now use `absoluteFill`.
> 
> **Onboarding** (`Onboarding/index.tsx`): the Android notification overlay style spread now uses `absoluteFill`.
> 
> On the app’s current RN version these APIs are equivalent aliases, so layout and behavior should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d70bc8faff55a9b6cf93067daa1886d4c1bbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->