### PR TITLE
fix: remove gap between symbol and price change on default token card watchlist cp-8.5.0

### DIFF
--- a/app/components/UI/Assets/watchlist/components/WatchlistDefaultTokenCard/WatchlistDefaultTokenCard.tsx
+++ b/app/components/UI/Assets/watchlist/components/WatchlistDefaultTokenCard/WatchlistDefaultTokenCard.tsx
@@ -96,22 +96,24 @@ const WatchlistDefaultTokenCard: React.FC<WatchlistDefaultTokenCardProps> = ({
           />
         </View>
       </View>
-      <Text
-        variant={TextVariant.BodyMd}
-        fontWeight={FontWeight.Bold}
-        testID={`${WatchlistDefaultTokenCardTestIds.SYMBOL}-${assetId}`}
-      >
-        {token.symbol}
-      </Text>
-      {changeLabel ? (
+      <View>
         <Text
-          variant={TextVariant.BodySm}
-          color={changeTextColor}
-          testID={`${WatchlistDefaultTokenCardTestIds.PRICE_CHANGE}-${assetId}`}
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Bold}
+          testID={`${WatchlistDefaultTokenCardTestIds.SYMBOL}-${assetId}`}
         >
-          {changeLabel}
+          {token.symbol}
         </Text>
-      ) : null}
+        {changeLabel ? (
+          <Text
+            variant={TextVariant.BodySm}
+            color={changeTextColor}
+            testID={`${WatchlistDefaultTokenCardTestIds.PRICE_CHANGE}-${assetId}`}
+          >
+            {changeLabel}
+          </Text>
+        ) : null}
+      </View>
     </Pressable>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Removes the unintended 12px vertical gap between the token symbol and price change percentage on default watchlist token cards in the empty watchlist view.

The card container uses `flexDirection: 'column'` with `gap: 12`, which was applying between the symbol and percentage when they were separate direct children. Wrapping them in a parent `View` groups them into a single card child so only the gap between the top row (logo + checkbox) and the text group remains.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed spacing between token symbol and price change on empty watchlist default token cards

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3774

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="447" height="858" alt="Screenshot 2026-07-27 at 17 12 17" src="https://github.com/user-attachments/assets/767f9629-3fbb-408e-bee4-c758d5d37663" />


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="822" height="1754" alt="image" src="https://github.com/user-attachments/assets/2dec7fe1-8d24-4cc4-83c5-cd60866427f9" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only JSX grouping in one watchlist card component; no logic, API, or data changes.
> 
> **Overview**
> Fixes **extra vertical space** between the token symbol and 24h price change on default watchlist token cards (empty watchlist).
> 
> The card column uses **`gap: 12`**, which previously applied between the symbol and percentage because they were separate direct children of the pressable. **Symbol and price change are now wrapped in a single parent `View`**, so they read as one block and only the intended 12px gap remains between the top row (logo + checkbox) and that text group.
> 
> Test IDs and conditional rendering for the price change line are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11654db9c9c896d0684653674ddc74b911c4a830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->