### PR TITLE
test(ci): verify flakiness-detection wiring for #33921 [DO NOT MERGE]

### DIFF
--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -138,3 +138,9 @@ e2e_smoke_infra:
 
 all_changes:
   - '**'
+
+# Spec files used for flakiness detection (run changed specs twice).
+# Kept separate from all_changes so only this short list is passed through
+# workflow outputs/env vars — the full list overflows ARG_MAX on large PRs.
+e2e_spec_files:
+  - '**/*.spec.{ts,js}'

--- a/.github/scripts/compute-e2e-platform-flags.cjs
+++ b/.github/scripts/compute-e2e-platform-flags.cjs
@@ -20,7 +20,7 @@ function computeE2EPlatformFlags(input) {
     iosCount,
     androidOrIgnorableCount,
     iosOrIgnorableCount,
-    allChangesFiles = '',
+    changedSpecFiles = '',
   } = input;
 
   let android = false;
@@ -58,7 +58,7 @@ function computeE2EPlatformFlags(input) {
     android = true;
     ios = true;
     nativeBuildNeeded = false;
-    changed = allChangesFiles;
+    changed = changedSpecFiles;
   } else if (
     androidCount > 0 &&
     iosCount === 0 &&
@@ -67,7 +67,7 @@ function computeE2EPlatformFlags(input) {
   ) {
     message = 'E2E Android only';
     android = true;
-    changed = allChangesFiles;
+    changed = changedSpecFiles;
   } else if (
     iosCount > 0 &&
     androidCount === 0 &&
@@ -76,12 +76,12 @@ function computeE2EPlatformFlags(input) {
   ) {
     message = 'E2E iOS only';
     ios = true;
-    changed = allChangesFiles;
+    changed = changedSpecFiles;
   } else {
     message = 'E2E for both platforms';
     android = true;
     ios = true;
-    changed = allChangesFiles;
+    changed = changedSpecFiles;
   }
 
   const e2eNeeded = android || ios;

--- a/.github/scripts/compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/compute-e2e-platform-flags.test.ts
@@ -14,7 +14,7 @@ describe('computeE2EPlatformFlags', () => {
     iosCount: 0,
     androidOrIgnorableCount: 0,
     iosOrIgnorableCount: 0,
-    allChangesFiles: 'tests/smoke/wallet/foo.spec.ts',
+    changedSpecFiles: 'tests/smoke/wallet/foo.spec.ts',
   };
 
   it('skips native builds for test-only PR changes', () => {
@@ -37,12 +37,13 @@ describe('computeE2EPlatformFlags', () => {
       e2eTestOrIgnorableCount: 1,
       androidCount: 1,
       androidOrIgnorableCount: 1,
-      allChangesFiles: 'app/components/Foo.tsx tests/smoke/wallet/foo.spec.ts',
+      changedSpecFiles: 'tests/smoke/wallet/foo.spec.ts',
     });
 
     expect(result.nativeBuildNeeded).toBe(true);
     expect(result.android).toBe(true);
     expect(result.ios).toBe(true);
+    expect(result.changedFiles).toBe('tests/smoke/wallet/foo.spec.ts');
   });
 
   it('skips E2E for ignorable-only changes', () => {
@@ -51,7 +52,7 @@ describe('computeE2EPlatformFlags', () => {
       e2eTestFilesCount: 0,
       ignorableCount: 1,
       e2eTestOrIgnorableCount: 1,
-      allChangesFiles: 'README.md',
+      changedSpecFiles: '',
     });
 
     expect(result.e2eNeeded).toBe(false);

--- a/.github/scripts/run-compute-e2e-platform-flags.cjs
+++ b/.github/scripts/run-compute-e2e-platform-flags.cjs
@@ -45,7 +45,7 @@ const flags = computeE2EPlatformFlags({
   iosCount: readInt(process.env.IOS_COUNT),
   androidOrIgnorableCount: readInt(process.env.ANDROID_OR_IGNORABLE_COUNT),
   iosOrIgnorableCount: readInt(process.env.IOS_OR_IGNORABLE_COUNT),
-  allChangesFiles: process.env.ALL_CHANGES_FILES || '',
+  changedSpecFiles: process.env.CHANGED_SPEC_FILES || '',
 });
 
 let runAppiumIos = false;

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -18,7 +18,7 @@ on:
         description: 'Whether iOS E2E tests and builds should run (true when iOS-specific or shared files changed)'
         value: ${{ jobs.detect-changes.outputs.ios_e2e_needed }}
       changed_files:
-        description: 'Space-separated list of changed file paths. Smoke test workflows use this to run modified spec files twice for flakiness detection (catches flaky tests before they land on main)'
+        description: 'Space-separated list of changed E2E spec file paths only — never the full changed-file list, which overflows ARG_MAX and kills this job on large PRs. Smoke test workflows use this to run modified spec files twice for flakiness detection (catches flaky tests before they land on main)'
         value: ${{ jobs.detect-changes.outputs.changed_files }}
       block_merge_for_e2e_readiness:
         description: 'Whether merge should be blocked for E2E readiness. True when "pr-not-ready-for-e2e" label is applied AND changes are not ignorable-only (i.e. E2E is actually relevant). Ignorable-only PRs (docs, assets, configs, test files) bypass the block automatically.'
@@ -157,7 +157,7 @@ jobs:
           RUN_APPIUM_IOS_LABEL: ${{ steps.check-labels.outputs.RUN_APPIUM_IOS }}
           E2E_SMOKE_INFRA_COUNT: ${{ steps.filter.outputs.e2e_smoke_infra_count }}
           ALL_CHANGES_COUNT: ${{ steps.filter.outputs.all_changes_count }}
-          ALL_CHANGES_FILES: ${{ github.event_name == 'pull_request' && steps.filter.outputs.all_changes_files || '' }}
+          CHANGED_SPEC_FILES: ${{ github.event_name == 'pull_request' && steps.filter.outputs.e2e_spec_files_files || '' }}
           IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_ignorable_count }}
           E2E_TEST_FILES_COUNT: ${{ steps.filter.outputs.e2e_test_files_count }}
           E2E_TEST_OR_IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_test_or_ignorable_count }}

--- a/tests/smoke/confirmations/signatures/signatures.spec.ts
+++ b/tests/smoke/confirmations/signatures/signatures.spec.ts
@@ -20,6 +20,9 @@ import { confirmationFeatureFlags } from '../../../api-mocking/mock-responses/fe
 import { LocalNode } from '../../../framework/types';
 import { AnvilManager } from '../../../seeder/anvil-manager';
 
+// TEMPORARY — do not merge. No-op touch on a throwaway branch to verify that
+// the spec-file list still reaches E2E flakiness detection after PR #33921.
+// Expected: one shard logs "Duplicated 1 changed file(s) for flakiness detection".
 const SIGNATURE_LIST = [
   {
     specName: 'Personal Sign',

--- a/tests/smoke/confirmations/signatures/signatures.spec.ts
+++ b/tests/smoke/confirmations/signatures/signatures.spec.ts
@@ -23,6 +23,8 @@ import { AnvilManager } from '../../../seeder/anvil-manager';
 // TEMPORARY — do not merge. No-op touch on a throwaway branch to verify that
 // the spec-file list still reaches E2E flakiness detection after PR #33921.
 // Expected: one shard logs "Duplicated 1 changed file(s) for flakiness detection".
+// Must be observed on run attempt 1: e2e-split-tags-shards.mjs gates flakiness
+// detection behind RUN_ATTEMPT === 1, so a re-run never exercises this path.
 const SIGNATURE_LIST = [
   {
     specName: 'Personal Sign',


### PR DESCRIPTION
## Purpose — throwaway branch, DO NOT MERGE

Validation-only branch for #33921. Delete once the signal below is confirmed.

#33921 changes where the changed-file list comes from:

```diff
- ALL_CHANGES_FILES: ${{ ... steps.filter.outputs.all_changes_files ... }}
+ CHANGED_SPEC_FILES: ${{ ... steps.filter.outputs.e2e_spec_files_files ... }}
```

Everything about that change is verified except one link: that `e2e_spec_files_files` is genuinely the output name `dorny/paths-filter` emits for a filter named `e2e_spec_files`. If it were wrong, the env var would be **silently empty** and flakiness detection would quietly stop duplicating changed specs — no error, no failed job. Nothing in the test suite covers that link, because it only exists at runtime inside GitHub Actions.

Critically, **neither #33921 nor its stacked rename modifies a spec file**, so neither of their CI runs exercises this path. Their logs read `No changed spec files found for this shard split` whether the wiring works or not. This branch adds a three-line comment to `tests/smoke/confirmations/signatures/signatures.spec.ts` (`SmokeConfirmations`) purely so the path executes.

## What to look for

In the `SmokeConfirmations` iOS/Android smoke shards, find the shard whose split contains `signatures.spec.ts`:

- **Wiring works:** `ℹ️  Duplicated 1 changed file(s) for flakiness detection.` and `🧪 Duplicated for flakiness check: ...signatures.spec.ts`
- **Wiring broken:** every shard logs `ℹ️  No changed spec files found for this shard split -> No test retries.`

Only one shard duplicates the spec; the others legitimately report no changed specs. So the pass condition is "at least one shard duplicated it", not "all shards did".

## Why the base is the fix branch

Based on `fix/compute-e2e-flags-arg-max` rather than `main` so the PR diff is *only* the spec touch. That keeps #33921 reviewable and makes this a test-only change, so `native_build_needed` is false and CI reuses main's native builds instead of rebuilding.

## Notes

- Do not apply `skip-e2e-flakiness-detection` to this PR — that label short-circuits the exact code path under test.
- Must stay a real PR: `shouldSkipFlakinessDetection()` returns early when `PR_NUMBER` is unset.

Made with [Cursor](https://cursor.com)