### PR TITLE
fix(perf): stop passing LT_ACCESS_KEY via job outputs (avoids build fallback)

### DIFF
--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -158,19 +158,20 @@ jobs:
     outputs:
       testmu_ready: ${{ steps.resolve.outputs.testmu_ready }}
       lt_username: ${{ steps.resolve.outputs.lt_username }}
-      lt_access_key: ${{ steps.resolve.outputs.lt_access_key }}
     steps:
       - name: Resolve TestMu AI credentials
         id: resolve
         env:
           # PoC: only one secret slot available — username is fixed, key from LT_ACCESS_KEY.
+          # Do NOT put LT_ACCESS_KEY in job outputs: GitHub strips secret-valued outputs
+          # ("Skip output ... since it may contain secret"), which left uploads unauthorized
+          # and forced a fresh Android build fallback.
           SECRET_KEY: ${{ secrets.LT_ACCESS_KEY }}
         run: |
           if [ -n "$SECRET_KEY" ]; then
             echo "Using fixed TestMu AI username javiervera + LT_ACCESS_KEY secret"
             {
               echo "lt_username=javiervera"
-              echo "lt_access_key=$SECRET_KEY"
               echo "testmu_ready=true"
             } >> "$GITHUB_OUTPUT"
           else
@@ -428,7 +429,7 @@ jobs:
         id: upload
         env:
           LT_USERNAME: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-          LT_ACCESS_KEY: ${{ needs.check-testmu-credentials.outputs.lt_access_key }}
+          LT_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
           FIND_FOUND: ${{ steps.find.outputs.found }}
           SOURCE_RUN_ID: ${{ steps.find.outputs.run_id }}
         run: |
@@ -527,7 +528,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ needs.check-testmu-credentials.outputs.lt_access_key }}
+      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
     secrets: inherit
 
   trigger-ios-dual-versions:
@@ -625,7 +626,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       testmu_build_name: ${{ needs.set-build-names.outputs.testmu_android_build_name }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ needs.check-testmu-credentials.outputs.lt_access_key }}
+      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}
     secrets: inherit
 
@@ -778,7 +779,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       testmu_build_name: ${{ needs.set-build-names.outputs.testmu_android_build_name }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ needs.check-testmu-credentials.outputs.lt_access_key }}
+      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}
     secrets: inherit
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why the latest run rebuilt Android

With `reuse_main_builds=true` + TestMu enabled, [run 30378720565](https://github.com/MetaMask/metamask-mobile/actions/runs/30378720565) still triggered Android dual builds because:

1. BrowserStack apps from main resolved successfully
2. Main APKs were found and downloaded for TestMu re-upload
3. Re-upload failed with `Unauthorized User, please login again`
4. `upload-reused-apks-to-testmu.outputs.found` stayed `false`
5. `trigger-android-dual-versions` treats that as a miss and falls back to a fresh build so TestMu can still get `lt://` URLs

## Root cause

`check-testmu-credentials` wrote `LT_ACCESS_KEY` into a job output. GitHub Actions skipped it:

`Skip output 'lt_access_key' since it may contain secret.`

Downstream jobs then called TestMu with an empty key → Unauthorized → build fallback.

## Fix

- Keep the credentials job for readiness + fixed username (`javiervera`) only
- Pass `secrets.LT_ACCESS_KEY` directly to re-upload / build / TestMu runner jobs

After merge into the PoC branch, re-run with `reuse_main_builds=true` — re-upload should succeed and Android compile should be skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

