### PR TITLE
feat(perf): AI triage & failure correlation for app profiling check (MMQA-2110)

### DIFF
--- a/.github/workflows/app-profiling-check.yml
+++ b/.github/workflows/app-profiling-check.yml
@@ -247,6 +247,10 @@ jobs:
           DEVICE: ${{ inputs.device }}
           COMPARE_ALL: ${{ inputs.compare_all }}
           BASELINE_BRANCH: ${{ inputs.baseline_branch }}
+          # Optional AI triage (same keys as Smart E2E). Diff still posts if missing.
+          E2E_CLAUDE_API_KEY: ${{ secrets.E2E_CLAUDE_API_KEY }}
+          E2E_OPENAI_API_KEY: ${{ secrets.E2E_OPENAI_API_KEY }}
+          E2E_GEMINI_API_KEY: ${{ secrets.E2E_GEMINI_API_KEY }}
         run: |
           set -euo pipefail
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -735,6 +735,28 @@ Or compare all failed scenarios from that run:
 This runs `.github/workflows/app-profiling-check.yml`, which downloads
 `aggregated-reports` for the current run + baseline and posts a diff comment.
 
+The comment includes:
+
+1. **Deterministic metric table** vs last green baseline (⚠️ only when
+   Current > Baseline + 10%).
+2. **Scenario failure context** (quality gates / test error / recording link)
+   from `summary.json`.
+3. **Optional AI triage** (when `E2E_CLAUDE_API_KEY`, `E2E_OPENAI_API_KEY`, or
+   `E2E_GEMINI_API_KEY` is available):
+   - Regression triage: likely `device_noise` / `ui_regression` / `test_or_setup` / `network`
+   - Correlation between the failure reason / QG violations and profiling signals
+   - One concrete next step for the owning team
+
+AI is additive and non-blocking: missing keys or LLM errors still post the
+deterministic diff. Use `--skip-ai` locally to disable it.
+
+Local dry-run:
+
+```bash
+node tests/scripts/diff-app-profiling.mjs \
+  --pr <PR> --run <RUN_ID> --all --dry-run
+```
+
 ### HTML Dashboard Features
 
 The aggregated HTML report (`performance-report.html`) includes:

--- a/tests/scripts/app-profiling-ai.mjs
+++ b/tests/scripts/app-profiling-ai.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+
+/**
+ * AI triage + failure-correlation for app profiling checks.
+ *
+ * Single LLM call (no agentic loop). Uses the same E2E_* env keys as
+ * Smart E2E selection. Never throws to callers — returns null on skip/error.
+ *
+ * Env (first available wins):
+ *   E2E_CLAUDE_API_KEY  → Anthropic claude-sonnet-4-6
+ *   E2E_OPENAI_API_KEY  → OpenAI gpt-5.2-chat-latest
+ *   E2E_GEMINI_API_KEY  → Google gemini-2.5-flash
+ */
+
+const PROVIDERS = [
+  {
+    id: 'anthropic',
+    envKey: 'E2E_CLAUDE_API_KEY',
+    model: 'claude-sonnet-4-6',
+  },
+  {
+    id: 'openai',
+    envKey: 'E2E_OPENAI_API_KEY',
+    model: 'gpt-5.2-chat-latest',
+  },
+  {
+    id: 'google',
+    envKey: 'E2E_GEMINI_API_KEY',
+    model: 'gemini-2.5-flash',
+  },
+];
+
+const MAX_OUTPUT_TOKENS = 1200;
+const MAX_API_CALLS = 12;
+
+const SYSTEM_PROMPT = `You are a MetaMask Mobile performance QA assistant.
+You analyze BrowserStack app profiling diffs for a single failed (or borderline) performance scenario.
+
+Goals:
+1) Triage: decide the most likely explanation for metric changes vs baseline.
+   Prefer one of: device_noise | ui_regression | test_or_setup | network | unclear
+2) Correlate: relate the scenario failure reason / quality-gate violations to the profiling metrics.
+
+Rules:
+- Be concise and concrete. No marketing language.
+- Do not invent metrics that are not in the input.
+- If there is no baseline, triage from current metrics + failure context only.
+- Treat Current <= Baseline + 10% as acceptable noise (do not call that a regression).
+- Highlight only metrics marked as warned (over +10%).
+- If apiCalls are missing/errored, say so; do not invent network evidence.
+- Output MUST be a single JSON object matching the schema. No markdown fences.`;
+
+function resolveProvider(env = process.env) {
+  for (const provider of PROVIDERS) {
+    const apiKey = env[provider.envKey];
+    if (apiKey && String(apiKey).trim()) {
+      return { ...provider, apiKey: String(apiKey).trim() };
+    }
+  }
+  return null;
+}
+
+function truncateApiCalls(apiCalls, limit = MAX_API_CALLS) {
+  if (!Array.isArray(apiCalls) || apiCalls.length === 0) {
+    return [];
+  }
+
+  return apiCalls.slice(0, limit).map((call) => {
+    if (!call || typeof call !== 'object') {
+      return call;
+    }
+    return {
+      method: call.method ?? call.requestMethod ?? null,
+      url: call.url ?? call.requestUrl ?? null,
+      status: call.status ?? call.statusCode ?? null,
+      durationMs: call.durationMs ?? call.duration ?? call.time ?? null,
+    };
+  });
+}
+
+function buildPromptPayload({
+  testName,
+  platform,
+  deviceLabel,
+  failureContext,
+  metricRows,
+  baselineSummary,
+  currentSummary,
+  apiCalls,
+  apiCallsError,
+  hasBaseline,
+}) {
+  const warnedMetrics = (metricRows ?? [])
+    .filter((row) => row.warn)
+    .map((row) => ({
+      metric: row.label,
+      baseline: row.baselineText,
+      current: row.currentText?.replace(/\*\*/g, ''),
+      delta: row.deltaText?.replace(/\*\*/g, ''),
+    }));
+
+  return {
+    scenario: {
+      testName,
+      platform: platform ?? null,
+      device: deviceLabel ?? null,
+    },
+    failure: failureContext
+      ? {
+          reason: failureContext.failureReason ?? null,
+          qualityGatesPassed: failureContext.qualityGates?.passed ?? null,
+          qualityGatesViolations: failureContext.qualityGatesViolations ?? null,
+          recordingLink: failureContext.recordingLink ?? null,
+        }
+      : null,
+    comparison: {
+      hasBaseline: Boolean(hasBaseline),
+      warnedMetrics,
+      baselineSummary: baselineSummary ?? null,
+      currentSummary: currentSummary ?? null,
+    },
+    network: {
+      apiCallsError: apiCallsError ?? null,
+      apiCallsSample: truncateApiCalls(apiCalls),
+    },
+    responseSchema: {
+      likelyCause:
+        'device_noise | ui_regression | test_or_setup | network | unclear',
+      confidence: 'high | medium | low',
+      triageSummary: '2-4 sentences explaining the metric triage',
+      failureCorrelation:
+        '2-4 sentences linking failureReason/QG violations to profiling signals',
+      nextStep: 'one concrete next action for the owning team',
+    },
+  };
+}
+
+function buildUserPrompt(payload) {
+  return [
+    'Analyze this app profiling case and return JSON only.',
+    '',
+    JSON.stringify(payload, null, 2),
+  ].join('\n');
+}
+
+function extractJsonObject(text) {
+  if (!text || typeof text !== 'string') {
+    return null;
+  }
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // fall through
+  }
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) {
+    try {
+      return JSON.parse(fenced[1].trim());
+    } catch {
+      // fall through
+    }
+  }
+
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function normalizeReasoning(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const likelyCause = String(raw.likelyCause || 'unclear').trim();
+  const confidence = String(raw.confidence || 'low').trim();
+  const triageSummary = String(raw.triageSummary || '').trim();
+  const failureCorrelation = String(raw.failureCorrelation || '').trim();
+  const nextStep = String(raw.nextStep || '').trim();
+
+  if (!triageSummary && !failureCorrelation) {
+    return null;
+  }
+
+  return {
+    likelyCause,
+    confidence,
+    triageSummary,
+    failureCorrelation,
+    nextStep,
+  };
+}
+
+function formatReasoningMarkdown(reasoning, { providerId, model } = {}) {
+  if (!reasoning) {
+    return '';
+  }
+
+  let md = `<details>\n<summary>🤖 AI triage & failure correlation`;
+  if (reasoning.confidence) {
+    md += ` (confidence: ${reasoning.confidence})`;
+  }
+  md += `</summary>\n\n`;
+  md += `**Likely cause:** \`${reasoning.likelyCause}\`\n\n`;
+  if (reasoning.triageSummary) {
+    md += `### Triage\n\n${reasoning.triageSummary}\n\n`;
+  }
+  if (reasoning.failureCorrelation) {
+    md += `### Correlation with scenario failure\n\n${reasoning.failureCorrelation}\n\n`;
+  }
+  if (reasoning.nextStep) {
+    md += `### Next step\n\n${reasoning.nextStep}\n\n`;
+  }
+  if (providerId || model) {
+    md += `> Model: \`${providerId ?? 'unknown'}${model ? ` / ${model}` : ''}\`\n\n`;
+  }
+  md += `</details>\n`;
+  return md;
+}
+
+async function callAnthropic({ apiKey, model, system, user }) {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      temperature: 0,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Anthropic HTTP ${response.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = await response.json();
+  const text = (data.content ?? [])
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('\n');
+  return text;
+}
+
+async function callOpenAI({ apiKey, model, system, user }) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0,
+      max_completion_tokens: MAX_OUTPUT_TOKENS,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OpenAI HTTP ${response.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content ?? '';
+}
+
+async function callGoogle({ apiKey, model, system, user }) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: system }] },
+      contents: [{ role: 'user', parts: [{ text: user }] }],
+      generationConfig: {
+        temperature: 0,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        responseMimeType: 'application/json',
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Google HTTP ${response.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = await response.json();
+  return (data.candidates?.[0]?.content?.parts ?? [])
+    .map((part) => part.text ?? '')
+    .join('\n');
+}
+
+async function callProvider(provider, { system, user }) {
+  switch (provider.id) {
+    case 'anthropic':
+      return callAnthropic({
+        apiKey: provider.apiKey,
+        model: provider.model,
+        system,
+        user,
+      });
+    case 'openai':
+      return callOpenAI({
+        apiKey: provider.apiKey,
+        model: provider.model,
+        system,
+        user,
+      });
+    case 'google':
+      return callGoogle({
+        apiKey: provider.apiKey,
+        model: provider.model,
+        system,
+        user,
+      });
+    default:
+      throw new Error(`Unknown provider ${provider.id}`);
+  }
+}
+
+/**
+ * Generate AI triage markdown for one scenario.
+ * Returns empty string when skipped or on failure.
+ */
+async function generateAppProfilingAiReasoning(input, options = {}) {
+  const { skipAi = false, env = process.env, fetchImpl } = options;
+  if (skipAi) {
+    return '';
+  }
+
+  const provider = resolveProvider(env);
+  if (!provider) {
+    console.warn(
+      '⚠️  Skipping AI triage: no E2E_CLAUDE_API_KEY / E2E_OPENAI_API_KEY / E2E_GEMINI_API_KEY',
+    );
+    return '';
+  }
+
+  const payload = buildPromptPayload(input);
+  const user = buildUserPrompt(payload);
+
+  try {
+    // Allow tests to inject fetch without hitting the network.
+    if (fetchImpl) {
+      globalThis.fetch = fetchImpl;
+    }
+
+    console.log(`🤖 AI triage via ${provider.id} (${provider.model})...`);
+    const rawText = await callProvider(provider, {
+      system: SYSTEM_PROMPT,
+      user,
+    });
+    const parsed = normalizeReasoning(extractJsonObject(rawText));
+    if (!parsed) {
+      console.warn('⚠️  AI triage returned unparseable output; skipping section');
+      return '';
+    }
+    return formatReasoningMarkdown(parsed, {
+      providerId: provider.id,
+      model: provider.model,
+    });
+  } catch (error) {
+    console.warn(
+      `⚠️  AI triage failed (${error instanceof Error ? error.message : String(error)}); continuing without it`,
+    );
+    return '';
+  }
+}
+
+export {
+  PROVIDERS,
+  SYSTEM_PROMPT,
+  resolveProvider,
+  truncateApiCalls,
+  buildPromptPayload,
+  buildUserPrompt,
+  extractJsonObject,
+  normalizeReasoning,
+  formatReasoningMarkdown,
+  generateAppProfilingAiReasoning,
+};

--- a/tests/scripts/app-profiling-ai.test.mjs
+++ b/tests/scripts/app-profiling-ai.test.mjs
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  resolveProvider,
+  truncateApiCalls,
+  buildPromptPayload,
+  extractJsonObject,
+  normalizeReasoning,
+  formatReasoningMarkdown,
+  generateAppProfilingAiReasoning,
+} from './app-profiling-ai.mjs';
+
+test('resolveProvider prefers Anthropic when E2E_CLAUDE_API_KEY is set', () => {
+  const provider = resolveProvider({
+    E2E_CLAUDE_API_KEY: 'claude-key',
+    E2E_OPENAI_API_KEY: 'openai-key',
+  });
+  assert.equal(provider?.id, 'anthropic');
+  assert.equal(provider?.apiKey, 'claude-key');
+});
+
+test('resolveProvider falls back to OpenAI then Google', () => {
+  assert.equal(
+    resolveProvider({ E2E_OPENAI_API_KEY: 'oai' })?.id,
+    'openai',
+  );
+  assert.equal(
+    resolveProvider({ E2E_GEMINI_API_KEY: 'gem' })?.id,
+    'google',
+  );
+  assert.equal(resolveProvider({}), null);
+});
+
+test('truncateApiCalls keeps only safe fields and caps length', () => {
+  const sample = truncateApiCalls(
+    Array.from({ length: 20 }, (_, i) => ({
+      method: 'GET',
+      url: `https://example.com/${i}`,
+      status: 200,
+      durationMs: i,
+      authorization: 'secret',
+      body: 'do-not-send',
+    })),
+    3,
+  );
+  assert.equal(sample.length, 3);
+  assert.deepEqual(sample[0], {
+    method: 'GET',
+    url: 'https://example.com/0',
+    status: 200,
+    durationMs: 0,
+  });
+  assert.equal('authorization' in sample[0], false);
+});
+
+test('buildPromptPayload includes failure + warned metrics', () => {
+  const payload = buildPromptPayload({
+    testName: 'Cross-chain swap',
+    platform: 'Android',
+    deviceLabel: 'Pixel 8 (v14.0)',
+    failureContext: {
+      failureReason: 'quality_gates_exceeded',
+      qualityGates: { passed: false },
+      qualityGatesViolations: [{ step: 'swap', metric: 'duration', actual: 12 }],
+      recordingLink: 'https://example.com/rec',
+    },
+    metricRows: [
+      {
+        label: 'Slow frames',
+        baselineText: '7%',
+        currentText: '**15%**',
+        deltaText: '+8 (**+107%**) ⚠️',
+        warn: true,
+      },
+      {
+        label: 'CPU avg',
+        baselineText: '8%',
+        currentText: '8%',
+        deltaText: '0 (0%)',
+        warn: false,
+      },
+    ],
+    baselineSummary: { cpu: { avg: 8 } },
+    currentSummary: { cpu: { avg: 8 }, uiRendering: { slowFrames: 15 } },
+    apiCalls: [{ url: 'https://api.example/x', status: 500, durationMs: 900 }],
+    apiCallsError: null,
+    hasBaseline: true,
+  });
+
+  assert.equal(payload.scenario.testName, 'Cross-chain swap');
+  assert.equal(payload.failure.reason, 'quality_gates_exceeded');
+  assert.equal(payload.comparison.warnedMetrics.length, 1);
+  assert.equal(payload.comparison.warnedMetrics[0].metric, 'Slow frames');
+  assert.equal(payload.comparison.warnedMetrics[0].current, '15%');
+  assert.equal(payload.network.apiCallsSample.length, 1);
+});
+
+test('extractJsonObject and normalizeReasoning handle fenced JSON', () => {
+  const parsed = extractJsonObject(`\`\`\`json
+{"likelyCause":"ui_regression","confidence":"high","triageSummary":"Slow frames doubled.","failureCorrelation":"QG duration exceeded matches UI jank.","nextStep":"Inspect swap confirmation recording."}
+\`\`\``);
+  const normalized = normalizeReasoning(parsed);
+  assert.equal(normalized?.likelyCause, 'ui_regression');
+  assert.match(normalized?.failureCorrelation ?? '', /QG duration/);
+});
+
+test('formatReasoningMarkdown renders triage sections', () => {
+  const md = formatReasoningMarkdown(
+    {
+      likelyCause: 'ui_regression',
+      confidence: 'medium',
+      triageSummary: 'Slow frames regressed beyond +10%.',
+      failureCorrelation: 'Quality gates failed on swap duration.',
+      nextStep: 'Review BrowserStack recording around confirmation.',
+    },
+    { providerId: 'anthropic', model: 'claude-sonnet-4-6' },
+  );
+
+  assert.match(md, /AI triage & failure correlation/);
+  assert.match(md, /Likely cause/);
+  assert.match(md, /ui_regression/);
+  assert.match(md, /Correlation with scenario failure/);
+  assert.match(md, /Next step/);
+  assert.match(md, /claude-sonnet-4-6/);
+});
+
+test('generateAppProfilingAiReasoning skips without keys', async () => {
+  const md = await generateAppProfilingAiReasoning(
+    {
+      testName: 'x',
+      metricRows: [],
+      hasBaseline: false,
+    },
+    { env: {} },
+  );
+  assert.equal(md, '');
+});
+
+test('generateAppProfilingAiReasoning formats a successful Anthropic response', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    async json() {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              likelyCause: 'ui_regression',
+              confidence: 'high',
+              triageSummary: 'Slow frames above margin.',
+              failureCorrelation: 'QG exceeded aligns with UI jank.',
+              nextStep: 'Check recording.',
+            }),
+          },
+        ],
+      };
+    },
+  });
+
+  const md = await generateAppProfilingAiReasoning(
+    {
+      testName: 'Cross-chain swap',
+      platform: 'Android',
+      deviceLabel: 'Pixel 8',
+      failureContext: { failureReason: 'quality_gates_exceeded' },
+      metricRows: [{ label: 'Slow frames', warn: true, baselineText: '7%', currentText: '15%', deltaText: '+8' }],
+      baselineSummary: { uiRendering: { slowFrames: 7 } },
+      currentSummary: { uiRendering: { slowFrames: 15 } },
+      hasBaseline: true,
+    },
+    {
+      env: { E2E_CLAUDE_API_KEY: 'test-key' },
+      fetchImpl,
+    },
+  );
+
+  assert.match(md, /Slow frames above margin/);
+  assert.match(md, /QG exceeded aligns with UI jank/);
+});

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -17,12 +17,14 @@
  * Environment:
  *   GITHUB_REPOSITORY  owner/repo (required unless --repo is passed)
  *   GH_TOKEN / GITHUB_TOKEN  GitHub token with actions:read + pull_requests:write
+ *   E2E_CLAUDE_API_KEY / E2E_OPENAI_API_KEY / E2E_GEMINI_API_KEY  optional AI triage
  */
 
 import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { generateAppProfilingAiReasoning } from './app-profiling-ai.mjs';
 
 const COMMENT_MARKER = '<!-- app-profiling-check -->';
 const DEFAULT_BASELINE_BRANCH = 'main';
@@ -42,6 +44,7 @@ function parseArgs(argv) {
     workflow: DEFAULT_WORKFLOW,
     repo: process.env.GITHUB_REPOSITORY || null,
     dryRun: false,
+    skipAi: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -85,6 +88,9 @@ function parseArgs(argv) {
         break;
       case '--dry-run':
         args.dryRun = true;
+        break;
+      case '--skip-ai':
+        args.skipAi = true;
         break;
       default:
         break;
@@ -221,10 +227,70 @@ function getFailedScenariosFromSummary(summaryDir) {
         testName: test.testName,
         platform: test.platform ?? null,
         device,
+        failureReason: test.failureReason ?? null,
+        qualityGates: test.qualityGates ?? null,
+        qualityGatesViolations: test.qualityGatesViolations ?? null,
+        recordingLink: test.recordingLink ?? null,
+        sessionId: test.sessionId ?? null,
       });
     }
   }
   return scenarios;
+}
+
+function findFailureContext(summaryDir, { testName, device }) {
+  const failed = getFailedScenariosFromSummary(summaryDir);
+  const fromSummary = failed.find(
+    (entry) =>
+      entry.testName === testName &&
+      (!device?.name || devicesMatch(entry.device, device)),
+  );
+  if (fromSummary) {
+    return fromSummary;
+  }
+
+  // Fallback: performance-results.json may still carry failure metadata.
+  const resultsPath = path.join(summaryDir, 'performance-results.json');
+  if (!fs.existsSync(resultsPath)) {
+    return null;
+  }
+  const results = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+  const match = flattenPerformanceResults(results).find(
+    (entry) =>
+      entry.test.testName === testName &&
+      (!device?.name || devicesMatch(entry.device, device)),
+  );
+  if (!match) {
+    return null;
+  }
+  return {
+    testName: match.test.testName,
+    platform: match.platform,
+    device: match.device,
+    failureReason: match.test.failureReason ?? null,
+    qualityGates: match.test.qualityGates ?? null,
+    qualityGatesViolations:
+      match.test.qualityGatesViolations ??
+      match.test.qualityGates?.violations ??
+      null,
+    recordingLink: match.test.recordingLink ?? null,
+    sessionId: match.test.sessionId ?? null,
+  };
+}
+
+function formatFailureReasonLabel(reason) {
+  switch (reason) {
+    case 'quality_gates_exceeded':
+      return 'Quality gates exceeded';
+    case 'timedOut':
+      return 'Timed out';
+    case 'failed':
+      return 'Failed';
+    case 'test_error':
+      return 'Test error';
+    default:
+      return reason || null;
+  }
 }
 
 function downloadAggregatedReports(runId, destDir, repo) {
@@ -527,6 +593,8 @@ function buildScenarioComment({
   baseline,
   repo,
   baselineBranch = DEFAULT_BASELINE_BRANCH,
+  failureContext = null,
+  aiReasoningMarkdown = '',
 }) {
   const deviceLabel = formatDeviceLabel(device);
   const currentUrl = `https://github.com/${repo}/actions/runs/${currentRunId}`;
@@ -538,35 +606,53 @@ function buildScenarioComment({
   md += '\n\n';
   md += `**Current:** [run ${currentRunId}](${currentUrl})`;
 
+  if (baseline) {
+    const baselineUrl =
+      baseline.run.url ||
+      `https://github.com/${repo}/actions/runs/${baseline.run.databaseId}`;
+    const baselineSha = (baseline.run.headSha || '').slice(0, 7);
+    md += ` · **Baseline (last green on \`${baselineBranch}\`):** [run ${baseline.run.databaseId}](${baselineUrl})`;
+    if (baselineSha) {
+      md += ` @ \`${baselineSha}\``;
+    }
+  }
+  md += '\n';
+
+  if (failureContext?.failureReason) {
+    const reasonLabel = formatFailureReasonLabel(failureContext.failureReason);
+    md += `\n**Scenario failure:** ${reasonLabel}`;
+    if (failureContext.recordingLink) {
+      md += ` · [📹 Recording](${failureContext.recordingLink})`;
+    }
+    md += '\n';
+  }
+
   if (!currentArtifact || !hasUsableProfilingSummary(currentArtifact)) {
-    md += `\n\n⚠️ Current run has no usable \`profilingSummary\` for this scenario.\n`;
+    md += `\n⚠️ Current run has no usable \`profilingSummary\` for this scenario.\n`;
     if (currentArtifact?.apiCallsError) {
       md += `\nAPI calls note: \`${currentArtifact.apiCallsError}\`\n`;
+    }
+    if (aiReasoningMarkdown) {
+      md += `\n${aiReasoningMarkdown}\n`;
     }
     md += `\n${COMMENT_MARKER}\n`;
     return md;
   }
 
   if (!baseline) {
-    md += `\n\n⚠️ No green baseline found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
+    md += `\n⚠️ No green baseline found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
     md += `### Current profilingSummary\n\n`;
     md += '```json\n';
     md += `${JSON.stringify(currentArtifact.profilingSummary, null, 2)}\n`;
     md += '```\n';
+    if (aiReasoningMarkdown) {
+      md += `\n${aiReasoningMarkdown}\n`;
+    }
     md += `\n${COMMENT_MARKER}\n`;
     return md;
   }
 
-  const baselineUrl =
-    baseline.run.url ||
-    `https://github.com/${repo}/actions/runs/${baseline.run.databaseId}`;
-  const baselineSha = (baseline.run.headSha || '').slice(0, 7);
-  md += ` · **Baseline (last green on \`${baselineBranch}\`):** [run ${baseline.run.databaseId}](${baselineUrl})`;
-  if (baselineSha) {
-    md += ` @ \`${baselineSha}\``;
-  }
-  md += '\n\n';
-  md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
+  md += `\n> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
   md += `> - If \`Current <= Baseline + 10%\`, the change is treated as acceptable noise (no highlight).\n`;
   md += `> - If \`Current > Baseline + 10%\`, **Current** and the **variance %** are highlighted and marked with ⚠️.\n\n`;
 
@@ -585,6 +671,10 @@ function buildScenarioComment({
     md += `\n> ℹ️ API calls unavailable on current run: \`${currentArtifact.apiCallsError}\`\n`;
   }
 
+  if (aiReasoningMarkdown) {
+    md += `\n${aiReasoningMarkdown}\n`;
+  }
+
   md += `\n<details>\n<summary>Raw profilingSummary JSON</summary>\n\n`;
   md += `**Baseline**\n\n\`\`\`json\n${JSON.stringify(
     baseline.artifact.profilingSummary,
@@ -601,6 +691,40 @@ function buildScenarioComment({
   return md;
 }
 
+async function buildAiReasoningForScenario({
+  testName,
+  platform,
+  device,
+  currentArtifact,
+  baseline,
+  failureContext,
+  skipAi,
+}) {
+  const metricRows =
+    baseline && currentArtifact && hasUsableProfilingSummary(currentArtifact)
+      ? getMetricRows(
+          baseline.artifact.profilingSummary,
+          currentArtifact.profilingSummary,
+        )
+      : [];
+
+  return generateAppProfilingAiReasoning(
+    {
+      testName,
+      platform,
+      deviceLabel: formatDeviceLabel(device),
+      failureContext,
+      metricRows,
+      baselineSummary: baseline?.artifact?.profilingSummary ?? null,
+      currentSummary: currentArtifact?.profilingSummary ?? null,
+      apiCalls: currentArtifact?.apiCalls ?? null,
+      apiCallsError: currentArtifact?.apiCallsError ?? null,
+      hasBaseline: Boolean(baseline),
+    },
+    { skipAi },
+  );
+}
+
 function resolveScenarios(args, currentDir) {
   if (args.all) {
     const failed = getFailedScenariosFromSummary(currentDir);
@@ -614,16 +738,27 @@ function resolveScenarios(args, currentDir) {
     fail('Provide --test "Scenario name" or --all');
   }
 
+  const device = parseDeviceKey(args.device);
+  const failureContext = findFailureContext(currentDir, {
+    testName: args.test,
+    device,
+  });
+
   return [
     {
       testName: args.test,
-      platform: args.platform,
-      device: parseDeviceKey(args.device),
+      platform: args.platform ?? failureContext?.platform ?? null,
+      device: device.name ? device : failureContext?.device ?? device,
+      failureReason: failureContext?.failureReason ?? null,
+      qualityGates: failureContext?.qualityGates ?? null,
+      qualityGatesViolations: failureContext?.qualityGatesViolations ?? null,
+      recordingLink: failureContext?.recordingLink ?? null,
+      sessionId: failureContext?.sessionId ?? null,
     },
   ];
 }
 
-function main() {
+async function main() {
   const args = parseArgs(process.argv.slice(2));
 
   if (!args.pr) fail('Missing --pr <number>');
@@ -666,6 +801,24 @@ function main() {
       workRoot,
     });
 
+    const failureContext = {
+      failureReason: scenario.failureReason ?? null,
+      qualityGates: scenario.qualityGates ?? null,
+      qualityGatesViolations: scenario.qualityGatesViolations ?? null,
+      recordingLink: scenario.recordingLink ?? null,
+      sessionId: scenario.sessionId ?? null,
+    };
+
+    const aiReasoningMarkdown = await buildAiReasoningForScenario({
+      testName: scenario.testName,
+      platform: scenario.platform,
+      device: scenario.device,
+      currentArtifact,
+      baseline,
+      failureContext,
+      skipAi: args.skipAi,
+    });
+
     comments.push(
       buildScenarioComment({
         testName: scenario.testName,
@@ -676,6 +829,8 @@ function main() {
         baseline,
         repo: args.repo,
         baselineBranch: args.baselineBranch,
+        failureContext,
+        aiReasoningMarkdown,
       }),
     );
   }
@@ -705,14 +860,15 @@ export {
   hasUsableProfilingSummary,
   findMatchingArtifact,
   findGreenScenarioInDir,
+  getFailedScenariosFromSummary,
+  findFailureContext,
+  formatFailureReasonLabel,
   buildScenarioComment,
   COMMENT_MARKER,
 };
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     fail(error instanceof Error ? error.message : String(error));
-  }
+  });
 }

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -181,12 +181,99 @@ test('buildScenarioComment includes marker and delta table when baseline exists'
   });
 
   assert.match(md, /## 🔬 App Profiling Check: Cold Start Login/);
-      assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
-      assert.match(md, /Disclaimer — allowed variance/);
-      assert.match(md, /\+10%/);
-      assert.match(md, new RegExp(COMMENT_MARKER));
-      assert.match(md, /run 222/);
-    });
+  assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
+  assert.match(md, /Disclaimer — allowed variance/);
+  assert.match(md, /\+10%/);
+  assert.match(md, new RegExp(COMMENT_MARKER));
+  assert.match(md, /run 222/);
+});
+
+test('buildScenarioComment includes failure context and AI section', () => {
+  const md = buildScenarioComment({
+    testName: 'Cross-chain swap',
+    platform: 'Android',
+    device: { name: 'Pixel 8', osVersion: '14.0' },
+    currentRunId: '111',
+    currentArtifact: {
+      profilingSummary: {
+        cpu: { avg: 9, max: 20 },
+        memory: { avg: 200, max: 250 },
+        uiRendering: { slowFrames: 15, frozenFrames: 0, anrs: 0 },
+        issues: 1,
+        criticalIssues: 0,
+      },
+    },
+    baseline: {
+      run: {
+        databaseId: 222,
+        headSha: 'abcdef123456',
+        url: 'https://github.com/MetaMask/metamask-mobile/actions/runs/222',
+      },
+      artifact: {
+        profilingSummary: {
+          cpu: { avg: 8, max: 18 },
+          memory: { avg: 190, max: 240 },
+          uiRendering: { slowFrames: 7, frozenFrames: 0, anrs: 0 },
+          issues: 1,
+          criticalIssues: 0,
+        },
+      },
+    },
+    repo: 'MetaMask/metamask-mobile',
+    failureContext: {
+      failureReason: 'quality_gates_exceeded',
+      recordingLink: 'https://example.com/recording',
+    },
+    aiReasoningMarkdown:
+      '<details>\n<summary>🤖 AI triage & failure correlation</summary>\n\ntriage\n\n</details>\n',
+  });
+
+  assert.match(md, /\*\*Scenario failure:\*\* Quality gates exceeded/);
+  assert.match(md, /https:\/\/example\.com\/recording/);
+  assert.match(md, /AI triage & failure correlation/);
+});
+
+test('getFailedScenariosFromSummary preserves failure metadata', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const { tmpdir } = await import('node:os');
+  const { getFailedScenariosFromSummary } = await import(
+    './diff-app-profiling.mjs'
+  );
+
+  const dir = mkdtempSync(join(tmpdir(), 'profiling-summary-'));
+  try {
+    writeFileSync(
+      join(dir, 'summary.json'),
+      JSON.stringify({
+        failedTestsStats: {
+          failedTestsByTeam: {
+            '@swap-bridge-dev-team': {
+              tests: [
+                {
+                  testName: 'Cross-chain swap',
+                  platform: 'Android',
+                  device: 'Pixel 8+14.0',
+                  failureReason: 'quality_gates_exceeded',
+                  qualityGatesViolations: [{ step: 'swap' }],
+                  recordingLink: 'https://example.com/r',
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const scenarios = getFailedScenariosFromSummary(dir);
+    assert.equal(scenarios.length, 1);
+    assert.equal(scenarios[0].failureReason, 'quality_gates_exceeded');
+    assert.equal(scenarios[0].recordingLink, 'https://example.com/r');
+    assert.deepEqual(scenarios[0].qualityGatesViolations, [{ step: 'swap' }]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test('buildScenarioComment explains missing baseline', () => {
   const md = buildScenarioComment({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the on-demand **App profiling check** (from MMQA-2081) with AI reasoning focused on:

1. **Regression triage** — classify likely cause (`device_noise` / `ui_regression` / `test_or_setup` / `network` / `unclear`) for metrics over the +10% baseline margin
2. **Failure correlation** — relate `failureReason` / quality-gate violations from `summary.json` to profiling signals, plus one concrete next step

Deterministic diff + table remain the source of truth. AI is additive and non-blocking.

## Changes

- `tests/scripts/app-profiling-ai.mjs` — single LLM call via Anthropic → OpenAI → Gemini (`E2E_*` keys, same as Smart E2E)
- `tests/scripts/diff-app-profiling.mjs` — passes failure context into the PR comment; appends AI `<details>` section; supports `--skip-ai`
- `.github/workflows/app-profiling-check.yml` — wires `E2E_CLAUDE_API_KEY` / `E2E_OPENAI_API_KEY` / `E2E_GEMINI_API_KEY`
- Docs + unit tests (`node --test`)

## Example comment addition

```markdown
**Scenario failure:** Quality gates exceeded · 📹 Recording

| Metric | Baseline | Current | Δ |
| Slow frames | 7% | **15%** | +8 (**+114%**) ⚠️ |

<details>
<summary>🤖 AI triage & failure correlation (confidence: high)</summary>

**Likely cause:** `ui_regression`
### Triage
...
### Correlation with scenario failure
...
### Next step
...
</details>
```

## Test plan

- [x] `node --test tests/scripts/diff-app-profiling.test.mjs tests/scripts/app-profiling-ai.test.mjs`
- [ ] Trigger `@metamaskbot app-profiling-check --all --run <id>` on a PR with failed perf scenarios and confirm AI section appears when secrets are present
- [ ] Confirm comment still posts when AI keys are missing / LLM errors (deterministic table only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1033c242-8668-4156-ac2e-cbe32698bb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1033c242-8668-4156-ac2e-cbe32698bb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

