### PR TITLE
refactor(TransactionElement): enhance transaction status handling and UI components

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BridgeActivityItemTxSegments.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BridgeActivityItemTxSegments.tsx
@@ -10,6 +10,11 @@ import { FlexDirection } from '../../../Box/box.types';
 import { Transaction } from '@metamask/keyring-api';
 import { StatusTypes } from '@metamask/bridge-controller';
 
+type TransactionDisplayStatus =
+  | TransactionStatus
+  | Transaction['status']
+  | 'pending';
+
 const getTxIndex = (srcTxStatus: StatusTypes) => {
   if (srcTxStatus === StatusTypes.PENDING) {
     return 1;
@@ -22,9 +27,7 @@ const getTxIndex = (srcTxStatus: StatusTypes) => {
   throw new Error('No more possible states for srcTxStatus');
 };
 
-const getSrcTxStatus = (
-  transactionStatus: TransactionStatus | Transaction['status'],
-) =>
+const getSrcTxStatus = (transactionStatus: TransactionDisplayStatus) =>
   transactionStatus === TransactionStatus.confirmed
     ? StatusTypes.COMPLETE
     : StatusTypes.PENDING;
@@ -51,14 +54,14 @@ const getDestTxStatus = ({
  *
  * @param options
  * @param options.bridgeTxHistoryItem - The bridge history item for the transaction
- * @param options.transactionStatus - The transaction status for the transaction. TransactionStatus is for EVM, Transaction['status'] is for Solana
+ * @param options.transactionStatus - The transaction status for the transaction. TransactionStatus is for EVM, Transaction['status'] is for Solana, and pending is used by intent-backed bridge activity
  */
 export default function BridgeActivityItemTxSegments({
   bridgeTxHistoryItem,
   transactionStatus,
 }: {
   bridgeTxHistoryItem?: BridgeHistoryItem;
-  transactionStatus: TransactionStatus | Transaction['status'];
+  transactionStatus: TransactionDisplayStatus;
 }) {
   const srcTxStatus = getSrcTxStatus(transactionStatus);
   const destTxStatus = getDestTxStatus({ bridgeTxHistoryItem, srcTxStatus });

--- a/app/components/UI/TransactionElement/TransactionElementContainer.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionElementContainer.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { act, render } from '@testing-library/react-native';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import Routes from '../../../constants/navigation/Routes';
+import { handleUnifiedSwapsTxHistoryItemClick } from '../Bridge/utils/transaction-history';
+import useDecodedTransaction from './hooks/useDecodedTransaction';
+import { TransactionElement } from './index';
+import TransactionElementView from './TransactionElementView';
+
+jest.mock('react-redux', () => ({
+  connect: () => (component: React.ComponentType) => component,
+  useSelector: jest.fn(),
+}));
+jest.mock('./hooks/useDecodedTransaction', () => jest.fn());
+jest.mock('./TransactionElementView', () => jest.fn(() => null));
+jest.mock('../Bridge/utils/transaction-history', () => ({
+  handleUnifiedSwapsTxHistoryItemClick: jest.fn(),
+}));
+
+const mockUseDecodedTransaction = jest.mocked(useDecodedTransaction);
+const mockTransactionElementView = jest.mocked(TransactionElementView);
+const mockHandleBridgeClick = jest.mocked(handleUnifiedSwapsTxHistoryItemClick);
+
+const createProps = () => ({
+  assetSymbol: 'ETH',
+  bridgeTxHistoryData: {
+    bridgeTxHistoryItem: undefined as unknown,
+    isBridgeComplete: null,
+  },
+  cancelUnsignedQRTransaction: jest.fn(),
+  i: 3,
+  isLedgerAccount: false,
+  isQRHardwareAccount: false,
+  navigation: {
+    navigate: jest.fn(),
+  },
+  onCancelAction: jest.fn(),
+  onPressItem: jest.fn(),
+  onSpeedUpAction: jest.fn(),
+  selectSelectedAccountGroupInternalAccounts: [],
+  selectedAddress: '0x123',
+  selectedInternalAccount: undefined,
+  showBottomBorder: false,
+  signLedgerTransaction: jest.fn(),
+  signQRTransaction: jest.fn(),
+  swapsTransactions: {},
+  ticker: 'ETH',
+  trackTransactionDetailClicked: jest.fn(),
+  transactions: [],
+  tx: {
+    id: 'transaction-id',
+    chainId: '0x1',
+    status: TransactionStatus.confirmed,
+    time: 100,
+    txParams: {
+      from: '0x123',
+      to: '0x456',
+      nonce: '0x1',
+    },
+  },
+  txChainId: '0x1',
+});
+
+const renderContainer = () => {
+  const props = createProps();
+  render(<TransactionElement {...props} />);
+  const viewProps = mockTransactionElementView.mock.calls[0][0];
+
+  return { props, viewProps };
+};
+
+describe('TransactionElement container callbacks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDecodedTransaction.mockReturnValue({
+      transactionElement: {
+        actionKey: 'Send',
+        value: '1 ETH',
+      },
+      transactionDetails: {
+        summaryAmount: '1 ETH',
+      },
+    });
+  });
+
+  it('opens the cancellation flow', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onCancel());
+
+    expect(props.onCancelAction).toHaveBeenCalledWith(true, props.tx);
+  });
+
+  it('opens the speed-up flow', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onSpeedUp());
+
+    expect(props.onSpeedUpAction).toHaveBeenCalledWith(true, props.tx);
+  });
+
+  it('opens QR signing', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onSignQR());
+
+    expect(props.signQRTransaction).toHaveBeenCalledWith(props.tx);
+  });
+
+  it('opens Ledger signing', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onSignLedger());
+
+    expect(props.signLedgerTransaction).toHaveBeenCalledWith(props.tx);
+  });
+
+  it('cancels an unsigned QR transaction', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onCancelUnsignedQR());
+
+    expect(props.cancelUnsignedQRTransaction).toHaveBeenCalledWith(props.tx);
+  });
+
+  it('opens the import wallet tip', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onImportWalletTip());
+
+    expect(props.navigation.navigate).toHaveBeenCalledWith(
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      {
+        screen: Routes.SHEET.IMPORT_WALLET_TIP,
+      },
+    );
+  });
+
+  it('opens legacy transaction details for a standard transaction', () => {
+    const { props, viewProps } = renderContainer();
+
+    act(() => viewProps.onPress());
+
+    expect(props.navigation.navigate).toHaveBeenCalledWith(
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      expect.objectContaining({
+        screen: Routes.SHEET.TRANSACTION_DETAILS,
+      }),
+    );
+    expect(props.onPressItem).toHaveBeenCalledWith(props.tx.id, props.i);
+    expect(props.trackTransactionDetailClicked).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates bridge transaction presses to unified history navigation', () => {
+    const bridgeTxHistoryItem = {
+      quote: {
+        srcChainId: 1,
+        destChainId: 10,
+      },
+    };
+    const props = createProps();
+    props.bridgeTxHistoryData.bridgeTxHistoryItem = bridgeTxHistoryItem;
+    render(<TransactionElement {...props} />);
+    const viewProps = mockTransactionElementView.mock.calls[0][0];
+
+    act(() => viewProps.onPress());
+
+    expect(mockHandleBridgeClick).toHaveBeenCalledWith({
+      navigation: props.navigation,
+      evmTxMeta: props.tx,
+      bridgeTxHistoryItem,
+    });
+  });
+});

--- a/app/components/UI/TransactionElement/TransactionElementIcon.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionElementIcon.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { BadgeVariant } from '../../../component-library/components/Badges/Badge';
+import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
+import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
+import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
+import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
+import { TRANSACTION_TYPES } from '../../../util/transactions';
+import transactionIconApprove from '../../../images/transaction-icons/approve.png';
+import transactionIconInteraction from '../../../images/transaction-icons/interaction.png';
+import transactionIconSent from '../../../images/transaction-icons/send.png';
+import transactionIconReceived from '../../../images/transaction-icons/receive.png';
+import transactionIconSwap from '../../../images/transaction-icons/swap.png';
+import transactionIconApproveFailed from '../../../images/transaction-icons/approve-failed.png';
+import transactionIconInteractionFailed from '../../../images/transaction-icons/interaction-failed.png';
+import transactionIconSentFailed from '../../../images/transaction-icons/send-failed.png';
+import transactionIconReceivedFailed from '../../../images/transaction-icons/receive-failed.png';
+import transactionIconSwapFailed from '../../../images/transaction-icons/swap-failed.png';
+import { mockTheme } from '../../../util/theme';
+import createStyles from './styles';
+import TransactionElementIcon from './TransactionElementIcon';
+import type { DecodedTransactionElement } from './types';
+
+jest.mock('../../../component-library/components/Badges/BadgeWrapper', () =>
+  jest.fn(({ children }: { children: React.ReactNode }) => children),
+);
+jest.mock('../../../component-library/components/Badges/Badge', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+  BadgeVariant: { Network: 'Network' },
+}));
+jest.mock('../AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: jest.fn(() => ({ uri: 'network-badge' })),
+}));
+jest.mock('../../Views/confirmations/utils/transaction', () => ({
+  hasTransactionType: jest.fn(() => false),
+}));
+
+const mockBadgeWrapper = jest.mocked(BadgeWrapper);
+const mockNetworkBadgeSource = jest.mocked(NetworkBadgeSource);
+const mockHasTransactionType = jest.mocked(hasTransactionType);
+const styles = createStyles(mockTheme.colors, mockTheme.typography);
+
+const createTransaction = (
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta =>
+  ({
+    id: 'transaction-id',
+    chainId: '0x1',
+    status: 'confirmed',
+    time: 1,
+    txParams: {
+      from: '0x123',
+      to: '0x456',
+    },
+    ...overrides,
+  }) as TransactionMeta;
+
+const renderIcon = (
+  transactionType: string | undefined,
+  txOverrides: Partial<TransactionMeta> = {},
+  transactions: TransactionMeta[] = [],
+) =>
+  render(
+    <TransactionElementIcon
+      transactionElement={
+        {
+          actionKey: 'Transaction',
+          transactionType,
+        } as DecodedTransactionElement
+      }
+      tx={createTransaction(txOverrides)}
+      transactions={transactions}
+      styles={styles}
+    />,
+  );
+
+const successfulIcons = [
+  [TRANSACTION_TYPES.SENT_TOKEN, transactionIconSent],
+  [TRANSACTION_TYPES.SENT_COLLECTIBLE, transactionIconSent],
+  [TRANSACTION_TYPES.SENT, transactionIconSent],
+  [TRANSACTION_TYPES.RECEIVED_TOKEN, transactionIconReceived],
+  [TRANSACTION_TYPES.RECEIVED_COLLECTIBLE, transactionIconReceived],
+  [TRANSACTION_TYPES.RECEIVED, transactionIconReceived],
+  [TRANSACTION_TYPES.SITE_INTERACTION, transactionIconInteraction],
+  [TRANSACTION_TYPES.BATCH_SELL_TRANSACTION, transactionIconSwap],
+  [TRANSACTION_TYPES.SWAPS_TRANSACTION, transactionIconSwap],
+  [TRANSACTION_TYPES.BRIDGE_TRANSACTION, transactionIconSwap],
+  [TRANSACTION_TYPES.APPROVE, transactionIconApprove],
+  [TRANSACTION_TYPES.INCREASE_ALLOWANCE, transactionIconApprove],
+  [TRANSACTION_TYPES.SET_APPROVAL_FOR_ALL, transactionIconApprove],
+] as const;
+
+const failedIcons = [
+  [TRANSACTION_TYPES.SENT, transactionIconSentFailed],
+  [TRANSACTION_TYPES.RECEIVED, transactionIconReceivedFailed],
+  [TRANSACTION_TYPES.SITE_INTERACTION, transactionIconInteractionFailed],
+  [TRANSACTION_TYPES.SWAPS_TRANSACTION, transactionIconSwapFailed],
+  [TRANSACTION_TYPES.APPROVE, transactionIconApproveFailed],
+] as const;
+
+describe('TransactionElementIcon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasTransactionType.mockReturnValue(false);
+  });
+
+  it.each(successfulIcons)('renders the %s icon', (transactionType, icon) => {
+    renderIcon(transactionType);
+
+    const image = screen.UNSAFE_getByType(Image);
+
+    expect(image.props.source).toBe(icon);
+  });
+
+  it.each(failedIcons)(
+    'renders the failed %s icon',
+    (transactionType, icon) => {
+      renderIcon(transactionType, { status: TransactionStatus.failed });
+
+      const image = screen.UNSAFE_getByType(Image);
+
+      expect(image.props.source).toBe(icon);
+    },
+  );
+
+  it('renders no transaction icon for an unknown decoded type', () => {
+    renderIcon('unknown');
+
+    const image = screen.UNSAFE_getByType(Image);
+
+    expect(image.props.source).toBeUndefined();
+  });
+
+  it('uses the required transaction chain for a perps deposit', () => {
+    const requiredTransaction = createTransaction({
+      id: 'required-transaction',
+      chainId: '0x89',
+    });
+
+    renderIcon(
+      TRANSACTION_TYPES.SENT,
+      {
+        type: TransactionType.perpsDeposit,
+        requiredTransactionIds: ['required-transaction'],
+      },
+      [requiredTransaction],
+    );
+
+    expect(mockNetworkBadgeSource).toHaveBeenCalledWith('0x89');
+  });
+
+  it('uses the transaction chain when a required perps transaction is absent', () => {
+    renderIcon(TRANSACTION_TYPES.SENT, {
+      type: TransactionType.perpsDeposit,
+      requiredTransactionIds: ['missing-transaction'],
+    });
+
+    expect(mockNetworkBadgeSource).toHaveBeenCalledWith('0x1');
+  });
+
+  it('uses the MetaMask Pay chain for a withdrawal', () => {
+    mockHasTransactionType.mockReturnValue(true);
+
+    renderIcon(TRANSACTION_TYPES.SENT, {
+      metamaskPay: { chainId: '0xa' },
+    });
+
+    expect(mockNetworkBadgeSource).toHaveBeenCalledWith('0xa');
+  });
+
+  it('configures the network badge', () => {
+    renderIcon(TRANSACTION_TYPES.SENT);
+
+    expect(mockBadgeWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        badgeElement: expect.objectContaining({
+          props: expect.objectContaining({
+            variant: BadgeVariant.Network,
+            imageSource: { uri: 'network-badge' },
+            isScaled: false,
+            size: AvatarSize.Xs,
+          }),
+        }),
+      }),
+      undefined,
+    );
+  });
+});

--- a/app/components/UI/TransactionElement/TransactionElementIcon.tsx
+++ b/app/components/UI/TransactionElement/TransactionElementIcon.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Image, type ImageSourcePropType } from 'react-native';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { TRANSACTION_TYPES } from '../../../util/transactions';
+import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
+import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
+import Badge, {
+  BadgeVariant,
+} from '../../../component-library/components/Badges/Badge';
+import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
+import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
+import type { TransactionWithImportTime } from '../Transactions/AssetDetailsActivityListItem.utils';
+import type { TransactionElementStyles } from './styles';
+import type { DecodedTransactionElement } from './types';
+import transactionIconApprove from '../../../images/transaction-icons/approve.png';
+import transactionIconInteraction from '../../../images/transaction-icons/interaction.png';
+import transactionIconSent from '../../../images/transaction-icons/send.png';
+import transactionIconReceived from '../../../images/transaction-icons/receive.png';
+import transactionIconSwap from '../../../images/transaction-icons/swap.png';
+import transactionIconApproveFailed from '../../../images/transaction-icons/approve-failed.png';
+import transactionIconInteractionFailed from '../../../images/transaction-icons/interaction-failed.png';
+import transactionIconSentFailed from '../../../images/transaction-icons/send-failed.png';
+import transactionIconReceivedFailed from '../../../images/transaction-icons/receive-failed.png';
+import transactionIconSwapFailed from '../../../images/transaction-icons/swap-failed.png';
+
+interface TransactionElementIconProps {
+  transactionElement: DecodedTransactionElement;
+  tx: TransactionWithImportTime;
+  transactions: TransactionMeta[];
+  styles: TransactionElementStyles;
+}
+
+const TransactionElementIcon = ({
+  transactionElement,
+  tx,
+  transactions,
+  styles,
+}: TransactionElementIconProps) => {
+  const { chainId: txChainId, requiredTransactionIds, status, type } = tx;
+  const { transactionType } = transactionElement;
+  const isFailedTransaction = status === 'cancelled' || status === 'failed';
+  let icon: ImageSourcePropType | undefined;
+
+  switch (transactionType) {
+    case TRANSACTION_TYPES.SENT_TOKEN:
+    case TRANSACTION_TYPES.SENT_COLLECTIBLE:
+    case TRANSACTION_TYPES.SENT:
+      icon = isFailedTransaction
+        ? transactionIconSentFailed
+        : transactionIconSent;
+      break;
+    case TRANSACTION_TYPES.RECEIVED_TOKEN:
+    case TRANSACTION_TYPES.RECEIVED_COLLECTIBLE:
+    case TRANSACTION_TYPES.RECEIVED:
+      icon = isFailedTransaction
+        ? transactionIconReceivedFailed
+        : transactionIconReceived;
+      break;
+    case TRANSACTION_TYPES.SITE_INTERACTION:
+      icon = isFailedTransaction
+        ? transactionIconInteractionFailed
+        : transactionIconInteraction;
+      break;
+    case TRANSACTION_TYPES.BATCH_SELL_TRANSACTION:
+    case TRANSACTION_TYPES.SWAPS_TRANSACTION:
+    case TRANSACTION_TYPES.BRIDGE_TRANSACTION:
+      icon = isFailedTransaction
+        ? transactionIconSwapFailed
+        : transactionIconSwap;
+      break;
+    case TRANSACTION_TYPES.APPROVE:
+    case TRANSACTION_TYPES.INCREASE_ALLOWANCE:
+    case TRANSACTION_TYPES.SET_APPROVAL_FOR_ALL:
+      icon = isFailedTransaction
+        ? transactionIconApproveFailed
+        : transactionIconApprove;
+      break;
+  }
+
+  const perpsDepositChainId =
+    type === TransactionType.perpsDeposit && requiredTransactionIds?.length
+      ? transactions.find(
+          (transaction) => transaction.id === requiredTransactionIds[0],
+        )?.chainId
+      : undefined;
+
+  const withdrawChainId = hasTransactionType(tx, [
+    TransactionType.predictWithdraw,
+    TransactionType.perpsWithdraw,
+  ])
+    ? tx.metamaskPay?.chainId
+    : undefined;
+
+  const chainId = perpsDepositChainId ?? withdrawChainId ?? txChainId;
+
+  return (
+    <BadgeWrapper
+      badgePosition={styles.iconBadgePosition}
+      badgeElement={
+        <Badge
+          variant={BadgeVariant.Network}
+          imageSource={NetworkBadgeSource(chainId)}
+          isScaled={false}
+          size={AvatarSize.Xs}
+        />
+      }
+    >
+      <Image source={icon} style={styles.icon} resizeMode="stretch" />
+    </BadgeWrapper>
+  );
+};
+
+export default TransactionElementIcon;

--- a/app/components/UI/TransactionElement/TransactionElementView.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionElementView.test.tsx
@@ -1,0 +1,412 @@
+import React from 'react';
+import {
+  TouchableHighlight,
+  TouchableOpacity,
+  type TextStyle,
+} from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { strings } from '../../../../locales/i18n';
+import { mockTheme } from '../../../util/theme';
+import { isTestNet } from '../../../util/networks';
+import StatusText from '../../Base/StatusText';
+import { useBridgeTxHistoryData } from '../../../util/bridge/hooks/useBridgeTxHistoryData';
+import BridgeActivityItemTxSegments from '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments';
+import {
+  getSwapBridgeTxActivityTitle,
+  isBridgeTxHistoryItemBridge,
+} from '../Bridge/utils/transaction-history';
+import { hasGasFeeTokenSelected } from '../../Views/confirmations/utils/transaction';
+import TransactionElementIcon from './TransactionElementIcon';
+import TransactionElementView from './TransactionElementView';
+import createStyles from './styles';
+import type { DecodedTransactionElement } from './types';
+
+jest.mock('../../../util/networks', () => ({
+  isTestNet: jest.fn(() => false),
+}));
+jest.mock('../../../util/bridge/hooks/useBridgeTxHistoryData', () => ({
+  FINAL_NON_CONFIRMED_STATUSES: ['failed', 'dropped', 'rejected'],
+  useBridgeTxHistoryData: jest.fn(),
+}));
+jest.mock(
+  '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments',
+  () => jest.fn(() => null),
+);
+jest.mock('../Bridge/utils/transaction-history', () => ({
+  getSwapBridgeTxActivityTitle: jest.fn(),
+  isBridgeTxHistoryItemBridge: jest.fn(() => false),
+}));
+jest.mock('../../Views/confirmations/utils/transaction', () => ({
+  hasGasFeeTokenSelected: jest.fn(() => false),
+}));
+jest.mock('../../Base/StatusText', () => jest.fn(() => null));
+jest.mock('./TransactionElementIcon', () => jest.fn(() => null));
+
+const mockIsTestNet = jest.mocked(isTestNet);
+const mockBridgeSegments = jest.mocked(BridgeActivityItemTxSegments);
+const mockGetBridgeTitle = jest.mocked(getSwapBridgeTxActivityTitle);
+const mockIsBridgeHistoryItem = jest.mocked(isBridgeTxHistoryItemBridge);
+const mockHasGasFeeTokenSelected = jest.mocked(hasGasFeeTokenSelected);
+const mockStatusText = jest.mocked(StatusText);
+const mockTransactionElementIcon = jest.mocked(TransactionElementIcon);
+
+const styles = {
+  ...createStyles(mockTheme.colors, mockTheme.typography),
+  infoIcon: {} as TextStyle,
+};
+
+type BridgeTxHistoryData = ReturnType<typeof useBridgeTxHistoryData>;
+
+interface RenderViewOptions {
+  accountImportTime?: number;
+  bridgeTxHistoryData?: BridgeTxHistoryData;
+  isDecoded?: boolean;
+  isLedgerAccount?: boolean;
+  isQRHardwareAccount?: boolean;
+  showBottomBorder?: boolean;
+  transactionElement?: DecodedTransactionElement;
+  transactionDetails?: Record<string, unknown>;
+  transactions?: TransactionMeta[];
+  tx?: TransactionMeta & {
+    insertImportTime?: boolean;
+    isSmartTransaction?: boolean;
+  };
+}
+
+const createTransaction = (
+  overrides: Partial<TransactionMeta> & {
+    insertImportTime?: boolean;
+    isSmartTransaction?: boolean;
+  } = {},
+) =>
+  ({
+    id: 'transaction-id',
+    chainId: '0x1',
+    status: TransactionStatus.confirmed,
+    time: 100,
+    txParams: {
+      from: '0x123',
+      to: '0x456',
+    },
+    ...overrides,
+  }) as TransactionMeta & {
+    insertImportTime?: boolean;
+    isSmartTransaction?: boolean;
+  };
+
+const createBridgeData = (
+  status: string,
+  overrides: Partial<BridgeTxHistoryData> = {},
+): BridgeTxHistoryData =>
+  ({
+    bridgeTxHistoryItem: {
+      status: { status },
+      quote: { intent: { id: 'intent-id' } },
+    },
+    is7702Batch: false,
+    isBridgeComplete: false,
+    ...overrides,
+  }) as unknown as BridgeTxHistoryData;
+
+const renderView = (options: RenderViewOptions = {}) => {
+  const callbacks = {
+    onCancel: jest.fn(),
+    onCancelUnsignedQR: jest.fn(),
+    onImportWalletTip: jest.fn(),
+    onPress: jest.fn(),
+    onSignLedger: jest.fn(),
+    onSignQR: jest.fn(),
+    onSpeedUp: jest.fn(),
+  };
+  const transactionElement =
+    options.isDecoded === false
+      ? undefined
+      : (options.transactionElement ?? {
+          actionKey: 'Send',
+          value: '1 ETH',
+          fiatValue: '$3,000',
+          transactionType: 'transaction_sent',
+        });
+  const transactionDetails =
+    options.isDecoded === false
+      ? undefined
+      : (options.transactionDetails ?? { summaryAmount: '1 ETH' });
+
+  const view = render(
+    <TransactionElementView
+      accountImportTime={options.accountImportTime}
+      bridgeTxHistoryData={
+        options.bridgeTxHistoryData ?? {
+          bridgeTxHistoryItem: undefined,
+          isBridgeComplete: null,
+        }
+      }
+      colors={mockTheme.colors}
+      i={7}
+      isLedgerAccount={options.isLedgerAccount}
+      isQRHardwareAccount={options.isQRHardwareAccount}
+      showBottomBorder={options.showBottomBorder}
+      styles={styles}
+      transactionElement={transactionElement}
+      transactionDetails={transactionDetails}
+      transactions={options.transactions ?? []}
+      tx={options.tx ?? createTransaction()}
+      txTime="Jul 27"
+      {...callbacks}
+    />,
+  );
+
+  return { ...view, ...callbacks };
+};
+
+describe('TransactionElementView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsTestNet.mockReturnValue(false);
+    mockIsBridgeHistoryItem.mockReturnValue(false);
+    mockHasGasFeeTokenSelected.mockReturnValue(false);
+    mockGetBridgeTitle.mockReturnValue(undefined);
+  });
+
+  it('renders a pending row while decoded details are absent', () => {
+    renderView({ isDecoded: false });
+
+    expect(mockStatusText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testID: 'transaction-status-7',
+        status: TransactionStatus.confirmed,
+      }),
+      undefined,
+    );
+    expect(screen.getByText('...')).toBeOnTheScreen();
+  });
+
+  it('disables row presses while decoded details are absent', () => {
+    const { onPress } = renderView({ isDecoded: false });
+
+    fireEvent.press(screen.UNSAFE_getByType(TouchableHighlight));
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('invokes the row callback after decoding completes', () => {
+    const { onPress } = renderView();
+
+    fireEvent.press(screen.UNSAFE_getByType(TouchableHighlight));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the bordered row style when requested', () => {
+    renderView({ showBottomBorder: true });
+
+    const row = screen.UNSAFE_getByType(TouchableHighlight);
+
+    expect(row.props.style).toBe(styles.rowWithBorder);
+  });
+
+  it('renders decoded values for a mainnet transaction', () => {
+    renderView();
+
+    expect(screen.getByText('Send')).toBeOnTheScreen();
+    expect(screen.getByText('1 ETH')).toBeOnTheScreen();
+    expect(screen.getByText('$3,000')).toBeOnTheScreen();
+    expect(mockTransactionElementIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the fiat value for a testnet transaction', () => {
+    mockIsTestNet.mockReturnValue(true);
+
+    renderView();
+
+    expect(screen.queryByText('$3,000')).not.toBeOnTheScreen();
+    expect(screen.getByText('1 ETH')).toBeOnTheScreen();
+  });
+
+  it('omits amount fields when decoded value is empty', () => {
+    renderView({
+      transactionElement: {
+        actionKey: 'Contract interaction',
+        value: '',
+      },
+    });
+
+    expect(screen.queryByText('$3,000')).not.toBeOnTheScreen();
+    expect(screen.queryByText('1 ETH')).not.toBeOnTheScreen();
+  });
+
+  it('invokes speed-up from submitted transaction actions', () => {
+    const { onSpeedUp } = renderView({
+      tx: createTransaction({ status: TransactionStatus.submitted }),
+    });
+
+    fireEvent.press(screen.getByText(strings('transaction.speedup')));
+
+    expect(onSpeedUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes cancellation from submitted transaction actions', () => {
+    const { onCancel } = renderView({
+      tx: createTransaction({ status: TransactionStatus.submitted }),
+    });
+
+    fireEvent.press(screen.getByText(strings('transaction.cancel')));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes QR signing for an approved QR transaction', () => {
+    const { onSignQR } = renderView({
+      isQRHardwareAccount: true,
+      tx: createTransaction({ status: TransactionStatus.approved }),
+    });
+
+    fireEvent.press(
+      screen.getByText(strings('transaction.sign_with_keystone')),
+    );
+
+    expect(onSignQR).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes unsigned QR cancellation for an approved QR transaction', () => {
+    const { onCancelUnsignedQR } = renderView({
+      isQRHardwareAccount: true,
+      tx: createTransaction({ status: TransactionStatus.approved }),
+    });
+
+    fireEvent.press(screen.getByText(strings('transaction.cancel')));
+
+    expect(onCancelUnsignedQR).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes Ledger signing for an approved Ledger transaction', () => {
+    const { onSignLedger } = renderView({
+      isLedgerAccount: true,
+      tx: createTransaction({ status: TransactionStatus.approved }),
+    });
+
+    fireEvent.press(screen.getByText(strings('transaction.sign_with_ledger')));
+
+    expect(onSignLedger).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [
+      'smart',
+      createTransaction({
+        status: TransactionStatus.submitted,
+        isSmartTransaction: true,
+      }),
+    ],
+    [
+      'bridge',
+      createTransaction({
+        status: TransactionStatus.submitted,
+        type: TransactionType.bridge,
+      }),
+    ],
+    [
+      'gas-fee-token',
+      createTransaction({ status: TransactionStatus.submitted }),
+    ],
+  ])('omits normal actions for a %s transaction', (condition, tx) => {
+    if (condition === 'gas-fee-token') {
+      mockHasGasFeeTokenSelected.mockReturnValue(true);
+    }
+
+    renderView({ tx });
+
+    expect(
+      screen.queryByText(strings('transaction.speedup')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it.each([
+    ['PENDING', 'pending'],
+    ['COMPLETE', TransactionStatus.confirmed],
+    ['FAILED', TransactionStatus.failed],
+    ['SUBMITTED', TransactionStatus.submitted],
+    ['UNKNOWN', TransactionStatus.failed],
+  ])('maps %s bridge intent status to %s', (intentStatus, expectedStatus) => {
+    const bridgeTxHistoryData = createBridgeData(intentStatus, {
+      isBridgeComplete: true,
+    });
+    mockIsBridgeHistoryItem.mockReturnValue(true);
+
+    renderView({ bridgeTxHistoryData });
+
+    expect(mockStatusText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: expectedStatus,
+      }),
+      undefined,
+    );
+  });
+
+  it('renders bridge progress segments for an incomplete bridge', () => {
+    const bridgeTxHistoryData = createBridgeData('COMPLETE');
+    mockIsBridgeHistoryItem.mockReturnValue(true);
+
+    renderView({ bridgeTxHistoryData });
+
+    expect(mockBridgeSegments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactionStatus: TransactionStatus.confirmed,
+      }),
+      undefined,
+    );
+    expect(mockStatusText).not.toHaveBeenCalled();
+  });
+
+  it('uses the bridge activity title when available', () => {
+    const bridgeTxHistoryData = createBridgeData('COMPLETE', {
+      isBridgeComplete: true,
+      is7702Batch: true,
+    });
+    mockGetBridgeTitle.mockReturnValue('Bridge complete');
+
+    renderView({ bridgeTxHistoryData });
+
+    expect(screen.getByText('Bridge complete')).toBeOnTheScreen();
+    expect(mockGetBridgeTitle).toHaveBeenCalledWith(
+      bridgeTxHistoryData.bridgeTxHistoryItem,
+      true,
+    );
+  });
+
+  it('renders import time before an older transaction', () => {
+    const { onImportWalletTip } = renderView({
+      accountImportTime: 200,
+      tx: createTransaction({ insertImportTime: true, time: 100 }),
+    });
+
+    fireEvent.press(screen.UNSAFE_getByType(TouchableOpacity));
+
+    expect(onImportWalletTip).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders import time after a newer transaction', () => {
+    const { onImportWalletTip } = renderView({
+      accountImportTime: 50,
+      tx: createTransaction({ insertImportTime: true, time: 100 }),
+    });
+
+    fireEvent.press(screen.UNSAFE_getByType(TouchableOpacity));
+
+    expect(onImportWalletTip).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits import time when the transaction flag is absent', () => {
+    renderView({
+      accountImportTime: 200,
+      tx: createTransaction({ time: 100 }),
+    });
+
+    expect(screen.UNSAFE_queryByType(TouchableOpacity)).not.toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/TransactionElement/TransactionElementView.tsx
+++ b/app/components/UI/TransactionElement/TransactionElementView.tsx
@@ -1,0 +1,367 @@
+import React, { type ReactNode } from 'react';
+import {
+  Text,
+  TouchableHighlight,
+  TouchableOpacity,
+  View,
+  type TextStyle,
+} from 'react-native';
+import FAIcon from 'react-native-vector-icons/FontAwesome';
+import type { ThemeColors } from '@metamask/design-tokens';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { strings } from '../../../../locales/i18n';
+import { toDateFormat } from '../../../util/date';
+import { isTestNet } from '../../../util/networks';
+import ListItem from '../../Base/ListItem';
+import StatusText from '../../Base/StatusText';
+import StyledButton from '../StyledButton';
+import {
+  FINAL_NON_CONFIRMED_STATUSES,
+  useBridgeTxHistoryData,
+} from '../../../util/bridge/hooks/useBridgeTxHistoryData';
+import BridgeActivityItemTxSegments from '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments';
+import {
+  getSwapBridgeTxActivityTitle,
+  isBridgeTxHistoryItemBridge,
+} from '../Bridge/utils/transaction-history';
+import { hasGasFeeTokenSelected } from '../../Views/confirmations/utils/transaction';
+import type { TransactionWithImportTime } from '../Transactions/AssetDetailsActivityListItem.utils';
+import TransactionElementIcon from './TransactionElementIcon';
+import type { TransactionElementStyles } from './styles';
+import type {
+  DecodedTransactionDetails,
+  DecodedTransactionElement,
+} from './types';
+
+const INTENT_STATUS = {
+  SUBMITTED: 'SUBMITTED',
+  PENDING: 'PENDING',
+  COMPLETE: 'COMPLETE',
+  FAILED: 'FAILED',
+} as const;
+
+const TRANSACTION_STATUS = {
+  SUBMITTED: TransactionStatus.submitted,
+  PENDING: 'pending',
+  CONFIRMED: TransactionStatus.confirmed,
+  FAILED: TransactionStatus.failed,
+} as const;
+
+type DisplayTransactionStatus = TransactionStatus | 'pending';
+
+type ViewStyles = TransactionElementStyles & {
+  infoIcon?: TextStyle;
+};
+
+const mapIntentStatusToTransactionStatus = (
+  intentStatus: string,
+): DisplayTransactionStatus => {
+  if (intentStatus === INTENT_STATUS.PENDING) {
+    return TRANSACTION_STATUS.PENDING;
+  }
+  if (intentStatus === INTENT_STATUS.COMPLETE) {
+    return TRANSACTION_STATUS.CONFIRMED;
+  }
+  if (intentStatus === INTENT_STATUS.FAILED) {
+    return TRANSACTION_STATUS.FAILED;
+  }
+  if (intentStatus === INTENT_STATUS.SUBMITTED) {
+    return TRANSACTION_STATUS.SUBMITTED;
+  }
+
+  // if it is unknown status, default to failed
+  return TRANSACTION_STATUS.FAILED;
+};
+
+interface ActionButtonProps {
+  children: ReactNode;
+  onPress: () => void;
+  styles: ViewStyles;
+  type: 'cancel' | 'normal';
+  withMargin?: boolean;
+}
+
+const ActionButton = ({
+  children,
+  onPress,
+  styles,
+  type,
+  withMargin,
+}: ActionButtonProps) => (
+  <StyledButton
+    type={type}
+    containerStyle={[
+      styles.actionContainerStyle,
+      withMargin && styles.speedupActionContainerStyle,
+    ]}
+    style={styles.actionStyle}
+    onPress={onPress}
+  >
+    {children}
+  </StyledButton>
+);
+
+interface ImportTimeRowProps {
+  accountImportTime: number;
+  onPress: () => void;
+  styles: ViewStyles;
+}
+
+const ImportTimeRow = ({
+  accountImportTime,
+  onPress,
+  styles,
+}: ImportTimeRowProps) => (
+  <View style={styles.row}>
+    <TouchableOpacity onPress={onPress} style={styles.importRowBody}>
+      <Text style={styles.importText}>
+        {`${strings('transactions.import_wallet_row')} `}
+        <FAIcon name="info-circle" style={styles.infoIcon} />
+      </Text>
+      <ListItem.Date>{toDateFormat(accountImportTime)}</ListItem.Date>
+    </TouchableOpacity>
+  </View>
+);
+
+type TransactionElementTransaction = TransactionWithImportTime & {
+  isSmartTransaction?: boolean;
+};
+
+interface TransactionElementViewProps {
+  accountImportTime?: number;
+  bridgeTxHistoryData: ReturnType<typeof useBridgeTxHistoryData>;
+  colors: ThemeColors;
+  i?: number;
+  isLedgerAccount?: boolean;
+  isQRHardwareAccount?: boolean;
+  onCancel: () => void;
+  onCancelUnsignedQR: () => void;
+  onImportWalletTip: () => void;
+  onPress: () => void;
+  onSignLedger: () => void;
+  onSignQR: () => void;
+  onSpeedUp: () => void;
+  showBottomBorder?: boolean;
+  styles: ViewStyles;
+  transactionElement?: DecodedTransactionElement;
+  transactionDetails?: DecodedTransactionDetails;
+  transactions: TransactionMeta[];
+  tx: TransactionElementTransaction;
+  txTime: string;
+}
+
+const TransactionElementView = ({
+  accountImportTime,
+  bridgeTxHistoryData,
+  colors,
+  i,
+  isLedgerAccount,
+  isQRHardwareAccount,
+  onCancel,
+  onCancelUnsignedQR,
+  onImportWalletTip,
+  onPress,
+  onSignLedger,
+  onSignQR,
+  onSpeedUp,
+  showBottomBorder,
+  styles,
+  transactionElement,
+  transactionDetails,
+  transactions,
+  tx,
+  txTime,
+}: TransactionElementViewProps) => {
+  const isReady = Boolean(transactionElement && transactionDetails);
+
+  const renderImportTime = () => {
+    if (!tx.insertImportTime || !accountImportTime) {
+      return null;
+    }
+
+    return (
+      <ImportTimeRow
+        accountImportTime={accountImportTime}
+        onPress={onImportWalletTip}
+        styles={styles}
+      />
+    );
+  };
+
+  const renderPendingElement = () => (
+    <ListItem>
+      <ListItem.Date style={styles.listItemDate}>{txTime}</ListItem.Date>
+      <ListItem.Content style={styles.listItemContent}>
+        <ListItem.Icon>
+          <View style={styles.icon} />
+        </ListItem.Icon>
+        <ListItem.Body>
+          <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
+            ...
+          </ListItem.Title>
+          <StatusText
+            testID={`transaction-status-${i}`}
+            status={tx.status}
+            style={styles.listItemStatus}
+          />
+        </ListItem.Body>
+      </ListItem.Content>
+    </ListItem>
+  );
+
+  const renderReadyElement = () => {
+    if (!transactionElement) {
+      return renderPendingElement();
+    }
+
+    const { bridgeTxHistoryItem, is7702Batch, isBridgeComplete } =
+      bridgeTxHistoryData;
+    const isBridgeTransaction =
+      tx.type === TransactionType.bridge ||
+      Boolean(
+        bridgeTxHistoryItem && isBridgeTxHistoryItemBridge(bridgeTxHistoryItem),
+      );
+    const { value, fiatValue = false, actionKey } = transactionElement;
+    const transactionStatus =
+      bridgeTxHistoryItem?.status && bridgeTxHistoryItem.quote.intent
+        ? mapIntentStatusToTransactionStatus(bridgeTxHistoryItem.status.status)
+        : tx.status;
+    const renderNormalActions =
+      (transactionStatus === 'submitted' ||
+        (transactionStatus === 'approved' &&
+          !isQRHardwareAccount &&
+          !isLedgerAccount)) &&
+      !tx.isSmartTransaction &&
+      !isBridgeTransaction &&
+      !hasGasFeeTokenSelected(tx);
+    const renderUnsignedQRActions =
+      transactionStatus === 'approved' && isQRHardwareAccount;
+    const renderLedgerActions =
+      transactionStatus === 'approved' && isLedgerAccount;
+    const title = bridgeTxHistoryItem
+      ? (getSwapBridgeTxActivityTitle(bridgeTxHistoryItem, is7702Batch) ??
+        actionKey)
+      : actionKey;
+
+    return (
+      <ListItem>
+        <ListItem.Date style={styles.listItemDate}>{txTime}</ListItem.Date>
+        <ListItem.Content style={styles.listItemContent}>
+          <ListItem.Icon>
+            <TransactionElementIcon
+              transactionElement={transactionElement}
+              tx={tx}
+              transactions={transactions}
+              styles={styles}
+            />
+          </ListItem.Icon>
+          <ListItem.Body>
+            <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
+              {title}
+            </ListItem.Title>
+            {!FINAL_NON_CONFIRMED_STATUSES.some(
+              (status) => status === transactionStatus,
+            ) &&
+            isBridgeTransaction &&
+            !isBridgeComplete ? (
+              <BridgeActivityItemTxSegments
+                bridgeTxHistoryItem={bridgeTxHistoryItem}
+                transactionStatus={transactionStatus}
+              />
+            ) : (
+              <StatusText
+                testID={`transaction-status-${i}`}
+                status={transactionStatus}
+                style={styles.listItemStatus}
+              />
+            )}
+          </ListItem.Body>
+          {Boolean(value) && (
+            <ListItem.Amounts>
+              {!isTestNet(tx.chainId) && (
+                <ListItem.FiatAmount style={styles.listItemFiatAmount}>
+                  {fiatValue}
+                </ListItem.FiatAmount>
+              )}
+              <ListItem.Amount style={styles.listItemAmount}>
+                {value}
+              </ListItem.Amount>
+            </ListItem.Amounts>
+          )}
+        </ListItem.Content>
+        {renderNormalActions && (
+          <ListItem.Actions>
+            <ActionButton
+              type="normal"
+              styles={styles}
+              onPress={onSpeedUp}
+              withMargin
+            >
+              {strings('transaction.speedup')}
+            </ActionButton>
+            <ActionButton type="cancel" styles={styles} onPress={onCancel}>
+              {strings('transaction.cancel')}
+            </ActionButton>
+          </ListItem.Actions>
+        )}
+        {renderUnsignedQRActions && (
+          <ListItem.Actions>
+            <ActionButton
+              type="normal"
+              styles={styles}
+              onPress={onSignQR}
+              withMargin
+            >
+              {strings('transaction.sign_with_keystone')}
+            </ActionButton>
+            <ActionButton
+              type="cancel"
+              styles={styles}
+              onPress={onCancelUnsignedQR}
+              withMargin
+            >
+              {strings('transaction.cancel')}
+            </ActionButton>
+          </ListItem.Actions>
+        )}
+        {renderLedgerActions && (
+          <ListItem.Actions>
+            <ActionButton
+              type="normal"
+              styles={styles}
+              onPress={onSignLedger}
+              withMargin
+            >
+              {strings('transaction.sign_with_ledger')}
+            </ActionButton>
+          </ListItem.Actions>
+        )}
+      </ListItem>
+    );
+  };
+
+  return (
+    <>
+      {accountImportTime !== undefined &&
+        accountImportTime > tx.time &&
+        renderImportTime()}
+      <TouchableHighlight
+        style={showBottomBorder ? styles.rowWithBorder : styles.row}
+        onPress={isReady ? onPress : undefined}
+        underlayColor={colors.background.alternative}
+        activeOpacity={1}
+      >
+        {isReady ? renderReadyElement() : renderPendingElement()}
+      </TouchableHighlight>
+      {accountImportTime !== undefined &&
+        accountImportTime <= tx.time &&
+        renderImportTime()}
+    </>
+  );
+};
+
+export default TransactionElementView;

--- a/app/components/UI/TransactionElement/hooks/useDecodedTransaction.test.ts
+++ b/app/components/UI/TransactionElement/hooks/useDecodedTransaction.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import decodeTransaction from '../utils';
+import useDecodedTransaction from './useDecodedTransaction';
+import type { DecodedTransaction } from '../types';
+
+jest.mock('../utils');
+
+const mockDecodeTransaction = jest.mocked(decodeTransaction);
+
+const createDecodedTransaction = (actionKey: string): DecodedTransaction => [
+  {
+    actionKey,
+    value: '1 ETH',
+    fiatValue: '$3,000',
+  },
+  {
+    summaryAmount: '1 ETH',
+  },
+];
+
+const createDeferredDecode = () => {
+  let resolve!: (value: DecodedTransaction) => void;
+  const promise = new Promise<DecodedTransaction>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+};
+
+describe('useDecodedTransaction', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns decoded transaction data', async () => {
+    const decodedTransaction = createDecodedTransaction('Send');
+    const swapsTransactions = {};
+    mockDecodeTransaction.mockResolvedValue(decodedTransaction);
+
+    const { result } = renderHook(() =>
+      useDecodedTransaction({
+        props: { tx: { id: 'transaction-id' } },
+        txChainId: '0x1',
+        swapsTransactions,
+        selectedAddress: '0x123',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        transactionElement: decodedTransaction[0],
+        transactionDetails: decodedTransaction[1],
+      });
+    });
+  });
+
+  it('decodes with the latest props when a dependency changes', async () => {
+    const swapsTransactions = {};
+    mockDecodeTransaction.mockResolvedValue(createDecodedTransaction('Send'));
+    const { rerender } = renderHook(
+      ({ txChainId, props }) =>
+        useDecodedTransaction({
+          props,
+          txChainId,
+          swapsTransactions,
+          selectedAddress: '0x123',
+        }),
+      {
+        initialProps: {
+          txChainId: '0x1',
+          props: { ticker: 'ETH' },
+        },
+      },
+    );
+    await waitFor(() => {
+      expect(mockDecodeTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({
+      txChainId: '0x89',
+      props: { ticker: 'POL' },
+    });
+
+    await waitFor(() => {
+      expect(mockDecodeTransaction).toHaveBeenLastCalledWith({ ticker: 'POL' });
+    });
+  });
+
+  it('ignores an older decode result after a newer request resolves', async () => {
+    const firstDecode = createDeferredDecode();
+    const secondDecode = createDeferredDecode();
+    const swapsTransactions = {};
+    mockDecodeTransaction
+      .mockReturnValueOnce(firstDecode.promise)
+      .mockReturnValueOnce(secondDecode.promise);
+    const { result, rerender } = renderHook(
+      ({ txChainId }) =>
+        useDecodedTransaction({
+          props: { txChainId },
+          txChainId,
+          swapsTransactions,
+          selectedAddress: '0x123',
+        }),
+      { initialProps: { txChainId: '0x1' } },
+    );
+    await waitFor(() => {
+      expect(mockDecodeTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ txChainId: '0x89' });
+    const latestTransaction = createDecodedTransaction('Latest');
+    await act(async () => {
+      secondDecode.resolve(latestTransaction);
+      await secondDecode.promise;
+    });
+
+    await act(async () => {
+      firstDecode.resolve(createDecodedTransaction('Stale'));
+      await firstDecode.promise;
+    });
+
+    expect(result.current.transactionElement).toEqual(latestTransaction[0]);
+  });
+
+  it('ignores a decode result after unmounting', async () => {
+    const deferredDecode = createDeferredDecode();
+    const swapsTransactions = {};
+    mockDecodeTransaction.mockReturnValue(deferredDecode.promise);
+    const { unmount } = renderHook(() =>
+      useDecodedTransaction({
+        props: {},
+        txChainId: '0x1',
+        swapsTransactions,
+        selectedAddress: '0x123',
+      }),
+    );
+    unmount();
+
+    await act(async () => {
+      deferredDecode.resolve(createDecodedTransaction('Unmounted'));
+      await deferredDecode.promise;
+    });
+
+    expect(mockDecodeTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/TransactionElement/hooks/useDecodedTransaction.ts
+++ b/app/components/UI/TransactionElement/hooks/useDecodedTransaction.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import decodeTransaction from '../utils';
+import type {
+  DecodedTransactionElement,
+  DecodedTransactionDetails,
+  DecodedTransaction,
+} from '../types';
+
+interface UseDecodedTransactionParams {
+  props: Record<string, unknown>;
+  txChainId?: string;
+  swapsTransactions: unknown;
+  selectedAddress?: string;
+}
+
+interface DecodedTransactionState {
+  transactionElement?: DecodedTransactionElement;
+  transactionDetails?: DecodedTransactionDetails;
+}
+
+const useDecodedTransaction = ({
+  props,
+  txChainId,
+  swapsTransactions,
+  selectedAddress,
+}: UseDecodedTransactionParams): DecodedTransactionState => {
+  const [transactionData, setTransactionData] =
+    useState<DecodedTransactionState>({
+      transactionElement: undefined,
+      transactionDetails: undefined,
+    });
+  const mountedRef = useRef(false);
+  const decodeRequestRef = useRef(0);
+  const latestPropsRef = useRef(props);
+
+  useEffect(() => {
+    latestPropsRef.current = props;
+  });
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const requestId = ++decodeRequestRef.current;
+
+    const decode = async () => {
+      const decodedTransaction: DecodedTransaction = await decodeTransaction(
+        latestPropsRef.current,
+      );
+      const [transactionElement, transactionDetails] = decodedTransaction;
+
+      if (mountedRef.current && requestId === decodeRequestRef.current) {
+        setTransactionData({
+          transactionElement,
+          transactionDetails,
+        });
+      }
+    };
+
+    decode();
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [txChainId, swapsTransactions, selectedAddress]);
+
+  return transactionData;
+};
+
+export default useDecodedTransaction;

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -1,30 +1,21 @@
-import React, { PureComponent, useCallback } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import PropTypes from 'prop-types';
-import {
-  TouchableOpacity,
-  TouchableHighlight,
-  StyleSheet,
-  Image,
-  Text,
-  View,
-} from 'react-native';
-import { fontStyles } from '../../../styles/common';
-import FAIcon from 'react-native-vector-icons/FontAwesome';
-import { strings } from '../../../../locales/i18n';
-import { toDateFormat } from '../../../util/date';
-import { safeToChecksumAddress } from '../../../util/address';
 import { connect, useSelector } from 'react-redux';
-import StyledButton from '../StyledButton';
-import decodeTransaction from './utils';
-import { TRANSACTION_TYPES } from '../../../util/transactions';
-import ListItem from '../../Base/ListItem';
-import StatusText from '../../Base/StatusText';
-import { isTestNet, getDecimalChainId } from '../../../util/networks';
 import {
   TransactionType,
   WalletDevice,
 } from '@metamask/transaction-controller';
+import { safeToChecksumAddress } from '../../../util/address';
+import { toDateFormat } from '../../../util/date';
+import { getDecimalChainId } from '../../../util/networks';
 import { ThemeContext, mockTheme } from '../../../util/theme';
+import { strings } from '../../../../locales/i18n';
 import { selectTickerByChainId } from '../../../selectors/networkController';
 import {
   selectSelectedInternalAccount,
@@ -36,26 +27,8 @@ import {
   selectSwapsTransactions,
   selectTransactions,
 } from '../../../selectors/transactionController';
-import {
-  FINAL_NON_CONFIRMED_STATUSES,
-  useBridgeTxHistoryData,
-} from '../../../util/bridge/hooks/useBridgeTxHistoryData';
-import BridgeActivityItemTxSegments from '../Bridge/components/TransactionDetails/BridgeActivityItemTxSegments';
-import {
-  getSwapBridgeTxActivityTitle,
-  handleUnifiedSwapsTxHistoryItemClick,
-  isBridgeTxHistoryItemBridge,
-} from '../Bridge/utils/transaction-history';
-import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
-import Badge, {
-  BadgeVariant,
-} from '../../../component-library/components/Badges/Badge';
-import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
-import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
-import {
-  getFontFamily,
-  TextVariant,
-} from '../../../component-library/components/Texts/Text';
+import { useBridgeTxHistoryData } from '../../../util/bridge/hooks/useBridgeTxHistoryData';
+import { handleUnifiedSwapsTxHistoryItemClick } from '../Bridge/utils/transaction-history';
 import {
   selectConversionRateByChainId,
   selectCurrencyRates,
@@ -64,10 +37,7 @@ import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRa
 import { selectTokensByChainIdAndWalletAddress } from '../../../selectors/tokensController';
 import Routes from '../../../constants/navigation/Routes';
 import { navigateToTransactionDetails } from '../../../util/navigation/navigateToTransactionDetails';
-import {
-  hasGasFeeTokenSelected,
-  hasTransactionType,
-} from '../../Views/confirmations/utils/transaction';
+import { hasTransactionType } from '../../Views/confirmations/utils/transaction';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import {
   TRANSACTION_DETAIL_EVENTS,
@@ -75,92 +45,9 @@ import {
   getMonetizedPrimitive,
 } from '../../../core/Analytics/events/transactions';
 import { getTransactionTypeValue } from '../../../core/Engine/controllers/transaction-controller/metrics_properties/base';
-
-const createStyles = (colors, typography) =>
-  StyleSheet.create({
-    row: {
-      backgroundColor: colors.background.default,
-      flex: 1,
-    },
-    rowWithBorder: {
-      backgroundColor: colors.background.default,
-      flex: 1,
-      borderBottomWidth: 1,
-      borderBottomColor: colors.border.muted,
-    },
-    actionContainerStyle: {
-      height: 25,
-      padding: 0,
-    },
-    speedupActionContainerStyle: {
-      marginRight: 10,
-    },
-    actionStyle: {
-      fontSize: 10,
-      padding: 0,
-      paddingHorizontal: 10,
-    },
-    icon: {
-      width: 32,
-      height: 32,
-    },
-    iconBadgePosition: {
-      bottom: -4,
-      right: -4,
-    },
-    importText: {
-      color: colors.text.alternative,
-      fontSize: 14,
-      ...fontStyles.bold,
-      alignContent: 'center',
-    },
-    importRowBody: {
-      alignItems: 'center',
-      paddingTop: 10,
-    },
-    listItemDate: {
-      marginBottom: 10,
-      paddingBottom: 0,
-    },
-    listItemContent: {
-      alignItems: 'flex-start',
-      marginTop: 0,
-      paddingTop: 0,
-    },
-    listItemTitle: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
-      marginTop: 0,
-    },
-    listItemStatus: {
-      ...typography.sBodyMDBold,
-      fontFamily: getFontFamily(TextVariant.BodyMDBold),
-    },
-    listItemFiatAmount: {
-      ...typography.sBodyLGMedium,
-      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
-      marginTop: 0,
-    },
-    listItemAmount: {
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-      color: colors.text.alternative,
-    },
-  });
-
-/* eslint-disable import-x/no-commonjs */
-const transactionIconApprove = require('../../../images/transaction-icons/approve.png');
-const transactionIconInteraction = require('../../../images/transaction-icons/interaction.png');
-const transactionIconSent = require('../../../images/transaction-icons/send.png');
-const transactionIconReceived = require('../../../images/transaction-icons/receive.png');
-const transactionIconSwap = require('../../../images/transaction-icons/swap.png');
-
-const transactionIconApproveFailed = require('../../../images/transaction-icons/approve-failed.png');
-const transactionIconInteractionFailed = require('../../../images/transaction-icons/interaction-failed.png');
-const transactionIconSentFailed = require('../../../images/transaction-icons/send-failed.png');
-const transactionIconReceivedFailed = require('../../../images/transaction-icons/receive-failed.png');
-const transactionIconSwapFailed = require('../../../images/transaction-icons/swap-failed.png');
-/* eslint-enable import-x/no-commonjs */
+import useDecodedTransaction from './hooks/useDecodedTransaction';
+import TransactionElementView from './TransactionElementView';
+import createStyles from './styles';
 
 const NEW_TRANSACTION_DETAILS_TYPES = [
   TransactionType.musdClaim,
@@ -175,616 +62,225 @@ const NEW_TRANSACTION_DETAILS_TYPES = [
   TransactionType.predictWithdraw,
 ];
 
-const INTENT_STATUS = {
-  SUBMITTED: 'SUBMITTED',
-  PENDING: 'PENDING',
-  COMPLETE: 'COMPLETE',
-  FAILED: 'FAILED',
-  UNKNOWN: 'UNKNOWN',
+const transactionElementPropTypes = {
+  assetSymbol: PropTypes.string,
+  /**
+   * Asset object (in this case ERC721 token)
+   */
+  tx: PropTypes.object.isRequired,
+  /**
+   * InternalAccount object required to get import time name
+   */
+  selectedInternalAccount: PropTypes.object,
+  /**
+   * Internal accounts for the selected account group
+   */
+  selectSelectedAccountGroupInternalAccounts: PropTypes.array,
+  /**
+   * Current element of the list index
+   */
+  i: PropTypes.number,
+  /**
+   * Callback to render transaction details view
+   */
+  onPressItem: PropTypes.func,
+  /**
+   * Callback to speed up tx
+   */
+  onSpeedUpAction: PropTypes.func,
+  /**
+   * Callback to cancel tx
+   */
+  onCancelAction: PropTypes.func,
+  swapsTransactions: PropTypes.object,
+  signQRTransaction: PropTypes.func,
+  cancelUnsignedQRTransaction: PropTypes.func,
+  isQRHardwareAccount: PropTypes.bool,
+  isLedgerAccount: PropTypes.bool,
+  signLedgerTransaction: PropTypes.func,
+  bridgeTxHistoryData: PropTypes.object.isRequired,
+  /**
+   * Chain Id
+   */
+  txChainId: PropTypes.string,
+  /**
+   * Selected wallet address for decoding and token map (optional override from parent)
+   */
+  selectedAddress: PropTypes.string,
+  /**
+   * Ticker
+   */
+  ticker: PropTypes.string,
+  /**
+   * Navigation object for routing
+   */
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func.isRequired,
+  }).isRequired,
+  /**
+   * Whether to render a bottom border for row separation (used in unified list)
+   */
+  showBottomBorder: PropTypes.bool,
+  /**
+   * All EVM transactions in controller state
+   */
+  transactions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   * Callback to track transaction detail click analytics
+   */
+  trackTransactionDetailClicked: PropTypes.func,
 };
 
-const TRANSACTION_STATUS = {
-  SUBMITTED: 'submitted',
-  PENDING: 'pending',
-  CONFIRMED: 'confirmed',
-  FAILED: 'failed',
-};
 /**
- * View that renders a transaction item part of transactions list
+ * Connected transaction item container for the transactions list.
  */
-class TransactionElement extends PureComponent {
-  static propTypes = {
-    assetSymbol: PropTypes.string,
-    /**
-     * Asset object (in this case ERC721 token)
-     */
-    tx: PropTypes.object,
-    /**
-    /* InternalAccount object required to get import time name
-    */
-    selectedInternalAccount: PropTypes.object,
-    /**
-     * Internal accounts for the selected account group
-     */
-    selectSelectedAccountGroupInternalAccounts: PropTypes.array,
-    /**
-     * Current element of the list index
-     */
-    i: PropTypes.number,
-    /**
-     * Callback to render transaction details view
-     */
-    onPressItem: PropTypes.func,
-    /**
-     * Callback to speed up tx
-     */
-    onSpeedUpAction: PropTypes.func,
-    /**
-     * Callback to cancel tx
-     */
-    onCancelAction: PropTypes.func,
-    swapsTransactions: PropTypes.object,
-    signQRTransaction: PropTypes.func,
-    cancelUnsignedQRTransaction: PropTypes.func,
-    isQRHardwareAccount: PropTypes.bool,
-    isLedgerAccount: PropTypes.bool,
-    signLedgerTransaction: PropTypes.func,
-    bridgeTxHistoryData: PropTypes.object,
-    /**
-     * Chain Id
-     */
-    txChainId: PropTypes.string,
-    /**
-     * Selected wallet address for decoding and token map (optional override from parent)
-     */
-    selectedAddress: PropTypes.string,
-    /**
-     * Ticker
-     */
-    ticker: PropTypes.string,
-    /**
-     * Navigation object for routing
-     */
-    navigation: PropTypes.shape({
-      navigate: PropTypes.func.isRequired,
-    }).isRequired,
-    /**
-     * Whether to render a bottom border for row separation (used in unified list)
-     */
-    showBottomBorder: PropTypes.bool,
-    /**
-     * All EVM transactions in controller state
-     */
-    transactions: PropTypes.arrayOf(PropTypes.object).isRequired,
-    /**
-     * Callback to track transaction detail click analytics
-     */
-    trackTransactionDetailClicked: PropTypes.func,
+const TransactionElement = (props) => {
+  const {
+    assetSymbol,
+    bridgeTxHistoryData,
+    i,
+    isLedgerAccount,
+    isQRHardwareAccount,
+    selectedAddress,
+    selectedInternalAccount,
+    selectSelectedAccountGroupInternalAccounts: selectedGroupAccounts,
+    showBottomBorder,
+    swapsTransactions,
+    ticker,
+    transactions,
+    tx,
+    txChainId,
+  } = props;
+  const theme = useContext(ThemeContext) || mockTheme;
+  const styles = useMemo(
+    () => createStyles(theme.colors, theme.typography),
+    [theme.colors, theme.typography],
+  );
+  const mountedRef = useRef(false);
+  const decodeProps = {
+    ...props,
+    assetSymbol,
+    ticker,
+  };
+  const { transactionElement, transactionDetails } = useDecodedTransaction({
+    props: decodeProps,
+    txChainId,
+    swapsTransactions,
+    selectedAddress,
+  });
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const showCancelModal = () => {
+    mountedRef.current && props.onCancelAction(true, tx);
+  };
+  const showSpeedUpModal = () => {
+    mountedRef.current && props.onSpeedUpAction(true, tx);
+  };
+  const showQRSigningModal = () => {
+    mountedRef.current && props.signQRTransaction(tx);
+  };
+  const showLedgerSigninModal = () => {
+    mountedRef.current && props.signLedgerTransaction(tx);
+  };
+  const cancelUnsignedQRTransaction = () => {
+    mountedRef.current && props.cancelUnsignedQRTransaction(tx);
   };
 
-  state = {
-    actionKey: undefined,
-    cancelIsOpen: false,
-    speedUpIsOpen: false,
-    transactionGas: {
-      gasBN: undefined,
-      gasPriceBN: undefined,
-      gasTotal: undefined,
-    },
-    transactionElement: undefined,
-    transactionDetails: undefined,
-  };
-
-  mounted = false;
-
-  componentDidMount = async () => {
-    this.mounted = true;
-    const [transactionElement, transactionDetails] = await decodeTransaction({
-      ...this.props,
-      swapsTransactions: this.props.swapsTransactions,
-      assetSymbol: this.props.assetSymbol,
-      ticker: this.props.ticker,
-    });
-
-    this.mounted && this.setState({ transactionElement, transactionDetails });
-  };
-
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.txChainId !== this.props.txChainId ||
-      prevProps.swapsTransactions !== this.props.swapsTransactions ||
-      prevProps.selectedAddress !== this.props.selectedAddress
-    ) {
-      this.componentDidMount();
-    }
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  onPressItem = () => {
-    const { tx, i, onPressItem, trackTransactionDetailClicked } = this.props;
-    const bridgeTxHistoryItem =
-      this.props.bridgeTxHistoryData?.bridgeTxHistoryItem;
-    onPressItem && onPressItem(tx.id, i);
-    trackTransactionDetailClicked && trackTransactionDetailClicked();
+  const onPressItem = () => {
+    const bridgeTxHistoryItem = bridgeTxHistoryData?.bridgeTxHistoryItem;
+    props.onPressItem && props.onPressItem(tx.id, i);
+    props.trackTransactionDetailClicked &&
+      props.trackTransactionDetailClicked();
 
     if (tx.type === TransactionType.bridge || bridgeTxHistoryItem) {
       handleUnifiedSwapsTxHistoryItemClick({
-        navigation: this.props.navigation,
+        navigation: props.navigation,
         evmTxMeta: tx,
         bridgeTxHistoryItem,
       });
     } else if (hasTransactionType(tx, NEW_TRANSACTION_DETAILS_TYPES)) {
-      navigateToTransactionDetails(this.props.navigation, {
+      navigateToTransactionDetails(props.navigation, {
         transactionId: tx.id,
       });
     } else {
-      const { transactionElement, transactionDetails } = this.state;
-      this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.SHEET.TRANSACTION_DETAILS,
         params: {
           tx,
           transactionElement,
           transactionDetails,
-          showSpeedUpModal: this.showSpeedUpModal,
-          showCancelModal: this.showCancelModal,
+          showSpeedUpModal,
+          showCancelModal,
         },
       });
     }
   };
 
-  onPressImportWalletTip = () => {
-    this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+  const onPressImportWalletTip = () => {
+    props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.IMPORT_WALLET_TIP,
     });
   };
 
-  renderTxTime = () => {
-    const {
-      tx,
-      selectedInternalAccount,
-      selectSelectedAccountGroupInternalAccounts,
-    } = this.props;
+  const selectedAddresses = selectedGroupAccounts.map(
+    (account) => account.address,
+  );
+  const incoming = selectedAddresses.includes(
+    safeToChecksumAddress(tx.txParams.to),
+  );
+  const selfSent =
+    incoming &&
+    selectedAddresses.includes(safeToChecksumAddress(tx.txParams.from));
+  const shouldShowFromDevice =
+    (!incoming || selfSent) && tx.deviceConfirmedOn === WalletDevice.MM_MOBILE;
+  const hasNonce = tx.txParams?.nonce;
+  let txTime = `${toDateFormat(tx.time)}`;
 
-    let incoming = false;
-    let selfSent = false;
-
-    const selectedAddresses = selectSelectedAccountGroupInternalAccounts.map(
-      (account) => account.address,
-    );
-    incoming = selectedAddresses.includes(
-      safeToChecksumAddress(tx.txParams.to),
-    );
-    selfSent =
-      incoming &&
-      selectedAddresses.includes(safeToChecksumAddress(tx.txParams.from));
-    const shouldShowFromDevice =
-      (!incoming || selfSent) &&
-      tx.deviceConfirmedOn === WalletDevice.MM_MOBILE;
-    const hasNonce = tx.txParams?.nonce;
-
-    if (shouldShowFromDevice && hasNonce) {
-      return `#${parseInt(tx.txParams.nonce, 16)} - ${toDateFormat(
-        tx.time,
-      )} ${strings('transactions.from_device_label')}`;
-    }
-    if (shouldShowFromDevice && !hasNonce) {
-      return `${toDateFormat(tx.time)} ${strings('transactions.from_device_label')}`;
-    }
-    return `${toDateFormat(tx.time)}`;
-  };
-
-  /**
-   * Function that evaluates tx to see if the Added Wallet label should be rendered.
-   * @returns Account added to wallet view
-   */
-  renderImportTime = () => {
-    const { tx, selectedInternalAccount } = this.props;
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    const accountImportTime = selectedInternalAccount?.metadata.importTime;
-    if (tx.insertImportTime && accountImportTime) {
-      return (
-        <View style={styles.row}>
-          <TouchableOpacity
-            onPress={this.onPressImportWalletTip}
-            style={styles.importRowBody}
-          >
-            <Text style={styles.importText}>
-              {`${strings('transactions.import_wallet_row')} `}
-              <FAIcon name="info-circle" style={styles.infoIcon} />
-            </Text>
-            <ListItem.Date>{toDateFormat(accountImportTime)}</ListItem.Date>
-          </TouchableOpacity>
-        </View>
-      );
-    }
-    return null;
-  };
-
-  renderTxElementIcon = (transactionElement, tx) => {
-    const { chainId: txChainId, requiredTransactionIds, status, type } = tx;
-    const { transactionType } = transactionElement;
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    const { transactions } = this.props;
-
-    const isFailedTransaction = status === 'cancelled' || status === 'failed';
-    let icon;
-    switch (transactionType) {
-      case TRANSACTION_TYPES.SENT_TOKEN:
-      case TRANSACTION_TYPES.SENT_COLLECTIBLE:
-      case TRANSACTION_TYPES.SENT:
-        icon = isFailedTransaction
-          ? transactionIconSentFailed
-          : transactionIconSent;
-        break;
-      case TRANSACTION_TYPES.RECEIVED_TOKEN:
-      case TRANSACTION_TYPES.RECEIVED_COLLECTIBLE:
-      case TRANSACTION_TYPES.RECEIVED:
-        icon = isFailedTransaction
-          ? transactionIconReceivedFailed
-          : transactionIconReceived;
-        break;
-      case TRANSACTION_TYPES.SITE_INTERACTION:
-        icon = isFailedTransaction
-          ? transactionIconInteractionFailed
-          : transactionIconInteraction;
-        break;
-      case TRANSACTION_TYPES.BATCH_SELL_TRANSACTION:
-      case TRANSACTION_TYPES.SWAPS_TRANSACTION:
-        icon = isFailedTransaction
-          ? transactionIconSwapFailed
-          : transactionIconSwap;
-        break;
-      case TRANSACTION_TYPES.BRIDGE_TRANSACTION:
-        icon = isFailedTransaction
-          ? transactionIconSwapFailed
-          : transactionIconSwap;
-        break;
-      case TRANSACTION_TYPES.APPROVE:
-      case TRANSACTION_TYPES.INCREASE_ALLOWANCE:
-      case TRANSACTION_TYPES.SET_APPROVAL_FOR_ALL:
-        icon = isFailedTransaction
-          ? transactionIconApproveFailed
-          : transactionIconApprove;
-        break;
-    }
-
-    const perpsDepositChainId =
-      type === TransactionType.perpsDeposit && requiredTransactionIds?.length
-        ? transactions?.find((t) => t.id === requiredTransactionIds[0])?.chainId
-        : undefined;
-
-    const withdrawChainId = hasTransactionType(this.props.tx, [
-      TransactionType.predictWithdraw,
-      TransactionType.perpsWithdraw,
-    ])
-      ? this.props.tx.metamaskPay?.chainId
-      : undefined;
-
-    const chainId = perpsDepositChainId ?? withdrawChainId ?? txChainId;
-
-    return (
-      <BadgeWrapper
-        badgePosition={styles.iconBadgePosition}
-        badgeElement={
-          <Badge
-            variant={BadgeVariant.Network}
-            imageSource={NetworkBadgeSource(chainId)}
-            isScaled={false}
-            size={AvatarSize.Xs}
-          />
-        }
-      >
-        <Image source={icon} style={styles.icon} resizeMode="stretch" />
-      </BadgeWrapper>
-    );
-  };
-
-  mapIntentStatusToTransactionStatus = (intentStatus) => {
-    if (intentStatus === INTENT_STATUS.PENDING) {
-      return TRANSACTION_STATUS.PENDING;
-    }
-    if (intentStatus === INTENT_STATUS.COMPLETE) {
-      return TRANSACTION_STATUS.CONFIRMED;
-    }
-    if (intentStatus === INTENT_STATUS.FAILED) {
-      return TRANSACTION_STATUS.FAILED;
-    }
-    if (intentStatus === INTENT_STATUS.SUBMITTED) {
-      return TRANSACTION_STATUS.SUBMITTED;
-    }
-
-    // if it is unknown status, default to failed
-    return TRANSACTION_STATUS.FAILED;
-  };
-
-  /**
-   * Renders an horizontal bar with basic tx information
-   *
-   * @param {object} transactionElement - Transaction information to render, containing addressTo, actionKey, value, fiatValue, contractDeployment
-   */
-  renderTxElement = (transactionElement) => {
-    const {
-      isQRHardwareAccount,
-      isLedgerAccount,
-      i,
-      tx: { status, isSmartTransaction, chainId, type },
-      tx,
-      bridgeTxHistoryData: {
-        bridgeTxHistoryItem,
-        is7702Batch,
-        isBridgeComplete,
-      },
-    } = this.props;
-    const isBridgeTransaction =
-      type === TransactionType.bridge ||
-      (bridgeTxHistoryItem && isBridgeTxHistoryItemBridge(bridgeTxHistoryItem));
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    const { value, fiatValue = false, actionKey } = transactionElement;
-    const transactionStatus =
-      bridgeTxHistoryItem?.status && bridgeTxHistoryItem.quote.intent
-        ? this.mapIntentStatusToTransactionStatus(
-            bridgeTxHistoryItem.status.status,
-          )
-        : status;
-
-    const renderNormalActions =
-      (transactionStatus === 'submitted' ||
-        (transactionStatus === 'approved' &&
-          !isQRHardwareAccount &&
-          !isLedgerAccount)) &&
-      !isSmartTransaction &&
-      !isBridgeTransaction &&
-      !hasGasFeeTokenSelected(tx);
-    const renderUnsignedQRActions =
-      transactionStatus === 'approved' && isQRHardwareAccount;
-    const renderLedgerActions =
-      transactionStatus === 'approved' && isLedgerAccount;
-    let title = actionKey;
-    if (bridgeTxHistoryItem) {
-      title =
-        getSwapBridgeTxActivityTitle(bridgeTxHistoryItem, is7702Batch) ?? title;
-    }
-
-    return (
-      <ListItem>
-        <ListItem.Date style={styles.listItemDate}>
-          {this.renderTxTime()}
-        </ListItem.Date>
-        <ListItem.Content style={styles.listItemContent}>
-          <ListItem.Icon>
-            {this.renderTxElementIcon(transactionElement, tx)}
-          </ListItem.Icon>
-          <ListItem.Body>
-            <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
-              {title}
-            </ListItem.Title>
-            {!FINAL_NON_CONFIRMED_STATUSES.includes(transactionStatus) &&
-            isBridgeTransaction &&
-            !isBridgeComplete ? (
-              <BridgeActivityItemTxSegments
-                bridgeTxHistoryItem={bridgeTxHistoryItem}
-                transactionStatus={transactionStatus}
-              />
-            ) : (
-              <StatusText
-                testID={`transaction-status-${i}`}
-                status={transactionStatus}
-                style={styles.listItemStatus}
-              />
-            )}
-          </ListItem.Body>
-          {Boolean(value) && (
-            <ListItem.Amounts>
-              {!isTestNet(chainId) && (
-                <ListItem.FiatAmount style={styles.listItemFiatAmount}>
-                  {fiatValue}
-                </ListItem.FiatAmount>
-              )}
-              <ListItem.Amount style={styles.listItemAmount}>
-                {value}
-              </ListItem.Amount>
-            </ListItem.Amounts>
-          )}
-        </ListItem.Content>
-        {renderNormalActions && (
-          <ListItem.Actions>
-            {this.renderSpeedUpButton()}
-            {this.renderCancelButton()}
-          </ListItem.Actions>
-        )}
-        {renderUnsignedQRActions && (
-          <ListItem.Actions>
-            {this.renderQRSignButton()}
-            {this.renderCancelUnsignedButton()}
-          </ListItem.Actions>
-        )}
-        {renderLedgerActions && (
-          <ListItem.Actions>{this.renderLedgerSignButton()}</ListItem.Actions>
-        )}
-      </ListItem>
-    );
-  };
-
-  renderCancelButton = () => {
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-
-    return (
-      <StyledButton
-        type={'cancel'}
-        containerStyle={styles.actionContainerStyle}
-        style={styles.actionStyle}
-        onPress={this.showCancelModal}
-      >
-        {strings('transaction.cancel')}
-      </StyledButton>
-    );
-  };
-
-  showCancelModal = () => {
-    this.mounted && this.props.onCancelAction(true, this.props.tx);
-  };
-
-  showSpeedUpModal = () => {
-    this.mounted && this.props.onSpeedUpAction(true, this.props.tx);
-  };
-
-  hideSpeedUpModal = () => {
-    this.mounted && this.props.onSpeedUpAction(false);
-  };
-
-  showQRSigningModal = () => {
-    this.mounted && this.props.signQRTransaction(this.props.tx);
-  };
-
-  showLedgerSigninModal = () => {
-    this.mounted && this.props.signLedgerTransaction(this.props.tx);
-  };
-
-  cancelUnsignedQRTransaction = () => {
-    this.mounted && this.props.cancelUnsignedQRTransaction(this.props.tx);
-  };
-
-  renderSpeedUpButton = () => {
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-
-    return (
-      <StyledButton
-        type={'normal'}
-        containerStyle={[
-          styles.actionContainerStyle,
-          styles.speedupActionContainerStyle,
-        ]}
-        style={styles.actionStyle}
-        onPress={this.showSpeedUpModal}
-      >
-        {strings('transaction.speedup')}
-      </StyledButton>
-    );
-  };
-
-  renderQRSignButton = () => {
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    return (
-      <StyledButton
-        type={'normal'}
-        containerStyle={[
-          styles.actionContainerStyle,
-          styles.speedupActionContainerStyle,
-        ]}
-        style={styles.actionStyle}
-        onPress={this.showQRSigningModal}
-      >
-        {strings('transaction.sign_with_keystone')}
-      </StyledButton>
-    );
-  };
-
-  renderLedgerSignButton = () => {
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    return (
-      <StyledButton
-        type={'normal'}
-        containerStyle={[
-          styles.actionContainerStyle,
-          styles.speedupActionContainerStyle,
-        ]}
-        style={styles.actionStyle}
-        onPress={this.showLedgerSigninModal}
-      >
-        {strings('transaction.sign_with_ledger')}
-      </StyledButton>
-    );
-  };
-
-  renderCancelUnsignedButton = () => {
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-    return (
-      <StyledButton
-        type={'cancel'}
-        containerStyle={[
-          styles.actionContainerStyle,
-          styles.speedupActionContainerStyle,
-        ]}
-        style={styles.actionStyle}
-        onPress={this.cancelUnsignedQRTransaction}
-      >
-        {strings('transaction.cancel')}
-      </StyledButton>
-    );
-  };
-
-  renderPendingElement = () => {
-    const { i, tx } = this.props;
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-
-    return (
-      <ListItem>
-        <ListItem.Date style={styles.listItemDate}>
-          {this.renderTxTime()}
-        </ListItem.Date>
-        <ListItem.Content style={styles.listItemContent}>
-          <ListItem.Icon>
-            <View style={styles.icon} />
-          </ListItem.Icon>
-          <ListItem.Body>
-            <ListItem.Title numberOfLines={1} style={styles.listItemTitle}>
-              ...
-            </ListItem.Title>
-            <StatusText
-              testID={`transaction-status-${i}`}
-              status={tx.status}
-              style={styles.listItemStatus}
-            />
-          </ListItem.Body>
-        </ListItem.Content>
-      </ListItem>
-    );
-  };
-
-  render() {
-    const { tx, selectedInternalAccount } = this.props;
-    const { transactionElement, transactionDetails } = this.state;
-
-    const { colors, typography } = this.context || mockTheme;
-    const styles = createStyles(colors, typography);
-
-    const isReady = Boolean(transactionElement && transactionDetails);
-
-    const accountImportTime = selectedInternalAccount?.metadata.importTime;
-    const { time } = tx;
-
-    return (
-      <>
-        {accountImportTime > time && this.renderImportTime()}
-        <TouchableHighlight
-          style={
-            this.props.showBottomBorder ? styles.rowWithBorder : styles.row
-          }
-          onPress={isReady ? this.onPressItem : undefined}
-          underlayColor={colors.background.alternative}
-          activeOpacity={1}
-        >
-          {isReady
-            ? this.renderTxElement(transactionElement)
-            : this.renderPendingElement()}
-        </TouchableHighlight>
-        {accountImportTime <= time && this.renderImportTime()}
-      </>
-    );
+  if (shouldShowFromDevice && hasNonce) {
+    txTime = `#${parseInt(tx.txParams.nonce, 16)} - ${toDateFormat(
+      tx.time,
+    )} ${strings('transactions.from_device_label')}`;
+  } else if (shouldShowFromDevice) {
+    txTime = `${toDateFormat(tx.time)} ${strings(
+      'transactions.from_device_label',
+    )}`;
   }
-}
+
+  return (
+    <TransactionElementView
+      accountImportTime={selectedInternalAccount?.metadata.importTime}
+      bridgeTxHistoryData={bridgeTxHistoryData}
+      colors={theme.colors}
+      i={i}
+      isLedgerAccount={isLedgerAccount}
+      isQRHardwareAccount={isQRHardwareAccount}
+      onCancel={showCancelModal}
+      onCancelUnsignedQR={cancelUnsignedQRTransaction}
+      onImportWalletTip={onPressImportWalletTip}
+      onPress={onPressItem}
+      onSignLedger={showLedgerSigninModal}
+      onSignQR={showQRSigningModal}
+      onSpeedUp={showSpeedUpModal}
+      showBottomBorder={showBottomBorder}
+      styles={styles}
+      transactionElement={transactionElement}
+      transactionDetails={transactionDetails}
+      transactions={transactions}
+      tx={tx}
+      txTime={txTime}
+    />
+  );
+};
+
+export { TransactionElement };
+
+TransactionElement.propTypes = transactionElementPropTypes;
 
 const mapStateToProps = (state, ownProps) => {
   const walletAddressForTokens =
@@ -810,9 +306,6 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-TransactionElement.contextType = ThemeContext;
-
-// Create a wrapper functional component
 const TransactionElementWithBridge = (props) => {
   const bridgeTxHistoryData = useBridgeTxHistoryData({ evmTxMeta: props.tx });
   const transactions = useSelector(selectTransactions);

--- a/app/components/UI/TransactionElement/index.test.tsx
+++ b/app/components/UI/TransactionElement/index.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import TransactionElement from './';
+import decodeTransaction from './utils';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import {
   TransactionType,
   WalletDevice,
@@ -95,6 +96,45 @@ const initialState = {
   },
 };
 const store = mockStore(initialState);
+const mockDecodeTransaction = jest.mocked(decodeTransaction);
+
+type DecodedTransaction = [
+  {
+    actionKey: string;
+    value: string;
+    fiatValue: string;
+  },
+  {
+    summaryAmount: string;
+    summaryFiat: string;
+  },
+];
+
+const createDecodedTransaction = (actionKey: string): DecodedTransaction => [
+  { actionKey, value: '0.1 ETH', fiatValue: '$100' },
+  { summaryAmount: '0.1 ETH', summaryFiat: '$100' },
+];
+
+const createDeferredDecode = () => {
+  let resolve!: (value: DecodedTransaction) => void;
+  const promise = new Promise<DecodedTransaction>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+};
+
+const createTransaction = () => ({
+  id: 'transaction-id',
+  chainId: '0x1',
+  status: 'confirmed',
+  time: Date.now(),
+  txParams: {
+    to: '0x456',
+    from: '0x123',
+    nonce: '0x1',
+  },
+});
 
 describe('TransactionElement', () => {
   beforeEach(() => {
@@ -128,6 +168,85 @@ describe('TransactionElement', () => {
     );
     await waitFor(() => {
       expect(screen.getByText('Test Action')).toBeOnTheScreen();
+    });
+  });
+
+  describe('decode lifecycle', () => {
+    it('re-decodes the transaction when the chain ID changes', async () => {
+      const tx = createTransaction();
+      mockDecodeTransaction
+        .mockResolvedValueOnce(createDecodedTransaction('First decode'))
+        .mockResolvedValueOnce(createDecodedTransaction('Second decode'));
+      const { rerender } = renderWithProvider(
+        <Provider store={store}>
+          <TransactionElement
+            tx={tx}
+            txChainId="0x1"
+            navigation={{ navigate: mockNavigate }}
+          />
+        </Provider>,
+      );
+      await waitFor(() => {
+        expect(screen.getByText('First decode')).toBeOnTheScreen();
+      });
+
+      rerender(
+        <Provider store={store}>
+          <TransactionElement
+            tx={tx}
+            txChainId="0x89"
+            navigation={{ navigate: mockNavigate }}
+          />
+        </Provider>,
+      );
+
+      await waitFor(() => {
+        expect(mockDecodeTransaction).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('Second decode')).toBeOnTheScreen();
+      });
+    });
+
+    it('ignores an older decode result after a newer request resolves', async () => {
+      const tx = createTransaction();
+      const firstDecode = createDeferredDecode();
+      const secondDecode = createDeferredDecode();
+      mockDecodeTransaction
+        .mockReturnValueOnce(firstDecode.promise)
+        .mockReturnValueOnce(secondDecode.promise);
+      const { rerender } = renderWithProvider(
+        <Provider store={store}>
+          <TransactionElement
+            tx={tx}
+            txChainId="0x1"
+            navigation={{ navigate: mockNavigate }}
+          />
+        </Provider>,
+      );
+
+      rerender(
+        <Provider store={store}>
+          <TransactionElement
+            tx={tx}
+            txChainId="0x89"
+            navigation={{ navigate: mockNavigate }}
+          />
+        </Provider>,
+      );
+      await act(async () => {
+        secondDecode.resolve(createDecodedTransaction('Latest decode'));
+        await secondDecode.promise;
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Latest decode')).toBeOnTheScreen();
+      });
+
+      await act(async () => {
+        firstDecode.resolve(createDecodedTransaction('Stale decode'));
+        await firstDecode.promise;
+      });
+
+      expect(screen.getByText('Latest decode')).toBeOnTheScreen();
+      expect(screen.queryByText('Stale decode')).not.toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/TransactionElement/styles.test.ts
+++ b/app/components/UI/TransactionElement/styles.test.ts
@@ -1,0 +1,56 @@
+import { TextVariant } from '../../../component-library/components/Texts/Text';
+import { mockTheme } from '../../../util/theme';
+import createStyles from './styles';
+
+const mockGetFontFamily = jest.fn((variant: TextVariant) => `font-${variant}`);
+
+jest.mock('../../../component-library/components/Texts/Text', () => ({
+  TextVariant: {
+    BodyLGMedium: 'BodyLGMedium',
+    BodyMDBold: 'BodyMDBold',
+    BodyMD: 'BodyMD',
+  },
+  getFontFamily: (variant: TextVariant) => mockGetFontFamily(variant),
+}));
+
+describe('createStyles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates themed transaction element styles', () => {
+    const styles = createStyles(mockTheme.colors, mockTheme.typography);
+
+    expect(styles.row).toEqual(
+      expect.objectContaining({
+        backgroundColor: mockTheme.colors.background.default,
+        flex: 1,
+      }),
+    );
+    expect(styles.rowWithBorder).toEqual(
+      expect.objectContaining({
+        borderBottomColor: mockTheme.colors.border.muted,
+        borderBottomWidth: 1,
+      }),
+    );
+    expect(styles.importText).toEqual(
+      expect.objectContaining({
+        color: mockTheme.colors.text.alternative,
+      }),
+    );
+    expect(styles.listItemAmount).toEqual(
+      expect.objectContaining({
+        color: mockTheme.colors.text.alternative,
+      }),
+    );
+  });
+
+  it('uses the matching font family for each text variant', () => {
+    const styles = createStyles(mockTheme.colors, mockTheme.typography);
+
+    expect(styles.listItemTitle.fontFamily).toBe('font-BodyLGMedium');
+    expect(styles.listItemStatus.fontFamily).toBe('font-BodyMDBold');
+    expect(styles.listItemAmount.fontFamily).toBe('font-BodyMD');
+    expect(mockGetFontFamily).toHaveBeenCalledTimes(4);
+  });
+});

--- a/app/components/UI/TransactionElement/styles.ts
+++ b/app/components/UI/TransactionElement/styles.ts
@@ -1,0 +1,83 @@
+import { StyleSheet, type TextStyle } from 'react-native';
+import type { ThemeColors, ThemeTypography } from '@metamask/design-tokens';
+import { fontStyles } from '../../../styles/common';
+import {
+  getFontFamily,
+  TextVariant,
+} from '../../../component-library/components/Texts/Text';
+
+const createStyles = (colors: ThemeColors, typography: ThemeTypography) =>
+  StyleSheet.create({
+    row: {
+      backgroundColor: colors.background.default,
+      flex: 1,
+    },
+    rowWithBorder: {
+      backgroundColor: colors.background.default,
+      flex: 1,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border.muted,
+    },
+    actionContainerStyle: {
+      height: 25,
+      padding: 0,
+    },
+    speedupActionContainerStyle: {
+      marginRight: 10,
+    },
+    actionStyle: {
+      fontSize: 10,
+      padding: 0,
+      paddingHorizontal: 10,
+    },
+    icon: {
+      width: 32,
+      height: 32,
+    },
+    iconBadgePosition: {
+      bottom: -4,
+      right: -4,
+    },
+    importText: {
+      color: colors.text.alternative,
+      fontSize: 14,
+      ...fontStyles.bold,
+      alignContent: 'center',
+    },
+    importRowBody: {
+      alignItems: 'center',
+      paddingTop: 10,
+    },
+    listItemDate: {
+      marginBottom: 10,
+      paddingBottom: 0,
+    },
+    listItemContent: {
+      alignItems: 'flex-start',
+      marginTop: 0,
+      paddingTop: 0,
+    },
+    listItemTitle: {
+      ...typography.sBodyLGMedium,
+      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      marginTop: 0,
+    } as TextStyle,
+    listItemStatus: {
+      ...typography.sBodyMDBold,
+      fontFamily: getFontFamily(TextVariant.BodyMDBold),
+    } as TextStyle,
+    listItemFiatAmount: {
+      ...typography.sBodyLGMedium,
+      fontFamily: getFontFamily(TextVariant.BodyLGMedium),
+      marginTop: 0,
+    } as TextStyle,
+    listItemAmount: {
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+      color: colors.text.alternative,
+    } as TextStyle,
+  });
+
+export type TransactionElementStyles = ReturnType<typeof createStyles>;
+
+export default createStyles;

--- a/app/components/UI/TransactionElement/types.ts
+++ b/app/components/UI/TransactionElement/types.ts
@@ -1,0 +1,13 @@
+export interface DecodedTransactionElement {
+  actionKey: string;
+  value?: string;
+  fiatValue?: string | false;
+  transactionType?: string;
+}
+
+export type DecodedTransactionDetails = Record<string, unknown>;
+
+export type DecodedTransaction = [
+  DecodedTransactionElement,
+  DecodedTransactionDetails,
+];

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -1008,6 +1008,7 @@ function decodeMusdClaimTx(args) {
  *
  * @param {*} args - Should contain tx, selectedAddress, ticker, conversionRate,
  * currentCurrency, exchangeRate, contractExchangeRates, collectibleContracts, tokens
+ * @returns {Promise<import('./types').DecodedTransaction>}
  */
 export default async function decodeTransaction(args) {
   const { tx, selectedAddress, chainId, ticker } = args;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrates the legacy Activity/Transactions row renderer from `PureComponent` to a React Compiler-compatible functional component.

The transaction row is now split into a connected container, decoded-transaction hook, presentation view, icon renderer, shared styles, and decoded transaction types. The decode hook preserves the existing refresh triggers and prevents stale or unmounted async decode results from updating state. The presentation and icon paths are covered by focused unit tests, including transaction status, bridge, hardware wallet, import-time, and icon-selection variants.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TMCU-1195

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large structural change to a core activity-list UI with many navigation and hardware-wallet paths; behavior is intended to be parity-preserving but regression risk is moderate across bridge, speed-up/cancel, and decode timing.
> 
> **Overview**
> Refactors the **Activity** transaction list row from a monolithic `PureComponent` into a React Compiler–friendly functional stack: a connected **container**, **`useDecodedTransaction`** (same re-decode triggers as before, with request IDs and mount guards so stale async decodes cannot update state), **`TransactionElementView`** for list UI and actions, **`TransactionElementIcon`** for type/network badges, plus shared **`styles.ts`** and **`types.ts`**.
> 
> **Bridge / intent status:** `TransactionElementView` maps intent-backed bridge history to a display status that includes **`pending`**, and passes that through to **`BridgeActivityItemTxSegments`** via a widened **`TransactionDisplayStatus`** type. Final non-confirmed status checks use **`.some()`** instead of **`.includes()`** on the shared status list.
> 
> Adds focused unit tests for container navigation/callbacks, view states (pending decode, bridge segments, QR/Ledger, import time), icon selection, decode lifecycle, and styles; extends integration tests for decode races and chain changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3642da6f233b40283b17ff759833bad9d123f3c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->