### PR TITLE
test(e2e): share Android WebView helpers via multi-platform WebView API

### DIFF
--- a/tests/framework/AndroidWebViewNative.ts
+++ b/tests/framework/AndroidWebViewNative.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import-x/no-nodejs-modules */
 import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/BrowserView.testIds';
 import { wrapElement, type PlaywrightElement } from './PlaywrightAdapter';
+import PlaywrightContextHelpers from './PlaywrightContextHelpers';
 import { getDriver } from './PlaywrightUtilities';
 import PlaywrightGestures from './PlaywrightGestures';
 import { sleep } from './Utilities';
@@ -160,11 +161,15 @@ async function scrollNativeWebIdIntoViewViaScrollGesture(
 /**
  * Scroll an Android WebView accessibility node (resource-id) into view.
  * Prefer this over Chromedriver WebView context on CI where context switching flakes.
+ * Always switches to NATIVE_APP first so UiAutomator works even if a prior step
+ * left the session in a WEBVIEW context.
  */
 export async function scrollAndroidWebIdIntoView(
   webId: string,
   options: AndroidWebViewScrollOptions = {},
 ): Promise<PlaywrightElement> {
+  await PlaywrightContextHelpers.switchToNativeContext();
+
   // Generous in-place wait: nodes often appear in the current viewport, and a
   // UiScrollable sweep from the top is far costlier than waiting a few seconds.
   const alreadyVisible = await tryFindNativeWebIdElement(

--- a/tests/framework/AndroidWebViewNative.ts
+++ b/tests/framework/AndroidWebViewNative.ts
@@ -3,7 +3,7 @@ import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/B
 import { wrapElement, type PlaywrightElement } from './PlaywrightAdapter';
 import { getDriver } from './PlaywrightUtilities';
 import PlaywrightGestures from './PlaywrightGestures';
-import Utilities, { sleep } from './Utilities';
+import { sleep } from './Utilities';
 import { createPlaywrightLogger } from './playwrightLogger';
 
 const logger = createPlaywrightLogger('AndroidWebViewNative');
@@ -194,10 +194,7 @@ export async function tapAndroidWebId(
   const description =
     options.description ?? `Android native WebView tap: ${webId}`;
   logger.debug(description);
-  // Retry click to handle transient post-scroll interactability issues.
-  await Utilities.executeWithRetry(async () => elem.click(), {
-    description,
-  });
+  await PlaywrightGestures.waitAndTap(elem);
 }
 
 /**

--- a/tests/framework/AndroidWebViewNative.ts
+++ b/tests/framework/AndroidWebViewNative.ts
@@ -1,8 +1,6 @@
 /* eslint-disable import-x/no-nodejs-modules */
 import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/BrowserView.testIds';
-import type { EncapsulatedElementType } from './EncapsulatedElement';
 import { wrapElement, type PlaywrightElement } from './PlaywrightAdapter';
-import Gestures from './Gestures';
 import { getDriver } from './PlaywrightUtilities';
 import PlaywrightGestures from './PlaywrightGestures';
 import { sleep } from './Utilities';
@@ -19,12 +17,12 @@ export interface AndroidWebViewScrollOptions {
   scrollLabels?: Record<string, string>;
 }
 
+export type AndroidWebViewTapOptions = AndroidWebViewScrollOptions & {
+  description?: string;
+};
+
 function escapeUiAutomatorString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-
-function asEncapsulated(elem: PlaywrightElement): EncapsulatedElementType {
-  return elem as unknown as EncapsulatedElementType;
 }
 
 async function findNativeWebIdElement(
@@ -190,13 +188,13 @@ export async function scrollAndroidWebIdIntoView(
 
 export async function tapAndroidWebId(
   webId: string,
-  options: AndroidWebViewScrollOptions & { description?: string } = {},
+  options: AndroidWebViewTapOptions = {},
 ): Promise<void> {
   const elem = await scrollAndroidWebIdIntoView(webId, options);
-  await Gestures.tap(asEncapsulated(elem), {
-    elemDescription:
-      options.description ?? `Android native WebView tap: ${webId}`,
-  });
+  logger.debug(options.description ?? `Android native WebView tap: ${webId}`);
+  // Avoid importing Gestures here — Gestures re-exports these helpers and that
+  // would create a circular dependency.
+  await elem.click();
 }
 
 /**

--- a/tests/framework/AndroidWebViewNative.ts
+++ b/tests/framework/AndroidWebViewNative.ts
@@ -3,7 +3,7 @@ import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/B
 import { wrapElement, type PlaywrightElement } from './PlaywrightAdapter';
 import { getDriver } from './PlaywrightUtilities';
 import PlaywrightGestures from './PlaywrightGestures';
-import { sleep } from './Utilities';
+import Utilities, { sleep } from './Utilities';
 import { createPlaywrightLogger } from './playwrightLogger';
 
 const logger = createPlaywrightLogger('AndroidWebViewNative');
@@ -191,10 +191,13 @@ export async function tapAndroidWebId(
   options: AndroidWebViewTapOptions = {},
 ): Promise<void> {
   const elem = await scrollAndroidWebIdIntoView(webId, options);
-  logger.debug(options.description ?? `Android native WebView tap: ${webId}`);
-  // Avoid importing Gestures here — Gestures re-exports these helpers and that
-  // would create a circular dependency.
-  await elem.click();
+  const description =
+    options.description ?? `Android native WebView tap: ${webId}`;
+  logger.debug(description);
+  // Retry click to handle transient post-scroll interactability issues.
+  await Utilities.executeWithRetry(async () => elem.click(), {
+    description,
+  });
 }
 
 /**

--- a/tests/framework/WebView.ts
+++ b/tests/framework/WebView.ts
@@ -11,7 +11,6 @@ import { FrameworkDetector } from './FrameworkDetector.ts';
 import Gestures from './Gestures.ts';
 import Matchers from './Matchers.ts';
 import { type PlaywrightElement } from './PlaywrightAdapter.ts';
-import PlaywrightContextHelpers from './PlaywrightContextHelpers.ts';
 import PlaywrightWebMatchers from './PlaywrightWebMatchers.ts';
 import { PlatformDetector } from './PlatformLocator.ts';
 
@@ -35,19 +34,15 @@ export type { AndroidWebViewScrollOptions, AndroidWebViewTapOptions };
 export default class WebView {
   /**
    * Run an action in the appropriate WebView context for the current framework.
-   * Android Appium stays in native context; iOS Appium switches into the page;
-   * Detox runs the action as-is.
+   *
+   * Used by iOS Appium (switches into the page) and Detox (runs as-is).
+   * Android Appium callers must use the native UiAutomator helpers instead —
+   * public methods early-return before invoking this.
    */
   static async withContext(
     pageUrl: string | undefined,
     action: () => Promise<void>,
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await PlaywrightContextHelpers.switchToNativeContext();
-      await action();
-      return;
-    }
-
     if (FrameworkDetector.isAppium()) {
       if (!pageUrl) {
         throw new Error(

--- a/tests/framework/WebView.ts
+++ b/tests/framework/WebView.ts
@@ -1,0 +1,151 @@
+import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/BrowserView.testIds';
+import {
+  fillAndroidWebId,
+  readAndroidWebIdText,
+  scrollAndroidWebIdIntoView,
+  tapAndroidWebId,
+  type AndroidWebViewScrollOptions,
+  type AndroidWebViewTapOptions,
+} from './AndroidWebViewNative.ts';
+import { FrameworkDetector } from './FrameworkDetector.ts';
+import Gestures from './Gestures.ts';
+import Matchers from './Matchers.ts';
+import { type PlaywrightElement } from './PlaywrightAdapter.ts';
+import PlaywrightContextHelpers from './PlaywrightContextHelpers.ts';
+import PlaywrightWebMatchers from './PlaywrightWebMatchers.ts';
+import { PlatformDetector } from './PlatformLocator.ts';
+
+export type WebViewByIdOptions = AndroidWebViewScrollOptions & {
+  /** Required for Appium Chromedriver / iOS WebView context lookups. */
+  pageUrl?: string;
+  /** Native WebView container testID. Defaults to the in-app browser WebView. */
+  webviewId?: string;
+  description?: string;
+};
+
+export type { AndroidWebViewScrollOptions, AndroidWebViewTapOptions };
+
+/**
+ * Multi-platform WebView interaction by HTML id.
+ *
+ * Android Appium uses native UiAutomator (`AndroidWebViewNative`) to avoid
+ * Chromedriver context flakes. iOS Appium and Detox use the existing web-context
+ * element path + Gestures.
+ */
+export default class WebView {
+  /**
+   * Run an action in the appropriate WebView context for the current framework.
+   * Android Appium stays in native context; iOS Appium switches into the page;
+   * Detox runs the action as-is.
+   */
+  static async withContext(
+    pageUrl: string | undefined,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    if (PlatformDetector.isAndroidAppium()) {
+      await PlaywrightContextHelpers.switchToNativeContext();
+      await action();
+      return;
+    }
+
+    if (FrameworkDetector.isAppium()) {
+      if (!pageUrl) {
+        throw new Error(
+          'pageUrl is required for Appium WebView context actions',
+        );
+      }
+      await PlaywrightWebMatchers.withWebViewAction(pageUrl, action);
+      return;
+    }
+
+    await action();
+  }
+
+  static async tapById(
+    webId: string,
+    options: WebViewByIdOptions = {},
+  ): Promise<void> {
+    if (PlatformDetector.isAndroidAppium()) {
+      await tapAndroidWebId(webId, options);
+      return;
+    }
+
+    await this.withContext(options.pageUrl, async () => {
+      const webElement = await this.getElementById(webId, options);
+      await Gestures.scrollToWebViewPort(webElement);
+      await Gestures.tap(webElement, {
+        elemDescription: options.description ?? `WebView tapById: ${webId}`,
+      });
+    });
+  }
+
+  static async fillById(
+    webId: string,
+    value: string,
+    options: WebViewByIdOptions = {},
+  ): Promise<void> {
+    if (PlatformDetector.isAndroidAppium()) {
+      await fillAndroidWebId(webId, value, options);
+      return;
+    }
+
+    await this.withContext(options.pageUrl, async () => {
+      const webElement = await this.getElementById(webId, options);
+      await Gestures.typeInWebElement(webElement, value);
+    });
+  }
+
+  static async readTextById(
+    webId: string,
+    options: WebViewByIdOptions = {},
+  ): Promise<string> {
+    if (PlatformDetector.isAndroidAppium()) {
+      return readAndroidWebIdText(webId, options);
+    }
+
+    let text = '';
+    await this.withContext(options.pageUrl, async () => {
+      const webElement = await this.getElementById(webId, options);
+      text = await webElement.getText();
+    });
+    return text;
+  }
+
+  static async scrollIntoView(
+    webId: string,
+    options: WebViewByIdOptions = {},
+  ): Promise<PlaywrightElement | WebElement> {
+    if (PlatformDetector.isAndroidAppium()) {
+      return scrollAndroidWebIdIntoView(webId, options);
+    }
+
+    let webElement: PlaywrightElement | WebElement | undefined;
+    await this.withContext(options.pageUrl, async () => {
+      webElement = await this.getElementById(webId, options);
+      await Gestures.scrollToWebViewPort(webElement);
+    });
+    if (!webElement) {
+      throw new Error(`WebView.scrollIntoView failed for id "${webId}"`);
+    }
+    return webElement;
+  }
+
+  private static async getElementById(
+    webId: string,
+    options: WebViewByIdOptions,
+  ): Promise<PlaywrightElement | WebElement> {
+    const webviewId =
+      options.webviewId ?? BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID;
+
+    if (FrameworkDetector.isAppium()) {
+      if (!options.pageUrl) {
+        throw new Error(
+          'pageUrl is required for Appium WebView element lookup',
+        );
+      }
+      return Matchers.getElementByWebID(webviewId, webId, options.pageUrl);
+    }
+
+    return Matchers.getElementByWebID(webviewId, webId);
+  }
+}

--- a/tests/framework/WebView.ts
+++ b/tests/framework/WebView.ts
@@ -121,8 +121,9 @@ export default class WebView {
 
     let webElement: PlaywrightElement | WebElement | undefined;
     await this.withContext(options.pageUrl, async () => {
-      webElement = await this.getElementById(webId, options);
-      await Gestures.scrollToWebViewPort(webElement);
+      const resolved = await this.getElementById(webId, options);
+      await Gestures.scrollToWebViewPort(resolved);
+      webElement = resolved;
     });
     if (!webElement) {
       throw new Error(`WebView.scrollIntoView failed for id "${webId}"`);

--- a/tests/framework/index.ts
+++ b/tests/framework/index.ts
@@ -3,6 +3,12 @@ export { default as Assertions } from './Assertions.ts';
 export { default as Gestures } from './Gestures.ts';
 export { default as Matchers } from './Matchers.ts';
 export { default as Utilities, BASE_DEFAULTS, sleep } from './Utilities.ts';
+export {
+  default as WebView,
+  type AndroidWebViewScrollOptions,
+  type AndroidWebViewTapOptions,
+  type WebViewByIdOptions,
+} from './WebView.ts';
 export { Logger, createLogger, LogLevel, logger } from './logger.ts';
 export { default as PortManager, ResourceType } from './PortManager.ts';
 export * from './types.ts';

--- a/tests/page-objects/Browser/BrowserView.ts
+++ b/tests/page-objects/Browser/BrowserView.ts
@@ -496,8 +496,17 @@ class Browser {
 
   async navigateToURL(
     url: string,
-    options: { skipUrlEditorDismissal?: boolean } = {},
+    options: {
+      skipUrlEditorDismissal?: boolean;
+      closeAllTabsIfOpen?: boolean;
+    } = {},
   ): Promise<void> {
+    // Android Appium accumulates stale WebView tabs that confuse Chromedriver /
+    // native resource-id lookups. Opt in from callers (e.g. Test Snaps).
+    if (options.closeAllTabsIfOpen && PlatformDetector.isAndroidAppium()) {
+      await this.closeAllBrowserTabsIfOpen();
+    }
+
     if (FrameworkDetector.isAppium()) {
       await this.typeUrlAppium(url);
       return;

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -126,6 +126,8 @@ class TestSnaps {
     },
   ): Promise<void> {
     const webId = TestSnapResultSelectorWebIDS[selector];
+    // Normalize quotes for cross-platform compatibility
+    const normalizedExpected = expectedMessage.replace(/^"|"$/g, '');
 
     await Utilities.executeWithRetry(
       async () => {
@@ -133,12 +135,16 @@ class TestSnaps {
           webId,
           TEST_SNAPS_WEBVIEW_OPTIONS,
         );
-        await Assertions.checkIfTextMatches(actualText, expectedMessage);
+        if (!actualText.includes(normalizedExpected)) {
+          throw new Error(
+            `Expected "${webId}" text to contain "${normalizedExpected}", got "${actualText}"`,
+          );
+        }
       },
       {
         timeout: options.timeout ?? 5_000,
         interval: options.interval ?? 100,
-        description: `Assert result "${webId}" equals expected text`,
+        description: `Assert result "${webId}" contains "${normalizedExpected}"`,
       },
     );
   }

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -11,6 +11,7 @@ import {
   NativeDropdownSelectorWebIDS,
   TEST_SNAPS_URL,
 } from '../../selectors/Browser/TestSnaps.selectors';
+import WebView, { type WebViewByIdOptions } from '../../framework/WebView';
 import Gestures from '../../framework/Gestures';
 import { SNAP_INSTALL_CONNECT } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants';
 import { SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants';
@@ -24,22 +25,17 @@ import { waitForTestSnapsToLoad } from '../../flows/browser.flow';
 import { RetryOptions, EncapsulatedElementType } from '../../framework';
 import { FrameworkDetector } from '../../framework/FrameworkDetector';
 import { PlatformDetector } from '../../framework/PlatformLocator';
-import PlaywrightWebMatchers from '../../framework/PlaywrightWebMatchers';
-import PlaywrightContextHelpers from '../../framework/PlaywrightContextHelpers';
-import {
-  assertAndroidTestSnapsClientStatus,
-  assertAndroidTestSnapsJson,
-  assertAndroidTestSnapsJsonExcluding,
-  assertAndroidTestSnapsTextContains,
-  fillAndroidTestSnapsInput,
-  tapAndroidTestSnapsButton,
-} from '../../smoke-appium/snaps/helpers/android-test-snaps-native.helpers';
+import { testSnapsAndroidScrollOptions } from '../../smoke-appium/snaps/helpers/android-test-snaps-native.helpers';
 import { Json } from '@metamask/utils';
 import ToastModal from '../wallet/ToastModal';
 import SolanaTestDApp from './SolanaTestDApp';
 
 export { TEST_SNAPS_URL } from '../../selectors/Browser/TestSnaps.selectors';
 
+const TEST_SNAPS_WEBVIEW_OPTIONS: WebViewByIdOptions = {
+  pageUrl: TEST_SNAPS_URL,
+  ...testSnapsAndroidScrollOptions,
+};
 class TestSnaps {
   get getConnectSnapButton(): EncapsulatedElementType {
     return Matchers.getElementByID(SNAP_INSTALL_CONNECT);
@@ -107,20 +103,6 @@ class TestSnaps {
     return Matchers.getIdentifier('snap-ui-renderer__scrollview');
   }
 
-  private async withWebView(action: () => Promise<void>): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await PlaywrightContextHelpers.switchToNativeContext();
-      await action();
-      return;
-    }
-
-    if (FrameworkDetector.isAppium()) {
-      await PlaywrightWebMatchers.withWebViewAction(TEST_SNAPS_URL, action);
-    } else {
-      await action();
-    }
-  }
-
   private getTestSnapsWebElement(innerID: string) {
     if (FrameworkDetector.isAppium()) {
       return Matchers.getElementByWebID(
@@ -143,25 +125,22 @@ class TestSnaps {
       interval: 100,
     },
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await assertAndroidTestSnapsTextContains(
-        selector,
-        expectedMessage,
-        options,
-      );
-      return;
-    }
+    const webId = TestSnapResultSelectorWebIDS[selector];
 
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS[selector],
-      );
-
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         await Assertions.checkIfTextMatches(actualText, expectedMessage);
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert result "${webId}" equals expected text`,
+      },
+    );
   }
 
   async checkInstalledSnaps(
@@ -186,25 +165,26 @@ class TestSnaps {
       interval: 100,
     },
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await assertAndroidTestSnapsJson(selector, expectedJson, options);
-      return;
-    }
+    const webId = TestSnapResultSelectorWebIDS[selector];
 
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS[selector],
-      );
-
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         await Assertions.checkParsedJsonEqual(
           actualText,
           expectedJson,
           `result span "${selector}"`,
         );
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert JSON result "${webId}"`,
+      },
+    );
   }
 
   async checkResultJsonExcluding(
@@ -216,31 +196,27 @@ class TestSnaps {
       interval: 100,
     },
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await assertAndroidTestSnapsJsonExcluding(
-        selector,
-        excludedKeys,
-        expectedJson,
-        options,
-      );
-      return;
-    }
+    const webId = TestSnapResultSelectorWebIDS[selector];
 
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS[selector],
-      );
-
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         await Assertions.checkParsedJsonEqualExcluding(
           actualText,
           expectedJson,
           excludedKeys,
           `result span "${selector}"`,
         );
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert JSON result "${webId}" excluding ${excludedKeys.join(', ')}`,
+      },
+    );
   }
 
   async checkResultSpanIncludes(
@@ -251,18 +227,24 @@ class TestSnaps {
       interval: 100,
     },
   ): Promise<void> {
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS[selector],
-      );
+    const webId = TestSnapResultSelectorWebIDS[selector];
 
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         if (!actualText.includes(expectedMessage)) {
           throw new Error(`Text did not contain "${expectedMessage}"`);
         }
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert result "${webId}" contains "${expectedMessage}"`,
+      },
+    );
   }
 
   async checkResultSpanNotEmpty(
@@ -272,18 +254,24 @@ class TestSnaps {
       interval: 100,
     },
   ): Promise<void> {
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS[selector],
-      );
+    const webId = TestSnapResultSelectorWebIDS[selector];
 
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         if (!actualText || actualText.trim() === '') {
           throw new Error(`Result span is empty`);
         }
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert result "${webId}" is not empty`,
+      },
+    );
   }
 
   async checkClientStatus(
@@ -296,28 +284,18 @@ class TestSnaps {
       interval: 100,
     },
   ) {
-    if (PlatformDetector.isAndroidAppium()) {
-      await assertAndroidTestSnapsClientStatus(
-        {
-          clientVersion: expectedClientVersion,
-          ...expectedStatus,
-        },
-        options,
-      );
-      return;
-    }
+    const webId = TestSnapResultSelectorWebIDS.clientStatusResultSpan;
 
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapResultSelectorWebIDS.clientStatusResultSpan,
-      );
-
-      return Utilities.executeWithRetry(async () => {
-        const actualText = await webElement.getText();
+    await Utilities.executeWithRetry(
+      async () => {
+        const actualText = await WebView.readTextById(
+          webId,
+          TEST_SNAPS_WEBVIEW_OPTIONS,
+        );
         let actualStatusWithVersion;
         try {
           actualStatusWithVersion = JSON.parse(actualText);
-        } catch (error) {
+        } catch {
           throw new Error(
             `Failed to parse JSON from client status span: ${actualText}`,
           );
@@ -327,55 +305,48 @@ class TestSnaps {
           actualStatusWithVersion;
 
         await Assertions.checkIfJsonEqual(actualStatus, expectedStatus);
-        if (!actualClientVersion.startsWith(expectedClientVersion)) {
+        if (
+          typeof expectedClientVersion !== 'string' ||
+          typeof actualClientVersion !== 'string' ||
+          !actualClientVersion.startsWith(expectedClientVersion)
+        ) {
           throw new Error(
-            `Client version mismatch: Expected version to start with "${expectedClientVersion}", got "${actualClientVersion}".`,
+            `Client version mismatch: Expected version to start with "${String(
+              expectedClientVersion,
+            )}", got "${String(actualClientVersion)}".`,
           );
         }
-      }, options);
-    });
+      },
+      {
+        timeout: options.timeout ?? 5_000,
+        interval: options.interval ?? 100,
+        description: `Assert client status JSON "${webId}"`,
+      },
+    );
   }
 
   async navigateToTestSnap(
     options: { skipTabCleanup?: boolean } = {},
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium() && !options.skipTabCleanup) {
-      await Browser.closeAllBrowserTabsIfOpen();
-    }
-
     // Appium uses dapp:// deeplink for https test-snaps URLs in navigateToURL.
     // Tapping the URL bar first is unnecessary and races with browser chrome.
     if (!FrameworkDetector.isAppium()) {
       await Browser.tapUrlInputBox();
     }
-    await Browser.navigateToURL(TEST_SNAPS_URL);
+    await Browser.navigateToURL(TEST_SNAPS_URL, {
+      closeAllTabsIfOpen: !options.skipTabCleanup,
+    });
     await waitForTestSnapsToLoad();
   }
 
   async tapButton(
     buttonLocator: keyof typeof TestSnapViewSelectorWebIDS,
   ): Promise<void> {
-    if (PlatformDetector.isAndroidAppium()) {
-      await tapAndroidTestSnapsButton(buttonLocator);
-      return;
-    }
-
-    const tap = async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapViewSelectorWebIDS[buttonLocator],
-      );
-      await Gestures.scrollToWebViewPort(webElement);
-      await Gestures.tap(webElement, {
-        elemDescription: `tapButton:: ${buttonLocator}`,
-      });
-    };
-
-    if (FrameworkDetector.isAppium()) {
-      await this.withWebView(tap);
-      return;
-    }
-
-    await tap();
+    const webId = TestSnapViewSelectorWebIDS[buttonLocator];
+    await WebView.tapById(webId, {
+      ...TEST_SNAPS_WEBVIEW_OPTIONS,
+      description: `tapButton:: ${buttonLocator}`,
+    });
   }
 
   async tapOkButton() {
@@ -574,17 +545,8 @@ class TestSnaps {
     locator: keyof typeof TestSnapInputSelectorWebIDS,
     message: string,
   ) {
-    if (PlatformDetector.isAndroidAppium()) {
-      await fillAndroidTestSnapsInput(locator, message);
-      return;
-    }
-
-    await this.withWebView(async () => {
-      const webElement = await this.getTestSnapsWebElement(
-        TestSnapInputSelectorWebIDS[locator],
-      );
-      await Gestures.typeInWebElement(webElement, message);
-    });
+    const webId = TestSnapInputSelectorWebIDS[locator];
+    await WebView.fillById(webId, message, TEST_SNAPS_WEBVIEW_OPTIONS);
   }
 
   async approveSignRequest() {

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -126,8 +126,6 @@ class TestSnaps {
     },
   ): Promise<void> {
     const webId = TestSnapResultSelectorWebIDS[selector];
-    // Normalize quotes for cross-platform compatibility
-    const normalizedExpected = expectedMessage.replace(/^"|"$/g, '');
 
     await Utilities.executeWithRetry(
       async () => {
@@ -135,16 +133,24 @@ class TestSnaps {
           webId,
           TEST_SNAPS_WEBVIEW_OPTIONS,
         );
-        if (!actualText.includes(normalizedExpected)) {
-          throw new Error(
-            `Expected "${webId}" text to contain "${normalizedExpected}", got "${actualText}"`,
-          );
+
+        // Android Appium UiAutomator omits JSON string quotes; Detox/iOS include them
+        if (PlatformDetector.isAndroidAppium()) {
+          const normalizedExpected = expectedMessage.replace(/^"|"$/g, '');
+          if (!actualText.includes(normalizedExpected)) {
+            throw new Error(
+              `Expected "${webId}" text to contain "${normalizedExpected}", got "${actualText}"`,
+            );
+          }
+          return;
         }
+
+        await Assertions.checkIfTextMatches(actualText, expectedMessage);
       },
       {
         timeout: options.timeout ?? 5_000,
         interval: options.interval ?? 100,
-        description: `Assert result "${webId}" contains "${normalizedExpected}"`,
+        description: `Assert result "${webId}" matches expected text`,
       },
     );
   }

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -240,6 +240,10 @@ class TestSnaps {
     },
   ): Promise<void> {
     const webId = TestSnapResultSelectorWebIDS[selector];
+    // Android Appium UiAutomator omits JSON string quotes; Detox/iOS include them.
+    const formattedExpectedMessage = PlatformDetector.isAndroidAppium()
+      ? expectedMessage.replace(/^"|"$/g, '')
+      : expectedMessage;
 
     await Utilities.executeWithRetry(
       async () => {
@@ -247,14 +251,14 @@ class TestSnaps {
           webId,
           TEST_SNAPS_WEBVIEW_OPTIONS,
         );
-        if (!actualText.includes(expectedMessage)) {
-          throw new Error(`Text did not contain "${expectedMessage}"`);
+        if (!actualText.includes(formattedExpectedMessage)) {
+          throw new Error(`Text did not contain "${formattedExpectedMessage}"`);
         }
       },
       {
         timeout: options.timeout ?? 5_000,
         interval: options.interval ?? 100,
-        description: `Assert result "${webId}" contains "${expectedMessage}"`,
+        description: `Assert result "${webId}" contains "${formattedExpectedMessage}"`,
       },
     );
   }

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -321,15 +321,9 @@ class TestSnaps {
           actualStatusWithVersion;
 
         await Assertions.checkIfJsonEqual(actualStatus, expectedStatus);
-        if (
-          typeof expectedClientVersion !== 'string' ||
-          typeof actualClientVersion !== 'string' ||
-          !actualClientVersion.startsWith(expectedClientVersion)
-        ) {
+        if (!actualClientVersion.startsWith(expectedClientVersion)) {
           throw new Error(
-            `Client version mismatch: Expected version to start with "${String(
-              expectedClientVersion,
-            )}", got "${String(actualClientVersion)}".`,
+            `Client version mismatch: Expected version to start with "${expectedClientVersion}", got "${actualClientVersion}".`,
           );
         }
       },

--- a/tests/smoke-appium/snaps/helpers/android-test-snaps-native.helpers.ts
+++ b/tests/smoke-appium/snaps/helpers/android-test-snaps-native.helpers.ts
@@ -1,23 +1,7 @@
-import type { Json } from '@metamask/utils';
 import { BrowserViewSelectorsIDs } from '../../../../app/components/Views/BrowserTab/BrowserView.testIds';
 import Assertions from '../../../framework/Assertions';
 import Matchers from '../../../framework/Matchers';
-import Utilities from '../../../framework/Utilities';
-import {
-  fillAndroidWebId,
-  readAndroidWebIdText,
-  tapAndroidWebId,
-} from '../../../framework/AndroidWebViewNative';
-import {
-  TestSnapInputSelectorWebIDS,
-  TestSnapResultSelectorWebIDS,
-  TestSnapViewSelectorWebIDS,
-} from '../../../selectors/Browser/TestSnaps.selectors';
 import { createPlaywrightLogger } from '../../../framework/playwrightLogger';
-
-type ButtonKey = keyof typeof TestSnapViewSelectorWebIDS;
-type InputKey = keyof typeof TestSnapInputSelectorWebIDS;
-type ResultKey = keyof typeof TestSnapResultSelectorWebIDS;
 
 const logger = createPlaywrightLogger('AndroidTestSnapsNative');
 
@@ -41,7 +25,7 @@ export const ANDROID_TEST_SNAPS_LOAD_LABEL = 'Test Snaps';
  * Visible button labels for UiScrollable fallbacks when resource-id nodes are
  * virtualized off-screen in the WebView accessibility tree.
  */
-const TEST_SNAPS_SCROLL_LABELS: Record<string, string> = {
+export const TEST_SNAPS_ANDROID_SCROLL_LABELS: Record<string, string> = {
   connectbip32: 'Connect to BIP-32 Snap',
   'connectclient-status': 'Connect to Client Status Snap',
   connectcronjobs: 'Connect to Cronjobs Snap',
@@ -59,7 +43,9 @@ const TEST_SNAPS_SCROLL_LABELS: Record<string, string> = {
   getPreferences: 'Submit',
 };
 
-const scrollOptions = { scrollLabels: TEST_SNAPS_SCROLL_LABELS };
+export const testSnapsAndroidScrollOptions = {
+  scrollLabels: TEST_SNAPS_ANDROID_SCROLL_LABELS,
+};
 
 export async function waitForAndroidTestSnapsNativeLoad(): Promise<void> {
   await logAndroidTestSnapsNativeBridgeOnce();
@@ -73,145 +59,4 @@ export async function waitForAndroidTestSnapsNativeLoad(): Promise<void> {
   await Assertions.expectTextDisplayed(ANDROID_TEST_SNAPS_LOAD_LABEL, {
     timeout: 30_000,
   });
-}
-
-export async function tapAndroidTestSnapsButton(
-  buttonKey: ButtonKey,
-): Promise<void> {
-  const webId = TestSnapViewSelectorWebIDS[buttonKey];
-  await tapAndroidWebId(webId, {
-    ...scrollOptions,
-    description: `Android native Test Snaps button: ${buttonKey} (${webId})`,
-  });
-}
-
-export async function fillAndroidTestSnapsInput(
-  inputKey: InputKey,
-  value: string,
-): Promise<void> {
-  const webId = TestSnapInputSelectorWebIDS[inputKey];
-  await fillAndroidWebId(webId, value, scrollOptions);
-}
-
-export async function assertAndroidTestSnapsTextContains(
-  resultKey: ResultKey,
-  expectedMessage: string,
-  options: { timeout?: number; interval?: number } = {},
-): Promise<void> {
-  const webId = TestSnapResultSelectorWebIDS[resultKey];
-  const normalized = expectedMessage.replace(/^"|"$/g, '');
-
-  await Utilities.executeWithRetry(
-    async () => {
-      const actualText = await readAndroidWebIdText(webId, scrollOptions);
-      if (!actualText.includes(normalized)) {
-        throw new Error(
-          `Expected "${webId}" text to contain "${normalized}", got "${actualText}"`,
-        );
-      }
-    },
-    {
-      timeout: options.timeout ?? 5_000,
-      interval: options.interval ?? 100,
-      description: `Assert native result "${webId}" contains "${normalized}"`,
-    },
-  );
-}
-
-export async function assertAndroidTestSnapsJsonExcluding(
-  resultKey: ResultKey,
-  excludedKeys: string[],
-  expectedJson: Json,
-  options: { timeout?: number; interval?: number } = {},
-): Promise<void> {
-  const webId = TestSnapResultSelectorWebIDS[resultKey];
-
-  await Utilities.executeWithRetry(
-    async () => {
-      const actualText = await readAndroidWebIdText(webId, scrollOptions);
-      await Assertions.checkParsedJsonEqualExcluding(
-        actualText,
-        expectedJson,
-        excludedKeys,
-        `native result "${webId}"`,
-      );
-    },
-    {
-      timeout: options.timeout ?? 5_000,
-      interval: options.interval ?? 100,
-      description: `Assert native JSON result "${webId}" excluding ${excludedKeys.join(', ')}`,
-    },
-  );
-}
-
-export async function assertAndroidTestSnapsJson(
-  resultKey: ResultKey,
-  expectedJson: Json,
-  options: { timeout?: number; interval?: number } = {},
-): Promise<void> {
-  const webId = TestSnapResultSelectorWebIDS[resultKey];
-
-  await Utilities.executeWithRetry(
-    async () => {
-      const actualText = await readAndroidWebIdText(webId, scrollOptions);
-      await Assertions.checkParsedJsonEqual(
-        actualText,
-        expectedJson,
-        `native result "${webId}"`,
-      );
-    },
-    {
-      timeout: options.timeout ?? 5_000,
-      interval: options.interval ?? 100,
-      description: `Assert native JSON result "${webId}"`,
-    },
-  );
-}
-
-export async function assertAndroidTestSnapsClientStatus(
-  expectedStatus: Record<string, Json>,
-  options: { timeout?: number; interval?: number } = {},
-): Promise<void> {
-  const { clientVersion: expectedClientVersion, ...statusWithoutVersion } =
-    expectedStatus;
-  const webId = TestSnapResultSelectorWebIDS.clientStatusResultSpan;
-
-  await Utilities.executeWithRetry(
-    async () => {
-      const actualText = await readAndroidWebIdText(webId, scrollOptions);
-      let actualStatusWithVersion: Record<string, Json>;
-      try {
-        actualStatusWithVersion = JSON.parse(actualText) as Record<
-          string,
-          Json
-        >;
-      } catch {
-        throw new Error(
-          `Failed to parse JSON from native client status "${webId}": ${actualText}`,
-        );
-      }
-
-      const { clientVersion: actualClientVersion, ...actualStatus } =
-        actualStatusWithVersion;
-
-      await Assertions.checkIfJsonEqual(actualStatus, statusWithoutVersion);
-
-      if (
-        typeof expectedClientVersion !== 'string' ||
-        typeof actualClientVersion !== 'string' ||
-        !actualClientVersion.startsWith(expectedClientVersion)
-      ) {
-        throw new Error(
-          `Client version mismatch: expected prefix "${String(
-            expectedClientVersion,
-          )}", got "${String(actualClientVersion)}"`,
-        );
-      }
-    },
-    {
-      timeout: options.timeout ?? 5_000,
-      interval: options.interval ?? 100,
-      description: `Assert native client status JSON "${webId}"`,
-    },
-  );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->
Android WebView tap/fill/read lived behind snaps-only helpers and `TestSnaps` had many `isAndroidAppium()` branches. This PR introduces a multi-platform `WebView` framework facade (`tapById` / `fillById` / `readTextById`) that routes Android Appium to `AndroidWebViewNative` and iOS Appium/Detox to the existing web-context + Gestures path. `TestSnaps` now uses that single API, snaps helpers keep only scroll labels + load wait, and tab cleanup moves behind `Browser.navigateToURL({ closeAllTabsIfOpen })`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/32877

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — E2E framework refactor only; no product UI changes. Validate by running existing Appium snap smoke specs (Android + iOS) and confirming Detox snap smoke still exercises `TestSnaps` via the shared `WebView` path.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test framework / page-object refactor with no user-facing UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)