### PR TITLE
fix(perf): map TestMu device aliases for Perps account selection

### DIFF
--- a/tests/framework/PlaywrightUtilities.test.ts
+++ b/tests/framework/PlaywrightUtilities.test.ts
@@ -299,3 +299,21 @@ describe('executeMobileDeepLink', () => {
     });
   });
 });
+
+describe('PlaywrightUtilities.buildDeviceAccountMapping', () => {
+  it('maps BrowserStack matrix names and TestMu catalog aliases to the same account', () => {
+    const mapping = PlaywrightUtilities.buildDeviceAccountMapping();
+
+    // Low-tier Android: matrix name + TestMu catalog alias
+    expect(mapping['Google Pixel 8 Pro']).toBe('Account 1');
+    expect(mapping['Pixel 8 Pro']).toBe('Account 1');
+
+    // High-tier Android: matrix name + TestMu catalog alias
+    expect(mapping['Samsung Galaxy S25 Ultra']).toBe('Account 3');
+    expect(mapping['Galaxy S25 Ultra']).toBe('Account 3');
+
+    // iOS names are shared across providers
+    expect(mapping['iPhone 16 Pro Max']).toBe('Account 4');
+    expect(mapping['iPhone 12']).toBe('Account 5');
+  });
+});

--- a/tests/framework/PlaywrightUtilities.ts
+++ b/tests/framework/PlaywrightUtilities.ts
@@ -21,6 +21,7 @@ import { execSync } from 'child_process';
 import type { CurrentDeviceDetails } from './fixtures/playwright';
 import { createPlaywrightLogger } from './playwrightLogger.ts';
 import { PlatformDetector } from './PlatformLocator.ts';
+import { resolveTestMuDeviceCapabilities } from './services/providers/testmu/TestMuDeviceResolver.ts';
 
 const logger = createPlaywrightLogger('PlaywrightUtilities');
 
@@ -451,22 +452,40 @@ class PlaywrightUtilities {
   static buildDeviceAccountMapping(): Record<string, string | null> {
     const mapping: Record<string, string | null> = {};
 
+    /**
+     * Register the matrix device name and its TestMu catalog alias.
+     * CI sets TESTMU_DEVICE to the resolved catalog name (e.g. "Pixel 8 Pro")
+     * while device-matrix.json keeps BrowserStack names (e.g. "Google Pixel 8 Pro").
+     * Perps/account selection uses currentDeviceDetails.deviceName, so both keys
+     * must resolve to the same account.
+     */
+    const assignAccount = (deviceName: string, account: string): void => {
+      mapping[deviceName] = account;
+      const { deviceName: testMuName } = resolveTestMuDeviceCapabilities(
+        deviceName,
+        '0',
+      );
+      if (testMuName !== deviceName) {
+        mapping[testMuName] = account;
+      }
+    };
+
     // Process Android devices
     deviceMatrix.android_devices.forEach((device) => {
       if (device.category === 'high') {
-        mapping[device.name] = 'Account 3';
+        assignAccount(device.name, 'Account 3');
       } else if (device.category === 'low') {
         // Low category Android devices use default Account 1
-        mapping[device.name] = 'Account 1';
+        assignAccount(device.name, 'Account 1');
       }
     });
 
     // Process iOS devices
     deviceMatrix.ios_devices.forEach((device) => {
       if (device.category === 'high') {
-        mapping[device.name] = 'Account 4';
+        assignAccount(device.name, 'Account 4');
       } else if (device.category === 'low') {
-        mapping[device.name] = 'Account 5';
+        assignAccount(device.name, 'Account 5');
       }
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes TestMu failure of **Perps open position and close it** (`Account name not found for device: Pixel 8 Pro`).
- `buildDeviceAccountMapping()` now registers TestMu catalog aliases (via `resolveTestMuDeviceCapabilities`) alongside BrowserStack matrix names, so `selectAccountByDevice` works when `TESTMU_DEVICE=Pixel 8 Pro`.
- Adds unit coverage for Pixel / Galaxy BS ↔ TestMu name pairs.

## Root cause
CI maps matrix `Google Pixel 8 Pro` → TestMu catalog `Pixel 8 Pro`. The account mapping only keyed matrix names, so Perps account selection threw before the flow could run.

## Test plan
- [x] `yarn jest tests/framework/PlaywrightUtilities.test.ts`
- [ ] Re-run performance E2E (TestMu Android onboarding) and confirm Perps open/close no longer fails with account-name mapping error

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

