### PR TITLE
fix(earn): stop Rive animation before navigating away from Money onboarding

### DIFF
--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { act, render } from '@testing-library/react-native';
-import { Dimensions, StyleSheet } from 'react-native';
+import {
+  AppState,
+  type AppStateStatus,
+  Dimensions,
+  StyleSheet,
+} from 'react-native';
 import { useSharedValue, withTiming } from 'react-native-reanimated';
 import MoneyOnboardingView from './MoneyOnboardingView';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -118,6 +123,9 @@ let mockOnError: (error: { message: string; type: string }) => void;
 let mockTriggerCallbacks: Record<string, () => void> = {};
 const mockSetNumber = jest.fn();
 const mockSetString = jest.fn();
+const mockRiveStop = jest.fn();
+const mockRivePause = jest.fn();
+const mockRivePlay = jest.fn();
 
 const triggerStateChange = (stateName: string) => {
   act(() => {
@@ -128,7 +136,13 @@ const triggerStateChange = (stateName: string) => {
 const renderMoneyOnboardingView = () => render(<MoneyOnboardingView />);
 
 jest.mock('rive-react-native', () => {
-  const mockRiveRef = {};
+  // Wrapped in arrow functions because the factory runs before the jest.fn
+  // declarations above are initialized.
+  const mockRiveRef = {
+    stop: () => mockRiveStop(),
+    pause: () => mockRivePause(),
+    play: () => mockRivePlay(),
+  };
 
   return {
     __esModule: true,
@@ -151,8 +165,24 @@ jest.mock('rive-react-native', () => {
 });
 
 describe('MoneyOnboardingView', () => {
+  let appStateChangeHandler: ((state: AppStateStatus) => void) | undefined;
+
+  const triggerAppStateChange = (state: AppStateStatus) => {
+    act(() => {
+      appStateChangeHandler?.(state);
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    appStateChangeHandler = undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(((
+      _event: string,
+      handler: (state: AppStateStatus) => void,
+    ) => {
+      appStateChangeHandler = handler;
+      return { remove: jest.fn() };
+    }) as unknown as typeof AppState.addEventListener);
     mockTriggerCallbacks = {};
     mockIsUsUnauthenticatedNonCardholder = false;
     mockRouteParams = undefined;
@@ -618,6 +648,102 @@ describe('MoneyOnboardingView', () => {
             'MoneyOnboardingView: Rive error: Unable to load artboard - IncorrectArtboardName',
         }),
       );
+    });
+  });
+
+  describe('Rive teardown', () => {
+    it('stops the Rive animation before navigating away on completion', () => {
+      renderMoneyOnboardingView();
+
+      triggerStateChange('FinalState');
+
+      expect(mockRiveStop).toHaveBeenCalledTimes(1);
+      expect(mockRiveStop.mock.invocationCallOrder[0]).toBeLessThan(
+        mockNavigate.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('stops the Rive animation before navigating away on close', () => {
+      renderMoneyOnboardingView();
+
+      mockTriggerCallbacks.close();
+
+      expect(mockRiveStop).toHaveBeenCalledTimes(1);
+      expect(mockRiveStop.mock.invocationCallOrder[0]).toBeLessThan(
+        mockNavigate.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('stops the Rive animation before navigating away on error', () => {
+      renderMoneyOnboardingView();
+
+      mockOnError({ message: 'boom', type: 'Malformed' });
+
+      expect(mockRiveStop).toHaveBeenCalledTimes(1);
+      expect(mockRiveStop.mock.invocationCallOrder[0]).toBeLessThan(
+        mockNavigate.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('navigates once when close fires repeatedly', () => {
+      renderMoneyOnboardingView();
+
+      mockTriggerCallbacks.close();
+      mockTriggerCallbacks.close();
+
+      expect(mockRiveStop).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it('navigates once when a state change arrives after an exit started', () => {
+      renderMoneyOnboardingView();
+
+      mockTriggerCallbacks.close();
+      triggerStateChange('FinalState');
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockTrackOnboardingEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          step_action: MONEY_ONBOARDING_STEP_ACTIONS.COMPLETED,
+        }),
+      );
+    });
+  });
+
+  describe('App state changes', () => {
+    it('pauses the Rive animation when the app is backgrounded', () => {
+      renderMoneyOnboardingView();
+
+      triggerAppStateChange('background');
+
+      expect(mockRivePause).toHaveBeenCalledTimes(1);
+      expect(mockRivePlay).not.toHaveBeenCalled();
+    });
+
+    it('pauses the Rive animation when the app becomes inactive', () => {
+      renderMoneyOnboardingView();
+
+      triggerAppStateChange('inactive');
+
+      expect(mockRivePause).toHaveBeenCalledTimes(1);
+    });
+
+    it('resumes the Rive animation when the app returns to the foreground', () => {
+      renderMoneyOnboardingView();
+
+      triggerAppStateChange('background');
+      triggerAppStateChange('active');
+
+      expect(mockRivePlay).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resume the Rive animation once the screen is exiting', () => {
+      renderMoneyOnboardingView();
+
+      mockTriggerCallbacks.close();
+      triggerAppStateChange('active');
+
+      expect(mockRivePlay).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -45,6 +45,8 @@ import Rive, {
 import { MoneyOnboardingViewTestIds } from './MoneyOnboardingView.testIds';
 import { selectIsUsUnauthenticatedNonCardholder } from '../../selectors/eligibility';
 import {
+  AppState,
+  type AppStateStatus,
   PixelRatio,
   StyleSheet,
   useWindowDimensions,
@@ -270,6 +272,7 @@ const MoneyOnboardingView = () => {
   const [ref, riveRef] = useRive();
 
   const stepRef = useRef(0);
+  const isExitingRef = useRef(false);
   const [overlayStep, setOverlayStep] = useState(0);
   const overlayOpacity = useSharedValue(0);
 
@@ -336,6 +339,44 @@ const MoneyOnboardingView = () => {
     );
   }, [riveRef, setTransitionSpeed, setButtonText, overlayOpacity]);
 
+  /**
+   * Tears the Rive state machine down before navigation unmounts the native
+   * view. On Android the render thread otherwise keeps calling into a view
+   * that React Native is disposing of, which segfaults inside the Rive JNI
+   * layer. Returns false when an exit is already in flight, since Rive can
+   * emit several terminal callbacks for a single exit.
+   */
+  const beginExit = useCallback(() => {
+    if (isExitingRef.current) {
+      return false;
+    }
+
+    isExitingRef.current = true;
+    riveRef?.stop();
+
+    return true;
+  }, [riveRef]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener(
+      'change',
+      (nextAppState: AppStateStatus) => {
+        if (isExitingRef.current) {
+          return;
+        }
+
+        if (nextAppState === 'active') {
+          riveRef?.play();
+          return;
+        }
+
+        riveRef?.pause();
+      },
+    );
+
+    return () => subscription.remove();
+  }, [riveRef]);
+
   const navigateToMoneyHome = useCallback(() => {
     navigation.navigate(Routes.HOME_TABS, {
       screen: Routes.MONEY.ROOT,
@@ -372,6 +413,10 @@ const MoneyOnboardingView = () => {
 
   const handleClose = useCallback(
     async (stepIndex: number) => {
+      if (!beginExit()) {
+        return;
+      }
+
       playImpact(ImpactMoment.PageNavigation);
       trackOnboardingEvent({
         step: stepIndex + 1, // Use 1-based index for event tracking to match total_steps count.
@@ -385,6 +430,7 @@ const MoneyOnboardingView = () => {
       await navigateToPostOnboardingDestination();
     },
     [
+      beginExit,
       dispatch,
       navigateToPostOnboardingDestination,
       postOnboardingRedirectTarget,
@@ -408,6 +454,10 @@ const MoneyOnboardingView = () => {
 
   const handleComplete = useCallback(
     async (stepIndex: number) => {
+      if (!beginExit()) {
+        return;
+      }
+
       trackOnboardingEvent({
         step: stepIndex + 1, // Use 1-based index for event tracking to match total_steps count.
         step_title: stepTitlesEnglish[stepIndex],
@@ -420,6 +470,7 @@ const MoneyOnboardingView = () => {
       await navigateToPostOnboardingDestination();
     },
     [
+      beginExit,
       dispatch,
       navigateToPostOnboardingDestination,
       postOnboardingRedirectTarget,
@@ -434,6 +485,12 @@ const MoneyOnboardingView = () => {
 
   const handleStateChanged = useCallback(
     (_stateMachineName: string, stateName: string) => {
+      // State machine events emitted while the view is being torn down are
+      // part of the teardown race and must not drive navigation.
+      if (isExitingRef.current) {
+        return;
+      }
+
       if (RIVE_TRANSITION_STATES.has(stateName)) {
         playImpact(ImpactMoment.PageNavigation);
         overlayOpacity.set(
@@ -475,10 +532,15 @@ const MoneyOnboardingView = () => {
           `MoneyOnboardingView: Rive error: ${riveError.message} - ${riveError.type}`,
         ),
       );
+
+      if (!beginExit()) {
+        return;
+      }
+
       dispatch(setMoneyOnboardingSeen(true));
       navigateToMoneyHome();
     },
-    [dispatch, navigateToMoneyHome],
+    [beginExit, dispatch, navigateToMoneyHome],
   );
 
   return (


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Money onboarding (`MoneyOnboardingView`) crashes on Android with `rive_android::JNIExceptionHandler::CallVoidMethod` (SIGSEGV), typically preceded by a `LOW_MEMORY` breadcrumb. All three exit paths — completing onboarding, tapping close, and the Rive error handler — navigated away while the Rive state machine was still active. Under Fabric, React Navigation can unmount the native Rive view mid-frame, so the render thread's next JNI call lands on a stale reference. Low memory widens this race window (slower frames, surface teardown, GC pressure), matching the reported repro conditions. This mirrors the pattern already fixed elsewhere in the app (#31076, "stop rive before navigate").

This PR hardens `MoneyOnboardingView` against that race:

- Adds a guarded `beginExit()` helper that calls `riveRef.stop()` before any navigation away from the screen (on completion, on close, and on Rive error), and ignores duplicate/late terminal callbacks so navigation only happens once.
- Ignores `onStateChanged` events that arrive after an exit has started, since they are part of the teardown race rather than genuine step transitions.
- Adds an `AppState` listener that pauses the Rive animation when the app is backgrounded/inactive and resumes it on foreground, reducing the chance of the render thread doing work while the app is being memory-trimmed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a crash on Android when exiting the Money onboarding animation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33827, #33825

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money onboarding Rive lifecycle on Android

  Background:
    Given I am logged into MetaMask Mobile on Android
    And the Money onboarding stepper animation is enabled

  Scenario: user completes onboarding without crashing
    Given I am on the Money onboarding screen

    When user steps through all Rive onboarding states to FinalState
    Then the app navigates to the Money home screen without crashing

  Scenario: user closes onboarding partway through
    Given I am on the Money onboarding screen
    And the animation is on an intermediate step (e.g. APY)

    When user taps close
    Then the app navigates to the Money home screen without crashing
    And navigation only happens once even if further Rive callbacks fire

  Scenario: user backgrounds the app during onboarding
    Given I am on the Money onboarding screen
    And the animation is playing

    When user backgrounds the app (or the app receives a low-memory trim)
    Then the Rive animation pauses
    When user returns the app to the foreground
    Then the Rive animation resumes from where it left off

  Scenario: reproducing the original crash conditions
    Given I am on the Money onboarding screen
    And the device is forced into a low memory state (e.g. `adb shell am send-trim-memory <pid> RUNNING_CRITICAL`)

    When user goes through Money onboarding, backgrounding and exiting on various steps
    Then the app does not crash
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no visual change; this is a crash fix. The animation renders identically.

### **After**

N/A — no visual change; this is a crash fix. The animation renders identically.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
