### PR TITLE
fix: show correct top line value in txn details

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -407,6 +407,80 @@ describe('TransactionDetailsHero', () => {
       expect(getByText(/\+\$200/)).toBeDefined();
     });
 
+    describe('post-quote withdrawals (inflated totalFiat)', () => {
+      // The controller builds totalFiat as `source amount + fees`, but a
+      // post-quote withdrawal's source amount already includes the fees, so
+      // totalFiat overstates what left the account. The hero must reconstruct
+      // it from targetFiat + the fees the details screen lists.
+      it('shows the source amount rather than the inflated totalFiat for moneyAccountWithdraw', () => {
+        useTransactionDetailsMock.mockReturnValue({
+          transactionMeta: {
+            ...TRANSACTION_META_MOCK,
+            type: TransactionType.moneyAccountWithdraw,
+            metamaskPay: {
+              tokenAddress: TOKEN_ADDRESS_MOCK,
+              chainId: CHAIN_ID_MOCK,
+              isPostQuote: true,
+              targetFiat: '0.75',
+              bridgeFeeFiat: '0.25',
+              networkFeeFiat: '0',
+              totalFiat: '1.25',
+            },
+          } as unknown as TransactionMeta,
+        });
+
+        const { getByText, queryByText } = render();
+
+        expect(getByText(/^-\$1$/)).toBeDefined();
+        expect(getByText(/\+\$0\.75/)).toBeDefined();
+        expect(queryByText(/\$1\.25/)).toBeNull();
+      });
+
+      it('includes the network fee in the source amount', () => {
+        useTransactionDetailsMock.mockReturnValue({
+          transactionMeta: {
+            ...TRANSACTION_META_MOCK,
+            type: TransactionType.perpsWithdraw,
+            metamaskPay: {
+              tokenAddress: TOKEN_ADDRESS_MOCK,
+              chainId: CHAIN_ID_MOCK,
+              isPostQuote: true,
+              targetFiat: '50.00',
+              bridgeFeeFiat: '1.50',
+              networkFeeFiat: '0.84',
+              totalFiat: '54.68',
+            },
+          } as unknown as TransactionMeta,
+        });
+
+        const { getByText } = render();
+
+        expect(getByText(/-\$52\.34/)).toBeDefined();
+        expect(getByText(/\+\$50/)).toBeDefined();
+      });
+
+      it('keeps totalFiat for deposits, where fees are genuinely paid on top', () => {
+        useTransactionDetailsMock.mockReturnValue({
+          transactionMeta: {
+            ...TRANSACTION_META_MOCK,
+            type: TransactionType.perpsDeposit,
+            metamaskPay: {
+              tokenAddress: TOKEN_ADDRESS_MOCK,
+              chainId: CHAIN_ID_MOCK,
+              targetFiat: '123.46',
+              bridgeFeeFiat: '2.34',
+              totalFiat: '125.80',
+            },
+          } as unknown as TransactionMeta,
+        });
+
+        const { getByText } = render();
+
+        expect(getByText(/-\$125\.80/)).toBeDefined();
+        expect(getByText(/\+\$123\.46/)).toBeDefined();
+      });
+    });
+
     it('renders single-row hero with Money Account icon for mUSD-to-mUSD moneyAccountWithdraw', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -346,13 +346,43 @@ function isSingleRowMoneyDeposit(transactionMeta: TransactionMeta): boolean {
   return Boolean(fiat?.orderId) || isMusdToken(tokenAddress);
 }
 
+/**
+ * Fiat value of what actually left the account.
+ *
+ * `metamaskPay.totalFiat` is documented as the total cost "including gas, fees,
+ * and the funds themselves", which holds for deposits: the required token is the
+ * target and the fees are paid on top of it. Post-quote flows (withdrawals)
+ * invert that — the required token is the source, so the amount the user chose
+ * already covers the fees — yet the controller still adds them, inflating
+ * `totalFiat` by the fee amount.
+ *
+ * For those flows, rebuild the sent amount from what the user received plus the
+ * fees the details screen itself lists, so the hero reconciles with the rows
+ * below it. `targetFiat` is '0' for same-token flows that produce no quotes;
+ * those have no fees to double-count, so `totalFiat` stands.
+ */
+function resolveSentFiat(transactionMeta: TransactionMeta): string | undefined {
+  const { bridgeFeeFiat, isPostQuote, networkFeeFiat, targetFiat, totalFiat } =
+    transactionMeta.metamaskPay ?? {};
+
+  if (!isPostQuote || !targetFiat || targetFiat === '0') {
+    return totalFiat;
+  }
+
+  return new BigNumber(targetFiat)
+    .plus(bridgeFeeFiat ?? 0)
+    .plus(networkFeeFiat ?? 0)
+    .toString(10);
+}
+
 function resolveTwoAssetData(
   transactionMeta: TransactionMeta,
   sentData: TokenData,
   receivedData: TokenData,
   formatFiat: (value: BigNumber) => string,
 ): { sent: TokenDisplayData; received: TokenDisplayData } {
-  const { totalFiat, targetFiat } = transactionMeta.metamaskPay ?? {};
+  const { targetFiat } = transactionMeta.metamaskPay ?? {};
+  const sentFiat = resolveSentFiat(transactionMeta);
 
   const isOutbound = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountWithdraw,
@@ -362,7 +392,7 @@ function resolveTwoAssetData(
     return {
       sent: {
         ...receivedData,
-        fiatAmount: formatFiat(new BigNumber(totalFiat ?? receivedData.amount)),
+        fiatAmount: formatFiat(new BigNumber(sentFiat ?? receivedData.amount)),
       },
       received: {
         ...sentData,
@@ -371,7 +401,7 @@ function resolveTwoAssetData(
     };
   }
 
-  const fiatSent = formatFiat(new BigNumber(totalFiat ?? sentData.amount));
+  const fiatSent = formatFiat(new BigNumber(sentFiat ?? sentData.amount));
   const fiatReceived = formatFiat(
     new BigNumber(targetFiat ?? receivedData.amount),
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Fix an issue where we showed an incorrect top line value for post quote transactions 
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show correct top line values for post-quote money account transactions

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1141

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/09a62349-a0b9-4d89-9b14-1325e5c87722


<!-- [screenshots/recordings] -->

### **After**
<img width="554" height="1041" alt="Screenshot 2026-07-30 at 09 51 37" src="https://github.com/user-attachments/assets/c7ae927b-42a6-45eb-a68d-747652c2bea3" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in transaction details hero with targeted tests; no auth, payment execution, or controller logic changes.
> 
> **Overview**
> Fixes the **transaction details hero** “You sent” top-line for **post-quote withdrawals** (`isPostQuote`), where `metamaskPay.totalFiat` double-counts fees because the controller still adds bridge/network fees on top of a source amount that already includes them.
> 
> The hero now derives the sent fiat via **`resolveSentFiat`**: for post-quote flows with a non-zero `targetFiat`, it uses `targetFiat + bridgeFeeFiat + networkFeeFiat` so the headline matches the fee rows below. Deposits and same-token flows (`targetFiat` `'0'`) still use **`totalFiat`**.
> 
> Unit tests cover money account and perps post-quote withdrawals plus deposit behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5751aab0192618a8bc341c78b70089ab288d15fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->