### PR TITLE
feat(perf): auto-enable inline app profiling on failed PR performance tests

### DIFF
--- a/.github/workflows/app-profiling-check.yml
+++ b/.github/workflows/app-profiling-check.yml
@@ -1,7 +1,9 @@
 # Compares BrowserStack app profiling for a failed performance scenario against
 # the last green baseline on main, then posts a diff comment on the PR.
 #
-# Trigger via bot command on a PR:
+# Automatic: run-performance-e2e.yml posts this for failed PR scenarios.
+#
+# Manual trigger via bot command on a PR:
 #   @metamaskbot app-profiling-check --test "Cold Start Login" --platform Android --device "Google Pixel 8 Pro+14.0" --run 123456789
 #   @metamaskbot app-profiling-check --all --run 123456789
 #

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -563,7 +563,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ALL_COMMENT_IDS=$(gh api "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+          ALL_COMMENT_IDS=$(gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments?per_page=100" \
             --jq '.[] | select(.body | contains("<!-- perf-test-results -->")) | .id')
 
           if [ -n "$ALL_COMMENT_IDS" ]; then

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -554,17 +554,19 @@ jobs:
         env:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node tests/scripts/generate-performance-pr-comment.mjs \
             aggregated-reports/summary.json \
             performance-pr-comment.md
 
-      - name: Delete previous performance results comments
+      - name: Delete previous performance / app-profiling comments
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ALL_COMMENT_IDS=$(gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments?per_page=100" \
-            --jq '.[] | select(.body | contains("<!-- perf-test-results -->")) | .id')
+            --jq '.[] | select(.body | contains("<!-- perf-test-results -->") or contains("<!-- app-profiling-check -->")) | .id')
 
           if [ -n "$ALL_COMMENT_IDS" ]; then
             echo "$ALL_COMMENT_IDS" | while read -r COMMENT_ID; do
@@ -573,7 +575,7 @@ jobs:
                   --method DELETE > /dev/null 2>&1 || true
               fi
             done
-            echo "Deleted previous performance results comments"
+            echo "Deleted previous performance / app-profiling comments"
           fi
 
       - name: Post PR comment
@@ -585,38 +587,6 @@ jobs:
           FULL_COMMENT="${COMMENT}"$'\n'"${MARKER}"
           gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body "$FULL_COMMENT"
           echo "Performance results posted to PR #${{ inputs.pr_number }}"
-
-      - name: Auto app profiling check for failed tests
-        if: always() && !cancelled()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          SUMMARY="aggregated-reports/summary.json"
-          if [ ! -f "$SUMMARY" ]; then
-            echo "⚠️ No aggregated summary found — skipping auto app profiling check"
-            exit 0
-          fi
-
-          FAILED=$(node -p "JSON.parse(require('fs').readFileSync('aggregated-reports/summary.json','utf8')).failedTestsStats?.uniqueFailedTests ?? 0")
-          if [ "${FAILED}" = "0" ]; then
-            echo "✅ No failed performance tests — skipping auto app profiling check"
-            exit 0
-          fi
-
-          echo "🔬 Auto-running app profiling check for ${FAILED} failed scenario(s)..."
-          node tests/scripts/diff-app-profiling.mjs \
-            --pr "${PR_NUMBER}" \
-            --run "${CURRENT_RUN_ID}" \
-            --all \
-            --current-dir aggregated-reports \
-            --replace
 
   slack-notification:
     name: Send Slack Notification

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -586,6 +586,38 @@ jobs:
           gh pr comment "${{ inputs.pr_number }}" --repo "${{ github.repository }}" --body "$FULL_COMMENT"
           echo "Performance results posted to PR #${{ inputs.pr_number }}"
 
+      - name: Auto app profiling check for failed tests
+        if: always() && !cancelled()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          SUMMARY="aggregated-reports/summary.json"
+          if [ ! -f "$SUMMARY" ]; then
+            echo "⚠️ No aggregated summary found — skipping auto app profiling check"
+            exit 0
+          fi
+
+          FAILED=$(node -p "JSON.parse(require('fs').readFileSync('aggregated-reports/summary.json','utf8')).failedTestsStats?.uniqueFailedTests ?? 0")
+          if [ "${FAILED}" = "0" ]; then
+            echo "✅ No failed performance tests — skipping auto app profiling check"
+            exit 0
+          fi
+
+          echo "🔬 Auto-running app profiling check for ${FAILED} failed scenario(s)..."
+          node tests/scripts/diff-app-profiling.mjs \
+            --pr "${PR_NUMBER}" \
+            --run "${CURRENT_RUN_ID}" \
+            --all \
+            --current-dir aggregated-reports \
+            --replace
+
   slack-notification:
     name: Send Slack Notification
     runs-on: ubuntu-latest

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -663,21 +663,14 @@ node tests/scripts/aggregate-performance-reports.mjs
 
 ### App profiling check (automatic on PR failures)
 
-When a PR performance run has failed scenarios, the
-`Post Performance Results to PR` job automatically runs
-`tests/scripts/diff-app-profiling.mjs --all` and posts a separate comment with
-BrowserStack `profilingSummary` vs the last green baseline on `main`
-(⚠️ only when Current > Baseline + 10%).
+When a PR performance run has failed scenarios, the results comment includes
+an inline **App profiling check** under each failed scenario that has a prior
+usable baseline on `main` (short summary + collapsed metric table). Scenarios
+without a prior baseline are omitted from that block.
 
-Baseline preference:
-1. Last **green** scenario on `main` with usable profiling
-2. Else latest usable profiling on `main` even if that scenario is also
-   failing (labeled as such in the comment)
+Header uses ⚠️ when there are failed tests.
 
-Failed scenarios **without** a prior usable baseline on `main` are skipped
-(not listed in the profiling comment), since there is nothing to compare.
-
-Manual re-run is still available via PR comment:
+Manual re-run remains available via:
 
 ```text
 @metamaskbot app-profiling-check --test "Cold Start Login" --platform Android --device "Google Pixel 8 Pro+14.0" --run <RUN_ID>
@@ -690,9 +683,8 @@ Or compare all failed scenarios from that run:
 ```
 
 This uses `.github/workflows/app-profiling-check.yml` (bot command /
-`workflow_dispatch`). The automatic path runs the same script from
-`run-performance-e2e.yml` with `--current-dir` (local aggregated reports) and
-`--replace` (updates the previous profiling comment).
+`workflow_dispatch`). The automatic PR path embeds profiling into the
+performance results comment from `run-performance-e2e.yml`.
 
 ### HTML Dashboard Features
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -669,6 +669,11 @@ When a PR performance run has failed scenarios, the
 BrowserStack `profilingSummary` vs the last green baseline on `main`
 (⚠️ only when Current > Baseline + 10%).
 
+Baseline preference:
+1. Last **green** scenario on `main` with usable profiling
+2. Else latest usable profiling on `main` even if that scenario is also
+   failing (labeled as such in the comment)
+
 Manual re-run is still available via PR comment:
 
 ```text

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -661,11 +661,15 @@ node tests/scripts/aggregate-performance-reports.mjs
 | `tests/aggregated-reports/performance-report.html`            | **Visual HTML dashboard**                   |
 | `tests/aggregated-reports/app-profiling/*.json`               | Per-scenario app profiling + API call files |
 
-### App profiling check (on-demand PR diff)
+### App profiling check (automatic on PR failures)
 
-When a performance scenario fails on a PR, the results comment includes an
-**App profiling check** command. Paste it as a PR comment to compare BrowserStack
-`profilingSummary` against the last green run of that scenario on `main`:
+When a PR performance run has failed scenarios, the
+`Post Performance Results to PR` job automatically runs
+`tests/scripts/diff-app-profiling.mjs --all` and posts a separate comment with
+BrowserStack `profilingSummary` vs the last green baseline on `main`
+(⚠️ only when Current > Baseline + 10%).
+
+Manual re-run is still available via PR comment:
 
 ```text
 @metamaskbot app-profiling-check --test "Cold Start Login" --platform Android --device "Google Pixel 8 Pro+14.0" --run <RUN_ID>
@@ -677,8 +681,10 @@ Or compare all failed scenarios from that run:
 @metamaskbot app-profiling-check --all --run <RUN_ID>
 ```
 
-This runs `.github/workflows/app-profiling-check.yml`, which downloads
-`aggregated-reports` for the current run + baseline and posts a diff comment.
+This uses `.github/workflows/app-profiling-check.yml` (bot command /
+`workflow_dispatch`). The automatic path runs the same script from
+`run-performance-e2e.yml` with `--current-dir` (local aggregated reports) and
+`--replace` (updates the previous profiling comment).
 
 ### HTML Dashboard Features
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -674,6 +674,9 @@ Baseline preference:
 2. Else latest usable profiling on `main` even if that scenario is also
    failing (labeled as such in the comment)
 
+Failed scenarios **without** a prior usable baseline on `main` are skipped
+(not listed in the profiling comment), since there is nothing to compare.
+
 Manual re-run is still available via PR comment:
 
 ```text

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -14,6 +14,10 @@
  * Or compare all failed tests from the current run:
  *   node tests/scripts/diff-app-profiling.mjs --pr 33656 --run 29931469755 --all
  *
+ * From the performance workflow (local aggregated-reports already present):
+ *   node tests/scripts/diff-app-profiling.mjs --pr 33656 --run 29931469755 --all \
+ *     --current-dir aggregated-reports --replace
+ *
  * Environment:
  *   GITHUB_REPOSITORY  owner/repo (required unless --repo is passed)
  *   GH_TOKEN / GITHUB_TOKEN  GitHub token with actions:read + pull_requests:write
@@ -292,7 +296,10 @@ function flattenPerformanceResults(results) {
   return entries;
 }
 
-function findGreenScenarioInDir(dir, { testName, device }) {
+function findScenarioWithProfilingInDir(
+  dir,
+  { testName, device, requireGreen = false },
+) {
   const resultsPath = path.join(dir, 'performance-results.json');
   if (!fs.existsSync(resultsPath)) {
     return null;
@@ -302,11 +309,13 @@ function findGreenScenarioInDir(dir, { testName, device }) {
     (entry) =>
       entry.test.testName === testName &&
       devicesMatch(entry.device, device) &&
-      isScenarioGreen(entry.test),
+      (!requireGreen || isScenarioGreen(entry.test)),
   );
   if (!match) {
     return null;
   }
+
+  const isGreen = isScenarioGreen(match.test);
 
   // Prefer dedicated app-profiling sidecars when present (new artifact layout).
   const artifacts = findProfilingArtifacts(dir);
@@ -316,6 +325,7 @@ function findGreenScenarioInDir(dir, { testName, device }) {
       platform: match.platform,
       device: match.device,
       artifact: sidecar.data,
+      isGreen,
     };
   }
 
@@ -340,7 +350,17 @@ function findGreenScenarioInDir(dir, { testName, device }) {
     platform: match.platform,
     device: match.device,
     artifact: embeddedArtifact,
+    isGreen,
   };
+}
+
+/** @deprecated Prefer findScenarioWithProfilingInDir({ requireGreen: true }) */
+function findGreenScenarioInDir(dir, { testName, device }) {
+  return findScenarioWithProfilingInDir(dir, {
+    testName,
+    device,
+    requireGreen: true,
+  });
 }
 
 function findBaselineScenario({
@@ -358,12 +378,14 @@ function findBaselineScenario({
     branch: baselineBranch,
   });
 
+  const downloaded = [];
+
   for (const run of candidates) {
     if (String(run.databaseId) === String(currentRunId)) {
       continue;
     }
-    // Prefer completed runs; performance can be non-blocking so conclusion
-    // success still needs per-scenario green checks below.
+    // Prefer completed workflow runs. Per-scenario green is checked below;
+    // performance can be non-blocking so workflow success ≠ scenario green.
     if (run.conclusion && run.conclusion !== 'success') {
       continue;
     }
@@ -378,11 +400,39 @@ function findBaselineScenario({
       continue;
     }
 
-    const found = findGreenScenarioInDir(dest, { testName, device });
-    if (found) {
+    downloaded.push({ run, dest });
+
+    const green = findScenarioWithProfilingInDir(dest, {
+      testName,
+      device,
+      requireGreen: true,
+    });
+    if (green) {
       return {
         run,
-        ...found,
+        ...green,
+        isGreen: true,
+      };
+    }
+  }
+
+  // Fallback: if the scenario is also failing on the baseline branch, still
+  // compare against the latest usable profilingSummary so teams can see
+  // whether the PR is worse/better than current main.
+  for (const { run, dest } of downloaded) {
+    const any = findScenarioWithProfilingInDir(dest, {
+      testName,
+      device,
+      requireGreen: false,
+    });
+    if (any) {
+      console.warn(
+        `⚠️  No green baseline for "${testName}"; using latest usable profiling from run ${run.databaseId} (scenario also failing on ${baselineBranch})`,
+      );
+      return {
+        run,
+        ...any,
+        isGreen: false,
       };
     }
   }
@@ -559,7 +609,7 @@ function buildScenarioComment({
   }
 
   if (!baseline) {
-    md += `\n\n⚠️ No green baseline found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
+    md += `\n\n⚠️ No usable baseline profiling found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
     md += `### Current profilingSummary\n\n`;
     md += '```json\n';
     md += `${JSON.stringify(currentArtifact.profilingSummary, null, 2)}\n`;
@@ -572,11 +622,20 @@ function buildScenarioComment({
     baseline.run.url ||
     `https://github.com/${repo}/actions/runs/${baseline.run.databaseId}`;
   const baselineSha = (baseline.run.headSha || '').slice(0, 7);
-  md += ` · **Baseline (last green on \`${baselineBranch}\`):** [run ${baseline.run.databaseId}](${baselineUrl})`;
+  const baselineKind =
+    baseline.isGreen === false
+      ? `last run on \`${baselineBranch}\` (scenario also failing)`
+      : `last green on \`${baselineBranch}\``;
+  md += ` · **Baseline (${baselineKind}):** [run ${baseline.run.databaseId}](${baselineUrl})`;
   if (baselineSha) {
     md += ` @ \`${baselineSha}\``;
   }
-  md += '\n\n';
+  md += '\n';
+
+  if (baseline.isGreen === false) {
+    md += `\n> ⚠️ No green baseline was available for this scenario on \`${baselineBranch}\`. Comparing against the latest usable profiling anyway.\n`;
+  }
+  md += '\n';
   md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
   md += `> - If \`Current <= Baseline + 10%\`, the change is treated as acceptable noise (no highlight).\n`;
   md += `> - If \`Current > Baseline + 10%\`, **Current** and the **variance %** are highlighted and marked with ⚠️.\n\n`;
@@ -758,6 +817,7 @@ export {
   hasUsableProfilingSummary,
   findMatchingArtifact,
   findGreenScenarioInDir,
+  findScenarioWithProfilingInDir,
   buildScenarioComment,
   parseArgs,
   COMMENT_MARKER,

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -243,6 +243,16 @@ function getFailedScenariosFromSummary(summaryDir) {
 }
 
 function downloadAggregatedReports(runId, destDir, repo) {
+  const resultsPath = path.join(destDir, 'performance-results.json');
+  // Reuse a prior download in this workRoot (common with --all when multiple
+  // scenarios share the same baseline candidates). Re-extracting into a
+  // non-empty dir fails with "file exists" and would skip a valid baseline.
+  if (fs.existsSync(resultsPath)) {
+    return;
+  }
+  if (fs.existsSync(destDir)) {
+    fs.rmSync(destDir, { recursive: true, force: true });
+  }
   fs.mkdirSync(destDir, { recursive: true });
   runGh([
     'run',

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -42,6 +42,10 @@ function parseArgs(argv) {
     workflow: DEFAULT_WORKFLOW,
     repo: process.env.GITHUB_REPOSITORY || null,
     dryRun: false,
+    /** When set, use this local aggregated-reports dir instead of downloading the current run. */
+    currentDir: null,
+    /** Delete previous app-profiling-check PR comments before posting a new one. */
+    replace: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -80,11 +84,18 @@ function parseArgs(argv) {
         args.repo = next;
         i += 1;
         break;
+      case '--current-dir':
+        args.currentDir = next;
+        i += 1;
+        break;
       case '--all':
         args.all = true;
         break;
       case '--dry-run':
         args.dryRun = true;
+        break;
+      case '--replace':
+        args.replace = true;
         break;
       default:
         break;
@@ -623,6 +634,32 @@ function resolveScenarios(args, currentDir) {
   ];
 }
 
+function deletePreviousAppProfilingComments({ pr, repo }) {
+  const raw = runGh([
+    'api',
+    `repos/${repo}/issues/${pr}/comments`,
+    '--jq',
+    `.[] | select(.body | contains("${COMMENT_MARKER}")) | .id`,
+  ]);
+  const ids = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const id of ids) {
+    try {
+      runGh(['api', `repos/${repo}/issues/comments/${id}`, '--method', 'DELETE']);
+      console.log(`🗑️  Deleted previous app profiling comment ${id}`);
+    } catch (error) {
+      console.warn(
+        `⚠️  Could not delete comment ${id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
 
@@ -631,10 +668,21 @@ function main() {
   if (!args.repo) fail('Missing --repo owner/repo or GITHUB_REPOSITORY');
 
   const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'app-profiling-check-'));
-  const currentDir = path.join(workRoot, 'current');
+  let currentDir = args.currentDir;
 
-  console.log(`📥 Downloading current aggregated-reports from run ${args.run}...`);
-  downloadAggregatedReports(args.run, currentDir, args.repo);
+  if (currentDir) {
+    currentDir = path.resolve(currentDir);
+    if (!fs.existsSync(currentDir)) {
+      fail(`--current-dir does not exist: ${currentDir}`);
+    }
+    console.log(`📂 Using local aggregated-reports at ${currentDir}`);
+  } else {
+    currentDir = path.join(workRoot, 'current');
+    console.log(
+      `📥 Downloading current aggregated-reports from run ${args.run}...`,
+    );
+    downloadAggregatedReports(args.run, currentDir, args.repo);
+  }
 
   const scenarios = resolveScenarios(args, currentDir);
   const currentArtifacts = findProfilingArtifacts(currentDir);
@@ -690,6 +738,11 @@ function main() {
     return;
   }
 
+  if (args.replace) {
+    console.log('🧹 Replacing previous app profiling check comments...');
+    deletePreviousAppProfilingComments({ pr: args.pr, repo: args.repo });
+  }
+
   console.log(`💬 Posting comment on PR #${args.pr}...`);
   runGh(['pr', 'comment', String(args.pr), '--repo', args.repo, '--body-file', bodyFile]);
   console.log('✅ App profiling check comment posted');
@@ -706,6 +759,7 @@ export {
   findMatchingArtifact,
   findGreenScenarioInDir,
   buildScenarioComment,
+  parseArgs,
   COMMENT_MARKER,
 };
 

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -611,6 +611,14 @@ function buildRegressionSummary(rows) {
   } over +10%: ${list}`;
 }
 
+function shouldIncludeScenarioInComment({ currentArtifact, baseline }) {
+  // Without a prior baseline there is nothing useful to compare — omit the
+  // scenario from the PR comment instead of posting a "no baseline" stub.
+  return Boolean(
+    baseline && currentArtifact && hasUsableProfilingSummary(currentArtifact),
+  );
+}
+
 function buildScenarioComment({
   testName,
   platform,
@@ -631,24 +639,10 @@ function buildScenarioComment({
   md += '\n\n';
   md += `**Current:** [run ${currentRunId}](${currentUrl})`;
 
-  if (!currentArtifact || !hasUsableProfilingSummary(currentArtifact)) {
-    md += `\n\n⚠️ Current run has no usable \`profilingSummary\` for this scenario.\n`;
-    if (currentArtifact?.apiCallsError) {
-      md += `\nAPI calls note: \`${currentArtifact.apiCallsError}\`\n`;
-    }
+  if (!shouldIncludeScenarioInComment({ currentArtifact, baseline })) {
+    // Kept for callers/tests; main() skips these scenarios before posting.
+    md += `\n\n⚠️ Skipping scenario: need usable current profiling and a baseline on \`${baselineBranch}\`.\n`;
     md += `\n${COMMENT_MARKER}\n`;
-    return md;
-  }
-
-  if (!baseline) {
-    md += `\n\n⚠️ No usable baseline profiling found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
-    md += `**Summary:** current profiling only (no baseline comparison).\n\n`;
-    md += `<details>\n<summary>Current profilingSummary JSON</summary>\n\n`;
-    md += '```json\n';
-    md += `${JSON.stringify(currentArtifact.profilingSummary, null, 2)}\n`;
-    md += '```\n\n';
-    md += `</details>\n\n`;
-    md += `${COMMENT_MARKER}\n`;
     return md;
   }
 
@@ -814,6 +808,15 @@ function main() {
       workRoot,
     });
 
+    if (!shouldIncludeScenarioInComment({ currentArtifact, baseline })) {
+      console.warn(
+        `⏭️  Skipping "${scenario.testName}" on ${formatDeviceLabel(
+          scenario.device,
+        )}: no usable current profiling and/or no prior baseline on ${args.baselineBranch}`,
+      );
+      continue;
+    }
+
     comments.push(
       buildScenarioComment({
         testName: scenario.testName,
@@ -826,6 +829,17 @@ function main() {
         baselineBranch: args.baselineBranch,
       }),
     );
+  }
+
+  if (comments.length === 0) {
+    console.log(
+      'ℹ️  No failed scenarios had both usable current profiling and a prior baseline — nothing to post',
+    );
+    if (args.replace && !args.dryRun) {
+      console.log('🧹 Clearing previous app profiling check comments...');
+      deletePreviousAppProfilingComments({ pr: args.pr, repo: args.repo });
+    }
+    return;
   }
 
   const body = comments.join('\n---\n\n');
@@ -862,6 +876,7 @@ export {
   downloadAggregatedReports,
   buildRegressionSummary,
   buildScenarioComment,
+  shouldIncludeScenarioInComment,
   parseArgs,
   COMMENT_MARKER,
 };

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -619,6 +619,82 @@ function shouldIncludeScenarioInComment({ currentArtifact, baseline }) {
   );
 }
 
+/**
+ * Compact profiling block for embedding under a failed performance test.
+ * Returns null when there is no usable baseline comparison.
+ */
+function buildEmbeddedProfilingSection({
+  currentRunId,
+  currentArtifact,
+  baseline,
+  repo,
+  baselineBranch = DEFAULT_BASELINE_BRANCH,
+  includeRawJson = false,
+}) {
+  if (!shouldIncludeScenarioInComment({ currentArtifact, baseline })) {
+    return null;
+  }
+
+  const currentUrl = `https://github.com/${repo}/actions/runs/${currentRunId}`;
+  const baselineUrl =
+    baseline.run.url ||
+    `https://github.com/${repo}/actions/runs/${baseline.run.databaseId}`;
+  const baselineSha = (baseline.run.headSha || '').slice(0, 7);
+  const baselineKind =
+    baseline.isGreen === false
+      ? `last run on \`${baselineBranch}\` (scenario also failing)`
+      : `last green on \`${baselineBranch}\``;
+
+  const rows = getMetricRows(
+    baseline.artifact.profilingSummary,
+    currentArtifact.profilingSummary,
+  );
+
+  let md = `🔬 **App profiling check** · Current [run ${currentRunId}](${currentUrl}) · Baseline (${baselineKind}) [run ${baseline.run.databaseId}](${baselineUrl})`;
+  if (baselineSha) {
+    md += ` @ \`${baselineSha}\``;
+  }
+  md += '\n\n';
+
+  if (baseline.isGreen === false) {
+    md += `> ⚠️ No green baseline on \`${baselineBranch}\` — comparing against the latest usable profiling.\n\n`;
+  }
+
+  md += `**Summary:** ${buildRegressionSummary(rows)}\n`;
+
+  if (currentArtifact.apiCallsError) {
+    md += `\n> ℹ️ API calls unavailable: \`${currentArtifact.apiCallsError}\`\n`;
+  }
+
+  md += `\n<details>\n<summary>Full metric table (+10% variance rules)</summary>\n\n`;
+  md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
+  md += `> - If \`Current <= Baseline + 10%\`, treated as acceptable noise.\n`;
+  md += `> - If \`Current > Baseline + 10%\`, **Current** and **variance %** are highlighted with ⚠️.\n\n`;
+  md += `| Metric | Baseline | Current | Δ |\n`;
+  md += `|--------|----------|---------|---|\n`;
+  for (const row of rows) {
+    md += `| ${row.label} | ${row.baselineText} | ${row.currentText} | ${row.deltaText} |\n`;
+  }
+  md += `\n</details>\n`;
+
+  if (includeRawJson) {
+    md += `\n<details>\n<summary>Raw profilingSummary JSON</summary>\n\n`;
+    md += `**Baseline**\n\n\`\`\`json\n${JSON.stringify(
+      baseline.artifact.profilingSummary,
+      null,
+      2,
+    )}\n\`\`\`\n\n`;
+    md += `**Current**\n\n\`\`\`json\n${JSON.stringify(
+      currentArtifact.profilingSummary,
+      null,
+      2,
+    )}\n\`\`\`\n\n`;
+    md += `</details>\n`;
+  }
+
+  return md;
+}
+
 function buildScenarioComment({
   testName,
   platform,
@@ -640,7 +716,6 @@ function buildScenarioComment({
   md += `**Current:** [run ${currentRunId}](${currentUrl})`;
 
   if (!shouldIncludeScenarioInComment({ currentArtifact, baseline })) {
-    // Kept for callers/tests; main() skips these scenarios before posting.
     md += `\n\n⚠️ Skipping scenario: need usable current profiling and a baseline on \`${baselineBranch}\`.\n`;
     md += `\n${COMMENT_MARKER}\n`;
     return md;
@@ -660,45 +735,22 @@ function buildScenarioComment({
   }
   md += '\n';
 
-  if (baseline.isGreen === false) {
-    md += `\n> ⚠️ No green baseline was available for this scenario on \`${baselineBranch}\`. Comparing against the latest usable profiling anyway.\n`;
-  }
+  const embedded = buildEmbeddedProfilingSection({
+    currentRunId,
+    currentArtifact,
+    baseline,
+    repo,
+    baselineBranch,
+    includeRawJson: true,
+  });
 
-  const rows = getMetricRows(
-    baseline.artifact.profilingSummary,
-    currentArtifact.profilingSummary,
-  );
-
-  md += `\n**Summary:** ${buildRegressionSummary(rows)}\n`;
-
-  if (currentArtifact.apiCallsError) {
-    md += `\n> ℹ️ API calls unavailable on current run: \`${currentArtifact.apiCallsError}\`\n`;
-  }
-
-  md += `\n<details>\n<summary>Full metric table (+10% variance rules)</summary>\n\n`;
-  md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
-  md += `> - If \`Current <= Baseline + 10%\`, the change is treated as acceptable noise (no highlight).\n`;
-  md += `> - If \`Current > Baseline + 10%\`, **Current** and the **variance %** are highlighted and marked with ⚠️.\n\n`;
-  md += `| Metric | Baseline | Current | Δ |\n`;
-  md += `|--------|----------|---------|---|\n`;
-  for (const row of rows) {
-    md += `| ${row.label} | ${row.baselineText} | ${row.currentText} | ${row.deltaText} |\n`;
-  }
-  md += `\n</details>\n`;
-
-  md += `\n<details>\n<summary>Raw profilingSummary JSON</summary>\n\n`;
-  md += `**Baseline**\n\n\`\`\`json\n${JSON.stringify(
-    baseline.artifact.profilingSummary,
-    null,
-    2,
-  )}\n\`\`\`\n\n`;
-  md += `**Current**\n\n\`\`\`json\n${JSON.stringify(
-    currentArtifact.profilingSummary,
-    null,
-    2,
-  )}\n\`\`\`\n\n`;
-  md += `</details>\n\n`;
-  md += `${COMMENT_MARKER}\n`;
+  // Reuse summary + collapsed details from the embedded builder; drop its
+  // leading "App profiling check · Current/Baseline" line (already above).
+  const detailsOnly = embedded
+    .replace(/^🔬 \*\*App profiling check\*\*[^\n]*\n\n/, '')
+    .replace(/^\n+/, '\n');
+  md += detailsOnly;
+  md += `\n${COMMENT_MARKER}\n`;
   return md;
 }
 
@@ -875,8 +927,11 @@ export {
   findScenarioWithProfilingInDir,
   downloadAggregatedReports,
   buildRegressionSummary,
+  buildEmbeddedProfilingSection,
   buildScenarioComment,
   shouldIncludeScenarioInComment,
+  findBaselineScenario,
+  findProfilingArtifacts,
   parseArgs,
   COMMENT_MARKER,
 };

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -590,6 +590,27 @@ function getMetricRows(baselineSummary, currentSummary) {
   });
 }
 
+function buildRegressionSummary(rows) {
+  const warned = (rows ?? []).filter((row) => row.warn);
+  if (warned.length === 0) {
+    return '✅ No metrics over the +10% baseline margin.';
+  }
+
+  const list = warned
+    .map((row) => {
+      const delta = String(row.deltaText ?? '')
+        .replaceAll('**', '')
+        .replace(' ⚠️', '')
+        .trim();
+      return delta ? `${row.label} (${delta})` : row.label;
+    })
+    .join(', ');
+
+  return `⚠️ **${warned.length}** metric${
+    warned.length === 1 ? '' : 's'
+  } over +10%: ${list}`;
+}
+
 function buildScenarioComment({
   testName,
   platform,
@@ -621,11 +642,13 @@ function buildScenarioComment({
 
   if (!baseline) {
     md += `\n\n⚠️ No usable baseline profiling found on \`${baselineBranch}\` (within recent \`aggregated-reports\` retention) for this scenario + device.\n\n`;
-    md += `### Current profilingSummary\n\n`;
+    md += `**Summary:** current profiling only (no baseline comparison).\n\n`;
+    md += `<details>\n<summary>Current profilingSummary JSON</summary>\n\n`;
     md += '```json\n';
     md += `${JSON.stringify(currentArtifact.profilingSummary, null, 2)}\n`;
-    md += '```\n';
-    md += `\n${COMMENT_MARKER}\n`;
+    md += '```\n\n';
+    md += `</details>\n\n`;
+    md += `${COMMENT_MARKER}\n`;
     return md;
   }
 
@@ -646,25 +669,28 @@ function buildScenarioComment({
   if (baseline.isGreen === false) {
     md += `\n> ⚠️ No green baseline was available for this scenario on \`${baselineBranch}\`. Comparing against the latest usable profiling anyway.\n`;
   }
-  md += '\n';
-  md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
-  md += `> - If \`Current <= Baseline + 10%\`, the change is treated as acceptable noise (no highlight).\n`;
-  md += `> - If \`Current > Baseline + 10%\`, **Current** and the **variance %** are highlighted and marked with ⚠️.\n\n`;
 
   const rows = getMetricRows(
     baseline.artifact.profilingSummary,
     currentArtifact.profilingSummary,
   );
 
+  md += `\n**Summary:** ${buildRegressionSummary(rows)}\n`;
+
+  if (currentArtifact.apiCallsError) {
+    md += `\n> ℹ️ API calls unavailable on current run: \`${currentArtifact.apiCallsError}\`\n`;
+  }
+
+  md += `\n<details>\n<summary>Full metric table (+10% variance rules)</summary>\n\n`;
+  md += `> **Disclaimer — allowed variance:** a **+10%** margin over the baseline is permitted.\n`;
+  md += `> - If \`Current <= Baseline + 10%\`, the change is treated as acceptable noise (no highlight).\n`;
+  md += `> - If \`Current > Baseline + 10%\`, **Current** and the **variance %** are highlighted and marked with ⚠️.\n\n`;
   md += `| Metric | Baseline | Current | Δ |\n`;
   md += `|--------|----------|---------|---|\n`;
   for (const row of rows) {
     md += `| ${row.label} | ${row.baselineText} | ${row.currentText} | ${row.deltaText} |\n`;
   }
-
-  if (currentArtifact.apiCallsError) {
-    md += `\n> ℹ️ API calls unavailable on current run: \`${currentArtifact.apiCallsError}\`\n`;
-  }
+  md += `\n</details>\n`;
 
   md += `\n<details>\n<summary>Raw profilingSummary JSON</summary>\n\n`;
   md += `**Baseline**\n\n\`\`\`json\n${JSON.stringify(
@@ -834,6 +860,7 @@ export {
   findGreenScenarioInDir,
   findScenarioWithProfilingInDir,
   downloadAggregatedReports,
+  buildRegressionSummary,
   buildScenarioComment,
   parseArgs,
   COMMENT_MARKER,

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -694,9 +694,13 @@ function resolveScenarios(args, currentDir) {
 }
 
 function deletePreviousAppProfilingComments({ pr, repo }) {
+  // Paginate: without --paginate gh only returns the first page (30 comments,
+  // oldest-first), so recent <!-- app-profiling-check --> comments on busy PRs
+  // would be missed and --replace would stack duplicates.
   const raw = runGh([
     'api',
-    `repos/${repo}/issues/${pr}/comments`,
+    '--paginate',
+    `repos/${repo}/issues/${pr}/comments?per_page=100`,
     '--jq',
     `.[] | select(.body | contains("${COMMENT_MARKER}")) | .id`,
   ]);

--- a/tests/scripts/diff-app-profiling.mjs
+++ b/tests/scripts/diff-app-profiling.mjs
@@ -242,19 +242,19 @@ function getFailedScenariosFromSummary(summaryDir) {
   return scenarios;
 }
 
-function downloadAggregatedReports(runId, destDir, repo) {
+function downloadAggregatedReports(runId, destDir, repo, { runGhFn = runGh } = {}) {
   const resultsPath = path.join(destDir, 'performance-results.json');
   // Reuse a prior download in this workRoot (common with --all when multiple
   // scenarios share the same baseline candidates). Re-extracting into a
   // non-empty dir fails with "file exists" and would skip a valid baseline.
   if (fs.existsSync(resultsPath)) {
-    return;
+    return { reused: true };
   }
   if (fs.existsSync(destDir)) {
     fs.rmSync(destDir, { recursive: true, force: true });
   }
   fs.mkdirSync(destDir, { recursive: true });
-  runGh([
+  runGhFn([
     'run',
     'download',
     String(runId),
@@ -265,6 +265,7 @@ function downloadAggregatedReports(runId, destDir, repo) {
     '-D',
     destDir,
   ]);
+  return { reused: false };
 }
 
 function listBaselineCandidateRuns({ repo, workflow, branch, limit = 40 }) {
@@ -832,6 +833,7 @@ export {
   findMatchingArtifact,
   findGreenScenarioInDir,
   findScenarioWithProfilingInDir,
+  downloadAggregatedReports,
   buildScenarioComment,
   parseArgs,
   COMMENT_MARKER,

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -12,6 +12,7 @@ import {
   parseArgs,
   buildRegressionSummary,
   shouldIncludeScenarioInComment,
+  buildEmbeddedProfilingSection,
   COMMENT_MARKER,
 } from './diff-app-profiling.mjs';
 
@@ -241,6 +242,95 @@ test('buildScenarioComment explains missing baseline', () => {
   assert.match(md, new RegExp(COMMENT_MARKER));
 });
 
+test('buildEmbeddedProfilingSection returns null without baseline', () => {
+  assert.equal(
+    buildEmbeddedProfilingSection({
+      currentRunId: '111',
+      currentArtifact: { profilingSummary: { cpu: { avg: 1 } } },
+      baseline: null,
+      repo: 'MetaMask/metamask-mobile',
+    }),
+    null,
+  );
+});
+
+test('buildEmbeddedProfilingSection returns compact summary and collapsed table', () => {
+  const md = buildEmbeddedProfilingSection({
+    currentRunId: '111',
+    currentArtifact: {
+      profilingSummary: {
+        cpu: { avg: 20, max: 40 },
+        memory: { avg: 200, max: 250 },
+        uiRendering: { slowFrames: 2, frozenFrames: 0, anrs: 0 },
+        issues: 1,
+        criticalIssues: 0,
+      },
+    },
+    baseline: {
+      isGreen: true,
+      run: {
+        databaseId: 222,
+        headSha: 'abcdef123456',
+        url: 'https://github.com/MetaMask/metamask-mobile/actions/runs/222',
+      },
+      artifact: {
+        profilingSummary: {
+          cpu: { avg: 10, max: 20 },
+          memory: { avg: 180, max: 220 },
+          uiRendering: { slowFrames: 1, frozenFrames: 0, anrs: 0 },
+          issues: 0,
+          criticalIssues: 0,
+        },
+      },
+    },
+    repo: 'MetaMask/metamask-mobile',
+  });
+
+  assert.match(md, /App profiling check/);
+  assert.match(md, /\*\*Summary:\*\*/);
+  assert.match(md, /Full metric table/);
+  assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
+  assert.equal(md.includes('Raw profilingSummary JSON'), false);
+});
+
+test('buildEmbeddedProfilingSection labels non-green baseline fallback', () => {
+  const md = buildEmbeddedProfilingSection({
+    currentRunId: '111',
+    currentArtifact: {
+      profilingSummary: {
+        cpu: { avg: 10, max: 20 },
+        memory: { avg: 200, max: 250 },
+        uiRendering: { slowFrames: 10, frozenFrames: 0, anrs: 0 },
+        issues: 1,
+        criticalIssues: 0,
+      },
+    },
+    baseline: {
+      isGreen: false,
+      run: {
+        databaseId: 222,
+        headSha: 'abcdef123456',
+        url: 'https://github.com/MetaMask/metamask-mobile/actions/runs/222',
+      },
+      artifact: {
+        profilingSummary: {
+          cpu: { avg: 8, max: 18 },
+          memory: { avg: 190, max: 240 },
+          uiRendering: { slowFrames: 7, frozenFrames: 0, anrs: 0 },
+          issues: 1,
+          criticalIssues: 0,
+        },
+      },
+    },
+    repo: 'MetaMask/metamask-mobile',
+  });
+
+  assert.match(md, /scenario also failing/);
+  assert.match(md, /No green baseline on `main`/);
+  assert.match(md, /\*\*Summary:\*\*/);
+  assert.match(md, /Full metric table/);
+});
+
 test('shouldIncludeScenarioInComment requires baseline and usable current', () => {
   assert.equal(
     shouldIncludeScenarioInComment({
@@ -301,7 +391,7 @@ test('buildScenarioComment labels non-green baseline fallback', () => {
   });
 
   assert.match(md, /scenario also failing/);
-  assert.match(md, /No green baseline was available/);
+  assert.match(md, /No green baseline on `main`/);
   assert.match(md, /\*\*Summary:\*\*/);
   assert.match(md, /Full metric table/);
   assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -11,6 +11,7 @@ import {
   buildScenarioComment,
   parseArgs,
   buildRegressionSummary,
+  shouldIncludeScenarioInComment,
   COMMENT_MARKER,
 } from './diff-app-profiling.mjs';
 
@@ -236,10 +237,32 @@ test('buildScenarioComment explains missing baseline', () => {
     repo: 'MetaMask/metamask-mobile',
   });
 
-  assert.match(md, /No usable baseline profiling found/);
-  assert.match(md, /Current profilingSummary JSON/);
-  assert.match(md, /<details>/);
+  assert.match(md, /Skipping scenario/);
   assert.match(md, new RegExp(COMMENT_MARKER));
+});
+
+test('shouldIncludeScenarioInComment requires baseline and usable current', () => {
+  assert.equal(
+    shouldIncludeScenarioInComment({
+      currentArtifact: { profilingSummary: { cpu: { avg: 1 } } },
+      baseline: null,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldIncludeScenarioInComment({
+      currentArtifact: { profilingSummary: { error: 'missing' } },
+      baseline: { artifact: { profilingSummary: { cpu: { avg: 1 } } } },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldIncludeScenarioInComment({
+      currentArtifact: { profilingSummary: { cpu: { avg: 1 } } },
+      baseline: { artifact: { profilingSummary: { cpu: { avg: 1 } } } },
+    }),
+    true,
+  );
 });
 
 test('buildScenarioComment labels non-green baseline fallback', () => {

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -264,7 +264,47 @@ test('buildScenarioComment labels non-green baseline fallback', () => {
   assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
 });
 
-test('findScenarioWithProfilingInDir can use failed scenarios with profiling', async () => {
+test('downloadAggregatedReports reuses an existing baseline directory', async () => {
+  const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = await import(
+    'node:fs'
+  );
+  const { join } = await import('node:path');
+  const { tmpdir } = await import('node:os');
+  const mod = await import('./diff-app-profiling.mjs');
+
+  // Access via dynamic re-import after exporting — call through a thin wrapper
+  // by simulating the reuse condition: directory with performance-results.json
+  // must be treated as already downloaded.
+  const dir = mkdtempSync(join(tmpdir(), 'profiling-reuse-'));
+  try {
+    writeFileSync(
+      join(dir, 'performance-results.json'),
+      JSON.stringify({
+        Android: {
+          'Pixel 8+14.0': [
+            {
+              testName: 'Fresh SRP wallet creation performance',
+              testFailed: true,
+              device: { name: 'Pixel 8', osVersion: '14.0' },
+              profilingSummary: { cpu: { avg: 9, max: 18 } },
+            },
+          ],
+        },
+      }),
+    );
+
+    const found = mod.findScenarioWithProfilingInDir(dir, {
+      testName: 'Fresh SRP wallet creation performance',
+      device: { name: 'Pixel 8', osVersion: '14.0' },
+      requireGreen: false,
+    });
+    assert.equal(found?.artifact?.profilingSummary?.cpu?.avg, 9);
+    assert.equal(found?.isGreen, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
   const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
   const { join } = await import('node:path');
   const { tmpdir } = await import('node:os');

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -265,16 +265,15 @@ test('buildScenarioComment labels non-green baseline fallback', () => {
 });
 
 test('downloadAggregatedReports reuses an existing baseline directory', async () => {
-  const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = await import(
-    'node:fs'
-  );
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
   const { join } = await import('node:path');
   const { tmpdir } = await import('node:os');
-  const mod = await import('./diff-app-profiling.mjs');
+  const { findScenarioWithProfilingInDir } = await import(
+    './diff-app-profiling.mjs'
+  );
 
-  // Access via dynamic re-import after exporting — call through a thin wrapper
-  // by simulating the reuse condition: directory with performance-results.json
-  // must be treated as already downloaded.
+  // Directory already containing performance-results.json must remain usable
+  // for a later scenario in the same --all run (no re-extract needed).
   const dir = mkdtempSync(join(tmpdir(), 'profiling-reuse-'));
   try {
     writeFileSync(
@@ -293,7 +292,7 @@ test('downloadAggregatedReports reuses an existing baseline directory', async ()
       }),
     );
 
-    const found = mod.findScenarioWithProfilingInDir(dir, {
+    const found = findScenarioWithProfilingInDir(dir, {
       testName: 'Fresh SRP wallet creation performance',
       device: { name: 'Pixel 8', osVersion: '14.0' },
       requireGreen: false,
@@ -305,6 +304,7 @@ test('downloadAggregatedReports reuses an existing baseline directory', async ()
   }
 });
 
+test('findScenarioWithProfilingInDir can use failed scenarios with profiling', async () => {
   const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
   const { join } = await import('node:path');
   const { tmpdir } = await import('node:os');

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -9,8 +9,27 @@ import {
   hasUsableProfilingSummary,
   findMatchingArtifact,
   buildScenarioComment,
+  parseArgs,
   COMMENT_MARKER,
 } from './diff-app-profiling.mjs';
+
+test('parseArgs accepts --current-dir, --replace, and --all', () => {
+  const args = parseArgs([
+    '--pr',
+    '1',
+    '--run',
+    '2',
+    '--all',
+    '--current-dir',
+    './aggregated-reports',
+    '--replace',
+  ]);
+  assert.equal(args.pr, '1');
+  assert.equal(args.run, '2');
+  assert.equal(args.all, true);
+  assert.equal(args.currentDir, './aggregated-reports');
+  assert.equal(args.replace, true);
+});
 
 test('parseDeviceKey parses Name+OSVersion keys', () => {
   assert.deepEqual(parseDeviceKey('Google Pixel 8 Pro+14.0'), {

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -10,6 +10,7 @@ import {
   findMatchingArtifact,
   buildScenarioComment,
   parseArgs,
+  buildRegressionSummary,
   COMMENT_MARKER,
 } from './diff-app-profiling.mjs';
 
@@ -200,12 +201,27 @@ test('buildScenarioComment includes marker and delta table when baseline exists'
   });
 
   assert.match(md, /## 🔬 App Profiling Check: Cold Start Login/);
-      assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
-      assert.match(md, /Disclaimer — allowed variance/);
-      assert.match(md, /\+10%/);
-      assert.match(md, new RegExp(COMMENT_MARKER));
-      assert.match(md, /run 222/);
-    });
+  assert.match(md, /\*\*Summary:\*\*/);
+  assert.match(md, /metric/);
+  assert.match(md, /<details>/);
+  assert.match(md, /Full metric table/);
+  assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
+  assert.match(md, /Disclaimer — allowed variance/);
+  assert.match(md, /\+10%/);
+  assert.match(md, /Raw profilingSummary JSON/);
+  assert.match(md, new RegExp(COMMENT_MARKER));
+  assert.match(md, /run 222/);
+});
+
+test('buildRegressionSummary lists only warned metrics', () => {
+  const summary = buildRegressionSummary([
+    { label: 'CPU avg', warn: true, deltaText: '+2 (**+20%**) ⚠️' },
+    { label: 'Memory avg', warn: false, deltaText: '+1 (+1%)' },
+  ]);
+  assert.match(summary, /CPU avg/);
+  assert.match(summary, /\+20%/);
+  assert.equal(summary.includes('Memory avg'), false);
+});
 
 test('buildScenarioComment explains missing baseline', () => {
   const md = buildScenarioComment({
@@ -221,6 +237,8 @@ test('buildScenarioComment explains missing baseline', () => {
   });
 
   assert.match(md, /No usable baseline profiling found/);
+  assert.match(md, /Current profilingSummary JSON/);
+  assert.match(md, /<details>/);
   assert.match(md, new RegExp(COMMENT_MARKER));
 });
 
@@ -261,6 +279,8 @@ test('buildScenarioComment labels non-green baseline fallback', () => {
 
   assert.match(md, /scenario also failing/);
   assert.match(md, /No green baseline was available/);
+  assert.match(md, /\*\*Summary:\*\*/);
+  assert.match(md, /Full metric table/);
   assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
 });
 

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -265,40 +265,70 @@ test('buildScenarioComment labels non-green baseline fallback', () => {
 });
 
 test('downloadAggregatedReports reuses an existing baseline directory', async () => {
-  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } =
+    await import('node:fs');
   const { join } = await import('node:path');
   const { tmpdir } = await import('node:os');
-  const { findScenarioWithProfilingInDir } = await import(
-    './diff-app-profiling.mjs'
-  );
+  const { downloadAggregatedReports } = await import('./diff-app-profiling.mjs');
 
-  // Directory already containing performance-results.json must remain usable
-  // for a later scenario in the same --all run (no re-extract needed).
   const dir = mkdtempSync(join(tmpdir(), 'profiling-reuse-'));
+  const resultsPath = join(dir, 'performance-results.json');
+  const payload = JSON.stringify({ ok: true });
   try {
-    writeFileSync(
-      join(dir, 'performance-results.json'),
-      JSON.stringify({
-        Android: {
-          'Pixel 8+14.0': [
-            {
-              testName: 'Fresh SRP wallet creation performance',
-              testFailed: true,
-              device: { name: 'Pixel 8', osVersion: '14.0' },
-              profilingSummary: { cpu: { avg: 9, max: 18 } },
-            },
-          ],
-        },
-      }),
-    );
+    writeFileSync(resultsPath, payload);
 
-    const found = findScenarioWithProfilingInDir(dir, {
-      testName: 'Fresh SRP wallet creation performance',
-      device: { name: 'Pixel 8', osVersion: '14.0' },
-      requireGreen: false,
+    let ghCalls = 0;
+    const result = downloadAggregatedReports(123, dir, 'MetaMask/metamask-mobile', {
+      runGhFn: () => {
+        ghCalls += 1;
+        throw new Error('gh should not be called when reusing');
+      },
     });
-    assert.equal(found?.artifact?.profilingSummary?.cpu?.avg, 9);
-    assert.equal(found?.isGreen, false);
+
+    assert.equal(result.reused, true);
+    assert.equal(ghCalls, 0);
+    assert.equal(existsSync(resultsPath), true);
+    assert.equal(readFileSync(resultsPath, 'utf8'), payload);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('downloadAggregatedReports downloads when directory is empty', async () => {
+  const { mkdtempSync, writeFileSync, rmSync, existsSync } = await import(
+    'node:fs'
+  );
+  const { join } = await import('node:path');
+  const { tmpdir } = await import('node:os');
+  const { downloadAggregatedReports } = await import('./diff-app-profiling.mjs');
+
+  const dir = mkdtempSync(join(tmpdir(), 'profiling-download-'));
+  try {
+    let seenArgs = null;
+    const result = downloadAggregatedReports(456, dir, 'MetaMask/metamask-mobile', {
+      runGhFn: (args) => {
+        seenArgs = args;
+        // Simulate gh extracting the artifact into destDir.
+        writeFileSync(
+          join(dir, 'performance-results.json'),
+          JSON.stringify({ downloaded: true }),
+        );
+      },
+    });
+
+    assert.equal(result.reused, false);
+    assert.deepEqual(seenArgs, [
+      'run',
+      'download',
+      '456',
+      '--repo',
+      'MetaMask/metamask-mobile',
+      '-n',
+      'aggregated-reports',
+      '-D',
+      dir,
+    ]);
+    assert.equal(existsSync(join(dir, 'performance-results.json')), true);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/scripts/diff-app-profiling.test.mjs
+++ b/tests/scripts/diff-app-profiling.test.mjs
@@ -220,8 +220,94 @@ test('buildScenarioComment explains missing baseline', () => {
     repo: 'MetaMask/metamask-mobile',
   });
 
-  assert.match(md, /No green baseline found/);
+  assert.match(md, /No usable baseline profiling found/);
   assert.match(md, new RegExp(COMMENT_MARKER));
+});
+
+test('buildScenarioComment labels non-green baseline fallback', () => {
+  const md = buildScenarioComment({
+    testName: 'Import SRP with +50 accounts',
+    platform: 'Android',
+    device: { name: 'Pixel 8', osVersion: '14.0' },
+    currentRunId: '111',
+    currentArtifact: {
+      profilingSummary: {
+        cpu: { avg: 10, max: 20 },
+        memory: { avg: 200, max: 250 },
+        uiRendering: { slowFrames: 10, frozenFrames: 0, anrs: 0 },
+        issues: 1,
+        criticalIssues: 0,
+      },
+    },
+    baseline: {
+      isGreen: false,
+      run: {
+        databaseId: 222,
+        headSha: 'abcdef123456',
+        url: 'https://github.com/MetaMask/metamask-mobile/actions/runs/222',
+      },
+      artifact: {
+        profilingSummary: {
+          cpu: { avg: 8, max: 18 },
+          memory: { avg: 190, max: 240 },
+          uiRendering: { slowFrames: 7, frozenFrames: 0, anrs: 0 },
+          issues: 1,
+          criticalIssues: 0,
+        },
+      },
+    },
+    repo: 'MetaMask/metamask-mobile',
+  });
+
+  assert.match(md, /scenario also failing/);
+  assert.match(md, /No green baseline was available/);
+  assert.match(md, /\| Metric \| Baseline \| Current \| Δ \|/);
+});
+
+test('findScenarioWithProfilingInDir can use failed scenarios with profiling', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const { tmpdir } = await import('node:os');
+  const { findScenarioWithProfilingInDir } = await import(
+    './diff-app-profiling.mjs'
+  );
+
+  const dir = mkdtempSync(join(tmpdir(), 'profiling-failed-baseline-'));
+  try {
+    writeFileSync(
+      join(dir, 'performance-results.json'),
+      JSON.stringify({
+        Android: {
+          'Pixel 8+14.0': [
+            {
+              testName: 'Import SRP',
+              testFailed: true,
+              failureReason: 'failed',
+              device: { name: 'Pixel 8', osVersion: '14.0' },
+              profilingSummary: { cpu: { avg: 5, max: 12 }, issues: 1 },
+            },
+          ],
+        },
+      }),
+    );
+
+    const greenOnly = findScenarioWithProfilingInDir(dir, {
+      testName: 'Import SRP',
+      device: { name: 'Pixel 8', osVersion: '14.0' },
+      requireGreen: true,
+    });
+    assert.equal(greenOnly, null);
+
+    const any = findScenarioWithProfilingInDir(dir, {
+      testName: 'Import SRP',
+      device: { name: 'Pixel 8', osVersion: '14.0' },
+      requireGreen: false,
+    });
+    assert.equal(any?.isGreen, false);
+    assert.equal(any?.artifact?.profilingSummary?.cpu?.avg, 5);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('findGreenScenarioInDir falls back to embedded profilingSummary', async () => {

--- a/tests/scripts/generate-performance-pr-comment.mjs
+++ b/tests/scripts/generate-performance-pr-comment.mjs
@@ -222,7 +222,8 @@ const passedTestRuns = allTestRuns.filter((test) => test.passed);
 // Failed tests table (one section per team)
 if (uniqueFailedTests > 0) {
   md += `### ❌ Failed Tests (${uniqueFailedTests})\n\n`;
-  md += `> 🔬 To compare BrowserStack app profiling vs the last green run on \`main\`, copy/paste the **App profiling check** command for a failed test as a PR comment.\n\n`;
+  md += `> 🔬 An **App profiling check** runs automatically for failed scenarios and posts a separate comment with BrowserStack profiling vs the last green run on \`main\`.\n`;
+  md += `> You can also re-run it manually with the commands below.\n\n`;
 
   for (const [, teamData] of Object.entries(failedByTeam)) {
     const teamName = teamData.team?.teamId ?? 'Unknown Team';
@@ -257,7 +258,7 @@ if (uniqueFailedTests > 0) {
   }
 
   if (runId) {
-    md += `<details>\n<summary>Compare all failed scenarios</summary>\n\n`;
+    md += `<details>\n<summary>Re-run app profiling check manually</summary>\n\n`;
     md += `\`@metamaskbot app-profiling-check --all --run ${runId}\`\n\n`;
     md += `</details>\n\n`;
   }

--- a/tests/scripts/generate-performance-pr-comment.mjs
+++ b/tests/scripts/generate-performance-pr-comment.mjs
@@ -3,6 +3,10 @@
 /**
  * Generate a GitHub PR comment with performance test results.
  *
+ * Failed scenarios with a prior app-profiling baseline are enriched inline
+ * (short summary + collapsed metric table) so a separate profiling comment
+ * is not required.
+ *
  * Usage:
  *   node generate-performance-pr-comment.mjs [summary_file] [output_file]
  *
@@ -10,288 +14,386 @@
  *   summary_file = aggregated-reports/summary.json
  *   output_file  = performance-pr-comment.md
  *
- * Environment variables used for links:
+ * Environment variables used for links / baseline lookup:
  *   GITHUB_RUN_ID       - workflow run ID
  *   GITHUB_REPOSITORY   - owner/repo
+ *   GH_TOKEN / GITHUB_TOKEN - needed when enriching with baselines from main
+ *   SKIP_APP_PROFILING_ENRICHMENT=true - skip baseline lookup (tests / offline)
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import {
+  parseDeviceKey,
+  findProfilingArtifacts,
+  findMatchingArtifact,
+  findBaselineScenario,
+  buildEmbeddedProfilingSection,
+  COMMENT_MARKER as APP_PROFILING_MARKER,
+} from './diff-app-profiling.mjs';
 
 const SUMMARY_FILE = process.argv[2] || 'aggregated-reports/summary.json';
 const OUTPUT_FILE = process.argv[3] || 'performance-pr-comment.md';
+const DEFAULT_BASELINE_BRANCH = 'main';
+const DEFAULT_WORKFLOW = 'run-performance-e2e.yml';
 
-if (!fs.existsSync(SUMMARY_FILE)) {
-  console.log(`⚠️  No summary file found at ${SUMMARY_FILE} — skipping comment generation`);
-  fs.writeFileSync(OUTPUT_FILE, '⚠️ Performance test results are not available for this run.');
-  process.exit(0);
-}
-
-const summary = JSON.parse(fs.readFileSync(SUMMARY_FILE, 'utf8'));
-const resultsFile = path.join(path.dirname(SUMMARY_FILE), 'performance-results.json');
-const performanceResults = fs.existsSync(resultsFile)
-  ? JSON.parse(fs.readFileSync(resultsFile, 'utf8'))
-  : null;
-
-const totalTests = summary.uniqueTests ?? summary.totalTests ?? 0;
-const androidDevices = summary.platformDevices?.Android ?? [];
-const iosDevices = summary.platformDevices?.iOS ?? [];
-const totalDevices = androidDevices.length + iosDevices.length;
-const buildType = summary.buildType ?? 'Normal';
-const branch = summary.branch ?? 'unknown';
-const commit = (summary.commit ?? 'unknown').slice(0, 7);
-const runId = summary.metadata?.workflowRun ?? process.env.GITHUB_RUN_ID ?? '';
-const repo = process.env.GITHUB_REPOSITORY ?? '';
-
-const failedStats = summary.failedTestsStats ?? {};
-const uniqueFailedTests = failedStats.uniqueFailedTests ?? 0;
-const failedByTeam = failedStats.failedTestsByTeam ?? {};
-
-const overallPassed = uniqueFailedTests === 0 && !summary.error && !summary.warning;
-
-/** Convert "DeviceName+OSVersion" → "DeviceName (vOSVersion)" */
-function formatDevice(key) {
-  const lastPlus = key.lastIndexOf('+');
-  if (lastPlus !== -1) {
-    const name = key.slice(0, lastPlus);
-    const ver = key.slice(lastPlus + 1);
-    return `${name} (v${ver})`;
-  }
-  return key;
-}
-
-/** Map raw failureReason to a human-readable label */
-function formatReason(reason) {
-  switch (reason) {
-    case 'quality_gates_exceeded':
-      return 'Quality gates exceeded';
-    case 'timedOut':
-      return 'Timed out';
-    case 'test_error':
-    case 'failed':
-      return 'Test error';
-    default:
-      return reason ?? 'Unknown';
-  }
-}
-
-function escapeMarkdownTable(value) {
-  return String(value ?? '—')
-    .replaceAll('|', '\\|')
-    .replaceAll('\n', ' ');
-}
-
-function getDeviceKey(device) {
-  if (!device) {
-    return '';
+async function main() {
+  if (!fs.existsSync(SUMMARY_FILE)) {
+    console.log(
+      `⚠️  No summary file found at ${SUMMARY_FILE} — skipping comment generation`,
+    );
+    fs.writeFileSync(
+      OUTPUT_FILE,
+      '⚠️ Performance test results are not available for this run.',
+    );
+    return;
   }
 
-  if (typeof device === 'object') {
-    return `${device.name ?? ''}+${device.osVersion ?? ''}`;
+  const summary = JSON.parse(fs.readFileSync(SUMMARY_FILE, 'utf8'));
+  const reportsDir = path.dirname(SUMMARY_FILE);
+  const resultsFile = path.join(reportsDir, 'performance-results.json');
+  const performanceResults = fs.existsSync(resultsFile)
+    ? JSON.parse(fs.readFileSync(resultsFile, 'utf8'))
+    : null;
+
+  const totalTests = summary.uniqueTests ?? summary.totalTests ?? 0;
+  const androidDevices = summary.platformDevices?.Android ?? [];
+  const iosDevices = summary.platformDevices?.iOS ?? [];
+  const totalDevices = androidDevices.length + iosDevices.length;
+  const buildType = summary.buildType ?? 'Normal';
+  const branch = summary.branch ?? 'unknown';
+  const commit = (summary.commit ?? 'unknown').slice(0, 7);
+  const runId =
+    summary.metadata?.workflowRun ?? process.env.GITHUB_RUN_ID ?? '';
+  const repo = process.env.GITHUB_REPOSITORY ?? '';
+
+  const failedStats = summary.failedTestsStats ?? {};
+  const uniqueFailedTests = failedStats.uniqueFailedTests ?? 0;
+  const failedByTeam = failedStats.failedTestsByTeam ?? {};
+
+  const overallPassed =
+    uniqueFailedTests === 0 && !summary.error && !summary.warning;
+
+  /** Convert "DeviceName+OSVersion" → "DeviceName (vOSVersion)" */
+  function formatDevice(key) {
+    const lastPlus = key.lastIndexOf('+');
+    if (lastPlus !== -1) {
+      const name = key.slice(0, lastPlus);
+      const ver = key.slice(lastPlus + 1);
+      return `${name} (v${ver})`;
+    }
+    return key;
   }
 
-  return String(device);
-}
-
-function buildAppProfilingCheckCommand({ testName, platform, device, runId }) {
-  const deviceKey = getDeviceKey(device);
-  const parts = [
-    '@metamaskbot app-profiling-check',
-    `--test "${testName}"`,
-  ];
-  if (platform) {
-    parts.push(`--platform ${platform}`);
-  }
-  if (deviceKey) {
-    parts.push(`--device "${deviceKey}"`);
-  }
-  if (runId) {
-    parts.push(`--run ${runId}`);
-  }
-  return `\`${parts.join(' ')}\``;
-}
-
-function getDeviceLabel(device, fallbackPlatform) {
-  if (typeof device === 'object') {
-    const name = device?.name ?? fallbackPlatform;
-    const version = device?.osVersion ? ` (v${device.osVersion})` : '';
-    return `${name}${version}`;
+  /** Map raw failureReason to a human-readable label */
+  function formatReason(reason) {
+    switch (reason) {
+      case 'quality_gates_exceeded':
+        return 'Quality gates exceeded';
+      case 'timedOut':
+        return 'Timed out';
+      case 'test_error':
+      case 'failed':
+        return 'Test error';
+      default:
+        return reason ?? 'Unknown';
+    }
   }
 
-  return device ? formatDevice(String(device)) : fallbackPlatform;
-}
+  function escapeMarkdownTable(value) {
+    return String(value ?? '—')
+      .replaceAll('|', '\\|')
+      .replaceAll('\n', ' ');
+  }
 
-function getFailedTestKeys() {
-  const failedTests = Object.values(failedByTeam).flatMap(
-    (teamData) => teamData.tests ?? [],
-  );
-  const bySessionId = new Map();
-  const byTestIdentity = new Map();
-
-  for (const test of failedTests) {
-    if (test.sessionId) {
-      bySessionId.set(test.sessionId, test);
+  function getDeviceKey(device) {
+    if (!device) {
+      return '';
     }
 
-    byTestIdentity.set(
-      `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`,
-      test,
+    if (typeof device === 'object') {
+      return `${device.name ?? ''}+${device.osVersion ?? ''}`;
+    }
+
+    return String(device);
+  }
+
+  function getDeviceLabel(device, fallbackPlatform) {
+    if (typeof device === 'object') {
+      const name = device?.name ?? fallbackPlatform;
+      const version = device?.osVersion ? ` (v${device.osVersion})` : '';
+      return `${name}${version}`;
+    }
+
+    return device ? formatDevice(String(device)) : fallbackPlatform;
+  }
+
+  function getFailedTestKeys() {
+    const failedTests = Object.values(failedByTeam).flatMap(
+      (teamData) => teamData.tests ?? [],
+    );
+    const bySessionId = new Map();
+    const byTestIdentity = new Map();
+
+    for (const test of failedTests) {
+      if (test.sessionId) {
+        bySessionId.set(test.sessionId, test);
+      }
+
+      byTestIdentity.set(
+        `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`,
+        test,
+      );
+    }
+
+    return { bySessionId, byTestIdentity };
+  }
+
+  function getAllTestRuns() {
+    if (!performanceResults) {
+      return [];
+    }
+
+    const failedTestKeys = getFailedTestKeys();
+
+    return Object.entries(performanceResults).flatMap(([platform, devices]) =>
+      Object.entries(devices ?? {}).flatMap(([deviceKey, tests]) =>
+        (tests ?? []).map((test) => {
+          const failedTest =
+            failedTestKeys.bySessionId.get(test.sessionId) ??
+            failedTestKeys.byTestIdentity.get(
+              `${platform}|${deviceKey}|${test.testName}`,
+            );
+          const qualityGatesFailed = test.qualityGates?.passed === false;
+          const failed = Boolean(failedTest) || qualityGatesFailed;
+          const duration =
+            typeof test.totalTime === 'number'
+              ? `${test.totalTime.toFixed(2)}s`
+              : '—';
+
+          return {
+            passed: !failed,
+            status: failed ? '❌ Failed' : '✅ Passed',
+            testName: test.testName,
+            platform,
+            device: getDeviceLabel(test.device ?? deviceKey, platform),
+            duration,
+            reason: failed
+              ? formatReason(
+                  failedTest?.failureReason ??
+                    (qualityGatesFailed
+                      ? 'quality_gates_exceeded'
+                      : undefined),
+                )
+              : '—',
+            team: test.team?.teamId ?? 'Unknown Team',
+            recordingLink: test.videoURL ?? failedTest?.recordingLink,
+          };
+        }),
+      ),
     );
   }
 
-  return { bySessionId, byTestIdentity };
-}
+  const skipEnrichment =
+    process.env.SKIP_APP_PROFILING_ENRICHMENT === 'true' || !repo || !runId;
 
-function getAllTestRuns() {
-  if (!performanceResults) {
-    return [];
-  }
+  const profilingByKey = new Map();
+  if (!skipEnrichment && uniqueFailedTests > 0) {
+    const workRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'perf-pr-profiling-'),
+    );
+    const currentArtifacts = findProfilingArtifacts(reportsDir);
 
-  const failedTestKeys = getFailedTestKeys();
+    console.log(
+      `🔬 Enriching failed scenarios with app profiling vs \`${DEFAULT_BASELINE_BRANCH}\`...`,
+    );
 
-  return Object.entries(performanceResults).flatMap(([platform, devices]) =>
-    Object.entries(devices ?? {}).flatMap(([deviceKey, tests]) =>
-      (tests ?? []).map((test) => {
-        const failedTest =
-          failedTestKeys.bySessionId.get(test.sessionId) ??
-          failedTestKeys.byTestIdentity.get(
-            `${platform}|${deviceKey}|${test.testName}`,
-          );
-        const qualityGatesFailed = test.qualityGates?.passed === false;
-        const failed = Boolean(failedTest) || qualityGatesFailed;
-        const duration =
-          typeof test.totalTime === 'number' ? `${test.totalTime.toFixed(2)}s` : '—';
+    for (const teamData of Object.values(failedByTeam)) {
+      for (const test of teamData.tests ?? []) {
+        const device = parseDeviceKey(test.device);
+        const key = `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`;
 
-        return {
-          passed: !failed,
-          status: failed ? '❌ Failed' : '✅ Passed',
+        let currentArtifact = findMatchingArtifact(currentArtifacts, {
           testName: test.testName,
-          platform,
-          device: getDeviceLabel(test.device ?? deviceKey, platform),
-          duration,
-          reason: failed
-            ? formatReason(
-                failedTest?.failureReason ??
-                  (qualityGatesFailed ? 'quality_gates_exceeded' : undefined),
-              )
-            : '—',
-          team: test.team?.teamId ?? 'Unknown Team',
-          recordingLink: test.videoURL ?? failedTest?.recordingLink,
-        };
-      }),
-    ),
-  );
-}
+          device,
+        })?.data;
 
-// ─── Build the comment ────────────────────────────────────────────────────────
+        if (!currentArtifact && !device.name) {
+          currentArtifact = currentArtifacts.find(
+            ({ data }) => data.testName === test.testName,
+          )?.data;
+        }
 
-let md = '';
+        try {
+          const baseline = findBaselineScenario({
+            repo,
+            workflow: DEFAULT_WORKFLOW,
+            baselineBranch: DEFAULT_BASELINE_BRANCH,
+            currentRunId: runId,
+            testName: test.testName,
+            device: currentArtifact?.device ?? device,
+            workRoot,
+          });
 
-// Title
-md += `## ⚡ Performance Test Results\n\n`;
-md += `> ℹ️ Performance test results are currently non-blocking and will not block this PR.\n\n`;
+          const section = buildEmbeddedProfilingSection({
+            currentRunId: runId,
+            currentArtifact,
+            baseline,
+            repo,
+            baselineBranch: DEFAULT_BASELINE_BRANCH,
+            includeRawJson: false,
+          });
 
-// Overall status line
-if (summary.warning || summary.error) {
-  md += `⚠️ **Results incomplete** — ${summary.warning ?? summary.error}\n\n`;
-} else if (overallPassed) {
-  md += `✅ **All tests passed**`;
-  if (totalTests > 0) md += ` · ${totalTests} tests · ${totalDevices} device${totalDevices !== 1 ? 's' : ''}`;
-  md += '\n\n';
-} else {
-  md += `❌ **${uniqueFailedTests} test${uniqueFailedTests !== 1 ? 's' : ''} failed**`;
-  if (totalTests > 0) md += ` · ${totalTests} tests · ${totalDevices} device${totalDevices !== 1 ? 's' : ''}`;
-  md += '\n\n';
-}
-
-// Devices (collapsible)
-if (totalDevices > 0) {
-  md += `<details>\n<summary>📱 Devices tested (${totalDevices})</summary>\n\n`;
-  if (androidDevices.length > 0) {
-    md += `**Android:** ${androidDevices.map(formatDevice).join(', ')}\n\n`;
-  }
-  if (iosDevices.length > 0) {
-    md += `**iOS:** ${iosDevices.map(formatDevice).join(', ')}\n\n`;
-  }
-  md += `</details>\n\n`;
-}
-
-const allTestRuns = getAllTestRuns();
-const passedTestRuns = allTestRuns.filter((test) => test.passed);
-
-// Failed tests table (one section per team)
-if (uniqueFailedTests > 0) {
-  md += `### ❌ Failed Tests (${uniqueFailedTests})\n\n`;
-  md += `> 🔬 An **App profiling check** runs automatically for failed scenarios and posts a separate comment with BrowserStack profiling vs the last green run on \`main\`.\n`;
-  md += `> You can also re-run it manually with the commands below.\n\n`;
-
-  for (const [, teamData] of Object.entries(failedByTeam)) {
-    const teamName = teamData.team?.teamId ?? 'Unknown Team';
-    const tests = teamData.tests ?? [];
-    if (tests.length === 0) continue;
-
-    md += `**${teamName}**\n\n`;
-    md += `| Test | Platform | Device | Reason | Recording | App profiling check |\n`;
-    md += `|------|----------|--------|--------|-----------|---------------------|\n`;
-
-    for (const t of tests) {
-      const device =
-        typeof t.device === 'object'
-          ? (t.device?.name ?? t.platform)
-          : (t.device ? formatDevice(String(t.device)) : t.platform);
-
-      const reason = formatReason(t.failureReason);
-      const recording = t.recordingLink ? `[📹 Watch](${t.recordingLink})` : '—';
-      const profilingCheck = buildAppProfilingCheckCommand({
-        testName: t.testName,
-        platform: t.platform,
-        device: t.device,
-        runId,
-      });
-      md += `| ${escapeMarkdownTable(t.testName)} | ${escapeMarkdownTable(
-        t.platform,
-      )} | ${escapeMarkdownTable(device)} | ${escapeMarkdownTable(
-        reason,
-      )} | ${recording} | ${profilingCheck} |\n`;
+          if (section) {
+            profilingByKey.set(key, section);
+          } else {
+            console.warn(
+              `⏭️  No comparable baseline for "${test.testName}" — omitting profiling block`,
+            );
+          }
+        } catch (error) {
+          console.warn(
+            `⚠️  Could not enrich "${test.testName}": ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
     }
-    md += '\n';
   }
 
-  if (runId) {
-    md += `<details>\n<summary>Re-run app profiling check manually</summary>\n\n`;
-    md += `\`@metamaskbot app-profiling-check --all --run ${runId}\`\n\n`;
+  // ─── Build the comment ────────────────────────────────────────────────────────
+
+  let md = '';
+
+  // Title — warn in the header when there are failed tests
+  if (uniqueFailedTests > 0) {
+    md += `## ⚠️ Performance Test Results\n\n`;
+  } else {
+    md += `## ⚡ Performance Test Results\n\n`;
+  }
+  md += `> ℹ️ Performance test results are currently non-blocking and will not block this PR.\n\n`;
+
+  // Overall status line
+  if (summary.warning || summary.error) {
+    md += `⚠️ **Results incomplete** — ${summary.warning ?? summary.error}\n\n`;
+  } else if (overallPassed) {
+    md += `✅ **All tests passed**`;
+    if (totalTests > 0)
+      md += ` · ${totalTests} tests · ${totalDevices} device${
+        totalDevices !== 1 ? 's' : ''
+      }`;
+    md += '\n\n';
+  } else {
+    md += `❌ **${uniqueFailedTests} test${
+      uniqueFailedTests !== 1 ? 's' : ''
+    } failed**`;
+    if (totalTests > 0)
+      md += ` · ${totalTests} tests · ${totalDevices} device${
+        totalDevices !== 1 ? 's' : ''
+      }`;
+    md += '\n\n';
+  }
+
+  // Devices (collapsible)
+  if (totalDevices > 0) {
+    md += `<details>\n<summary>📱 Devices tested (${totalDevices})</summary>\n\n`;
+    if (androidDevices.length > 0) {
+      md += `**Android:** ${androidDevices.map(formatDevice).join(', ')}\n\n`;
+    }
+    if (iosDevices.length > 0) {
+      md += `**iOS:** ${iosDevices.map(formatDevice).join(', ')}\n\n`;
+    }
     md += `</details>\n\n`;
   }
-}
 
-if (passedTestRuns.length > 0) {
-  md += `<details>\n<summary>✅ Passed Tests (${passedTestRuns.length})</summary>\n\n`;
-  md += `| Test | Platform | Device | Duration | Team | Recording |\n`;
-  md += `|------|----------|--------|----------|------|-----------|\n`;
+  const allTestRuns = getAllTestRuns();
+  const passedTestRuns = allTestRuns.filter((test) => test.passed);
 
-  for (const test of passedTestRuns) {
-    const recording = test.recordingLink
-      ? `[📹 Watch](${test.recordingLink})`
-      : '—';
+  // Failed tests — compact row + inline app profiling (when available)
+  if (uniqueFailedTests > 0) {
+    md += `### ❌ Failed Tests (${uniqueFailedTests})\n\n`;
+    if (profilingByKey.size > 0) {
+      md += `> 🔬 App profiling vs \`main\` is included under each failed scenario that has a prior baseline.\n\n`;
+    }
 
-    md += `| ${escapeMarkdownTable(test.testName)} | ${
-      test.platform
-    } | ${escapeMarkdownTable(test.device)} | ${test.duration} | ${escapeMarkdownTable(
-      test.team,
-    )} | ${recording} |\n`;
+    for (const [, teamData] of Object.entries(failedByTeam)) {
+      const teamName = teamData.team?.teamId ?? 'Unknown Team';
+      const tests = teamData.tests ?? [];
+      if (tests.length === 0) continue;
+
+      md += `**${teamName}**\n\n`;
+
+      for (const t of tests) {
+        const device =
+          typeof t.device === 'object'
+            ? t.device?.osVersion
+              ? `${t.device.name} (v${t.device.osVersion})`
+              : (t.device?.name ?? t.platform)
+            : t.device
+              ? formatDevice(String(t.device))
+              : t.platform;
+
+        const reason = formatReason(t.failureReason);
+        const recording = t.recordingLink
+          ? `[📹 Watch](${t.recordingLink})`
+          : '—';
+        const key = `${t.platform}|${getDeviceKey(t.device)}|${t.testName}`;
+        const profilingSection = profilingByKey.get(key);
+
+        md += `#### ${escapeMarkdownTable(t.testName)}\n\n`;
+        md += `| Platform | Device | Reason | Recording |\n`;
+        md += `|----------|--------|--------|-----------|\n`;
+        md += `| ${escapeMarkdownTable(t.platform)} | ${escapeMarkdownTable(
+          device,
+        )} | ${escapeMarkdownTable(reason)} | ${recording} |\n\n`;
+
+        if (profilingSection) {
+          md += `${profilingSection}\n`;
+        }
+      }
+    }
   }
 
-  md += `\n</details>\n\n`;
+  if (passedTestRuns.length > 0) {
+    md += `<details>\n<summary>✅ Passed Tests (${passedTestRuns.length})</summary>\n\n`;
+    md += `| Test | Platform | Device | Duration | Team | Recording |\n`;
+    md += `|------|----------|--------|----------|------|-----------|\n`;
+
+    for (const test of passedTestRuns) {
+      const recording = test.recordingLink
+        ? `[📹 Watch](${test.recordingLink})`
+        : '—';
+
+      md += `| ${escapeMarkdownTable(test.testName)} | ${
+        test.platform
+      } | ${escapeMarkdownTable(test.device)} | ${test.duration} | ${escapeMarkdownTable(
+        test.team,
+      )} | ${recording} |\n`;
+    }
+
+    md += `\n</details>\n\n`;
+  }
+
+  // Footer
+  md += `---\n`;
+  md += `**Branch:** \`${branch}\` · **Build:** ${buildType} · **Commit:** \`${commit}\``;
+  if (runId && repo) {
+    md += ` · [View full run](https://github.com/${repo}/actions/runs/${runId})`;
+  }
+  md += '\n';
+
+  // Keep both markers so cleanup can find either legacy style.
+  if (profilingByKey.size > 0) {
+    md += `${APP_PROFILING_MARKER}\n`;
+  }
+
+  fs.writeFileSync(OUTPUT_FILE, md);
+  console.log(`✅ PR comment written to ${OUTPUT_FILE}`);
 }
 
-// Footer
-md += `---\n`;
-md += `**Branch:** \`${branch}\` · **Build:** ${buildType} · **Commit:** \`${commit}\``;
-if (runId && repo) {
-  md += ` · [View full run](https://github.com/${repo}/actions/runs/${runId})`;
-}
-md += '\n';
-
-// Write output
-fs.writeFileSync(OUTPUT_FILE, md);
-console.log(`✅ PR comment written to ${OUTPUT_FILE}`);
+main().catch((error) => {
+  console.error(`❌ ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Failed PR performance runs previously posted two comments: **Performance Test Results** (with copy/paste `@metamaskbot` commands) and a separate long **App Profiling Check** comment. That made PRs noisy and hard to scan.

This change embeds app profiling into the single Performance Test Results comment:

1. Under each failed scenario with a usable prior baseline on `main`, show an inline **App profiling check** (short **Summary** + collapsed full metric table)
2. Use `## ⚠️ Performance Test Results` when there are failures (`⚡` when all green)
3. Prefer last green baseline; fall back to latest usable profiling on `main` when the scenario is also red, labeled clearly
4. Omit profiling blocks when there is no prior baseline
5. Stop auto-posting a separate app-profiling comment (manual `@metamaskbot` / `workflow_dispatch` still works)
6. On each PR update, delete previous `<!-- perf-test-results -->` and legacy `<!-- app-profiling-check -->` comments

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2081 (follow-up: auto-enable inline app profiling on failed PR performance scenarios)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Inline app profiling on failed PR performance tests

  Scenario: failed performance scenarios include profiling inline
    Given a PR triggers the performance E2E workflow with at least one failed scenario
    And aggregated-reports were uploaded for that run
    When the "Post Performance Results to PR" job finishes
    Then one Performance Test Results comment is posted
    And the header uses ⚠️ when there are failures
    And each failed scenario with a prior baseline shows App profiling check + Summary + collapsed metric table
    And no separate App Profiling Check comment is posted automatically

  Scenario: chronically red scenarios still get a baseline comparison
    Given a failed scenario that is also failing on main
    When the performance comment is enriched
    Then it uses the latest usable profilingSummary from main as baseline
    And the block labels the baseline as "scenario also failing"

  Scenario: scenarios without prior baseline are omitted from profiling
    Given a failed scenario that never ran with profiling on main
    When the performance comment is generated
    Then that scenario has no App profiling check block

  Scenario: all-green performance run stays compact
    Given a PR performance run with zero failed scenarios
    When the "Post Performance Results to PR" job finishes
    Then the header uses ⚡ and there is no failed-tests / profiling section

  Scenario: manual re-run still works
    Given a PR with a known performance run id
    When a reviewer posts `@metamaskbot app-profiling-check --all --run <RUN_ID>`
    Then the App Profiling Check workflow runs and posts/updates a standalone diff comment
```

Local unit verification:

```bash
node --test tests/scripts/diff-app-profiling.test.mjs
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI/workflow and Node script changes only; no app UI. Evidence is the unified Performance Test Results PR comment produced by `run-performance-e2e.yml`.

### **Before**

Two comments: Performance results (bot command column) + a separate long App Profiling Check comment.

### **After**

One Performance Test Results comment with ⚠️ on failures and compact inline profiling under each failed scenario.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
  - N/A for this PR: no app/runtime UI changes (CI comment + Node scripts only)
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - N/A for this PR: no app/runtime UI changes (CI comment + Node scripts only)
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
  - N/A for this PR: no app/runtime UI changes (CI comment + Node scripts only)

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1033c242-8668-4156-ac2e-cbe32698bb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1033c242-8668-4156-ac2e-cbe32698bb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

