### PR TITLE
test: ActivityScreen empty-state component view coverage (MMQA-2079)

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -265,9 +265,17 @@ describeForPlatforms('ActivityScreen — empty state', () => {
       'activity_view.empty_state.transactions_unfunded.action',
     );
 
-    const { findByTestId, findByText } = renderActivityScreenViewWithRoutes({
-      state: emptyActivityStateWithGeo().build(),
-      extraRoutes: [{ name: Routes.RAMP.TOKEN_SELECTION }],
+    const { getAllByText, findByTestId, findByText } =
+      renderActivityScreenViewWithRoutes({
+        state: emptyActivityStateWithGeo().build(),
+        extraRoutes: [{ name: Routes.RAMP.TOKEN_SELECTION }],
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
+          .length,
+      ).toBeGreaterThan(0);
     });
 
     expect(
@@ -313,7 +321,7 @@ describeForPlatforms('ActivityScreen — empty state', () => {
     );
     const addFundsLabel = strings('activity_view.empty_state.buy_sell.action');
 
-    const { getByTestId, findByTestId, findByText } =
+    const { getByTestId, getAllByText, findByTestId, findByText } =
       renderActivityScreenViewWithRoutes({
         state: emptyActivityStateWithGeo().build(),
         extraRoutes: [{ name: Routes.RAMP.TOKEN_SELECTION }],
@@ -323,6 +331,13 @@ describeForPlatforms('ActivityScreen — empty state', () => {
     fireEvent.press(
       await findByTestId(optionTestId(ActivityTypeFilter.BuySell)),
     );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.BuySell))
+          .length,
+      ).toBeGreaterThan(0);
+    });
 
     expect(
       await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),

--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -307,7 +307,7 @@ describeForPlatforms('ActivityScreen — empty state', () => {
     ).toBeOnTheScreen();
   });
 
-  it('shows Buy/Sell empty state and Add funds opens ramp token selection', async () => {
+  it('shows unfunded Buy/Sell empty state and Add funds opens ramp token selection', async () => {
     const buySellDescription = strings(
       'activity_view.empty_state.buy_sell.description',
     );

--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -8,12 +8,22 @@ import {
   renderActivityScreenView,
   renderActivityScreenViewWithRoutes,
 } from '../../../../tests/component-view/renderers/activity';
-import { activityLineaNetworkOverride } from '../../../../tests/component-view/presets/activity';
+import {
+  ACTIVITY_CV_ACCOUNT,
+  activityLineaNetworkOverride,
+  initialStateActivityWithAccountsApi,
+} from '../../../../tests/component-view/presets/activity';
+import {
+  clearAccountsTransactionsApiMocks,
+  setupAccountsTransactionsApiMock,
+} from '../../../../tests/component-view/api-mocking/accounts-transactions';
 import { strings } from '../../../../locales/i18n';
 import { ActivityScreenSelectorsIDs } from './ActivityScreen.testIds';
 import { ACTIVITY_TYPE_FILTER_LABEL_KEY } from './components/ActivityTypeFilterSheet';
 import { PERPS_ACTIVITY_FILTER_LABEL_KEY } from './components/PerpsActivityFilterSheet';
 import { ActivityTypeFilter, PerpsActivityFilter } from './types';
+
+const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
 const optionTestId = (filter: ActivityTypeFilter) =>
   `${ActivityScreenSelectorsIDs.TYPE_FILTER_OPTION_PREFIX}${filter}`;
@@ -27,6 +37,34 @@ const selectedTypeFilterLabel = (filter: ActivityTypeFilter) =>
 
 const perpsFilterLabel = (filter: PerpsActivityFilter) =>
   strings(PERPS_ACTIVITY_FILTER_LABEL_KEY[filter]);
+
+const emptyActivityStateWithGeo = () =>
+  initialStateActivityWithAccountsApi().withOverrides({
+    engine: {
+      backgroundState: {
+        GeolocationController: {
+          location: 'us-ca',
+        },
+      },
+    },
+  } as never);
+
+const emptyActivityStateFunded = () =>
+  initialStateActivityWithAccountsApi().withOverrides({
+    engine: {
+      backgroundState: {
+        TokenBalancesController: {
+          tokenBalances: {
+            [ACTIVITY_CV_ACCOUNT]: {
+              '0x1': {
+                [USDC_MAINNET]: '0x5f5e100', // 100 USDC
+              },
+            },
+          },
+        },
+      },
+    },
+  } as never);
 
 describeForPlatforms('ActivityScreen', () => {
   it('updates the selected type filter through the real screen controls', async () => {
@@ -206,6 +244,191 @@ describeForPlatforms('ActivityScreen', () => {
 
     expect(
       await findByTestId(getRouteProbeTestId(Routes.HOME_TABS)),
+    ).toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — empty state', () => {
+  beforeEach(() => {
+    setupAccountsTransactionsApiMock([]);
+  });
+
+  afterEach(() => {
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows unfunded Transactions empty state and Add funds opens ramp token selection', async () => {
+    const unfundedDescription = strings(
+      'activity_view.empty_state.transactions_unfunded.description',
+    );
+    const addFundsLabel = strings(
+      'activity_view.empty_state.transactions_unfunded.action',
+    );
+
+    const { findByTestId, findByText } = renderActivityScreenViewWithRoutes({
+      state: emptyActivityStateWithGeo().build(),
+      extraRoutes: [{ name: Routes.RAMP.TOKEN_SELECTION }],
+    });
+
+    expect(
+      await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),
+    ).toBeOnTheScreen();
+    expect(await findByText(unfundedDescription)).toBeOnTheScreen();
+
+    fireEvent.press(await findByText(addFundsLabel));
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.RAMP.TOKEN_SELECTION)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows funded Transactions empty state and Swap tokens opens bridge', async () => {
+    const fundedDescription = strings(
+      'activity_view.empty_state.transactions_funded.description',
+    );
+    const swapTokensLabel = strings(
+      'activity_view.empty_state.transactions_funded.action',
+    );
+
+    const { findByTestId, findByText } = renderActivityScreenViewWithRoutes({
+      state: emptyActivityStateFunded().build(),
+      extraRoutes: [{ name: Routes.BRIDGE.ROOT }],
+    });
+
+    expect(
+      await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),
+    ).toBeOnTheScreen();
+    expect(await findByText(fundedDescription)).toBeOnTheScreen();
+
+    fireEvent.press(await findByText(swapTokensLabel));
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.BRIDGE.ROOT)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Buy/Sell empty state and Add funds opens ramp token selection', async () => {
+    const buySellDescription = strings(
+      'activity_view.empty_state.buy_sell.description',
+    );
+    const addFundsLabel = strings('activity_view.empty_state.buy_sell.action');
+
+    const { getByTestId, findByTestId, findByText } =
+      renderActivityScreenViewWithRoutes({
+        state: emptyActivityStateWithGeo().build(),
+        extraRoutes: [{ name: Routes.RAMP.TOKEN_SELECTION }],
+      });
+
+    fireEvent.press(getByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP));
+    fireEvent.press(
+      await findByTestId(optionTestId(ActivityTypeFilter.BuySell)),
+    );
+
+    expect(
+      await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),
+    ).toBeOnTheScreen();
+    expect(await findByText(buySellDescription)).toBeOnTheScreen();
+
+    fireEvent.press(await findByText(addFundsLabel));
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.RAMP.TOKEN_SELECTION)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Make a prediction CTA on the Predictions empty state', async () => {
+    const makePredictionLabel = strings(
+      'activity_view.empty_state.predictions.action',
+    );
+    const state = initialStateActivityWithAccountsApi()
+      .withRemoteFeatureFlags({
+        predictTradingEnabled: {
+          enabled: true,
+          minimumVersion: '0.0.0',
+        },
+      })
+      .build();
+
+    const { getByTestId, findByTestId, findByText } = renderActivityScreenView({
+      state,
+    });
+
+    fireEvent.press(getByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP));
+    fireEvent.press(
+      await findByTestId(optionTestId(ActivityTypeFilter.Predictions)),
+    );
+
+    expect(
+      await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),
+    ).toBeOnTheScreen();
+    expect(await findByText(makePredictionLabel)).toBeOnTheScreen();
+  });
+
+  it('shows Perps empty state and Browse markets opens perps market list', async () => {
+    const browseMarketsLabel = strings(
+      'activity_view.empty_state.perps.action',
+    );
+    const perpsDescription = strings(
+      'activity_view.empty_state.perps.description',
+    );
+    // Keep Perps disabled so the list does not mount PerpsActivitySource /
+    // connection providers (which can stay loading). Empty CTA still resolves
+    // from typeFilter alone.
+    const state = initialStateActivityWithAccountsApi()
+      .withRemoteFeatureFlags({
+        perpsPerpTradingEnabled: {
+          enabled: false,
+          minimumVersion: '0.0.0',
+        },
+      })
+      .build();
+
+    const { getByTestId, findByTestId, findByText } =
+      renderActivityScreenViewWithRoutes({
+        state,
+        extraRoutes: [{ name: Routes.PERPS.ROOT }],
+      });
+
+    fireEvent.press(getByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP));
+    fireEvent.press(await findByTestId(optionTestId(ActivityTypeFilter.Perps)));
+
+    // Wait for Perps-specific copy — EMPTY_STATE may still be the prior
+    // Transactions empty until the filter re-render settles.
+    expect(await findByText(perpsDescription)).toBeOnTheScreen();
+    expect(await findByText(browseMarketsLabel)).toBeOnTheScreen();
+
+    fireEvent.press(await findByText(browseMarketsLabel));
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Card empty state and Open MetaMask Card opens card home', async () => {
+    const openCardLabel = strings(
+      'activity_view.empty_state.metamask_card.action',
+    );
+
+    const { getByTestId, findByTestId, findByText } =
+      renderActivityScreenViewWithRoutes({
+        state: initialStateActivityWithAccountsApi().build(),
+        extraRoutes: [{ name: Routes.CARD.ROOT }],
+      });
+
+    fireEvent.press(getByTestId(ActivityScreenSelectorsIDs.TYPE_FILTER_CHIP));
+    fireEvent.press(
+      await findByTestId(optionTestId(ActivityTypeFilter.MetamaskCard)),
+    );
+
+    expect(
+      await findByTestId(ActivityScreenSelectorsIDs.EMPTY_STATE),
+    ).toBeOnTheScreen();
+    expect(await findByText(openCardLabel)).toBeOnTheScreen();
+
+    fireEvent.press(await findByText(openCardLabel));
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.CARD.ROOT)),
     ).toBeOnTheScreen();
   });
 });


### PR DESCRIPTION
## Summary
- Adds component view tests for Activity redesign empty states in `ActivityScreen.view.test.tsx` (MMQA-2079).
- Covers unfunded/funded Transactions, Buy/Sell, Predictions, Perps, and Card empty CTAs, asserting copy and navigation via route probes (not full destination screens).
- Funded Buy/Sell (“Browse tokens”) and funded Card (“Transfer funds” → Money) deferred until product empty-state support lands.

## Test plan
- [x] `yarn jest -c jest.config.view.js app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx -t "ActivityScreen — empty state" --runInBand --coverage=false`
- [x] Confirm all empty-state cases pass on iOS and Android (`describeForPlatforms`)
- [x] Confirm no forbidden `jest.mock` in the view test (Engine/native only via component-view framework)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; low risk aside from possible CI flakiness from async empty-state rendering.
> 
> **Overview**
> Adds a new **`ActivityScreen — empty state`** `describeForPlatforms` block in `ActivityScreen.view.test.tsx` with component-view coverage for Activity redesign empty states (MMQA-2079).
> 
> Tests mock an empty accounts/transactions API and use preset helpers for **unfunded** (geo) vs **funded** (USDC balance) wallet state. They assert localized empty-state copy, `EMPTY_STATE` visibility, and that primary CTAs navigate to the expected routes via **route probes** (ramp token selection, bridge, perps root, card home)—not full destination screens.
> 
> Coverage spans **Transactions** (unfunded Add funds / funded Swap tokens), **Buy/Sell** (unfunded Add funds), **Predictions** (Make a prediction CTA with `predictTradingEnabled`), **Perps** (Browse markets with perps trading disabled to avoid loading providers), and **MetaMask Card** (Open Card). Feature-flag and filter-chip interactions are included where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358e245dc24702c2b60fda5faa621b22ce80cfd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->