### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (shared UI, no code owner)

### DIFF
--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -45,20 +45,20 @@ const createStyles = (colors: any) =>
       marginRight: 12,
     },
     absoluteFillWithCenter: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       alignItems: 'center',
       justifyContent: 'center',
     },
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     preCompletedContainerStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.default,
     },
     outerCircle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.inverse,
     },

--- a/app/components/UI/DesignerMode/DesignerModeRN.tsx
+++ b/app/components/UI/DesignerMode/DesignerModeRN.tsx
@@ -1295,7 +1295,7 @@ function createDesignerStyles() {
 
     // Backdrop
     backdrop: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: C.backdrop,
     } as ViewStyle,
 

--- a/app/components/UI/ReusableModal/styles.ts
+++ b/app/components/UI/ReusableModal/styles.ts
@@ -16,10 +16,10 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     overlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.overlay.default,
     },
   });

--- a/app/components/UI/SlippageSlider/index.js
+++ b/app/components/UI/SlippageSlider/index.js
@@ -88,7 +88,7 @@ const createStyles = (colors, shadows) =>
       top: 4,
     },
     tooltipText: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       textAlign: 'center',
       ...fontStyles.normal,
       color: colors.overlay.inverse,

--- a/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
+++ b/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
@@ -47,7 +47,7 @@ const createStyles = (colors: ThemeColors) =>
       flex: 1,
     },
     tabImage: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       resizeMode: 'cover',
     },
     activeTab: {

--- a/app/components/UI/UrlAutocomplete/styles.ts
+++ b/app/components/UI/UrlAutocomplete/styles.ts
@@ -8,7 +8,7 @@ import {
 const styleSheet = ({ theme: { colors, typography } }: { theme: Theme }) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       // Hidden by default
       display: 'none',

--- a/app/components/UI/WebviewError/index.js
+++ b/app/components/UI/WebviewError/index.js
@@ -10,7 +10,7 @@ import { WebviewErrorSelectorsIDs } from './WebviewError.testIds';
 const createStyles = (colors) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/Views/MediaPlayer/index.js
+++ b/app/components/Views/MediaPlayer/index.js
@@ -34,7 +34,7 @@ const styleSheet = ({ theme: { colors }, vars: { isPlaying } }) =>
       alignItems: 'center',
     },
     videoControlsStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -505,13 +505,8 @@ function TradeWalletActions() {
 
   return (
     <View style={tw.style('flex-1 justify-end')}>
-      <Animated.View
-        style={[StyleSheet.absoluteFillObject, backdropAnimatedStyle]}
-      >
-        <Pressable
-          style={StyleSheet.absoluteFillObject}
-          onPress={handleNavigateBack}
-        >
+      <Animated.View style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleNavigateBack}>
           <OverlayWithHole
             width={windowWidth}
             height={windowHeight + insetsTop}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces its 14 usages in shared UI components with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade.

This is a split of #33192 into per-team PRs so each one only needs its owning teams' approval (the original touched 10+ teams' code). This slice covers only files with **no CODEOWNERS entry** (any reviewer with write access can approve):

- `app/components/UI/ButtonReveal/index.tsx`
- `app/components/UI/DesignerMode/DesignerModeRN.tsx`
- `app/components/UI/ReusableModal/styles.ts`
- `app/components/UI/SlippageSlider/index.js`
- `app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts`
- `app/components/UI/UrlAutocomplete/styles.ts`
- `app/components/UI/WebviewError/index.js`
- `app/components/Views/MediaPlayer/index.js`
- `app/components/Views/TradeWalletActions/TradeWalletActions.tsx`

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change.

Unit tests for all touched component folders pass locally (86/86).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR, being split per-team), RN 0.85 upgrade pre-work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user opens surfaces that use absolute-fill overlays
    Given the app is built from this branch
    When user opens the in-app browser tabs view
    Then tab thumbnails render with their overlays unchanged
    When user reveals SRP/private key with the hold-to-reveal button
    Then the reveal progress overlay fills the button as before
    When user types a URL in the browser address bar
    Then the autocomplete dropdown overlays the page as before
    When user opens a modal (ReusableModal-based) or plays a media file
    Then overlays and player controls fill their containers as before
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical StyleSheet constant rename with no logic changes; intended runtime parity on current RN and low blast radius limited to overlay positioning styles.
> 
> **Overview**
> Replaces deprecated **`StyleSheet.absoluteFillObject`** with **`StyleSheet.absoluteFill`** across nine shared UI/View files (hold-to-reveal button, Designer Mode backdrop, modals, slippage slider, tab thumbnails, URL autocomplete, webview error, media player controls, and trade wallet action backdrop). This is **RN 0.85 prep**—the old API is removed in that release—while spread and inline `StyleSheet.*` usage stay the same.
> 
> **TradeWalletActions** only tightens JSX around the same backdrop `Pressable` pattern; layout behavior is unchanged. On the current RN line this is intended as a **no-op** alias swap with no visual or functional change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa92783ae4c43a80975a1d78fe16ad5f4598c4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->