### PR TITLE
feat: improve import-cancelled sheet UX for account sync failures

### DIFF
--- a/app/components/Views/AddDeviceToWallet/index.test.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.test.tsx
@@ -313,24 +313,19 @@ describe('AddDeviceToWallet', () => {
       ).toBeOnTheScreen();
     });
 
-    it('shows sync error message when the session fails in dev', () => {
-      const globalWithDev = global as unknown as { __DEV__: boolean };
-      const originalDev = globalWithDev.__DEV__;
-      globalWithDev.__DEV__ = true;
+    it('does not show sync error message on the instructions screen', () => {
+      const { queryByText, getByText } = renderComponent({
+        phase: QrSyncPhases.FAILED,
+        error: {
+          code: 'SYNC_FAILED',
+          message: 'Sync failed',
+        },
+      });
 
-      try {
-        const { getByText } = renderComponent({
-          phase: QrSyncPhases.FAILED,
-          error: {
-            code: 'SYNC_FAILED',
-            message: 'Sync failed',
-          },
-        });
-
-        expect(getByText('Sync failed')).toBeOnTheScreen();
-      } finally {
-        globalWithDev.__DEV__ = originalDev;
-      }
+      expect(
+        getByText(strings('app_settings.add_device.add_device_to_wallet')),
+      ).toBeOnTheScreen();
+      expect(queryByText('Sync failed')).toBeNull();
     });
   });
 

--- a/app/components/Views/AddDeviceToWallet/index.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.tsx
@@ -36,7 +36,6 @@ import {
 } from '../../../core/QrSync/qrSyncTelemetry';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import {
-  selectQrSyncError,
   selectQrSyncIsBusy,
   selectQrSyncIsSessionActive,
   selectQrSyncPresentation,
@@ -79,7 +78,6 @@ const AddDeviceToWallet = () => {
   const shouldShowOtpSheet = useSelector(selectQrSyncShouldShowOtpSheet);
   const isBusy = useSelector(selectQrSyncIsBusy);
   const isSessionActive = useSelector(selectQrSyncIsSessionActive);
-  const error = useSelector(selectQrSyncError);
 
   const handleBack = useCallback(() => {
     Engine.context.QrSyncController.resetState();
@@ -210,12 +208,6 @@ const AddDeviceToWallet = () => {
           >
             {strings('app_settings.add_device.scan_qr_code_button')}
           </Button>
-
-          {presentation === 'error' && error?.message ? (
-            <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
-              {error.message}
-            </Text>
-          ) : null}
         </Box>
       </Box>
     </SafeAreaView>

--- a/app/components/Views/QRTabSwitcher/QRTabSwitcher.test.tsx
+++ b/app/components/Views/QRTabSwitcher/QRTabSwitcher.test.tsx
@@ -335,8 +335,16 @@ describe('QRTabSwitcher', () => {
       useSelector: jest.Mock;
     };
 
+    const syncError = {
+      code: 'INVALID_PAYLOAD' as const,
+      message:
+        'QR sync payload must include a primary mnemonic when onboarding is not completed.',
+    };
+
     let phase: (typeof defaultQrSyncControllerState)['phase'] =
       QrSyncPhases.AWAITING_SYNC_READY;
+    let error: (typeof defaultQrSyncControllerState)['error'] = null;
+
     reactReduxModule.useSelector.mockImplementation(
       (selector: (state: RootState) => unknown) =>
         selector({
@@ -345,6 +353,7 @@ describe('QRTabSwitcher', () => {
               QrSyncController: {
                 ...defaultQrSyncControllerState,
                 phase,
+                error,
               },
             },
           },
@@ -354,11 +363,20 @@ describe('QRTabSwitcher', () => {
         } as RootState),
     );
 
-    const { rerender } = render(<QRTabSwitcher />);
+    const { getByTestId, rerender } = render(<QRTabSwitcher />);
 
-    phase = QrSyncPhases.IDLE;
+    expect(getByTestId('device-added-loader-screen')).toBeOnTheScreen();
+
+    phase = QrSyncPhases.FAILED;
+    error = syncError;
     rerender(<QRTabSwitcher />);
 
     expect(mockShowExtensionCancelledErrorSheet).toHaveBeenCalledTimes(1);
+    expect(mockShowExtensionCancelledErrorSheet).toHaveBeenCalledWith(
+      expect.anything(),
+      { errorMessage: syncError.message },
+    );
+    // Waiting UI must stay mounted so the cancel sheet is not over the camera.
+    expect(getByTestId('device-added-loader-screen')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
+++ b/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -24,6 +24,7 @@ import type { QrSyncPhase } from '../../../core/QrSync/types';
 import Engine from '../../../core/Engine';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import {
+  selectQrSyncError,
   selectQrSyncIsSessionActive,
   selectQrSyncPhase,
   selectQrSyncPresentation,
@@ -86,9 +87,12 @@ const QRTabSwitcher = () => {
   const isSessionActive = useSelector(selectQrSyncIsSessionActive);
   const presentation = useSelector(selectQrSyncPresentation);
   const shouldShowOtpSheet = useSelector(selectQrSyncShouldShowOtpSheet);
+  const qrSyncError = useSelector(selectQrSyncError);
   const hasOpenedVerificationSheetRef = useRef(false);
   const hasShownExtensionCancelSheetRef = useRef(false);
   const prevPhaseRef = useRef(phase);
+  const [keepWaitingScreenAfterCancel, setKeepWaitingScreenAfterCancel] =
+    useState(false);
 
   const showExtensionCancelSheetOnce = useCallback(() => {
     if (hasShownExtensionCancelSheetRef.current) {
@@ -96,8 +100,11 @@ const QRTabSwitcher = () => {
     }
 
     hasShownExtensionCancelSheetRef.current = true;
-    showExtensionCancelledErrorSheet(navigation);
-  }, [navigation]);
+    setKeepWaitingScreenAfterCancel(true);
+    showExtensionCancelledErrorSheet(navigation, {
+      errorMessage: qrSyncError?.message,
+    });
+  }, [navigation, qrSyncError?.message]);
 
   const showVerificationSheet = useCallback(() => {
     showAddDeviceVerificationSheet(navigation);
@@ -105,6 +112,7 @@ const QRTabSwitcher = () => {
 
   const resetExtensionCancelSheetState = useCallback(() => {
     hasShownExtensionCancelSheetRef.current = false;
+    setKeepWaitingScreenAfterCancel(false);
   }, []);
 
   useEffect(() => {
@@ -128,7 +136,8 @@ const QRTabSwitcher = () => {
   useQrSyncImportNavigation({ enabled: isAddDeviceOrigin });
 
   const showDeviceAddedLoader =
-    isAddDeviceOrigin && presentation === 'device-linked';
+    isAddDeviceOrigin &&
+    (presentation === 'device-linked' || keepWaitingScreenAfterCancel);
 
   useEffect(() => {
     if (!isAddDeviceOrigin) {
@@ -140,6 +149,7 @@ const QRTabSwitcher = () => {
       phase === QrSyncPhases.DISPLAYING_OTP
     ) {
       hasShownExtensionCancelSheetRef.current = false;
+      setKeepWaitingScreenAfterCancel(false);
     }
   }, [isAddDeviceOrigin, phase]);
 

--- a/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
+++ b/app/components/Views/QRTabSwitcher/QRTabSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import React, { useRef, useEffect, useCallback, useState } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -91,8 +91,21 @@ const QRTabSwitcher = () => {
   const hasOpenedVerificationSheetRef = useRef(false);
   const hasShownExtensionCancelSheetRef = useRef(false);
   const prevPhaseRef = useRef(phase);
-  const [keepWaitingScreenAfterCancel, setKeepWaitingScreenAfterCancel] =
-    useState(false);
+  const keepWaitingScreenAfterCancelRef = useRef(false);
+
+  if (isAddDeviceOrigin) {
+    if (
+      phase === QrSyncPhases.INITIALIZING ||
+      phase === QrSyncPhases.DISPLAYING_OTP
+    ) {
+      keepWaitingScreenAfterCancelRef.current = false;
+    } else if (
+      DEVICE_LINKED_WAIT_PHASES.has(prevPhaseRef.current) &&
+      (phase === QrSyncPhases.IDLE || phase === QrSyncPhases.FAILED)
+    ) {
+      keepWaitingScreenAfterCancelRef.current = true;
+    }
+  }
 
   const showExtensionCancelSheetOnce = useCallback(() => {
     if (hasShownExtensionCancelSheetRef.current) {
@@ -100,7 +113,6 @@ const QRTabSwitcher = () => {
     }
 
     hasShownExtensionCancelSheetRef.current = true;
-    setKeepWaitingScreenAfterCancel(true);
     showExtensionCancelledErrorSheet(navigation, {
       errorMessage: qrSyncError?.message,
     });
@@ -112,7 +124,7 @@ const QRTabSwitcher = () => {
 
   const resetExtensionCancelSheetState = useCallback(() => {
     hasShownExtensionCancelSheetRef.current = false;
-    setKeepWaitingScreenAfterCancel(false);
+    keepWaitingScreenAfterCancelRef.current = false;
   }, []);
 
   useEffect(() => {
@@ -137,7 +149,8 @@ const QRTabSwitcher = () => {
 
   const showDeviceAddedLoader =
     isAddDeviceOrigin &&
-    (presentation === 'device-linked' || keepWaitingScreenAfterCancel);
+    (presentation === 'device-linked' ||
+      keepWaitingScreenAfterCancelRef.current);
 
   useEffect(() => {
     if (!isAddDeviceOrigin) {
@@ -149,7 +162,6 @@ const QRTabSwitcher = () => {
       phase === QrSyncPhases.DISPLAYING_OTP
     ) {
       hasShownExtensionCancelSheetRef.current = false;
-      setKeepWaitingScreenAfterCancel(false);
     }
   }, [isAddDeviceOrigin, phase]);
 

--- a/app/core/QrSync/showExtensionCancelledErrorSheet.test.ts
+++ b/app/core/QrSync/showExtensionCancelledErrorSheet.test.ts
@@ -33,7 +33,22 @@ describe('showExtensionCancelledErrorSheet', () => {
           'app_settings.add_device.extension_cancelled_button',
         ),
         closeOnPrimaryButtonPress: true,
+        onClose: expect.any(Function),
         onPrimaryButtonPress: expect.any(Function),
+      }),
+    });
+  });
+
+  it('uses the controller error message when provided', () => {
+    const errorMessage =
+      'QR sync payload must include a primary mnemonic when onboarding is not completed.';
+
+    showExtensionCancelledErrorSheet(mockNavigation, { errorMessage });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+      params: expect.objectContaining({
+        description: errorMessage,
       }),
     });
   });
@@ -52,6 +67,28 @@ describe('showExtensionCancelledErrorSheet', () => {
     expect(emitSpy).toHaveBeenCalledWith(
       ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT,
     );
+
+    emitSpy.mockRestore();
+  });
+
+  it('resets to instructions when the sheet is dismissed without try again', () => {
+    const emitSpy = jest.spyOn(DeviceEventEmitter, 'emit');
+
+    showExtensionCancelledErrorSheet(mockNavigation);
+
+    const { params } = mockNavigate.mock.calls[0][1] as {
+      params: { onClose?: () => void; onPrimaryButtonPress?: () => void };
+    };
+
+    params.onClose?.();
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT,
+    );
+
+    // Primary press after close must not double-emit.
+    params.onPrimaryButtonPress?.();
+    expect(emitSpy).toHaveBeenCalledTimes(1);
 
     emitSpy.mockRestore();
   });

--- a/app/core/QrSync/showExtensionCancelledErrorSheet.ts
+++ b/app/core/QrSync/showExtensionCancelledErrorSheet.ts
@@ -6,25 +6,43 @@ import type { AppNavigationProp } from '../NavigationService/types';
 export const ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT =
   'addDeviceResetToInstructions';
 
+export interface ShowExtensionCancelledErrorSheetOptions {
+  /** Controller failure detail; falls back to generic cancel copy when omitted. */
+  errorMessage?: string | null;
+}
+
 export const showExtensionCancelledErrorSheet = (
   navigation: AppNavigationProp,
+  options: ShowExtensionCancelledErrorSheetOptions = {},
 ): void => {
+  let hasEmittedReset = false;
+
+  const emitResetToInstructions = () => {
+    if (hasEmittedReset) {
+      return;
+    }
+
+    hasEmittedReset = true;
+    DeviceEventEmitter.emit(ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT);
+  };
+
+  const description =
+    options.errorMessage?.trim() ||
+    strings('app_settings.add_device.extension_cancelled_description');
+
   navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
     screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
     params: {
       type: 'error',
       title: strings('app_settings.add_device.extension_cancelled_title'),
-      description: strings(
-        'app_settings.add_device.extension_cancelled_description',
-      ),
+      description,
       descriptionAlign: 'center',
       primaryButtonLabel: strings(
         'app_settings.add_device.extension_cancelled_button',
       ),
       closeOnPrimaryButtonPress: true,
-      onPrimaryButtonPress: () => {
-        DeviceEventEmitter.emit(ADD_DEVICE_RESET_TO_INSTRUCTIONS_EVENT);
-      },
+      onClose: emitResetToInstructions,
+      onPrimaryButtonPress: emitResetToInstructions,
     },
   });
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
When add-device QR sync fails or the extension cancels during the waiting phase, the Import cancelled bottomsheet could appear over the camera scanner, and dismissing it without "Try again" left a leftover sync error on the Add Device instructions screen.

This PR:
- Surfaces the controller error message on the bottomsheet when present, otherwise falls back to the generic cancel copy
- Resets QR sync state on sheet dismiss (swipe / close) the same way as "Try again", so instructions never show an orphaned error
- Removes the inline sync error from the Add Device instructions screen

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed add-device import-cancelled sheet so it stays on the waiting screen, shows the sync error when available, and no longer leaves an error on the instructions screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add device import-cancelled bottomsheet ux

   Background:
    Given I am on the Add Device to Wallet flow
    And I have scanned the extension QR and reached the waiting screen

  Scenario: Cancel sheet stays on waiting screen when sync fails
    When the extension cancels or sync fails during waiting
    Then the Import cancelled bottomsheet is shown
    And the waiting screen remains behind the sheet
    And the camera scanner does not appear

  Scenario: Bottomsheet shows controller error when present
    Given sync failed with a controller error message
    When the Import cancelled bottomsheet opens
    Then the sheet description shows that error message

  Scenario: Bottomsheet falls back to generic copy without controller error
    Given the session ended without a controller error message
    When the Import cancelled bottomsheet opens
    Then the sheet description shows the generic cancelled/failed copy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="960" height="1280" alt="photo_2026-07-28 08 06 34" src="https://github.com/user-attachments/assets/81191f37-f61a-43ba-93b5-f92c44b22442" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized add-device QR sync UI and navigation; no changes to wallet import, auth, or controller sync logic beyond how errors are displayed and reset.
> 
> **Overview**
> When add-device QR sync fails or the extension cancels during the waiting phase, errors are handled on the **Import cancelled** bottom sheet instead of on the instructions screen.
> 
> **`showExtensionCancelledErrorSheet`** now accepts an optional controller **`errorMessage`** for the sheet body (generic cancel copy when missing). Dismissing the sheet via swipe/close runs the same **`addDeviceResetToInstructions`** reset as **Try again**, with a single emit if both fire.
> 
> **`QRTabSwitcher`** keeps the waiting (**DeviceAdded**) UI mounted after showing that sheet so the camera is not visible behind it, and forwards the sync error into the sheet.
> 
> **Add Device to Wallet** no longer renders inline QR sync errors on the instructions view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bba9ad7924e11525f1d72c9642977de761927ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->