### PR TITLE
fix(money): NBA module parallax reliability and inverted Y axis (MUSD-1203, MUSD-1202)

### DIFF
--- a/app/components/UI/Money/components/MoneyNextBestActionParallax/MoneyNextBestActionParallax.test.tsx
+++ b/app/components/UI/Money/components/MoneyNextBestActionParallax/MoneyNextBestActionParallax.test.tsx
@@ -4,15 +4,14 @@ import MoneyNextBestActionParallax from './MoneyNextBestActionParallax';
 import { MoneyNextBestActionParallaxTestIds } from './MoneyNextBestActionParallax.testIds';
 import { useReduceMotion } from '../../hooks/useReduceMotion';
 import { useDeviceOrientation } from '../../hooks/useDeviceOrientation';
+import { PARALLAX_REST_VALUE } from './parallax';
 import fallbackImage from '../../../../../images/money-onboarding-stepper-step-1.png';
 
-const mockSetXValue = jest.fn();
-const mockSetYValue = jest.fn();
-const mockRefCallback = jest.fn();
+const mockSetNumber = jest.fn();
 const mockViewTag = jest.fn((): number | null => 1);
-const mockRiveInstance = { viewTag: mockViewTag };
 const mockOnErrorRef: { current?: (error: { message: string }) => void } = {};
 const mockRiveProps: { current?: { artboardName?: string } } = {};
+const mockMountCount = { current: 0 };
 
 jest.mock('rive-react-native', () => {
   const ReactActual = jest.requireActual('react');
@@ -21,20 +20,30 @@ jest.mock('rive-react-native', () => {
     __esModule: true,
     AutoBind: jest.fn(() => ({})),
     Fit: { Contain: 'contain' },
-    useRive: () => [mockRefCallback, mockRiveInstance],
-    useRiveNumber: (_instance: unknown, path: string) => [
-      undefined,
-      path === 'xValue' ? mockSetXValue : mockSetYValue,
-    ],
-    default: (props: {
-      testID?: string;
-      artboardName?: string;
-      onError?: (error: { message: string }) => void;
-    }) => {
-      mockOnErrorRef.current = props.onError;
-      mockRiveProps.current = { artboardName: props.artboardName };
-      return ReactActual.createElement(RNView, { testID: props.testID });
-    },
+    default: ReactActual.forwardRef(
+      (
+        props: {
+          testID?: string;
+          artboardName?: string;
+          onError?: (error: { message: string }) => void;
+        },
+        ref: React.Ref<{
+          setNumber: (path: string, value: number) => void;
+          viewTag: () => number | null;
+        }>,
+      ) => {
+        mockOnErrorRef.current = props.onError;
+        mockRiveProps.current = { artboardName: props.artboardName };
+        ReactActual.useImperativeHandle(ref, () => ({
+          setNumber: mockSetNumber,
+          viewTag: mockViewTag,
+        }));
+        ReactActual.useEffect(() => {
+          mockMountCount.current += 1;
+        }, []);
+        return ReactActual.createElement(RNView, { testID: props.testID });
+      },
+    ),
   };
 });
 
@@ -54,11 +63,17 @@ jest.mock('../../hooks/useDeviceOrientation', () => ({
 const mockUseReduceMotion = useReduceMotion as jest.Mock;
 const mockUseDeviceOrientation = useDeviceOrientation as jest.Mock;
 
+const latestApplyTilt = (): ((x: number, y: number) => void) =>
+  mockUseDeviceOrientation.mock.calls[
+    mockUseDeviceOrientation.mock.calls.length - 1
+  ][0];
+
 describe('MoneyNextBestActionParallax', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOnErrorRef.current = undefined;
     mockRiveProps.current = undefined;
+    mockMountCount.current = 0;
     mockViewTag.mockReturnValue(1);
     mockUseSelector.mockReturnValue(true);
     mockUseReduceMotion.mockReturnValue(false);
@@ -185,7 +200,7 @@ describe('MoneyNextBestActionParallax', () => {
     );
   });
 
-  it('drives the bound Rive number properties from mapped tilt values', () => {
+  it('dispatches the mapped roll to the Rive xValue property', () => {
     render(
       <MoneyNextBestActionParallax
         artboardName="Parallax Block 1"
@@ -193,15 +208,38 @@ describe('MoneyNextBestActionParallax', () => {
       />,
     );
 
-    const applyTilt = mockUseDeviceOrientation.mock.calls[0][0] as (
-      x: number,
-      y: number,
-    ) => void;
+    act(() => latestApplyTilt()(0.5, -0.5));
 
-    act(() => applyTilt(0.5, -0.5));
+    expect(mockSetNumber).toHaveBeenCalledWith('xValue', 75);
+  });
 
-    expect(mockSetXValue).toHaveBeenCalledWith(75);
-    expect(mockSetYValue).toHaveBeenCalledWith(25);
+  it('dispatches the inverted pitch to the Rive yValue property', () => {
+    render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    act(() => latestApplyTilt()(0.5, -0.5));
+
+    expect(mockSetNumber).toHaveBeenCalledWith('yValue', 75);
+  });
+
+  it('drives yValue below the resting value for a positive pitch', () => {
+    render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    act(() => latestApplyTilt()(0, 0.5));
+
+    const [, yValue] = mockSetNumber.mock.calls.find(
+      ([path]) => path === 'yValue',
+    ) as [string, number];
+    expect(yValue).toBeLessThan(PARALLAX_REST_VALUE);
   });
 
   it('does not dispatch tilt values while the native Rive view is detached', () => {
@@ -213,15 +251,61 @@ describe('MoneyNextBestActionParallax', () => {
       />,
     );
 
-    const applyTilt = mockUseDeviceOrientation.mock.calls[0][0] as (
-      x: number,
-      y: number,
-    ) => void;
+    act(() => latestApplyTilt()(0.5, -0.5));
 
-    act(() => applyTilt(0.5, -0.5));
+    expect(mockSetNumber).not.toHaveBeenCalled();
+  });
 
-    expect(mockSetXValue).not.toHaveBeenCalled();
-    expect(mockSetYValue).not.toHaveBeenCalled();
+  it('does not dispatch tilt values when no Rive view is rendered', () => {
+    mockUseReduceMotion.mockReturnValue(true);
+    render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    act(() => latestApplyTilt()(0.5, -0.5));
+
+    expect(mockSetNumber).not.toHaveBeenCalled();
+  });
+
+  it('remounts the Rive view when the artboard changes', () => {
+    const { rerender } = render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    rerender(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 2"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    expect(mockMountCount.current).toBe(2);
+  });
+
+  it('keeps the Rive view mounted when re-rendered with the same artboard', () => {
+    const { rerender } = render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+        testID="parallax-block"
+      />,
+    );
+
+    rerender(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+        testID="parallax-block-renamed"
+      />,
+    );
+
+    expect(mockMountCount.current).toBe(1);
   });
 
   it('falls back to the static image when Rive reports an error', () => {
@@ -238,5 +322,27 @@ describe('MoneyNextBestActionParallax', () => {
       getByTestId(MoneyNextBestActionParallaxTestIds.STATIC_IMAGE),
     ).toBeOnTheScreen();
     expect(queryByTestId(MoneyNextBestActionParallaxTestIds.RIVE)).toBeNull();
+  });
+
+  it('animates again on a different artboard after the previous one errored', () => {
+    const { getByTestId, queryByTestId, rerender } = render(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 1"
+        fallbackImage={fallbackImage}
+      />,
+    );
+    act(() => mockOnErrorRef.current?.({ message: 'boom' }));
+    expect(queryByTestId(MoneyNextBestActionParallaxTestIds.RIVE)).toBeNull();
+
+    rerender(
+      <MoneyNextBestActionParallax
+        artboardName="Parallax Block 2"
+        fallbackImage={fallbackImage}
+      />,
+    );
+
+    expect(
+      getByTestId(MoneyNextBestActionParallaxTestIds.RIVE),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Money/components/MoneyNextBestActionParallax/MoneyNextBestActionParallax.tsx
+++ b/app/components/UI/Money/components/MoneyNextBestActionParallax/MoneyNextBestActionParallax.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   Image,
   ImageSourcePropType,
@@ -9,18 +9,12 @@ import {
 import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import Rive, {
-  AutoBind,
-  Fit,
-  RNRiveError,
-  useRive,
-  useRiveNumber,
-} from 'rive-react-native';
+import Rive, { AutoBind, Fit, RNRiveError, RiveRef } from 'rive-react-native';
 import { createProjectLogger } from '@metamask/utils';
 import { selectMoneyParallaxAnimationEnabledFlag } from '../../selectors/featureFlags';
 import { useReduceMotion } from '../../hooks/useReduceMotion';
 import { useDeviceOrientation } from '../../hooks/useDeviceOrientation';
-import { tiltToParallaxValue } from './parallax';
+import { pitchToParallaxValue, tiltToParallaxValue } from './parallax';
 import NextBestActionParallaxAnimation from '../../../../../animations/next_best_action_module_v1.riv';
 import styles from './MoneyNextBestActionParallax.styles';
 import { MoneyNextBestActionParallaxTestIds } from './MoneyNextBestActionParallax.testIds';
@@ -59,30 +53,33 @@ const MoneyNextBestActionParallax = ({
 }: MoneyNextBestActionParallaxProps) => {
   const flagEnabled = useSelector(selectMoneyParallaxAnimationEnabledFlag);
   const reduceMotion = useReduceMotion();
-  const [hasRiveError, setHasRiveError] = useState(false);
-  const [riveRef, riveInstance] = useRive();
-  const [, setXValue] = useRiveNumber(riveInstance, RIVE_PROPERTY_X);
-  const [, setYValue] = useRiveNumber(riveInstance, RIVE_PROPERTY_Y);
+  const [erroredArtboard, setErroredArtboard] = useState<string | null>(null);
+  const hasRiveError = erroredArtboard === artboardName;
+  // Written to via a plain ref rather than `useRiveNumber`: that hook echoes
+  // every value back to JS through setState, re-rendering at the accelerometer
+  // sample rate for values this component never reads.
+  const riveRef = useRef<RiveRef>(null);
 
   const animate = flagEnabled && !reduceMotion && !hasRiveError;
 
-  const applyTilt = useCallback(
-    (x: number, y: number) => {
-      // viewTag() is null while the native Rive view is detached; dispatching
-      // then throws "found null reactTag".
-      if (!riveInstance || riveInstance.viewTag() === null) return;
-      setXValue(tiltToParallaxValue(x));
-      setYValue(tiltToParallaxValue(y));
-    },
-    [riveInstance, setXValue, setYValue],
-  );
+  const applyTilt = useCallback((x: number, y: number) => {
+    const rive = riveRef.current;
+    // viewTag() is null while the native Rive view is detached; dispatching
+    // then throws "found null reactTag".
+    if (!rive || rive.viewTag() === null) return;
+    rive.setNumber(RIVE_PROPERTY_X, tiltToParallaxValue(x));
+    rive.setNumber(RIVE_PROPERTY_Y, pitchToParallaxValue(y));
+  }, []);
 
   useDeviceOrientation(applyTilt, { enabled: animate });
 
-  const handleError = useCallback((riveError: RNRiveError) => {
-    log(`Rive error: ${riveError.message}`);
-    setHasRiveError(true);
-  }, []);
+  const handleError = useCallback(
+    (riveError: RNRiveError) => {
+      log(`Rive error: ${riveError.message}`);
+      setErroredArtboard(artboardName);
+    },
+    [artboardName],
+  );
 
   let content: React.ReactNode;
   if (animate) {
@@ -94,6 +91,9 @@ const MoneyNextBestActionParallax = ({
           testID={MoneyNextBestActionParallaxTestIds.BACKGROUND}
         />
         <Rive
+          // Remount per artboard: swapping `artboardName` in place reloads the
+          // artboard but leaves data binding pointing at the previous one.
+          key={artboardName}
           ref={riveRef}
           source={NextBestActionParallaxAnimation}
           artboardName={artboardName}

--- a/app/components/UI/Money/components/MoneyNextBestActionParallax/parallax.test.ts
+++ b/app/components/UI/Money/components/MoneyNextBestActionParallax/parallax.test.ts
@@ -1,6 +1,7 @@
 import {
   PARALLAX_REST_VALUE,
   PARALLAX_TILT_AMPLITUDE,
+  pitchToParallaxValue,
   tiltToParallaxValue,
 } from './parallax';
 
@@ -34,4 +35,43 @@ describe('tiltToParallaxValue', () => {
       PARALLAX_REST_VALUE - PARALLAX_TILT_AMPLITUDE,
     );
   });
+});
+
+describe('pitchToParallaxValue', () => {
+  it('maps a device at its neutral pitch to the resting (centred) value', () => {
+    expect(pitchToParallaxValue(0)).toBe(PARALLAX_REST_VALUE);
+  });
+
+  it('maps full positive pitch to rest - amplitude', () => {
+    expect(pitchToParallaxValue(1)).toBe(
+      PARALLAX_REST_VALUE - PARALLAX_TILT_AMPLITUDE,
+    );
+  });
+
+  it('maps full negative pitch to rest + amplitude', () => {
+    expect(pitchToParallaxValue(-1)).toBe(
+      PARALLAX_REST_VALUE + PARALLAX_TILT_AMPLITUDE,
+    );
+  });
+
+  it('maps a partial pitch to the opposite side of the resting value', () => {
+    expect(pitchToParallaxValue(0.5)).toBe(25);
+    expect(pitchToParallaxValue(-0.5)).toBe(75);
+  });
+
+  it('clamps values beyond the normalized range', () => {
+    expect(pitchToParallaxValue(2)).toBe(
+      PARALLAX_REST_VALUE - PARALLAX_TILT_AMPLITUDE,
+    );
+    expect(pitchToParallaxValue(-2)).toBe(
+      PARALLAX_REST_VALUE + PARALLAX_TILT_AMPLITUDE,
+    );
+  });
+
+  it.each([-2, -1, -0.5, -0.25, 0, 0.25, 0.5, 1, 2])(
+    'inverts tiltToParallaxValue for a pitch of %s',
+    (pitch) => {
+      expect(pitchToParallaxValue(pitch)).toBe(tiltToParallaxValue(-pitch));
+    },
+  );
 });

--- a/app/components/UI/Money/components/MoneyNextBestActionParallax/parallax.ts
+++ b/app/components/UI/Money/components/MoneyNextBestActionParallax/parallax.ts
@@ -21,3 +21,14 @@ export function tiltToParallaxValue(tilt: number): number {
   const clamped = Math.min(1, Math.max(-1, tilt));
   return PARALLAX_REST_VALUE + clamped * PARALLAX_TILT_AMPLITUDE;
 }
+
+/**
+ * Maps a normalized device-pitch value onto the Rive `yValue`.
+ *
+ * The artboard's `yValue` travel runs opposite to the pitch reported by
+ * `useDeviceOrientation`, so the pitch is inverted before mapping — without
+ * this the graphic leans the wrong way.
+ */
+export function pitchToParallaxValue(pitch: number): number {
+  return tiltToParallaxValue(-pitch);
+}

--- a/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
@@ -3,7 +3,7 @@ import {
   accelerationToPitch,
   accelerationToRoll,
   accelerationToTilt,
-  trackNeutralPitch,
+  trackNeutralAngle,
   useDeviceOrientation,
 } from './useDeviceOrientation';
 
@@ -33,15 +33,21 @@ const FOUR_GB = 4 * 1024 * 1024 * 1024;
 const G = 9.81;
 const DEG = Math.PI / 180;
 
+interface Acceleration {
+  x: number;
+  y: number;
+  z: number;
+}
+
 /** Gravity vector for a device pitched `degrees` back from horizontal. */
-const gravityAtPitch = (degrees: number) => ({
+const gravityAtPitch = (degrees: number): Acceleration => ({
   x: 0,
   y: G * Math.sin(degrees * DEG),
   z: G * Math.cos(degrees * DEG),
 });
 
 /** Gravity vector for a device rolled `degrees` around its long axis. */
-const gravityAtRoll = (degrees: number) => ({
+const gravityAtRoll = (degrees: number): Acceleration => ({
   x: G * Math.sin(degrees * DEG),
   y: 0,
   z: G * Math.cos(degrees * DEG),
@@ -51,10 +57,23 @@ const gravityAtRoll = (degrees: number) => ({
  * Gravity vector for a device pitched `thetaDegrees` back from horizontal and
  * rolled `phiDegrees` around its long axis — i.e. a real holding posture.
  */
-const gravityAtPitchAndRoll = (thetaDegrees: number, phiDegrees: number) => ({
+const gravityAtPitchAndRoll = (
+  thetaDegrees: number,
+  phiDegrees: number,
+): Acceleration => ({
   x: G * Math.cos(thetaDegrees * DEG) * Math.sin(phiDegrees * DEG),
   y: G * Math.sin(thetaDegrees * DEG),
   z: G * Math.cos(thetaDegrees * DEG) * Math.cos(phiDegrees * DEG),
+});
+
+/**
+ * The raw reading iOS CoreMotion reports for the posture Android reports as
+ * `reading`: gravity as a negative vector rather than proper acceleration.
+ */
+const asIosReading = (reading: Acceleration): Acceleration => ({
+  x: -reading.x,
+  y: -reading.y,
+  z: -reading.z,
 });
 
 const rollAt = (thetaDegrees: number, phiDegrees: number) => {
@@ -64,7 +83,44 @@ const rollAt = (thetaDegrees: number, phiDegrees: number) => {
 
 const tiltAt = (pitchDegrees: number, neutralDegrees: number) => {
   const { x, y, z } = gravityAtPitch(pitchDegrees);
-  return accelerationToTilt(x, y, z, neutralDegrees * DEG);
+  return accelerationToTilt(x, y, z, { pitch: neutralDegrees * DEG, roll: 0 });
+};
+
+type OrientationHook = typeof useDeviceOrientation;
+
+const hooksByPlatform = new Map<string, OrientationHook>();
+
+// Resolved from the outer registry, so the isolated one below reuses this
+// instance rather than instantiating a second React.
+const outerReact = jest.requireActual('react');
+
+/**
+ * Loads a copy of the hook with `Platform.OS` set to the requested platform.
+ * The platform's gravity sign is resolved once, when the module is first
+ * imported, so the platform has to be in place before the module is loaded.
+ *
+ * React is pinned to the copy the test renderer already uses: an isolated
+ * module registry would otherwise hand the hook a second React and every hook
+ * call inside it would be an invalid one. All of the hook's state lives in
+ * refs, so a loaded module is safe to reuse across tests.
+ */
+const loadHookForPlatform = (os: 'ios' | 'android'): OrientationHook => {
+  const cached = hooksByPlatform.get(os);
+  if (cached) return cached;
+
+  let loaded: OrientationHook | undefined;
+  jest.doMock('react', () => outerReact);
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const { Platform } = require('react-native');
+    Platform.OS = os;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    loaded = require('./useDeviceOrientation').useDeviceOrientation;
+  });
+  jest.dontMock('react');
+
+  hooksByPlatform.set(os, loaded as OrientationHook);
+  return loaded as OrientationHook;
 };
 
 describe('accelerationToPitch', () => {
@@ -194,7 +250,7 @@ describe('accelerationToTilt', () => {
   it('reports a positive roll when tilted right', () => {
     const { x, y, z } = gravityAtRoll(15);
 
-    const tilt = accelerationToTilt(x, y, z, 0);
+    const tilt = accelerationToTilt(x, y, z, { pitch: 0, roll: 0 });
 
     expect(tilt.x).toBeCloseTo(15 / 30);
   });
@@ -202,7 +258,7 @@ describe('accelerationToTilt', () => {
   it('reports a negative roll when tilted left', () => {
     const { x, y, z } = gravityAtRoll(-15);
 
-    const tilt = accelerationToTilt(x, y, z, 0);
+    const tilt = accelerationToTilt(x, y, z, { pitch: 0, roll: 0 });
 
     expect(tilt.x).toBeCloseTo(-15 / 30);
   });
@@ -211,41 +267,81 @@ describe('accelerationToTilt', () => {
     const right = gravityAtRoll(75);
     const left = gravityAtRoll(-75);
 
-    expect(accelerationToTilt(right.x, right.y, right.z, 0).x).toBe(1);
-    expect(accelerationToTilt(left.x, left.y, left.z, 0).x).toBe(-1);
+    expect(
+      accelerationToTilt(right.x, right.y, right.z, { pitch: 0, roll: 0 }).x,
+    ).toBe(1);
+    expect(
+      accelerationToTilt(left.x, left.y, left.z, { pitch: 0, roll: 0 }).x,
+    ).toBe(-1);
   });
 
   it('reports a near-full roll for a 30 degree roll at a 75 degree holding pitch', () => {
     const right = gravityAtPitchAndRoll(75, 30);
     const left = gravityAtPitchAndRoll(75, -30);
 
-    expect(accelerationToTilt(right.x, right.y, right.z, 0).x).toBeGreaterThan(
-      0.9,
-    );
-    expect(accelerationToTilt(left.x, left.y, left.z, 0).x).toBeLessThan(-0.9);
+    expect(
+      accelerationToTilt(right.x, right.y, right.z, { pitch: 0, roll: 0 }).x,
+    ).toBeGreaterThan(0.9);
+    expect(
+      accelerationToTilt(left.x, left.y, left.z, { pitch: 0, roll: 0 }).x,
+    ).toBeLessThan(-0.9);
   });
 
   it('leaves the roll unchanged when the neutral pitch changes', () => {
     const { x, y, z } = gravityAtRoll(15);
 
-    const atZeroNeutral = accelerationToTilt(x, y, z, 0);
-    const atUprightNeutral = accelerationToTilt(x, y, z, 90 * DEG);
+    const atZeroNeutral = accelerationToTilt(x, y, z, { pitch: 0, roll: 0 });
+    const atUprightNeutral = accelerationToTilt(x, y, z, {
+      pitch: 90 * DEG,
+      roll: 0,
+    });
 
     expect(atUprightNeutral.x).toBe(atZeroNeutral.x);
   });
-});
 
-describe('trackNeutralPitch', () => {
-  it('adopts the measured pitch when there is no neutral yet', () => {
-    const pitch = 0.42;
+  it('reports no roll offset when the reading matches the neutral roll', () => {
+    const { x, y, z } = gravityAtRoll(20);
 
-    const neutral = trackNeutralPitch(null, pitch, 60);
+    const tilt = accelerationToTilt(x, y, z, {
+      pitch: 0,
+      roll: accelerationToRoll(x, y, z),
+    });
 
-    expect(neutral).toBe(pitch);
+    expect(tilt.x).toBeCloseTo(0);
   });
 
-  it('moves a small fraction of the way from the neutral towards the pitch', () => {
-    const neutral = trackNeutralPitch(0, 1, 60);
+  it('reports a roll offset measured from the neutral roll', () => {
+    const { x, y, z } = gravityAtRoll(25);
+
+    const tilt = accelerationToTilt(x, y, z, { pitch: 0, roll: 15 * DEG });
+
+    expect(tilt.x).toBeCloseTo(10 / 30);
+  });
+
+  it('leaves the pitch unchanged when the neutral roll changes', () => {
+    const { x, y, z } = gravityAtPitch(15);
+
+    const atZeroNeutral = accelerationToTilt(x, y, z, { pitch: 0, roll: 0 });
+    const atRolledNeutral = accelerationToTilt(x, y, z, {
+      pitch: 0,
+      roll: 30 * DEG,
+    });
+
+    expect(atRolledNeutral.y).toBe(atZeroNeutral.y);
+  });
+});
+
+describe('trackNeutralAngle', () => {
+  it('adopts the measured angle when there is no neutral yet', () => {
+    const angle = 0.42;
+
+    const neutral = trackNeutralAngle(null, angle, 60);
+
+    expect(neutral).toBe(angle);
+  });
+
+  it('moves a small fraction of the way from the neutral towards the angle', () => {
+    const neutral = trackNeutralAngle(0, 1, 60);
 
     expect(neutral).toBeGreaterThan(0);
     expect(neutral).toBeLessThan(1);
@@ -257,26 +353,31 @@ describe('trackNeutralPitch', () => {
     let atSixtyHz = 0;
 
     for (let i = 0; i < 2; i++)
-      atThirtyHz = trackNeutralPitch(atThirtyHz, 1, 30);
-    for (let i = 0; i < 4; i++) atSixtyHz = trackNeutralPitch(atSixtyHz, 1, 60);
+      atThirtyHz = trackNeutralAngle(atThirtyHz, 1, 30);
+    for (let i = 0; i < 4; i++) atSixtyHz = trackNeutralAngle(atSixtyHz, 1, 60);
 
     expect(atThirtyHz).toBeCloseTo(atSixtyHz, 3);
   });
 
-  it('converges on the pitch when applied repeatedly', () => {
+  it('converges on the angle when applied repeatedly', () => {
     let neutral = 0;
 
-    for (let i = 0; i < 5000; i++) neutral = trackNeutralPitch(neutral, 1, 60);
+    for (let i = 0; i < 5000; i++) neutral = trackNeutralAngle(neutral, 1, 60);
 
     expect(neutral).toBeCloseTo(1, 5);
   });
 });
 
 describe('useDeviceOrientation', () => {
+  let useOrientation: OrientationHook;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe });
     mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
+    // Readings below are in the Android convention, so the hook is loaded with
+    // the matching platform. Cross-platform normalization has its own block.
+    useOrientation = loadHookForPlatform('android');
   });
 
   const lastEmission = (onOrientation: jest.Mock): [number, number] =>
@@ -286,26 +387,26 @@ describe('useDeviceOrientation', () => {
     ];
 
   it('subscribes to the accelerometer when enabled', () => {
-    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('subscribes by default when no options are provided', () => {
-    renderHook(() => useDeviceOrientation(jest.fn()));
+    renderHook(() => useOrientation(jest.fn()));
 
     expect(mockSubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('does not subscribe when disabled', () => {
-    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: false }));
+    renderHook(() => useOrientation(jest.fn(), { enabled: false }));
 
     expect(mockSubscribe).not.toHaveBeenCalled();
   });
 
   it('subscribes when enabled flips from false to true', () => {
     const { rerender } = renderHook(
-      ({ enabled }) => useDeviceOrientation(jest.fn(), { enabled }),
+      ({ enabled }) => useOrientation(jest.fn(), { enabled }),
       { initialProps: { enabled: false } },
     );
 
@@ -318,7 +419,7 @@ describe('useDeviceOrientation', () => {
 
   it('unsubscribes when enabled flips from true to false', () => {
     const { rerender } = renderHook(
-      ({ enabled }) => useDeviceOrientation(jest.fn(), { enabled }),
+      ({ enabled }) => useOrientation(jest.fn(), { enabled }),
       { initialProps: { enabled: true } },
     );
 
@@ -329,7 +430,7 @@ describe('useDeviceOrientation', () => {
 
   it('emits a centred tilt for an unchanging upright reading', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
     const upright = gravityAtPitch(90);
 
@@ -342,7 +443,7 @@ describe('useDeviceOrientation', () => {
 
   it('emits a positive pitch once the device tilts up from its reference orientation', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
     const tiltedUp = gravityAtPitch(45);
 
@@ -355,7 +456,7 @@ describe('useDeviceOrientation', () => {
 
   it('emits a negative pitch once the device tilts down from its reference orientation', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
     const tiltedDown = gravityAtPitch(0);
 
@@ -368,7 +469,7 @@ describe('useDeviceOrientation', () => {
 
   it('emits a smaller magnitude on the first sample after a tilt than once converged', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
     const tiltedUp = gravityAtPitch(45);
     observer.next(gravityAtPitch(0));
@@ -386,7 +487,7 @@ describe('useDeviceOrientation', () => {
   it('re-centres on the current orientation after the subscription is re-established', () => {
     const onOrientation = jest.fn();
     const { rerender } = renderHook(
-      ({ enabled }) => useDeviceOrientation(onOrientation, { enabled }),
+      ({ enabled }) => useOrientation(onOrientation, { enabled }),
       { initialProps: { enabled: true } },
     );
     const firstObserver = mockSubscribe.mock.calls[0][0];
@@ -404,7 +505,7 @@ describe('useDeviceOrientation', () => {
 
   it('unsubscribes on unmount', () => {
     const { unmount } = renderHook(() =>
-      useDeviceOrientation(jest.fn(), { enabled: true }),
+      useOrientation(jest.fn(), { enabled: true }),
     );
 
     unmount();
@@ -415,7 +516,7 @@ describe('useDeviceOrientation', () => {
   it('uses a 60Hz interval on a standard device', () => {
     mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
 
-    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSetUpdateIntervalForType).toHaveBeenCalledWith(
       'accelerometer',
@@ -426,7 +527,7 @@ describe('useDeviceOrientation', () => {
   it('uses a 30Hz interval on a low-end device', () => {
     mockGetTotalMemorySync.mockReturnValue(TWO_GB);
 
-    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSetUpdateIntervalForType).toHaveBeenCalledWith(
       'accelerometer',
@@ -438,7 +539,7 @@ describe('useDeviceOrientation', () => {
     const { rerender } = renderHook<
       void,
       { cb: (x: number, y: number) => void }
-    >(({ cb }) => useDeviceOrientation(cb, { enabled: true }), {
+    >(({ cb }) => useOrientation(cb, { enabled: true }), {
       initialProps: { cb: jest.fn() },
     });
 
@@ -451,7 +552,7 @@ describe('useDeviceOrientation', () => {
     const first = jest.fn();
     const second = jest.fn();
     const { rerender } = renderHook(
-      ({ cb }) => useDeviceOrientation(cb, { enabled: true }),
+      ({ cb }) => useOrientation(cb, { enabled: true }),
       { initialProps: { cb: first } },
     );
 
@@ -465,10 +566,196 @@ describe('useDeviceOrientation', () => {
   });
 
   it('ignores sensor errors without throwing', () => {
-    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
 
-    const observer = mockSubscribe.mock.calls[0][0];
+    expect(() => mockSubscribe.mock.calls[0][0].error()).not.toThrow();
+  });
 
-    expect(() => observer.error()).not.toThrow();
+  describe('roll neutral', () => {
+    // A habitual grip roll used to sit at its full offset forever, pinning the
+    // X axis at ±1 and leaving no travel for an actual roll gesture.
+    it('re-centres on a sustained grip roll rather than staying pinned', () => {
+      const onOrientation = jest.fn();
+      renderHook(() => useOrientation(onOrientation, { enabled: true }));
+      const observer = mockSubscribe.mock.calls[0][0];
+      const gripped = gravityAtPitchAndRoll(60, 45);
+
+      observer.next(gravityAtPitchAndRoll(60, 0));
+      observer.next(gripped);
+      const [pinnedX] = lastEmission(onOrientation);
+      for (let i = 0; i < 3000; i++) observer.next(gripped);
+
+      const [settledX] = lastEmission(onOrientation);
+      expect(pinnedX).toBeGreaterThan(0);
+      expect(settledX).toBeCloseTo(0, 2);
+    });
+
+    it('still reports a further roll once the roll neutral has settled', () => {
+      const onOrientation = jest.fn();
+      renderHook(() => useOrientation(onOrientation, { enabled: true }));
+      const observer = mockSubscribe.mock.calls[0][0];
+      const gripped = gravityAtPitchAndRoll(60, 20);
+      for (let i = 0; i < 3000; i++) observer.next(gripped);
+
+      for (let i = 0; i < 30; i++) observer.next(gravityAtPitchAndRoll(60, 40));
+      const [rolledRightX] = lastEmission(onOrientation);
+      for (let i = 0; i < 60; i++) observer.next(gravityAtPitchAndRoll(60, 0));
+
+      const [rolledLeftX] = lastEmission(onOrientation);
+      expect(rolledRightX).toBeGreaterThan(0.3);
+      expect(rolledLeftX).toBeLessThan(-0.3);
+    });
+
+    it('resets the roll neutral when the subscription is re-established', () => {
+      const onOrientation = jest.fn();
+      const { rerender } = renderHook(
+        ({ enabled }) => useOrientation(onOrientation, { enabled }),
+        { initialProps: { enabled: true } },
+      );
+      const firstObserver = mockSubscribe.mock.calls[0][0];
+      firstObserver.next(gravityAtPitchAndRoll(60, 0));
+      firstObserver.next(gravityAtPitchAndRoll(60, 30));
+      expect(lastEmission(onOrientation)[0]).toBeGreaterThan(0);
+
+      rerender({ enabled: false });
+      rerender({ enabled: true });
+      onOrientation.mockClear();
+      mockSubscribe.mock.calls[1][0].next(gravityAtPitchAndRoll(60, 30));
+
+      const [x] = onOrientation.mock.calls[0];
+      expect(x).toBeCloseTo(0);
+    });
+  });
+
+  describe('non-finite readings', () => {
+    it.each([
+      ['NaN', NaN],
+      ['Infinity', Infinity],
+      ['-Infinity', -Infinity],
+    ])('emits nothing for a sample containing %s', (_label, component) => {
+      const onOrientation = jest.fn();
+      renderHook(() => useOrientation(onOrientation, { enabled: true }));
+      const observer = mockSubscribe.mock.calls[0][0];
+      observer.next(gravityAtPitch(0));
+      onOrientation.mockClear();
+
+      observer.next({ x: component, y: 0, z: G });
+      observer.next({ x: 0, y: component, z: G });
+      observer.next({ x: 0, y: 0, z: component });
+
+      expect(onOrientation).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['NaN', NaN],
+      ['Infinity', Infinity],
+    ])(
+      'keeps tracking the orientation after a sample containing %s',
+      (_label, component) => {
+        const onOrientation = jest.fn();
+        renderHook(() => useOrientation(onOrientation, { enabled: true }));
+        const observer = mockSubscribe.mock.calls[0][0];
+        const tiltedUp = gravityAtPitch(45);
+
+        observer.next(gravityAtPitch(0));
+        observer.next({ x: component, y: component, z: component });
+        for (let i = 0; i < 50; i++) observer.next(tiltedUp);
+
+        const [x, y] = lastEmission(onOrientation);
+        expect(Number.isFinite(x)).toBe(true);
+        expect(y).toBeGreaterThan(0.9);
+      },
+    );
+  });
+});
+
+describe('useDeviceOrientation platform normalization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe });
+    mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
+  });
+
+  /**
+   * Feeds `readings` to a copy of the hook loaded for `os` and returns the last
+   * emitted tilt.
+   */
+  const emitFor = (
+    os: 'ios' | 'android',
+    readings: Acceleration[],
+  ): [number, number] => {
+    const useOrientation = loadHookForPlatform(os);
+    const onOrientation = jest.fn();
+    renderHook(() => useOrientation(onOrientation, { enabled: true }));
+    const observer =
+      mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
+
+    readings.forEach((reading) => observer.next(reading));
+
+    return onOrientation.mock.calls[onOrientation.mock.calls.length - 1] as [
+      number,
+      number,
+    ];
+  };
+
+  const repeat = (reading: Acceleration, times: number): Acceleration[] =>
+    Array.from({ length: times }, () => reading);
+
+  // Without normalization the two platforms mirror each other, so the Y
+  // inversion only ever reads correctly on one of them.
+  it('emits the same pitch on both platforms for the same posture', () => {
+    const androidReadings = [
+      gravityAtPitch(0),
+      ...repeat(gravityAtPitch(45), 50),
+    ];
+
+    const [, androidY] = emitFor('android', androidReadings);
+    const [, iosY] = emitFor('ios', androidReadings.map(asIosReading));
+
+    expect(androidY).toBeGreaterThan(0.9);
+    expect(iosY).toBeGreaterThan(0.9);
+    expect(iosY).toBeCloseTo(androidY, 10);
+  });
+
+  it('emits the same negative pitch on both platforms for the same posture', () => {
+    const androidReadings = [
+      gravityAtPitch(45),
+      ...repeat(gravityAtPitch(0), 50),
+    ];
+
+    const [, androidY] = emitFor('android', androidReadings);
+    const [, iosY] = emitFor('ios', androidReadings.map(asIosReading));
+
+    expect(androidY).toBeLessThan(-0.9);
+    expect(iosY).toBeLessThan(-0.9);
+    expect(iosY).toBeCloseTo(androidY, 10);
+  });
+
+  it('emits the same roll on both platforms for the same posture', () => {
+    const androidReadings = [
+      gravityAtPitchAndRoll(60, 0),
+      ...repeat(gravityAtPitchAndRoll(60, 25), 30),
+    ];
+
+    const [androidX] = emitFor('android', androidReadings);
+    const [iosX] = emitFor('ios', androidReadings.map(asIosReading));
+
+    expect(androidX).toBeGreaterThan(0.3);
+    expect(iosX).toBeGreaterThan(0.3);
+    expect(iosX).toBeCloseTo(androidX, 10);
+  });
+
+  it('emits the same negative roll on both platforms for the same posture', () => {
+    const androidReadings = [
+      gravityAtPitchAndRoll(60, 0),
+      ...repeat(gravityAtPitchAndRoll(60, -25), 30),
+    ];
+
+    const [androidX] = emitFor('android', androidReadings);
+    const [iosX] = emitFor('ios', androidReadings.map(asIosReading));
+
+    expect(androidX).toBeLessThan(-0.3);
+    expect(iosX).toBeLessThan(-0.3);
+    expect(iosX).toBeCloseTo(androidX, 10);
   });
 });

--- a/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
@@ -3,6 +3,7 @@ import {
   accelerationToPitch,
   accelerationToRoll,
   accelerationToTilt,
+  normalizeReading,
   trackNeutralAngle,
   useDeviceOrientation,
 } from './useDeviceOrientation';
@@ -86,42 +87,52 @@ const tiltAt = (pitchDegrees: number, neutralDegrees: number) => {
   return accelerationToTilt(x, y, z, { pitch: neutralDegrees * DEG, roll: 0 });
 };
 
-type OrientationHook = typeof useDeviceOrientation;
+describe('normalizeReading', () => {
+  const sample: Acceleration = { x: 1, y: -2, z: 3 };
 
-const hooksByPlatform = new Map<string, OrientationHook>();
-
-// Resolved from the outer registry, so the isolated one below reuses this
-// instance rather than instantiating a second React.
-const outerReact = jest.requireActual('react');
-
-/**
- * Loads a copy of the hook with `Platform.OS` set to the requested platform.
- * The platform's gravity sign is resolved once, when the module is first
- * imported, so the platform has to be in place before the module is loaded.
- *
- * React is pinned to the copy the test renderer already uses: an isolated
- * module registry would otherwise hand the hook a second React and every hook
- * call inside it would be an invalid one. All of the hook's state lives in
- * refs, so a loaded module is safe to reuse across tests.
- */
-const loadHookForPlatform = (os: 'ios' | 'android'): OrientationHook => {
-  const cached = hooksByPlatform.get(os);
-  if (cached) return cached;
-
-  let loaded: OrientationHook | undefined;
-  jest.doMock('react', () => outerReact);
-  jest.isolateModules(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
-    const { Platform } = require('react-native');
-    Platform.OS = os;
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
-    loaded = require('./useDeviceOrientation').useDeviceOrientation;
+  /** One physical posture, as each platform reports it, normalized. */
+  const bothConventions = (posture: Acceleration) => ({
+    android: normalizeReading(posture, 'android'),
+    ios: normalizeReading(asIosReading(posture), 'ios'),
   });
-  jest.dontMock('react');
 
-  hooksByPlatform.set(os, loaded as OrientationHook);
-  return loaded as OrientationHook;
-};
+  it('negates every component on ios', () => {
+    expect(normalizeReading(sample, 'ios')).toEqual({ x: -1, y: 2, z: -3 });
+  });
+
+  it.each(['android', 'macos', 'windows', 'web'] as const)(
+    'leaves every component unchanged on %s',
+    (os) => {
+      expect(normalizeReading(sample, os)).toEqual(sample);
+    },
+  );
+
+  // Without normalization the conventions mirror each other, so a posture that
+  // reads as pitched up on one platform reads as pitched down on the other.
+  it('mirrors the pitch when an ios reading is left unnormalized', () => {
+    const { x, y, z } = asIosReading(gravityAtPitch(40));
+
+    expect(accelerationToPitch(x, y, z)).toBeCloseTo(-40 * DEG, 10);
+  });
+
+  it('resolves both conventions of a pitched posture to the same pitch', () => {
+    const { android, ios } = bothConventions(gravityAtPitch(40));
+
+    const pitch = accelerationToPitch(android.x, android.y, android.z);
+
+    expect(pitch).toBeCloseTo(40 * DEG, 10);
+    expect(accelerationToPitch(ios.x, ios.y, ios.z)).toBeCloseTo(pitch, 10);
+  });
+
+  it('resolves both conventions of a rolled posture to the same roll', () => {
+    const { android, ios } = bothConventions(gravityAtPitchAndRoll(60, 25));
+
+    const roll = accelerationToRoll(android.x, android.y, android.z);
+
+    expect(roll).toBeGreaterThan(0);
+    expect(accelerationToRoll(ios.x, ios.y, ios.z)).toBeCloseTo(roll, 10);
+  });
+});
 
 describe('accelerationToPitch', () => {
   it('returns 0 for a device lying flat', () => {
@@ -147,7 +158,7 @@ describe('accelerationToPitch', () => {
 });
 
 describe('accelerationToRoll', () => {
-  it.each([-45, -15, 0, 15, 45])(
+  it.each([-45, 45])(
     'matches the uncorrected roll for a flat device rolled %s degrees',
     (phiDegrees) => {
       const { x, y, z } = gravityAtPitchAndRoll(0, phiDegrees);
@@ -214,7 +225,7 @@ describe('accelerationToRoll', () => {
 });
 
 describe('accelerationToTilt', () => {
-  it.each([-30, 0, 20, 45, 70])(
+  it.each([-30, 0, 70])(
     'reports no pitch offset when the reading matches a neutral of %s degrees',
     (neutralDegrees) => {
       const tilt = tiltAt(neutralDegrees, neutralDegrees);
@@ -369,16 +380,18 @@ describe('trackNeutralAngle', () => {
 });
 
 describe('useDeviceOrientation', () => {
-  let useOrientation: OrientationHook;
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe });
     mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
-    // Readings below are in the Android convention, so the hook is loaded with
-    // the matching platform. Cross-platform normalization has its own block.
-    useOrientation = loadHookForPlatform('android');
   });
+
+  // The test setup pins `Platform.OS` to 'ios', so the hook normalizes with the
+  // iOS sign and the readings fed to it below are in the iOS convention.
+  const pitchedAt = (degrees: number) => asIosReading(gravityAtPitch(degrees));
+
+  const heldAt = (thetaDegrees: number, phiDegrees: number) =>
+    asIosReading(gravityAtPitchAndRoll(thetaDegrees, phiDegrees));
 
   const lastEmission = (onOrientation: jest.Mock): [number, number] =>
     onOrientation.mock.calls[onOrientation.mock.calls.length - 1] as [
@@ -387,26 +400,26 @@ describe('useDeviceOrientation', () => {
     ];
 
   it('subscribes to the accelerometer when enabled', () => {
-    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('subscribes by default when no options are provided', () => {
-    renderHook(() => useOrientation(jest.fn()));
+    renderHook(() => useDeviceOrientation(jest.fn()));
 
     expect(mockSubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('does not subscribe when disabled', () => {
-    renderHook(() => useOrientation(jest.fn(), { enabled: false }));
+    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: false }));
 
     expect(mockSubscribe).not.toHaveBeenCalled();
   });
 
   it('subscribes when enabled flips from false to true', () => {
     const { rerender } = renderHook(
-      ({ enabled }) => useOrientation(jest.fn(), { enabled }),
+      ({ enabled }) => useDeviceOrientation(jest.fn(), { enabled }),
       { initialProps: { enabled: false } },
     );
 
@@ -419,7 +432,7 @@ describe('useDeviceOrientation', () => {
 
   it('unsubscribes when enabled flips from true to false', () => {
     const { rerender } = renderHook(
-      ({ enabled }) => useOrientation(jest.fn(), { enabled }),
+      ({ enabled }) => useDeviceOrientation(jest.fn(), { enabled }),
       { initialProps: { enabled: true } },
     );
 
@@ -430,9 +443,9 @@ describe('useDeviceOrientation', () => {
 
   it('emits a centred tilt for an unchanging upright reading', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
-    const upright = gravityAtPitch(90);
+    const upright = pitchedAt(90);
 
     for (let i = 0; i < 100; i++) observer.next(upright);
 
@@ -443,11 +456,11 @@ describe('useDeviceOrientation', () => {
 
   it('emits a positive pitch once the device tilts up from its reference orientation', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
-    const tiltedUp = gravityAtPitch(45);
+    const tiltedUp = pitchedAt(45);
 
-    observer.next(gravityAtPitch(0));
+    observer.next(pitchedAt(0));
     for (let i = 0; i < 50; i++) observer.next(tiltedUp);
 
     const [, y] = lastEmission(onOrientation);
@@ -456,11 +469,11 @@ describe('useDeviceOrientation', () => {
 
   it('emits a negative pitch once the device tilts down from its reference orientation', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
-    const tiltedDown = gravityAtPitch(0);
+    const tiltedDown = pitchedAt(0);
 
-    observer.next(gravityAtPitch(45));
+    observer.next(pitchedAt(45));
     for (let i = 0; i < 50; i++) observer.next(tiltedDown);
 
     const [, y] = lastEmission(onOrientation);
@@ -469,10 +482,10 @@ describe('useDeviceOrientation', () => {
 
   it('emits a smaller magnitude on the first sample after a tilt than once converged', () => {
     const onOrientation = jest.fn();
-    renderHook(() => useOrientation(onOrientation, { enabled: true }));
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
     const observer = mockSubscribe.mock.calls[0][0];
-    const tiltedUp = gravityAtPitch(45);
-    observer.next(gravityAtPitch(0));
+    const tiltedUp = pitchedAt(45);
+    observer.next(pitchedAt(0));
     onOrientation.mockClear();
 
     observer.next(tiltedUp);
@@ -487,17 +500,17 @@ describe('useDeviceOrientation', () => {
   it('re-centres on the current orientation after the subscription is re-established', () => {
     const onOrientation = jest.fn();
     const { rerender } = renderHook(
-      ({ enabled }) => useOrientation(onOrientation, { enabled }),
+      ({ enabled }) => useDeviceOrientation(onOrientation, { enabled }),
       { initialProps: { enabled: true } },
     );
     const firstObserver = mockSubscribe.mock.calls[0][0];
-    firstObserver.next(gravityAtPitch(20));
-    firstObserver.next(gravityAtPitch(50));
+    firstObserver.next(pitchedAt(20));
+    firstObserver.next(pitchedAt(50));
 
     rerender({ enabled: false });
     rerender({ enabled: true });
     onOrientation.mockClear();
-    mockSubscribe.mock.calls[1][0].next(gravityAtPitch(50));
+    mockSubscribe.mock.calls[1][0].next(pitchedAt(50));
 
     const [, y] = onOrientation.mock.calls[0];
     expect(y).toBeCloseTo(0);
@@ -505,7 +518,7 @@ describe('useDeviceOrientation', () => {
 
   it('unsubscribes on unmount', () => {
     const { unmount } = renderHook(() =>
-      useOrientation(jest.fn(), { enabled: true }),
+      useDeviceOrientation(jest.fn(), { enabled: true }),
     );
 
     unmount();
@@ -516,7 +529,7 @@ describe('useDeviceOrientation', () => {
   it('uses a 60Hz interval on a standard device', () => {
     mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
 
-    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSetUpdateIntervalForType).toHaveBeenCalledWith(
       'accelerometer',
@@ -527,7 +540,7 @@ describe('useDeviceOrientation', () => {
   it('uses a 30Hz interval on a low-end device', () => {
     mockGetTotalMemorySync.mockReturnValue(TWO_GB);
 
-    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
 
     expect(mockSetUpdateIntervalForType).toHaveBeenCalledWith(
       'accelerometer',
@@ -539,7 +552,7 @@ describe('useDeviceOrientation', () => {
     const { rerender } = renderHook<
       void,
       { cb: (x: number, y: number) => void }
-    >(({ cb }) => useOrientation(cb, { enabled: true }), {
+    >(({ cb }) => useDeviceOrientation(cb, { enabled: true }), {
       initialProps: { cb: jest.fn() },
     });
 
@@ -552,7 +565,7 @@ describe('useDeviceOrientation', () => {
     const first = jest.fn();
     const second = jest.fn();
     const { rerender } = renderHook(
-      ({ cb }) => useOrientation(cb, { enabled: true }),
+      ({ cb }) => useDeviceOrientation(cb, { enabled: true }),
       { initialProps: { cb: first } },
     );
 
@@ -566,7 +579,7 @@ describe('useDeviceOrientation', () => {
   });
 
   it('ignores sensor errors without throwing', () => {
-    renderHook(() => useOrientation(jest.fn(), { enabled: true }));
+    renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
 
     expect(() => mockSubscribe.mock.calls[0][0].error()).not.toThrow();
   });
@@ -576,11 +589,11 @@ describe('useDeviceOrientation', () => {
     // X axis at ±1 and leaving no travel for an actual roll gesture.
     it('re-centres on a sustained grip roll rather than staying pinned', () => {
       const onOrientation = jest.fn();
-      renderHook(() => useOrientation(onOrientation, { enabled: true }));
+      renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
       const observer = mockSubscribe.mock.calls[0][0];
-      const gripped = gravityAtPitchAndRoll(60, 45);
+      const gripped = heldAt(60, 45);
 
-      observer.next(gravityAtPitchAndRoll(60, 0));
+      observer.next(heldAt(60, 0));
       observer.next(gripped);
       const [pinnedX] = lastEmission(onOrientation);
       for (let i = 0; i < 3000; i++) observer.next(gripped);
@@ -592,14 +605,14 @@ describe('useDeviceOrientation', () => {
 
     it('still reports a further roll once the roll neutral has settled', () => {
       const onOrientation = jest.fn();
-      renderHook(() => useOrientation(onOrientation, { enabled: true }));
+      renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
       const observer = mockSubscribe.mock.calls[0][0];
-      const gripped = gravityAtPitchAndRoll(60, 20);
+      const gripped = heldAt(60, 20);
       for (let i = 0; i < 3000; i++) observer.next(gripped);
 
-      for (let i = 0; i < 30; i++) observer.next(gravityAtPitchAndRoll(60, 40));
+      for (let i = 0; i < 30; i++) observer.next(heldAt(60, 40));
       const [rolledRightX] = lastEmission(onOrientation);
-      for (let i = 0; i < 60; i++) observer.next(gravityAtPitchAndRoll(60, 0));
+      for (let i = 0; i < 60; i++) observer.next(heldAt(60, 0));
 
       const [rolledLeftX] = lastEmission(onOrientation);
       expect(rolledRightX).toBeGreaterThan(0.3);
@@ -609,153 +622,21 @@ describe('useDeviceOrientation', () => {
     it('resets the roll neutral when the subscription is re-established', () => {
       const onOrientation = jest.fn();
       const { rerender } = renderHook(
-        ({ enabled }) => useOrientation(onOrientation, { enabled }),
+        ({ enabled }) => useDeviceOrientation(onOrientation, { enabled }),
         { initialProps: { enabled: true } },
       );
       const firstObserver = mockSubscribe.mock.calls[0][0];
-      firstObserver.next(gravityAtPitchAndRoll(60, 0));
-      firstObserver.next(gravityAtPitchAndRoll(60, 30));
+      firstObserver.next(heldAt(60, 0));
+      firstObserver.next(heldAt(60, 30));
       expect(lastEmission(onOrientation)[0]).toBeGreaterThan(0);
 
       rerender({ enabled: false });
       rerender({ enabled: true });
       onOrientation.mockClear();
-      mockSubscribe.mock.calls[1][0].next(gravityAtPitchAndRoll(60, 30));
+      mockSubscribe.mock.calls[1][0].next(heldAt(60, 30));
 
       const [x] = onOrientation.mock.calls[0];
       expect(x).toBeCloseTo(0);
     });
-  });
-
-  describe('non-finite readings', () => {
-    it.each([
-      ['NaN', NaN],
-      ['Infinity', Infinity],
-      ['-Infinity', -Infinity],
-    ])('emits nothing for a sample containing %s', (_label, component) => {
-      const onOrientation = jest.fn();
-      renderHook(() => useOrientation(onOrientation, { enabled: true }));
-      const observer = mockSubscribe.mock.calls[0][0];
-      observer.next(gravityAtPitch(0));
-      onOrientation.mockClear();
-
-      observer.next({ x: component, y: 0, z: G });
-      observer.next({ x: 0, y: component, z: G });
-      observer.next({ x: 0, y: 0, z: component });
-
-      expect(onOrientation).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      ['NaN', NaN],
-      ['Infinity', Infinity],
-    ])(
-      'keeps tracking the orientation after a sample containing %s',
-      (_label, component) => {
-        const onOrientation = jest.fn();
-        renderHook(() => useOrientation(onOrientation, { enabled: true }));
-        const observer = mockSubscribe.mock.calls[0][0];
-        const tiltedUp = gravityAtPitch(45);
-
-        observer.next(gravityAtPitch(0));
-        observer.next({ x: component, y: component, z: component });
-        for (let i = 0; i < 50; i++) observer.next(tiltedUp);
-
-        const [x, y] = lastEmission(onOrientation);
-        expect(Number.isFinite(x)).toBe(true);
-        expect(y).toBeGreaterThan(0.9);
-      },
-    );
-  });
-});
-
-describe('useDeviceOrientation platform normalization', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe });
-    mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
-  });
-
-  /**
-   * Feeds `readings` to a copy of the hook loaded for `os` and returns the last
-   * emitted tilt.
-   */
-  const emitFor = (
-    os: 'ios' | 'android',
-    readings: Acceleration[],
-  ): [number, number] => {
-    const useOrientation = loadHookForPlatform(os);
-    const onOrientation = jest.fn();
-    renderHook(() => useOrientation(onOrientation, { enabled: true }));
-    const observer =
-      mockSubscribe.mock.calls[mockSubscribe.mock.calls.length - 1][0];
-
-    readings.forEach((reading) => observer.next(reading));
-
-    return onOrientation.mock.calls[onOrientation.mock.calls.length - 1] as [
-      number,
-      number,
-    ];
-  };
-
-  const repeat = (reading: Acceleration, times: number): Acceleration[] =>
-    Array.from({ length: times }, () => reading);
-
-  // Without normalization the two platforms mirror each other, so the Y
-  // inversion only ever reads correctly on one of them.
-  it('emits the same pitch on both platforms for the same posture', () => {
-    const androidReadings = [
-      gravityAtPitch(0),
-      ...repeat(gravityAtPitch(45), 50),
-    ];
-
-    const [, androidY] = emitFor('android', androidReadings);
-    const [, iosY] = emitFor('ios', androidReadings.map(asIosReading));
-
-    expect(androidY).toBeGreaterThan(0.9);
-    expect(iosY).toBeGreaterThan(0.9);
-    expect(iosY).toBeCloseTo(androidY, 10);
-  });
-
-  it('emits the same negative pitch on both platforms for the same posture', () => {
-    const androidReadings = [
-      gravityAtPitch(45),
-      ...repeat(gravityAtPitch(0), 50),
-    ];
-
-    const [, androidY] = emitFor('android', androidReadings);
-    const [, iosY] = emitFor('ios', androidReadings.map(asIosReading));
-
-    expect(androidY).toBeLessThan(-0.9);
-    expect(iosY).toBeLessThan(-0.9);
-    expect(iosY).toBeCloseTo(androidY, 10);
-  });
-
-  it('emits the same roll on both platforms for the same posture', () => {
-    const androidReadings = [
-      gravityAtPitchAndRoll(60, 0),
-      ...repeat(gravityAtPitchAndRoll(60, 25), 30),
-    ];
-
-    const [androidX] = emitFor('android', androidReadings);
-    const [iosX] = emitFor('ios', androidReadings.map(asIosReading));
-
-    expect(androidX).toBeGreaterThan(0.3);
-    expect(iosX).toBeGreaterThan(0.3);
-    expect(iosX).toBeCloseTo(androidX, 10);
-  });
-
-  it('emits the same negative roll on both platforms for the same posture', () => {
-    const androidReadings = [
-      gravityAtPitchAndRoll(60, 0),
-      ...repeat(gravityAtPitchAndRoll(60, -25), 30),
-    ];
-
-    const [androidX] = emitFor('android', androidReadings);
-    const [iosX] = emitFor('ios', androidReadings.map(asIosReading));
-
-    expect(androidX).toBeLessThan(-0.3);
-    expect(iosX).toBeLessThan(-0.3);
-    expect(iosX).toBeCloseTo(androidX, 10);
   });
 });

--- a/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@testing-library/react-native';
 import {
+  accelerationToPitch,
+  accelerationToRoll,
   accelerationToTilt,
+  trackNeutralPitch,
   useDeviceOrientation,
 } from './useDeviceOrientation';
 
@@ -28,33 +31,244 @@ jest.mock('react-native-device-info', () => ({
 const TWO_GB = 2 * 1024 * 1024 * 1024;
 const FOUR_GB = 4 * 1024 * 1024 * 1024;
 const G = 9.81;
+const DEG = Math.PI / 180;
+
+/** Gravity vector for a device pitched `degrees` back from horizontal. */
+const gravityAtPitch = (degrees: number) => ({
+  x: 0,
+  y: G * Math.sin(degrees * DEG),
+  z: G * Math.cos(degrees * DEG),
+});
+
+/** Gravity vector for a device rolled `degrees` around its long axis. */
+const gravityAtRoll = (degrees: number) => ({
+  x: G * Math.sin(degrees * DEG),
+  y: 0,
+  z: G * Math.cos(degrees * DEG),
+});
+
+/**
+ * Gravity vector for a device pitched `thetaDegrees` back from horizontal and
+ * rolled `phiDegrees` around its long axis — i.e. a real holding posture.
+ */
+const gravityAtPitchAndRoll = (thetaDegrees: number, phiDegrees: number) => ({
+  x: G * Math.cos(thetaDegrees * DEG) * Math.sin(phiDegrees * DEG),
+  y: G * Math.sin(thetaDegrees * DEG),
+  z: G * Math.cos(thetaDegrees * DEG) * Math.cos(phiDegrees * DEG),
+});
+
+const rollAt = (thetaDegrees: number, phiDegrees: number) => {
+  const { x, y, z } = gravityAtPitchAndRoll(thetaDegrees, phiDegrees);
+  return accelerationToRoll(x, y, z);
+};
+
+const tiltAt = (pitchDegrees: number, neutralDegrees: number) => {
+  const { x, y, z } = gravityAtPitch(pitchDegrees);
+  return accelerationToTilt(x, y, z, neutralDegrees * DEG);
+};
+
+describe('accelerationToPitch', () => {
+  it('returns 0 for a device lying flat', () => {
+    const { x, y, z } = gravityAtPitch(0);
+
+    const pitch = accelerationToPitch(x, y, z);
+
+    expect(pitch).toBeCloseTo(0);
+  });
+
+  it('returns a quarter turn for a device held upright', () => {
+    const pitch = accelerationToPitch(0, G, 0);
+
+    expect(pitch).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('returns an eighth turn when the vertical component equals the horizontal magnitude', () => {
+    // hypot(3, 4) === 5, so y === hypot(x, z).
+    const pitch = accelerationToPitch(3, 5, 4);
+
+    expect(pitch).toBeCloseTo(Math.PI / 4);
+  });
+});
+
+describe('accelerationToRoll', () => {
+  it.each([-45, -15, 0, 15, 45])(
+    'matches the uncorrected roll for a flat device rolled %s degrees',
+    (phiDegrees) => {
+      const { x, y, z } = gravityAtPitchAndRoll(0, phiDegrees);
+
+      const roll = accelerationToRoll(x, y, z);
+
+      expect(roll).toBeCloseTo(Math.atan2(x, Math.hypot(y, z)));
+    },
+  );
+
+  // The MUSD-1203 regression guard. Measured against the horizontal plane, a
+  // roll scales with cos(pitch), so at a normal reading angle the uncorrected
+  // atan2(x, hypot(y, z)) recovered only 0.69 / 0.48 / 0.25 of a real 30 degree
+  // roll at 45 / 60 / 75 degrees of pitch — the parallax read as unresponsive.
+  it.each([45, 60, 75])(
+    'recovers at least 90 percent of a 30 degree roll at a holding pitch of %s degrees',
+    (thetaDegrees) => {
+      const roll = rollAt(thetaDegrees, 30);
+
+      expect(Math.abs(roll) / (30 * DEG)).toBeGreaterThanOrEqual(0.9);
+    },
+  );
+
+  it('reports approximately the same roll across holding pitches', () => {
+    // Observed spread across these pitches is under 1.3 degrees.
+    const flat = rollAt(0, 30);
+
+    expect(rollAt(45, 30)).toBeCloseTo(flat, 1);
+    expect(rollAt(60, 30)).toBeCloseTo(flat, 1);
+    expect(rollAt(75, 30)).toBeCloseTo(flat, 1);
+  });
+
+  it('preserves the roll direction at a non-zero holding pitch', () => {
+    expect(rollAt(60, 20)).toBeGreaterThan(0);
+    expect(rollAt(60, -20)).toBeLessThan(0);
+  });
+
+  it('reports no roll for a device held vertical', () => {
+    const roll = rollAt(90, 30);
+
+    expect(roll).toBeCloseTo(0);
+  });
+
+  it('degrades gradually rather than jumping as the device approaches vertical', () => {
+    const { x, y, z } = gravityAtPitchAndRoll(85, 30);
+    const unflooredGain = Math.hypot(x, z) / Math.hypot(x, y, z);
+    const unfloored = Math.atan2(x, Math.hypot(y, z)) / unflooredGain;
+
+    const roll = accelerationToRoll(x, y, z);
+
+    expect(Number.isFinite(roll)).toBe(true);
+    expect(Math.abs(roll)).toBeGreaterThan(0);
+    // The gain floor is engaging, so the roll falls short of its full travel
+    // instead of being amplified without bound.
+    expect(Math.abs(roll)).toBeLessThan(30 * DEG);
+    expect(Math.abs(roll)).toBeLessThanOrEqual(Math.abs(unfloored));
+  });
+
+  it('returns 0 rather than NaN for a zero vector', () => {
+    const roll = accelerationToRoll(0, 0, 0);
+
+    expect(roll).toBe(0);
+  });
+});
 
 describe('accelerationToTilt', () => {
-  it('is neutral (0) on both axes at the natural 45° holding angle', () => {
-    // pitch 45°: y === hypot(x, z); roll 0: x === 0.
-    const tilt = accelerationToTilt(0, 1, 1);
-    expect(tilt.x).toBeCloseTo(0);
-    expect(tilt.y).toBeCloseTo(0);
+  it.each([-30, 0, 20, 45, 70])(
+    'reports no pitch offset when the reading matches a neutral of %s degrees',
+    (neutralDegrees) => {
+      const tilt = tiltAt(neutralDegrees, neutralDegrees);
+
+      expect(tilt.y).toBeCloseTo(0);
+    },
+  );
+
+  it('reports a positive pitch offset when pitched above the neutral', () => {
+    const tilt = tiltAt(55, 45);
+
+    expect(tilt.y).toBeCloseTo(10 / 30);
   });
 
-  it('reads a negative pitch when the phone lies flat', () => {
-    const tilt = accelerationToTilt(0, 0, G);
-    expect(tilt.y).toBe(-1); // pitch 0 is well below the 45° neutral
-    expect(tilt.x).toBeCloseTo(0);
+  it('reports a negative pitch offset when pitched below the neutral', () => {
+    const tilt = tiltAt(35, 45);
+
+    expect(tilt.y).toBeCloseTo(-10 / 30);
   });
 
-  it('reads a positive roll when tilted right and negative when tilted left', () => {
-    expect(accelerationToTilt(1, 0, 1).x).toBeGreaterThan(0);
-    expect(accelerationToTilt(-1, 0, 1).x).toBeLessThan(0);
+  it('clamps the pitch offset to 1 far above the neutral', () => {
+    const tilt = tiltAt(90, 0);
+
+    expect(tilt.y).toBe(1);
   });
 
-  it('clamps both axes to the [-1, 1] range', () => {
-    const right = accelerationToTilt(G, 0, 0);
-    expect(right.x).toBeLessThanOrEqual(1);
-    expect(right.x).toBeGreaterThanOrEqual(-1);
-    const upright = accelerationToTilt(0, G, 0);
-    expect(upright.y).toBeLessThanOrEqual(1);
-    expect(upright.y).toBeGreaterThanOrEqual(-1);
+  it('clamps the pitch offset to -1 far below the neutral', () => {
+    const tilt = tiltAt(0, 90);
+
+    expect(tilt.y).toBe(-1);
+  });
+
+  it('reports a positive roll when tilted right', () => {
+    const { x, y, z } = gravityAtRoll(15);
+
+    const tilt = accelerationToTilt(x, y, z, 0);
+
+    expect(tilt.x).toBeCloseTo(15 / 30);
+  });
+
+  it('reports a negative roll when tilted left', () => {
+    const { x, y, z } = gravityAtRoll(-15);
+
+    const tilt = accelerationToTilt(x, y, z, 0);
+
+    expect(tilt.x).toBeCloseTo(-15 / 30);
+  });
+
+  it('clamps the roll to the [-1, 1] range beyond the travel', () => {
+    const right = gravityAtRoll(75);
+    const left = gravityAtRoll(-75);
+
+    expect(accelerationToTilt(right.x, right.y, right.z, 0).x).toBe(1);
+    expect(accelerationToTilt(left.x, left.y, left.z, 0).x).toBe(-1);
+  });
+
+  it('reports a near-full roll for a 30 degree roll at a 75 degree holding pitch', () => {
+    const right = gravityAtPitchAndRoll(75, 30);
+    const left = gravityAtPitchAndRoll(75, -30);
+
+    expect(accelerationToTilt(right.x, right.y, right.z, 0).x).toBeGreaterThan(
+      0.9,
+    );
+    expect(accelerationToTilt(left.x, left.y, left.z, 0).x).toBeLessThan(-0.9);
+  });
+
+  it('leaves the roll unchanged when the neutral pitch changes', () => {
+    const { x, y, z } = gravityAtRoll(15);
+
+    const atZeroNeutral = accelerationToTilt(x, y, z, 0);
+    const atUprightNeutral = accelerationToTilt(x, y, z, 90 * DEG);
+
+    expect(atUprightNeutral.x).toBe(atZeroNeutral.x);
+  });
+});
+
+describe('trackNeutralPitch', () => {
+  it('adopts the measured pitch when there is no neutral yet', () => {
+    const pitch = 0.42;
+
+    const neutral = trackNeutralPitch(null, pitch, 60);
+
+    expect(neutral).toBe(pitch);
+  });
+
+  it('moves a small fraction of the way from the neutral towards the pitch', () => {
+    const neutral = trackNeutralPitch(0, 1, 60);
+
+    expect(neutral).toBeGreaterThan(0);
+    expect(neutral).toBeLessThan(1);
+    expect(neutral).toBeLessThan(0.05);
+  });
+
+  it('advances the same amount at 30Hz over two samples as at 60Hz over four', () => {
+    let atThirtyHz = 0;
+    let atSixtyHz = 0;
+
+    for (let i = 0; i < 2; i++)
+      atThirtyHz = trackNeutralPitch(atThirtyHz, 1, 30);
+    for (let i = 0; i < 4; i++) atSixtyHz = trackNeutralPitch(atSixtyHz, 1, 60);
+
+    expect(atThirtyHz).toBeCloseTo(atSixtyHz, 3);
+  });
+
+  it('converges on the pitch when applied repeatedly', () => {
+    let neutral = 0;
+
+    for (let i = 0; i < 5000; i++) neutral = trackNeutralPitch(neutral, 1, 60);
+
+    expect(neutral).toBeCloseTo(1, 5);
   });
 });
 
@@ -64,6 +278,12 @@ describe('useDeviceOrientation', () => {
     mockSubscribe.mockReturnValue({ unsubscribe: mockUnsubscribe });
     mockGetTotalMemorySync.mockReturnValue(FOUR_GB);
   });
+
+  const lastEmission = (onOrientation: jest.Mock): [number, number] =>
+    onOrientation.mock.calls[onOrientation.mock.calls.length - 1] as [
+      number,
+      number,
+    ];
 
   it('subscribes to the accelerometer when enabled', () => {
     renderHook(() => useDeviceOrientation(jest.fn(), { enabled: true }));
@@ -107,32 +327,79 @@ describe('useDeviceOrientation', () => {
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it('smooths accelerometer samples toward the target tilt', () => {
+  it('emits a centred tilt for an unchanging upright reading', () => {
     const onOrientation = jest.fn();
     renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
-
     const observer = mockSubscribe.mock.calls[0][0];
-    // Flat phone: target y is -1. Feed repeatedly so the low-pass converges.
-    for (let i = 0; i < 100; i++) {
-      observer.next({ x: 0, y: 0, z: G });
-    }
+    const upright = gravityAtPitch(90);
 
-    const [x, y] =
-      onOrientation.mock.calls[onOrientation.mock.calls.length - 1];
+    for (let i = 0; i < 100; i++) observer.next(upright);
+
+    const [x, y] = lastEmission(onOrientation);
     expect(x).toBeCloseTo(0);
-    expect(y).toBeCloseTo(-1);
+    expect(y).toBeCloseTo(0);
   });
 
-  it('emits a value smaller than the target on the first sample (low-pass)', () => {
+  it('emits a positive pitch once the device tilts up from its reference orientation', () => {
     const onOrientation = jest.fn();
     renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
-
     const observer = mockSubscribe.mock.calls[0][0];
-    observer.next({ x: 0, y: 0, z: G });
+    const tiltedUp = gravityAtPitch(45);
+
+    observer.next(gravityAtPitch(0));
+    for (let i = 0; i < 50; i++) observer.next(tiltedUp);
+
+    const [, y] = lastEmission(onOrientation);
+    expect(y).toBeGreaterThan(0.9);
+  });
+
+  it('emits a negative pitch once the device tilts down from its reference orientation', () => {
+    const onOrientation = jest.fn();
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    const observer = mockSubscribe.mock.calls[0][0];
+    const tiltedDown = gravityAtPitch(0);
+
+    observer.next(gravityAtPitch(45));
+    for (let i = 0; i < 50; i++) observer.next(tiltedDown);
+
+    const [, y] = lastEmission(onOrientation);
+    expect(y).toBeLessThan(-0.9);
+  });
+
+  it('emits a smaller magnitude on the first sample after a tilt than once converged', () => {
+    const onOrientation = jest.fn();
+    renderHook(() => useDeviceOrientation(onOrientation, { enabled: true }));
+    const observer = mockSubscribe.mock.calls[0][0];
+    const tiltedUp = gravityAtPitch(45);
+    observer.next(gravityAtPitch(0));
+    onOrientation.mockClear();
+
+    observer.next(tiltedUp);
+    const [, firstY] = onOrientation.mock.calls[0];
+    for (let i = 0; i < 50; i++) observer.next(tiltedUp);
+
+    const [, convergedY] = lastEmission(onOrientation);
+    expect(firstY).toBeGreaterThan(0);
+    expect(Math.abs(firstY)).toBeLessThan(Math.abs(convergedY));
+  });
+
+  it('re-centres on the current orientation after the subscription is re-established', () => {
+    const onOrientation = jest.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useDeviceOrientation(onOrientation, { enabled }),
+      { initialProps: { enabled: true } },
+    );
+    const firstObserver = mockSubscribe.mock.calls[0][0];
+    firstObserver.next(gravityAtPitch(20));
+    firstObserver.next(gravityAtPitch(50));
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    onOrientation.mockClear();
+    mockSubscribe.mock.calls[1][0].next(gravityAtPitch(50));
 
     const [, y] = onOrientation.mock.calls[0];
-    expect(y).toBeLessThan(0);
-    expect(y).toBeGreaterThan(-1); // not yet fully converged to -1
+    expect(y).toBeCloseTo(0);
   });
 
   it('unsubscribes on unmount', () => {

--- a/app/components/UI/Money/hooks/useDeviceOrientation.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.ts
@@ -8,14 +8,6 @@ import {
 import { getTotalMemorySync } from 'react-native-device-info';
 
 const DEG = Math.PI / 180;
-// react-native-sensors forwards raw platform readings without normalizing them,
-// and the two platforms disagree on sign: CoreMotion reports gravity as a
-// negative vector (flat device reads z = -1g) while Android reports proper
-// acceleration (flat device reads z = +9.81). Left unhandled, every axis is
-// mirrored between platforms. iOS is flipped into Android's convention here —
-// the axis pointing up reads positive. Magnitude differences (g vs m/s²) need
-// no handling: every reading below is either an atan2 or a ratio.
-const GRAVITY_SIGN = Platform.OS === 'ios' ? -1 : 1;
 // Rotation away from neutral (per axis) that maps to a full ±1 tilt.
 const PITCH_TRAVEL = 30 * DEG;
 const ROLL_TRAVEL = 30 * DEG;
@@ -35,6 +27,32 @@ const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 
 const isLowEndDevice = (): boolean => getTotalMemorySync() <= 2 * ONE_GIGABYTE;
+
+export interface Acceleration {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Normalizes a raw accelerometer reading so the axis pointing up reads
+ * positive, whichever platform produced it. Pure so it can be unit-tested
+ * directly.
+ *
+ * `react-native-sensors` forwards raw platform values, and the platforms
+ * disagree on sign: CoreMotion reports gravity as a negative vector (a flat
+ * device reads z = -1, in g) while Android reports proper acceleration
+ * (z = +9.81, in m/s²). Left unhandled, every axis is mirrored between the two.
+ * Magnitude differences need no handling — every reading below is consumed by
+ * an atan2 or a ratio.
+ */
+export function normalizeReading(
+  sample: Acceleration,
+  os: typeof Platform.OS,
+): Acceleration {
+  const sign = os === 'ios' ? -1 : 1;
+  return { x: sample.x * sign, y: sample.y * sign, z: sample.z * sign };
+}
 
 /**
  * Converts a gravity vector (accelerometer reading) into the device's absolute
@@ -144,20 +162,7 @@ export function useDeviceOrientation(
 
     const subscription = accelerometer.subscribe({
       next: (sample) => {
-        // A single non-finite sample would otherwise poison the neutral and the
-        // smoothing accumulators for the life of the subscription.
-        if (
-          !Number.isFinite(sample.x) ||
-          !Number.isFinite(sample.y) ||
-          !Number.isFinite(sample.z)
-        ) {
-          return;
-        }
-
-        const x = sample.x * GRAVITY_SIGN;
-        const y = sample.y * GRAVITY_SIGN;
-        const z = sample.z * GRAVITY_SIGN;
-
+        const { x, y, z } = normalizeReading(sample, Platform.OS);
         const pitch = accelerationToPitch(x, y, z);
         const roll = accelerationToRoll(x, y, z);
         neutralPitch.current = trackNeutralAngle(

--- a/app/components/UI/Money/hooks/useDeviceOrientation.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.ts
@@ -7,13 +7,15 @@ import {
 import { getTotalMemorySync } from 'react-native-device-info';
 
 const DEG = Math.PI / 180;
-// Natural holding angle: people hold the phone tilted ~this far back from
-// horizontal. Treated as the neutral (rest) pitch, so holding normally sits at
-// the centre of the parallax rather than an extreme.
-const NEUTRAL_PITCH = 45 * DEG;
 // Rotation away from neutral (per axis) that maps to a full ±1 tilt.
 const PITCH_TRAVEL = 30 * DEG;
 const ROLL_TRAVEL = 30 * DEG;
+// How long the neutral takes to follow a sustained change in holding angle.
+const NEUTRAL_TRACKING_SECONDS = 4;
+// Smallest roll gain the correction below will divide by. The gain vanishes as
+// the device approaches vertical, where roll is no longer measurable and the
+// reading is mostly sensor noise.
+const ROLL_GAIN_FLOOR = 0.15;
 // Low-pass factor: higher = snappier but noisier, lower = smoother but laggier.
 const SMOOTHING = 0.2;
 const HZ_LOW_END = 30;
@@ -26,20 +28,68 @@ const clamp = (value: number, min: number, max: number): number =>
 const isLowEndDevice = (): boolean => getTotalMemorySync() <= 2 * ONE_GIGABYTE;
 
 /**
+ * Converts a gravity vector (accelerometer reading) into the device's absolute
+ * pitch in radians. Pure so it can be unit-tested directly.
+ */
+export function accelerationToPitch(x: number, y: number, z: number): number {
+  return Math.atan2(y, Math.hypot(x, z));
+}
+
+/**
+ * Advances the neutral pitch towards the pitch currently being measured, so the
+ * neutral follows the posture the device is actually held in and the response
+ * never saturates at an extreme. Tracking is deliberately slow: an intentional
+ * tilt still reads as a tilt before it decays back to rest.
+ *
+ * Dividing by the sample rate keeps the tracking speed identical at 30Hz and
+ * 60Hz. A `null` neutral means this is the first sample, so it adopts the
+ * current pitch rather than sliding in from a fixed angle.
+ */
+export function trackNeutralPitch(
+  neutral: number | null,
+  pitch: number,
+  hz: number,
+): number {
+  if (neutral === null) return pitch;
+  return neutral + (pitch - neutral) / (NEUTRAL_TRACKING_SECONDS * hz);
+}
+
+/**
+ * Converts a gravity vector (accelerometer reading) into the device's roll in
+ * radians, corrected for how far back the device is pitched.
+ *
+ * Roll measured against the horizontal plane scales with the cosine of the
+ * pitch, so a device held upright barely registers a roll it would register
+ * fully when lying flat. Dividing that factor out keeps the response constant
+ * across holding angles; the floor bounds the correction near vertical, where
+ * the roll component has collapsed into noise. Pure so it can be unit-tested
+ * directly.
+ */
+export function accelerationToRoll(x: number, y: number, z: number): number {
+  const magnitude = Math.hypot(x, y, z);
+  if (magnitude === 0) return 0;
+  const pitchGain = Math.max(Math.hypot(x, z) / magnitude, ROLL_GAIN_FLOOR);
+  return Math.atan2(x, Math.hypot(y, z)) / pitchGain;
+}
+
+/**
  * Converts a gravity vector (accelerometer reading) into a normalized,
- * clamped [-1, 1] tilt per axis, measured as absolute pitch/roll relative to
- * the natural holding position. Pure so it can be unit-tested directly.
+ * clamped [-1, 1] tilt per axis, measured as pitch/roll relative to the
+ * supplied neutral pitch. Pure so it can be unit-tested directly.
  */
 export function accelerationToTilt(
   x: number,
   y: number,
   z: number,
+  neutralPitch: number,
 ): { x: number; y: number } {
-  const pitch = Math.atan2(y, Math.hypot(x, z));
-  const roll = Math.atan2(x, Math.hypot(y, z));
   return {
-    x: clamp(roll / ROLL_TRAVEL, -1, 1),
-    y: clamp((pitch - NEUTRAL_PITCH) / PITCH_TRAVEL, -1, 1),
+    x: clamp(accelerationToRoll(x, y, z) / ROLL_TRAVEL, -1, 1),
+    y: clamp(
+      (accelerationToPitch(x, y, z) - neutralPitch) / PITCH_TRAVEL,
+      -1,
+      1,
+    ),
   };
 }
 
@@ -49,9 +99,9 @@ interface UseDeviceOrientationOptions {
 
 /**
  * Reports device tilt as a normalized, clamped [-1, 1] value per axis, derived
- * from the accelerometer's absolute orientation (gravity) with a natural-hold
- * neutral. Unlike integrating the gyroscope, this is drift-free and returns to
- * the same neutral for the same physical orientation.
+ * from the accelerometer's absolute orientation (gravity), relative to an
+ * adaptive neutral that follows the posture the device is held in. Unlike
+ * integrating the gyroscope, this is drift-free.
  *
  * @param onOrientation - receives (x, y) roll/pitch in the [-1, 1] range.
  */
@@ -62,6 +112,7 @@ export function useDeviceOrientation(
   const enabled = options?.enabled ?? true;
   const onOrientationRef = useRef(onOrientation);
   const smoothed = useRef({ x: 0, y: 0 });
+  const neutralPitch = useRef<number | null>(null);
 
   useEffect(() => {
     onOrientationRef.current = onOrientation;
@@ -76,10 +127,17 @@ export function useDeviceOrientation(
     setUpdateIntervalForType(SensorTypes.accelerometer, 1000 / hz);
 
     smoothed.current = { x: 0, y: 0 };
+    neutralPitch.current = null;
 
     const subscription = accelerometer.subscribe({
       next: ({ x, y, z }) => {
-        const tilt = accelerationToTilt(x, y, z);
+        const pitch = accelerationToPitch(x, y, z);
+        neutralPitch.current = trackNeutralPitch(
+          neutralPitch.current,
+          pitch,
+          hz,
+        );
+        const tilt = accelerationToTilt(x, y, z, neutralPitch.current);
         smoothed.current = {
           x: smoothed.current.x + SMOOTHING * (tilt.x - smoothed.current.x),
           y: smoothed.current.y + SMOOTHING * (tilt.y - smoothed.current.y),

--- a/app/components/UI/Money/hooks/useDeviceOrientation.ts
+++ b/app/components/UI/Money/hooks/useDeviceOrientation.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
 import {
   accelerometer,
   SensorTypes,
@@ -7,6 +8,14 @@ import {
 import { getTotalMemorySync } from 'react-native-device-info';
 
 const DEG = Math.PI / 180;
+// react-native-sensors forwards raw platform readings without normalizing them,
+// and the two platforms disagree on sign: CoreMotion reports gravity as a
+// negative vector (flat device reads z = -1g) while Android reports proper
+// acceleration (flat device reads z = +9.81). Left unhandled, every axis is
+// mirrored between platforms. iOS is flipped into Android's convention here —
+// the axis pointing up reads positive. Magnitude differences (g vs m/s²) need
+// no handling: every reading below is either an atan2 or a ratio.
+const GRAVITY_SIGN = Platform.OS === 'ios' ? -1 : 1;
 // Rotation away from neutral (per axis) that maps to a full ±1 tilt.
 const PITCH_TRAVEL = 30 * DEG;
 const ROLL_TRAVEL = 30 * DEG;
@@ -36,22 +45,23 @@ export function accelerationToPitch(x: number, y: number, z: number): number {
 }
 
 /**
- * Advances the neutral pitch towards the pitch currently being measured, so the
+ * Advances a neutral angle towards the angle currently being measured, so the
  * neutral follows the posture the device is actually held in and the response
- * never saturates at an extreme. Tracking is deliberately slow: an intentional
- * tilt still reads as a tilt before it decays back to rest.
+ * never saturates at an extreme. Applied per axis: a habitual holding pitch or
+ * a habitual grip roll both settle back to centre. Tracking is deliberately
+ * slow: an intentional tilt still reads as a tilt before it decays to rest.
  *
  * Dividing by the sample rate keeps the tracking speed identical at 30Hz and
  * 60Hz. A `null` neutral means this is the first sample, so it adopts the
- * current pitch rather than sliding in from a fixed angle.
+ * current angle rather than sliding in from a fixed one.
  */
-export function trackNeutralPitch(
+export function trackNeutralAngle(
   neutral: number | null,
-  pitch: number,
+  angle: number,
   hz: number,
 ): number {
-  if (neutral === null) return pitch;
-  return neutral + (pitch - neutral) / (NEUTRAL_TRACKING_SECONDS * hz);
+  if (neutral === null) return angle;
+  return neutral + (angle - neutral) / (NEUTRAL_TRACKING_SECONDS * hz);
 }
 
 /**
@@ -75,18 +85,18 @@ export function accelerationToRoll(x: number, y: number, z: number): number {
 /**
  * Converts a gravity vector (accelerometer reading) into a normalized,
  * clamped [-1, 1] tilt per axis, measured as pitch/roll relative to the
- * supplied neutral pitch. Pure so it can be unit-tested directly.
+ * supplied neutral angles. Pure so it can be unit-tested directly.
  */
 export function accelerationToTilt(
   x: number,
   y: number,
   z: number,
-  neutralPitch: number,
+  neutral: { pitch: number; roll: number },
 ): { x: number; y: number } {
   return {
-    x: clamp(accelerationToRoll(x, y, z) / ROLL_TRAVEL, -1, 1),
+    x: clamp((accelerationToRoll(x, y, z) - neutral.roll) / ROLL_TRAVEL, -1, 1),
     y: clamp(
-      (accelerationToPitch(x, y, z) - neutralPitch) / PITCH_TRAVEL,
+      (accelerationToPitch(x, y, z) - neutral.pitch) / PITCH_TRAVEL,
       -1,
       1,
     ),
@@ -100,8 +110,9 @@ interface UseDeviceOrientationOptions {
 /**
  * Reports device tilt as a normalized, clamped [-1, 1] value per axis, derived
  * from the accelerometer's absolute orientation (gravity), relative to an
- * adaptive neutral that follows the posture the device is held in. Unlike
- * integrating the gyroscope, this is drift-free.
+ * adaptive neutral that follows the posture the device is held in on both
+ * axes. Readings are normalized across platforms first. Unlike integrating the
+ * gyroscope, this is drift-free.
  *
  * @param onOrientation - receives (x, y) roll/pitch in the [-1, 1] range.
  */
@@ -113,6 +124,7 @@ export function useDeviceOrientation(
   const onOrientationRef = useRef(onOrientation);
   const smoothed = useRef({ x: 0, y: 0 });
   const neutralPitch = useRef<number | null>(null);
+  const neutralRoll = useRef<number | null>(null);
 
   useEffect(() => {
     onOrientationRef.current = onOrientation;
@@ -128,16 +140,36 @@ export function useDeviceOrientation(
 
     smoothed.current = { x: 0, y: 0 };
     neutralPitch.current = null;
+    neutralRoll.current = null;
 
     const subscription = accelerometer.subscribe({
-      next: ({ x, y, z }) => {
+      next: (sample) => {
+        // A single non-finite sample would otherwise poison the neutral and the
+        // smoothing accumulators for the life of the subscription.
+        if (
+          !Number.isFinite(sample.x) ||
+          !Number.isFinite(sample.y) ||
+          !Number.isFinite(sample.z)
+        ) {
+          return;
+        }
+
+        const x = sample.x * GRAVITY_SIGN;
+        const y = sample.y * GRAVITY_SIGN;
+        const z = sample.z * GRAVITY_SIGN;
+
         const pitch = accelerationToPitch(x, y, z);
-        neutralPitch.current = trackNeutralPitch(
+        const roll = accelerationToRoll(x, y, z);
+        neutralPitch.current = trackNeutralAngle(
           neutralPitch.current,
           pitch,
           hz,
         );
-        const tilt = accelerationToTilt(x, y, z, neutralPitch.current);
+        neutralRoll.current = trackNeutralAngle(neutralRoll.current, roll, hz);
+        const tilt = accelerationToTilt(x, y, z, {
+          pitch: neutralPitch.current,
+          roll: neutralRoll.current,
+        });
         smoothed.current = {
           x: smoothed.current.x + SMOOTHING * (tilt.x - smoothed.current.x),
           y: smoothed.current.y + SMOOTHING * (tilt.y - smoothed.current.y),


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money onboarding next-best-action parallax now responds to device tilt every time the module is on screen, and tilts the graphic in the direction the design specifies. Several independent defects were behind the two reported symptoms.

**Data binding survives a step change.** `StepperCard` swaps `step.media` in place, so advancing the onboarding step only changes the `<Rive>` component's `artboardName` prop instead of remounting it. `rive-react-native` reloads the artboard natively but does not re-run data binding on it — iOS `createNewView` configures binding only while its config state is `.pending`, and Android's `setArtboardName` never calls `configureDataBinding` at all. `xValue`/`yValue` therefore kept writing into the previous artboard's view-model instance, leaving the Get/Link Card module inert. It is now keyed on `artboardName`, so a new artboard always gets a freshly bound native view.

**Tilt is written one-way.** `useRiveNumber` registers a native property listener, so every value written was echoed back over the bridge and stored with `setState` — roughly 120 re-renders per second while streaming the accelerometer, for values this component never reads. It also made the effect depend on `useRive()`'s `RiveReactNativeLoaded` event, which iOS drops outright when no JS listener is active as it fires. Tilt is now dispatched through a plain `RiveRef` with `setNumber`.

**The neutral pitch follows the user.** `useDeviceOrientation` assumed a fixed 45° holding angle with ±30° of travel, so the common 70–90° upright posture sat clamped at an extreme and the Y axis read as dead. The neutral is now seeded from the first sample and tracks the held posture slowly (4s time constant, normalised across the 30Hz and 60Hz sample rates), so the effect self-centres on however the device is actually held while an intentional tilt still reads as a tilt.

**Roll no longer fades out as the device is pitched back.** Roll measured against the horizontal plane scales with the cosine of the pitch, so at a normal 75° reading angle a full 30° roll produced only a quarter of the intended X travel, and at 85° less than a tenth — indistinguishable from "not responding". `accelerationToRoll` divides that pitch-dependent gain out, bounded near vertical where roll collapses into sensor noise. A device lying flat is unaffected.

**Sensor readings are normalized across platforms.** `react-native-sensors` forwards raw platform values without normalizing them, and the two platforms disagree on sign: CoreMotion reports gravity as a negative vector (a flat device reads `z = -1`, in g) while Android reports proper acceleration (`z = +9.81`, in m/s²). Every axis was therefore mirrored between iOS and Android, so any direction fix could only be correct on one of them. iOS is now flipped into Android's convention at the subscription boundary. The magnitude difference needs no handling — every consumer is an `atan2` or a ratio.

Y-axis values are inverted via a new `pitchToParallaxValue`, correcting the reported direction.

The adaptive neutral is applied to **both** axes. Roll needed it once the gain correction landed: with the collapse removed, a user's habitual grip roll would otherwise park the X layer at an extreme.

Both NBA modules render the same `MoneyNextBestActionParallax`, so this closes MUSD-1203 (Get/Link Card) and MUSD-1202 (Fund Account) together. The two tickets had different primary causes — the card module was broken by the stale data binding, the fund module by the saturated neutral — and shared the inverted Y mapping.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money onboarding parallax animation so it responds to device tilt reliably and moves the artwork in the correct direction.

## **Related issues**

Fixes: [MUSD-1203](https://consensyssoftware.atlassian.net/browse/MUSD-1203)
Fixes: [MUSD-1202](https://consensyssoftware.atlassian.net/browse/MUSD-1202)

## **Manual testing steps**

```gherkin
Feature: Money onboarding next-best-action parallax

  Scenario: Parallax responds on the Get/Link Card module after a step change
    Given the user is on the Money tab with the onboarding card showing "Fund your account"
    And the user has reduce motion disabled

    When the user completes or skips the funding step so the Get/Link Card step appears
    And the user tilts the device left and right
    Then the card artwork shifts on the X axis in step with the tilt

  Scenario: Y-axis tilt moves the artwork in the correct direction
    Given the user is on the Money tab with a next-best-action module showing
    And the user holds the device in the normal upright orientation

    When the user tilts the top of the device away from themselves
    Then the artwork moves in the direction shown in the Figma motion spec
    And the response is no longer inverted relative to that spec

  Scenario: Parallax stays responsive at any holding angle
    Given the user is on the Money tab with a next-best-action module showing

    When the user holds the device upright at roughly 80 degrees and tilts it
    Then the artwork still responds rather than sitting pinned at an extreme
    And rolling the device left and right moves the artwork by the same amount
      as it does with the device held flat

  Scenario: Reduce motion is respected
    Given the user has enabled reduce motion in the OS accessibility settings

    When the user opens the Money tab with a next-best-action module showing
    Then the static fallback image is displayed and no tilt animation runs
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1203]: https://consensyssoftware.atlassian.net/browse/MUSD-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches accelerometer math and high-frequency Rive updates in Money onboarding UI; behavior is well covered by new tests but affects motion UX on both platforms.
> 
> **Overview**
> Fixes Money next-best-action **parallax** so tilt works across onboarding steps, at real holding angles, and with artwork moving the right way on iOS and Android.
> 
> **Rive / parallax UI:** `MoneyNextBestActionParallax` no longer uses `useRive` / `useRiveNumber`; tilt is pushed through a `RiveRef` and `setNumber` to avoid bridge echo re-renders. The Rive view is **`key`ed by `artboardName`** so step changes get fresh data binding; Rive errors are tracked **per artboard** so switching steps can animate again. Pitch maps to Rive `yValue` via new **`pitchToParallaxValue`** (inverted vs roll).
> 
> **Device orientation:** `useDeviceOrientation` drops the fixed 45° pitch neutral in favor of **`trackNeutralAngle`** on pitch and roll (4s tracking, reset on resubscribe). Adds **`normalizeReading`** for iOS vs Android accelerometer sign, **`accelerationToRoll`** with pitch gain correction (MUSD-1203 roll-at-upright case), and tilt relative to adaptive neutrals. Tests expanded for these paths and parallax/Rive behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b8f1c32cd14b463c36eac93f07485efc92ce92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->