### PR TITLE
feat(migrations): add migration 148 to replace Infura IPFS gateway with default

### DIFF
--- a/app/store/migrations/148.test.ts
+++ b/app/store/migrations/148.test.ts
@@ -1,0 +1,109 @@
+import { captureException } from '@sentry/react-native';
+import migrate, { migrationVersion } from './148';
+import { ensureValidState } from './util';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const INFURA_IPFS_GATEWAY = 'https://ipfs.infura.io/ipfs/';
+const DEFAULT_IPFS_GATEWAY = 'https://dweb.link/ipfs/';
+
+const createState = (preferencesController: unknown) => ({
+  engine: {
+    backgroundState: {
+      PreferencesController: preferencesController,
+      OtherController: { preserved: true },
+    },
+    preserved: true,
+  },
+  preserved: true,
+});
+
+describe(`Migration ${migrationVersion}: replace the Infura IPFS gateway`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
+  });
+
+  it('reports migration version 148', () => {
+    expect(migrationVersion).toBe(148);
+  });
+
+  it('replaces the Infura IPFS gateway with the default gateway', () => {
+    const state = createState({
+      ipfsGateway: INFURA_IPFS_GATEWAY,
+      useTokenDetection: true,
+    });
+
+    const result = migrate(state) as ReturnType<typeof createState>;
+
+    expect(result.engine.backgroundState.PreferencesController).toStrictEqual({
+      ipfsGateway: DEFAULT_IPFS_GATEWAY,
+      useTokenDetection: true,
+    });
+  });
+
+  it('preserves unrelated persisted state when replacing the gateway', () => {
+    const state = createState({ ipfsGateway: INFURA_IPFS_GATEWAY });
+
+    const result = migrate(state) as ReturnType<typeof createState>;
+
+    expect(result.preserved).toBe(true);
+    expect(result.engine.preserved).toBe(true);
+    expect(result.engine.backgroundState.OtherController).toStrictEqual({
+      preserved: true,
+    });
+  });
+
+  it('returns the same state when another IPFS gateway is selected', () => {
+    const state = createState({ ipfsGateway: 'https://ipfs.io/ipfs/' });
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns the same state when the IPFS gateway is absent', () => {
+    const state = createState({ useTokenDetection: true });
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 'invalid'])(
+    'captures an exception when PreferencesController is %p',
+    (preferencesController) => {
+      const state = createState(preferencesController);
+
+      const result = migrate(state);
+
+      expect(result).toBe(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(
+        new Error(
+          `Migration ${migrationVersion}: Invalid PreferencesController state: '${typeof preferencesController}'`,
+        ),
+      );
+    },
+  );
+
+  it('returns the same state when state validation fails', () => {
+    const state = createState({ ipfsGateway: INFURA_IPFS_GATEWAY });
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/app/store/migrations/148.ts
+++ b/app/store/migrations/148.ts
@@ -1,0 +1,51 @@
+import { captureException } from '@sentry/react-native';
+import { isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+
+export const migrationVersion = 148;
+
+const INFURA_IPFS_GATEWAY = 'https://ipfs.infura.io/ipfs/';
+const DEFAULT_IPFS_GATEWAY = 'https://dweb.link/ipfs/';
+
+/**
+ * Migration 148: Replace the decommissioned Infura IPFS gateway with the
+ * current default gateway.
+ *
+ * @param state - The persisted Redux state.
+ * @returns The migrated Redux state.
+ */
+export default function migrate(state: unknown): unknown {
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  const preferencesController =
+    state.engine.backgroundState.PreferencesController;
+
+  if (!isObject(preferencesController)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid PreferencesController state: '${typeof preferencesController}'`,
+      ),
+    );
+    return state;
+  }
+
+  if (preferencesController.ipfsGateway !== INFURA_IPFS_GATEWAY) {
+    return state;
+  }
+
+  return {
+    ...state,
+    engine: {
+      ...state.engine,
+      backgroundState: {
+        ...state.engine.backgroundState,
+        PreferencesController: {
+          ...preferencesController,
+          ipfsGateway: DEFAULT_IPFS_GATEWAY,
+        },
+      },
+    },
+  };
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -148,6 +148,7 @@ import migration144 from './144';
 import migration145 from './145';
 import migration146 from './146';
 import migration147 from './147';
+import migration148 from './148';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -315,6 +316,7 @@ export const migrationList: MigrationsList = {
   145: migration145,
   146: migration146,
   147: migration147,
+  148: migration148,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/ipfs-gateways.json
+++ b/app/util/ipfs-gateways.json
@@ -10,11 +10,6 @@
     "label": "https://gateway.ipfs.io/ipfs/"
   },
   {
-    "value": "https://ipfs.infura.io/ipfs/",
-    "key": 2,
-    "label": "https://ipfs.infura.io/ipfs/"
-  },
-  {
     "value": "https://gateway.pinata.cloud/ipfs/",
     "key": 24,
     "label": "https://gateway.pinata.cloud/ipfs/"

--- a/tests/api-mocking/mock-responses/infura-mocks.ts
+++ b/tests/api-mocking/mock-responses/infura-mocks.ts
@@ -64,7 +64,6 @@ const createInfuraMocks = () => {
     'starknet-mainnet.infura.io',
     'starknet-goerli.infura.io',
     'starknet-sepolia.infura.io',
-    'ipfs.infura.io',
     'sei-mainnet.infura.io',
     'monad-mainnet.infura.io',
     'megaeth-mainnet.infura.io',
@@ -72,36 +71,19 @@ const createInfuraMocks = () => {
   ];
 
   endpoints.forEach((endpoint) => {
-    if (endpoint === 'ipfs.infura.io') {
-      // IPFS endpoints are GET requests, not JSON-RPC
-      mocks.push({
-        urlEndpoint: new RegExp(
-          `^https://${endpoint.replace(/\./g, '\\.')}/ipfs/[a-zA-Z0-9]+.*$`,
-        ),
-        responseCode: 200,
-        response: 'Mock IPFS content',
-      });
-    } else {
-      // Regular Infura endpoints are POST requests with JSON-RPC
-      mocks.push({
-        urlEndpoint: new RegExp(
-          // E2E builds use INFURA_PROJECT_ID fallback "NON_EMPTY" (see network-controller-init).
-          `^https://${endpoint.replace(/\./g, '\\.')}/v3/[a-zA-Z0-9_-]+$`,
-        ),
-        responseCode: 200,
-        response: createJsonRpcResponse(1, '0x0'),
-      });
-    }
+    mocks.push({
+      urlEndpoint: new RegExp(
+        // E2E builds use INFURA_PROJECT_ID fallback "NON_EMPTY" (see network-controller-init).
+        `^https://${endpoint.replace(/\./g, '\\.')}/v3/[a-zA-Z0-9_-]+$`,
+      ),
+      responseCode: 200,
+      response: createJsonRpcResponse(1, '0x0'),
+    });
   });
 
   return mocks;
 };
 
 export const INFURA_MOCKS: MockEventsObject = {
-  GET: createInfuraMocks().filter((mock) =>
-    mock.urlEndpoint.toString().includes('ipfs'),
-  ),
-  POST: createInfuraMocks().filter(
-    (mock) => !mock.urlEndpoint.toString().includes('ipfs'),
-  ),
+  POST: createInfuraMocks(),
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrates persisted `PreferencesController.ipfsGateway` values from the decommissioned `https://ipfs.infura.io/ipfs/` gateway to the current default, `https://dweb.link/ipfs/`, during store migration 148. Removes Infura from the selectable gateway list and deletes its obsolete E2E GET mock, preventing existing users from being left with a broken IPFS gateway after the public Infura endpoint is retired.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Migrated IPFS gateway settings from the retired Infura gateway

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1102

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Infura IPFS gateway migration

  Scenario: user upgrades with Infura selected as the IPFS gateway
    Given I have an app state persisted with "https://ipfs.infura.io/ipfs/" as my IPFS gateway

    When I upgrade to this app version
    Then my IPFS gateway is "https://dweb.link/ipfs/"
    And IPFS-hosted media and ipfs:// browser content load through dweb.link

  Scenario: user selects an IPFS gateway after the upgrade
    Given I am on the IPFS gateway settings screen

    When I view the available gateways
    Then "https://ipfs.infura.io/ipfs/" is not selectable
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="263" height="232" alt="Screenshot 2026-07-28 at 13 37 53" src="https://github.com/user-attachments/assets/c1f91bc1-5a78-469f-9869-57efdce85a7e" />

<!-- [screenshots/recordings] -->

### **After**
<img width="260" height="196" alt="Screenshot 2026-07-28 at 13 33 57" src="https://github.com/user-attachments/assets/5ef6a472-9d4e-4349-b758-1a03682de954" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
