### PR TITLE
feat(ci): reuse main BrowserStack builds on manual performance dispatch

### DIFF
--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -44,6 +44,15 @@ on:
         required: false
         type: string
         default: ''
+      reuse_main_builds:
+        description: >-
+          When true, skip fresh Android BrowserStack builds and reuse the latest
+          uploaded apps from main-branch CI instead (same behavior as CI test-only PRs).
+          Falls back to a fresh build if no reusable main apps are found. Ignored when
+          manual browserstack_app_url_* inputs are provided.
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       description:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Exposes the existing `reuse_main_builds` flag on **manual** `workflow_dispatch` for `Build Apps and Run Performance E2E Tests`.

CI already passes this via `workflow_call` for test-only PRs. Manual runs can now opt in to the same path: resolve the latest main-branch BrowserStack apps and skip a fresh Android build when found.

### Behavior
- `reuse_main_builds=false` (default): build/upload as today
- `reuse_main_builds=true`: run `resolve-main-browserstack-urls`; skip Android dual build when apps are found
- Falls back to a fresh build if main apps are not found
- Ignored when manual `browserstack_app_url_*` inputs are provided

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MMQA — expose `reuse_main_builds` on manual performance workflow dispatch

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Open Actions → **Build Apps and Run Performance E2E Tests** → Run workflow.
2. Confirm the new `reuse_main_builds` boolean input appears.
3. Dispatch with `reuse_main_builds=true` and no manual BrowserStack URLs → expect `resolve-main-browserstack-urls` to run and Android dual build to be skipped when main apps exist.
4. Dispatch with `reuse_main_builds=false` → expect normal Android build/upload.
5. Dispatch with `reuse_main_builds=true` plus a manual `browserstack_app_url_*` → expect resolve/build skipped as today when URLs are provided.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow input change only; no app UI.

### **Before**

N/A — manual `workflow_dispatch` could not opt into reusing main BrowserStack apps.

### **After**

N/A — `reuse_main_builds` boolean is available on manual dispatch (same behavior as the existing `workflow_call` path).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

N/A for app performance checks — this change only adds a CI `workflow_dispatch` input; no app code.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a75116c-34e8-4488-896c-267d304e469b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a75116c-34e8-4488-896c-267d304e469b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

