### PR TITLE
feat(notifications): refresh Social API preferences cache after AUS write

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -257,6 +257,7 @@ jest.mock('../../../selectors/deFiPositionsSectionEnabled', () => ({
 jest.mock('../../../selectors/featureFlagController/socialLeaderboard', () => ({
   selectSocialLeaderboardEnabled: jest.fn(() => false),
   selectSocialLeaderboardPerpsEnabled: jest.fn(() => true),
+  selectAiSocialAusCacheRefreshEnabled: jest.fn(() => false),
 }));
 
 jest.mock('../../UI/Assets/selectors/featureFlags', () => ({

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import { useQueryClient } from '@tanstack/react-query';
 import type { NotificationPreferences } from '@metamask/authenticated-user-storage';
@@ -41,6 +42,7 @@ const mockGetQueryData = jest.fn();
 const mockCancelQueries = jest.fn();
 const mockRefetch = jest.fn();
 const mockCall = Engine.controllerMessenger.call as jest.Mock;
+const mockUseSelector = useSelector as unknown as jest.Mock;
 
 let queryCache: NotificationPreferences | null | undefined;
 
@@ -128,6 +130,9 @@ describe('useNotificationStoragePreferences', () => {
     mockCancelQueries.mockResolvedValue(undefined);
     mockRefetch.mockResolvedValue(undefined);
     mockCall.mockResolvedValue(undefined);
+    // Default: aiSocialAusCacheRefreshEnabled flag on. The hook's only
+    // useSelector call is for that flag.
+    mockUseSelector.mockReturnValue(true);
   });
 
   it('scopes the query to the active account and exposes query state', () => {
@@ -211,6 +216,31 @@ describe('useNotificationStoragePreferences', () => {
 
     // The AUS write failed, so there is nothing to refresh — and crucially no
     // compensating rollback call is made.
+    expect(mockCall).not.toHaveBeenCalledWith(REFRESH_SOCIAL_CACHE_ACTION);
+  });
+
+  it('does not refresh the Social API cache when the feature flag is disabled', async () => {
+    mockUseSelector.mockReturnValue(false);
+    queryCache = buildPreferences();
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
+
+    const { result } = renderHook(() => useNotificationStoragePreferences());
+
+    await act(async () => {
+      await result.current.updateSectionChannel(
+        'perps',
+        'pushNotificationsEnabled',
+        false,
+      );
+    });
+
+    // The AUS write still happens...
+    expect(mockCall).toHaveBeenCalledWith(
+      PUT_ACTION,
+      expect.anything(),
+      CLIENT_TYPE,
+    );
+    // ...but the gated Social API cache-refresh does not.
     expect(mockCall).not.toHaveBeenCalledWith(REFRESH_SOCIAL_CACHE_ACTION);
   });
 

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -28,6 +28,8 @@ jest.mock('../../../../../util/Logger', () => ({
 
 const GET_ACTION = 'AuthenticatedUserStorageService:getNotificationPreferences';
 const PUT_ACTION = 'AuthenticatedUserStorageService:putNotificationPreferences';
+const REFRESH_SOCIAL_CACHE_ACTION =
+  'SocialService:refreshNotificationPreferencesCache';
 const CLIENT_TYPE = 'mobile';
 
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
@@ -178,6 +180,38 @@ describe('useNotificationStoragePreferences', () => {
       CLIENT_TYPE,
     );
     expect(mockCall).not.toHaveBeenCalledWith(GET_ACTION);
+    expect(mockCall).toHaveBeenCalledWith(REFRESH_SOCIAL_CACHE_ACTION);
+  });
+
+  it('fires a best-effort Social API cache refresh only after the write succeeds', async () => {
+    const initialPreferences = buildPreferences();
+    queryCache = initialPreferences;
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
+    const persistError = new Error('network down');
+    mockCall.mockImplementation(async (action: string) => {
+      if (action === PUT_ACTION) {
+        throw persistError;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useNotificationStoragePreferences());
+
+    await act(async () => {
+      try {
+        await result.current.updateSectionChannel(
+          'perps',
+          'pushNotificationsEnabled',
+          false,
+        );
+      } catch {
+        // expected — the write failed
+      }
+    });
+
+    // The AUS write failed, so there is nothing to refresh — and crucially no
+    // compensating rollback call is made.
+    expect(mockCall).not.toHaveBeenCalledWith(REFRESH_SOCIAL_CACHE_ACTION);
   });
 
   it('accepts a section updater that receives the latest cached section', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -13,6 +13,10 @@ const GET_ACTION =
   'AuthenticatedUserStorageService:getNotificationPreferences' as const;
 const PUT_ACTION =
   'AuthenticatedUserStorageService:putNotificationPreferences' as const;
+// Tells the social API to re-read this user's preferences from AUS and refresh
+// its cache so the change is honoured near-instantly (see @metamask/social-controllers).
+const REFRESH_SOCIAL_CACHE_ACTION =
+  'SocialService:refreshNotificationPreferencesCache' as const;
 
 type NotificationPreferencesResult = Awaited<
   ReturnType<
@@ -166,6 +170,19 @@ export const useNotificationStoragePreferences =
         try {
           await persistWrite;
           lastConfirmedPreferencesRef.current = nextPreferences;
+          // Best-effort: nudge the Social API to refresh its cached copy so
+          // the change is honoured immediately rather than after its cache
+          // TTL. Fire-and-forget — the AUS write above is the source of truth
+          // and has already succeeded, so a failure here must not roll back
+          // the change or surface to the user, hence the swallowed catch.
+          Engine.controllerMessenger
+            .call(REFRESH_SOCIAL_CACHE_ACTION)
+            .catch((refreshError) => {
+              Logger.error(
+                refreshError as Error,
+                'Failed to refresh Social API notification preferences cache',
+              );
+            });
           finishWrite();
         } catch (err) {
           Logger.error(

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useQuery } from '@metamask/react-data-query';
 import { useQueryClient } from '@tanstack/react-query';
 import type {
@@ -7,6 +8,7 @@ import type {
 } from '@metamask/authenticated-user-storage';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
+import { selectAiSocialAusCacheRefreshEnabled } from '../../../../../selectors/featureFlagController/socialLeaderboard';
 
 const CLIENT_TYPE = 'mobile' as const;
 const GET_ACTION =
@@ -78,6 +80,9 @@ export const useNotificationStoragePreferences =
         queryKey: QUERY_KEY,
         refetchOnWindowFocus: false,
       });
+    const isSocialCacheRefreshEnabled = useSelector(
+      selectAiSocialAusCacheRefreshEnabled,
+    );
     const queryClient = useQueryClient();
     const [pendingWrites, setPendingWrites] = useState(0);
     const pendingWritesRef = useRef(0);
@@ -172,17 +177,21 @@ export const useNotificationStoragePreferences =
           lastConfirmedPreferencesRef.current = nextPreferences;
           // Best-effort: nudge the Social API to refresh its cached copy so
           // the change is honoured immediately rather than after its cache
-          // TTL. Fire-and-forget — the AUS write above is the source of truth
-          // and has already succeeded, so a failure here must not roll back
-          // the change or surface to the user, hence the swallowed catch.
-          Engine.controllerMessenger
-            .call(REFRESH_SOCIAL_CACHE_ACTION)
-            .catch((refreshError) => {
-              Logger.error(
-                refreshError as Error,
-                'Failed to refresh Social API notification preferences cache',
-              );
-            });
+          // TTL. Gated behind the aiSocialAusCacheRefreshEnabled flag so it
+          // only runs once the Social API cache-refresh endpoint is rolled out.
+          // Fire-and-forget — the AUS write above is the source of truth and
+          // has already succeeded, so a failure here must not roll back the
+          // change or surface to the user, hence the swallowed catch.
+          if (isSocialCacheRefreshEnabled) {
+            Engine.controllerMessenger
+              .call(REFRESH_SOCIAL_CACHE_ACTION)
+              .catch((refreshError) => {
+                Logger.error(
+                  refreshError as Error,
+                  'Failed to refresh Social API notification preferences cache',
+                );
+              });
+          }
           finishWrite();
         } catch (err) {
           Logger.error(
@@ -199,7 +208,14 @@ export const useNotificationStoragePreferences =
           throw err;
         }
       },
-      [beginWrite, data, finishWrite, getCachedPreferences, queryClient],
+      [
+        beginWrite,
+        data,
+        finishWrite,
+        getCachedPreferences,
+        isSocialCacheRefreshEnabled,
+        queryClient,
+      ],
     );
 
     const updateSectionChannel = useCallback(

--- a/app/selectors/featureFlagController/socialLeaderboard/index.test.ts
+++ b/app/selectors/featureFlagController/socialLeaderboard/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  selectAiSocialAusCacheRefreshEnabled,
   selectAiSocialLeaderboardOnboardingEnabled,
   selectSocialAIQuickBuyStreamQuotesEnabled,
   selectSocialLeaderboardEnabled,
@@ -335,6 +336,63 @@ describe('selectSocialAIQuickBuyStreamQuotesEnabled', () => {
         minimumVersion: 123,
       },
     });
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('selectAiSocialAusCacheRefreshEnabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mockHasMinimumRequiredVersion?.mockRestore();
+  });
+
+  it('returns true when remote flag is enabled and version requirement is met', () => {
+    const result = selectAiSocialAusCacheRefreshEnabled.resultFunc({
+      aiSocialAusCacheRefreshEnabled: {
+        enabled: true,
+        minimumVersion: '7.72.0',
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when remote flag is disabled', () => {
+    const result = selectAiSocialAusCacheRefreshEnabled.resultFunc({
+      aiSocialAusCacheRefreshEnabled: {
+        enabled: false,
+        minimumVersion: '7.72.0',
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when version requirement is not met', () => {
+    mockHasMinimumRequiredVersion.mockReturnValue(false);
+    const result = selectAiSocialAusCacheRefreshEnabled.resultFunc({
+      aiSocialAusCacheRefreshEnabled: {
+        enabled: true,
+        minimumVersion: '99.0.0',
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when remote flag is absent', () => {
+    const result = selectAiSocialAusCacheRefreshEnabled.resultFunc({});
 
     expect(result).toBe(false);
   });

--- a/app/selectors/featureFlagController/socialLeaderboard/index.ts
+++ b/app/selectors/featureFlagController/socialLeaderboard/index.ts
@@ -64,3 +64,13 @@ export const selectSocialAIQuickBuyStreamQuotesEnabled = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );
+
+export const selectAiSocialAusCacheRefreshEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.aiSocialAusCacheRefreshEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
     "type": "git",
     "url": "https://github.com/MetaMask/metamask-mobile.git"
   },
+  "previewBuilds": {
+    "@metamask/social-controllers": {
+      "type": "non-breaking",
+      "previewVersion": "2.6.0-preview-3d3ef9d3a"
+    }
+  },
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",
     "anvil": "node_modules/.bin/anvil",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
     "type": "git",
     "url": "https://github.com/MetaMask/metamask-mobile.git"
   },
-  "previewBuilds": {
-    "@metamask/social-controllers": {
-      "type": "non-breaking",
-      "previewVersion": "2.6.0-preview-3d3ef9d3a"
-    }
-  },
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",
     "anvil": "node_modules/.bin/anvil",
@@ -370,7 +364,7 @@
     "@metamask/snaps-rpc-methods": "^17.1.0",
     "@metamask/snaps-sdk": "^11.2.0",
     "@metamask/snaps-utils": "^12.4.0",
-    "@metamask/social-controllers": "^2.6.0",
+    "@metamask/social-controllers": "^2.7.0",
     "@metamask/solana-wallet-snap": "^2.10.0",
     "@metamask/solana-wallet-standard": "^0.6.0",
     "@metamask/stake-sdk": "^3.4.0",

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -126,6 +126,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  aiSocialAusCacheRefreshEnabled: {
+    name: 'aiSocialAusCacheRefreshEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '8.7.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   aiSocialLeaderboardOnboardingEnabled: {
     name: 'aiSocialLeaderboardOnboardingEnabled',
     type: FeatureFlagType.Remote,

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -132,7 +132,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     inProd: true,
     productionDefault: {
       enabled: false,
-      minimumVersion: '8.7.0',
+      minimumVersion: '8.5.0',
     },
     status: FeatureFlagStatus.Active,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10494,9 +10494,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/social-controllers@npm:@metamask-previews/social-controllers@2.6.0-preview-3d3ef9d3a":
-  version: 2.6.0-preview-3d3ef9d3a
-  resolution: "@metamask-previews/social-controllers@npm:2.6.0-preview-3d3ef9d3a"
+"@metamask/social-controllers@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "@metamask/social-controllers@npm:2.7.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/base-data-service": "npm:^0.1.3"
@@ -10504,7 +10504,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/profile-sync-controller": "npm:^28.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/6f34273e6b2c24ddb5d49263cc8556fa77f754eb10d1e9b11c3cd2236c5e190057730de93977a6775aac01c18372efb1e4291ea5c99b5c1588207e0a25542b27
+  checksum: 10/11fae1b2ef9025254579e59459de815401bbedd2aa201680b78e244ae149209ad0e89a1b1ee02349ca420b2367edeec3f40ed57cd05749005d2ff05e75806d69
   languageName: node
   linkType: hard
 
@@ -35996,7 +35996,7 @@ __metadata:
     "@metamask/snaps-rpc-methods": "npm:^17.1.0"
     "@metamask/snaps-sdk": "npm:^11.2.0"
     "@metamask/snaps-utils": "npm:^12.4.0"
-    "@metamask/social-controllers": "npm:^2.6.0"
+    "@metamask/social-controllers": "npm:^2.7.0"
     "@metamask/solana-wallet-snap": "npm:^2.10.0"
     "@metamask/solana-wallet-standard": "npm:^0.6.0"
     "@metamask/stake-sdk": "npm:^3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10494,9 +10494,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/social-controllers@npm:^2.6.0":
-  version: 2.6.0
-  resolution: "@metamask/social-controllers@npm:2.6.0"
+"@metamask/social-controllers@npm:@metamask-previews/social-controllers@2.6.0-preview-3d3ef9d3a":
+  version: 2.6.0-preview-3d3ef9d3a
+  resolution: "@metamask-previews/social-controllers@npm:2.6.0-preview-3d3ef9d3a"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/base-data-service": "npm:^0.1.3"
@@ -10504,7 +10504,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/profile-sync-controller": "npm:^28.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
-  checksum: 10/44832ec78dc1f292f49cf65f3d951b1cc3b0dc3c1d7aea3fbbc545a29f38fc09270183eea4ad993e7d13cf7e6b8ba2e191e93e0a1278baa811446e77bf065a47
+  checksum: 10/6f34273e6b2c24ddb5d49263cc8556fa77f754eb10d1e9b11c3cd2236c5e190057730de93977a6775aac01c18372efb1e4291ea5c99b5c1588207e0a25542b27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

When a user changes their Social / Top-Traders notification preferences, the app writes them to Authenticated User Storage (AUS). The Social API caches each user's AUS preferences per-user to keep its notification-delivery pipeline fast, which means a change could take until the cache TTL lapses to be honoured.

This PR makes the app, right after a **successful** AUS write, fire a best-effort `SocialService:refreshNotificationPreferencesCache` messenger action. The Social API then re-reads AUS and refreshes its cache, so the change takes effect near-instantly.

It is fire-and-forget: the AUS write is the source of truth and has already succeeded by the time this runs, so a failure here is logged and **never** rolled back or surfaced to the user (no compensating write).

The refresh call is **gated behind the `aiSocialAusCacheRefreshEnabled` remote feature flag** (version-gated, `selectAiSocialAusCacheRefreshEnabled`). It's off by default, so the client behaviour is unchanged until the Social API cache-refresh endpoint is rolled out — and it can be killed remotely. The AUS write itself is not gated.

- Reason: preference changes were only honoured after the Social API cache TTL.
- Solution: proactively refresh the Social API cache on change (behind a flag), letting that TTL stay long.

Depends on `@metamask/social-controllers` (MetaMask/core#9662), wired here via preview build `2.6.0-preview-3d3ef9d3a` until that releases.

## **Changelog**

CHANGELOG entry: Social notification preference changes now take effect immediately instead of after a short delay.

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TSA-935
Refs: MetaMask/core#9662 (SocialService method) and va-mmcx-social-api#148 (cache-refresh endpoint)

## **Manual testing steps**

```gherkin
Feature: Social notification preferences are honoured immediately

  Scenario: user changes a preference with the feature flag enabled
    Given the user is signed in with Social notifications available
    And the aiSocialAusCacheRefreshEnabled feature flag is enabled
    When the user toggles a Social/Top-Traders notification preference
    Then the preference is written to AUS
    And the app fires SocialService:refreshNotificationPreferencesCache
    And the Social API re-reads AUS and refreshes its per-user cache

  Scenario: user changes a preference with the feature flag disabled
    Given the aiSocialAusCacheRefreshEnabled feature flag is disabled
    When the user toggles a Social/Top-Traders notification preference
    Then the preference is written to AUS
    And the app does NOT call SocialService:refreshNotificationPreferencesCache

  Scenario: the cache-refresh call fails
    Given the AUS write has already succeeded
    When the cache-refresh call fails (offline / server error)
    Then the failure is logged
    And the user's saved preference is not rolled back
    And no error is surfaced to the user
```

Backend behaviour was verified end-to-end against a local Social API + mocked AUS: a preference write triggers exactly one AUS re-read on the Social API and repopulates its Redis cache with the new value (see va-mmcx-social-api#148 for the cache-refresh endpoint and its test evidence).

## **Screenshots/Recordings**

### **Before**

N/A — no UI change. The change is a background, fire-and-forget network call made after an existing preference write; the settings UI and its optimistic update are unchanged.

### **After**

N/A — see "Manual testing steps"; effect is server-side (Social API cache freshness), verified in va-mmcx-social-api#148.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification preference persistence and adds a fire-and-forget Social API call behind a remote flag; user-facing prefs still depend on AUS write success, with low rollback risk from refresh failures.
> 
> **Overview**
> After a **successful** Authenticated User Storage (AUS) notification-preferences write, the app can now trigger a best-effort `SocialService:refreshNotificationPreferencesCache` call so the Social API re-reads AUS and updates its per-user cache instead of waiting on cache TTL.
> 
> That refresh is **gated** by the new version-gated remote flag `aiSocialAusCacheRefreshEnabled` (`selectAiSocialAusCacheRefreshEnabled`, off by default in the feature-flag registry). The AUS write is unchanged; refresh failures are logged only and never roll back the saved preference.
> 
> `@metamask/social-controllers` is bumped to **^2.7.0**. Tests cover refresh on success, no refresh when the write fails, and no refresh when the flag is off; Homepage tests mock the new selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5a8dc494629699a20abea76b8ed8e49447131f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->