### PR TITLE
feat(ramps): attribute PayPal quote fetch CUF outcomes (TRAM-3805)

### DIFF
--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -7,6 +7,10 @@ export const RAMPS_BUY_CUF_TAG = {
   REASON: 'reason',
   BOUNDARY: 'boundary',
   RAMP_TYPE: 'ramp_type',
+  /** Provider id (e.g. `/providers/paypal`) when a single provider was requested. */
+  PROVIDER: 'provider',
+  /** `true` when the usable quote is a custom-action quote (PayPal, Robinhood). */
+  CUSTOM_ACTION: 'custom_action',
 } as const;
 
 /** Feature tag value for Buy CUF spans (dashboard filter). */
@@ -29,6 +33,8 @@ export type RampsBuyCufSurface =
 export const RAMPS_BUY_CUF_PATH = {
   WIDGET: 'widget',
   NATIVE: 'native',
+  /** Custom-action checkout (PayPal, Robinhood) — TRAM-3805. */
+  CUSTOM_ACTION: 'custom_action',
 } as const;
 
 /** Which surface closed the Buy E2E CUF span. */
@@ -45,6 +51,8 @@ export const RAMPS_BUY_CUF_END_REASON = {
   CANCELLED: 'cancelled',
   ABANDONED: 'abandoned',
   HEADLESS: 'headless',
+  /** HTTP succeeded but requested provider(s) returned no usable quote. */
+  NO_QUOTE: 'no_quote',
 } as const;
 
 /**

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -8,6 +8,7 @@ import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import {
   RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_TAG,
 } from '../constants/rampsBuyCufTags';
 
@@ -23,12 +24,16 @@ jest.mock('../../../../core/Engine', () => ({
 
 const mockStartRampsBuyQuoteFetchTrace = jest.fn(() => 'quote-cuf-op-1');
 const mockEndRampsBuyQuoteFetchTrace = jest.fn();
-jest.mock('../utils/rampsBuyCufTrace', () => ({
-  startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
-    mockStartRampsBuyQuoteFetchTrace(...args),
-  endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
-    mockEndRampsBuyQuoteFetchTrace(...args),
-}));
+jest.mock('../utils/rampsBuyCufTrace', () => {
+  const actual = jest.requireActual('../utils/rampsBuyCufTrace') as typeof import('../utils/rampsBuyCufTrace');
+  return {
+    ...actual,
+    startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+      mockStartRampsBuyQuoteFetchTrace(...args),
+    endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+      mockEndRampsBuyQuoteFetchTrace(...args),
+  };
+});
 
 const createMockStore = () =>
   configureStore({
@@ -65,7 +70,7 @@ const createWrapper = (store: ReturnType<typeof createMockStore>) => {
 };
 
 const mockQuotesResponse = {
-  success: [{ provider: 'test', quote: { amountIn: 100 } }],
+  success: [{ provider: '/providers/transak', quote: { amountIn: 100 } }],
   sorted: [],
   error: [],
   customActions: [],
@@ -193,7 +198,9 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(true);
       expect(result.current.status).toBe('loading');
       expect(result.current.data).toBeNull();
-      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalled();
+      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak' },
+      });
 
       await waitFor(() => {
         expect(result.current.status).toBe('success');
@@ -205,7 +212,11 @@ describe('useRampsQuotes', () => {
       expect(result.current.error).toBeNull();
       expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
         id: 'quote-cuf-op-1',
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak',
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: false,
+        },
       });
       expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -242,6 +253,87 @@ describe('useRampsQuotes', () => {
         data: {
           [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
           [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak',
+        },
+      });
+    });
+
+    it('records PayPal custom-action quote success with provider + path tags (TRAM-3805)', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
+        success: [
+          {
+            provider: '/providers/paypal',
+            quote: { amountIn: 100, isCustomAction: true },
+          },
+        ],
+        sorted: [],
+        error: [],
+        customActions: [],
+      });
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal' },
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+          [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+        },
+      });
+    });
+
+    it('records provider-level PayPal quote miss as CUF failure (TRAM-3805)', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      // Quotes API returns HTTP 200 with the provider error in error[] — the
+      // query layer succeeds, but BuildQuote shows "no quotes" for PayPal.
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
+        success: [],
+        sorted: [],
+        error: [
+          { provider: '/providers/paypal', error: 'PayPal unavailable' },
+        ],
+        customActions: [],
+      });
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
         },
       });
     });

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -6,6 +6,8 @@ import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
 import {
+  buildRampsBuyQuoteFetchCufCompletion,
+  buildRampsBuyQuoteFetchStartTags,
   endRampsBuyQuoteFetchTrace,
   startRampsBuyQuoteFetchTrace,
 } from '../utils/rampsBuyCufTrace';
@@ -57,6 +59,15 @@ export function useRampsQuotes(
     options?.assetId && options.walletAddress && options.amount > 0,
   );
 
+  // Stabilize by provider-id value so inline `providers: [id]` arrays do not
+  // retrigger the quote CUF effect every render.
+  const requestedProvidersKey = (options?.providers ?? []).join(',');
+  const requestedProviders = useMemo(
+    () => options?.providers,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by value
+    [requestedProvidersKey],
+  );
+
   const quotesQuery = useQuery({
     ...rampsQueries.quotes.options({
       assetId: options?.assetId,
@@ -64,7 +75,7 @@ export function useRampsQuotes(
       walletAddress: options?.walletAddress ?? '',
       redirectUrl: options?.redirectUrl,
       paymentMethods: options?.paymentMethods,
-      providers: options?.providers,
+      providers: requestedProviders,
       forceRefresh: options?.forceRefresh,
       ttl: options?.ttl,
     }),
@@ -73,7 +84,8 @@ export function useRampsQuotes(
 
   const quoteCufOpIdRef = useRef<string | null>(null);
 
-  // Buy Quote Fetch CUF (TRAM-3780): fetch start → quotes rendered or error.
+  // Buy Quote Fetch CUF (TRAM-3780 / TRAM-3805): fetch start → quotes rendered
+  // or provider-level failure (incl. PayPal custom-action quotes).
   // Fires for every Unified Buy quote fetch; nests under E2E parent when active.
   useEffect(() => {
     if (!queryEnabled) {
@@ -91,7 +103,9 @@ export function useRampsQuotes(
     }
 
     if (quotesQuery.isFetching && !quoteCufOpIdRef.current) {
-      quoteCufOpIdRef.current = startRampsBuyQuoteFetchTrace();
+      quoteCufOpIdRef.current = startRampsBuyQuoteFetchTrace({
+        tags: buildRampsBuyQuoteFetchStartTags(requestedProviders),
+      });
       return;
     }
 
@@ -100,15 +114,20 @@ export function useRampsQuotes(
       quoteCufOpIdRef.current = null;
       endRampsBuyQuoteFetchTrace({
         id: opId,
-        data: quotesQuery.isError
-          ? {
-              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
-            }
-          : { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+        data: buildRampsBuyQuoteFetchCufCompletion({
+          isQueryError: quotesQuery.isError,
+          response: quotesQuery.data,
+          requestedProviders,
+        }),
       });
     }
-  }, [queryEnabled, quotesQuery.isFetching, quotesQuery.isError]);
+  }, [
+    queryEnabled,
+    quotesQuery.isFetching,
+    quotesQuery.isError,
+    quotesQuery.data,
+    requestedProviders,
+  ]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -13,6 +13,8 @@ import {
   endOpenRampsBuyCufChildrenByName,
   startRampsBuyQuoteFetchTrace,
   endRampsBuyQuoteFetchTrace,
+  buildRampsBuyQuoteFetchStartTags,
+  buildRampsBuyQuoteFetchCufCompletion,
   getRampsBuyCufParentContext,
   hasActiveRampsBuyCufTrace,
   surfaceFromBuyFlowOrigin,
@@ -21,6 +23,7 @@ import {
 import {
   RAMPS_BUY_CUF_FEATURE,
   RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_TAG,
   RAMPS_BUY_CUF_END_REASON,
   RAMPS_BUY_CUF_TIMEOUT_MS,
@@ -400,6 +403,71 @@ describe('rampsBuyCufTrace', () => {
           },
         }),
       );
+    });
+  });
+
+  describe('Buy Quote Fetch provider attribution (TRAM-3805)', () => {
+    it('tags single-provider quote starts with the provider id', () => {
+      expect(buildRampsBuyQuoteFetchStartTags(['/providers/paypal'])).toEqual({
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+      expect(
+        buildRampsBuyQuoteFetchStartTags([
+          '/providers/paypal',
+          '/providers/transak',
+        ]),
+      ).toBeUndefined();
+      expect(buildRampsBuyQuoteFetchStartTags([])).toBeUndefined();
+    });
+
+    it('marks PayPal custom-action quotes as successful custom_action path', () => {
+      expect(
+        buildRampsBuyQuoteFetchCufCompletion({
+          isQueryError: false,
+          requestedProviders: ['/providers/paypal'],
+          response: {
+            success: [
+              {
+                provider: '/providers/paypal',
+                quote: { isCustomAction: true },
+              },
+            ],
+          },
+        }),
+      ).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+        [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+        [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+      });
+    });
+
+    it('marks HTTP-ok PayPal misses as no_quote failures', () => {
+      expect(
+        buildRampsBuyQuoteFetchCufCompletion({
+          isQueryError: false,
+          requestedProviders: ['/providers/paypal'],
+          response: { success: [] },
+        }),
+      ).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it('keeps transport errors as error failures with provider tag', () => {
+      expect(
+        buildRampsBuyQuoteFetchCufCompletion({
+          isQueryError: true,
+          requestedProviders: ['/providers/paypal'],
+          response: null,
+        }),
+      ).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
     });
   });
 });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -10,6 +10,7 @@ import {
   RAMPS_BUY_CUF_FEATURE,
   RAMPS_BUY_CUF_TAG,
   RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_END_REASON,
   RAMPS_BUY_CUF_TIMEOUT_MS,
   type RampsBuyCufSurface,
@@ -222,6 +223,99 @@ export interface StartRampsBuyQuoteFetchTraceOptions {
   tags?: Record<string, TraceValue>;
   startTime?: number;
   data?: Record<string, TraceValue>;
+}
+
+/**
+ * Start tags for a quote-fetch CUF when callers know the provider filter.
+ * Single-provider fetches (BuildQuote / PayPal) get a filterable `provider` tag.
+ */
+export function buildRampsBuyQuoteFetchStartTags(
+  providers?: string[],
+): Record<string, TraceValue> | undefined {
+  if (!providers?.length) {
+    return undefined;
+  }
+  if (providers.length === 1) {
+    return { [RAMPS_BUY_CUF_TAG.PROVIDER]: providers[0] };
+  }
+  return undefined;
+}
+
+export interface BuildRampsBuyQuoteFetchCufCompletionParams {
+  isQueryError: boolean;
+  /** Quotes API body when the HTTP/query layer succeeded. */
+  response?: {
+    success?: Array<{
+      provider?: string;
+      quote?: { isCustomAction?: boolean };
+    }>;
+  } | null;
+  /** Provider ids passed to getQuotes (single-provider = BuildQuote). */
+  requestedProviders?: string[];
+}
+
+/**
+ * Build end-span attributes for Buy Quote Fetch (TRAM-3780 / TRAM-3805).
+ *
+ * Provider-filtered fetches (e.g. PayPal on BuildQuote) treat "HTTP 200 with
+ * no usable quote for the requested provider" as failure — the quotes API
+ * returns provider errors in `error[]` without rejecting the request, which
+ * would otherwise look like a successful CUF to Prometheus/Grafana SLOs.
+ *
+ * Custom-action quotes (PayPal / Robinhood) count as usable and are tagged
+ * `path: custom_action` + `custom_action: true`.
+ */
+export function buildRampsBuyQuoteFetchCufCompletion({
+  isQueryError,
+  response,
+  requestedProviders,
+}: BuildRampsBuyQuoteFetchCufCompletionParams): Record<string, TraceValue> {
+  if (isQueryError) {
+    return {
+      [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+      [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+      ...(requestedProviders?.length === 1
+        ? { [RAMPS_BUY_CUF_TAG.PROVIDER]: requestedProviders[0] }
+        : {}),
+    };
+  }
+
+  const successQuotes = response?.success ?? [];
+  const singleProvider =
+    requestedProviders?.length === 1 ? requestedProviders[0] : undefined;
+
+  const usableQuotes = singleProvider
+    ? successQuotes.filter((quote) => quote.provider === singleProvider)
+    : successQuotes;
+
+  if (usableQuotes.length === 0) {
+    return {
+      [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+      [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+      ...(singleProvider
+        ? { [RAMPS_BUY_CUF_TAG.PROVIDER]: singleProvider }
+        : {}),
+    };
+  }
+
+  const matched = usableQuotes[0];
+  const isCustomActionQuote = matched.quote?.isCustomAction === true;
+
+  return {
+    [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+    ...(singleProvider || matched.provider
+      ? {
+          [RAMPS_BUY_CUF_TAG.PROVIDER]:
+            singleProvider ?? (matched.provider as string),
+        }
+      : {}),
+    ...(isCustomActionQuote
+      ? {
+          [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+        }
+      : { [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: false }),
+  };
 }
 
 /**

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -65,9 +65,10 @@ export enum TraceName {
   /** Nested under RampBuyToOrderDetails: Continue (native) → order created. */
   RampBuyNativeToOrderCreated = 'Ramp Buy Native To Order Created',
   /**
-   * Buy Quote Fetch CUF (TRAM-3780): amount/payment/provider change → quotes
-   * rendered or error. Standalone; nests under RampBuyToOrderDetails when that
-   * parent is active.
+   * Buy Quote Fetch CUF (TRAM-3780 / TRAM-3805): amount/payment/provider change
+   * → quotes rendered or provider-level miss (incl. PayPal custom-action).
+   * Standalone; nests under RampBuyToOrderDetails when that parent is active.
+   * Tags: provider, custom_action, path=custom_action when applicable.
    */
   RampBuyQuoteFetch = 'Ramp Buy Quote Fetch',
   RevealSrp = 'Reveal SRP',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Fixes the PayPal quotes observability gap called out on [TRAM-3805](https://consensyssoftware.atlassian.net/browse/TRAM-3805) (parent: Observability / Ramps SLO Phase 2).

SRE reported PayPal quotes missing instrumentation for the Prometheus → Grafana SLOs. Root cause in the Buy Quote Fetch CUF (`useRampsQuotes` / TRAM-3780):

1. The quotes API returns provider failures (including PayPal) as HTTP 200 with an empty `success[]` + entries in `error[]`. The CUF previously ended `success:true` whenever React Query succeeded, so PayPal BuildQuote misses looked healthy.
2. Spans had no `provider` / `custom_action` tags, so PayPal traffic could not be filtered in Discover / downstream SLOs.

This change:

- Tags single-provider quote fetches with `provider` (e.g. `/providers/paypal`)
- Treats custom-action quotes (PayPal / Robinhood) as usable successes and tags `path: custom_action` + `custom_action: true`
- Ends the CUF as `success:false` / `reason: no_quote` when the requested provider returns no usable quote

Stacked on #33916 (TRAM-3780 Buy Quote Fetch CUF).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3805

Depends on: https://consensyssoftware.atlassian.net/browse/TRAM-3780 (#33916)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: PayPal quote fetch CUF attribution

  Scenario: successful PayPal custom-action quote
    Given metrics consent is enabled and MM_SENTRY_DSN is configured
    And the user is on Unified Buy Amount Input with PayPal selected

    When a PayPal quote loads successfully
    Then Sentry shows "Ramp Buy Quote Fetch" with provider:/providers/paypal
    And path:custom_action and custom_action:true
    And success:true

  Scenario: PayPal provider miss is recorded as failure
    When PayPal returns no usable quote (HTTP 200, empty success)
    Then the span ends with success:false and reason:no_quote
    And provider:/providers/paypal
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — performance instrumentation only; no UI changes. Validate in Sentry Discover → Transactions for `Ramp Buy Quote Fetch` filtered by `provider:/providers/paypal`.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/contributor-docs/blob/main/docs/coding-guidelines/about-coding-guidelines.md).
- [x] I've clearly explained the reason for this PR, the improvement/solution, and relevant context.
- [x] I’ve linked related issues.
- [x] I’ve included manual testing steps.
- [x] I’ve included screenshots/recordings OR explicitly noted N/A.
- [x] I’ve included a brief [changelog entry](https://github.com/MetaMask/metamask-extension/blob/main/.github/pull_request_template.md#changelog) OR noted this is not user-facing.

## **Pre-merge reviewer checklist**

- [ ] Manual testing (or automated testing) has been completed and approved.
- [ ] PR is squashed and rebased onto the merge-base branch.
- [ ] PR has pull request labels for QA.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d88829-6ec4-4ccc-a04f-4f6349a89e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d88829-6ec4-4ccc-a04f-4f6349a89e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TRAM-3805]: https://consensyssoftware.atlassian.net/browse/TRAM-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ