### PR TITLE
Add portfolio allocation summary to wallet homepage

### DIFF
--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -16,6 +16,7 @@ import DeFiSection from './Sections/DeFi';
 import NFTsSection from './Sections/NFTs';
 import WatchlistSection from './Sections/Watchlist';
 import MoreSection from './Sections/More';
+import AllocationSection from './Sections/Allocation';
 import { SectionRefreshHandle } from './types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../Wallet/WalletView.testIds';
@@ -156,6 +157,7 @@ const Homepage = forwardRef<SectionRefreshHandle, object>((_props, ref) => {
       testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
       accessible={false}
     >
+      <AllocationSection />
       <TokensSection
         ref={tokensSectionRef}
         sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
@@ -1,0 +1,5 @@
+export const AllocationSectionTestIds = {
+  CONTAINER: 'homepage-allocation-section',
+  BAR: 'homepage-allocation-bar',
+  ROW: (key: string) => `homepage-allocation-row-${key}`,
+};

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -45,8 +45,6 @@ interface AllocationRow {
   onPress: () => void;
 }
 
-const GREEN_ALPHAS = ['', 'D6', 'AD', '84', '5C'];
-
 const styles = StyleSheet.create({
   allocationBar: {
     flexDirection: 'row',
@@ -174,10 +172,13 @@ const AllocationSectionContent = ({
     return null;
   }
 
-  const greenColors = rows.map(
-    (_row, index) =>
-      `${colors.success.default}${GREEN_ALPHAS[index] ?? GREEN_ALPHAS[GREEN_ALPHAS.length - 1]}`,
-  );
+  const categoryColors: Record<AllocationRow['key'], string> = {
+    money: colors.success.default,
+    tokens: colors.primary.default,
+    perpetuals: `${colors.success.default}B8`,
+    predictions: `${colors.primary.default}A3`,
+    defi: `${colors.success.default}73`,
+  };
 
   return (
     <View testID={AllocationSectionTestIds.CONTAINER}>
@@ -194,21 +195,21 @@ const AllocationSectionContent = ({
           style={styles.allocationBar}
           testID={AllocationSectionTestIds.BAR}
         >
-          {rows.map((row, index) => (
+          {rows.map((row) => (
             <View
               key={row.key}
               style={[
                 styles.allocationSegment,
                 {
                   flex: Math.max(row.percentage, 2),
-                  backgroundColor: greenColors[index],
+                  backgroundColor: categoryColors[row.key],
                 },
               ]}
             />
           ))}
         </View>
         <Box gap={1}>
-          {rows.map((row, index) => (
+          {rows.map((row) => (
             <Pressable
               key={row.key}
               onPress={row.onPress}
@@ -221,7 +222,10 @@ const AllocationSectionContent = ({
               ]}
             >
               <View
-                style={[styles.dot, { backgroundColor: greenColors[index] }]}
+                style={[
+                  styles.dot,
+                  { backgroundColor: categoryColors[row.key] },
+                ]}
               />
               <View style={styles.label}>
                 <Text

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -8,13 +8,16 @@ import {
   SectionDivider,
   SensitiveText,
   SensitiveTextLength,
-  Tag,
-  TagSeverity,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { brandColor } from '@metamask/design-tokens';
+import TagBase from '../../../../../component-library/base-components/TagBase';
+import {
+  TagSeverity,
+  TagShape,
+} from '../../../../../component-library/base-components/TagBase/TagBase.types';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -48,11 +51,11 @@ interface AllocationRow {
 }
 
 const ALLOCATION_RANK_COLORS = [
-  brandColor.green700,
-  brandColor.green500,
-  brandColor.green300,
-  brandColor.lime300,
-  brandColor.green100,
+  brandColor.blue600,
+  brandColor.blue500,
+  brandColor.blue300,
+  brandColor.indigo300,
+  brandColor.blue100,
 ] as const;
 
 const styles = StyleSheet.create({
@@ -246,9 +249,12 @@ const AllocationSectionContent = ({
                     </Text>
                   </Text>
                   {row.apy !== undefined && row.apy > 0 ? (
-                    <Tag severity={TagSeverity.Success}>
+                    <TagBase
+                      severity={TagSeverity.Success}
+                      shape={TagShape.Rectangle}
+                    >
                       {`${row.apy}% APY`}
-                    </Tag>
+                    </TagBase>
                   ) : null}
                 </View>
               </View>

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  FontWeight,
+  SectionDivider,
+  SensitiveText,
+  SensitiveTextLength,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
+import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import useMoneyAccountInfo from '../../../../UI/Money/hooks/useMoneyAccountInfo';
+import { useMoneyNavigation } from '../../../../UI/Money/hooks/useMoneyNavigation';
+import { useDeFiPositionsForHomepage } from '../DeFi/hooks';
+import { usePredictPositionsForHomepage } from '../Predictions/hooks';
+import { usePredictionsCommonSetup } from '../Predictions/hooks/usePredictionsSectionNavigation';
+import { usePerpsPortfolioBalance } from '../../../../UI/Perps/hooks/usePerpsPortfolioBalance';
+import { PerpsConnectionProvider } from '../../../../UI/Perps/providers/PerpsConnectionProvider';
+import { PerpsStreamProvider } from '../../../../UI/Perps/providers/PerpsStreamManager';
+import { selectPerpsEnabledFlag } from '../../../../UI/Perps';
+import { buildAllocationValues } from './allocationUtils';
+import { AllocationSectionTestIds } from './AllocationSection.testIds';
+
+interface AllocationSectionContentProps {
+  perpsBalance: number;
+}
+
+interface AllocationRow {
+  key: 'money' | 'tokens' | 'perpetuals' | 'predictions' | 'defi';
+  label: string;
+  value: number;
+  percentage: number;
+  apy?: number;
+  onPress: () => void;
+}
+
+const GREEN_ALPHAS = ['', 'D6', 'AD', '84', '5C'];
+
+const styles = StyleSheet.create({
+  allocationBar: {
+    flexDirection: 'row',
+    gap: 4,
+    height: 8,
+    overflow: 'hidden',
+  },
+  allocationSegment: {
+    minWidth: 4,
+    borderRadius: 4,
+  },
+  row: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  rowPressed: {
+    opacity: 0.65,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  label: {
+    flex: 1,
+    minWidth: 0,
+  },
+});
+
+const AllocationSectionContent = ({
+  perpsBalance,
+}: AllocationSectionContentProps) => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const { colors } = useTheme();
+  const { formatCurrency } = useFormatters();
+  const privacyMode = useSelector(selectPrivacyMode);
+  const accountGroupBalance = useSelector(
+    selectAccountGroupBalanceForEmptyState,
+  );
+  const { totalFiatRaw, apyPercent } = useMoneyAccountBalance();
+  const { hasMoneyAccount } = useMoneyAccountInfo();
+  const { navigateToMoneyHome } = useMoneyNavigation();
+  const { handleViewAllFromPositions, isPredictEnabled } =
+    usePredictionsCommonSetup();
+  const { positions: predictPositions } = usePredictPositionsForHomepage({
+    enabled: isPredictEnabled,
+  });
+  const { positions: defiPositions } = useDeFiPositionsForHomepage(
+    Number.MAX_SAFE_INTEGER,
+  );
+
+  const currency = accountGroupBalance?.userCurrency ?? 'USD';
+  const tokenBalance = accountGroupBalance?.totalBalanceInUserCurrency ?? 0;
+  const moneyBalance = hasMoneyAccount
+    ? Number.parseFloat(totalFiatRaw ?? '0')
+    : 0;
+  const predictionsBalance = predictPositions.reduce(
+    (sum, position) => sum + Math.max(position.currentValue ?? 0, 0),
+    0,
+  );
+  const defiBalance = defiPositions.reduce(
+    (sum, position) =>
+      sum +
+      Math.max(
+        Number(position.protocolAggregate.aggregatedMarketValue ?? 0),
+        0,
+      ),
+    0,
+  );
+
+  const navigateToTokens = useCallback(() => {
+    navigation.navigate(Routes.WALLET.TOKENS_FULL_VIEW);
+  }, [navigation]);
+  const navigateToPerps = useCallback(() => {
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'home_section' },
+    } as never);
+  }, [navigation]);
+  const navigateToDeFi = useCallback(() => {
+    navigation.navigate(Routes.WALLET.DEFI_FULL_VIEW as never);
+  }, [navigation]);
+
+  const rows = useMemo(() => {
+    const allocations = buildAllocationValues([
+      { key: 'money', value: moneyBalance },
+      { key: 'tokens', value: tokenBalance },
+      { key: 'perpetuals', value: perpsBalance },
+      { key: 'predictions', value: predictionsBalance },
+      { key: 'defi', value: defiBalance },
+    ]);
+    const navigationByKey = {
+      money: navigateToMoneyHome,
+      tokens: navigateToTokens,
+      perpetuals: navigateToPerps,
+      predictions: handleViewAllFromPositions,
+      defi: navigateToDeFi,
+    };
+
+    return allocations.map(({ key, value, percentage }) => ({
+      key,
+      label: strings(`homepage.sections.${key}`),
+      value,
+      percentage,
+      apy: key === 'money' ? apyPercent : undefined,
+      onPress: navigationByKey[key as keyof typeof navigationByKey],
+    })) as AllocationRow[];
+  }, [
+    apyPercent,
+    defiBalance,
+    handleViewAllFromPositions,
+    moneyBalance,
+    navigateToDeFi,
+    navigateToMoneyHome,
+    navigateToPerps,
+    navigateToTokens,
+    perpsBalance,
+    predictionsBalance,
+    tokenBalance,
+  ]);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const greenColors = rows.map(
+    (_row, index) =>
+      `${colors.success.default}${GREEN_ALPHAS[index] ?? GREEN_ALPHAS[GREEN_ALPHAS.length - 1]}`,
+  );
+
+  return (
+    <View testID={AllocationSectionTestIds.CONTAINER}>
+      <SectionDivider />
+      <Box paddingHorizontal={4} paddingVertical={4} gap={4}>
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
+          {strings('homepage.sections.allocation')}
+        </Text>
+        <View
+          style={styles.allocationBar}
+          testID={AllocationSectionTestIds.BAR}
+        >
+          {rows.map((row, index) => (
+            <View
+              key={row.key}
+              style={[
+                styles.allocationSegment,
+                {
+                  flex: Math.max(row.percentage, 2),
+                  backgroundColor: greenColors[index],
+                },
+              ]}
+            />
+          ))}
+        </View>
+        <Box gap={1}>
+          {rows.map((row, index) => (
+            <Pressable
+              key={row.key}
+              onPress={row.onPress}
+              testID={AllocationSectionTestIds.ROW(row.key)}
+              accessibilityRole="button"
+              accessibilityLabel={`${row.label}, ${row.percentage.toFixed(1)}%, ${formatCurrency(row.value, currency)}`}
+              style={({ pressed }) => [
+                styles.row,
+                pressed && styles.rowPressed,
+              ]}
+            >
+              <View
+                style={[styles.dot, { backgroundColor: greenColors[index] }]}
+              />
+              <View style={styles.label}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                  numberOfLines={1}
+                >
+                  {row.label}
+                  <Text color={TextColor.TextAlternative}>
+                    {` · ${row.percentage.toFixed(1)}%`}
+                  </Text>
+                  {row.apy !== undefined && row.apy > 0 ? (
+                    <Text color={TextColor.SuccessDefault}>
+                      {` · ${row.apy}% APY`}
+                    </Text>
+                  ) : null}
+                </Text>
+              </View>
+              <SensitiveText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Medium}
+                numberOfLines={1}
+              >
+                {formatCurrency(row.value, currency)}
+              </SensitiveText>
+            </Pressable>
+          ))}
+        </Box>
+      </Box>
+    </View>
+  );
+};
+
+const AllocationSectionWithPerps = () => {
+  const { perpsBalance } = usePerpsPortfolioBalance();
+  return <AllocationSectionContent perpsBalance={perpsBalance} />;
+};
+
+const AllocationSection = () => {
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  if (!isPerpsEnabled) {
+    return <AllocationSectionContent perpsBalance={0} />;
+  }
+
+  return (
+    <PerpsConnectionProvider suppressErrorView>
+      <PerpsStreamProvider>
+        <AllocationSectionWithPerps />
+      </PerpsStreamProvider>
+    </PerpsConnectionProvider>
+  );
+};
+
+export default AllocationSection;

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -12,10 +12,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { brandColor } from '@metamask/design-tokens';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
-import { useTheme } from '../../../../../util/theme';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
@@ -80,7 +80,6 @@ const AllocationSectionContent = ({
   perpsBalance,
 }: AllocationSectionContentProps) => {
   const navigation = useNavigation<AppNavigationProp>();
-  const { colors } = useTheme();
   const { formatCurrency } = useFormatters();
   const privacyMode = useSelector(selectPrivacyMode);
   const accountGroupBalance = useSelector(
@@ -173,11 +172,11 @@ const AllocationSectionContent = ({
   }
 
   const categoryColors: Record<AllocationRow['key'], string> = {
-    money: colors.success.default,
-    tokens: colors.primary.default,
-    perpetuals: `${colors.success.default}B8`,
-    predictions: `${colors.primary.default}A3`,
-    defi: `${colors.success.default}73`,
+    money: brandColor.green600,
+    tokens: brandColor.green500,
+    perpetuals: brandColor.green400,
+    predictions: brandColor.lime400,
+    defi: brandColor.green200,
   };
 
   return (

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -8,6 +8,8 @@ import {
   SectionDivider,
   SensitiveText,
   SensitiveTextLength,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -45,6 +47,14 @@ interface AllocationRow {
   onPress: () => void;
 }
 
+const ALLOCATION_RANK_COLORS = [
+  brandColor.green700,
+  brandColor.green500,
+  brandColor.green300,
+  brandColor.lime300,
+  brandColor.green100,
+] as const;
+
 const styles = StyleSheet.create({
   allocationBar: {
     flexDirection: 'row',
@@ -73,6 +83,11 @@ const styles = StyleSheet.create({
   label: {
     flex: 1,
     minWidth: 0,
+  },
+  labelLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
 });
 
@@ -171,14 +186,6 @@ const AllocationSectionContent = ({
     return null;
   }
 
-  const categoryColors: Record<AllocationRow['key'], string> = {
-    money: brandColor.green600,
-    tokens: brandColor.green500,
-    perpetuals: brandColor.green400,
-    predictions: brandColor.lime400,
-    defi: brandColor.green200,
-  };
-
   return (
     <View testID={AllocationSectionTestIds.CONTAINER}>
       <SectionDivider />
@@ -194,21 +201,21 @@ const AllocationSectionContent = ({
           style={styles.allocationBar}
           testID={AllocationSectionTestIds.BAR}
         >
-          {rows.map((row) => (
+          {rows.map((row, index) => (
             <View
               key={row.key}
               style={[
                 styles.allocationSegment,
                 {
                   flex: Math.max(row.percentage, 2),
-                  backgroundColor: categoryColors[row.key],
+                  backgroundColor: ALLOCATION_RANK_COLORS[index],
                 },
               ]}
             />
           ))}
         </View>
         <Box gap={1}>
-          {rows.map((row) => (
+          {rows.map((row, index) => (
             <Pressable
               key={row.key}
               onPress={row.onPress}
@@ -223,25 +230,27 @@ const AllocationSectionContent = ({
               <View
                 style={[
                   styles.dot,
-                  { backgroundColor: categoryColors[row.key] },
+                  { backgroundColor: ALLOCATION_RANK_COLORS[index] },
                 ]}
               />
               <View style={styles.label}>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                  numberOfLines={1}
-                >
-                  {row.label}
-                  <Text color={TextColor.TextAlternative}>
-                    {` · ${row.percentage.toFixed(1)}%`}
+                <View style={styles.labelLine}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                    numberOfLines={1}
+                  >
+                    {row.label}
+                    <Text color={TextColor.TextAlternative}>
+                      {` · ${row.percentage.toFixed(1)}%`}
+                    </Text>
                   </Text>
                   {row.apy !== undefined && row.apy > 0 ? (
-                    <Text color={TextColor.SuccessDefault}>
-                      {` · ${row.apy}% APY`}
-                    </Text>
+                    <Tag severity={TagSeverity.Success}>
+                      {`${row.apy}% APY`}
+                    </Tag>
                   ) : null}
-                </Text>
+                </View>
               </View>
               <SensitiveText
                 variant={TextVariant.BodyMd}

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
@@ -25,4 +25,14 @@ describe('buildAllocationValues', () => {
       ]),
     ).toEqual([]);
   });
+
+  it('orders categories from highest to lowest allocation', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 100 },
+        { key: 'tokens', value: 700 },
+        { key: 'perpetuals', value: 200 },
+      ]).map(({ key }) => key),
+    ).toEqual(['tokens', 'perpetuals', 'money']);
+  });
 });

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
@@ -1,0 +1,28 @@
+import { buildAllocationValues } from './allocationUtils';
+
+describe('buildAllocationValues', () => {
+  it('omits empty and invalid categories and calculates percentages', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 4000 },
+        { key: 'tokens', value: 3000 },
+        { key: 'perpetuals', value: 0 },
+        { key: 'predictions', value: Number.NaN },
+        { key: 'defi', value: 1000 },
+      ]),
+    ).toEqual([
+      { key: 'money', value: 4000, percentage: 50 },
+      { key: 'tokens', value: 3000, percentage: 37.5 },
+      { key: 'defi', value: 1000, percentage: 12.5 },
+    ]);
+  });
+
+  it('returns no rows when the wallet has no allocations', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 0 },
+        { key: 'tokens', value: -1 },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
@@ -19,8 +19,10 @@ export const buildAllocationValues = (
     return [];
   }
 
-  return positiveValues.map((item) => ({
-    ...item,
-    percentage: (item.value / total) * 100,
-  }));
+  return positiveValues
+    .map((item) => ({
+      ...item,
+      percentage: (item.value / total) * 100,
+    }))
+    .sort((a, b) => b.percentage - a.percentage);
 };

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
@@ -1,0 +1,26 @@
+export interface AllocationValue {
+  key: string;
+  value: number;
+}
+
+export interface AllocationValueWithPercentage extends AllocationValue {
+  percentage: number;
+}
+
+export const buildAllocationValues = (
+  values: AllocationValue[],
+): AllocationValueWithPercentage[] => {
+  const positiveValues = values.filter(
+    ({ value }) => Number.isFinite(value) && value > 0,
+  );
+  const total = positiveValues.reduce((sum, { value }) => sum + value, 0);
+
+  if (total === 0) {
+    return [];
+  }
+
+  return positiveValues.map((item) => ({
+    ...item,
+    percentage: (item.value / total) * 100,
+  }));
+};

--- a/app/components/Views/Homepage/Sections/Allocation/index.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AllocationSection';

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -60,6 +60,7 @@ import {
   ButtonIconSize,
   IconColor as MMDSIconColor,
   IconName as MMDSIconName,
+  SectionDivider,
   Text as CustomText,
   TextColor,
 } from '@metamask/design-system-react-native';
@@ -1024,7 +1025,12 @@ const Wallet = ({
       {walletHomeMainAssetDetailsActions}
       {/* Hide growth banners when money account is enabled but user is geo-blocked */}
       {(!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
-        homeGrowthBannerContent}
+        homeGrowthBannerContent && (
+          <>
+            <SectionDivider />
+            {homeGrowthBannerContent}
+          </>
+        )}
       {homepageDiscoveryPills}
       {isMoneyAccountVisible && <MoneyBalanceCard />}
     </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10514,6 +10514,7 @@
       "traders": "Traders"
     },
     "sections": {
+      "allocation": "Allocation",
       "money": "Money",
       "money_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Money section on the homepage.",
       "money_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",


### PR DESCRIPTION
## **Description**

Adds a data-driven Allocation section to the wallet homepage between the portfolio header content and Tokens. The section aggregates positive balances across Money, Tokens, Perpetuals, Predictions, and DeFi, displays each visible category's proportional percentage in a segmented green bar, and keeps every row tappable without a trailing arrow. Categories with zero or unavailable balances are omitted, and the entire section stays hidden when no allocation is available. Fiat amounts continue to respect privacy mode.

## **Changelog**

CHANGELOG entry: Added a portfolio allocation summary to the wallet homepage

## **Related issues**

Refs: N/A - homepage allocation design exploration

## **Manual testing steps**

```gherkin
Feature: Wallet homepage allocation

  Scenario: user has balances in supported portfolio categories
    Given the wallet is unlocked with a positive balance in one or more of Money, Tokens, Perpetuals, Predictions, or DeFi

    When the user opens the wallet homepage
    Then Allocation appears above Tokens
    And only positive-balance categories are shown
    And each category displays its fiat value and percentage of the visible allocation total
    And the green graph segments are proportional to those percentages
    And tapping a category row opens that product's existing page

  Scenario: user has no supported allocation
    Given every supported allocation category has a zero or unavailable balance

    When the user opens the wallet homepage
    Then the Allocation section is not shown
```

## **Screenshots/Recordings**

### **Before**

N/A - new section.

### **After**

N/A for this draft. The section was exercised in the iOS Expo development build; final post-unlock capture still needs to be attached.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn jest app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts --runInBand --verbose`
- Targeted ESLint for the changed TypeScript files
- `yarn lint:tsc`
- `git diff --check`
- iOS Expo artifact and Metro bundle from matching upstream commit `d233a22`

Note: one combined targeted lint invocation exhausted Node's default heap after the Jest pass; rerunning ESLint directly with an 8 GB heap completed successfully with no findings.
