### PR TITLE
Refine wallet homepage layout and discovery

### DIFF
--- a/app/components/UI/BrazeBanner/BrazeBanner.test.tsx
+++ b/app/components/UI/BrazeBanner/BrazeBanner.test.tsx
@@ -301,6 +301,24 @@ describe('BrazeBanner', () => {
     assertBannerState(queryByTestId, 'empty');
   });
 
+  it('reports rendered visibility and dismissal to its parent', () => {
+    const onVisibilityChange = jest.fn();
+    const { getByTestId } = render(
+      <BrazeBanner
+        placementId={TEST_PLACEMENT_ID}
+        onVisibilityChange={onVisibilityChange}
+      />,
+    );
+
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(false);
+
+    fireBannerEvent([makeBanner()]);
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(true);
+
+    fireEvent.press(getByTestId(BRAZE_BANNER_TEST_IDS.DISMISS_BUTTON));
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('dispatches setLastDismissedBrazeBanner on dismiss when banner_name and dismissable:true are set', () => {
     const { getByTestId } = render(
       <BrazeBanner placementId={TEST_PLACEMENT_ID} />,

--- a/app/components/UI/BrazeBanner/BrazeBanner.tsx
+++ b/app/components/UI/BrazeBanner/BrazeBanner.tsx
@@ -16,6 +16,7 @@ import BrazeBannerCard from './BrazeBannerCard';
 
 interface BrazeBannerProps {
   placementId: string;
+  onVisibilityChange?: (isVisible: boolean) => void;
 }
 
 /**
@@ -31,7 +32,7 @@ interface BrazeBannerProps {
  * - `empty`     → returns null (no campaign / timeout reached)
  * - `dismissed` → returns null immediately, no skeleton shown again
  */
-const BrazeBanner = ({ placementId }: BrazeBannerProps) => {
+const BrazeBanner = ({ placementId, onVisibilityChange }: BrazeBannerProps) => {
   const tw = useTailwind();
   const {
     status,
@@ -49,6 +50,10 @@ const BrazeBanner = ({ placementId }: BrazeBannerProps) => {
       logBrazeBannerImpression(placementId, eventProperties);
     }
   }, [status, placementId, eventProperties]);
+
+  useEffect(() => {
+    onVisibilityChange?.(status === 'visible' && Boolean(body));
+  }, [body, onVisibilityChange, status]);
 
   const handlePress = useCallback(() => {
     if (!deeplink) return;
@@ -69,6 +74,11 @@ const BrazeBanner = ({ placementId }: BrazeBannerProps) => {
       });
   }, [deeplink, placementId]);
 
+  const handleDismiss = useCallback(() => {
+    onVisibilityChange?.(false);
+    dismiss();
+  }, [dismiss, onVisibilityChange]);
+
   if (status === 'empty' || status === 'dismissed' || status === 'loading')
     return null;
 
@@ -80,7 +90,7 @@ const BrazeBanner = ({ placementId }: BrazeBannerProps) => {
           body={body}
           imageUrl={imageUrl}
           ctaLabel={ctaLabel}
-          onDismiss={dismiss}
+          onDismiss={handleDismiss}
         />
       </Pressable>
     </Box>

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
@@ -101,11 +101,11 @@ describe('WalletHomeOnboardingSteps', () => {
       },
     });
 
-  it('does not render Skip on the fund step', () => {
+  it('does not render Close on the fund step', () => {
     const { queryByTestId } = renderSteps();
 
     expect(
-      queryByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      queryByTestId(WalletHomeOnboardingStepsSelectors.CLOSE_BUTTON),
     ).toBeNull();
   });
 
@@ -322,13 +322,13 @@ describe('WalletHomeOnboardingSteps', () => {
     });
   });
 
-  it('advances from trade step when Skip is pressed', async () => {
+  it('advances from trade step when Close is pressed', async () => {
     const { getByTestId, store } = renderSteps({
       walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 1 },
     });
 
     fireEvent.press(
-      getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      getByTestId(WalletHomeOnboardingStepsSelectors.CLOSE_BUTTON),
     );
 
     await flushWalletHomeStepTransition();
@@ -489,7 +489,7 @@ describe('WalletHomeOnboardingSteps', () => {
     });
   });
 
-  it('does not invoke trade primary commit when Skip is pressed on trade step', async () => {
+  it('does not invoke trade primary commit when Close is pressed on trade step', async () => {
     const onTradePrimaryPress = jest.fn();
     const { getByTestId, store } = renderWithProvider(
       <WalletHomeOnboardingSteps
@@ -511,7 +511,7 @@ describe('WalletHomeOnboardingSteps', () => {
     );
 
     fireEvent.press(
-      getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      getByTestId(WalletHomeOnboardingStepsSelectors.CLOSE_BUTTON),
     );
 
     expect(onTradePrimaryPress).not.toHaveBeenCalled();
@@ -545,13 +545,13 @@ describe('WalletHomeOnboardingSteps', () => {
     });
   });
 
-  it('completes flow when Skip is pressed on last step', async () => {
+  it('completes flow when Close is pressed on last step', async () => {
     const { getByTestId, store } = renderSteps({
       walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 2 },
     });
 
     fireEvent.press(
-      getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      getByTestId(WalletHomeOnboardingStepsSelectors.CLOSE_BUTTON),
     );
 
     await act(async () => {
@@ -599,13 +599,10 @@ describe('WalletHomeOnboardingSteps', () => {
     expect(getByTestId(primaryTestId)).toBeDisabled();
   });
 
-  it('renders fund hero and progress for step 0', () => {
+  it('renders the fund hero for step 0', () => {
     const { getByTestId } = renderSteps();
 
     expect(getByTestId('steps-root-hero-fund')).toBeOnTheScreen();
-    expect(
-      getByTestId(WalletHomeOnboardingStepsSelectors.PROGRESS_LABEL),
-    ).toBeOnTheScreen();
   });
 
   it('fires checklist Rive outro before advancing from fund step', async () => {
@@ -674,10 +671,7 @@ describe('WalletHomeOnboardingSteps', () => {
     });
   });
 
-  describe('onboarding checklist progress bar', () => {
-    const progressTestId = WalletHomeOnboardingStepsSelectors.PROGRESS_LABEL;
-    const firstSegmentTestId = `${progressTestId}-segment-0`;
-
+  describe('onboarding checklist progress animation', () => {
     const renderWithOnboardingState = (onboardingOverrides?: {
       walletHomeOnboardingSteps?: {
         suppressedReason: null;
@@ -693,18 +687,6 @@ describe('WalletHomeOnboardingSteps', () => {
           engine: { backgroundState },
         },
       });
-
-    it('renders the continuous progress bar with checklist title and step counter', () => {
-      const { getByTestId, getByText, queryByTestId } =
-        renderWithOnboardingState();
-
-      expect(getByTestId(progressTestId)).toBeOnTheScreen();
-      expect(queryByTestId(firstSegmentTestId)).toBeNull();
-      expect(
-        getByText(strings('wallet.home_onboarding_steps.get_started_title')),
-      ).toBeOnTheScreen();
-      expect(getByText('1/3')).toBeOnTheScreen();
-    });
 
     it('animates continuous progress to 100% on last-step complete', () => {
       const { getByTestId } = renderWithOnboardingState({

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.testIds.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.testIds.ts
@@ -1,6 +1,5 @@
 export const WalletHomeOnboardingStepsSelectors = {
   CONTAINER: 'wallet-home-onboarding-steps',
-  PROGRESS_LABEL: 'wallet-home-onboarding-steps-progress',
-  SKIP_BUTTON: 'wallet-home-onboarding-steps-skip',
+  CLOSE_BUTTON: 'wallet-home-onboarding-steps-close',
   PRIMARY_BUTTON: 'wallet-home-onboarding-steps-primary',
 };

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
@@ -24,9 +24,11 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   Button,
+  ButtonIcon,
+  ButtonIconSize,
   ButtonSize,
-  ButtonVariant,
   FontWeight,
+  IconName,
   Text,
   TextColor,
   TextVariant,
@@ -39,7 +41,6 @@ import {
 } from '../../../actions/onboarding';
 import { selectWalletHomeOnboardingSteps } from '../../../selectors/onboarding';
 import { WalletHomeOnboardingStepsSelectors } from './WalletHomeOnboardingSteps.testIds';
-import WalletHomeOnboardingProgressBar from './WalletHomeOnboardingProgressBar';
 import { animateWalletHomeOnboardingProgressRatio } from './walletHomeOnboardingProgressAnimation';
 import Logger from '../../../util/Logger';
 import onboardChecklistV07Animation from '../../../animations/onboard_checklist_v07.riv';
@@ -93,9 +94,9 @@ export interface WalletHomeOnboardingStepsProps {
   onCoordinatedFlowExit?: () => Promise<void>;
   /** Pauses checklist Rive while the Wallet parent finishes the coordinated exit handoff. */
   suspendRiveForCurtain?: boolean;
-  /** Trade step: invoked when user taps Primary (before advancing). Skip does not call this. */
+  /** Trade step: invoked when user taps Primary (before advancing). Close does not call this. */
   onTradePrimaryPress?: () => void;
-  /** Notifications step: invoked when user taps Primary (before advancing). Skip does not call this. */
+  /** Notifications step: invoked when user taps Primary (before advancing). Close does not call this. */
   onNotificationsPrimaryPress?: () => void;
   /** Fund step: opens buy / on-ramp; advance runs only once {@link canAdvanceFundStepAfterBalance} is true. */
   onFundPrimaryPress?: () => void;
@@ -110,7 +111,7 @@ export interface WalletHomeOnboardingStepsProps {
  * Multi-step onboarding flow for newly onboarded users with zero aggregated balance.
  * Primary on trade/notifications with navigation callbacks defers advance until the user
  * returns to the wallet, briefly holds on the completed step, then runs outro + transition.
- * Skip advances immediately (no navigation).
+ * Close advances immediately (no navigation).
  * Step 1 (fund): Primary opens on-ramp when {@link onFundPrimaryPress} is set; advance to trade uses
  * the same outro + slide as other steps only after {@link canAdvanceFundStepAfterBalance} becomes true
  * (or immediately when that is already true after return). Incoming funds without leaving the wallet
@@ -129,6 +130,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
   const tw = useTailwind();
   const isFocused = useIsFocused();
   const checklistRiveRef = useRef<RiveRef>(null);
+  const isChecklistOutroPlayingRef = useRef(false);
   const prevSuspendRiveForCurtainRef = useRef(false);
   const [checklistFadeOpacity] = useState(() => new Animated.Value(1));
   const dispatch = useDispatch();
@@ -193,6 +195,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
    * autoplays before paint.
    */
   useLayoutEffect(() => {
+    isChecklistOutroPlayingRef.current = false;
     setSkipIntroAfterDeferredNavReturn(false);
   }, [stepIndex]);
 
@@ -329,7 +332,6 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     };
   }, [isAwaitingBalance, skipIntroAfterDeferredNavReturn]);
 
-  const totalSteps = WALLET_HOME_ONBOARDING_VISIBLE_STEPS.length;
   const currentStep =
     WALLET_HOME_ONBOARDING_VISIBLE_STEPS[visualStepIndexForProgress];
 
@@ -456,6 +458,8 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
       const rive = checklistRiveRef.current;
       if (rive) {
         try {
+          isChecklistOutroPlayingRef.current = true;
+          rive.play();
           rive.fireState(
             WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE,
             WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_OUTRO_TRIGGER,
@@ -676,14 +680,11 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     onTradePrimaryPress,
   ]);
 
-  const progressLabel = useMemo(
-    () =>
-      strings('wallet.home_onboarding_steps.progress_a11y', {
-        current: displayStepIndex + 1,
-        total: totalSteps,
-      }),
-    [displayStepIndex, totalSteps],
-  );
+  const handleChecklistRiveLoopEnd = useCallback(() => {
+    if (!isChecklistOutroPlayingRef.current) {
+      checklistRiveRef.current?.pause();
+    }
+  }, []);
 
   if (!currentStep) {
     return null;
@@ -718,6 +719,24 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
             importantForAccessibility="no-hide-descendants"
           />
         </View>
+        {currentStep.buttonLayout === 'skip_and_primary_row' ? (
+          <Box
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+            twClassName="absolute right-2 top-2 z-20 h-10 w-10"
+          >
+            <Box
+              pointerEvents="none"
+              twClassName="absolute inset-0 rounded-full bg-default opacity-40"
+            />
+            <ButtonIcon
+              iconName={IconName.Close}
+              size={ButtonIconSize.Sm}
+              onPress={goNextOrComplete}
+              testID={WalletHomeOnboardingStepsSelectors.CLOSE_BUTTON}
+            />
+          </Box>
+        ) : null}
         <Box
           flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
@@ -747,6 +766,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
               stateMachineName={
                 WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE
               }
+              onLoopEnd={handleChecklistRiveLoopEnd}
               testID={`${testID}-hero-${currentStep.kind}-rive`}
             />
           ) : null}
@@ -760,7 +780,11 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
         twClassName="w-full"
       >
         <Text
-          variant={TextVariant.HeadingLg}
+          variant={
+            currentStep.kind === 'fund'
+              ? TextVariant.HeadingLg
+              : TextVariant.HeadingMd
+          }
           color={TextColor.TextDefault}
           twClassName="w-full text-left"
         >
@@ -777,56 +801,19 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
       </Box>
 
       <Box flexDirection={BoxFlexDirection.Column} gap={3} twClassName="w-full">
-        {currentStep.buttonLayout === 'full_width_primary' ? (
-          <Button
-            size={ButtonSize.Lg}
-            onPress={handlePrimaryPress}
-            isFullWidth
-            isDisabled={
-              isStepTransitioning ||
-              isAwaitingBalance ||
-              isAwaitingDeferredNavResumeHold
-            }
-            testID={primaryTestID}
-          >
-            {walletHomeOnboardingPrimaryLabelForStep(currentStep.kind)}
-          </Button>
-        ) : (
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            gap={3}
-            twClassName="w-full"
-          >
-            <Button
-              variant={ButtonVariant.Secondary}
-              size={ButtonSize.Lg}
-              onPress={goNextOrComplete}
-              twClassName="min-w-0 flex-1"
-              isDisabled={
-                isStepTransitioning ||
-                isAwaitingBalance ||
-                isAwaitingDeferredNavResumeHold
-              }
-              testID={WalletHomeOnboardingStepsSelectors.SKIP_BUTTON}
-            >
-              {strings('wallet.home_onboarding_steps.skip')}
-            </Button>
-            <Button
-              size={ButtonSize.Lg}
-              onPress={handlePrimaryPress}
-              twClassName="min-w-0 flex-1"
-              isDisabled={
-                isStepTransitioning ||
-                isAwaitingBalance ||
-                isAwaitingDeferredNavResumeHold
-              }
-              testID={primaryTestID}
-            >
-              {walletHomeOnboardingPrimaryLabelForStep(currentStep.kind)}
-            </Button>
-          </Box>
-        )}
+        <Button
+          size={ButtonSize.Lg}
+          onPress={handlePrimaryPress}
+          isFullWidth
+          isDisabled={
+            isStepTransitioning ||
+            isAwaitingBalance ||
+            isAwaitingDeferredNavResumeHold
+          }
+          testID={primaryTestID}
+        >
+          {walletHomeOnboardingPrimaryLabelForStep(currentStep.kind)}
+        </Button>
       </Box>
     </>
   );
@@ -842,36 +829,6 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
         testID={testID}
         twClassName="rounded-2xl"
       >
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          gap={4}
-          twClassName="w-full"
-        >
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            gap={2}
-          >
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
-              {strings('wallet.home_onboarding_steps.get_started_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-              fontWeight={FontWeight.Medium}
-            >
-              {displayStepIndex + 1}/{totalSteps}
-            </Text>
-          </Box>
-
-          <WalletHomeOnboardingProgressBar
-            progressRatio={progressRatio}
-            accessibilityLabel={progressLabel}
-            testID={WalletHomeOnboardingStepsSelectors.PROGRESS_LABEL}
-          />
-        </Box>
-
         {/*
           Always use the same Animated.View wrapper for the step body. Switching between
           View vs Animated.View when `isStepTransitioning` flips on the last step remounted

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -16,6 +16,7 @@ import DeFiSection from './Sections/DeFi';
 import NFTsSection from './Sections/NFTs';
 import WatchlistSection from './Sections/Watchlist';
 import MoreSection from './Sections/More';
+import AllocationSection from './Sections/Allocation';
 import { SectionRefreshHandle } from './types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../Wallet/WalletView.testIds';
@@ -156,6 +157,7 @@ const Homepage = forwardRef<SectionRefreshHandle, object>((_props, ref) => {
       testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
       accessible={false}
     >
+      <AllocationSection />
       <TokensSection
         ref={tokensSectionRef}
         sectionIndex={getSectionIndex(HomeSectionNames.TOKENS)}

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -33,6 +33,7 @@ import { useNftDetection } from '../../hooks/useNftDetection';
 import { useThrottledFocusEffect } from '../../hooks/useThrottledFocusEffect';
 import { PerpsConnectionProvider } from '../../UI/Perps/providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager';
+import { HOMEPAGE_SECTION_GAP } from './constants';
 
 /**
  * Homepage component - Main view for the redesigned wallet homepage.
@@ -154,6 +155,7 @@ const Homepage = forwardRef<SectionRefreshHandle, object>((_props, ref) => {
   return (
     <Box
       marginBottom={8}
+      gap={HOMEPAGE_SECTION_GAP}
       testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
       accessible={false}
     >

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
@@ -1,5 +1,6 @@
 export const AllocationSectionTestIds = {
   CONTAINER: 'homepage-allocation-section',
   BAR: 'homepage-allocation-bar',
+  ADD_MONEY_BUTTON: 'homepage-allocation-add-money-button',
   ROW: (key: string) => `homepage-allocation-row-${key}`,
 };

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.testIds.ts
@@ -1,0 +1,5 @@
+export const AllocationSectionTestIds = {
+  CONTAINER: 'homepage-allocation-section',
+  BAR: 'homepage-allocation-bar',
+  ROW: (key: string) => `homepage-allocation-row-${key}`,
+};

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -45,8 +45,6 @@ interface AllocationRow {
   onPress: () => void;
 }
 
-const GREEN_ALPHAS = ['', 'D6', 'AD', '84', '5C'];
-
 const styles = StyleSheet.create({
   allocationBar: {
     flexDirection: 'row',
@@ -174,10 +172,13 @@ const AllocationSectionContent = ({
     return null;
   }
 
-  const greenColors = rows.map(
-    (_row, index) =>
-      `${colors.success.default}${GREEN_ALPHAS[index] ?? GREEN_ALPHAS[GREEN_ALPHAS.length - 1]}`,
-  );
+  const categoryColors: Record<AllocationRow['key'], string> = {
+    money: colors.success.default,
+    tokens: colors.primary.default,
+    perpetuals: `${colors.success.default}B8`,
+    predictions: `${colors.primary.default}A3`,
+    defi: `${colors.success.default}73`,
+  };
 
   return (
     <View testID={AllocationSectionTestIds.CONTAINER}>
@@ -194,21 +195,21 @@ const AllocationSectionContent = ({
           style={styles.allocationBar}
           testID={AllocationSectionTestIds.BAR}
         >
-          {rows.map((row, index) => (
+          {rows.map((row) => (
             <View
               key={row.key}
               style={[
                 styles.allocationSegment,
                 {
                   flex: Math.max(row.percentage, 2),
-                  backgroundColor: greenColors[index],
+                  backgroundColor: categoryColors[row.key],
                 },
               ]}
             />
           ))}
         </View>
         <Box gap={1}>
-          {rows.map((row, index) => (
+          {rows.map((row) => (
             <Pressable
               key={row.key}
               onPress={row.onPress}
@@ -221,7 +222,10 @@ const AllocationSectionContent = ({
               ]}
             >
               <View
-                style={[styles.dot, { backgroundColor: greenColors[index] }]}
+                style={[
+                  styles.dot,
+                  { backgroundColor: categoryColors[row.key] },
+                ]}
               />
               <View style={styles.label}>
                 <Text

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -8,13 +8,16 @@ import {
   SectionDivider,
   SensitiveText,
   SensitiveTextLength,
-  Tag,
-  TagSeverity,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { brandColor } from '@metamask/design-tokens';
+import TagBase from '../../../../../component-library/base-components/TagBase';
+import {
+  TagSeverity,
+  TagShape,
+} from '../../../../../component-library/base-components/TagBase/TagBase.types';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -48,11 +51,11 @@ interface AllocationRow {
 }
 
 const ALLOCATION_RANK_COLORS = [
-  brandColor.green700,
-  brandColor.green500,
-  brandColor.green300,
-  brandColor.lime300,
-  brandColor.green100,
+  brandColor.blue600,
+  brandColor.blue500,
+  brandColor.blue300,
+  brandColor.indigo300,
+  brandColor.blue100,
 ] as const;
 
 const styles = StyleSheet.create({
@@ -246,9 +249,12 @@ const AllocationSectionContent = ({
                     </Text>
                   </Text>
                   {row.apy !== undefined && row.apy > 0 ? (
-                    <Tag severity={TagSeverity.Success}>
+                    <TagBase
+                      severity={TagSeverity.Success}
+                      shape={TagShape.Rectangle}
+                    >
                       {`${row.apy}% APY`}
-                    </Tag>
+                    </TagBase>
                   ) : null}
                 </View>
               </View>

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -4,8 +4,9 @@ import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import {
   Box,
-  FontWeight,
-  SectionDivider,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   SensitiveText,
   SensitiveTextLength,
   Text,
@@ -47,6 +48,7 @@ interface AllocationRow {
   value: number;
   percentage: number;
   apy?: number;
+  showAddAction?: boolean;
   onPress: () => void;
 }
 
@@ -163,7 +165,7 @@ const AllocationSectionContent = ({
       defi: navigateToDeFi,
     };
 
-    return allocations.map(({ key, value, percentage }) => ({
+    const allocationRows = allocations.map(({ key, value, percentage }) => ({
       key,
       label: strings(`homepage.sections.${key}`),
       value,
@@ -171,6 +173,20 @@ const AllocationSectionContent = ({
       apy: key === 'money' ? apyPercent : undefined,
       onPress: navigationByKey[key as keyof typeof navigationByKey],
     })) as AllocationRow[];
+
+    if (moneyBalance <= 0) {
+      allocationRows.push({
+        key: 'money',
+        label: strings('homepage.sections.money'),
+        value: 0,
+        percentage: 0,
+        apy: apyPercent,
+        showAddAction: true,
+        onPress: navigateToMoneyHome,
+      });
+    }
+
+    return allocationRows;
   }, [
     apyPercent,
     defiBalance,
@@ -189,34 +205,33 @@ const AllocationSectionContent = ({
     return null;
   }
 
+  const allocatedRows = rows.filter((row) => row.percentage > 0);
+
   return (
     <View testID={AllocationSectionTestIds.CONTAINER}>
-      <SectionDivider />
-      <Box paddingHorizontal={4} paddingVertical={4} gap={4}>
-        <Text
-          variant={TextVariant.HeadingMd}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextDefault}
-        >
+      <Box paddingHorizontal={4} paddingTop={6} paddingBottom={3} gap={4}>
+        <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
           {strings('homepage.sections.allocation')}
         </Text>
-        <View
-          style={styles.allocationBar}
-          testID={AllocationSectionTestIds.BAR}
-        >
-          {rows.map((row, index) => (
-            <View
-              key={row.key}
-              style={[
-                styles.allocationSegment,
-                {
-                  flex: Math.max(row.percentage, 2),
-                  backgroundColor: ALLOCATION_RANK_COLORS[index],
-                },
-              ]}
-            />
-          ))}
-        </View>
+        {allocatedRows.length > 0 ? (
+          <View
+            style={styles.allocationBar}
+            testID={AllocationSectionTestIds.BAR}
+          >
+            {allocatedRows.map((row, index) => (
+              <View
+                key={row.key}
+                style={[
+                  styles.allocationSegment,
+                  {
+                    flex: Math.max(row.percentage, 2),
+                    backgroundColor: ALLOCATION_RANK_COLORS[index],
+                  },
+                ]}
+              />
+            ))}
+          </View>
+        ) : null}
         <Box gap={1}>
           {rows.map((row, index) => (
             <Pressable
@@ -224,7 +239,11 @@ const AllocationSectionContent = ({
               onPress={row.onPress}
               testID={AllocationSectionTestIds.ROW(row.key)}
               accessibilityRole="button"
-              accessibilityLabel={`${row.label}, ${row.percentage.toFixed(1)}%, ${formatCurrency(row.value, currency)}`}
+              accessibilityLabel={
+                row.showAddAction
+                  ? `${row.label}, ${strings('money.action.add')}`
+                  : `${row.label}, ${row.percentage.toFixed(1)}%, ${formatCurrency(row.value, currency)}`
+              }
               style={({ pressed }) => [
                 styles.row,
                 pressed && styles.rowPressed,
@@ -244,9 +263,11 @@ const AllocationSectionContent = ({
                     numberOfLines={1}
                   >
                     {row.label}
-                    <Text color={TextColor.TextAlternative}>
-                      {` · ${row.percentage.toFixed(1)}%`}
-                    </Text>
+                    {!row.showAddAction ? (
+                      <Text color={TextColor.TextAlternative}>
+                        {` · ${row.percentage.toFixed(1)}%`}
+                      </Text>
+                    ) : null}
                   </Text>
                   {row.apy !== undefined && row.apy > 0 ? (
                     <TagBase
@@ -258,15 +279,27 @@ const AllocationSectionContent = ({
                   ) : null}
                 </View>
               </View>
-              <SensitiveText
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextDefault}
-                isHidden={privacyMode}
-                length={SensitiveTextLength.Medium}
-                numberOfLines={1}
-              >
-                {formatCurrency(row.value, currency)}
-              </SensitiveText>
+              {row.showAddAction ? (
+                <Button
+                  size={ButtonSize.Sm}
+                  variant={ButtonVariant.Secondary}
+                  onPress={row.onPress}
+                  twClassName="self-center"
+                  testID={AllocationSectionTestIds.ADD_MONEY_BUTTON}
+                >
+                  {strings('money.action.add')}
+                </Button>
+              ) : (
+                <SensitiveText
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                  isHidden={privacyMode}
+                  length={SensitiveTextLength.Medium}
+                  numberOfLines={1}
+                >
+                  {formatCurrency(row.value, currency)}
+                </SensitiveText>
+              )}
             </Pressable>
           ))}
         </Box>

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -174,6 +174,10 @@ const AllocationSectionContent = ({
       onPress: navigationByKey[key as keyof typeof navigationByKey],
     })) as AllocationRow[];
 
+    if (allocationRows.length === 0) {
+      return allocationRows;
+    }
+
     if (moneyBalance <= 0) {
       allocationRows.push({
         key: 'money',

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -1,0 +1,281 @@
+import React, { useCallback, useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  FontWeight,
+  SectionDivider,
+  SensitiveText,
+  SensitiveTextLength,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { useTheme } from '../../../../../util/theme';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
+import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import useMoneyAccountInfo from '../../../../UI/Money/hooks/useMoneyAccountInfo';
+import { useMoneyNavigation } from '../../../../UI/Money/hooks/useMoneyNavigation';
+import { useDeFiPositionsForHomepage } from '../DeFi/hooks';
+import { usePredictPositionsForHomepage } from '../Predictions/hooks';
+import { usePredictionsCommonSetup } from '../Predictions/hooks/usePredictionsSectionNavigation';
+import { usePerpsPortfolioBalance } from '../../../../UI/Perps/hooks/usePerpsPortfolioBalance';
+import { PerpsConnectionProvider } from '../../../../UI/Perps/providers/PerpsConnectionProvider';
+import { PerpsStreamProvider } from '../../../../UI/Perps/providers/PerpsStreamManager';
+import { selectPerpsEnabledFlag } from '../../../../UI/Perps';
+import { buildAllocationValues } from './allocationUtils';
+import { AllocationSectionTestIds } from './AllocationSection.testIds';
+
+interface AllocationSectionContentProps {
+  perpsBalance: number;
+}
+
+interface AllocationRow {
+  key: 'money' | 'tokens' | 'perpetuals' | 'predictions' | 'defi';
+  label: string;
+  value: number;
+  percentage: number;
+  apy?: number;
+  onPress: () => void;
+}
+
+const GREEN_ALPHAS = ['', 'D6', 'AD', '84', '5C'];
+
+const styles = StyleSheet.create({
+  allocationBar: {
+    flexDirection: 'row',
+    gap: 4,
+    height: 8,
+    overflow: 'hidden',
+  },
+  allocationSegment: {
+    minWidth: 4,
+    borderRadius: 4,
+  },
+  row: {
+    minHeight: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  rowPressed: {
+    opacity: 0.65,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  label: {
+    flex: 1,
+    minWidth: 0,
+  },
+});
+
+const AllocationSectionContent = ({
+  perpsBalance,
+}: AllocationSectionContentProps) => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const { colors } = useTheme();
+  const { formatCurrency } = useFormatters();
+  const privacyMode = useSelector(selectPrivacyMode);
+  const accountGroupBalance = useSelector(
+    selectAccountGroupBalanceForEmptyState,
+  );
+  const { totalFiatRaw, apyPercent } = useMoneyAccountBalance();
+  const { hasMoneyAccount } = useMoneyAccountInfo();
+  const { navigateToMoneyHome } = useMoneyNavigation();
+  const { handleViewAllFromPositions, isPredictEnabled } =
+    usePredictionsCommonSetup();
+  const { positions: predictPositions } = usePredictPositionsForHomepage({
+    enabled: isPredictEnabled,
+  });
+  const { positions: defiPositions } = useDeFiPositionsForHomepage(
+    Number.MAX_SAFE_INTEGER,
+  );
+
+  const currency = accountGroupBalance?.userCurrency ?? 'USD';
+  const tokenBalance = accountGroupBalance?.totalBalanceInUserCurrency ?? 0;
+  const moneyBalance = hasMoneyAccount
+    ? Number.parseFloat(totalFiatRaw ?? '0')
+    : 0;
+  const predictionsBalance = predictPositions.reduce(
+    (sum, position) => sum + Math.max(position.currentValue ?? 0, 0),
+    0,
+  );
+  const defiBalance = defiPositions.reduce(
+    (sum, position) =>
+      sum +
+      Math.max(
+        Number(position.protocolAggregate.aggregatedMarketValue ?? 0),
+        0,
+      ),
+    0,
+  );
+
+  const navigateToTokens = useCallback(() => {
+    navigation.navigate(Routes.WALLET.TOKENS_FULL_VIEW);
+  }, [navigation]);
+  const navigateToPerps = useCallback(() => {
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'home_section' },
+    } as never);
+  }, [navigation]);
+  const navigateToDeFi = useCallback(() => {
+    navigation.navigate(Routes.WALLET.DEFI_FULL_VIEW as never);
+  }, [navigation]);
+
+  const rows = useMemo(() => {
+    const allocations = buildAllocationValues([
+      { key: 'money', value: moneyBalance },
+      { key: 'tokens', value: tokenBalance },
+      { key: 'perpetuals', value: perpsBalance },
+      { key: 'predictions', value: predictionsBalance },
+      { key: 'defi', value: defiBalance },
+    ]);
+    const navigationByKey = {
+      money: navigateToMoneyHome,
+      tokens: navigateToTokens,
+      perpetuals: navigateToPerps,
+      predictions: handleViewAllFromPositions,
+      defi: navigateToDeFi,
+    };
+
+    return allocations.map(({ key, value, percentage }) => ({
+      key,
+      label: strings(`homepage.sections.${key}`),
+      value,
+      percentage,
+      apy: key === 'money' ? apyPercent : undefined,
+      onPress: navigationByKey[key as keyof typeof navigationByKey],
+    })) as AllocationRow[];
+  }, [
+    apyPercent,
+    defiBalance,
+    handleViewAllFromPositions,
+    moneyBalance,
+    navigateToDeFi,
+    navigateToMoneyHome,
+    navigateToPerps,
+    navigateToTokens,
+    perpsBalance,
+    predictionsBalance,
+    tokenBalance,
+  ]);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const greenColors = rows.map(
+    (_row, index) =>
+      `${colors.success.default}${GREEN_ALPHAS[index] ?? GREEN_ALPHAS[GREEN_ALPHAS.length - 1]}`,
+  );
+
+  return (
+    <View testID={AllocationSectionTestIds.CONTAINER}>
+      <SectionDivider />
+      <Box paddingHorizontal={4} paddingVertical={4} gap={4}>
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
+          {strings('homepage.sections.allocation')}
+        </Text>
+        <View
+          style={styles.allocationBar}
+          testID={AllocationSectionTestIds.BAR}
+        >
+          {rows.map((row, index) => (
+            <View
+              key={row.key}
+              style={[
+                styles.allocationSegment,
+                {
+                  flex: Math.max(row.percentage, 2),
+                  backgroundColor: greenColors[index],
+                },
+              ]}
+            />
+          ))}
+        </View>
+        <Box gap={1}>
+          {rows.map((row, index) => (
+            <Pressable
+              key={row.key}
+              onPress={row.onPress}
+              testID={AllocationSectionTestIds.ROW(row.key)}
+              accessibilityRole="button"
+              accessibilityLabel={`${row.label}, ${row.percentage.toFixed(1)}%, ${formatCurrency(row.value, currency)}`}
+              style={({ pressed }) => [
+                styles.row,
+                pressed && styles.rowPressed,
+              ]}
+            >
+              <View
+                style={[styles.dot, { backgroundColor: greenColors[index] }]}
+              />
+              <View style={styles.label}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                  numberOfLines={1}
+                >
+                  {row.label}
+                  <Text color={TextColor.TextAlternative}>
+                    {` · ${row.percentage.toFixed(1)}%`}
+                  </Text>
+                  {row.apy !== undefined && row.apy > 0 ? (
+                    <Text color={TextColor.SuccessDefault}>
+                      {` · ${row.apy}% APY`}
+                    </Text>
+                  ) : null}
+                </Text>
+              </View>
+              <SensitiveText
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Medium}
+                numberOfLines={1}
+              >
+                {formatCurrency(row.value, currency)}
+              </SensitiveText>
+            </Pressable>
+          ))}
+        </Box>
+      </Box>
+    </View>
+  );
+};
+
+const AllocationSectionWithPerps = () => {
+  const { perpsBalance } = usePerpsPortfolioBalance();
+  return <AllocationSectionContent perpsBalance={perpsBalance} />;
+};
+
+const AllocationSection = () => {
+  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+
+  if (!isPerpsEnabled) {
+    return <AllocationSectionContent perpsBalance={0} />;
+  }
+
+  return (
+    <PerpsConnectionProvider suppressErrorView>
+      <PerpsStreamProvider>
+        <AllocationSectionWithPerps />
+      </PerpsStreamProvider>
+    </PerpsConnectionProvider>
+  );
+};
+
+export default AllocationSection;

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -12,10 +12,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { brandColor } from '@metamask/design-tokens';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
-import { useTheme } from '../../../../../util/theme';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { selectAccountGroupBalanceForEmptyState } from '../../../../../selectors/assets/balances';
@@ -80,7 +80,6 @@ const AllocationSectionContent = ({
   perpsBalance,
 }: AllocationSectionContentProps) => {
   const navigation = useNavigation<AppNavigationProp>();
-  const { colors } = useTheme();
   const { formatCurrency } = useFormatters();
   const privacyMode = useSelector(selectPrivacyMode);
   const accountGroupBalance = useSelector(
@@ -173,11 +172,11 @@ const AllocationSectionContent = ({
   }
 
   const categoryColors: Record<AllocationRow['key'], string> = {
-    money: colors.success.default,
-    tokens: colors.primary.default,
-    perpetuals: `${colors.success.default}B8`,
-    predictions: `${colors.primary.default}A3`,
-    defi: `${colors.success.default}73`,
+    money: brandColor.green600,
+    tokens: brandColor.green500,
+    perpetuals: brandColor.green400,
+    predictions: brandColor.lime400,
+    defi: brandColor.green200,
   };
 
   return (

--- a/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
+++ b/app/components/Views/Homepage/Sections/Allocation/AllocationSection.tsx
@@ -8,6 +8,8 @@ import {
   SectionDivider,
   SensitiveText,
   SensitiveTextLength,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -45,6 +47,14 @@ interface AllocationRow {
   onPress: () => void;
 }
 
+const ALLOCATION_RANK_COLORS = [
+  brandColor.green700,
+  brandColor.green500,
+  brandColor.green300,
+  brandColor.lime300,
+  brandColor.green100,
+] as const;
+
 const styles = StyleSheet.create({
   allocationBar: {
     flexDirection: 'row',
@@ -73,6 +83,11 @@ const styles = StyleSheet.create({
   label: {
     flex: 1,
     minWidth: 0,
+  },
+  labelLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
 });
 
@@ -171,14 +186,6 @@ const AllocationSectionContent = ({
     return null;
   }
 
-  const categoryColors: Record<AllocationRow['key'], string> = {
-    money: brandColor.green600,
-    tokens: brandColor.green500,
-    perpetuals: brandColor.green400,
-    predictions: brandColor.lime400,
-    defi: brandColor.green200,
-  };
-
   return (
     <View testID={AllocationSectionTestIds.CONTAINER}>
       <SectionDivider />
@@ -194,21 +201,21 @@ const AllocationSectionContent = ({
           style={styles.allocationBar}
           testID={AllocationSectionTestIds.BAR}
         >
-          {rows.map((row) => (
+          {rows.map((row, index) => (
             <View
               key={row.key}
               style={[
                 styles.allocationSegment,
                 {
                   flex: Math.max(row.percentage, 2),
-                  backgroundColor: categoryColors[row.key],
+                  backgroundColor: ALLOCATION_RANK_COLORS[index],
                 },
               ]}
             />
           ))}
         </View>
         <Box gap={1}>
-          {rows.map((row) => (
+          {rows.map((row, index) => (
             <Pressable
               key={row.key}
               onPress={row.onPress}
@@ -223,25 +230,27 @@ const AllocationSectionContent = ({
               <View
                 style={[
                   styles.dot,
-                  { backgroundColor: categoryColors[row.key] },
+                  { backgroundColor: ALLOCATION_RANK_COLORS[index] },
                 ]}
               />
               <View style={styles.label}>
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
-                  numberOfLines={1}
-                >
-                  {row.label}
-                  <Text color={TextColor.TextAlternative}>
-                    {` · ${row.percentage.toFixed(1)}%`}
+                <View style={styles.labelLine}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                    numberOfLines={1}
+                  >
+                    {row.label}
+                    <Text color={TextColor.TextAlternative}>
+                      {` · ${row.percentage.toFixed(1)}%`}
+                    </Text>
                   </Text>
                   {row.apy !== undefined && row.apy > 0 ? (
-                    <Text color={TextColor.SuccessDefault}>
-                      {` · ${row.apy}% APY`}
-                    </Text>
+                    <Tag severity={TagSeverity.Success}>
+                      {`${row.apy}% APY`}
+                    </Tag>
                   ) : null}
-                </Text>
+                </View>
               </View>
               <SensitiveText
                 variant={TextVariant.BodyMd}

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
@@ -25,4 +25,14 @@ describe('buildAllocationValues', () => {
       ]),
     ).toEqual([]);
   });
+
+  it('orders categories from highest to lowest allocation', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 100 },
+        { key: 'tokens', value: 700 },
+        { key: 'perpetuals', value: 200 },
+      ]).map(({ key }) => key),
+    ).toEqual(['tokens', 'perpetuals', 'money']);
+  });
 });

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.test.ts
@@ -1,0 +1,28 @@
+import { buildAllocationValues } from './allocationUtils';
+
+describe('buildAllocationValues', () => {
+  it('omits empty and invalid categories and calculates percentages', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 4000 },
+        { key: 'tokens', value: 3000 },
+        { key: 'perpetuals', value: 0 },
+        { key: 'predictions', value: Number.NaN },
+        { key: 'defi', value: 1000 },
+      ]),
+    ).toEqual([
+      { key: 'money', value: 4000, percentage: 50 },
+      { key: 'tokens', value: 3000, percentage: 37.5 },
+      { key: 'defi', value: 1000, percentage: 12.5 },
+    ]);
+  });
+
+  it('returns no rows when the wallet has no allocations', () => {
+    expect(
+      buildAllocationValues([
+        { key: 'money', value: 0 },
+        { key: 'tokens', value: -1 },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
@@ -19,8 +19,10 @@ export const buildAllocationValues = (
     return [];
   }
 
-  return positiveValues.map((item) => ({
-    ...item,
-    percentage: (item.value / total) * 100,
-  }));
+  return positiveValues
+    .map((item) => ({
+      ...item,
+      percentage: (item.value / total) * 100,
+    }))
+    .sort((a, b) => b.percentage - a.percentage);
 };

--- a/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/allocationUtils.ts
@@ -1,0 +1,26 @@
+export interface AllocationValue {
+  key: string;
+  value: number;
+}
+
+export interface AllocationValueWithPercentage extends AllocationValue {
+  percentage: number;
+}
+
+export const buildAllocationValues = (
+  values: AllocationValue[],
+): AllocationValueWithPercentage[] => {
+  const positiveValues = values.filter(
+    ({ value }) => Number.isFinite(value) && value > 0,
+  );
+  const total = positiveValues.reduce((sum, { value }) => sum + value, 0);
+
+  if (total === 0) {
+    return [];
+  }
+
+  return positiveValues.map((item) => ({
+    ...item,
+    percentage: (item.value / total) * 100,
+  }));
+};

--- a/app/components/Views/Homepage/Sections/Allocation/index.ts
+++ b/app/components/Views/Homepage/Sections/Allocation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AllocationSection';

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -11,11 +11,7 @@ import { useSelector } from 'react-redux';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
-import {
-  SectionDivider,
-  Box,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 import SectionRow from '../../components/SectionRow';
 import ErrorState from '../../components/ErrorState';
 import { SectionRefreshHandle } from '../../types';
@@ -154,7 +150,6 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
     if (!isLoading && hasError) {
       return (
         <View ref={sectionViewRef} onLayout={onLayout}>
-          <SectionDivider />
           <SectionHeader
             title={title}
             isInteractive
@@ -173,7 +168,6 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
-        <SectionDivider />
         <SectionHeader
           title={title}
           isInteractive

--- a/app/components/Views/Homepage/Sections/More/MoreSection.tsx
+++ b/app/components/Views/Homepage/Sections/More/MoreSection.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
@@ -21,6 +21,15 @@ import { strings } from '../../../../../../locales/i18n';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useSupportConsent } from '../../../../hooks/useSupportConsent';
 import { HomepageMoreSelectorsIDs } from '../../Homepage.testIds';
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: -20,
+  },
+  thickSectionDivider: {
+    borderTopWidth: 6,
+  },
+});
 
 const MoreSection = () => {
   const navigation = useNavigation<AppNavigationProp>();
@@ -82,8 +91,11 @@ const MoreSection = () => {
   }, [createEventBuilder, navigation, trackEvent, openSupportWithConsent]);
 
   return (
-    <View testID={HomepageMoreSelectorsIDs.HOMEPAGE_MORE_SECTION}>
-      <SectionDivider />
+    <View
+      style={styles.section}
+      testID={HomepageMoreSelectorsIDs.HOMEPAGE_MORE_SECTION}
+    >
+      <SectionDivider style={styles.thickSectionDivider} />
       <SectionHeader title={strings('homepage.sections.more.title')} />
       <ListItem
         isInteractive

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -12,7 +12,6 @@ import type { AppNavigationProp } from '../../../../../core/NavigationService/ty
 import {
   Box,
   BoxFlexDirection,
-  SectionDivider,
   SectionHeader,
 } from '@metamask/design-system-react-native';
 import SectionRow from '../../components/SectionRow';
@@ -105,7 +104,6 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
         <Box paddingBottom={3}>
-          <SectionDivider />
           <SectionHeader
             title={title}
             isInteractive

--- a/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import {
-  HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY,
-  HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS,
-  HomepagePerpsPillsEmptyVariant,
-} from '../../abTestConfig';
 import HomepagePerpsHomeSlot from './HomepagePerpsHomeSlot';
 
 jest.mock('@react-navigation/native', () => {
@@ -17,12 +12,6 @@ jest.mock('@react-navigation/native', () => {
     }),
   };
 });
-
-const mockUseABTest = jest.fn();
-jest.mock('../../../../../hooks', () => ({
-  useABTest: (...args: unknown[]) =>
-    Reflect.apply(mockUseABTest, undefined, args),
-}));
 
 jest.mock('./PerpsSection', () => {
   const ReactLib = jest.requireActual('react');
@@ -57,63 +46,13 @@ jest.mock('./PerpsSection', () => {
 });
 
 describe('HomepagePerpsHomeSlot', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('renders PerpsSection when experiment is control', () => {
-    mockUseABTest.mockImplementation((key: string) => {
-      if (key === HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY) {
-        return {
-          variant:
-            HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS[
-              HomepagePerpsPillsEmptyVariant.Control
-            ],
-          variantName: HomepagePerpsPillsEmptyVariant.Control,
-          isActive: true,
-        };
-      }
-      return {
-        variant: {},
-        variantName: 'control',
-        isActive: false,
-      };
-    });
-
-    renderWithProvider(
-      <HomepagePerpsHomeSlot sectionIndex={1} totalSectionsLoaded={5} />,
-    );
-
-    expect(screen.getByText('PerpsSection')).toBeOnTheScreen();
-    expect(screen.getByText('emptyStateContent:tiles')).toBeOnTheScreen();
-    expect(screen.getByText('emptyStateTitle:default')).toBeOnTheScreen();
-  });
-
-  it('asks PerpsSection to render pills for the empty state when experiment is treatment', () => {
-    mockUseABTest.mockImplementation((key: string) => {
-      if (key === HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY) {
-        return {
-          variant:
-            HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS[
-              HomepagePerpsPillsEmptyVariant.Treatment
-            ],
-          variantName: HomepagePerpsPillsEmptyVariant.Treatment,
-          isActive: true,
-        };
-      }
-      return {
-        variant: {},
-        variantName: 'control',
-        isActive: false,
-      };
-    });
-
+  it('asks PerpsSection to render Explore pills for the empty state', () => {
     renderWithProvider(
       <HomepagePerpsHomeSlot sectionIndex={1} totalSectionsLoaded={5} />,
     );
 
     expect(screen.getByText('PerpsSection')).toBeOnTheScreen();
     expect(screen.getByText('emptyStateContent:pills')).toBeOnTheScreen();
-    expect(screen.getByText('emptyStateTitle:Perps movers')).toBeOnTheScreen();
+    expect(screen.getByText('emptyStateTitle:default')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/HomepagePerpsHomeSlot.tsx
@@ -1,14 +1,7 @@
 import React, { forwardRef } from 'react';
-import { useABTest } from '../../../../../hooks';
-import {
-  HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY,
-  HOMEPAGE_PERPS_PILLS_EMPTY_AB_TEST_EXPOSURE_OPTIONS,
-  HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS,
-} from '../../abTestConfig';
 import type { SectionRefreshHandle } from '../../types';
 import type { PerpsSectionProps } from './PerpsSectionWithProvider';
 import PerpsSection from './PerpsSection';
-import { strings } from '../../../../../../locales/i18n';
 
 /**
  * Chooses the empty-state content for the homepage Perps section.
@@ -18,29 +11,9 @@ import { strings } from '../../../../../../locales/i18n';
 const HomepagePerpsHomeSlot = forwardRef<
   SectionRefreshHandle,
   PerpsSectionProps
->((props, ref) => {
-  const { variant: perpsPillsEmptyAbVariant } = useABTest(
-    HOMEPAGE_PERPS_PILLS_EMPTY_AB_KEY,
-    HOMEPAGE_PERPS_PILLS_EMPTY_VARIANTS,
-    HOMEPAGE_PERPS_PILLS_EMPTY_AB_TEST_EXPOSURE_OPTIONS,
-  );
-
-  const emptyStateUsesExplorePills =
-    perpsPillsEmptyAbVariant.showExplorePillsWhenEmpty;
-
-  if (!emptyStateUsesExplorePills) {
-    return <PerpsSection ref={ref} {...props} />;
-  }
-
-  return (
-    <PerpsSection
-      ref={ref}
-      {...props}
-      emptyStateContent="pills"
-      emptyStateTitleOverride={strings('trending.perps_movers')}
-    />
-  );
-});
+>((props, ref) => (
+  <PerpsSection ref={ref} {...props} emptyStateContent="pills" />
+));
 
 HomepagePerpsHomeSlot.displayName = 'HomepagePerpsHomeSlot';
 

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -8,11 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { View } from 'react-native';
-import {
-  Box,
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
@@ -308,13 +304,10 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       isLoading: isLoadingSection,
     });
 
-    const showsVerticalPositions = showSkeleton || pendingTrending || hasItems;
-
     if (connectionError) {
       return (
         <View ref={sectionViewRef} onLayout={onLayout}>
           <Box paddingBottom={3}>
-            <SectionDivider />
             <SectionHeader
               title={title}
               isInteractive
@@ -341,7 +334,6 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     const sectionContent = (
       <>
-        <SectionDivider />
         <SectionHeader
           title={title}
           isInteractive
@@ -403,11 +395,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
-        {showsVerticalPositions ? (
-          sectionContent
-        ) : (
-          <Box paddingBottom={3}>{sectionContent}</Box>
-        )}
+        {sectionContent}
       </View>
     );
   },

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsPillsRail.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsPillsRail.tsx
@@ -18,6 +18,7 @@ const PerpsPillsRail = ({
   <PillScrollList<PerpsFeedItem>
     data={data}
     isLoading={isLoading}
+    rowCount={3}
     wrapperTwClassName="bg-transparent py-3"
     renderItem={(item) => (
       <PerpsPillItem item={item} onNavigateToMarketDetails={onPressMarket} />

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../../../../Wallet/WalletView.testIds';
 import { strings } from '../../../../../../../locales/i18n';
@@ -47,7 +43,6 @@ const HomepagePredictPositions = ({
   <>
     {showHeader && (
       <>
-        <SectionDivider />
         <SectionHeader
           title={title}
           isInteractive

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingCarousel.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingCarousel.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import {
-  Box,
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../../../../Wallet/WalletView.testIds';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
@@ -48,7 +44,6 @@ const HomepagePredictTrendingCarousel = ({
 
   return (
     <>
-      <SectionDivider />
       <SectionHeader
         title={title}
         isInteractive

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import {
-  Box,
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -211,7 +207,6 @@ const HomepagePredictWorldCupDiscovery: React.FC<
 
   return (
     <>
-      <SectionDivider />
       <SectionHeader
         title={title}
         isInteractive

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -11,11 +11,7 @@ import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
-import {
-  SectionDivider,
-  Box,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 import ErrorState from '../../components/ErrorState';
 import Routes from '../../../../../constants/navigation/Routes';
 import SectionRow from '../../components/SectionRow';
@@ -207,9 +203,9 @@ const TokensSection = forwardRef<SectionRefreshHandle, TokensSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
-        <SectionDivider />
         <SectionHeader
           title={title}
+          twClassName="pt-0"
           isInteractive
           onPress={handleViewAllTokens}
           testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('tokens')}

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -1,8 +1,4 @@
-import {
-  Box,
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { Box, SectionHeader } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useNavigation } from '@react-navigation/native';
 import React, {
@@ -272,7 +268,6 @@ const TopTradersSection = forwardRef<
         testID="homepage-top-traders-section-root"
       >
         <Box paddingBottom={3}>
-          <SectionDivider />
           <SectionHeader
             title={title}
             isInteractive
@@ -300,7 +295,6 @@ const TopTradersSection = forwardRef<
         testID="homepage-top-traders-section-root"
       >
         <Box paddingBottom={3}>
-          <SectionDivider />
           <SectionHeader
             title={title}
             isInteractive

--- a/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.test.tsx
@@ -82,6 +82,27 @@ jest.mock(
   },
 );
 
+jest.mock('./components/PopularWatchlistTokens', () => {
+  const { Text } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: ReactActual.forwardRef(() =>
+      ReactActual.createElement(
+        ReactActual.Fragment,
+        null,
+        ['Ethereum', 'Bitcoin', 'Solana'].map((name) =>
+          ReactActual.createElement(
+            Text,
+            { key: name, testID: `popular-row-${name}` },
+            name,
+          ),
+        ),
+      ),
+    ),
+  };
+});
+
 jest.mock(
   '../../../../UI/Trending/hooks/useTrendingTokenPress/useTrendingTokenPress',
   () => ({
@@ -159,20 +180,21 @@ describe('WatchlistSection', () => {
     expect(getAllByTestId('trending-skeleton')).toHaveLength(3);
   });
 
-  it('shows empty state when watchlist has no items', () => {
+  it('shows three popular tokens when watchlist has no items', () => {
     mockUseTokenWatchlistQuery.mockReturnValue({
       data: [],
       isLoading: false,
       refetch: jest.fn(),
     });
 
-    const { getByTestId, getAllByText, getByText } = render(
+    const { getByTestId, queryByTestId } = render(
       <WatchlistSection sectionIndex={1} totalSectionsLoaded={5} />,
     );
 
-    expect(getByTestId('watchlist-empty-icon')).toBeDefined();
-    expect(getAllByText('Watchlist').length).toBeGreaterThanOrEqual(1);
-    expect(getByText('You have no watchlist items yet')).toBeDefined();
+    expect(getByTestId('popular-row-Ethereum')).toBeDefined();
+    expect(getByTestId('popular-row-Bitcoin')).toBeDefined();
+    expect(getByTestId('popular-row-Solana')).toBeDefined();
+    expect(queryByTestId('watchlist-empty-icon')).toBeNull();
   });
 
   it('renders up to 3 tokens when watchlist has items (newest first)', () => {

--- a/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/WatchlistSection.tsx
@@ -9,14 +9,11 @@ import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useSelector } from 'react-redux';
-import {
-  SectionDivider,
-  SectionHeader,
-} from '@metamask/design-system-react-native';
+import { SectionHeader } from '@metamask/design-system-react-native';
 import SectionRow from '../../components/SectionRow';
 import TrendingTokenRowItem from '../../../../UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem';
 import TrendingTokensSkeleton from '../../../../UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton';
-import WatchlistEmptyState from './components/WatchlistEmptyState';
+import PopularWatchlistTokens from './components/PopularWatchlistTokens';
 import { selectTokenWatchlistEnabled } from '../../../../UI/Assets/selectors/featureFlags';
 import { useTokenWatchlistQuery } from '../../../../UI/Assets/watchlist/hooks/useTokenWatchlistQuery';
 import { mapWatchlistTokenToTrendingAsset } from './utils/mapWatchlistTokenToTrendingAsset';
@@ -43,6 +40,7 @@ const WatchlistSection = forwardRef<
   WatchlistSectionProps
 >(({ sectionIndex, totalSectionsLoaded }, ref) => {
   const sectionViewRef = useRef<View>(null);
+  const popularTokensRef = useRef<SectionRefreshHandle>(null);
   const navigation = useNavigation<AppNavigationProp>();
   const isWatchlistEnabled = useSelector(selectTokenWatchlistEnabled);
   const { data, isLoading, refetch } = useTokenWatchlistQuery();
@@ -59,15 +57,16 @@ const WatchlistSection = forwardRef<
     [data],
   );
 
-  const isEmpty = !isLoading && displayTokens.length === 0;
-  const itemCount = displayTokens.length;
+  const isEmpty = false;
+  const itemCount =
+    displayTokens.length > 0 ? displayTokens.length : MAX_ITEMS_DISPLAYED;
 
   const handleSectionPress = useCallback(() => {
     navigation.navigate(Routes.WALLET.WATCHLIST_FULL_VIEW);
   }, [navigation]);
 
   const refresh = useCallback(async () => {
-    await refetch();
+    await Promise.all([refetch(), popularTokensRef.current?.refresh()]);
   }, [refetch]);
 
   useImperativeHandle(ref, () => ({ refresh }), [refresh]);
@@ -96,7 +95,6 @@ const WatchlistSection = forwardRef<
 
   return (
     <View ref={sectionViewRef} onLayout={onLayout}>
-      <SectionDivider />
       <SectionHeader
         title={title}
         isInteractive
@@ -108,8 +106,8 @@ const WatchlistSection = forwardRef<
           Array.from({ length: MAX_ITEMS_DISPLAYED }, (_, i) => (
             <TrendingTokensSkeleton key={`watchlist-skeleton-${i}`} />
           ))
-        ) : isEmpty ? (
-          <WatchlistEmptyState />
+        ) : displayTokens.length === 0 ? (
+          <PopularWatchlistTokens ref={popularTokensRef} />
         ) : (
           displayTokens.map((token, index) => (
             <TrendingTokenRowItem

--- a/app/components/Views/Homepage/Sections/Watchlist/components/PopularWatchlistTokens.tsx
+++ b/app/components/Views/Homepage/Sections/Watchlist/components/PopularWatchlistTokens.tsx
@@ -1,0 +1,53 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+} from 'react';
+import TrendingTokenRowItem from '../../../../../UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem';
+import TrendingTokensSkeleton from '../../../../../UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton';
+import { TokenDetailsSource } from '../../../../../UI/TokenDetails/constants/constants';
+import { useSuggestedWatchlistItemsQuery } from '../../../../../UI/Assets/watchlist/hooks/useSuggestedWatchlistItemsQuery';
+import type { SectionRefreshHandle } from '../../../types';
+import { mapWatchlistTokenToTrendingAsset } from '../utils/mapWatchlistTokenToTrendingAsset';
+
+const MAX_POPULAR_TOKENS = 3;
+
+const PopularWatchlistTokens = forwardRef<SectionRefreshHandle>(
+  (_props, ref) => {
+    const { data, isLoading, refetch } = useSuggestedWatchlistItemsQuery();
+
+    const tokens = useMemo(
+      () =>
+        (data ?? [])
+          .slice(0, MAX_POPULAR_TOKENS)
+          .map(mapWatchlistTokenToTrendingAsset),
+      [data],
+    );
+
+    const refresh = useCallback(async () => {
+      await refetch();
+    }, [refetch]);
+
+    useImperativeHandle(ref, () => ({ refresh }), [refresh]);
+
+    if (isLoading) {
+      return Array.from({ length: MAX_POPULAR_TOKENS }, (_, index) => (
+        <TrendingTokensSkeleton key={`popular-watchlist-skeleton-${index}`} />
+      ));
+    }
+
+    return tokens.map((token, index) => (
+      <TrendingTokenRowItem
+        key={token.assetId}
+        token={token}
+        position={index}
+        tokenDetailsSource={TokenDetailsSource.WatchlistHomepage}
+      />
+    ));
+  },
+);
+
+PopularWatchlistTokens.displayName = 'PopularWatchlistTokens';
+
+export default PopularWatchlistTokens;

--- a/app/components/Views/Homepage/constants.ts
+++ b/app/components/Views/Homepage/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Vertical spacing between top-level homepage sections.
+ * Design-system spacing unit 6 = 24 px.
+ */
+export const HOMEPAGE_SECTION_GAP = 6;

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -73,7 +73,7 @@ jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
 }));
 
 // Control Money account feature flag per test (default false so existing tests are unaffected)
-let mockMoneyAccountEnabled = false;
+const mockMoneyAccountEnabled = false;
 jest.mock('../../UI/Money/selectors/featureFlags', () => ({
   selectMoneyEnableMoneyAccountFlag: jest.fn(() => mockMoneyAccountEnabled),
 }));
@@ -82,19 +82,6 @@ const mockMoneyAccountGeoEligible = true;
 jest.mock('../../UI/Money/selectors/eligibility', () => ({
   selectIsMoneyAccountGeoEligible: jest.fn(() => mockMoneyAccountGeoEligible),
 }));
-
-// Mock MoneyBalanceCard so the integration test does not depend on its hooks/contexts.
-jest.mock('../../UI/Money/components/MoneyBalanceCard', () => {
-  const ReactMock = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: () =>
-      ReactMock.createElement(View, {
-        testID: 'money-balance-card-mock',
-      }),
-  };
-});
 
 // Mock NetworkConnectionBanner so the Wallet view's render does not depend on
 // NetworkController / controllerMessenger APIs. Without this, the banner hook
@@ -1820,36 +1807,5 @@ describe('useHomeDeepLinkEffects', () => {
 
     jest.advanceTimersByTime(PERFORMANCE_CONFIG.NavigationParamsDelayMs);
     assertCase(mocks);
-  });
-});
-
-describe('MoneyBalanceCard slot', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest
-      .mocked(useSelector)
-      .mockImplementation((callback: (state: unknown) => unknown) =>
-        callback(mockInitialState),
-      );
-  });
-
-  afterEach(() => {
-    mockMoneyAccountEnabled = false;
-  });
-
-  it('renders the MoneyBalanceCard when Money account is enabled', () => {
-    mockMoneyAccountEnabled = true;
-
-    const { getByTestId } = render(Wallet);
-
-    expect(getByTestId('money-balance-card-mock')).toBeOnTheScreen();
-  });
-
-  it('does not render the MoneyBalanceCard when Money account is disabled', () => {
-    mockMoneyAccountEnabled = false;
-
-    const { queryByTestId } = render(Wallet);
-
-    expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -45,7 +45,6 @@ import AddressCopy from '../../UI/AddressCopy';
 import CardButton from '../../UI/Card/components/CardButton';
 import { selectMoneyEnableMoneyAccountFlag } from '../../UI/Money/selectors/featureFlags';
 import { selectIsMoneyAccountGeoEligible } from '../../UI/Money/selectors/eligibility';
-import MoneyBalanceCard from '../../UI/Money/components/MoneyBalanceCard';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { createAccountSelectorNavDetails } from '../AccountSelector';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
@@ -201,7 +200,16 @@ const createStyles = ({ colors }: Theme) =>
     portfolioHeaderCluster: {
       flexDirection: 'column',
       gap: 16,
-      paddingBottom: 12,
+    },
+    growthBannerWithoutOnboarding: {
+      marginTop: 20,
+      marginBottom: 12,
+    },
+    homepageActionButtonsGrid: {
+      marginTop: 20,
+    },
+    homepageActionButtonsGridBeforeDiscovery: {
+      marginBottom: 20,
     },
     tabContainer: {
       flex: 1,
@@ -219,6 +227,9 @@ const createStyles = ({ colors }: Theme) =>
     },
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
+    },
+    thickSectionDivider: {
+      borderTopWidth: 6,
     },
     headerActionButtonsContainer: {
       flexDirection: 'row',
@@ -962,6 +973,9 @@ const Wallet = ({
         <Carousel style={styles.carousel} />
       </View>
     ) : null;
+  const isHomeGrowthBannerVisible =
+    (!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
+    Boolean(homeGrowthBannerContent);
 
   const bannerContent = (
     <View style={styles.banner}>
@@ -993,11 +1007,21 @@ const Wallet = ({
 
   const walletHomeMainAssetDetailsActions = showWalletHomeMainActions ? (
     actionButtonsGridVariant.layout === 'eightCircular' ? (
-      <HomepageActionButtonsGrid
-        onSend={onSendWithoutTracking}
-        onReceive={onReceiveWithoutTracking}
-        rowOrder={actionButtonsGridVariant.rowOrder}
-      />
+      <View
+        style={[
+          styles.homepageActionButtonsGrid,
+          !isHomeGrowthBannerVisible &&
+            (showDiscoveryPills
+              ? styles.homepageActionButtonsGridBeforeDiscovery
+              : undefined),
+        ]}
+      >
+        <HomepageActionButtonsGrid
+          onSend={onSendWithoutTracking}
+          onReceive={onReceiveWithoutTracking}
+          rowOrder={actionButtonsGridVariant.rowOrder}
+        />
+      </View>
     ) : (
       <AssetDetailsActions
         displayBuyButton={displayBuyButton}
@@ -1024,15 +1048,23 @@ const Wallet = ({
       <AccountGroupBalance {...walletHomeAccountGroupBalanceProps} />
       {walletHomeMainAssetDetailsActions}
       {/* Hide growth banners when money account is enabled but user is geo-blocked */}
-      {(!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
-        homeGrowthBannerContent && (
-          <>
-            <SectionDivider />
+      {isHomeGrowthBannerVisible && homeGrowthBannerContent && (
+        <>
+          {inWalletHomePostOnboardingFlow && (
+            <SectionDivider style={styles.thickSectionDivider} />
+          )}
+          <View
+            style={
+              !inWalletHomePostOnboardingFlow
+                ? styles.growthBannerWithoutOnboarding
+                : undefined
+            }
+          >
             {homeGrowthBannerContent}
-          </>
-        )}
+          </View>
+        </>
+      )}
       {homepageDiscoveryPills}
-      {isMoneyAccountVisible && <MoneyBalanceCard />}
     </View>
   );
 

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -15,6 +15,7 @@ import { useBalanceRefresh, useHomepageEntryPoint } from './hooks';
 import {
   ActivityIndicator,
   DeviceEventEmitter,
+  LayoutAnimation,
   Linking,
   RefreshControl,
   ScrollView,
@@ -208,8 +209,8 @@ const createStyles = ({ colors }: Theme) =>
     homepageActionButtonsGrid: {
       marginTop: 20,
     },
-    homepageActionButtonsGridBeforeDiscovery: {
-      marginBottom: 20,
+    homepageActionButtonsGridWithoutBanner: {
+      marginBottom: 12,
     },
     tabContainer: {
       flex: 1,
@@ -735,6 +736,28 @@ const Wallet = ({
   );
 
   const homeGrowthBanner = useHomeGrowthBanner();
+  const [isBrazeHomeBannerVisible, setIsBrazeHomeBannerVisible] =
+    useState(false);
+  const isBrazeHomeBannerVisibleRef = useRef(false);
+  const handleBrazeHomeBannerVisibilityChange = useCallback(
+    (isVisible: boolean) => {
+      if (isBrazeHomeBannerVisibleRef.current && !isVisible) {
+        LayoutAnimation.configureNext({
+          duration: 250,
+          update: {
+            type: LayoutAnimation.Types.easeInEaseOut,
+          },
+          delete: {
+            type: LayoutAnimation.Types.easeInEaseOut,
+            property: LayoutAnimation.Properties.opacity,
+          },
+        });
+      }
+      isBrazeHomeBannerVisibleRef.current = isVisible;
+      setIsBrazeHomeBannerVisible(isVisible);
+    },
+    [],
+  );
 
   /**
    * Shows Nft auto detect modal if the user is on mainnet, never saw the modal and have nft detection off
@@ -966,7 +989,10 @@ const Wallet = ({
         componentLabel="BrazeBanner"
         onError={handleBannerError}
       >
-        <BrazeBanner placementId={BRAZE_BANNER_WALLET_HOME_PLACEMENT_ID} />
+        <BrazeBanner
+          placementId={BRAZE_BANNER_WALLET_HOME_PLACEMENT_ID}
+          onVisibilityChange={handleBrazeHomeBannerVisibilityChange}
+        />
       </ComponentErrorBoundary>
     ) : homeGrowthBanner === 'carousel' ? (
       <View accessible={false}>
@@ -975,7 +1001,9 @@ const Wallet = ({
     ) : null;
   const isHomeGrowthBannerVisible =
     (!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
-    Boolean(homeGrowthBannerContent);
+    (homeGrowthBanner === 'braze'
+      ? isBrazeHomeBannerVisible
+      : Boolean(homeGrowthBannerContent));
 
   const bannerContent = (
     <View style={styles.banner}>
@@ -1011,9 +1039,7 @@ const Wallet = ({
         style={[
           styles.homepageActionButtonsGrid,
           !isHomeGrowthBannerVisible &&
-            (showDiscoveryPills
-              ? styles.homepageActionButtonsGridBeforeDiscovery
-              : undefined),
+            styles.homepageActionButtonsGridWithoutBanner,
         ]}
       >
         <HomepageActionButtonsGrid

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -60,6 +60,7 @@ import {
   ButtonIconSize,
   IconColor as MMDSIconColor,
   IconName as MMDSIconName,
+  SectionDivider,
   Text as CustomText,
   TextColor,
 } from '@metamask/design-system-react-native';
@@ -1024,7 +1025,12 @@ const Wallet = ({
       {walletHomeMainAssetDetailsActions}
       {/* Hide growth banners when money account is enabled but user is geo-blocked */}
       {(!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
-        homeGrowthBannerContent}
+        homeGrowthBannerContent && (
+          <>
+            <SectionDivider />
+            {homeGrowthBannerContent}
+          </>
+        )}
       {homepageDiscoveryPills}
       {isMoneyAccountVisible && <MoneyBalanceCard />}
     </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10514,6 +10514,7 @@
       "traders": "Traders"
     },
     "sections": {
+      "allocation": "Allocation",
       "money": "Money",
       "money_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Money section on the homepage.",
       "money_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",


### PR DESCRIPTION
## **Description**

Broadens the wallet homepage allocation work into a cohesive homepage refresh. This PR adds a data-driven Allocation summary; establishes a shared 24px section rhythm; removes redundant section dividers; uses three rows of shared Explore-style pills for the empty Perpetuals state; and populates an empty Watchlist with BTC, ETH, and SOL from the existing curated Watchlist source.

It also simplifies the zero-balance onboarding prompt by removing the progress header and Skip action, placing a dismiss control over the illustration, making the primary action full width, and stopping the Rive animation after one loop. The standalone Money balance banner is removed because funded Money is already represented in Allocation; when another positive allocation exists but Money is unfunded, Allocation instead shows the current APY and a compact secondary Add action. Allocation stays hidden when every supported balance is zero. The growth banner divider appears only while onboarding is present, and dismissing a Braze banner animates the homepage content upward into its no-banner spacing.

## **Changelog**

CHANGELOG entry: Refined the wallet homepage with portfolio allocation, consistent section spacing, populated discovery content, and simplified onboarding prompts

## **Related issues**

Refs: #33945

## **Manual testing steps**

```gherkin
Feature: Refreshed wallet homepage

  Scenario: user has supported portfolio positions
    Given the wallet has positive balances in one or more supported products
    When the user opens the wallet homepage
    Then Allocation appears above Tokens
    And categories are ordered by allocation percentage
    And tapping a category opens its product page

  Scenario: user has no Perpetuals positions or Watchlist tokens
    Given the Perpetuals and Watchlist sections are enabled
    When the user opens the wallet homepage
    Then Perpetuals displays three rows of horizontally scrolling Explore-style pills
    And Watchlist displays BTC, ETH, and SOL from the curated Watchlist source

  Scenario: user is in wallet-home onboarding
    Given the post-onboarding wallet prompt is active
    When the user views the homepage
    Then the unfunded Money banner is hidden
    And the prompt has a close control over the illustration and one full-width primary action
    And the illustration animation stops after one loop
    And a 6px divider separates the prompt from a following growth banner

  Scenario: user has no Money balance
    Given the user has another positive allocation but no funded Money position
    When the user views Allocation
    Then the Money row shows the current APY
    And a secondary Add button appears instead of a zero-dollar amount

  Scenario: user has no supported balances
    Given every supported allocation balance is zero
    When the user opens the wallet homepage
    Then the Allocation section is not shown

  Scenario: onboarding is no longer active
    Given a growth banner is available and the onboarding prompt is absent
    When the user views the homepage
    Then no divider appears above the growth banner
    And dismissing the banner animates the following content upward
```

## **Screenshots/Recordings**

### **Before**

N/A for this draft; the prior allocation-only state is available in #33945.

### **After**

N/A for this draft. The refreshed homepage was exercised in the matching iOS Simulator build; final review captures still need to be attached.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn lint:tsc`
- ESLint over all changed TypeScript files: no errors; existing deprecation/compiler warnings remain in Wallet files
- Focused Jest suites for MoneyBalanceCard, WalletHomeOnboardingSteps, WatchlistSection, and HomepagePerpsHomeSlot all reported PASS; the Jest process remained alive after completion and was stopped manually
- `git diff --check`
- Manual dark-mode iOS Simulator review using the matching Metro checkout
