### PR TITLE
fix: price Quick Buy minimum received for ERC20 tokens

### DIFF
--- a/app/components/UI/Bridge/utils/exchange-rates.test.tsx
+++ b/app/components/UI/Bridge/utils/exchange-rates.test.tsx
@@ -367,6 +367,48 @@ describe('exchange-rates', () => {
         expect(result).toBe(10000);
       });
 
+      it('prices a lowercased token address against checksummed market data', () => {
+        const checksumAddress =
+          '0x6B175474E89094C44Da98b954EedeAC495271d0F' as Hex;
+
+        const result = calcTokenFiatValue({
+          token: {
+            ...mockEvmToken,
+            address: checksumAddress.toLowerCase() as Hex,
+          },
+          amount: '1',
+          evmMultiChainMarketData: {
+            [mockChainId]: { [checksumAddress]: { price: 10 } },
+          },
+          networkConfigurationsByChainId: mockNetworkConfigurations,
+          evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+          nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+        });
+
+        // 1 * 2000 (conversionRate) * 10 (price) = 20000
+        expect(result).toBe(20000);
+      });
+
+      it('prices a checksummed token address against lowercased market data', () => {
+        const checksumAddress =
+          '0x6B175474E89094C44Da98b954EedeAC495271d0F' as Hex;
+
+        const result = calcTokenFiatValue({
+          token: { ...mockEvmToken, address: checksumAddress },
+          amount: '1',
+          evmMultiChainMarketData: {
+            [mockChainId]: {
+              [checksumAddress.toLowerCase() as Hex]: { price: 10 },
+            },
+          },
+          networkConfigurationsByChainId: mockNetworkConfigurations,
+          evmMultiChainCurrencyRates: mockEvmMultiChainCurrencyRates,
+          nonEvmMultichainAssetRates: mockNonEvmMultichainAssetRates,
+        });
+
+        expect(result).toBe(20000);
+      });
+
       it('falls back to currencyExchangeRate when market data is undefined', () => {
         const tokenWithExchangeRate = {
           ...mockEvmToken,

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -123,6 +123,30 @@ export interface CalcTokenFiatValueParams {
 export type CalcTokenFiatRateParams = Omit<CalcTokenFiatValueParams, 'amount'>;
 
 /**
+ * Reads a token's market data for an EVM chain, tolerating either address
+ * casing. `TokenRatesController` keys market data by checksummed address while
+ * `BridgeToken.address` is frequently lowercased (deeplinks, route params, API
+ * payloads), so a raw lookup silently misses and prices the token at zero.
+ */
+const getEvmTokenMarketData = (
+  marketDataByAddress: Record<Hex, { price: number | undefined }> | undefined,
+  address: string | undefined,
+): { price: number | undefined } | undefined => {
+  if (!marketDataByAddress || !address) {
+    return undefined;
+  }
+
+  const checksumAddress = safeToChecksumAddress(address);
+  return (
+    marketDataByAddress[address as Hex] ??
+    (checksumAddress
+      ? marketDataByAddress[checksumAddress as Hex]
+      : undefined) ??
+    marketDataByAddress[address.toLowerCase() as Hex]
+  );
+};
+
+/**
  * Gets the rate of one token in the user's current fiat currency.
  * @returns The numeric fiat rate, or undefined when price data is unavailable.
  */
@@ -149,7 +173,10 @@ export const calcTokenFiatRate = ({
 
   const evmChainId = token.chainId as Hex;
   const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
-  const evmTokenMarketData = evmMultiChainExchangeRates?.[token.address as Hex];
+  const evmTokenMarketData = getEvmTokenMarketData(
+    evmMultiChainExchangeRates,
+    token.address,
+  );
 
   const nativeCurrency =
     networkConfigurationsByChainId[evmChainId]?.nativeCurrency;
@@ -201,7 +228,10 @@ export const calcTokenFiatValue = ({
   // EVM
   const evmChainId = token.chainId as Hex;
   const evmMultiChainExchangeRates = evmMultiChainMarketData?.[evmChainId];
-  const evmTokenMarketData = evmMultiChainExchangeRates?.[token.address as Hex];
+  const evmTokenMarketData = getEvmTokenMarketData(
+    evmMultiChainExchangeRates,
+    token.address,
+  );
 
   const nativeCurrency =
     networkConfigurationsByChainId[evmChainId]?.nativeCurrency;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.test.ts
@@ -1,10 +1,16 @@
-import { renderHook } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
-import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../../../selectors/currencyRateController';
 import { selectMultichainAssetsRates } from '../../../../../../../selectors/multichain/multichain';
-import { calcTokenFiatRate } from '../../../../../../UI/Bridge/utils/exchange-rates';
+import {
+  calcTokenFiatRate,
+  getTokenExchangeRate,
+} from '../../../../../../UI/Bridge/utils/exchange-rates';
 import { useDestTokenExchangeRate } from './useDestTokenExchangeRate';
 
 jest.mock('react-redux', () => ({
@@ -17,6 +23,7 @@ jest.mock('../../../../../../../selectors/tokenRatesController', () => ({
 
 jest.mock('../../../../../../../selectors/currencyRateController', () => ({
   selectCurrencyRates: jest.fn(),
+  selectCurrentCurrency: jest.fn(),
 }));
 
 jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
@@ -25,10 +32,12 @@ jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
 
 jest.mock('../../../../../../UI/Bridge/utils/exchange-rates', () => ({
   calcTokenFiatRate: jest.fn(),
+  getTokenExchangeRate: jest.fn(),
 }));
 
 const mockUseSelector = useSelector as jest.Mock;
 const mockCalcTokenFiatRate = calcTokenFiatRate as jest.Mock;
+const mockGetTokenExchangeRate = getTokenExchangeRate as jest.Mock;
 
 const STATE = {
   engine: {
@@ -60,6 +69,8 @@ describe('useDestTokenExchangeRate', () => {
     (selectTokenMarketData as unknown as jest.Mock).mockReturnValue({});
     (selectCurrencyRates as unknown as jest.Mock).mockReturnValue({});
     (selectMultichainAssetsRates as unknown as jest.Mock).mockReturnValue({});
+    (selectCurrentCurrency as unknown as jest.Mock).mockReturnValue('usd');
+    mockGetTokenExchangeRate.mockResolvedValue(undefined);
   });
 
   it('returns undefined when the token is missing', () => {
@@ -100,5 +111,51 @@ describe('useDestTokenExchangeRate', () => {
     mockCalcTokenFiatRate.mockReturnValue(0);
     const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
     expect(result.current).toBeUndefined();
+  });
+
+  it('fetches the price when no cached rate exists for the token', async () => {
+    mockCalcTokenFiatRate.mockReturnValue(undefined);
+    mockGetTokenExchangeRate.mockResolvedValue(0.42);
+
+    const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
+
+    await waitFor(() => expect(result.current).toBe(0.42));
+    expect(mockGetTokenExchangeRate).toHaveBeenCalledWith({
+      chainId: '0x1',
+      tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      currency: 'usd',
+    });
+  });
+
+  it('skips the fetch when a cached rate is already available', () => {
+    mockCalcTokenFiatRate.mockReturnValue(1.23);
+    renderHook(() => useDestTokenExchangeRate(evmToken()));
+    expect(mockGetTokenExchangeRate).not.toHaveBeenCalled();
+  });
+
+  it('ignores a fetched price that is not a positive number', async () => {
+    mockCalcTokenFiatRate.mockReturnValue(undefined);
+    mockGetTokenExchangeRate.mockResolvedValue(0);
+
+    const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
+
+    await waitFor(() => expect(mockGetTokenExchangeRate).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('does not surface a fetched price against a different token', async () => {
+    mockCalcTokenFiatRate.mockReturnValue(undefined);
+    mockGetTokenExchangeRate.mockResolvedValue(0.42);
+
+    const { result, rerender } = renderHook(
+      (token: BridgeToken | undefined) => useDestTokenExchangeRate(token),
+      { initialProps: evmToken() },
+    );
+    await waitFor(() => expect(result.current).toBe(0.42));
+
+    mockGetTokenExchangeRate.mockResolvedValue(undefined);
+    rerender(evmToken('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'));
+
+    await waitFor(() => expect(result.current).toBeUndefined());
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.ts
@@ -1,13 +1,19 @@
 import { isNativeAddress, isNonEvmChainId } from '@metamask/bridge-controller';
 import type { Hex } from '@metamask/utils';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../../../../../../reducers';
-import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
+import {
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../../../../../../../selectors/currencyRateController';
 import { selectMultichainAssetsRates } from '../../../../../../../selectors/multichain/multichain';
 import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
 import { safeToChecksumAddress } from '../../../../../../../util/address';
-import { calcTokenFiatRate } from '../../../../../../UI/Bridge/utils/exchange-rates';
+import {
+  calcTokenFiatRate,
+  getTokenExchangeRate,
+} from '../../../../../../UI/Bridge/utils/exchange-rates';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 
 /**
@@ -17,12 +23,15 @@ import type { BridgeToken } from '../../../../../../UI/Bridge/types';
  * This is the same canonical `calcTokenFiatRate` calculation that
  * `usePositionTokenBalance` runs internally — but without the balance gate, so
  * the pre-quote rate pill can render for a token the user is buying for the
- * first time (and therefore holds no balance of). Returns `undefined` when no
- * price can be resolved or the token is missing.
+ * first time (and therefore holds no balance of). When no cached rate exists at
+ * all — `TokenRatesController` only tracks tokens the user holds — the price is
+ * fetched once from the price API, mirroring what Bridge's `TokenInputArea`
+ * does via `useBridgeExchangeRates`. Returns `undefined` when no price can be
+ * resolved or the token is missing.
  *
  * The returned rate is for display only. It must never be merged into the `BridgeToken`
  * reference passed to quote fetching / redux. Doing so would churn quote requests
- * on every market-data tick (see `destTokenForRate` in `useQuickBuyController`).
+ * on every market-data tick (see `pricedDestToken` in `useQuickBuyController`).
  */
 export const useDestTokenExchangeRate = (
   token: BridgeToken | undefined,
@@ -30,13 +39,14 @@ export const useDestTokenExchangeRate = (
   const tokenMarketData = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
   const multichainRates = useSelector(selectMultichainAssetsRates);
+  const currentCurrency = useSelector(selectCurrentCurrency);
   const networkConfigurations = useSelector(
     (state: RootState) =>
       state.engine.backgroundState.NetworkController
         .networkConfigurationsByChainId,
   );
 
-  return useMemo(() => {
+  const cachedRate = useMemo(() => {
     if (!token) return undefined;
 
     // `calcTokenFiatRate` looks up EVM `tokenMarketData` by the checksummed
@@ -71,4 +81,41 @@ export const useDestTokenExchangeRate = (
     multichainRates,
     networkConfigurations,
   ]);
+
+  const [fetchedRate, setFetchedRate] = useState<number | undefined>(undefined);
+  // Identity of the token the fetched rate belongs to, so a stale response for
+  // a previously selected token is never displayed against the current one.
+  const fetchedForRef = useRef<string | undefined>(undefined);
+  const fetchKey =
+    token && !cachedRate
+      ? `${token.chainId}:${token.address}:${currentCurrency}`
+      : undefined;
+
+  useEffect(() => {
+    if (!fetchKey || !token) return;
+    if (fetchedForRef.current === fetchKey) return;
+
+    let isStale = false;
+    fetchedForRef.current = fetchKey;
+    setFetchedRate(undefined);
+
+    getTokenExchangeRate({
+      chainId: token.chainId,
+      tokenAddress: token.address,
+      currency: currentCurrency,
+    })
+      .then((rate) => {
+        if (isStale) return;
+        setFetchedRate(typeof rate === 'number' && rate > 0 ? rate : undefined);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      isStale = true;
+    };
+    // `fetchKey` fully encodes the token identity and currency this fetch is for.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchKey]);
+
+  return cachedRate ?? (fetchKey ? fetchedRate : undefined);
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -806,11 +806,59 @@ export function useQuickBuyController(
     return `${formatted} ${symbol}`;
   }, [activeQuote, destToken]);
 
-  const minReceivedTokenAmount = activeQuote?.minToTokenAmount?.amount;
-  const formattedMinimumReceivedFiat = useDisplayCurrencyValue(
-    minReceivedTokenAmount,
+  // Display-only copy of the dest token enriched with a balance-independent
+  // rate (`useDestTokenExchangeRate`) so prices render even when the user holds
+  // no balance of the token being bought. Never propagated into `destToken` —
+  // the quote/redux reference must stay stable so market-data ticks don't churn
+  // quote requests.
+  //
+  // Price source priority for the buy token: the host-supplied chart price
+  // (display currency, present even for un-held tokens) → the cached market-data
+  // lookup → the held-balance rate. The first two cover the common case of
+  // buying a token the user doesn't hold, where the lookup alone resolves
+  // nothing (TokenRatesController only tracks held tokens).
+  const destTokenLookupRate = useDestTokenExchangeRate(destToken);
+  const hostTokenPriceFiat = analyticsContext?.tokenPriceFiat;
+  const pricedDestToken = useMemo<BridgeToken | undefined>(() => {
+    if (!destToken) return destToken;
+    const hostRate =
+      tradeMode === 'buy' &&
+      hostTokenPriceFiat !== undefined &&
+      hostTokenPriceFiat > 0
+        ? hostTokenPriceFiat
+        : undefined;
+    const rate =
+      hostRate ??
+      destTokenLookupRate ??
+      (tradeMode === 'buy' ? positionToken?.currencyExchangeRate : undefined) ??
+      destToken.currencyExchangeRate;
+    if (rate === undefined) return destToken;
+    return { ...destToken, currencyExchangeRate: rate };
+  }, [
+    tradeMode,
     destToken,
+    hostTokenPriceFiat,
+    destTokenLookupRate,
+    positionToken?.currencyExchangeRate,
+  ]);
+
+  const minReceivedTokenAmount = activeQuote?.minToTokenAmount?.amount;
+  // Priced against `pricedDestToken`: the bare `destToken` carries no
+  // `currencyExchangeRate`, so ERC20s fell back to a $0 fiat value while
+  // natives resolved through the chain's native conversion rate.
+  const minReceivedFiat = useDisplayCurrencyValue(
+    minReceivedTokenAmount,
+    pricedDestToken,
   );
+  const formattedMinimumReceivedFiat = useMemo(() => {
+    if (!minReceivedTokenAmount) return undefined;
+    // `useDisplayCurrencyValue` renders an unpriced token as an exact zero
+    // (anything priceable but tiny becomes "< $0.01"), so drop the fiat suffix
+    // instead of showing a misleading $0.00 next to the token amount.
+    return minReceivedFiat === formatCurrency(0, currentCurrency)
+      ? undefined
+      : minReceivedFiat;
+  }, [minReceivedFiat, minReceivedTokenAmount, currentCurrency]);
 
   // Derive both sides of the ratio from the same activeQuote so the rate is
   // always internally consistent. Previously we mixed the live
@@ -939,37 +987,7 @@ export function useQuickBuyController(
     ? maxSpendFiat <= 0
     : maxSpendTokens <= 0;
 
-  // Display-only copy of the dest token enriched with a balance-independent
-  // rate (`useDestTokenExchangeRate`) so the pre-quote pill renders even when
-  // the user holds no balance of the token being bought. Never propagated into
-  // `destToken` — the quote/redux reference must stay stable so market-data
-  // ticks don't churn quote requests.
-  const destTokenLookupRate = useDestTokenExchangeRate(
-    tradeMode === 'buy' ? destToken : undefined,
-  );
-  // Price source priority for the buy token: the host-supplied chart price
-  // (display currency, present even for un-held tokens) → the cached market-data
-  // lookup → the held-balance rate. The first two cover the common case of
-  // buying a token the user doesn't hold, where the lookup alone resolves
-  // nothing (TokenRatesController only tracks held tokens).
-  const hostTokenPriceFiat = analyticsContext?.tokenPriceFiat;
-  const destTokenForRate = useMemo<BridgeToken | undefined>(() => {
-    if (tradeMode !== 'buy' || !destToken) return destToken;
-    const rate =
-      (hostTokenPriceFiat !== undefined && hostTokenPriceFiat > 0
-        ? hostTokenPriceFiat
-        : undefined) ??
-      destTokenLookupRate ??
-      positionToken?.currencyExchangeRate;
-    if (rate === undefined) return destToken;
-    return { ...destToken, currencyExchangeRate: rate };
-  }, [
-    tradeMode,
-    destToken,
-    hostTokenPriceFiat,
-    destTokenLookupRate,
-    positionToken?.currencyExchangeRate,
-  ]);
+  const destTokenForRate = tradeMode === 'buy' ? pricedDestToken : destToken;
 
   const formattedExchangeRate = useMemo(
     () =>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -29,6 +29,7 @@ import {
   playImpact,
 } from '../../../../../../util/haptics';
 import Logger from '../../../../../../util/Logger';
+import { useDisplayCurrencyValue } from '../../../../../UI/Bridge/hooks/useDisplayCurrencyValue';
 import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
 import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
 import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
@@ -429,6 +430,7 @@ const setupDefaultMocks = () => {
   (useReceiveTokens as jest.Mock).mockReturnValue([]);
   (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
   (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
+  (useDisplayCurrencyValue as jest.Mock).mockReturnValue(undefined);
   (usePayWithTokens as jest.Mock).mockReturnValue({
     options: [createSourceToken()],
     isLoading: false,
@@ -1814,6 +1816,87 @@ describe('useQuickBuyController', () => {
       );
 
       expect(result.current.formattedExchangeRate).toBeUndefined();
+    });
+  });
+
+  describe('formattedMinimumReceivedFiat', () => {
+    const mockQuoteWithMinReceived = () => {
+      (useQuickBuyQuotes as jest.Mock).mockReturnValue({
+        activeQuote: createActiveQuote({
+          minToTokenAmount: { amount: '100' },
+        }),
+        destTokenAmount: '100',
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
+        sortedQuotes: [],
+        quoteCount: 1,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      });
+    };
+
+    it('prices the minimum received against the resolved dest token rate', () => {
+      mockQuoteWithMinReceived();
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(0.5);
+      (useDisplayCurrencyValue as jest.Mock).mockReturnValue('$50.00');
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(useDisplayCurrencyValue).toHaveBeenCalledWith(
+        '100',
+        expect.objectContaining({
+          symbol: 'TARGET',
+          currencyExchangeRate: 0.5,
+        }),
+      );
+      expect(result.current.formattedMinimumReceivedFiat).toBe('$50.00');
+    });
+
+    it('prices the minimum received with the host-supplied token price when no market rate exists', () => {
+      mockQuoteWithMinReceived();
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
+      (useDisplayCurrencyValue as jest.Mock).mockReturnValue('$95.63');
+
+      renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn(), {
+          tokenPriceFiat: 0.95625,
+        }),
+      );
+
+      expect(useDisplayCurrencyValue).toHaveBeenCalledWith(
+        '100',
+        expect.objectContaining({ currencyExchangeRate: 0.95625 }),
+      );
+    });
+
+    it('omits the fiat conversion when the dest token cannot be priced', () => {
+      mockQuoteWithMinReceived();
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
+      (useDisplayCurrencyValue as jest.Mock).mockReturnValue('$0.00');
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.formattedMinimumReceivedFiat).toBeUndefined();
+    });
+
+    it('omits the fiat conversion when there is no quote', () => {
+      (useDisplayCurrencyValue as jest.Mock).mockReturnValue('$0.00');
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.formattedMinimumReceivedFiat).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In the Quick Buy / Sell quote details, the "Minimum received" row always showed a `$0.00` fiat conversion for ERC20 tokens while native tokens converted correctly.

`useQuickBuyController` priced the minimum received amount with the bare `destToken` produced by `useQuickBuySetup`, which only carries metadata (address, symbol, decimals, image) and no `currencyExchangeRate`. Inside `calcTokenFiatValue`, native tokens short-circuit on `isNativeAddress` and resolve through the chain's native conversion rate, so they were unaffected; ERC20s depend on a market-data price keyed by the token address, and when that lookup misses the function falls through to `token.currencyExchangeRate` — undefined here — yielding `0`.

Changes:

- **Price the dest token before formatting.** The controller now derives a display-only `pricedDestToken` and passes it to `useDisplayCurrencyValue`. It reuses the exact resolution chain the pre-quote rate pill already relied on (host chart price → cached market-data lookup → held-balance rate), which was previously wired into `destTokenForRate` for the pill only. The token reference passed to quote fetching and Redux is still untouched, so quote requests don't churn on market-data ticks.
- **Tolerate either address casing in market-data lookups.** `calcTokenFiatRate` / `calcTokenFiatValue` indexed `TokenRatesController` market data with the raw `BridgeToken.address`, but that map is keyed by checksummed addresses while bridge tokens are frequently lowercased (deeplinks, route params, API payloads). Lookups now try raw, checksummed, and lowercased keys — the same tolerance `@metamask/bridge-controller`'s own selectors apply. This benefits every Bridge display path, not just Quick Buy.
- **Fetch a price when nothing is cached.** `useDestTokenExchangeRate` now fetches the token price once (via the existing `getTokenExchangeRate`) when no cached rate resolves, because `TokenRatesController` only tracks tokens the user holds — the common case when buying a token for the first time. This mirrors what Bridge's `TokenInputArea` does through `useBridgeExchangeRates`, and stale responses are discarded when the token changes.
- **Never render a misleading zero.** When no price resolves at all, `formattedMinimumReceivedFiat` is `undefined` and the row shows the token amount alone instead of `~$0.00`.

## **Changelog**

CHANGELOG entry: Fixed the Quick Buy minimum received amount showing a $0 fiat conversion for ERC20 tokens

## **Related issues**

Fixes: #33787

## **Manual testing steps**

```gherkin
Feature: Quick Buy minimum received fiat conversion

  Scenario: user reviews quote details for an ERC20 token
    Given the user is on the asset details screen of an ERC20 token

    When user taps the lightning (Quick Buy) button
    And user enters an amount
    And user opens the quote details via the rate pill
    Then the "Minimum received" row shows the token amount followed by a non-zero fiat conversion

  Scenario: user reviews quote details for a native token
    Given the user is on the asset details screen of a native token (e.g. ETH)

    When user taps the lightning (Quick Buy) button
    And user enters an amount
    And user opens the quote details via the rate pill
    Then the "Minimum received" fiat conversion is unchanged from before

  Scenario: user buys a token with no price data
    Given the user opens Quick Buy for a token whose price cannot be resolved

    When user enters an amount and opens the quote details
    Then the "Minimum received" row shows only the token amount, with no "~$0.00" suffix
```

## **Screenshots/Recordings**

### **Before**

See the recording attached to #33787 — the minimum received fiat reads `$0` for ERC20 tokens.

### **After**

N/A — verified through unit tests; this change has not been exercised on a device or simulator.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-591eed77-392a-45ee-9ce3-b2688befcf3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-591eed77-392a-45ee-9ce3-b2688befcf3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

