### PR TITLE
test: ActivityScreen Predictions row component-view coverage (MMQA-2117)

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -2,6 +2,7 @@ import '../../../../tests/component-view/mocks';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 
 import Routes from '../../../constants/navigation/Routes';
+import Engine from '../../../core/Engine';
 import { getRouteProbeTestId } from '../../../../tests/component-view/render';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import {
@@ -12,19 +13,26 @@ import {
   ACTIVITY_CV_ACCOUNT,
   ACTIVITY_CV_NFT_COLLECTION_NAME,
   ACTIVITY_CV_NFT_CONTRACT,
+  ACTIVITY_CV_PREDICT_MARKET_TITLE,
   ACTIVITY_CV_RECIPIENT,
   activityCvBridgeHistoryEntry,
   activityCvCrossChainSwapBridgeHistoryEntry,
   activityLineaNetworkOverride,
+  activityPredictTradingEnabledFlag,
   buildConfirmedLocalBridgeTransaction,
   buildConfirmedLocalContractInteractionTransaction,
   buildConfirmedLocalCrossChainSwapTransaction,
+  buildConfirmedLocalPredictDepositTransaction,
+  buildConfirmedLocalPredictWithdrawTransaction,
   buildConfirmedLocalSendTransaction,
   buildConfirmedLocalUsdcApproveTransaction,
   buildConfirmedLocalUsdcIncreaseAllowanceTransaction,
   buildConfirmedLocalUsdcRevokeTransaction,
   buildConfirmedLocalUsdcSendTransaction,
   buildConfirmedLocalUsdcUnlimitedApproveTransaction,
+  buildPredictBuyActivity,
+  buildPredictClaimActivity,
+  buildPredictSellActivity,
   initialStateActivityWithAccountsApi,
   initialStateActivityWithLocalTransactions,
 } from '../../../../tests/component-view/presets/activity';
@@ -1052,6 +1060,248 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
 
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(mintHash)),
+    ).toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — prediction rows', () => {
+  afterEach(() => {
+    clearAccountsTransactionsApiMocks();
+    (
+      Engine.context.PredictController.getActivity as jest.Mock
+    ).mockResolvedValue([]);
+  });
+
+  it('shows Account funded under Predictions with balance subtitle, + fiat, and USDC secondary', async () => {
+    const deposit = buildConfirmedLocalPredictDepositTransaction();
+    const depositHash = deposit.hash as string;
+    const state = initialStateActivityWithLocalTransactions([deposit])
+      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
+      .build();
+
+    const { findByTestId, getAllByText, queryByTestId } =
+      renderActivityScreenView({
+        state,
+        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(depositHash)),
+    ).toHaveTextContent(
+      strings('transactions.activity_prediction_account_funded'),
+    );
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(depositHash)),
+    ).toHaveTextContent(strings('transactions.activity_predictions_balance'));
+
+    const primaryAmount = await findByTestId(
+      activityListRowPrimaryAmountTestId(depositHash),
+    );
+    expect(primaryAmount).toHaveTextContent(/^\+/);
+    expect(primaryAmount).toHaveTextContent(/USD|\$/);
+
+    const secondaryAmount = await findByTestId(
+      activityListRowSecondaryAmountTestId(depositHash),
+    );
+    expect(secondaryAmount).toHaveTextContent(/4,?000 USDC/);
+    expect(secondaryAmount).not.toHaveTextContent(/^\+/);
+
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(depositHash)),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(activityListRowAvatarStackTestId(depositHash)),
+    ).toBeNull();
+  });
+
+  it('shows Prediction withdrawal under Predictions with balance subtitle and negative amounts', async () => {
+    const withdraw = buildConfirmedLocalPredictWithdrawTransaction();
+    const withdrawHash = withdraw.hash as string;
+    const state = initialStateActivityWithLocalTransactions([withdraw])
+      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
+      .build();
+
+    const { findByTestId, getAllByText } = renderActivityScreenView({
+      state,
+      params: { initialTypeFilter: ActivityTypeFilter.Predictions },
+    });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(withdrawHash)),
+    ).toHaveTextContent(strings('transactions.activity_prediction_withdrawal'));
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(withdrawHash)),
+    ).toHaveTextContent(strings('transactions.activity_predictions_balance'));
+
+    const primaryAmount = await findByTestId(
+      activityListRowPrimaryAmountTestId(withdrawHash),
+    );
+    expect(primaryAmount).toHaveTextContent(/^-/);
+    expect(primaryAmount).toHaveTextContent(/USD|\$/);
+
+    const secondaryAmount = await findByTestId(
+      activityListRowSecondaryAmountTestId(withdrawHash),
+    );
+    expect(secondaryAmount).toHaveTextContent(/^-.*4,?000 USDC/);
+
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(withdrawHash)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Claimed winnings under Predictions with market subtitle and + fiat primary', async () => {
+    const claim = buildPredictClaimActivity();
+    (
+      Engine.context.PredictController.getActivity as jest.Mock
+    ).mockResolvedValue([claim]);
+
+    const state = initialStateActivityWithAccountsApi()
+      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
+      .build();
+
+    const { findByTestId, getAllByText, queryByTestId } =
+      renderActivityScreenView({
+        state,
+        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    const title = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(claim.id)),
+      { timeout: 10000 },
+    );
+    expect(title).toHaveTextContent(
+      strings('predict.transactions.claim_title'),
+    );
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(claim.id)),
+    ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
+
+    const primaryAmount = await findByTestId(
+      activityListRowPrimaryAmountTestId(claim.id),
+    );
+    expect(primaryAmount).toHaveTextContent(/^\+/);
+    expect(primaryAmount).toHaveTextContent(/\$/);
+
+    expect(
+      queryByTestId(activityListRowSecondaryAmountTestId(claim.id)),
+    ).toBeNull();
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(claim.id)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Cashed out under Predictions with market subtitle and + fiat primary', async () => {
+    const sell = buildPredictSellActivity();
+    (
+      Engine.context.PredictController.getActivity as jest.Mock
+    ).mockResolvedValue([sell]);
+
+    const state = initialStateActivityWithAccountsApi()
+      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
+      .build();
+
+    const { findByTestId, getAllByText, queryByTestId } =
+      renderActivityScreenView({
+        state,
+        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    const title = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(sell.id)),
+      { timeout: 10000 },
+    );
+    expect(title).toHaveTextContent(strings('predict.transactions.sell_title'));
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(sell.id)),
+    ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
+
+    const primaryAmount = await findByTestId(
+      activityListRowPrimaryAmountTestId(sell.id),
+    );
+    expect(primaryAmount).toHaveTextContent(/^\+/);
+    expect(primaryAmount).toHaveTextContent(/\$/);
+
+    expect(
+      queryByTestId(activityListRowSecondaryAmountTestId(sell.id)),
+    ).toBeNull();
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(sell.id)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows Prediction placed under Predictions with market subtitle and - fiat primary', async () => {
+    const buy = buildPredictBuyActivity();
+    (
+      Engine.context.PredictController.getActivity as jest.Mock
+    ).mockResolvedValue([buy]);
+
+    const state = initialStateActivityWithAccountsApi()
+      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
+      .build();
+
+    const { findByTestId, getAllByText, queryByTestId } =
+      renderActivityScreenView({
+        state,
+        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    const title = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(buy.id)),
+      { timeout: 10000 },
+    );
+    expect(title).toHaveTextContent(
+      strings('transactions.activity_prediction_placed'),
+    );
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(buy.id)),
+    ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
+
+    const primaryAmount = await findByTestId(
+      activityListRowPrimaryAmountTestId(buy.id),
+    );
+    expect(primaryAmount).toHaveTextContent(/^-/);
+    expect(primaryAmount).toHaveTextContent(/\$/);
+
+    expect(
+      queryByTestId(activityListRowSecondaryAmountTestId(buy.id)),
+    ).toBeNull();
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(buy.id)),
     ).toBeOnTheScreen();
   });
 });

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -6,6 +6,7 @@ import {
 import { createStateFixture } from '../stateFixture';
 import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
 import type { RootState } from '../../../app/reducers';
+import type { PredictActivity } from '../../../app/components/UI/Predict/types';
 
 export const ACTIVITY_CV_ACCOUNT = '0x0000000000000000000000000000000000000001';
 
@@ -332,6 +333,140 @@ export const buildPendingLocalSendTransaction = (): TransactionMeta =>
       nonce: '0x1',
     },
   }) as unknown as TransactionMeta;
+
+/** Market question used as subtitle on Predict trade/claim Activity CV rows. */
+export const ACTIVITY_CV_PREDICT_MARKET_TITLE =
+  'Will Spain win the 2026 FIFA World Cup?';
+
+const ACTIVITY_CV_PREDICT_MARKET_ICON = 'https://example.com/spain.png';
+
+/** ERC-20 `transfer(to, amount)` calldata for Predict deposit/withdraw batches. */
+const buildErc20TransferCalldata = (to: string, amount: bigint): string =>
+  `0xa9059cbb${to.slice(2).toLowerCase().padStart(64, '0')}${amount
+    .toString(16)
+    .padStart(64, '0')}`;
+
+/** 4,000 USDC (6 decimals) — funded / withdrawal CV fixtures. */
+const ACTIVITY_CV_PREDICT_USDC_AMOUNT = 4_000_000_000n;
+
+/**
+ * Confirmed Predict deposit batch → `predictionsAddFunds` under Predictions filter.
+ */
+export const buildConfirmedLocalPredictDepositTransaction =
+  (): TransactionMeta =>
+    ({
+      id: 'activity-cv-predict-deposit',
+      hash: '0xactivitycvpredictdeposit',
+      chainId: '0x1',
+      status: TransactionStatus.confirmed,
+      time: 1_716_367_790_000,
+      type: TransactionType.batch,
+      txParams: {
+        from: ACTIVITY_CV_ACCOUNT,
+        to: ACTIVITY_CV_ACCOUNT,
+        value: '0x0',
+        nonce: '0x9',
+      },
+      nestedTransactions: [
+        {
+          type: TransactionType.predictDeposit,
+          to: ACTIVITY_CV_USDC,
+          data: buildErc20TransferCalldata(
+            ACTIVITY_CV_RECIPIENT,
+            ACTIVITY_CV_PREDICT_USDC_AMOUNT,
+          ),
+        },
+      ],
+      txReceipt: { status: '0x1' },
+    }) as unknown as TransactionMeta;
+
+/**
+ * Confirmed Predict withdraw batch → `predictionsWithdrawFunds` under Predictions filter.
+ */
+export const buildConfirmedLocalPredictWithdrawTransaction =
+  (): TransactionMeta =>
+    ({
+      id: 'activity-cv-predict-withdraw',
+      hash: '0xactivitycvpredictwithdraw',
+      chainId: '0x1',
+      status: TransactionStatus.confirmed,
+      time: 1_716_367_791_000,
+      type: TransactionType.batch,
+      txParams: {
+        from: ACTIVITY_CV_ACCOUNT,
+        to: ACTIVITY_CV_ACCOUNT,
+        value: '0x0',
+        nonce: '0xa',
+      },
+      nestedTransactions: [
+        {
+          type: TransactionType.predictWithdraw,
+          to: ACTIVITY_CV_USDC,
+          data: buildErc20TransferCalldata(
+            ACTIVITY_CV_ACCOUNT,
+            ACTIVITY_CV_PREDICT_USDC_AMOUNT,
+          ),
+        },
+      ],
+      txReceipt: { status: '0x1' },
+    }) as unknown as TransactionMeta;
+
+/** Provider feed buy → `predictionPlaced` (negative primary, market subtitle). */
+export const buildPredictBuyActivity = (): PredictActivity => ({
+  id: 'activity-cv-predict-buy',
+  providerId: 'polymarket',
+  title: ACTIVITY_CV_PREDICT_MARKET_TITLE,
+  icon: ACTIVITY_CV_PREDICT_MARKET_ICON,
+  outcome: 'Yes',
+  entry: {
+    type: 'buy',
+    timestamp: 1_716_367_792,
+    marketId: 'm-cv-1',
+    outcomeId: 'o-cv-1',
+    outcomeTokenId: 1,
+    amount: 3,
+    price: 0.42,
+  },
+});
+
+/** Provider feed sell → `predictionCashedOut` (positive primary, market subtitle). */
+export const buildPredictSellActivity = (): PredictActivity => ({
+  id: 'activity-cv-predict-sell',
+  providerId: 'polymarket',
+  title: ACTIVITY_CV_PREDICT_MARKET_TITLE,
+  icon: ACTIVITY_CV_PREDICT_MARKET_ICON,
+  outcome: 'Yes',
+  entry: {
+    type: 'sell',
+    timestamp: 1_716_367_793,
+    marketId: 'm-cv-1',
+    outcomeId: 'o-cv-1',
+    outcomeTokenId: 1,
+    amount: 75,
+    price: 0.6,
+  },
+});
+
+/** Provider feed claim → `predictionClaimWinnings` (positive primary, market subtitle). */
+export const buildPredictClaimActivity = (): PredictActivity => ({
+  id: 'activity-cv-predict-claim',
+  providerId: 'polymarket',
+  title: ACTIVITY_CV_PREDICT_MARKET_TITLE,
+  icon: ACTIVITY_CV_PREDICT_MARKET_ICON,
+  entry: {
+    type: 'claimWinnings',
+    timestamp: 1_716_367_794,
+    amount: 250,
+  },
+});
+
+/** Remote flag shape that enables PredictActivitySource on ActivityScreen CV. */
+export const activityPredictTradingEnabledFlag = {
+  predictTradingEnabled: {
+    enabled: true,
+    minimumVersion: '0.0.0',
+  },
+} as const;
 
 const enabledMainnetNetworkMap = {
   eip155: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds component-view coverage for ActivityScreen rows under the **Predictions** type filter. Cases exercise local Predict deposit/withdraw batches and provider feed activity (`buy` / `sell` / `claimWinnings`) via `PredictController.getActivity`, asserting title, subtitle, primary/secondary amounts, and single avatars. Fixtures live in `tests/component-view/presets/activity.ts`.

### Tests added (`ActivityScreen — prediction rows`)

| Case | Title / subtitle | Amounts | Avatar |
| --- | --- | --- | --- |
| Account funded | `Account funded` / `Predictions balance` | Primary `+…USD`; secondary `4,000 USDC` (no `+`) | Single |
| Prediction withdrawal | `Prediction withdrawal` / `Predictions balance` | Primary `-…USD`; secondary `-4,000 USDC` | Single |
| Claimed winnings | `Claimed winnings` / market question | Primary `+…$…`; secondary — | Single |
| Cashed out | `Cashed out` / market question | Primary `+…$…`; secondary — | Single |
| Prediction placed | `Prediction placed` / market question | Primary `-…$…`; secondary — | Single |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MMQA-2117

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — coverage is component-view only; verified with:

```bash
yarn jest -c jest.config.view.js \
  app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx \
  -t "prediction rows" \
  --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change; no UI product diff to capture.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)