### PR TITLE
refactor: use Arrow2UpRight for Send action buttons

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsActions.tsx
@@ -224,7 +224,7 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
       if (hasBalance) {
         actionButtons.push({
           key: 'send',
-          iconName: IconName.Send,
+          iconName: IconName.Arrow2UpRight,
           label: strings('asset_overview.send_button'),
           onPress: handleSendPress,
           isDisabled: !canSignTransactions,
@@ -255,7 +255,7 @@ export const TokenDetailsActions: React.FC<TokenDetailsActionsProps> = ({
       if (hasBalance) {
         actionButtons.push({
           key: 'send',
-          iconName: IconName.Send,
+          iconName: IconName.Arrow2UpRight,
           label: strings('asset_overview.send_button'),
           onPress: handleSendPress,
           isDisabled: !canSignTransactions,

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
@@ -168,7 +168,7 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
         />
       )}
       <MainActionButton
-        iconName={IconName.Send}
+        iconName={IconName.Arrow2UpRight}
         label={strings('asset_overview.send_button')}
         onPress={handleSendPress}
         isDisabled={!canSignTransactions}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Wallet home (4-square action buttons) and token details still used the legacy `IconName.Send` glyph for Send, while other Send entry points already use MMDS `Arrow2UpRight`. This change aligns those remaining Send action buttons to `IconName.Arrow2UpRight` for a consistent Send icon across the app.

**What changed:**
- `AssetDetailsActions`: Send main action button icon → `Arrow2UpRight`
- `TokenDetailsActions`: Send action button icon → `Arrow2UpRight` (both perps and non-perps button layouts)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated the Send action button icon on wallet home and token details to the Arrow2UpRight glyph

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-973

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Send action button icon alignment

  Scenario: user sees Arrow2UpRight on wallet home Send (4-square layout)
    Given the app is unlocked on the Home / Wallet tab
    And the homepage action-buttons A/B test is on the control (fourSquare) variant
    # Settings → Feature Flag Override → set homeTMCU1103AbtestActionButtonsGrid to "control"

    When the user views the main action button row under the balance
    Then the Send button shows the Arrow2UpRight icon

  Scenario: user sees Arrow2UpRight on token details Send
    Given the app is unlocked on the Home / Wallet tab
    And the selected account holds a token with a non-zero balance

    When the user opens that token's details screen
    Then the Send action button shows the Arrow2UpRight icon
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-27 at 14 14 58" src="https://github.com/user-attachments/assets/3a624f56-53a4-4984-94f9-444ebc0da694" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-27 at 14 13 55" src="https://github.com/user-attachments/assets/d7cd5322-eda1-4d42-849a-5159ae1d1504" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-27 at 14 21 05" src="https://github.com/user-attachments/assets/9dc4f665-a400-4c0a-86c9-3db4cc33e294" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-07-27 at 14 21 12" src="https://github.com/user-attachments/assets/5f84d0d8-28fc-4d5c-9364-40b312643b55" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only icon prop changes with no navigation, transaction, or auth logic touched.
> 
> **Overview**
> Aligns remaining **Send** primary actions with the MMDS glyph used elsewhere by swapping `IconName.Send` for **`IconName.Arrow2UpRight`** on wallet home and token details.
> 
> **Wallet home** (`AssetDetailsActions`): the main Send button in the four-square action row now uses the arrow-up-right icon. **Token details** (`TokenDetailsActions`): Send uses the same icon in both layouts—when a perps market is shown (with balance) and in the standard buyable/non-perps button sets. Labels, handlers, disabled state, and test IDs are unchanged; only the displayed icon differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cf4600ede4b29ff91d98e566dad12739ef13cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->