### PR TITLE
fix: Remove icons from token details sticky footer CTAs

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
@@ -60,7 +60,6 @@ const styles = StyleSheet.create({
 const BALANCE_THRESHOLD_USD = 100;
 
 const SUCCESS_TEXT_PROPS = { color: TextColor.SuccessInverse } as const;
-const PRIMARY_ICON_PROPS = { size: IconSize.Md } as const;
 
 interface TokenStickyFooterProps {
   token: TokenDetailsRouteParams;
@@ -142,11 +141,6 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
 
   const secondaryTextProps = useMemo(
     () => ({ twClassName: successText }) as const,
-    [successText],
-  );
-  const secondaryIconProps = useMemo(
-    () =>
-      ({ size: IconSize.Md, twClassName: `${successText} shrink-0` }) as const,
     [successText],
   );
 
@@ -285,10 +279,6 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
               swapIsSuccess ? successBg : `bg-transparent ${successBorder}`
             }
             textProps={swapIsSuccess ? SUCCESS_TEXT_PROPS : secondaryTextProps}
-            startIconName={IconName.SwapVertical}
-            startIconProps={
-              swapIsSuccess ? PRIMARY_ICON_PROPS : secondaryIconProps
-            }
             onPress={() => {
               trackStickyFooterTapped({
                 ctaType: 'swap',
@@ -318,10 +308,6 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
               buyIsSuccess ? successBg : `bg-transparent ${successBorder}`
             }
             textProps={buyIsSuccess ? SUCCESS_TEXT_PROPS : secondaryTextProps}
-            startIconName={IconName.Bank}
-            startIconProps={
-              buyIsSuccess ? PRIMARY_ICON_PROPS : secondaryIconProps
-            }
             onPress={() => {
               trackStickyFooterTapped({
                 ctaType: 'buy',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The token details sticky footer Swap and Buy CTAs were showing leading icons (`SwapVertical` and `Bank`) next to their labels, which made the footer feel visually crowded next to the quick-buy lightning control.

This PR removes those start icons so Swap and Buy are text-only, and cleans up the unused icon prop helpers. The circular quick-buy button still uses the `FlashFilled` icon.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed icons from the Swap and Buy buttons on the token details sticky footer

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: https://consensys.slack.com/archives/C0354T27M5M/p1785180921542019

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token details sticky footer CTAs

  Background:
    Given I am logged into MetaMask Mobile
    And I open Token Details for a swap-eligible token

  Scenario: Swap and Buy buttons show text without leading icons
    Given the sticky footer is visible with Swap and Buy actions

    When I view the Swap and Buy buttons
    Then each button shows its label only
    And neither button shows a leading icon

  Scenario: Quick buy lightning control still shows its icon
    Given the sticky footer shows the quick buy control

    When I view the circular quick buy button
    Then it still shows the lightning icon
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="344" height="734" alt="simulator_screenshot_D60884C3-4542-4639-948F-AD2342216DC9" src="https://github.com/user-attachments/assets/89c10e60-59dd-4422-9fee-f2e64b48cdea" />

### **After**


<img width="344" height="734" alt="Screenshot 2026-07-28 at 3 05 47 PM" src="https://github.com/user-attachments/assets/cafb0c19-2e5e-4733-812c-58c1db49b0f1" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI change in TokenDetailsStickyFooter with no impact on navigation, analytics, or action handlers.
> 
> **Overview**
> Removes the leading **Swap** and **Buy** icons on the token details sticky footer so those CTAs are **text-only**, reducing visual clutter next to the quick-buy control.
> 
> Swap and Buy no longer pass `startIconName` / `startIconProps` (`SwapVertical`, `Bank`). Unused helpers (`PRIMARY_ICON_PROPS`, `secondaryIconProps`) are deleted. **Quick buy** still uses the `FlashFilled` lightning icon on the circular button; success/secondary styling and press handlers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595833a0b4618641083a7e3653df936e6f34a40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->