### PR TITLE
fix: reduce Hyperliquid API calls on wallet unlock from 14 to 7

### DIFF
--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.test.ts
@@ -1884,6 +1884,172 @@ describe('CandleStreamChannel', () => {
     });
   });
 
+  describe('connectInFlight deduplication', () => {
+    it('suppresses a concurrent connectNow for the same key while REST snapshot is in-flight', () => {
+      // The connectInFlight guard prevents a race where:
+      // 1. connectNow fires, adding cacheKey to connectInFlight and calling subscribeToCandles
+      // 2. Before the REST callback resolves, something clears wsSubscriptions (but NOT connectInFlight)
+      //    and schedules another deferConnect for the same key
+      // 3. That second connectNow fires and would duplicate the REST call without the guard
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation((params) => {
+        capturedCallback = params.callback;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+
+      // First connectNow fired — REST in-flight
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+      mockSubscribeToCandles.mockClear();
+
+      // Simulate another subscriber arriving while REST is still pending.
+      // The connect() call will skip because wsSubscriptions still has the key
+      // (the in-flight guard isn't needed here). But if wsSubscriptions was
+      // already cleared externally (simulate by clearing it directly), a second
+      // connectNow would fire without the guard.
+      const m = channel as unknown as {
+        wsSubscriptions: Map<string, unknown>;
+      };
+      // Manually clear wsSubscriptions to simulate what reconnect() does
+      m.wsSubscriptions.clear();
+
+      // Now a new subscribe triggers connect() → deferConnect() → connectNow
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+
+      // connectNow is suppressed because connectInFlight still has the cacheKey
+      expect(mockSubscribeToCandles).not.toHaveBeenCalled();
+
+      // Once REST callback arrives, connectInFlight is cleared
+      capturedCallback?.(mockCandleData);
+      mockSubscribeToCandles.mockClear();
+
+      // Now a fresh subscribe should go through normally
+      m.wsSubscriptions.clear();
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears connectInFlight on REST error so a retry can proceed', () => {
+      let capturedOnError: ((error: Error) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation((params) => {
+        capturedOnError = params.onError;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+      mockSubscribeToCandles.mockClear();
+
+      // Simulate REST snapshot failure — onError should clear connectInFlight
+      capturedOnError?.(new Error('network error'));
+
+      // Manually clear wsSubscriptions to allow a retry
+      const m = channel as unknown as { wsSubscriptions: Map<string, unknown> };
+      m.wsSubscriptions.clear();
+
+      // A new subscribe now goes through — connectInFlight is cleared
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears connectInFlight on clearCache so fresh connect can proceed after cache wipe', () => {
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation((params) => {
+        capturedCallback = params.callback;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      mockSubscribeToCandles.mockClear();
+
+      // clearCache resets connectInFlight along with everything else
+      channel.clearCache();
+
+      // Re-subscribe — connectInFlight was wiped so a fresh connectNow fires
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+
+      // The original in-flight callback arriving after clearCache must not throw
+      expect(() => capturedCallback?.(mockCandleData)).not.toThrow();
+    });
+
+    it('clears connectInFlight on disconnectAll so fresh connect can proceed', () => {
+      let capturedCallback: ((data: CandleData) => void) | undefined;
+      mockSubscribeToCandles.mockImplementation((params) => {
+        capturedCallback = params.callback;
+        return jest.fn();
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      mockSubscribeToCandles.mockClear();
+
+      // disconnectAll (called via disconnect with no args) clears connectInFlight
+      channel.disconnect();
+
+      // Re-subscribe — should not be blocked by a stale in-flight entry
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.OneWeek,
+        callback: jest.fn(),
+      });
+      flushConnectDebounce();
+      expect(mockSubscribeToCandles).toHaveBeenCalledTimes(1);
+
+      expect(() => capturedCallback?.(mockCandleData)).not.toThrow();
+    });
+  });
+
   describe('reconnect', () => {
     it('should correctly parse cache keys with coin symbols containing hyphens', () => {
       const mockEthUsdUnsubscribe = jest.fn();

--- a/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
+++ b/app/components/UI/Perps/providers/channels/CandleStreamChannel.ts
@@ -126,6 +126,11 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
   >();
   private connectRetryCounts = new Map<string, number>();
   private readonly prewarmRequests = new Set<string>();
+  // Tracks cacheKeys for which subscribeToCandles() has been called and the
+  // initial REST snapshot is still in-flight. Prevents a second connectNow()
+  // (e.g. from reconnect() clearing wsSubscriptions mid-flight) from firing a
+  // duplicate candleSnapshot request before the first one has responded.
+  private readonly connectInFlight = new Set<string>();
   private static readonly MAX_CONNECT_RETRIES = 50;
   // Upper bound on cached candles per cacheKey. Matches fetchHistoricalCandles
   // so merge-on-update can't cause unbounded memory growth.
@@ -230,6 +235,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     this.pendingTeardownTimers.clear();
     this.connectRetryCounts.clear();
     this.prewarmRequests.clear();
+    this.connectInFlight.clear();
     super.clearCache();
   }
 
@@ -434,6 +440,16 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     if (this.wsSubscriptions.has(cacheKey)) {
       return;
     }
+    // Guard: a subscribeToCandles() call is already in-flight for this key.
+    // reconnect() clears wsSubscriptions but the underlying REST request is
+    // still pending — skip to avoid a duplicate candleSnapshot call.
+    if (this.connectInFlight.has(cacheKey)) {
+      DevLogger.log(
+        'CandleStreamChannel: connectNow skipped — REST request already in-flight',
+        { cacheKey },
+      );
+      return;
+    }
     if (
       !this.getIsInitialized() ||
       Engine.context.PerpsController.isCurrentlyReinitializing()
@@ -457,11 +473,17 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     const hasCachedData = this.cache.has(cacheKey);
     const duration = hasCachedData ? TimeDuration.OneDay : TimeDuration.OneWeek;
 
+    // Mark as in-flight before the call so any re-entrant connectNow() triggered
+    // by reconnect()/clearCache() during the REST round-trip is suppressed.
+    this.connectInFlight.add(cacheKey);
+
     const unsubscribe = Engine.context.PerpsController.subscribeToCandles({
       symbol,
       interval,
       duration,
       callback: (candleData: CandleData) => {
+        // First callback received — the initial REST snapshot is done.
+        this.connectInFlight.delete(cacheKey);
         // Merge incoming candles into the existing cache instead of replacing.
         // This preserves older candles on revisit (when we intentionally fetch
         // a lighter OneDay window) and keeps live-tick updates idempotent.
@@ -477,6 +499,8 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
         this.notifySubscribers(cacheKey, merged);
       },
       onError: (error: Error) => {
+        // REST snapshot failed — clear in-flight so a retry can proceed.
+        this.connectInFlight.delete(cacheKey);
         // Log initialization failure
         DevLogger.log(
           'CandleStreamChannel: Subscription initialization failed',
@@ -792,6 +816,7 @@ export class CandleStreamChannel extends StreamChannel<CandleData> {
     this.pendingTeardownTimers.clear();
     this.connectRetryCounts.clear();
     this.prewarmRequests.clear();
+    this.connectInFlight.clear();
 
     this.subscribers.forEach((subscriber) => {
       if (subscriber.timer) {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1390,6 +1390,92 @@ describe('PerpsConnectionManager', () => {
     });
   });
 
+  describe('state monitoring — isPreloading guard', () => {
+    let storeCallback: () => void;
+
+    beforeEach(() => {
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xabc123' }));
+      (selectPerpsNetwork as unknown as jest.Mock).mockReturnValue('mainnet');
+      (store.getState as jest.Mock).mockReturnValue({});
+    });
+
+    it('suppresses reconnectWithNewContext while preloadSubscriptions is in progress', async () => {
+      jest.useFakeTimers();
+
+      // Arrange: connect so isConnected=true and state monitoring is active
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      await PerpsConnectionManager.connect();
+
+      storeCallback = storeCallbacks[storeCallbacks.length - 1];
+
+      // Directly set isPreloading=true to simulate preloadSubscriptions running
+      const m = PerpsConnectionManager as unknown as {
+        isPreloading: boolean;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      m.isPreloading = true;
+
+      const reconnectSpy = jest
+        .spyOn(m, 'reconnectWithNewContext')
+        .mockResolvedValue(undefined);
+
+      // Simulate an account change arriving while preload is in progress
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xnewaddress' }));
+      storeCallback();
+
+      // Flush the 50ms debounce timer
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      // reconnectWithNewContext must NOT have been called because isPreloading=true
+      expect(reconnectSpy).not.toHaveBeenCalled();
+
+      reconnectSpy.mockRestore();
+      jest.useRealTimers();
+    });
+
+    it('triggers reconnectWithNewContext for the same state change after preload completes', async () => {
+      jest.useFakeTimers();
+
+      // Arrange: connect so isConnected=true
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      await PerpsConnectionManager.connect();
+
+      storeCallback = storeCallbacks[storeCallbacks.length - 1];
+
+      // isPreloading=false (default after connect completes)
+      const m = PerpsConnectionManager as unknown as {
+        isPreloading: boolean;
+        reconnectWithNewContext: () => Promise<void>;
+      };
+      m.isPreloading = false;
+
+      const reconnectSpy = jest
+        .spyOn(m, 'reconnectWithNewContext')
+        .mockResolvedValue(undefined);
+
+      // Simulate account change with preload NOT in progress
+      (
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xnewaddress' }));
+      storeCallback();
+
+      jest.runAllTimers();
+      await Promise.resolve();
+
+      expect(reconnectSpy).toHaveBeenCalledTimes(1);
+
+      reconnectSpy.mockRestore();
+      jest.useRealTimers();
+    });
+  });
+
   describe('ensureConnected', () => {
     it('cancels grace period, disconnects, and reconnects when connected', async () => {
       // Establish connection first
@@ -1465,6 +1551,33 @@ describe('PerpsConnectionManager', () => {
       expect(Engine.context.PerpsController.init).toHaveBeenCalled();
       expect(PerpsConnectionManager.getConnectionState().isConnected).toBe(
         true,
+      );
+    });
+
+    it('does not call resubscribeActiveStreamChannels on cold start (no prior connection)', async () => {
+      // Manager starts disconnected (hadPriorConnection=false).
+      // resubscribeActiveStreamChannels is only needed to rebind stale WS handles
+      // after tearing down a live connection — on cold start there is nothing to rebind
+      // and an unconditional call would double every REST preload call.
+      mockStreamManagerInstance.clearAllChannels.mockClear();
+
+      await PerpsConnectionManager.ensureConnected({ preserveCaches: true });
+
+      expect(mockStreamManagerInstance.clearAllChannels).not.toHaveBeenCalled();
+    });
+
+    it('calls resubscribeActiveStreamChannels after tearing down a prior connection (preserveCaches)', async () => {
+      // Establish a connection first so hadPriorConnection=true
+      await PerpsConnectionManager.connect();
+      mockStreamManagerInstance.clearAllChannels.mockClear();
+      (Engine.context.PerpsController.init as jest.Mock).mockClear();
+
+      // ensureConnected with preserveCaches=true tears down the existing
+      // connection and must rebind active channel handles afterwards.
+      await PerpsConnectionManager.ensureConnected({ preserveCaches: true });
+
+      expect(mockStreamManagerInstance.clearAllChannels).toHaveBeenCalledTimes(
+        1,
       );
     });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -139,13 +139,19 @@ class PerpsConnectionManagerClass {
         this.previousProvider !== currentProvider;
       const hasHip3Changed = this.previousHip3Version !== currentHip3Version;
 
-      // If account, network, provider, or HIP-3 config changed and we're connected, trigger reconnection
+      // If account, network, provider, or HIP-3 config changed and we're connected, trigger reconnection.
+      // Skip if preloadSubscriptions() is currently running: the initial connection captures
+      // the correct context at connect time, so any state change arriving in this window will
+      // already be reflected in the in-flight preload. A genuine context switch (e.g. network
+      // toggle during handshake) is handled by the next store-subscriber cycle once preload
+      // completes and isPreloading resets to false, via the previousXxx comparison below.
       if (
         (hasAccountChanged ||
           hasPerpsNetworkChanged ||
           hasProviderChanged ||
           hasHip3Changed) &&
-        this.isConnected
+        this.isConnected &&
+        !this.isPreloading
       ) {
         DevLogger.log(
           hasHip3Changed
@@ -1312,7 +1318,12 @@ class PerpsConnectionManagerClass {
     // Force clean state so connect() runs the full init → ping → preload path.
     // Uses force: true to bypass the refCount guard — ensureConnected must
     // always tear down, regardless of how many components hold references.
-    if (this.isConnected || this.isInitialized) {
+    // Track whether we tore down a prior connection so we only rebind channels
+    // that had active (now-stale) WS handles — on cold start there is nothing
+    // to rebind and calling resubscribeActiveStreamChannels() would fire a
+    // redundant prewarm + candleSnapshot batch.
+    const hadPriorConnection = this.isConnected || this.isInitialized;
+    if (hadPriorConnection) {
       await this.performActualDisconnection({ force: true, preserveCaches });
     }
 
@@ -1332,7 +1343,10 @@ class PerpsConnectionManagerClass {
     // clearing during disconnect. Rebind active channel handles after the
     // controller comes back so subscribers do not keep stale WebSocket
     // unsubscribe references from the pre-reconnect provider.
-    if (preserveCaches) {
+    // Only rebind if there was a prior connection — on cold start there are no
+    // stale handles to fix and an unconditional rebind would double every REST
+    // preload call (candleSnapshot × 5, allMids × 1).
+    if (preserveCaches && hadPriorConnection) {
       this.resubscribeActiveStreamChannels();
     }
   }


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On every cold-start wallet unlock, the app was making **14 Hyperliquid REST calls** instead of the minimum 7 needed to render the homepage Perps section. The 7 duplicates were caused by two independent bugs in the connection lifecycle:

**Bug 1 — `resubscribeActiveStreamChannels` called unconditionally on cold start**

`performEnsureConnected` always called `resubscribeActiveStreamChannels()` after connecting whenever `preserveCaches: true` was set (the path taken by every `resumeFromForeground` call). On a warm reconnect this is correct — it rebinds stale WebSocket handles after tearing down a live connection. On a cold start, however, `isConnected` was `false` so nothing was torn down, yet `resubscribeActiveStreamChannels` still fired. This triggered:
- `prices.reconnect()` → a second `getMarkets()` → a duplicate `allMids` REST call
- `candles.reconnect()` → `disconnectAll()` + 5 × `connectNow()` → 5 duplicate `candleSnapshot` REST calls

**Fix:** Capture `hadPriorConnection = this.isConnected || this.isInitialized` before the conditional disconnect. Only call `resubscribeActiveStreamChannels` when `hadPriorConnection` is true — i.e., when we actually tore down a live connection and stale handles need rebinding.

**Bug 2 — `reconnectWithNewContext` triggered during initial preload**

The Redux store subscriber in `setupStateMonitoring` watched for account/network/provider/HIP-3 changes. During `connect()`, the controller writes its initial state to Redux, which fired the subscriber and triggered `reconnectWithNewContext` while `preloadSubscriptions()` was still in progress. This called `clearCache()` on every channel, wiping the in-progress preload and causing it to restart — producing another wave of duplicate REST calls.

**Fix:** Add `&& !this.isPreloading` to the reconnection condition. The preload already captured the correct context at connect time; any genuine context switch that arrives during the preload window will be detected and handled by the same subscriber on the next store cycle after `isPreloading` resets.

**Defensive addition — `connectInFlight` set in `CandleStreamChannel`**

Added a belt-and-suspenders guard tracking which `cacheKey` entries have an outstanding `subscribeToCandles()` REST request. If `reconnect()` is legitimately called on the channel while a REST snapshot is in-flight (e.g. mid-session network restore), `connectNow` will skip rather than issue a duplicate `candleSnapshot`. The key is cleared on success, error, `clearCache`, and `disconnectAll`. This mirrors the pre-existing `prewarmRequests` Set pattern in the class.

**Result:** 14 → 7 Hyperliquid REST calls on cold-start wallet unlock (verified with HAR capture before/after).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: reduce Hyperliquid API calls on wallet unlock from 14 to 7

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3799

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Hyperliquid API call reduction on wallet unlock

  Scenario: Cold-start wallet unlock does not duplicate Hyperliquid REST calls
    Given the MetaMask app is closed completely (cold start)
    And the user has previously set up a wallet
    And the homepage Perps section is enabled

    When the user opens the app and unlocks their wallet

    Then exactly 5 candleSnapshot requests are made to api.hyperliquid.xyz (one per trending symbol)
    And exactly 1 allMids request is made for the main DEX
    And exactly 1 allMids request is made for the xyz DEX
    And no duplicate REST calls are observed in the network log
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

14 Hyperliquid REST calls on cold-start unlock:
- 9× `candleSnapshot` (5 initial + 4 duplicates)
- 4× `allMids` (2 expected + 2 duplicates)
- 1× social leaderboard


https://github.com/user-attachments/assets/b5a291ff-8bdf-4d3b-a8cb-c016f89fb64c





### **After**

7 Hyperliquid REST calls on cold-start unlock:
- 5× `candleSnapshot` (no duplicates)
- 2× `allMids` (main + xyz DEX, no duplicates)
- 1× social leaderboard

https://github.com/user-attachments/assets/ce8d239c-bf63-4db9-bf7d-7769dd0b6330


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps connection and candle subscription timing on unlock and reconnect; wrong guards could delay legitimate reconnects or leave stale streams, but changes are narrow and well-tested.
> 
> **Overview**
> Cuts duplicate **Hyperliquid** REST traffic on cold-start wallet unlock (14 → 7 calls) by fixing two connection-lifecycle races and adding a candle-stream guard.
> 
> **`PerpsConnectionManager`:** `performEnsureConnected` only calls `resubscribeActiveStreamChannels()` when `preserveCaches` is set **and** a prior connection was torn down (`hadPriorConnection`), so cold starts no longer double `candleSnapshot` / `allMids` preloads. The Redux state subscriber skips `reconnectWithNewContext` while `isPreloading` is true, avoiding preload restarts when controller init writes to the store.
> 
> **`CandleStreamChannel`:** Adds `connectInFlight` so `connectNow` does not start a second `subscribeToCandles` REST snapshot for the same cache key while the first is pending; the set is cleared on success, error, `clearCache`, and `disconnectAll`.
> 
> Tests cover the new guards and deduplication behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6b956faabcfd3139842b48eddaf869697783c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->