### PR TITLE
test: stabilize SmokeStake lending seed and stake Confirm flow

### DIFF
--- a/tests/smoke-appium/stake/helpers/lending-fixture.ts
+++ b/tests/smoke-appium/stake/helpers/lending-fixture.ts
@@ -108,25 +108,27 @@ async function seedAethUsdcViaDeposit(
   await testClient.impersonateAccount({ address: account });
 
   try {
-    const approveTx = await walletClient.writeContract({
-      account,
-      address: USDC_MAINNET as Hex,
-      abi: ERC20_APPROVE_ABI,
-      functionName: 'approve',
-      args: [AAVE_POOL as Hex, amount],
-    });
-    const approveReceipt = await publicClient.waitForTransactionReceipt({
-      hash: approveTx,
-    });
-    if (approveReceipt.status !== 'success') {
-      throw new Error(
-        `Aave seed approve reverted (status=${approveReceipt.status}, hash=${approveTx})`,
-      );
-    }
-
+    // Each supply attempt must be preceded by a fresh approve — a successful
+    // first supply consumes allowance, so bare supply retries would fail.
     let lastError: unknown;
     for (let attempt = 1; attempt <= AAVE_SUPPLY_MAX_ATTEMPTS; attempt++) {
       try {
+        const approveTx = await walletClient.writeContract({
+          account,
+          address: USDC_MAINNET as Hex,
+          abi: ERC20_APPROVE_ABI,
+          functionName: 'approve',
+          args: [AAVE_POOL as Hex, amount],
+        });
+        const approveReceipt = await publicClient.waitForTransactionReceipt({
+          hash: approveTx,
+        });
+        if (approveReceipt.status !== 'success') {
+          throw new Error(
+            `Aave seed approve reverted (status=${approveReceipt.status}, hash=${approveTx}, attempt=${attempt})`,
+          );
+        }
+
         const supplyTx = await walletClient.writeContract({
           account,
           address: AAVE_POOL as Hex,
@@ -163,7 +165,7 @@ async function seedAethUsdcViaDeposit(
       }
     }
     throw new Error(
-      `Aave seed failed after ${AAVE_SUPPLY_MAX_ATTEMPTS} supply attempt(s): ${
+      `Aave seed failed after ${AAVE_SUPPLY_MAX_ATTEMPTS} attempt(s): ${
         lastError instanceof Error ? lastError.message : String(lastError)
       }`,
     );

--- a/tests/smoke-appium/stake/helpers/lending-fixture.ts
+++ b/tests/smoke-appium/stake/helpers/lending-fixture.ts
@@ -66,6 +66,16 @@ const ERC20_APPROVE_ABI = [
   },
 ] as const;
 
+const ERC20_BALANCE_OF_ABI = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const;
+
 const AAVE_SUPPLY_ABI = [
   {
     name: 'supply',
@@ -105,7 +115,14 @@ async function seedAethUsdcViaDeposit(
       functionName: 'approve',
       args: [AAVE_POOL as Hex, amount],
     });
-    await publicClient.waitForTransactionReceipt({ hash: approveTx });
+    const approveReceipt = await publicClient.waitForTransactionReceipt({
+      hash: approveTx,
+    });
+    if (approveReceipt.status !== 'success') {
+      throw new Error(
+        `Aave seed approve reverted (status=${approveReceipt.status}, hash=${approveTx})`,
+      );
+    }
 
     let lastError: unknown;
     for (let attempt = 1; attempt <= AAVE_SUPPLY_MAX_ATTEMPTS; attempt++) {
@@ -117,7 +134,26 @@ async function seedAethUsdcViaDeposit(
           functionName: 'supply',
           args: [USDC_MAINNET as Hex, amount, account, 0],
         });
-        await publicClient.waitForTransactionReceipt({ hash: supplyTx });
+        const supplyReceipt = await publicClient.waitForTransactionReceipt({
+          hash: supplyTx,
+        });
+        if (supplyReceipt.status !== 'success') {
+          throw new Error(
+            `Aave seed supply reverted (status=${supplyReceipt.status}, hash=${supplyTx}, attempt=${attempt})`,
+          );
+        }
+
+        const aTokenBalance = await publicClient.readContract({
+          address: AAVE_USDC_OUTPUT_TOKEN as Hex,
+          abi: ERC20_BALANCE_OF_ABI,
+          functionName: 'balanceOf',
+          args: [account],
+        });
+        if (aTokenBalance <= 0n) {
+          throw new Error(
+            `Aave seed supply mined but aEthUSDC balanceOf(${account}) is ${aTokenBalance} (hash=${supplyTx})`,
+          );
+        }
         return;
       } catch (error) {
         lastError = error;
@@ -126,7 +162,11 @@ async function seedAethUsdcViaDeposit(
         }
       }
     }
-    throw lastError;
+    throw new Error(
+      `Aave seed failed after ${AAVE_SUPPLY_MAX_ATTEMPTS} supply attempt(s): ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }`,
+    );
   } finally {
     await testClient.stopImpersonatingAccount({ address: account });
   }

--- a/tests/smoke-appium/stake/stake-action-smoke.spec.ts
+++ b/tests/smoke-appium/stake/stake-action-smoke.spec.ts
@@ -14,6 +14,7 @@ import NetworkManager from '../../page-objects/wallet/NetworkManager.js';
 import { SmokeStake } from '../../tags.js';
 import Assertions from '../../framework/Assertions.js';
 import StakeView from '../../page-objects/Stake/StakeView.js';
+import FooterActions from '../../page-objects/Browser/Confirmations/FooterActions.js';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils.js';
 import { AnvilManager } from '../../seeder/anvil-manager.js';
 import { Mockttp } from 'mockttp';
@@ -143,11 +144,17 @@ appiumTest.describe(SmokeStake('Stake from Actions'), () => {
           await WalletView.tapOnEarnButton();
           await Assertions.expectElementToBeVisible(StakeView.stakeContainer);
           await StakeView.enterAmount(AMOUNT_TO_STAKE);
-          await StakeView.tapReviewWithRetry(30000);
-          await Assertions.expectElementToBeVisible(StakeView.confirmButton, {
-            timeout: 30000,
-          });
-          await StakeView.tapConfirm(30000);
+          // Redesigned stake confirmations use confirm-button (FooterActions),
+          // not the legacy text "Confirm" locator in StakeView.tapReviewWithRetry.
+          await StakeView.tapReview();
+          await Assertions.expectElementToBeVisible(
+            FooterActions.confirmButton,
+            {
+              description:
+                'Redesigned Confirm button should appear after Review',
+            },
+          );
+          await FooterActions.tapConfirmButton();
 
           await Assertions.expectElementToBeVisible(
             ActivitiesView.stakeDepositedLabel,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Stabilizes flaky Android Appium `SmokeStake` cases:

1. **Lending withdrawal** — Aave seed previously treated any mined receipt as success. Reverted supplies could still leave fixture/mocks advertising an `aEthUSDC` balance, so the UI withdraw then failed on-chain (`Row 0 status: "Failed"`). Seed now asserts approve/supply `receipt.status === 'success'` and on-chain `aEthUSDC.balanceOf > 0`, failing fast with a clear seed error.
2. **Stake action** — Review→Confirm used text `"Confirm"` + a short enabled wait, while redesigned stake confirmations expose `confirm-button`. Spec now mirrors lending: `tapReview` → wait for `FooterActions.confirmButton` → `FooterActions.tapConfirmButton()`.

Lending deposit was not code-changed; it shares the fixture module but does not use the existing-position seed path.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: Android SmokeStake flakes for lending withdrawal seed reverts and stake Review→Confirm locator mismatch

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: SmokeStake Appium stability

  Scenario: stake deposit confirm uses redesigned footer
    Given a main-e2e Appium build on Android or iOS
    When the stake-action smoke test runs
    Then Review opens redesigned Confirm and the deposit confirms

  Scenario: lending withdrawal seed is verified on-chain
    Given Anvil forks mainnet for lending withdrawal smoke
    When the fixture seeds an Aave USDC position
    Then approve and supply receipts succeed and aEthUSDC balance is non-zero
    And the withdrawal activity reaches Confirmed
```

Local validation:
- Android arm64 main-e2e: stake-action, lending-deposit, lending-withdrawal — all passed
- iOS (`iPhone 17 Pro`): all three specs — `3 passed (4.8m)`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — Appium smoke test stabilization only; no product UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Test plan

- [x] iOS Appium: `stake-action-smoke`, `lending-deposit-smoke`, `lending-withdrawal-smoke` — 3 passed
- [x] Android Appium: same three specs — each passed locally on arm64 main-e2e
- [ ] Confirm CI `appium-stake-android-smoke` / `appium-stake-ios-smoke` on this PR


Made with [Cursor](https://cursor.com)