### PR TITLE
fix(ci): pass LT_ACCESS_KEY via secrets inherit (not reusable with:)

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -28,10 +28,8 @@ on:
         required: false
         type: string
         description: 'TestMu AI username (from manual dispatch or secrets upstream)'
-      lt_access_key:
-        required: false
-        type: string
-        description: 'TestMu AI access key (from manual dispatch or secrets upstream)'
+      # LT_ACCESS_KEY must come from secrets (caller uses secrets: inherit).
+      # Passing it via `with:` is invalid — GitHub rejects secrets.* in reusable-workflow inputs.
     outputs:
       with-srp-browserstack-url:
         description: 'BrowserStack URL for with-SRP version'
@@ -267,7 +265,7 @@ jobs:
     name: Upload APKs to TestMu AI
     runs-on: ubuntu-latest
     needs: [check-builds-needed, build-with-srp, build-without-srp]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true' && needs.build-with-srp.result == 'success' && needs.build-without-srp.result == 'success' && inputs.lt_username != '' && inputs.lt_access_key != ''
+    if: needs.check-builds-needed.outputs.builds-needed == 'true' && needs.build-with-srp.result == 'success' && needs.build-without-srp.result == 'success' && inputs.lt_username != '' && secrets.LT_ACCESS_KEY != ''
     continue-on-error: true
     outputs:
       with-srp-testmu-url: ${{ steps.testmu-upload.outputs.with-srp-testmu-url }}
@@ -292,7 +290,7 @@ jobs:
         id: testmu-upload
         env:
           LT_USERNAME: ${{ inputs.lt_username }}
-          LT_ACCESS_KEY: ${{ inputs.lt_access_key }}
+          LT_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
         run: |
           set +e
           echo "Uploading APKs to TestMu AI..."

--- a/.github/workflows/performance-test-runner-testmu.yml
+++ b/.github/workflows/performance-test-runner-testmu.yml
@@ -59,11 +59,11 @@ on:
         required: true
         type: string
         description: 'TestMu AI username'
-      lt_access_key:
-        required: true
-        type: string
-        description: 'TestMu AI access key'
+      # LT_ACCESS_KEY is a secret (passed via secrets: inherit / secrets.LT_ACCESS_KEY).
+      # It cannot be a workflow_call input — secrets.* is illegal in caller `with:`.
     secrets:
+      LT_ACCESS_KEY:
+        required: true
       MM_TEST_ACCOUNT_SRP:
         required: true
       TEST_SRP_1:
@@ -146,7 +146,7 @@ jobs:
         if: inputs.build_type == 'mm-connect'
         env:
           LT_USERNAME: ${{ inputs.lt_username }}
-          LT_ACCESS_KEY: ${{ inputs.lt_access_key }}
+          LT_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
           TUNNEL_NAME: ${{ steps.tm-tunnel.outputs.name }}
         run: bash ./tests/scripts/start-testmu-tunnel.sh
 
@@ -220,7 +220,7 @@ jobs:
             echo "TESTMU_BUILD_NAME=${{ inputs.testmu_build_name }}"
             echo "TESTMU_GEO_LOCATION=$TESTMU_GEO_LOCATION"
             echo "LT_USERNAME=${{ inputs.lt_username }}"
-            echo "LT_ACCESS_KEY=${{ inputs.lt_access_key }}"
+            echo "LT_ACCESS_KEY=${{ secrets.LT_ACCESS_KEY }}"
             echo "MM_TEST_ACCOUNT_SRP=${{ secrets.MM_TEST_ACCOUNT_SRP }}"
             echo "TEST_SRP_1=${{ secrets.TEST_SRP_1 }}"
             echo "TEST_SRP_2=${{ secrets.TEST_SRP_2 }}"

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -528,7 +528,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
+      # LT_ACCESS_KEY must travel via secrets: inherit — secrets.* is illegal in reusable-workflow `with:`
     secrets: inherit
 
   trigger-ios-dual-versions:
@@ -626,7 +626,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       testmu_build_name: ${{ needs.set-build-names.outputs.testmu_android_build_name }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
+      # LT_ACCESS_KEY via secrets: inherit (secrets.* illegal in reusable-workflow `with:`)
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}
     secrets: inherit
 
@@ -779,7 +779,7 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       testmu_build_name: ${{ needs.set-build-names.outputs.testmu_android_build_name }}
       lt_username: ${{ needs.check-testmu-credentials.outputs.lt_username }}
-      lt_access_key: ${{ secrets.LT_ACCESS_KEY }}
+      # LT_ACCESS_KEY via secrets: inherit (secrets.* illegal in reusable-workflow `with:`)
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}
     secrets: inherit
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #33932, `run-performance-e2e.yml` is invalid on this branch:

`Unrecognized named-value: 'secrets' ... secrets.LT_ACCESS_KEY`

GitHub does **not** allow `secrets.*` inside reusable-workflow `with:` blocks.

## Fix

- Remove `lt_access_key: ${{ secrets.LT_ACCESS_KEY }}` from caller `with:` (keep `secrets: inherit`)
- Consume `secrets.LT_ACCESS_KEY` inside:
  - `build-android-upload-to-browserstack.yml`
  - `performance-test-runner-testmu.yml` (declare `LT_ACCESS_KEY` under `workflow_call.secrets`)

Same fix as #33939, adapted for the non-HyperExecute TestMu runner on this PoC branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cd73a7-d8af-42b0-ba8b-9ed0c1c62b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

