### PR TITLE
feat(ramps): instrument Unified Buy quote fetches with PayPal attribution (TRAM-3805)

### DIFF
--- a/app/components/UI/Ramp/constants/rampsQuoteFetchTags.ts
+++ b/app/components/UI/Ramp/constants/rampsQuoteFetchTags.ts
@@ -1,0 +1,28 @@
+/** Sentry tag / span-attribute keys for Unified Buy quote-fetch spans (TRAM-3805). */
+export const RAMPS_QUOTE_FETCH_TAG = {
+  FEATURE: 'feature',
+  RAMP_TYPE: 'ramp_type',
+  PROVIDER: 'provider',
+  PATH: 'path',
+  CUSTOM_ACTION: 'custom_action',
+  SUCCESS: 'success',
+  REASON: 'reason',
+} as const;
+
+export const RAMPS_QUOTE_FETCH_FEATURE = 'buy';
+
+export const RAMPS_QUOTE_FETCH_RAMP_TYPE = 'UNIFIED_BUY_2';
+
+/** Checkout-path tag when the usable quote is a custom-action (PayPal, etc.). */
+export const RAMPS_QUOTE_FETCH_PATH = {
+  CUSTOM_ACTION: 'custom_action',
+} as const;
+
+/** Terminal reasons when a quote-fetch span ends unsuccessfully. */
+export const RAMPS_QUOTE_FETCH_END_REASON = {
+  SUPERSEDED: 'superseded',
+  ERROR: 'error',
+  CANCELLED: 'cancelled',
+  /** HTTP succeeded but requested provider(s) returned no usable quote. */
+  NO_QUOTE: 'no_quote',
+} as const;

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -6,6 +6,11 @@ import React from 'react';
 import { useRampsQuotes, type GetQuotesOptions } from './useRampsQuotes';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
+import {
+  RAMPS_QUOTE_FETCH_END_REASON,
+  RAMPS_QUOTE_FETCH_PATH,
+  RAMPS_QUOTE_FETCH_TAG,
+} from '../constants/rampsQuoteFetchTags';
 
 const mockGetBuyWidgetData = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
@@ -16,6 +21,21 @@ jest.mock('../../../../core/Engine', () => ({
     },
   },
 }));
+
+const mockStartRampsQuoteFetchTrace = jest.fn(() => 'quote-fetch-op-1');
+const mockEndRampsQuoteFetchTrace = jest.fn();
+jest.mock('../utils/rampsQuoteFetchTrace', () => {
+  const actual = jest.requireActual(
+    '../utils/rampsQuoteFetchTrace',
+  ) as typeof import('../utils/rampsQuoteFetchTrace');
+  return {
+    ...actual,
+    startRampsQuoteFetchTrace: (...args: unknown[]) =>
+      mockStartRampsQuoteFetchTrace(...args),
+    endRampsQuoteFetchTrace: (...args: unknown[]) =>
+      mockEndRampsQuoteFetchTrace(...args),
+  };
+});
 
 const createMockStore = () =>
   configureStore({
@@ -52,7 +72,7 @@ const createWrapper = (store: ReturnType<typeof createMockStore>) => {
 };
 
 const mockQuotesResponse = {
-  success: [{ provider: 'test', quote: { amountIn: 100 } }],
+  success: [{ provider: '/providers/transak', quote: { amountIn: 100 } }],
   sorted: [],
   error: [],
   customActions: [],
@@ -180,6 +200,9 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(true);
       expect(result.current.status).toBe('loading');
       expect(result.current.data).toBeNull();
+      expect(mockStartRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/transak' },
+      });
 
       await waitFor(() => {
         expect(result.current.status).toBe('success');
@@ -189,6 +212,14 @@ describe('useRampsQuotes', () => {
       expect(result.current.data).toEqual(mockQuotesResponse);
       expect(result.current.isSuccess).toBe(true);
       expect(result.current.error).toBeNull();
+      expect(mockEndRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-fetch-op-1',
+        data: {
+          [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true,
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/transak',
+          [RAMPS_QUOTE_FETCH_TAG.CUSTOM_ACTION]: false,
+        },
+      });
       expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
           amount: 100,
@@ -219,6 +250,92 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.error).toBe(networkError);
       expect(result.current.data).toBeNull();
+      expect(mockEndRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-fetch-op-1',
+        data: {
+          [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+          [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.ERROR,
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/transak',
+        },
+      });
+    });
+
+    it('records PayPal custom-action quote success with provider + path tags', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
+        success: [
+          {
+            provider: '/providers/paypal',
+            quote: { amountIn: 100, isCustomAction: true },
+          },
+        ],
+        sorted: [],
+        error: [],
+        customActions: [],
+      });
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      expect(mockStartRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal' },
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-fetch-op-1',
+        data: {
+          [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true,
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+          [RAMPS_QUOTE_FETCH_TAG.PATH]: RAMPS_QUOTE_FETCH_PATH.CUSTOM_ACTION,
+          [RAMPS_QUOTE_FETCH_TAG.CUSTOM_ACTION]: true,
+        },
+      });
+    });
+
+    it('records provider-level PayPal quote miss as a failure', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
+        success: [],
+        sorted: [],
+        error: [
+          { provider: '/providers/paypal', error: 'PayPal unavailable' },
+        ],
+        customActions: [],
+      });
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-fetch-op-1',
+        data: {
+          [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+          [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.NO_QUOTE,
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+        },
+      });
     });
 
     it('preserves enriched error metadata when the request rejects', async () => {

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -22,7 +22,9 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-const mockStartRampsQuoteFetchTrace = jest.fn(() => 'quote-fetch-op-1');
+const mockStartRampsQuoteFetchTrace = jest
+  .fn()
+  .mockReturnValue('quote-fetch-op-1');
 const mockEndRampsQuoteFetchTrace = jest.fn();
 jest.mock('../utils/rampsQuoteFetchTrace', () => {
   const actual = jest.requireActual(
@@ -268,17 +270,19 @@ describe('useRampsQuotes', () => {
         providers: ['/providers/paypal'],
         paymentMethods: ['/payments/paypal'],
       };
-      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
-        success: [
-          {
-            provider: '/providers/paypal',
-            quote: { amountIn: 100, isCustomAction: true },
-          },
-        ],
-        sorted: [],
-        error: [],
-        customActions: [],
-      });
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        {
+          success: [
+            {
+              provider: '/providers/paypal',
+              quote: { amountIn: 100, isCustomAction: true },
+            },
+          ],
+          sorted: [],
+          error: [],
+          customActions: [],
+        },
+      );
 
       const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
         wrapper: Wrapper,
@@ -311,14 +315,16 @@ describe('useRampsQuotes', () => {
         providers: ['/providers/paypal'],
         paymentMethods: ['/payments/paypal'],
       };
-      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue({
-        success: [],
-        sorted: [],
-        error: [
-          { provider: '/providers/paypal', error: 'PayPal unavailable' },
-        ],
-        customActions: [],
-      });
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        {
+          success: [],
+          sorted: [],
+          error: [
+            { provider: '/providers/paypal', error: 'PayPal unavailable' },
+          ],
+          customActions: [],
+        },
+      );
 
       const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
         wrapper: Wrapper,

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -1,10 +1,20 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BuyWidget, QuotesResponse } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
+import {
+  buildRampsQuoteFetchCompletion,
+  buildRampsQuoteFetchStartTags,
+  endRampsQuoteFetchTrace,
+  startRampsQuoteFetchTrace,
+} from '../utils/rampsQuoteFetchTrace';
+import {
+  RAMPS_QUOTE_FETCH_END_REASON,
+  RAMPS_QUOTE_FETCH_TAG,
+} from '../constants/rampsQuoteFetchTags';
 
 export interface GetQuotesOptions {
   region?: string;
@@ -49,6 +59,15 @@ export function useRampsQuotes(
     options?.assetId && options.walletAddress && options.amount > 0,
   );
 
+  // Stabilize by provider-id value so inline `providers: [id]` arrays do not
+  // retrigger the quote-fetch effect every render.
+  const requestedProvidersKey = (options?.providers ?? []).join(',');
+  const requestedProviders = useMemo(
+    () => options?.providers,
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by value
+    [requestedProvidersKey],
+  );
+
   const quotesQuery = useQuery({
     ...rampsQueries.quotes.options({
       assetId: options?.assetId,
@@ -56,12 +75,59 @@ export function useRampsQuotes(
       walletAddress: options?.walletAddress ?? '',
       redirectUrl: options?.redirectUrl,
       paymentMethods: options?.paymentMethods,
-      providers: options?.providers,
+      providers: requestedProviders,
       forceRefresh: options?.forceRefresh,
       ttl: options?.ttl,
     }),
     enabled: queryEnabled,
   });
+
+  const quoteFetchOpIdRef = useRef<string | null>(null);
+
+  // Unified Buy quote-fetch tracing (TRAM-3805): fetch start → quotes rendered
+  // or provider-level failure (incl. PayPal custom-action quotes).
+  useEffect(() => {
+    if (!queryEnabled) {
+      if (quoteFetchOpIdRef.current) {
+        endRampsQuoteFetchTrace({
+          id: quoteFetchOpIdRef.current,
+          data: {
+            [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+            [RAMPS_QUOTE_FETCH_TAG.REASON]:
+              RAMPS_QUOTE_FETCH_END_REASON.CANCELLED,
+          },
+        });
+        quoteFetchOpIdRef.current = null;
+      }
+      return;
+    }
+
+    if (quotesQuery.isFetching && !quoteFetchOpIdRef.current) {
+      quoteFetchOpIdRef.current = startRampsQuoteFetchTrace({
+        tags: buildRampsQuoteFetchStartTags(requestedProviders),
+      });
+      return;
+    }
+
+    if (!quotesQuery.isFetching && quoteFetchOpIdRef.current) {
+      const opId = quoteFetchOpIdRef.current;
+      quoteFetchOpIdRef.current = null;
+      endRampsQuoteFetchTrace({
+        id: opId,
+        data: buildRampsQuoteFetchCompletion({
+          isQueryError: quotesQuery.isError,
+          response: quotesQuery.data,
+          requestedProviders,
+        }),
+      });
+    }
+  }, [
+    queryEnabled,
+    quotesQuery.isFetching,
+    quotesQuery.isError,
+    quotesQuery.data,
+    requestedProviders,
+  ]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.test.ts
@@ -1,0 +1,153 @@
+import { trace, endTrace, TraceName } from '../../../../util/trace';
+import {
+  startRampsQuoteFetchTrace,
+  endRampsQuoteFetchTrace,
+  buildRampsQuoteFetchStartTags,
+  buildRampsQuoteFetchCompletion,
+  resetRampsQuoteFetchTraceForTests,
+} from './rampsQuoteFetchTrace';
+import {
+  RAMPS_QUOTE_FETCH_END_REASON,
+  RAMPS_QUOTE_FETCH_FEATURE,
+  RAMPS_QUOTE_FETCH_PATH,
+  RAMPS_QUOTE_FETCH_RAMP_TYPE,
+  RAMPS_QUOTE_FETCH_TAG,
+} from '../constants/rampsQuoteFetchTags';
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+const mockTrace = trace as jest.Mock;
+const mockEndTrace = endTrace as jest.Mock;
+
+describe('rampsQuoteFetchTrace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetRampsQuoteFetchTraceForTests();
+  });
+
+  it('starts a RampQuoteLoading span with buy / UB2 tags', () => {
+    const opId = startRampsQuoteFetchTrace({
+      tags: { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal' },
+    });
+
+    expect(opId).toContain(TraceName.RampQuoteLoading);
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampQuoteLoading,
+        id: opId,
+        tags: {
+          [RAMPS_QUOTE_FETCH_TAG.FEATURE]: RAMPS_QUOTE_FETCH_FEATURE,
+          [RAMPS_QUOTE_FETCH_TAG.RAMP_TYPE]: RAMPS_QUOTE_FETCH_RAMP_TYPE,
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+        },
+      }),
+    );
+  });
+
+  it('supersedes a prior open quote fetch', () => {
+    const first = startRampsQuoteFetchTrace();
+    const second = startRampsQuoteFetchTrace();
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampQuoteLoading,
+        id: first,
+        data: {
+          [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+          [RAMPS_QUOTE_FETCH_TAG.REASON]:
+            RAMPS_QUOTE_FETCH_END_REASON.SUPERSEDED,
+        },
+      }),
+    );
+    expect(second).not.toEqual(first);
+  });
+
+  it('ends completions by op id and ignores unknown ids', () => {
+    const opId = startRampsQuoteFetchTrace();
+    endRampsQuoteFetchTrace({
+      id: opId,
+      data: { [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true },
+    });
+    endRampsQuoteFetchTrace({
+      id: opId,
+      data: { [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false },
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampQuoteLoading,
+        id: opId,
+        data: { [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true },
+      }),
+    );
+  });
+
+  describe('provider attribution (TRAM-3805)', () => {
+    it('tags single-provider starts with the provider id', () => {
+      expect(buildRampsQuoteFetchStartTags(['/providers/paypal'])).toEqual({
+        [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+      });
+      expect(
+        buildRampsQuoteFetchStartTags([
+          '/providers/paypal',
+          '/providers/transak',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('marks PayPal custom-action quotes as successful custom_action path', () => {
+      expect(
+        buildRampsQuoteFetchCompletion({
+          isQueryError: false,
+          requestedProviders: ['/providers/paypal'],
+          response: {
+            success: [
+              {
+                provider: '/providers/paypal',
+                quote: { isCustomAction: true },
+              },
+            ],
+          },
+        }),
+      ).toEqual({
+        [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true,
+        [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+        [RAMPS_QUOTE_FETCH_TAG.PATH]: RAMPS_QUOTE_FETCH_PATH.CUSTOM_ACTION,
+        [RAMPS_QUOTE_FETCH_TAG.CUSTOM_ACTION]: true,
+      });
+    });
+
+    it('marks HTTP-ok PayPal misses as no_quote failures', () => {
+      expect(
+        buildRampsQuoteFetchCompletion({
+          isQueryError: false,
+          requestedProviders: ['/providers/paypal'],
+          response: { success: [] },
+        }),
+      ).toEqual({
+        [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+        [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.NO_QUOTE,
+        [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it('keeps transport errors as error failures with provider tag', () => {
+      expect(
+        buildRampsQuoteFetchCompletion({
+          isQueryError: true,
+          requestedProviders: ['/providers/paypal'],
+          response: null,
+        }),
+      ).toEqual({
+        [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+        [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.ERROR,
+        [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+  });
+});

--- a/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.ts
@@ -1,0 +1,187 @@
+import {
+  trace,
+  endTrace,
+  TraceName,
+  type TraceValue,
+} from '../../../../util/trace';
+import {
+  RAMPS_QUOTE_FETCH_END_REASON,
+  RAMPS_QUOTE_FETCH_FEATURE,
+  RAMPS_QUOTE_FETCH_PATH,
+  RAMPS_QUOTE_FETCH_RAMP_TYPE,
+  RAMPS_QUOTE_FETCH_TAG,
+} from '../constants/rampsQuoteFetchTags';
+
+/**
+ * Standalone Unified Buy quote-fetch tracing (TRAM-3805).
+ *
+ * Instruments `useRampsQuotes` with provider attribution so PayPal (and other
+ * single-provider) quote outcomes are visible in Sentry → Prometheus/Grafana
+ * SLOs. Does not depend on Buy E2E CUF parent spans.
+ */
+
+const pendingOpIds = new Set<string>();
+let quoteFetchOpCounter = 0;
+
+function nextOpId(): string {
+  quoteFetchOpCounter += 1;
+  return `${TraceName.RampQuoteLoading}#${quoteFetchOpCounter}`;
+}
+
+function buildStartTags(
+  extra?: Record<string, TraceValue>,
+): Record<string, TraceValue> {
+  return {
+    [RAMPS_QUOTE_FETCH_TAG.FEATURE]: RAMPS_QUOTE_FETCH_FEATURE,
+    [RAMPS_QUOTE_FETCH_TAG.RAMP_TYPE]: RAMPS_QUOTE_FETCH_RAMP_TYPE,
+    ...extra,
+  };
+}
+
+/** Start tags when callers know the provider filter (BuildQuote = one id). */
+export function buildRampsQuoteFetchStartTags(
+  providers?: string[],
+): Record<string, TraceValue> | undefined {
+  if (providers?.length === 1) {
+    return { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: providers[0] };
+  }
+  return undefined;
+}
+
+export interface BuildRampsQuoteFetchCompletionParams {
+  isQueryError: boolean;
+  response?: {
+    success?: Array<{
+      provider?: string;
+      quote?: { isCustomAction?: boolean };
+    }>;
+  } | null;
+  requestedProviders?: string[];
+}
+
+/**
+ * End-span attributes for a quote fetch.
+ *
+ * Provider-filtered fetches (e.g. PayPal on BuildQuote) treat "HTTP 200 with
+ * no usable quote for the requested provider" as failure — the quotes API
+ * returns provider errors in `error[]` without rejecting the request.
+ *
+ * Custom-action quotes (PayPal / Robinhood) count as usable and are tagged
+ * `path: custom_action` + `custom_action: true`.
+ */
+export function buildRampsQuoteFetchCompletion({
+  isQueryError,
+  response,
+  requestedProviders,
+}: BuildRampsQuoteFetchCompletionParams): Record<string, TraceValue> {
+  if (isQueryError) {
+    return {
+      [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+      [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.ERROR,
+      ...(requestedProviders?.length === 1
+        ? { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: requestedProviders[0] }
+        : {}),
+    };
+  }
+
+  const successQuotes = response?.success ?? [];
+  const singleProvider =
+    requestedProviders?.length === 1 ? requestedProviders[0] : undefined;
+
+  const usableQuotes = singleProvider
+    ? successQuotes.filter((quote) => quote.provider === singleProvider)
+    : successQuotes;
+
+  if (usableQuotes.length === 0) {
+    return {
+      [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+      [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.NO_QUOTE,
+      ...(singleProvider
+        ? { [RAMPS_QUOTE_FETCH_TAG.PROVIDER]: singleProvider }
+        : {}),
+    };
+  }
+
+  const matched = usableQuotes[0];
+  const isCustomActionQuote = matched.quote?.isCustomAction === true;
+
+  return {
+    [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: true,
+    ...(singleProvider || matched.provider
+      ? {
+          [RAMPS_QUOTE_FETCH_TAG.PROVIDER]:
+            singleProvider ?? (matched.provider as string),
+        }
+      : {}),
+    ...(isCustomActionQuote
+      ? {
+          [RAMPS_QUOTE_FETCH_TAG.PATH]: RAMPS_QUOTE_FETCH_PATH.CUSTOM_ACTION,
+          [RAMPS_QUOTE_FETCH_TAG.CUSTOM_ACTION]: true,
+        }
+      : { [RAMPS_QUOTE_FETCH_TAG.CUSTOM_ACTION]: false }),
+  };
+}
+
+export interface StartRampsQuoteFetchTraceOptions {
+  tags?: Record<string, TraceValue>;
+}
+
+/**
+ * Start a Unified Buy quote-fetch span. A newer fetch supersedes any still-open
+ * one started by these helpers (unique op ids; Aggregator uses the default id).
+ */
+export function startRampsQuoteFetchTrace({
+  tags,
+}: StartRampsQuoteFetchTraceOptions = {}): string {
+  endOpenRampsQuoteFetchTraces({
+    [RAMPS_QUOTE_FETCH_TAG.SUCCESS]: false,
+    [RAMPS_QUOTE_FETCH_TAG.REASON]: RAMPS_QUOTE_FETCH_END_REASON.SUPERSEDED,
+  });
+
+  const opId = nextOpId();
+  pendingOpIds.add(opId);
+  trace({
+    name: TraceName.RampQuoteLoading,
+    id: opId,
+    tags: buildStartTags(tags),
+  });
+  return opId;
+}
+
+export interface EndRampsQuoteFetchTraceOptions {
+  id: string;
+  data?: Record<string, TraceValue>;
+}
+
+/** End a quote-fetch span by op id. Idempotent. */
+export function endRampsQuoteFetchTrace({
+  id,
+  data,
+}: EndRampsQuoteFetchTraceOptions): void {
+  if (!pendingOpIds.has(id)) {
+    return;
+  }
+  pendingOpIds.delete(id);
+  endTrace({
+    name: TraceName.RampQuoteLoading,
+    id,
+    data,
+  });
+}
+
+function endOpenRampsQuoteFetchTraces(
+  data?: Record<string, TraceValue>,
+): number {
+  let ended = 0;
+  for (const opId of Array.from(pendingOpIds)) {
+    endRampsQuoteFetchTrace({ id: opId, data });
+    ended += 1;
+  }
+  return ended;
+}
+
+/** Test-only: drop module state between tests. */
+export function resetRampsQuoteFetchTraceForTests(): void {
+  pendingOpIds.clear();
+  quoteFetchOpCounter = 0;
+}

--- a/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsQuoteFetchTrace.ts
@@ -50,11 +50,13 @@ export function buildRampsQuoteFetchStartTags(
 
 export interface BuildRampsQuoteFetchCompletionParams {
   isQueryError: boolean;
+  // Structural subset of `QuotesResponse`; the index signature keeps controller
+  // quote payloads (which do not declare `isCustomAction`) assignable.
   response?: {
-    success?: Array<{
+    success?: {
       provider?: string;
-      quote?: { isCustomAction?: boolean };
-    }>;
+      quote?: { isCustomAction?: boolean; [key: string]: unknown };
+    }[];
   } | null;
   requestedProviders?: string[];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Fixes the PayPal quotes observability gap on [TRAM-3805](https://consensyssoftware.atlassian.net/browse/TRAM-3805).

Unified Buy quote fetches via `useRampsQuotes` had no Sentry performance instrumentation (unlike Aggregator’s `RampQuoteLoading`). PayPal BuildQuote traffic was therefore missing from quote SLOs, and even after adding a span the quotes API’s HTTP-200 provider misses (`success: []` + `error[]`) would look healthy.

This PR adds **standalone** quote-fetch tracing (no Buy E2E / CUF dependency) that:

- Starts/ends `RampQuoteLoading` spans from `useRampsQuotes` with `ramp_type: UNIFIED_BUY_2`
- Tags single-provider fetches with `provider` (e.g. `/providers/paypal`)
- Treats custom-action quotes (PayPal) as usable successes (`path: custom_action`, `custom_action: true`)
- Ends as `success: false` / `reason: no_quote` when the requested provider returns no usable quote

Targets `main` directly; intentionally not stacked on TRAM-3779 / TRAM-3780 CUF work.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3805

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Unified Buy PayPal quote-fetch tracing

  Scenario: successful PayPal custom-action quote
    Given metrics consent is enabled and MM_SENTRY_DSN is configured
    And the user is on Unified Buy Amount Input with PayPal selected

    When a PayPal quote loads successfully
    Then Sentry shows "Ramp Quote Loading" with ramp_type:UNIFIED_BUY_2
    And provider:/providers/paypal
    And path:custom_action and custom_action:true
    And success:true

  Scenario: PayPal provider miss is recorded as failure
    When PayPal returns no usable quote (HTTP 200, empty success)
    Then the span ends with success:false and reason:no_quote
    And provider:/providers/paypal
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — performance instrumentation only; no UI changes. Validate in Sentry Discover → Transactions for `Ramp Quote Loading` filtered by `provider:/providers/paypal` and `ramp_type:UNIFIED_BUY_2`.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/contributor-docs/blob/main/docs/coding-guidelines/about-coding-guidelines.md).
- [x] I've clearly explained the reason for this PR, the improvement/solution, and relevant context.
- [x] I’ve linked related issues.
- [x] I’ve included manual testing steps.
- [x] I’ve included screenshots/recordings OR explicitly noted N/A.
- [x] I’ve included a brief [changelog entry](https://github.com/MetaMask/metamask-extension/blob/main/.github/pull_request_template.md#changelog) OR noted this is not user-facing.

## **Pre-merge reviewer checklist**

- [ ] Manual testing (or automated testing) has been completed and approved.
- [ ] PR is squashed and rebased onto the merge-base branch.
- [ ] PR has pull request labels for QA.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d88829-6ec4-4ccc-a04f-4f6349a89e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d88829-6ec4-4ccc-a04f-4f6349a89e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TRAM-3805]: https://consensyssoftware.atlassian.net/browse/TRAM-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ