### PR TITLE
fix(ci): re-run PR size check on base retarget

### DIFF
--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -10,10 +10,6 @@ permissions:
 
 jobs:
   check-pr-max-lines:
-    # Always recompute on every trigger, including title/body edits. A job-level
-    # `if` here would post a `skipped` check run for the same head SHA, which
-    # GitHub treats as the latest (authoritative) status and can silently clear
-    # a prior oversized-PR failure. Recomputing is cheap and always accurate.
     runs-on: ubuntu-latest
     steps:
       - name: Check PR lines changed

--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -10,9 +10,10 @@ permissions:
 
 jobs:
   check-pr-max-lines:
-    # Re-run on base retargets (e.g. unstacking a PR onto main), but skip
-    # re-runs for unrelated edits (title/body) which don't affect the diff.
-    if: github.event.action != 'edited' || github.event.changes.base != null
+    # Always recompute on every trigger, including title/body edits. A job-level
+    # `if` here would post a `skipped` check run for the same head SHA, which
+    # GitHub treats as the latest (authoritative) status and can silently clear
+    # a prior oversized-PR failure. Recomputing is cheap and always accurate.
     runs-on: ubuntu-latest
     steps:
       - name: Check PR lines changed

--- a/.github/workflows/check-pr-max-lines.yml
+++ b/.github/workflows/check-pr-max-lines.yml
@@ -2,7 +2,7 @@ name: 'Check PR Max Lines'
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
 
 permissions:
   contents: read
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   check-pr-max-lines:
+    # Re-run on base retargets (e.g. unstacking a PR onto main), but skip
+    # re-runs for unrelated edits (title/body) which don't affect the diff.
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - name: Check PR lines changed


### PR DESCRIPTION
## **Description**

`check-pr-max-lines` could report a stale/incorrect size label (e.g. `size-XL`) after a stacked PR was rebased onto `main` and its base branch retargeted. The workflow only re-ran on `opened | reopened | synchronize`, so a base change alone never triggered a fresh check against the new base.

This adds `edited` to the `pull_request` trigger types, gated so the job only re-runs for base-branch edits (`github.event.changes.base != null`), not unrelated title/body edits.

Related fix in the shared `pr-line-check` action (resolves the live PR base instead of trusting the webhook payload): https://github.com/MetaMask/github-tools/pull/273

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: [MCWP-747](https://consensyssoftware.atlassian.net/browse/MCWP-747)

## **Manual testing steps**

```gherkin
Feature: PR size check re-runs on base retarget

  Scenario: a stacked PR is rebased onto main and its base is retargeted
    Given a PR is stacked on another branch and the size check has already passed
    When the PR head is rebased onto main and the PR base is retargeted to main
    Then the check-pr-max-lines check re-runs and reports the correct size label against main
```

## **Screenshots/Recordings**

N/A - CI workflow change, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A - CI workflow-only change, no app runtime impact.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MCWP-747]: https://consensyssoftware.atlassian.net/browse/MCWP-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no app, auth, or data impact; `edited` may also run the job on title/body edits.
> 
> **Overview**
> **`check-pr-max-lines`** now listens for **`pull_request` `edited`** in addition to `opened`, `reopened`, and `synchronize`.
> 
> That lets the shared **`pr-line-check`** action run again when a PR is updated without a new push—e.g. after **retargeting the base branch** following a rebase—so size labels reflect the diff against the current base instead of staying stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756f1cf7820bcc5067c2594d83b7891007eba823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->