### PR TITLE
feat: add persisted collapse/expand to the Pro chart

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -468,6 +468,8 @@ export const PerpsProMarketViewSelectorsIDs = {
   CHART_PERIOD_SELECTOR: 'perps-pro-market-chart-period-selector',
   CHART_MORE_PERIODS_SHEET: 'perps-pro-market-chart-more-periods-sheet',
   CHART_FULLSCREEN_BUTTON: 'perps-pro-market-chart-fullscreen-button',
+  CHART_COLLAPSE_BUTTON: 'perps-pro-market-chart-collapse-button',
+  CHART_EXPAND_BUTTON: 'perps-pro-market-chart-expand-button',
   CHART_PRICE_DEVIATION_WARNING:
     'perps-pro-market-chart-price-deviation-warning',
   CHART_SERVICE_INTERRUPTION_BANNER:

--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -468,8 +468,7 @@ export const PerpsProMarketViewSelectorsIDs = {
   CHART_PERIOD_SELECTOR: 'perps-pro-market-chart-period-selector',
   CHART_MORE_PERIODS_SHEET: 'perps-pro-market-chart-more-periods-sheet',
   CHART_FULLSCREEN_BUTTON: 'perps-pro-market-chart-fullscreen-button',
-  CHART_COLLAPSE_BUTTON: 'perps-pro-market-chart-collapse-button',
-  CHART_EXPAND_BUTTON: 'perps-pro-market-chart-expand-button',
+  CHART_TOGGLE_BUTTON: 'perps-pro-market-chart-toggle-button',
   CHART_PRICE_DEVIATION_WARNING:
     'perps-pro-market-chart-price-deviation-warning',
   CHART_SERVICE_INTERRUPTION_BANNER:

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -571,5 +571,39 @@ describe('PerpsProChartPanel', () => {
         screen.queryByTestId('mock-perps-fullscreen-chart'),
       ).not.toBeOnTheScreen();
     });
+
+    it('follows the candle price (not the frozen Advanced Chart price) after collapsing', () => {
+      const view = renderChartPanel();
+
+      // Advanced Chart reports a live price while expanded.
+      act(() => {
+        getLastAdvancedChartProps().onLatestPriceChange?.(51000);
+      });
+      expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
+        expect.objectContaining({ currentPrice: 51000 }),
+      );
+
+      // Collapse: the Advanced Chart unmounts and can no longer report prices,
+      // so the summary must fall back to the retained candle price (50500).
+      mockUsePerpsProChartExpanded.mockReturnValue({
+        isChartExpanded: false,
+        setChartExpanded: mockSetChartExpanded,
+      });
+      view.rerender(
+        <PerpsProChartPanel
+          symbol="BTC"
+          selectedCandlePeriod={CandlePeriod.FifteenMinutes}
+          isAdvancedChartEnabled
+          effectiveChartLibrary={PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED}
+          onCandlePeriodChange={mockOnCandlePeriodChange}
+          onMorePress={mockOnMorePress}
+          onChartError={mockOnChartError}
+        />,
+      );
+
+      expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
+        expect.objectContaining({ currentPrice: 50500 }),
+      );
+    });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -10,7 +10,10 @@ import {
   type CandleData,
   type Position,
 } from '@metamask/perps-controller';
-import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '@metamask/perps-controller/constants';
 import type { PerpsAdvancedChartProps } from '../../../components/PerpsAdvancedChart/PerpsAdvancedChart';
 import PerpsCandlePeriodSelector from '../../../components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector';
 import type { PerpsChartFullscreenModalProps } from '../../../components/PerpsChartFullscreenModal/PerpsChartFullscreenModal';
@@ -104,9 +107,15 @@ const mockUsePerpsLiveCandles = jest.fn();
 const mockUseHasExistingPosition = jest.fn();
 const mockUsePerpsMarketData = jest.fn();
 const mockUsePriceDeviation = jest.fn();
+const mockSetChartExpanded = jest.fn();
+const mockUsePerpsProChartExpanded = jest.fn();
 
 jest.mock('../../../hooks/usePerpsEventTracking', () => ({
   usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+jest.mock('../../../hooks/usePerpsProChartExpanded', () => ({
+  usePerpsProChartExpanded: () => mockUsePerpsProChartExpanded(),
 }));
 
 jest.mock('../../../hooks/stream/usePerpsLiveCandles', () => ({
@@ -218,6 +227,10 @@ describe('PerpsProChartPanel', () => {
     mockUsePriceDeviation.mockReturnValue({
       isDeviatedAboveThreshold: false,
       isLoading: false,
+    });
+    mockUsePerpsProChartExpanded.mockReturnValue({
+      isChartExpanded: true,
+      setChartExpanded: mockSetChartExpanded,
     });
   });
 
@@ -435,5 +448,128 @@ describe('PerpsProChartPanel', () => {
     });
 
     expect(mockOnChartError).toHaveBeenCalledWith('WebView failed');
+  });
+
+  describe('collapse and expand', () => {
+    const renderCollapsed = (
+      overrides: Partial<PerpsProChartPanelProps> = {},
+    ) => {
+      mockUsePerpsProChartExpanded.mockReturnValue({
+        isChartExpanded: false,
+        setChartExpanded: mockSetChartExpanded,
+      });
+      return renderChartPanel(overrides);
+    };
+
+    it('keeps the market summary visible while collapsed', () => {
+      renderCollapsed();
+
+      expect(
+        screen.getByTestId(PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY),
+      ).toBeOnTheScreen();
+    });
+
+    it('unmounts the inline chart and its controls while collapsed', () => {
+      renderCollapsed();
+
+      expect(
+        screen.queryByTestId(PerpsProMarketViewSelectorsIDs.CHART_PANEL),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('mock-perps-advanced-chart'),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
+          PerpsProMarketViewSelectorsIDs.CHART_PERIOD_SELECTOR,
+        ),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
+          PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON,
+        ),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('unmounts the Lightweight chart WebView while collapsed', () => {
+      renderCollapsed({ isAdvancedChartEnabled: false });
+
+      expect(
+        screen.queryByTestId(PerpsProMarketViewSelectorsIDs.CHART_LIGHTWEIGHT),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders the compact expand action while collapsed', () => {
+      renderCollapsed();
+
+      const expandButton = screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON,
+      );
+      expect(expandButton).toBeOnTheScreen();
+      expect(expandButton.props.accessibilityState).toEqual(
+        expect.objectContaining({ expanded: false }),
+      );
+    });
+
+    it('persists chartExpanded=true and tracks analytics on expand', () => {
+      renderCollapsed();
+
+      fireEvent.press(
+        screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON),
+      );
+
+      expect(mockSetChartExpanded).toHaveBeenCalledWith(true);
+      expect(mockTrack).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+          [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]: 'expand_chart',
+          [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
+          [PERPS_EVENT_PROPERTY.CHART_LIBRARY]:
+            PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED,
+        }),
+      );
+    });
+
+    it('renders the collapse action while expanded', () => {
+      renderChartPanel();
+
+      const collapseButton = screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON,
+      );
+      expect(collapseButton).toBeOnTheScreen();
+      expect(collapseButton.props.accessibilityState).toEqual(
+        expect.objectContaining({ expanded: true }),
+      );
+    });
+
+    it('persists chartExpanded=false and tracks analytics on collapse', () => {
+      renderChartPanel();
+
+      fireEvent.press(
+        screen.getByTestId(
+          PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON,
+        ),
+      );
+
+      expect(mockSetChartExpanded).toHaveBeenCalledWith(false);
+      expect(mockTrack).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+          [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]: 'collapse_chart',
+          [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
+        }),
+      );
+    });
+
+    it('does not open the fullscreen modal while collapsed', () => {
+      renderCollapsed();
+
+      expect(
+        screen.queryByTestId('mock-perps-fullscreen-chart'),
+      ).not.toBeOnTheScreen();
+    });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -498,23 +498,35 @@ describe('PerpsProChartPanel', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('renders the compact expand action while collapsed', () => {
+    it('shows the toggle action in the collapsed state', () => {
       renderCollapsed();
 
-      const expandButton = screen.getByTestId(
-        PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON,
+      const toggleButton = screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_TOGGLE_BUTTON,
       );
-      expect(expandButton).toBeOnTheScreen();
-      expect(expandButton.props.accessibilityState).toEqual(
+      expect(toggleButton).toBeOnTheScreen();
+      expect(toggleButton.props.accessibilityState).toEqual(
         expect.objectContaining({ expanded: false }),
       );
     });
 
-    it('persists chartExpanded=true and tracks analytics on expand', () => {
+    it('keeps the toggle action visible in the expanded state', () => {
+      renderChartPanel();
+
+      const toggleButton = screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.CHART_TOGGLE_BUTTON,
+      );
+      expect(toggleButton).toBeOnTheScreen();
+      expect(toggleButton.props.accessibilityState).toEqual(
+        expect.objectContaining({ expanded: true }),
+      );
+    });
+
+    it('persists chartExpanded=true and tracks analytics when expanding', () => {
       renderCollapsed();
 
       fireEvent.press(
-        screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON),
+        screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_TOGGLE_BUTTON),
       );
 
       expect(mockSetChartExpanded).toHaveBeenCalledWith(true);
@@ -531,25 +543,11 @@ describe('PerpsProChartPanel', () => {
       );
     });
 
-    it('renders the collapse action while expanded', () => {
-      renderChartPanel();
-
-      const collapseButton = screen.getByTestId(
-        PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON,
-      );
-      expect(collapseButton).toBeOnTheScreen();
-      expect(collapseButton.props.accessibilityState).toEqual(
-        expect.objectContaining({ expanded: true }),
-      );
-    });
-
-    it('persists chartExpanded=false and tracks analytics on collapse', () => {
+    it('persists chartExpanded=false and tracks analytics when collapsing', () => {
       renderChartPanel();
 
       fireEvent.press(
-        screen.getByTestId(
-          PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON,
-        ),
+        screen.getByTestId(PerpsProMarketViewSelectorsIDs.CHART_TOGGLE_BUTTON),
       );
 
       expect(mockSetChartExpanded).toHaveBeenCalledWith(false);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -27,6 +27,7 @@ import ComponentErrorBoundary from '../../../../ComponentErrorBoundary';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import { PERPS_CHART_CONFIG } from '../../../constants/chartConfig';
 import { usePerpsMarketData } from '../../../hooks';
+import { usePerpsProChartExpanded } from '../../../hooks/usePerpsProChartExpanded';
 import { usePerpsEventTracking } from '../../../hooks/usePerpsEventTracking';
 import { useHasExistingPosition } from '../../../hooks/useHasExistingPosition';
 import { useIsPriceDeviatedAboveThreshold } from '../../../hooks/useIsPriceDeviatedAboveThreshold';
@@ -47,6 +48,16 @@ import TradingViewChart, {
 import PerpsProMarketSummary from './PerpsProMarketSummary';
 
 const PRO_CHART_HEIGHT = 288;
+/**
+ * Typed button-clicked labels for the Pro chart collapse/expand analytics
+ * (mirrors the local-constant pattern used by e.g. `COMPETITION_BANNER_BUTTON`),
+ * since `@metamask/perps-controller` has no dedicated chart collapse/expand
+ * interaction value.
+ */
+const PRO_CHART_BUTTON = {
+  COLLAPSE_CHART: 'collapse_chart',
+  EXPAND_CHART: 'expand_chart',
+} as const;
 const PRO_CANDLE_PERIODS = [
   { label: '1m', value: CandlePeriod.OneMinute },
   { label: '5m', value: CandlePeriod.FiveMinutes },
@@ -78,6 +89,7 @@ const PerpsProChartPanel = ({
   onChartError,
 }: PerpsProChartPanelProps) => {
   const { track } = usePerpsEventTracking();
+  const { isChartExpanded, setChartExpanded } = usePerpsProChartExpanded();
   const [isFullscreenChartVisible, setIsFullscreenChartVisible] =
     useState(false);
   const [ohlcData, setOhlcData] = useState<OhlcData | null>(null);
@@ -152,6 +164,22 @@ const PerpsProChartPanel = ({
     }
   }, [candleData, selectedCandlePeriod, visibleCandleCount]);
 
+  const handleToggleChartExpanded = useCallback(
+    (expanded: boolean) => {
+      setChartExpanded(expanded);
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]: expanded
+          ? PRO_CHART_BUTTON.EXPAND_CHART
+          : PRO_CHART_BUTTON.COLLAPSE_CHART,
+        [PERPS_EVENT_PROPERTY.ASSET]: symbol,
+        ...chartAnalyticsProperties,
+      });
+    },
+    [chartAnalyticsProperties, setChartExpanded, symbol, track],
+  );
+
   const handleFullscreenChartOpen = useCallback(() => {
     setIsFullscreenChartVisible(true);
     track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
@@ -212,64 +240,88 @@ const PerpsProChartPanel = ({
       <PerpsProMarketSummary
         symbol={symbol}
         currentPrice={syncedChartCurrentPrice}
+        endAccessory={
+          isChartExpanded ? undefined : (
+            <ButtonIcon
+              iconName={IconName.Candlestick}
+              size={ButtonIconSize.Lg}
+              onPress={() => handleToggleChartExpanded(true)}
+              testID={PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON}
+              accessibilityLabel={strings('perps.market_details.expand_chart')}
+              accessibilityState={{ expanded: false }}
+            />
+          )
+        }
       />
-      <Box
-        testID={PerpsProMarketViewSelectorsIDs.CHART_PANEL}
-        twClassName="my-2 h-[344px] px-4 py-2"
-      >
+      {isChartExpanded ? (
         <Box
-          testID={PerpsProMarketViewSelectorsIDs.CHART_CONTENT}
-          twClassName="flex-1 gap-2"
+          testID={PerpsProMarketViewSelectorsIDs.CHART_PANEL}
+          twClassName="my-2 h-[344px] px-4 py-2"
         >
           <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
+            testID={PerpsProMarketViewSelectorsIDs.CHART_CONTENT}
+            twClassName="flex-1 gap-2"
           >
-            <PerpsCandlePeriodSelector
-              selectedPeriod={selectedCandlePeriod}
-              onPeriodChange={onCandlePeriodChange}
-              onMorePress={onMorePress}
-              visiblePeriods={PRO_CANDLE_PERIODS}
-              twClassName="flex-1 py-0"
-              groupTwClassName="gap-2 justify-start"
-              filterVariant={FilterButtonVariant.Secondary}
-              periodButtonTwClassName="h-7 rounded px-1"
-              moreButtonTwClassName="h-7 rounded px-1"
-              textVariant={TextVariant.BodyXs}
-              testID={PerpsProMarketViewSelectorsIDs.CHART_PERIOD_SELECTOR}
-            />
-            <ButtonIcon
-              iconName={IconName.Expand}
-              size={ButtonIconSize.Sm}
-              onPress={handleFullscreenChartOpen}
-              testID={PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON}
-              accessibilityLabel={strings(
-                'perps.market_details.fullscreen_chart',
-              )}
-            />
-          </Box>
-          <ComponentErrorBoundary
-            componentLabel="PerpsProMarketChart"
-            onError={onChartError}
-          >
-            <Box twClassName="relative flex-1">
-              {ohlcData ? (
-                <Box twClassName="absolute left-0 right-0 top-0 z-10">
-                  <PerpsOHLCVBar
-                    open={ohlcData.open}
-                    high={ohlcData.high}
-                    low={ohlcData.low}
-                    close={ohlcData.close}
-                    volume={ohlcData.volume}
-                    testID={PerpsProMarketViewSelectorsIDs.CHART_OHLCV}
-                  />
-                </Box>
-              ) : null}
-              {chartContent}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+            >
+              <PerpsCandlePeriodSelector
+                selectedPeriod={selectedCandlePeriod}
+                onPeriodChange={onCandlePeriodChange}
+                onMorePress={onMorePress}
+                visiblePeriods={PRO_CANDLE_PERIODS}
+                twClassName="flex-1 py-0"
+                groupTwClassName="gap-2 justify-start"
+                filterVariant={FilterButtonVariant.Secondary}
+                periodButtonTwClassName="h-7 rounded px-1"
+                moreButtonTwClassName="h-7 rounded px-1"
+                textVariant={TextVariant.BodyXs}
+                testID={PerpsProMarketViewSelectorsIDs.CHART_PERIOD_SELECTOR}
+              />
+              <ButtonIcon
+                iconName={IconName.Expand}
+                size={ButtonIconSize.Sm}
+                onPress={handleFullscreenChartOpen}
+                testID={PerpsProMarketViewSelectorsIDs.CHART_FULLSCREEN_BUTTON}
+                accessibilityLabel={strings(
+                  'perps.market_details.fullscreen_chart',
+                )}
+              />
+              <ButtonIcon
+                iconName={IconName.Collapse}
+                size={ButtonIconSize.Sm}
+                onPress={() => handleToggleChartExpanded(false)}
+                testID={PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON}
+                accessibilityLabel={strings(
+                  'perps.market_details.collapse_chart',
+                )}
+                accessibilityState={{ expanded: true }}
+              />
             </Box>
-          </ComponentErrorBoundary>
+            <ComponentErrorBoundary
+              componentLabel="PerpsProMarketChart"
+              onError={onChartError}
+            >
+              <Box twClassName="relative flex-1">
+                {ohlcData ? (
+                  <Box twClassName="absolute left-0 right-0 top-0 z-10">
+                    <PerpsOHLCVBar
+                      open={ohlcData.open}
+                      high={ohlcData.high}
+                      low={ohlcData.low}
+                      close={ohlcData.close}
+                      volume={ohlcData.volume}
+                      testID={PerpsProMarketViewSelectorsIDs.CHART_OHLCV}
+                    />
+                  </Box>
+                ) : null}
+                {chartContent}
+              </Box>
+            </ComponentErrorBoundary>
+          </Box>
         </Box>
-      </Box>
+      ) : null}
       {isTradingHalted && !isLoadingTradingHalted ? (
         <PerpsPriceDeviationWarning
           testID={PerpsProMarketViewSelectorsIDs.CHART_PRICE_DEVIATION_WARNING}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -4,6 +4,7 @@ import {
   BoxFlexDirection,
   ButtonIcon,
   ButtonIconSize,
+  ButtonIconVariant,
   FilterButtonVariant,
   IconName,
   TextVariant,
@@ -248,16 +249,19 @@ const PerpsProChartPanel = ({
         symbol={symbol}
         currentPrice={syncedChartCurrentPrice}
         endAccessory={
-          isChartExpanded ? undefined : (
-            <ButtonIcon
-              iconName={IconName.Candlestick}
-              size={ButtonIconSize.Lg}
-              onPress={() => handleToggleChartExpanded(true)}
-              testID={PerpsProMarketViewSelectorsIDs.CHART_EXPAND_BUTTON}
-              accessibilityLabel={strings('perps.market_details.expand_chart')}
-              accessibilityState={{ expanded: false }}
-            />
-          )
+          <ButtonIcon
+            iconName={IconName.Candlestick}
+            size={ButtonIconSize.Lg}
+            variant={ButtonIconVariant.Filled}
+            onPress={() => handleToggleChartExpanded(!isChartExpanded)}
+            testID={PerpsProMarketViewSelectorsIDs.CHART_TOGGLE_BUTTON}
+            accessibilityLabel={strings(
+              isChartExpanded
+                ? 'perps.market_details.collapse_chart'
+                : 'perps.market_details.expand_chart',
+            )}
+            accessibilityState={{ expanded: isChartExpanded }}
+          />
         }
       />
       {isChartExpanded ? (
@@ -294,16 +298,6 @@ const PerpsProChartPanel = ({
                 accessibilityLabel={strings(
                   'perps.market_details.fullscreen_chart',
                 )}
-              />
-              <ButtonIcon
-                iconName={IconName.Collapse}
-                size={ButtonIconSize.Sm}
-                onPress={() => handleToggleChartExpanded(false)}
-                testID={PerpsProMarketViewSelectorsIDs.CHART_COLLAPSE_BUTTON}
-                accessibilityLabel={strings(
-                  'perps.market_details.collapse_chart',
-                )}
-                accessibilityState={{ expanded: true }}
               />
             </Box>
             <ComponentErrorBoundary

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -100,9 +100,14 @@ const PerpsProChartPanel = ({
   const previousIntervalRef = useRef<CandlePeriod | null>(null);
   const visibleCandleCount = PERPS_CHART_CONFIG.CANDLE_COUNT.DEFAULT;
 
+  // Clear the Advanced Chart's synced price whenever it (un)mounts or changes
+  // subject: symbol/period/flag changes, and collapse/expand. While collapsed
+  // the Advanced Chart is unmounted and can no longer report prices, so the
+  // always-visible summary must fall back to the retained candle price instead
+  // of freezing on the last Advanced Chart value.
   useEffect(() => {
     setAdvancedChartCurrentPrice(undefined);
-  }, [isAdvancedChartEnabled, selectedCandlePeriod, symbol]);
+  }, [isAdvancedChartEnabled, isChartExpanded, selectedCandlePeriod, symbol]);
 
   const chartAnalyticsProperties = useMemo(
     () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
@@ -131,7 +136,9 @@ const PerpsProChartPanel = ({
     return lastCandle?.close ? Number.parseFloat(lastCandle.close) : 0;
   }, [candleData]);
   const syncedChartCurrentPrice =
-    isAdvancedChartEnabled && advancedChartCurrentPrice !== undefined
+    isChartExpanded &&
+    isAdvancedChartEnabled &&
+    advancedChartCurrentPrice !== undefined
       ? advancedChartCurrentPrice
       : chartCurrentPrice;
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketSummary.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketSummary.tsx
@@ -10,6 +10,12 @@ import LivePriceHeader from '../../../components/LivePriceDisplay/LivePriceHeade
 interface PerpsProMarketSummaryProps {
   symbol: string;
   currentPrice: number;
+  /**
+   * Optional right-aligned accessory rendered on the same 76px row as the
+   * price (per Figma "Chart Compact"). Used for the collapsed-chart expand
+   * action so no extra row is introduced below the summary.
+   */
+  endAccessory?: React.ReactNode;
 }
 
 /**
@@ -18,14 +24,15 @@ interface PerpsProMarketSummaryProps {
 const PerpsProMarketSummary = ({
   symbol,
   currentPrice,
+  endAccessory,
 }: PerpsProMarketSummaryProps) => (
   <Box
     testID={PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY}
     flexDirection={BoxFlexDirection.Row}
     alignItems={BoxAlignItems.Center}
-    twClassName="h-[76px] px-4"
+    twClassName="h-[76px] gap-4 px-4"
   >
-    <Box twClassName="flex-1">
+    <Box twClassName="h-full flex-1 justify-start py-1">
       <LivePriceHeader
         symbol={symbol}
         currentPrice={currentPrice}
@@ -34,6 +41,7 @@ const PerpsProMarketSummary = ({
         testIDChange={PerpsProMarketViewSelectorsIDs.MARKET_PRICE_CHANGE}
       />
     </Box>
+    {endAccessory}
   </Box>
 );
 

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -22,6 +22,7 @@ export { usePerpsSearch } from './usePerpsSearch';
 export { usePerpsSorting } from './usePerpsSorting';
 export { usePerpsNavigation } from './usePerpsNavigation';
 export { usePerpsMode } from './usePerpsMode';
+export { usePerpsProChartExpanded } from './usePerpsProChartExpanded';
 
 // Connection management hooks
 export { usePerpsConnection } from './usePerpsConnection';

--- a/app/components/UI/Perps/hooks/usePerpsProChartExpanded.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProChartExpanded.test.ts
@@ -1,0 +1,67 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import { usePerpsProChartExpanded } from './usePerpsProChartExpanded';
+import { selectPerpsProChartExpanded } from '../selectors/perpsController';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PerpsController: {
+      setProLayoutPreferences: jest.fn(),
+    },
+  },
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+describe('usePerpsProChartExpanded', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the expanded state from the selectPerpsProChartExpanded selector', () => {
+    mockUseSelector.mockImplementation((selector) =>
+      selector === selectPerpsProChartExpanded ? true : undefined,
+    );
+
+    const { result } = renderHook(() => usePerpsProChartExpanded());
+
+    expect(result.current.isChartExpanded).toBe(true);
+  });
+
+  it('persists chartExpanded=true via setProLayoutPreferences', () => {
+    mockUseSelector.mockReturnValue(false);
+
+    const { result } = renderHook(() => usePerpsProChartExpanded());
+
+    act(() => {
+      result.current.setChartExpanded(true);
+    });
+
+    expect(
+      Engine.context.PerpsController.setProLayoutPreferences,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      Engine.context.PerpsController.setProLayoutPreferences,
+    ).toHaveBeenCalledWith({ chartExpanded: true });
+  });
+
+  it('persists chartExpanded=false via setProLayoutPreferences', () => {
+    mockUseSelector.mockReturnValue(true);
+
+    const { result } = renderHook(() => usePerpsProChartExpanded());
+
+    act(() => {
+      result.current.setChartExpanded(false);
+    });
+
+    expect(
+      Engine.context.PerpsController.setProLayoutPreferences,
+    ).toHaveBeenCalledWith({ chartExpanded: false });
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsProChartExpanded.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProChartExpanded.ts
@@ -11,7 +11,7 @@ export interface UsePerpsProChartExpandedReturn {
 }
 
 /**
- * Read and update the persisted Pro chart expand/collapse preference (TAT-3604).
+ * Read and update the persisted Pro chart expand/collapse preference.
  *
  * The flag lives on `PerpsController.proLayoutPreferences.chartExpanded`, so the
  * choice is global across markets and survives app restarts. Uses the

--- a/app/components/UI/Perps/hooks/usePerpsProChartExpanded.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProChartExpanded.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import { selectPerpsProChartExpanded } from '../selectors/perpsController';
+
+export interface UsePerpsProChartExpandedReturn {
+  /** Whether the Pro inline chart is expanded, from shared controller state. */
+  isChartExpanded: boolean;
+  /** Persist the expanded/collapsed choice on the shared PerpsController state. */
+  setChartExpanded: (expanded: boolean) => void;
+}
+
+/**
+ * Read and update the persisted Pro chart expand/collapse preference (TAT-3604).
+ *
+ * The flag lives on `PerpsController.proLayoutPreferences.chartExpanded`, so the
+ * choice is global across markets and survives app restarts. Uses the
+ * patch-style `setProLayoutPreferences` setter, passing only `chartExpanded`.
+ */
+export const usePerpsProChartExpanded = (): UsePerpsProChartExpandedReturn => {
+  const isChartExpanded = useSelector(selectPerpsProChartExpanded);
+
+  const setChartExpanded = useCallback((expanded: boolean) => {
+    Engine.context.PerpsController.setProLayoutPreferences({
+      chartExpanded: expanded,
+    });
+  }, []);
+
+  return { isChartExpanded, setChartExpanded };
+};

--- a/app/components/UI/Perps/selectors/perpsController/index.test.ts
+++ b/app/components/UI/Perps/selectors/perpsController/index.test.ts
@@ -3,6 +3,7 @@ import {
   InitializationState,
   PerpsMode,
   DEFAULT_PERPS_MODE,
+  DEFAULT_PRO_LAYOUT_PREFERENCES,
   type AccountState,
 } from '@metamask/perps-controller';
 import {
@@ -17,6 +18,8 @@ import {
   selectIsPerpsBalanceSelected,
   selectPerpsRecentlyViewedMarkets,
   selectPerpsMode,
+  selectPerpsProLayoutPreferences,
+  selectPerpsProChartExpanded,
 } from './index';
 
 describe('PerpsController Selectors', () => {
@@ -945,6 +948,59 @@ describe('PerpsController Selectors', () => {
       const result = selectPerpsMode(mockState);
 
       expect(result).toBe(DEFAULT_PERPS_MODE);
+    });
+  });
+
+  describe('selectPerpsProLayoutPreferences', () => {
+    it('returns the persisted Pro layout preferences merged over defaults', () => {
+      const mockState = createMockState({
+        proLayoutPreferences: { chartExpanded: true },
+      });
+
+      const result = selectPerpsProLayoutPreferences(mockState);
+
+      expect(result).toEqual({
+        ...DEFAULT_PRO_LAYOUT_PREFERENCES,
+        chartExpanded: true,
+      });
+    });
+
+    it('falls back to the defaults when PerpsController state is missing', () => {
+      const mockState = {
+        engine: { backgroundState: { PerpsController: undefined } },
+      } as unknown as RootState;
+
+      const result = selectPerpsProLayoutPreferences(mockState);
+
+      expect(result).toEqual(DEFAULT_PRO_LAYOUT_PREFERENCES);
+    });
+  });
+
+  describe('selectPerpsProChartExpanded', () => {
+    it('returns true when the chart is expanded', () => {
+      const mockState = createMockState({
+        proLayoutPreferences: { chartExpanded: true },
+      });
+
+      expect(selectPerpsProChartExpanded(mockState)).toBe(true);
+    });
+
+    it('returns the controller default when the preference is unset', () => {
+      const mockState = createMockState({});
+
+      expect(selectPerpsProChartExpanded(mockState)).toBe(
+        DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded,
+      );
+    });
+
+    it('falls back to the default when PerpsController state is missing', () => {
+      const mockState = {
+        engine: { backgroundState: { PerpsController: undefined } },
+      } as unknown as RootState;
+
+      expect(selectPerpsProChartExpanded(mockState)).toBe(
+        DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded,
+      );
     });
   });
 });

--- a/app/components/UI/Perps/selectors/perpsController/index.ts
+++ b/app/components/UI/Perps/selectors/perpsController/index.ts
@@ -186,7 +186,7 @@ const selectPerpsMode = createSelector(
 );
 
 /**
- * Persisted Pro-mode layout preferences (TAT-3604).
+ * Persisted Pro-mode layout preferences.
  *
  * Wraps the core `selectProLayoutPreferences` from `@metamask/perps-controller`,
  * defaulting to `DEFAULT_PRO_LAYOUT_PREFERENCES` when controller state is

--- a/app/components/UI/Perps/selectors/perpsController/index.ts
+++ b/app/components/UI/Perps/selectors/perpsController/index.ts
@@ -7,10 +7,13 @@ import {
   selectMarketFilterPreferences,
   selectRecentlyViewedMarkets,
   selectPerpsMode as selectPerpsModeCore,
+  selectProLayoutPreferences as selectProLayoutPreferencesCore,
   DEFAULT_PERPS_MODE,
+  DEFAULT_PRO_LAYOUT_PREFERENCES,
   InitializationState,
   type PerpsActiveProviderMode,
   type PerpsMode,
+  type ProLayoutPreferences,
 } from '@metamask/perps-controller';
 
 const selectPerpsControllerState = (state: RootState) =>
@@ -182,6 +185,38 @@ const selectPerpsMode = createSelector(
   },
 );
 
+/**
+ * Persisted Pro-mode layout preferences (TAT-3604).
+ *
+ * Wraps the core `selectProLayoutPreferences` from `@metamask/perps-controller`,
+ * defaulting to `DEFAULT_PRO_LAYOUT_PREFERENCES` when controller state is
+ * missing/partial (e.g. before Engine init, rehydration, or minimal E2E
+ * fixtures). The core selector already merges over defaults, so the wrapper
+ * only needs to guard the undefined-state path.
+ */
+const selectPerpsProLayoutPreferences = createSelector(
+  selectPerpsControllerState,
+  (perpsControllerState): ProLayoutPreferences => {
+    try {
+      return perpsControllerState
+        ? selectProLayoutPreferencesCore(perpsControllerState)
+        : DEFAULT_PRO_LAYOUT_PREFERENCES;
+    } catch {
+      return DEFAULT_PRO_LAYOUT_PREFERENCES;
+    }
+  },
+);
+
+/**
+ * Whether the Pro inline chart is expanded. Persisted globally across markets
+ * and app restarts via `PerpsController.proLayoutPreferences.chartExpanded`.
+ * Defaults to `false` (collapsed) per the controller default.
+ */
+const selectPerpsProChartExpanded = createSelector(
+  selectPerpsProLayoutPreferences,
+  (proLayoutPreferences): boolean => proLayoutPreferences.chartExpanded,
+);
+
 // Factory function to create selector for specific market
 export const createSelectIsWatchlistMarket = (symbol: string) =>
   createSelector(selectPerpsControllerState, (perpsControllerState) => {
@@ -209,4 +244,6 @@ export {
   selectIsPerpsBalanceSelected,
   selectPerpsPayWithToken,
   selectPerpsMode,
+  selectPerpsProLayoutPreferences,
+  selectPerpsProChartExpanded,
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2539,6 +2539,8 @@
     },
     "market_details": {
       "fullscreen_chart": "Fullscreen chart",
+      "collapse_chart": "Collapse chart",
+      "expand_chart": "Expand chart",
       "market_list": "Browse markets",
       "perp_pair": "{{ticker}}-{{collateral}} perp"
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
1. What is the reason for the change?
  TAT-3556 shipped the Pro Token + Chart section as always expanded and explicitly deferred inline-chart collapse and the persisted chartExpanded preference until the collapsed UI was designed. That design now exists in Figma, and the required Core state (proLayoutPreferences.chartExpanded, selectProLayoutPreferences, setProLayoutPreferences) is available in @metamask/perps-controller@10.0.0, so the previously-blocking Core dependency is resolved. Users need to reclaim vertical space on the Pro trading screen without losing the live price summary, and expect that preference to stick.

  2. What is the improvement/solution?
  A focused, reusable slice: a selectPerpsProChartExpanded selector wrapper (with a safe default for missing/partial state) and a usePerpsProChartExpanded hook, consumed by PerpsProChartPanel to conditionally render the chart body. Collapsing genuinely unmounts the WebView rather than hiding an active chart, while the always-visible summary keeps its live price from the retained candle subscription. Collapse/expand emit attributed PERPS_UI_INTERACTION analytics (asset + chart library) using typed constants, and both controls are accessible with localized labels and accessibilityState.expanded.

  Changes

  - selectors/perpsController/index.ts — selectPerpsProLayoutPreferences + selectPerpsProChartExpanded.
  - hooks/usePerpsProChartExpanded.ts (new) + barrel export.
  - Views/PerpsProMarketView/components/PerpsProChartPanel.tsx — collapse/expand UI, WebView unmount, analytics.
  - Perps.testIds.ts — CHART_COLLAPSE_BUTTON, CHART_EXPAND_BUTTON, CHART_COLLAPSED_ROW.
  - locales/languages/en.json — collapse_chart / expand_chart strings.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added persisted collapse/expand behavior to the Perps Pro inline chart.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3604

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Pro mode is required. Locally, set `OVERRIDE_REMOTE_FEATURE_FLAGS="false"` in `.js.env`, clear Metro's transform cache (`rm -rf $TMPDIR/metro-cache`) so the value is re-inlined, then switch the Perps mode toggle to **Pro** — the `perpsProModeEnabled` remote flag is enabled from app 8.5.0.

```gherkin
Feature: Persisted collapse/expand for the Perps Pro inline chart

  Scenario: chart is collapsed by default and keeps the live price summary
    Given I am in Perps Pro mode
    When I open the ETH market screen for the first time
    Then the 76px token summary shows the live price and 24h change
    And the compact chart action is shown on the summary row
    And the inline chart, timeframe controls, OHLCV overlay and fullscreen action are not rendered

  Scenario: expanding restores the full chart without losing the candle period
    Given the Pro chart is collapsed on the ETH market screen
    And my selected candle period is 15m
    When I tap the compact chart action
    Then the full candlestick chart is restored with the 1m/5m/15m/1h/1d timeframe tabs
    And 15m is still the selected candle period
    And PerpsController.proLayoutPreferences.chartExpanded is persisted as true

  Scenario: collapsing releases the chart WebView
    Given the Pro chart is expanded
    When I tap the chart action again
    Then the inline chart and its controls are unmounted rather than hidden
    And PerpsController.proLayoutPreferences.chartExpanded is persisted as false

  Scenario: the preference is global and survives a restart
    Given the Pro chart is expanded on the ETH market screen
    When I force quit and relaunch the app
    And I open the BTC market screen
    Then the chart is still expanded with my candle period unchanged

  Scenario: fullscreen stays a separate action
    Given the Pro chart is expanded
    When I tap the fullscreen icon
    Then the existing fullscreen chart modal opens
    And closing it returns me to the still-expanded inline chart

  Scenario: the control is usable with a screen reader
    Given the Pro chart is expanded
    Then the chart action is announced as "Collapse chart" with expanded state true
    And after collapsing it is announced as "Expand chart" with expanded state false
```

Automated proof of all of the above (53/53 recipe nodes, screenshots, controller state read-backs) is in [this comment](https://github.com/MetaMask/metamask-mobile/pull/33888#issuecomment-5131226000).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**



https://github.com/user-attachments/assets/fa554b6e-0d48-4637-a738-9db3f07e5605





<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference and chart mounting behavior only; no auth, payments, or trading logic changes. Main risk is brief WebView remount when re-expanding.
> 
> **Overview**
> Adds **persisted collapse/expand** for the Perps Pro inline chart so users can reclaim vertical space while keeping the live price summary.
> 
> **`usePerpsProChartExpanded`** reads/writes `PerpsController.proLayoutPreferences.chartExpanded` (global across markets, survives restarts) via new **`selectPerpsProLayoutPreferences`** / **`selectPerpsProChartExpanded`** wrappers. **`PerpsProChartPanel`** renders the chart block only when expanded—collapsing **unmounts** Advanced/Lightweight chart and period/fullscreen controls, not just hides them. A **candlestick toggle** on **`PerpsProMarketSummary`** (`endAccessory`, `CHART_TOGGLE_BUTTON`) drives the state with localized labels and `accessibilityState.expanded`.
> 
> When collapsed, the summary **falls back to the last candle close** instead of a stale Advanced Chart live price (`isChartExpanded` gates sync and clears advanced price on collapse). Toggle actions emit **`PERPS_UI_INTERACTION`** analytics (`expand_chart` / `collapse_chart`). Unit tests cover the hook, selectors, and panel collapse/expand behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca63dd1f62c8b3b6717c505793270c0fab46f8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
