### PR TITLE
feat(selectors): add conversion rate selector factories for chain IDs

### DIFF
--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -18,6 +18,7 @@ import {
   selectAssetsByAccountGroupId,
   selectAssetsBySelectedAccountGroup,
   selectHasEligibleSwapSource,
+  makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance,
   selectSortedAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroupForChainIds,
   selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance,
@@ -1326,6 +1327,24 @@ describe('selectSortedAssetsBySelectedAccountGroupForChainIds', () => {
 });
 
 describe('selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance', () => {
+  it('returns assets for the chain IDs bound to the selector factory', () => {
+    const state = mockState();
+    const chainIds = ['eip155:1', '0xa'];
+    const selectSortedAssets =
+      makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+        chainIds,
+      );
+
+    const result = selectSortedAssets(state);
+
+    expect(result).toEqual(
+      selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance(
+        state,
+        chainIds,
+      ),
+    );
+  });
+
   it('filters assets by explicit chain IDs (same as ForChainIds)', () => {
     const state = mockState();
     const chainIds = ['eip155:1', '0xa'];

--- a/app/selectors/currencyRateController.test.ts
+++ b/app/selectors/currencyRateController.test.ts
@@ -1,4 +1,6 @@
 import {
+  makeSelectConversionRateByChainId,
+  makeSelectUSDConversionRateByChainId,
   selectConversionRate,
   selectConversionRateByChainId,
   selectCurrencyRateForChainId,
@@ -287,6 +289,63 @@ describe('CurrencyRateController Selectors', () => {
         chainId,
       );
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('conversion rate selector factories', () => {
+    const chainId = '0x1';
+
+    beforeEach(() => {
+      (isTestNet as jest.Mock).mockReturnValue(false);
+      jest
+        .spyOn(
+          NetworkControllerSelectors,
+          'selectNetworkConfigurationByChainId',
+        )
+        .mockReturnValue({
+          nativeCurrency: 'ETH',
+        } as MultichainNetworkConfiguration);
+    });
+
+    const createMockState = (): RootState =>
+      ({
+        engine: {
+          backgroundState: {
+            CurrencyRateController: {
+              currencyRates: mockCurrencyRateState.currencyRates,
+            },
+            NetworkController: {
+              networkConfigurationsByChainId: {
+                [chainId]: {
+                  nativeCurrency: 'ETH',
+                },
+              },
+            },
+          },
+        },
+        settings: {
+          showFiatOnTestnets: true,
+        },
+      }) as unknown as RootState;
+
+    it('returns the conversion rate for the chain ID bound to the factory', () => {
+      const state = createMockState();
+      const selectConversionRateForChain =
+        makeSelectConversionRateByChainId(chainId);
+
+      const result = selectConversionRateForChain(state);
+
+      expect(result).toBe(3000);
+    });
+
+    it('returns the USD conversion rate for the chain ID bound to the factory', () => {
+      const state = createMockState();
+      const selectUSDConversionRateForChain =
+        makeSelectUSDConversionRateByChainId(chainId);
+
+      const result = selectUSDConversionRateForChain(state);
+
+      expect(result).toBe(3000);
     });
   });
 });

--- a/tests/api-mocking/mock-responses/defaults/index.ts
+++ b/tests/api-mocking/mock-responses/defaults/index.ts
@@ -35,6 +35,7 @@ import { STATIC_ASSETS_MOCKS } from './static-assets.ts';
 import { SIGNATURE_INSIGHTS_MOCKS } from './signature-insights.ts';
 import { NFT_API_MOCKS } from './nft-api.ts';
 import { SOCIAL_API_MOCKS } from './social-api.ts';
+import { PRICE_ALERTS_API_MOCKS } from './price-alerts.ts';
 
 // Get auth mocks
 const authMocks = getAuthMocks();
@@ -66,6 +67,7 @@ export const DEFAULT_MOCKS = {
     ...(STATIC_ASSETS_MOCKS.GET || []),
     ...(NFT_API_MOCKS.GET || []),
     ...(SOCIAL_API_MOCKS.GET || []),
+    ...(PRICE_ALERTS_API_MOCKS.GET || []),
     ...(PERPS_HYPERLIQUID_MOCKS.GET || []),
     // Chains Network Mock - Provides blockchain network data
     {

--- a/tests/api-mocking/mock-responses/defaults/price-alerts.ts
+++ b/tests/api-mocking/mock-responses/defaults/price-alerts.ts
@@ -1,0 +1,18 @@
+import { MockEventsObject } from '../../../framework';
+
+/**
+ * Default Price Alerts API mocks for E2E tests.
+ *
+ * An empty supported-chains response keeps Price Alerts disabled unless a test
+ * explicitly overrides this mock to exercise the feature.
+ */
+export const PRICE_ALERTS_API_MOCKS: MockEventsObject = {
+  GET: [
+    {
+      urlEndpoint:
+        /^https:\/\/price-alerts\.(api|dev-api)\.cx\.metamask\.io\/v1\/alerts\/supported-chains$/,
+      responseCode: 200,
+      response: [],
+    },
+  ],
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds unit coverage for selector factories introduced in the parent change. The tests verify that the assets-by-balance, conversion-rate, and USD-conversion-rate factories bind the supplied chain ID and return the expected result. No runtime behavior changes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1136

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector coverage plus a conservative E2E mock default; no application logic changes in this PR.
> 
> **Overview**
> Adds **unit tests** for chain-bound selector factories from the parent work: `makeSelectSortedAssetsBySelectedAccountGroupForChainIdsByBalance` is asserted to match the non-factory selector for the same chain IDs, and `makeSelectConversionRateByChainId` / `makeSelectUSDConversionRateByChainId` are covered to return the expected rates for a fixed chain ID.
> 
> For E2E, registers **default Price Alerts API mocks** that respond to `supported-chains` with an empty list and wires them into `DEFAULT_MOCKS`, so Price Alerts stays off in tests unless a scenario overrides the mock.
> 
> No production selector or app runtime behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bfe39c9fd46d062483e8c700d022277c4ffefc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->