### PR TITLE
Add Wallet Assistant portfolio transaction plans

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -80,7 +80,6 @@ import { ButtonSize as ButtonToggleSize } from '../../../../../component-library
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
   buildBatchSellEligibleChains,
-  getBatchSellDestinationToken,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   BatchSellTokenSortDirection,
   sortBatchSellTokens,
@@ -290,6 +289,10 @@ export function BatchSellTokenSelect() {
   const batchSellLocation =
     route.params?.batchSellLocation ?? BatchSellMetricsLocation.Unknown;
   const preserveBridgeState = route.params?.preserveBridgeState === true;
+  const preferredDestinationSymbol = route.params?.preferredDestinationSymbol
+    ?.trim()
+    .toUpperCase();
+  const committedSourceTokens = useSelector(selectBatchSellSourceTokens);
 
   useLayoutEffect(() => {
     Engine.context.BridgeController.setLocation(batchSellLocation);
@@ -306,9 +309,15 @@ export function BatchSellTokenSelect() {
 
   const [selectedChainId, setSelectedChainId] = useState<
     CaipChainId | undefined
-  >(() => sortedEligibleChains[0]?.chainId);
-  const [selectedTokens, setSelectedTokens] = useState<BridgeToken[]>([]);
-  const committedSourceTokens = useSelector(selectBatchSellSourceTokens);
+  >(
+    () =>
+      (preserveBridgeState && committedSourceTokens[0]
+        ? formatChainIdToCaip(committedSourceTokens[0].chainId)
+        : undefined) ?? sortedEligibleChains[0]?.chainId,
+  );
+  const [selectedTokens, setSelectedTokens] = useState<BridgeToken[]>(() =>
+    preserveBridgeState ? committedSourceTokens : [],
+  );
 
   useEffect(() => {
     if (preserveBridgeState) {
@@ -379,6 +388,10 @@ export function BatchSellTokenSelect() {
   const destinationStablecoins = useSelector((state: RootState) =>
     selectBatchSellDestStablecoins(state, activeChainId),
   );
+  const preferredDestinationToken =
+    destinationStablecoins.find(
+      (token) => token.symbol.toUpperCase() === preferredDestinationSymbol,
+    ) ?? destinationStablecoins[0];
   const selectedChainTokens = useMemo(
     () =>
       activeChainId
@@ -530,10 +543,7 @@ export function BatchSellTokenSelect() {
         screen: Routes.BRIDGE.MODALS.HIGH_RATE_ALERT_MODAL,
         params: {
           sourceToken,
-          destToken: getBatchSellDestinationToken(
-            sourceToken.chainId,
-            destinationStablecoins,
-          ),
+          destToken: preferredDestinationToken,
         },
       });
       return;
@@ -565,14 +575,7 @@ export function BatchSellTokenSelect() {
         getDefaultBatchSellSourceTokenAmounts(orderedSelectedTokens),
       ),
     );
-    dispatch(
-      setBatchSellDestToken(
-        getBatchSellDestinationToken(
-          orderedSelectedTokens[0].chainId,
-          destinationStablecoins,
-        ),
-      ),
-    );
+    dispatch(setBatchSellDestToken(preferredDestinationToken));
     dispatch(
       setBatchSellTokenSlippages(
         getDefaultBatchSellSlippages(orderedSelectedTokens),
@@ -581,12 +584,12 @@ export function BatchSellTokenSelect() {
     navigation.navigate(Routes.BRIDGE.BATCH_SELL_REVIEW);
   }, [
     currentChainId,
-    destinationStablecoins,
     dispatch,
     evmNetworkConfigurations,
     navigation,
     onNonEvmNetworkChange,
     onSetRpcTarget,
+    preferredDestinationToken,
     selectedTokens,
     trackBatchSellTokenPageContinueClicked,
     tokenSortDirection,

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/types.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/types.ts
@@ -2,5 +2,6 @@ import { BatchSellMetricsLocation } from '@metamask/bridge-controller';
 
 export interface BatchSellTokenSelectRouteParams {
   batchSellLocation?: BatchSellMetricsLocation;
+  preferredDestinationSymbol?: string;
   preserveBridgeState?: boolean;
 }

--- a/app/components/UI/Bridge/Views/WalletAssistant/WalletAssistant.tsx
+++ b/app/components/UI/Bridge/Views/WalletAssistant/WalletAssistant.tsx
@@ -23,8 +23,14 @@ import LinearGradient from 'react-native-linear-gradient';
 import { useNavigation } from '@react-navigation/native';
 import { fetch as expoFetch } from 'expo/fetch';
 import * as Keychain from 'react-native-keychain'; // eslint-disable-line import-x/no-namespace
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
-import type { TrendingAsset } from '@metamask/assets-controllers';
+import {
+  BatchSellMetricsLocation,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
+import {
+  fetchTokenAssets,
+  type TrendingAsset,
+} from '@metamask/assets-controllers';
 import type { CaipChainId } from '@metamask/utils';
 import {
   Box,
@@ -69,11 +75,13 @@ import { getAssetNavigationParams } from '../../../Trending/components/TrendingT
 import { useTrendingTokenPress } from '../../../Trending/hooks/useTrendingTokenPress/useTrendingTokenPress';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import {
   selectAllowedChainRanking,
+  selectBatchSellDestStablecoinsByChain,
   selectSelectedSourceChainIds,
+  setBatchSellSourceTokens,
 } from '../../../../../core/redux/slices/bridge';
 import { useBalancesByAssetId } from '../../hooks/useBalancesByAssetId';
 import { selectBridgeHistoryForAccount } from '../../../../../selectors/bridgeStatusController';
@@ -81,6 +89,7 @@ import AssistantResponseActions from './components/AssistantResponseActions';
 import AgentProgress, { AgentProgressStatus } from './components/AgentProgress';
 import { ConversationControlsTestIds } from './components/ConversationControls/ConversationControls.testIds';
 import EmbeddedSwapCard from './components/EmbeddedSwapCard';
+import PortfolioPlanCard from './components/PortfolioPlanCard';
 import ResearchChart from './components/ResearchChart';
 import { WalletAssistantTransactionStatusCard } from './components/TransactionStatusCard';
 import {
@@ -116,12 +125,20 @@ import {
 } from './performanceUtils';
 import { useWalletAssistantPersistence } from './persistence';
 import { WalletAssistantWalletContext } from './walletContext';
+import {
+  buildPortfolioPlan,
+  getTokenLabelsByAssetId,
+  getWalletTokenAssetId,
+  parsePortfolioPlanRequest,
+  type WalletAssistantPortfolioPlan,
+} from './portfolioPlan';
 
 type ResearchSource = WalletAssistantResearchSource;
 type ResearchResponse = WalletAssistantResearchResponse;
 
 interface Message {
   id: string;
+  portfolioPlan?: WalletAssistantPortfolioPlan;
   role: 'assistant' | 'user';
   research?: ResearchResponse;
   text: string;
@@ -130,6 +147,11 @@ interface Message {
 const INITIAL_MESSAGES: Message[] = [];
 const OPENAI_KEYCHAIN_SERVICE = 'metamask-wallet-assistant-openai-v2';
 const PROMPT_EXAMPLES = [
+  {
+    icon: IconName.Merge,
+    label: 'Consolidate positions',
+    prompt: 'Move all my meme coins into USDC',
+  },
   {
     icon: IconName.SwapVertical,
     label: 'Buy or swap a token',
@@ -975,6 +997,7 @@ interface ConversationHistoryProps {
   messages: Message[];
   onLatestUserAnchored: () => void;
   onOpenSource: (url: string) => void;
+  onReviewPortfolioPlan: (plan: WalletAssistantPortfolioPlan) => void;
   onRetry: (prompt: string) => void;
   onReviewSwap: (
     sourceToken: BridgeToken | undefined,
@@ -992,6 +1015,7 @@ const ConversationHistory = React.memo(
     messages,
     onLatestUserAnchored,
     onOpenSource,
+    onReviewPortfolioPlan,
     onRetry,
     onReviewSwap,
     scrollViewRef,
@@ -1076,19 +1100,30 @@ const ConversationHistory = React.memo(
                   onOpenSource={onOpenSource}
                   onReviewSwap={onReviewSwap}
                 />
+              ) : message.portfolioPlan ? (
+                <PortfolioPlanCard
+                  plan={message.portfolioPlan}
+                  onReview={() => {
+                    if (message.portfolioPlan) {
+                      onReviewPortfolioPlan(message.portfolioPlan);
+                    }
+                  }}
+                />
               ) : (
                 <Text variant={TextVariant.BodyMd}>{message.text}</Text>
               )}
-              <AssistantResponseActions
-                responseText={message.text}
-                onRetry={() => {
-                  if (previousUserPrompt) {
-                    onRetry(previousUserPrompt);
-                  }
-                }}
-                onThumbUp={NOOP}
-                onThumbDown={NOOP}
-              />
+              {!message.portfolioPlan && (
+                <AssistantResponseActions
+                  responseText={message.text}
+                  onRetry={() => {
+                    if (previousUserPrompt) {
+                      onRetry(previousUserPrompt);
+                    }
+                  }}
+                  onThumbUp={NOOP}
+                  onThumbDown={NOOP}
+                />
+              )}
             </Box>
           ),
         )}
@@ -1104,6 +1139,7 @@ const ConversationHistory = React.memo(
  */
 const WalletAssistant = () => {
   const navigation = useNavigation<AppNavigationProp>();
+  const dispatch = useDispatch();
   const tw = useTailwind();
   const {
     isLoading: isPersistenceLoading,
@@ -1113,6 +1149,9 @@ const WalletAssistant = () => {
   const hasHydratedPersistence = useRef(false);
   const selectedSourceChainIds = useSelector(selectSelectedSourceChainIds);
   const allowedChainRanking = useSelector(selectAllowedChainRanking);
+  const batchSellDestinationsByChain = useSelector(
+    selectBatchSellDestStablecoinsByChain,
+  );
   const [draft, setDraft] = useState('');
   const draftResearchPlan = useMemo(() => buildResearchPlan(draft), [draft]);
   const walletChainIds = useMemo(
@@ -1337,6 +1376,62 @@ const WalletAssistant = () => {
       ...messages,
       { id: `user-${messages.length}`, role: 'user', text },
     ];
+    const portfolioPlanRequest = parsePortfolioPlanRequest(text);
+    if (portfolioPlanRequest) {
+      if (messages.length === 0 && !reduceMotion) {
+        LayoutAnimation.configureNext(FIRST_CHAT_LAYOUT_ANIMATION);
+      }
+      shouldAnchorLatestMessage.current = true;
+      setMessages(nextMessages);
+      setDraft('');
+      setError('');
+      setErrorRecovery(undefined);
+      setIsLoading(true);
+      setRequestStatus(AgentProgressStatus.PreparingPlan);
+
+      try {
+        const assetIds = walletTokens
+          .map(getWalletTokenAssetId)
+          .filter((assetId): assetId is NonNullable<typeof assetId> =>
+            Boolean(assetId),
+          );
+        const assetIdBatches = Array.from(
+          { length: Math.ceil(assetIds.length / 100) },
+          (_, index) => assetIds.slice(index * 100, (index + 1) * 100),
+        );
+        const assets = (
+          await Promise.all(
+            assetIdBatches.map((batch) =>
+              fetchTokenAssets(batch, {
+                includeLabels: true,
+              }),
+            ),
+          )
+        ).flat();
+        const portfolioPlan = buildPortfolioPlan({
+          destinationTokensByChain: batchSellDestinationsByChain,
+          labelsByAssetId: getTokenLabelsByAssetId(assets),
+          request: portfolioPlanRequest,
+          walletTokens,
+        });
+
+        setMessages((current) => [
+          ...current,
+          {
+            id: `assistant-${current.length}`,
+            portfolioPlan,
+            role: 'assistant',
+            text: `Consolidate ${portfolioPlan.sourceTokens.length} positions into ${portfolioPlan.destinationSymbol}.`,
+          },
+        ]);
+      } catch {
+        setError('Could not prepare this portfolio plan. Please try again.');
+        setDraft(text);
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
     const previousAssistantMessage = [...messages]
       .reverse()
       .find((message) => message.role === 'assistant');
@@ -1510,12 +1605,14 @@ const WalletAssistant = () => {
     }
   }, [
     apiKey,
+    batchSellDestinationsByChain,
     draft,
     isLoading,
     localMarketTokens,
     messages,
     reduceMotion,
     walletSnapshot,
+    walletTokens,
   ]);
 
   const handleStop = useCallback(() => {
@@ -1592,6 +1689,29 @@ const WalletAssistant = () => {
       });
     },
     [navigation],
+  );
+
+  const handleReviewPortfolioPlan = useCallback(
+    (plan: WalletAssistantPortfolioPlan) => {
+      if (
+        plan.status !== 'ready' ||
+        plan.sourceTokens.length === 0 ||
+        !plan.sourceChainId
+      ) {
+        return;
+      }
+
+      dispatch(setBatchSellSourceTokens(plan.sourceTokens));
+      navigation.navigate(Routes.BRIDGE.ROOT, {
+        screen: Routes.BRIDGE.BATCH_SELL_TOKEN_SELECT,
+        params: {
+          batchSellLocation: BatchSellMetricsLocation.Unknown,
+          preferredDestinationSymbol: plan.destinationSymbol,
+          preserveBridgeState: true,
+        },
+      });
+    },
+    [dispatch, navigation],
   );
 
   const handleRetryResponse = useCallback((prompt: string) => {
@@ -1769,6 +1889,7 @@ const WalletAssistant = () => {
                 messages={messages}
                 onLatestUserAnchored={handleLatestUserAnchored}
                 onOpenSource={handleOpenSource}
+                onReviewPortfolioPlan={handleReviewPortfolioPlan}
                 onRetry={handleRetryResponse}
                 onReviewSwap={handleReviewSwap}
                 scrollViewRef={scrollViewRef}

--- a/app/components/UI/Bridge/Views/WalletAssistant/components/AgentProgress/AgentProgress.tsx
+++ b/app/components/UI/Bridge/Views/WalletAssistant/components/AgentProgress/AgentProgress.tsx
@@ -15,6 +15,7 @@ export enum AgentProgressStatus {
   Thinking = 'thinking',
   SearchingWeb = 'searching-web',
   CheckingPrices = 'checking-prices',
+  PreparingPlan = 'preparing-plan',
   PreparingQuote = 'preparing-quote',
 }
 
@@ -32,6 +33,7 @@ export const AGENT_PROGRESS_LABELS: Record<AgentProgressStatus, string> = {
   [AgentProgressStatus.Thinking]: 'Thinking',
   [AgentProgressStatus.SearchingWeb]: 'Searching the web',
   [AgentProgressStatus.CheckingPrices]: 'Checking prices',
+  [AgentProgressStatus.PreparingPlan]: 'Preparing transaction plan',
   [AgentProgressStatus.PreparingQuote]: 'Preparing quote',
 };
 

--- a/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/PortfolioPlanCard.test.tsx
+++ b/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/PortfolioPlanCard.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+import PortfolioPlanCard from './PortfolioPlanCard';
+
+describe('PortfolioPlanCard', () => {
+  it('summarizes the selected positions and opens review', () => {
+    const onReview = jest.fn();
+    const { getByText } = render(
+      <PortfolioPlanCard
+        onReview={onReview}
+        plan={{
+          destinationSymbol: 'USDC',
+          excludedSourceCount: 0,
+          sourceChainId: 'eip155:1',
+          sourceTokens: [
+            {
+              address: '0x0000000000000000000000000000000000000001',
+              balance: '100',
+              chainId: 'eip155:1',
+              decimals: 18,
+              symbol: 'PEPE',
+              tokenFiatAmount: 24,
+            },
+            {
+              address: '0x0000000000000000000000000000000000000002',
+              balance: '50',
+              chainId: 'eip155:1',
+              decimals: 18,
+              symbol: 'SHIB',
+              tokenFiatAmount: 16,
+            },
+          ],
+          status: 'ready',
+        }}
+      />,
+    );
+
+    expect(getByText('Consolidate 2 positions')).toBeOnTheScreen();
+    expect(getByText('Approximately $40.00')).toBeOnTheScreen();
+    expect(getByText('USDC')).toBeOnTheScreen();
+
+    fireEvent.press(getByText('Review plan'));
+    expect(onReview).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/PortfolioPlanCard.tsx
+++ b/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/PortfolioPlanCard.tsx
@@ -1,0 +1,148 @@
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React, { memo } from 'react';
+
+import type { WalletAssistantPortfolioPlan } from '../../portfolioPlan';
+
+export interface PortfolioPlanCardProps {
+  onReview: () => void;
+  plan: WalletAssistantPortfolioPlan;
+}
+
+const PortfolioPlanCard = ({ onReview, plan }: PortfolioPlanCardProps) => {
+  const totalFiatValue = plan.sourceTokens.reduce(
+    (total, token) => total + (token.tokenFiatAmount ?? 0),
+    0,
+  );
+
+  return (
+    <Box twClassName="gap-4 rounded-2xl border border-muted bg-muted p-4">
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={2}
+      >
+        <Icon
+          name={IconName.Merge}
+          size={IconSize.Md}
+          color={IconColor.IconDefault}
+        />
+        <Box twClassName="min-w-0 flex-1">
+          <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
+            Consolidate {plan.sourceTokens.length} positions
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {totalFiatValue > 0
+              ? `Approximately $${totalFiatValue.toFixed(2)}`
+              : 'Use full available balances'}
+          </Text>
+        </Box>
+      </Box>
+
+      {plan.sourceTokens.length > 0 && (
+        <Box twClassName="gap-2">
+          {plan.sourceTokens.map((token) => (
+            <Box
+              key={`${token.chainId}:${token.address}`}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
+              twClassName="rounded-xl bg-default px-3 py-2"
+            >
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                gap={2}
+              >
+                <AvatarToken
+                  name={token.symbol}
+                  src={token.image ? { uri: token.image } : undefined}
+                  size={AvatarTokenSize.Sm}
+                />
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                >
+                  {token.symbol}
+                </Text>
+              </Box>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {token.tokenFiatAmount !== undefined
+                  ? `$${token.tokenFiatAmount.toFixed(2)}`
+                  : 'Full balance'}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {plan.status === 'ready' ? (
+        <>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+            gap={2}
+          >
+            <Icon
+              name={IconName.ArrowDown}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {plan.destinationSymbol}
+            </Text>
+          </Box>
+
+          {plan.excludedSourceCount > 0 && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {plan.excludedSourceCount} additional position
+              {plan.excludedSourceCount === 1 ? '' : 's'} excluded because Batch
+              Swap is currently single-network and limited to five sources.
+            </Text>
+          )}
+
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            onPress={onReview}
+          >
+            Review plan
+          </Button>
+        </>
+      ) : (
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {plan.status === 'no-matches'
+            ? 'No wallet positions were classified as meme coins by MetaMask token data.'
+            : `${plan.destinationSymbol} is not currently supported as a Batch Swap destination. No transactions have been prepared.`}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+export default memo(PortfolioPlanCard);

--- a/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/index.ts
+++ b/app/components/UI/Bridge/Views/WalletAssistant/components/PortfolioPlanCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PortfolioPlanCard';
+export type { PortfolioPlanCardProps } from './PortfolioPlanCard';

--- a/app/components/UI/Bridge/Views/WalletAssistant/portfolioPlan.test.ts
+++ b/app/components/UI/Bridge/Views/WalletAssistant/portfolioPlan.test.ts
@@ -1,0 +1,113 @@
+import type { TokenAsset } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+
+import type { BridgeToken } from '../../types';
+import {
+  buildPortfolioPlan,
+  getTokenLabelsByAssetId,
+  parsePortfolioPlanRequest,
+} from './portfolioPlan';
+
+const token = (
+  symbol: string,
+  address: string,
+  tokenFiatAmount: number,
+): BridgeToken => ({
+  address,
+  balance: '10',
+  chainId: 'eip155:1',
+  decimals: 18,
+  symbol,
+  tokenFiatAmount,
+});
+
+describe('portfolioPlan', () => {
+  it.each([
+    ['Move all my meme coins into USDC', 'USDC'],
+    ['Consolidate all my memecoins to NVIDIA stock', 'NVDA'],
+  ])('parses %p', (prompt, destinationSymbol) => {
+    expect(parsePortfolioPlanRequest(prompt)).toEqual({
+      category: 'meme',
+      destinationSymbol,
+    });
+  });
+
+  it('builds a highest-value, same-chain batch from token labels', () => {
+    const pepe = token(
+      'PEPE',
+      '0x0000000000000000000000000000000000000001',
+      20,
+    );
+    const shib = token(
+      'SHIB',
+      '0x0000000000000000000000000000000000000002',
+      30,
+    );
+    const eth = token('ETH', '0x0000000000000000000000000000000000000003', 500);
+    const usdc = token(
+      'USDC',
+      '0x0000000000000000000000000000000000000004',
+      10,
+    );
+    const metadata = [
+      {
+        assetId:
+          'eip155:1/erc20:0x0000000000000000000000000000000000000001' as CaipAssetType,
+        labels: ['meme_coin'],
+      },
+      {
+        assetId:
+          'eip155:1/erc20:0x0000000000000000000000000000000000000002' as CaipAssetType,
+        labels: ['meme_coin'],
+      },
+    ] as TokenAsset[];
+
+    expect(
+      buildPortfolioPlan({
+        destinationTokensByChain: { 'eip155:1': [usdc] },
+        labelsByAssetId: getTokenLabelsByAssetId(metadata),
+        request: {
+          category: 'meme',
+          destinationSymbol: 'USDC',
+        },
+        walletTokens: [pepe, shib, eth],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        destinationSymbol: 'USDC',
+        sourceChainId: 'eip155:1',
+        sourceTokens: [shib, pepe],
+        status: 'ready',
+      }),
+    );
+  });
+
+  it('keeps an unsupported stock target as a reviewable limitation', () => {
+    const pepe = token(
+      'PEPE',
+      '0x0000000000000000000000000000000000000001',
+      20,
+    );
+    const metadata = [
+      {
+        assetId:
+          'eip155:1/erc20:0x0000000000000000000000000000000000000001' as CaipAssetType,
+        labels: ['meme_coin'],
+      },
+    ] as TokenAsset[];
+
+    expect(
+      buildPortfolioPlan({
+        destinationTokensByChain: {},
+        labelsByAssetId: getTokenLabelsByAssetId(metadata),
+        request: { category: 'meme', destinationSymbol: 'NVDA' },
+        walletTokens: [pepe],
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        destinationSymbol: 'NVDA',
+        status: 'unsupported-target',
+      }),
+    );
+  });
+});

--- a/app/components/UI/Bridge/Views/WalletAssistant/portfolioPlan.ts
+++ b/app/components/UI/Bridge/Views/WalletAssistant/portfolioPlan.ts
@@ -1,0 +1,181 @@
+import type { TokenAsset } from '@metamask/assets-controllers';
+import {
+  formatAddressToAssetId,
+  formatChainIdToCaip,
+} from '@metamask/bridge-controller';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+
+import type { BridgeToken } from '../../types';
+import {
+  MAX_BATCH_SELL_SOURCE_TOKENS,
+  SUPPORTED_BATCH_SELL_CHAIN_IDS,
+  sortBatchSellTokens,
+} from '../BatchSellTokenSelect/BatchSellTokenSelect.utils';
+
+export interface PortfolioPlanRequest {
+  category: 'meme';
+  destinationSymbol: string;
+}
+
+export interface WalletAssistantPortfolioPlan {
+  destinationSymbol: string;
+  excludedSourceCount: number;
+  sourceChainId?: CaipChainId;
+  sourceTokens: BridgeToken[];
+  status: 'ready' | 'no-matches' | 'unsupported-target';
+}
+
+const PORTFOLIO_ACTION =
+  /\b(?:move|convert|swap|sell|exit|consolidate|roll)\b[\s\S]*\b(?:all|my)\b[\s\S]*\b(?:meme\s*coins?|memecoins?)\b/i;
+const DESTINATION =
+  /\b(?:into|to|for)\s+(?:the\s+)?([a-z0-9][a-z0-9 ._-]{1,40})[.!?]?\s*$/i;
+const MEME_LABEL = /meme/i;
+const NVIDIA = /\b(?:nvidia|nvda)(?:\s+stock)?\b/i;
+
+export const parsePortfolioPlanRequest = (
+  prompt: string,
+): PortfolioPlanRequest | undefined => {
+  if (!PORTFOLIO_ACTION.test(prompt)) {
+    return undefined;
+  }
+
+  const destinationPhrase = DESTINATION.exec(prompt)?.[1]?.trim() ?? '';
+  const destinationSymbol = NVIDIA.test(destinationPhrase)
+    ? 'NVDA'
+    : (destinationPhrase.split(/\s+/)[0]?.toUpperCase() ?? '');
+
+  return destinationSymbol
+    ? { category: 'meme', destinationSymbol }
+    : undefined;
+};
+
+export const getWalletTokenAssetId = (
+  token: BridgeToken,
+): CaipAssetType | undefined =>
+  formatAddressToAssetId(token.address, token.chainId);
+
+export const getTokenLabelsByAssetId = (
+  assets: readonly TokenAsset[],
+): ReadonlyMap<string, readonly string[]> =>
+  new Map(
+    assets.map((asset) => [asset.assetId.toLowerCase(), asset.labels ?? []]),
+  );
+
+const isMemeToken = (
+  token: BridgeToken,
+  labelsByAssetId: ReadonlyMap<string, readonly string[]>,
+) => {
+  const assetId = getWalletTokenAssetId(token);
+  return Boolean(
+    assetId &&
+      labelsByAssetId
+        .get(assetId.toLowerCase())
+        ?.some((label) => MEME_LABEL.test(label)),
+  );
+};
+
+const getDestinationForChain = (
+  destinationSymbol: string,
+  chainId: CaipChainId,
+  destinationTokensByChain: Partial<Record<CaipChainId, BridgeToken[]>>,
+) =>
+  destinationTokensByChain[chainId]?.find(
+    (token) =>
+      token.symbol.trim().toUpperCase() === destinationSymbol.toUpperCase(),
+  );
+
+export const buildPortfolioPlan = ({
+  destinationTokensByChain,
+  labelsByAssetId,
+  request,
+  walletTokens,
+}: {
+  destinationTokensByChain: Partial<Record<CaipChainId, BridgeToken[]>>;
+  labelsByAssetId: ReadonlyMap<string, readonly string[]>;
+  request: PortfolioPlanRequest;
+  walletTokens: readonly BridgeToken[];
+}): WalletAssistantPortfolioPlan => {
+  const supportedChains = new Set(SUPPORTED_BATCH_SELL_CHAIN_IDS);
+  const matchingTokens = walletTokens.filter(
+    (token) =>
+      Number(token.balance ?? 0) > 0 &&
+      !token.rwaData &&
+      supportedChains.has(formatChainIdToCaip(token.chainId)) &&
+      token.symbol.toUpperCase() !== request.destinationSymbol &&
+      isMemeToken(token, labelsByAssetId),
+  );
+
+  if (matchingTokens.length === 0) {
+    return {
+      destinationSymbol: request.destinationSymbol,
+      excludedSourceCount: 0,
+      sourceTokens: [],
+      status: 'no-matches',
+    };
+  }
+
+  const tokensByChain = new Map<CaipChainId, BridgeToken[]>();
+  matchingTokens.forEach((token) => {
+    const chainId = formatChainIdToCaip(token.chainId);
+    tokensByChain.set(chainId, [...(tokensByChain.get(chainId) ?? []), token]);
+  });
+
+  const executableGroups = Array.from(tokensByChain.entries())
+    .filter(([chainId]) =>
+      Boolean(
+        getDestinationForChain(
+          request.destinationSymbol,
+          chainId,
+          destinationTokensByChain,
+        ),
+      ),
+    )
+    .sort(
+      ([, left], [, right]) =>
+        right.reduce(
+          (total, token) => total + (token.tokenFiatAmount ?? 0),
+          0,
+        ) -
+        left.reduce((total, token) => total + (token.tokenFiatAmount ?? 0), 0),
+    );
+
+  const selectedGroup = executableGroups[0];
+  if (!selectedGroup) {
+    const fallbackGroup = Array.from(tokensByChain.entries()).sort(
+      ([, left], [, right]) =>
+        right.reduce(
+          (total, token) => total + (token.tokenFiatAmount ?? 0),
+          0,
+        ) -
+        left.reduce((total, token) => total + (token.tokenFiatAmount ?? 0), 0),
+    )[0];
+    const sourceTokens = fallbackGroup
+      ? sortBatchSellTokens(fallbackGroup[1]).slice(
+          0,
+          MAX_BATCH_SELL_SOURCE_TOKENS,
+        )
+      : [];
+
+    return {
+      destinationSymbol: request.destinationSymbol,
+      excludedSourceCount: matchingTokens.length - sourceTokens.length,
+      sourceChainId: fallbackGroup?.[0],
+      sourceTokens,
+      status: 'unsupported-target',
+    };
+  }
+
+  const [sourceChainId, chainTokens] = selectedGroup;
+  const sourceTokens = sortBatchSellTokens(chainTokens).slice(
+    0,
+    MAX_BATCH_SELL_SOURCE_TOKENS,
+  );
+
+  return {
+    destinationSymbol: request.destinationSymbol,
+    excludedSourceCount: matchingTokens.length - sourceTokens.length,
+    sourceChainId,
+    sourceTokens,
+    status: 'ready',
+  };
+};


### PR DESCRIPTION
## **Description**

Adds the first multi-transaction Wallet Assistant workflow on top of #33923.

The assistant now handles prompts such as "Move all my meme coins into USDC" locally, without waiting for an OpenAI response. It uses MetaMask wallet balances and token labels to identify eligible positions, groups them by network, and presents a compact transaction plan before handing execution to the existing Batch Swap flow.

No transaction is signed or submitted by the assistant. Batch Swap still fetches live quotes and requires the user to review and confirm. The initial slice intentionally follows current Batch Swap constraints: one source network, a maximum of five source tokens, and a supported stablecoin destination. Unsupported targets such as NVIDIA stock are explained without preparing transactions.

This is a stacked PR. Merge #33923 first.

## **Changelog**

CHANGELOG entry: Added Wallet Assistant plans for consolidating multiple token positions with Batch Swap

## **Related issues**

Refs: #33923

## **Manual testing steps**

```gherkin
Feature: Wallet Assistant portfolio consolidation

  Scenario: consolidate meme coin positions into USDC
    Given #33923 is installed
    And the wallet contains meme coin positions on a Batch Swap-supported network
    And USDC is a supported Batch Swap destination on that network

    When the user asks "Move all my meme coins into USDC"
    Then the assistant prepares a local plan using MetaMask wallet and token data
    And the plan lists the eligible source positions and approximate total value
    And no transaction has been submitted

    When the user taps "Review plan"
    Then the existing Batch Swap token selection screen opens
    And the source positions and USDC destination are preselected
    And MetaMask requires live quote review and explicit confirmation

  Scenario: request an unsupported destination
    Given the user is on the Wallet Assistant screen

    When the user asks "Move all my meme coins into NVIDIA stock"
    Then the assistant explains that NVDA is not a supported Batch Swap destination
    And no transaction is prepared
```

## **Screenshots/Recordings**

### **Before**

N/A — #33923 supports one swap intent per prompt but not portfolio plans.

### **After**

N/A — no shareable recording is attached to this draft.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Assessed as not yet tested on Android for this draft.
- [x] I've tested with a power user scenario
  - Assessed as not yet tested with a power-user SRP for this draft.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Assessed as not included in this prototype slice.

Validation completed:

- 47 focused Jest tests passed across the portfolio planner, plan card, progress UI, and Batch Swap token selection.
- `yarn lint:tsc` passed.
- Targeted ESLint passed.
- `git diff --check` passed.
- No OpenAI API key or credential is included in this branch.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
