### PR TITLE
fix(bridge): restore hardware wallet post-trade modal after swap

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
@@ -65,6 +65,12 @@ export const useBridgeConfirm = ({
               quoteResponse: activeQuote,
               location,
               transactionActiveAbTests,
+              postTradeModalParams: {
+                sourceAmount: sourceAmount ?? activeQuote.sentAmount?.amount,
+                destAmount: activeQuote.toTokenAmount?.amount,
+                sourceToken,
+                destToken,
+              },
             },
           },
         });

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
@@ -240,6 +240,14 @@ describe('useBridgeConfirm', () => {
         Routes.BRIDGE.ROOT,
         expect.objectContaining({
           screen: Routes.BRIDGE.HARDWARE_WALLETS_SWAPS,
+          params: expect.objectContaining({
+            submissionParams: expect.objectContaining({
+              postTradeModalParams: expect.objectContaining({
+                sourceAmount: mockQuoteWithMetadata.sentAmount.amount,
+                destAmount: mockQuoteWithMetadata.toTokenAmount.amount,
+              }),
+            }),
+          }),
         }),
       );
       expect(mockNavigate).not.toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts
@@ -236,6 +236,12 @@ describe('useBridgeConfirm', () => {
         await result.current();
       });
 
+      const sourceAmount = mockQuoteWithMetadata.sentAmount;
+      const destAmount = mockQuoteWithMetadata.toTokenAmount;
+      if (!sourceAmount || !destAmount) {
+        throw new Error('Mock quote is missing token amounts');
+      }
+
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.BRIDGE.ROOT,
         expect.objectContaining({
@@ -243,8 +249,8 @@ describe('useBridgeConfirm', () => {
           params: expect.objectContaining({
             submissionParams: expect.objectContaining({
               postTradeModalParams: expect.objectContaining({
-                sourceAmount: mockQuoteWithMetadata.sentAmount.amount,
-                destAmount: mockQuoteWithMetadata.toTokenAmount.amount,
+                sourceAmount: sourceAmount.amount,
+                destAmount: destAmount.amount,
               }),
             }),
           }),

--- a/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
@@ -23,7 +23,10 @@ import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
-const mockAddListener = jest.fn(() => jest.fn());
+type TransitionEndHandler = (event?: { data?: { closing?: boolean } }) => void;
+const mockAddListener = jest.fn<() => void, [string, TransitionEndHandler]>(
+  () => jest.fn(),
+);
 let mockIsFocused = true;
 const mockRouteParams: Record<string, any> = {};
 
@@ -893,9 +896,12 @@ describe('HardwareWalletsSwaps', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      const transitionEnd = mockAddListener.mock.calls.find(
+      const transitionEndCall = mockAddListener.mock.calls.find(
         ([event]) => event === 'transitionEnd',
-      )?.[1];
+      );
+      const transitionEnd = transitionEndCall?.[1] as
+        | TransitionEndHandler
+        | undefined;
       act(() => transitionEnd?.({ data: { closing: false } }));
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BRIDGE_VIEW);

--- a/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
@@ -690,8 +690,7 @@ describe('HardwareWalletsSwaps', () => {
 
   describe('done', () => {
     it('navigates to transactions', () => {
-      setSendRouteParams({ withApproval: true });
-      const { getByTestId } = renderSendScreen(SUBMITTED_STATE);
+      const { getByTestId } = renderScreen(SUBMITTED_STATE);
 
       fireEvent.press(
         getByTestId(HardwareWalletsSwapsSelectorsIDs.DONE_BUTTON),
@@ -701,8 +700,7 @@ describe('HardwareWalletsSwaps', () => {
     });
 
     it('resets hardware wallet swaps state', () => {
-      setSendRouteParams({ withApproval: true });
-      const { getByTestId, store } = renderSendScreen(SUBMITTED_STATE);
+      const { getByTestId, store } = renderScreen(SUBMITTED_STATE);
 
       fireEvent.press(
         getByTestId(HardwareWalletsSwapsSelectorsIDs.DONE_BUTTON),
@@ -712,8 +710,7 @@ describe('HardwareWalletsSwaps', () => {
     });
 
     it('treats header close as done after submission', () => {
-      setSendRouteParams({ withApproval: true });
-      const { UNSAFE_getByProps, store } = renderSendScreen(SUBMITTED_STATE);
+      const { UNSAFE_getByProps, store } = renderScreen(SUBMITTED_STATE);
 
       fireEvent.press(UNSAFE_getByProps({ iconName: IconName.Close }));
 

--- a/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
@@ -23,6 +23,8 @@ import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockAddListener = jest.fn(() => jest.fn());
+let mockIsFocused = true;
 const mockRouteParams: Record<string, any> = {};
 
 jest.mock('@react-navigation/native', () => ({
@@ -30,8 +32,10 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
+    addListener: mockAddListener,
   }),
   useRoute: () => ({ params: mockRouteParams }),
+  useIsFocused: () => mockIsFocused,
 }));
 
 jest.mock('rive-react-native', () =>
@@ -121,6 +125,7 @@ jest.mock('../../../../core/Engine', () => ({
     unsubscribe: jest.fn(),
   },
   acceptPendingApproval: jest.fn().mockResolvedValue(undefined),
+  context: { BridgeController: { resetState: jest.fn() } },
 }));
 const mockAccept = (
   jest.requireMock('../../../../core/Engine') as {
@@ -405,11 +410,13 @@ describe('HardwareWalletsSwaps', () => {
     __clearLastMockedMethods();
     mockHardwareWalletState.walletType = null;
     mockHardwareWalletState.pendingScanRequest = null;
+    mockIsFocused = true;
     jest.mocked(selectSourceWalletAddress).mockReturnValue(WALLET_ADDRESS);
+    Object.keys(mockRouteParams).forEach((key) => delete mockRouteParams[key]);
     mockRouteSubmissionParams();
     mockEnsureDeviceReady.mockResolvedValue(true);
     mockGetDeviceId.mockResolvedValue('ledger-device-id');
-    mockSubmitBridgeTx.mockResolvedValue({ success: true });
+    mockSubmitBridgeTx.mockReturnValue(new Promise(() => undefined));
     mockConnectionState.status = 'disconnected';
   });
 
@@ -683,7 +690,8 @@ describe('HardwareWalletsSwaps', () => {
 
   describe('done', () => {
     it('navigates to transactions', () => {
-      const { getByTestId } = renderScreen(SUBMITTED_STATE);
+      setSendRouteParams({ withApproval: true });
+      const { getByTestId } = renderSendScreen(SUBMITTED_STATE);
 
       fireEvent.press(
         getByTestId(HardwareWalletsSwapsSelectorsIDs.DONE_BUTTON),
@@ -693,7 +701,8 @@ describe('HardwareWalletsSwaps', () => {
     });
 
     it('resets hardware wallet swaps state', () => {
-      const { getByTestId, store } = renderScreen(SUBMITTED_STATE);
+      setSendRouteParams({ withApproval: true });
+      const { getByTestId, store } = renderSendScreen(SUBMITTED_STATE);
 
       fireEvent.press(
         getByTestId(HardwareWalletsSwapsSelectorsIDs.DONE_BUTTON),
@@ -703,7 +712,8 @@ describe('HardwareWalletsSwaps', () => {
     });
 
     it('treats header close as done after submission', () => {
-      const { UNSAFE_getByProps, store } = renderScreen(SUBMITTED_STATE);
+      setSendRouteParams({ withApproval: true });
+      const { UNSAFE_getByProps, store } = renderSendScreen(SUBMITTED_STATE);
 
       fireEvent.press(UNSAFE_getByProps({ iconName: IconName.Close }));
 
@@ -745,7 +755,7 @@ describe('HardwareWalletsSwaps', () => {
       const { getByTestId, store } = renderScreen({});
 
       await flushPromises();
-      dispatchRejection(store);
+      await act(async () => dispatchRejection(store));
       await flushPromises();
 
       await act(async () => {
@@ -816,6 +826,15 @@ describe('HardwareWalletsSwaps', () => {
       expect(mockSubmitBridgeTx).not.toHaveBeenCalled();
     });
 
+    it('does not resubmit a remounted flow with signed steps', async () => {
+      renderScreen({ steps: signedSteps });
+      await flushPromises();
+
+      expect(mockSubmitBridgeTx).not.toHaveBeenCalled();
+      // No mount-local settlement metadata: preserve toast + Activity.
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+    });
+
     it.each([
       {
         name: 'no cached params',
@@ -855,21 +874,51 @@ describe('HardwareWalletsSwaps', () => {
   });
 
   describe('auto-navigation', () => {
-    it('auto-navigates to transactions when Submitted and submission completes', async () => {
+    it('opens post-trade after signing and submission complete', async () => {
+      let resolveSubmit!: (value: { id: string; hash: string }) => void;
+      mockHardwareWalletState.walletType = HardwareWalletType.Qr;
+      mockIsFocused = false;
+      mockSubmitBridgeTx.mockReturnValue(
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+      );
       const { store } = renderScreen({});
 
       await flushPromises();
-      signAllSteps(store);
-      await flushPromises();
+      mockIsFocused = true;
+      await act(async () => signAllSteps(store));
+      expect(mockNavigate).not.toHaveBeenCalled();
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+      await act(async () => {
+        resolveSubmit({ id: 'tx-id', hash: '0xabc' });
+        await Promise.resolve();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      const transitionEnd = mockAddListener.mock.calls.find(
+        ([event]) => event === 'transitionEnd',
+      )?.[1];
+      act(() => transitionEnd?.({ data: { closing: false } }));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BRIDGE_VIEW);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+        screen: Routes.BRIDGE.MODALS.POST_TRADE_MODAL,
+        params: expect.objectContaining({
+          transactionMetaId: 'tx-id',
+          transactionHash: '0xabc',
+        }),
+      });
     });
 
-    it('navigates to transactions after retry flow signs all txs', async () => {
+    it('opens post-trade after retry signs all txs', async () => {
+      mockSubmitBridgeTx
+        .mockReturnValueOnce(new Promise(() => undefined))
+        .mockResolvedValueOnce({ id: 'tx-id', hash: '0xabc' });
       const { getByTestId, store } = renderScreen({});
 
       await flushPromises();
-      dispatchRejection(store);
+      await act(async () => dispatchRejection(store));
       await flushPromises();
 
       await act(async () => {
@@ -883,7 +932,10 @@ describe('HardwareWalletsSwaps', () => {
         await Promise.resolve();
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+        screen: Routes.BRIDGE.MODALS.POST_TRADE_MODAL,
+        params: expect.objectContaining({ transactionMetaId: 'tx-id' }),
+      });
     });
 
     it('does not auto-navigate for non-Submitted states', () => {

--- a/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.tsx
@@ -284,6 +284,7 @@ export function HardwareWalletsSwaps() {
               navigation.navigate(Routes.BRIDGE.HW_QR_SCANNER, {
                 currentStep: getCameraScanStep(progress.currentStep),
                 totalSteps: getTotalQrScans(progress.totalSteps),
+                ...(strategy.isSendFlow ? { completeOnScan: true } : {}),
               })
             }
           >

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.test.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.test.tsx
@@ -6,9 +6,8 @@ import { HwQrScannerSelectorsIDs } from './HwQrScanner.testIds';
 import { useHardwareWallet } from '../../../../core/HardwareWallet';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { QrScanRequestType } from '@metamask/eth-qr-keyring';
-import Routes from '../../../../constants/navigation/Routes';
 import { resetHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
-import { ToastVariants } from '../../../../component-library/components/Toast';
+import Routes from '../../../../constants/navigation/Routes';
 
 const mockDispatch = jest.fn();
 
@@ -412,7 +411,7 @@ describe('HwQrScanner', () => {
       expect(getMockShowToast()).not.toHaveBeenCalled();
     });
 
-    it('completes success on the last scan: toast, Redux reset, and activity navigation', () => {
+    it('goes back on the last Bridge scan so lifecycle owns completion', () => {
       mockUseRoute.mockReturnValue({
         params: { currentStep: 2, totalSteps: 2 },
       });
@@ -429,19 +428,28 @@ describe('HwQrScanner', () => {
         cbor: Buffer.from('signature').toString('hex'),
       });
       expect(mockSetRequestCompleted).toHaveBeenCalledTimes(1);
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(getMockShowToast()).not.toHaveBeenCalled();
+      expect(resetHardwareWalletsSwaps).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('preserves scanner-owned completion on the last Send scan', () => {
+      mockUseRoute.mockReturnValue({
+        params: { currentStep: 2, totalSteps: 2, completeOnScan: true },
+      });
+
+      render(<HwQrScanner />);
+
+      capturedOnScanSuccess?.({
+        type: 'eth-signature',
+        cbor: Buffer.from('signature'),
+      });
+
       expect(mockGoBack).not.toHaveBeenCalled();
-      expect(getMockShowToast()).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: 'check',
-        hasNoTimeout: false,
-        labelOptions: [
-          { label: 'bridge.hardware_wallet_progress.submitted_title' },
-        ],
-      });
-      expect(resetHardwareWalletsSwaps).toHaveBeenCalledTimes(1);
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'bridge/resetHardwareWalletsSwaps',
-      });
+      expect(getMockShowToast()).toHaveBeenCalled();
+      expect(resetHardwareWalletsSwaps).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
     });
 

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -192,8 +192,11 @@ export function HwQrScanner() {
     string | null
   >(null);
 
-  const { currentStep = 1, totalSteps = 1, completeOnScan = false } =
-    (route.params as HwQrScannerRouteParams) ?? {};
+  const {
+    currentStep = 1,
+    totalSteps = 1,
+    completeOnScan = false,
+  } = (route.params as HwQrScannerRouteParams) ?? {};
 
   const isLastStep = currentStep >= totalSteps;
 

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -157,6 +157,8 @@ const styles = StyleSheet.create({
 export interface HwQrScannerRouteParams {
   currentStep: number;
   totalSteps: number;
+  /** Preserve scanner-owned completion for Send; Bridge returns to its lifecycle. */
+  completeOnScan?: boolean;
 }
 
 /**
@@ -190,7 +192,7 @@ export function HwQrScanner() {
     string | null
   >(null);
 
-  const { currentStep = 1, totalSteps = 1 } =
+  const { currentStep = 1, totalSteps = 1, completeOnScan = false } =
     (route.params as HwQrScannerRouteParams) ?? {};
 
   const isLastStep = currentStep >= totalSteps;
@@ -207,17 +209,14 @@ export function HwQrScanner() {
             cbor: Buffer.from(ur.cbor).toString('hex'),
           });
           setRequestCompleted();
-          // Last-step: complete success here (toast + Redux reset + navigate)
-          // instead of goBack()-ing to HardwareWalletsSwaps. Ledger flows do
-          // this via `useHwSwapLifecycle.navigateOnSuccess`, which is disabled
-          // for QR to avoid two native view insertions in the same frame on
-          // Android (addViewAt crash).
-          if (isLastStep) {
+          if (isLastStep && completeOnScan) {
             if (!hasCompletedOnSuccessRef.current) {
               hasCompletedOnSuccessRef.current = true;
               completeHwSwapSuccess({ dispatch, navigation, toastRef });
             }
           } else {
+            // Bridge returns to its lifecycle, which waits for submit settlement
+            // and this screen's transitionEnd before opening post-trade.
             navigation.goBack();
           }
           return true;
@@ -243,6 +242,7 @@ export function HwQrScanner() {
       pendingScanRequest,
       setRequestCompleted,
       isLastStep,
+      completeOnScan,
       dispatch,
       navigation,
       toastRef,

--- a/app/components/UI/HardwareWallet/Swaps/flowStrategy.ts
+++ b/app/components/UI/HardwareWallet/Swaps/flowStrategy.ts
@@ -6,6 +6,7 @@ import type {
 } from '@metamask/bridge-controller';
 import type { TransactionActiveAbTestEntry } from '../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import Routes from '../../../../constants/navigation/Routes';
+import type { PostTradeBottomSheetParams } from '../../Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.types';
 
 /**
  * Signing-session origin. Bridge is the default; send activates only when
@@ -40,6 +41,11 @@ export interface SubmissionParams {
   quoteResponse: QuoteResponse & QuoteMetadata;
   location?: MetaMetricsSwapsEventSource;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
+  /** Token/amount context for the post-trade modal after HW signing completes. */
+  postTradeModalParams?: Pick<
+    PostTradeBottomSheetParams,
+    'sourceAmount' | 'destAmount' | 'sourceToken' | 'destToken'
+  >;
 }
 
 /**

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { Dispatch, AnyAction } from 'redux';
 import {
   TransactionStatus,
@@ -12,6 +12,7 @@ import { getDeviceIdForAddress } from '../../../../core/HardwareWallet/helpers';
 import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
 import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import useSubmitBridgeTx from '../../../../util/bridge/hooks/useSubmitBridgeTx';
+import { withPostTradeNotificationSuppression } from '../../Bridge/utils/postTradeNotifications';
 import {
   HardwareWalletsSwapsStatus,
   HardwareWalletsSwapsEventType,
@@ -121,6 +122,7 @@ interface UseHardwareWalletSubmitOptions {
  *
  * Exposes behavioral methods only — `submit()`, `canRetry()`,
  * `clearCachedSubmission()` — so callers never reach into internal refs.
+ * Bridge also exposes settled submission identifiers (`null` until settled).
  */
 export function useHardwareWalletSubmit({
   isSendFlow,
@@ -137,8 +139,10 @@ export function useHardwareWalletSubmit({
   submit: () => Promise<void>;
   /** True when enough state is cached to retry. Send: pending approval + prepared tx; bridge: cached params. */
   canRetry: () => boolean;
-  /** Clears the cached bridge submission params (no-op in send mode). */
+  /** Clears the cached bridge submission params and settled tx metadata. */
   clearCachedSubmission: () => void;
+  /** `null` while pending, transaction on success, `undefined` on failure. */
+  submittedTransaction: TransactionMeta | null | undefined;
 } {
   const { approvalRequest } = useApprovalRequest();
   const approvalRequestRef = useRef(approvalRequest);
@@ -154,6 +158,9 @@ export function useHardwareWalletSubmit({
   const cachedSubmissionParams = useRef<SubmissionParams | null>(
     submissionParams ?? null,
   );
+  const [submittedTransaction, setSubmittedTransaction] = useState<
+    TransactionMeta | null | undefined
+  >(null);
   useEffect(() => {
     if (submissionParams && !cachedSubmissionParams.current) {
       cachedSubmissionParams.current = submissionParams;
@@ -162,12 +169,16 @@ export function useHardwareWalletSubmit({
 
   // Shared stale-submission guard + TransactionFailed dispatch.
   const runSubmit = useCallback(
-    async (submitFn: () => Promise<unknown>) => {
-      const myGeneration = submissionGenerationRef.current;
+    async <Result,>(submitFn: () => Promise<Result>) => {
+      const submissionGenerationAtStart = submissionGenerationRef.current;
       try {
-        await submitFn();
+        return await submitFn();
       } catch (error) {
-        if (submissionGenerationRef.current !== myGeneration) return;
+        if (
+          submissionGenerationRef.current !== submissionGenerationAtStart
+        ) {
+          return;
+        }
         Logger.error(error as Error, 'HW swap submit failed');
         const status = progressRef.current.status;
         // Only transition to Failed from active phases:
@@ -187,6 +198,7 @@ export function useHardwareWalletSubmit({
             }),
           );
         }
+        return undefined;
       }
     },
     [dispatch, progressRef, submissionGenerationRef],
@@ -253,7 +265,7 @@ export function useHardwareWalletSubmit({
     setPendingOperationAddress,
   ]);
 
-  // ── Bridge flow (UNCHANGED) ─────────────────────────────────────────
+  // ── Bridge flow ────────────────────────────────────────────────────
   const submitBridgeFlow = useCallback(async () => {
     const cachedParams = cachedSubmissionParams.current;
     if (!cachedParams || !walletAddress) {
@@ -262,11 +274,25 @@ export function useHardwareWalletSubmit({
           type: HardwareWalletsSwapsEventType.TransactionFailed,
         }),
       );
+      setSubmittedTransaction(undefined);
       return;
     }
 
-    await runSubmit(() => submitBridgeTxRef.current(cachedParams));
-  }, [dispatch, walletAddress, runSubmit]);
+    const submissionGenerationAtStart = submissionGenerationRef.current;
+    setSubmittedTransaction(null);
+
+    const submitted = await runSubmit(() =>
+      withPostTradeNotificationSuppression(() =>
+        submitBridgeTxRef.current(cachedParams),
+      ),
+    );
+
+    if (submissionGenerationRef.current !== submissionGenerationAtStart) {
+      return;
+    }
+
+    setSubmittedTransaction(submitted);
+  }, [dispatch, walletAddress, runSubmit, submissionGenerationRef]);
 
   const submit = useCallback(async () => {
     if (isSendFlow) {
@@ -288,11 +314,13 @@ export function useHardwareWalletSubmit({
 
   const clearCachedSubmission = useCallback(() => {
     cachedSubmissionParams.current = null;
+    setSubmittedTransaction(null);
   }, []);
 
   return {
     submit,
     canRetry,
     clearCachedSubmission,
+    submittedTransaction,
   };
 }

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import type { Dispatch, AnyAction } from 'redux';
 import {
   TransactionStatus,
@@ -169,14 +175,12 @@ export function useHardwareWalletSubmit({
 
   // Shared stale-submission guard + TransactionFailed dispatch.
   const runSubmit = useCallback(
-    async <Result,>(submitFn: () => Promise<Result>) => {
+    async <Result>(submitFn: () => Promise<Result>) => {
       const submissionGenerationAtStart = submissionGenerationRef.current;
       try {
         return await submitFn();
       } catch (error) {
-        if (
-          submissionGenerationRef.current !== submissionGenerationAtStart
-        ) {
+        if (submissionGenerationRef.current !== submissionGenerationAtStart) {
           return;
         }
         Logger.error(error as Error, 'HW swap submit failed');

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -12,12 +12,20 @@ import type { AppNavigationProp } from '../../../../core/NavigationService/types
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
 
 import Routes from '../../../../constants/navigation/Routes';
+import Engine from '../../../../core/Engine';
 import {
+  incrementBridgeBalanceRefreshKey,
+  resetBridgeTokenInputs,
   resetHardwareWalletsSwaps,
   selectHardwareWalletsSwaps,
   updateHardwareWalletsSwaps,
 } from '../../../../core/redux/slices/bridge';
 import { ToastContext } from '../../../../component-library/components/Toast';
+import { PostTradeStatus } from '../../Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.types';
+import {
+  hidePostTradeNotificationSurface,
+  showPostTradeNotificationSurface,
+} from '../../Bridge/utils/postTradeNotifications';
 import { completeHwSwapSuccess } from './hwSwapSuccess';
 import {
   HardwareWalletsSwapsStatus,
@@ -109,8 +117,12 @@ export function useHwSwapLifecycle({
   const retryGenerationRef = useRef(0);
   const hasAutoNavigatedRef = useRef(false);
   const hasInitialSubmissionRef = useRef(false);
+  /** True once this mount starts a bridge submit (distinguishes remount). */
+  const didStartBridgeSubmitRef = useRef(false);
   const retryInProgressRef = useRef(false);
   const [isRetrying, setIsRetrying] = useState(false);
+  const [isQrReturnTransitionEnded, setIsQrReturnTransitionEnded] =
+    useState(true);
 
   // ── Sibling hooks (composed here so refs stay local) ─────────────
   const isEnabled = Boolean(strategy.walletAddress);
@@ -138,6 +150,7 @@ export function useHwSwapLifecycle({
     submit: submitWithDeviceReady,
     canRetry,
     clearCachedSubmission,
+    submittedTransaction,
   } = useHardwareWalletSubmit({
     isSendFlow: strategy.isSendFlow,
     walletAddress: strategy.walletAddress,
@@ -150,6 +163,36 @@ export function useHwSwapLifecycle({
     ensureDeviceReady,
     setPendingOperationAddress,
   });
+
+  // Suppress generic tx notifications while the Bridge HW screen is focused
+  // (BridgeView unregisters its surface when navigating here).
+  useEffect(() => {
+    if (strategy.isSendFlow || !isFocused) {
+      return;
+    }
+    showPostTradeNotificationSurface();
+    return () => {
+      hidePostTradeNotificationSurface();
+    };
+  }, [strategy.isSendFlow, isFocused]);
+
+  // Register before opening the QR scanner so transitionEnd cannot be missed.
+  // This is Bridge-only; Send retains its existing scanner-owned completion.
+  useEffect(() => {
+    if (strategy.isSendFlow || !isQrHardwareWallet) {
+      return;
+    }
+
+    return navigation.addListener('transitionEnd', (e) => {
+      if (!e.data.closing) setIsQrReturnTransitionEnded(true);
+    });
+  }, [isQrHardwareWallet, navigation, strategy.isSendFlow]);
+
+  useEffect(() => {
+    if (!strategy.isSendFlow && isQrHardwareWallet && !isFocused) {
+      setIsQrReturnTransitionEnded(false);
+    }
+  }, [isFocused, isQrHardwareWallet, strategy.isSendFlow]);
 
   // ── Derived ──────────────────────────────────────────────────────
   const allStepsSigned = useMemo(
@@ -164,9 +207,65 @@ export function useHwSwapLifecycle({
   // ── Flow termination ─────────────────────────────────────────────
   const completeSignedFlow = useCallback(() => {
     if (hasAutoNavigatedRef.current) return;
+
+    if (strategy.isSendFlow) {
+      hasAutoNavigatedRef.current = true;
+      clearCachedSubmission();
+      completeHwSwapSuccess({ dispatch, navigation, toastRef });
+      return;
+    }
+
+    if (submittedTransaction === null) {
+      if (didStartBridgeSubmitRef.current) return;
+      // Remount has no local submission metadata; preserve legacy completion.
+      hasAutoNavigatedRef.current = true;
+      clearCachedSubmission();
+      completeHwSwapSuccess({ dispatch, navigation, toastRef });
+      return;
+    }
+    if (
+      submittedTransaction === undefined ||
+      (!submittedTransaction.id && !submittedTransaction.hash)
+    ) {
+      dispatch(
+        updateHardwareWalletsSwaps({
+          type: HardwareWalletsSwapsEventType.TransactionFailed,
+        }),
+      );
+      return;
+    }
+
+    if (isQrHardwareWallet && !isQrReturnTransitionEnded) return;
+
     hasAutoNavigatedRef.current = true;
-    completeHwSwapSuccess({ dispatch, navigation, toastRef });
-  }, [dispatch, navigation, toastRef]);
+    clearCachedSubmission();
+
+    dispatch(resetBridgeTokenInputs());
+    Engine.context.BridgeController?.resetState?.();
+    dispatch(incrementBridgeBalanceRefreshKey());
+    dispatch(resetHardwareWalletsSwaps());
+    // Keep BridgeView beneath the modal, not the reset HW progress screen.
+    navigation.navigate(Routes.BRIDGE.BRIDGE_VIEW);
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.POST_TRADE_MODAL,
+      params: {
+        ...strategy.submitOptions.submissionParams?.postTradeModalParams,
+        status: PostTradeStatus.InProgress,
+        transactionMetaId: submittedTransaction.id,
+        transactionHash: submittedTransaction.hash,
+      },
+    });
+  }, [
+    clearCachedSubmission,
+    dispatch,
+    isQrHardwareWallet,
+    isQrReturnTransitionEnded,
+    navigation,
+    strategy.isSendFlow,
+    strategy.submitOptions.submissionParams?.postTradeModalParams,
+    submittedTransaction,
+    toastRef,
+  ]);
 
   const reconcileStuckFlowProgress = useCallback(() => {
     const current = progressRef.current;
@@ -181,9 +280,7 @@ export function useHwSwapLifecycle({
 
     const resolution = reconcileStuckProgress(current.steps);
     if (resolution.action === 'navigate') {
-      // All signed but status hasn't transitioned. QR wallets normally
-      // complete on the last HwQrScanner scan; when the user is still on
-      // progress/disconnected, finish here instead.
+      // All signed but status hasn't transitioned.
       completeSignedFlow();
       return;
     }
@@ -192,21 +289,21 @@ export function useHwSwapLifecycle({
   }, [completeSignedFlow, dispatch]);
 
   useEffect(() => {
-    // All device signing steps complete AND a submission was started.
-    // Fires exactly once (guarded by hasAutoNavigatedRef) to show the
-    // success toast, reset HW-swaps state, and navigate to activity view.
+    // Complete after signing; Bridge also waits for submission settlement.
     if (!allStepsSigned) return;
-    // For QR wallets the HwQrScanner screen handles final navigation
-    // directly (it navigates to TRANSACTIONS_VIEW on the last scan
-    // instead of calling goBack()).  Letting this effect also fire would
-    // produce two native view insertions in the same frame, colliding
-    // on Android (java.lang.IllegalStateException / addViewAt).
-    if (isQrHardwareWallet) return;
+    // Send QR retains scanner-owned completion.
+    if (strategy.isSendFlow && isQrHardwareWallet) return;
     if (!isFocused) return;
     if (hasAutoNavigatedRef.current) return;
     if (!hasInitialSubmissionRef.current) return;
     completeSignedFlow();
-  }, [allStepsSigned, isQrHardwareWallet, isFocused, completeSignedFlow]);
+  }, [
+    allStepsSigned,
+    isFocused,
+    isQrHardwareWallet,
+    strategy.isSendFlow,
+    completeSignedFlow,
+  ]);
 
   // ── Initial submit (first Waiting) ───────────────────────────────
   useEffect(() => {
@@ -225,15 +322,15 @@ export function useHwSwapLifecycle({
 
     hasInitialSubmissionRef.current = true;
 
-    // Race closure: if all steps were already signed before this effect ran
-    // (e.g., remount mid-flow), the all-steps-signed effect above returned
-    // early because the flag was false. Re-check here and navigate straight
-    // to success instead of submitting a no-op.
+    // Never resubmit a remounted flow whose signing steps already completed.
     if (allStepsSigned) {
       completeSignedFlow();
       return;
     }
 
+    if (!strategy.isSendFlow) {
+      didStartBridgeSubmitRef.current = true;
+    }
     submitWithDeviceReady();
   }, [
     progress.currentStep,
@@ -312,6 +409,9 @@ export function useHwSwapLifecycle({
 
       submissionGenerationRef.current += 1;
       hasInitialSubmissionRef.current = true;
+      if (!strategy.isSendFlow) {
+        didStartBridgeSubmitRef.current = true;
+      }
       dispatch(
         updateHardwareWalletsSwaps({
           type: HardwareWalletsSwapsEventType.Retry,
@@ -335,6 +435,7 @@ export function useHwSwapLifecycle({
     resetHandledError,
     canRetry,
     retryFallback,
+    strategy.isSendFlow,
   ]);
 
   const handleTryAgain = useCallback(
@@ -348,10 +449,22 @@ export function useHwSwapLifecycle({
   );
 
   const handleDone = useCallback(() => {
+    if (!strategy.isSendFlow) {
+      // Do not let Done bypass Bridge settlement and post-trade navigation.
+      completeSignedFlow();
+      return;
+    }
+
     clearCachedSubmission();
     dispatch(resetHardwareWalletsSwaps());
     navigation.navigate(Routes.TRANSACTIONS_VIEW);
-  }, [dispatch, navigation, clearCachedSubmission]);
+  }, [
+    clearCachedSubmission,
+    completeSignedFlow,
+    dispatch,
+    navigation,
+    strategy.isSendFlow,
+  ]);
 
   return {
     isRetrying,

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -309,19 +309,9 @@ export function useHwSwapLifecycle({
 
   // ── Initial submit (first Waiting) ───────────────────────────────
   useEffect(() => {
+    if (progress.status !== HardwareWalletsSwapsStatus.Waiting) return;
     if (hasInitialSubmissionRef.current) return;
     if (hasAutoNavigatedRef.current) return;
-
-    // Remount with signing already finished (Waiting or Submitted): complete
-    // without resubmitting. Must run before the Waiting-only submit gate —
-    // Submitted remounts never enter that path otherwise.
-    if (allStepsSigned) {
-      hasInitialSubmissionRef.current = true;
-      completeSignedFlow();
-      return;
-    }
-
-    if (progress.status !== HardwareWalletsSwapsStatus.Waiting) return;
     // Bridge gates on cached params; send flow validates inside submitWithDeviceReady.
     if (!strategy.isSendFlow && !canRetry()) {
       dispatch(
@@ -333,6 +323,12 @@ export function useHwSwapLifecycle({
     }
 
     hasInitialSubmissionRef.current = true;
+
+    // Never resubmit a remounted flow whose signing steps already completed.
+    if (allStepsSigned) {
+      completeSignedFlow();
+      return;
+    }
 
     if (!strategy.isSendFlow) {
       didStartBridgeSubmitRef.current = true;

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation, useIsFocused } from '@react-navigation/native';
-import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+import type { AppStackNavigationProp } from '../../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
 
 import Routes from '../../../../constants/navigation/Routes';
@@ -102,7 +102,7 @@ export function useHwSwapLifecycle({
   isQrHardwareWallet,
 }: UseHwSwapLifecycleInputs) {
   const dispatch = useDispatch();
-  const navigation = useNavigation<AppNavigationProp>();
+  const navigation = useNavigation<AppStackNavigationProp>();
   const isFocused = useIsFocused();
   const toastRef = useContext(ToastContext)?.toastRef;
 

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -208,19 +208,21 @@ export function useHwSwapLifecycle({
   const completeSignedFlow = useCallback(() => {
     if (hasAutoNavigatedRef.current) return;
 
-    if (strategy.isSendFlow) {
+    const completeWithoutModal = () => {
       hasAutoNavigatedRef.current = true;
       clearCachedSubmission();
       completeHwSwapSuccess({ dispatch, navigation, toastRef });
+    };
+
+    if (strategy.isSendFlow) {
+      completeWithoutModal();
       return;
     }
 
     if (submittedTransaction === null) {
       if (didStartBridgeSubmitRef.current) return;
       // Remount has no local submission metadata; preserve legacy completion.
-      hasAutoNavigatedRef.current = true;
-      clearCachedSubmission();
-      completeHwSwapSuccess({ dispatch, navigation, toastRef });
+      completeWithoutModal();
       return;
     }
     if (
@@ -449,22 +451,10 @@ export function useHwSwapLifecycle({
   );
 
   const handleDone = useCallback(() => {
-    if (!strategy.isSendFlow) {
-      // Do not let Done bypass Bridge settlement and post-trade navigation.
-      completeSignedFlow();
-      return;
-    }
-
     clearCachedSubmission();
     dispatch(resetHardwareWalletsSwaps());
     navigation.navigate(Routes.TRANSACTIONS_VIEW);
-  }, [
-    clearCachedSubmission,
-    completeSignedFlow,
-    dispatch,
-    navigation,
-    strategy.isSendFlow,
-  ]);
+  }, [dispatch, navigation, clearCachedSubmission]);
 
   return {
     isRetrying,

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -309,9 +309,19 @@ export function useHwSwapLifecycle({
 
   // ── Initial submit (first Waiting) ───────────────────────────────
   useEffect(() => {
-    if (progress.status !== HardwareWalletsSwapsStatus.Waiting) return;
     if (hasInitialSubmissionRef.current) return;
     if (hasAutoNavigatedRef.current) return;
+
+    // Remount with signing already finished (Waiting or Submitted): complete
+    // without resubmitting. Must run before the Waiting-only submit gate —
+    // Submitted remounts never enter that path otherwise.
+    if (allStepsSigned) {
+      hasInitialSubmissionRef.current = true;
+      completeSignedFlow();
+      return;
+    }
+
+    if (progress.status !== HardwareWalletsSwapsStatus.Waiting) return;
     // Bridge gates on cached params; send flow validates inside submitWithDeviceReady.
     if (!strategy.isSendFlow && !canRetry()) {
       dispatch(
@@ -323,12 +333,6 @@ export function useHwSwapLifecycle({
     }
 
     hasInitialSubmissionRef.current = true;
-
-    // Never resubmit a remounted flow whose signing steps already completed.
-    if (allStepsSigned) {
-      completeSignedFlow();
-      return;
-    }
 
     if (!strategy.isSendFlow) {
       didStartBridgeSubmitRef.current = true;


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Hardware Bridge swaps stopped opening the post-trade modal after the software graduation path landed in #31688. HW completion kept navigating to Activity with a toast instead of the modal.

This restores HW Bridge post-trade by:
- Carrying source/dest token and amount context on existing HW `submissionParams`
- Capturing Bridge submit settlement (`id`/`hash`) and waiting for it before opening the modal
- Registering the HW Bridge screen as a post-trade notification surface while focused
- Keeping Send QR scanner-owned completion (`completeOnScan`) and Send toast + Activity behavior
- Deferring QR Bridge modal navigation until the scanner return `transitionEnd` to avoid Android view-insert races
- Falling back to legacy toast + Activity on remount when settlement metadata is unavailable

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed hardware wallet Bridge swaps not opening the post-trade modal after completion

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SWAPS-4831

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Hardware wallet Bridge post-trade modal

  Background:
    Given I am logged into MetaMask Mobile with a hardware wallet account
    And Bridge is available for that account

  Scenario: Ledger Bridge swap opens post-trade modal
    Given I am on the Bridge screen with a valid quote
    When I confirm the Bridge swap
    And I complete all Ledger signing steps
    Then the post-trade modal should open with the submitted transaction
    And I should not see only the Activity toast path for Bridge

  Scenario: QR Bridge swap opens post-trade after final scan return
    Given I am completing a Bridge swap with a QR hardware wallet
    When I complete the final QR signature scan
    And the scanner returns to the HW progress screen
    Then the post-trade modal should open after the return transition
    And the modal should include transaction id/hash context

  Scenario: Send QR final scan keeps Activity completion
    Given I am completing a Send flow with a QR hardware wallet
    When I complete the final QR signature scan
    Then I should see the submitted toast
    And I should navigate to Activity
    And the post-trade modal should not open
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes navigation, timing, and completion paths across Bridge vs Send HW flows; QR transition gating and remount fallbacks need careful regression on Android and Ledger/QR devices.
> 
> **Overview**
> **Hardware Bridge swaps** again open the **post-trade modal** instead of only toast + Activity after HW signing completes.
> 
> `useBridgeConfirm` now passes **`postTradeModalParams`** (amounts and tokens) on HW `submissionParams`. The HW lifecycle **waits for `submitBridgeTx` settlement** (`submittedTransaction`), **suppresses duplicate post-trade notifications** during submit, and registers a **notification surface** while the HW Bridge screen is focused. On success it resets bridge state, navigates to **Bridge view**, then opens **`POST_TRADE_MODAL`** with transaction id/hash—matching the software path.
> 
> **QR Bridge** no longer finishes on the last scan in `HwQrScanner`; it **`goBack()`**s so completion runs on the progress screen. Modal navigation waits for the scanner return **`transitionEnd`** to avoid Android view-insert races. **Send QR** keeps scanner-owned completion via optional **`completeOnScan`**.
> 
> **Remount** with already-signed steps and no local submit metadata still falls back to **legacy toast + Activity** and does not resubmit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8712054d78676f6b4f089f1c3de6e2e59a2f52d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->