### PR TITLE
feat(rewards): surface VIP maintain-tier threshold on tier ladder

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -241,6 +241,7 @@ const dashboardWithTiers: VipDashboardState = {
       swapsBps: 42.5,
       perpsBps: 10,
       referralCarryoverBps: 0,
+      maintainPointsRequirement: null,
       status: 'completed',
     },
     {
@@ -252,6 +253,7 @@ const dashboardWithTiers: VipDashboardState = {
       swapsBps: 11,
       perpsBps: 7,
       referralCarryoverBps: 4242,
+      maintainPointsRequirement: null,
       status: 'current',
     },
   ],

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -873,4 +873,27 @@ describe('RewardsVipView', () => {
       queryByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
     ).toBeNull();
   });
+
+  it('does not pass a maintain subline when the maintain threshold is 0', () => {
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: {
+        ...defaultDashboard,
+        tiers: defaultDashboard.tiers.map((tier) =>
+          tier.id === defaultDashboard.currentTier.id
+            ? { ...tier, maintainPointsRequirement: 0 }
+            : tier,
+        ),
+      },
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: mockFetch,
+    });
+
+    const { queryByTestId } = render(<RewardsVipView />);
+
+    expect(
+      queryByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
+    ).toBeNull();
+  });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -317,6 +317,7 @@ const defaultDashboard: VipDashboardState = {
       swapsBps: 42.5,
       perpsBps: 7,
       referralCarryoverBps: 4242,
+      maintainPointsRequirement: null,
       status: 'current',
     },
     {
@@ -328,6 +329,7 @@ const defaultDashboard: VipDashboardState = {
       swapsBps: 11,
       perpsBps: 6,
       referralCarryoverBps: 5151,
+      maintainPointsRequirement: null,
       status: 'upcoming',
     },
   ],

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -199,6 +199,9 @@ jest.mock('../../../../../locales/i18n', () => ({
     if (key === 'rewards.vip.progress_to_next_tier' && params) {
       return `${params.pointsRemaining} points to next tier`;
     }
+    if (key === 'rewards.vip.maintain_this_tier' && params) {
+      return `${params.points} points to maintain this tier`;
+    }
     const translations: Record<string, string> = {
       'rewards.vip.swaps_label': 'Swaps',
       'rewards.vip.perps_label': 'Perps',
@@ -830,5 +833,44 @@ describe('RewardsVipView', () => {
     await waitFor(() => {
       expect(mockExitRewardsFlow).toHaveBeenCalled();
     });
+  });
+
+  it('passes the maintain subline to the progress card when the current tier has a maintain threshold', () => {
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: {
+        ...defaultDashboard,
+        tiers: defaultDashboard.tiers.map((tier) =>
+          tier.id === defaultDashboard.currentTier.id
+            ? { ...tier, maintainPointsRequirement: 250_000 }
+            : tier,
+        ),
+      },
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: mockFetch,
+    });
+
+    const { getByTestId } = render(<RewardsVipView />);
+
+    expect(
+      getByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
+    ).toHaveTextContent('250k points to maintain this tier');
+  });
+
+  it('does not pass a maintain subline when the current tier has no maintain threshold', () => {
+    mockUseVipDashboard.mockReturnValue({
+      dashboard: defaultDashboard,
+      isLoading: false,
+      hasError: false,
+      hasAttemptedFetch: true,
+      fetchVipDashboard: mockFetch,
+    });
+
+    const { queryByTestId } = render(<RewardsVipView />);
+
+    expect(
+      queryByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -160,7 +160,7 @@ const RewardsVipViewContent: React.FC = () => {
   })();
   const maintainSubline = (() => {
     const maintainPoints = currentTierDetails?.maintainPointsRequirement;
-    if (maintainPoints == null) return undefined;
+    if (maintainPoints == null || maintainPoints === 0) return undefined;
     return strings('rewards.vip.maintain_this_tier', {
       points: formatCompactValue(maintainPoints),
     });

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -158,6 +158,13 @@ const RewardsVipViewContent: React.FC = () => {
       ),
     });
   })();
+  const maintainSubline = (() => {
+    const maintainPoints = currentTierDetails?.maintainPointsRequirement;
+    if (maintainPoints == null) return undefined;
+    return strings('rewards.vip.maintain_this_tier', {
+      points: formatCompactValue(maintainPoints),
+    });
+  })();
 
   return (
     <ErrorBoundary navigation={navigation} view="RewardsVipView">
@@ -329,6 +336,7 @@ const RewardsVipViewContent: React.FC = () => {
                   programName={dashboard.program.name}
                   progress={dashboard.progress}
                   subline={progressSubline}
+                  maintainSubline={maintainSubline}
                   memberIdTitle={dashboard.localizedText.memberIdTitle}
                   memberId={referralCode ?? ''}
                 />

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralInfoSection.test.tsx
@@ -245,6 +245,7 @@ describe('ReferralInfoSection', () => {
             perpsBps: 7,
             revenueShareBps: 1200,
             referralCarryoverBps: 4242,
+            maintainPointsRequirement: null,
             status: 'upcoming',
           },
         ],

--- a/app/components/UI/Rewards/components/Vip/VipTierProgressCard.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierProgressCard.test.tsx
@@ -211,4 +211,27 @@ describe('VipTierProgressCard', () => {
       color: VIP_GOLD_TEXT_MUTED,
     });
   });
+
+  it('renders the maintain subline under the subline when provided', () => {
+    const { getByTestId } = renderWithTheme(
+      <VipTierProgressCard
+        {...baseProps}
+        maintainSubline="250k points to maintain this tier"
+      />,
+    );
+
+    expect(
+      getByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
+    ).toHaveTextContent('250k points to maintain this tier');
+  });
+
+  it('omits the maintain subline when maintainSubline is not provided', () => {
+    const { queryByTestId } = renderWithTheme(
+      <VipTierProgressCard {...baseProps} />,
+    );
+
+    expect(
+      queryByTestId(VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE),
+    ).toBeNull();
+  });
 });

--- a/app/components/UI/Rewards/components/Vip/VipTierProgressCard.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierProgressCard.tsx
@@ -34,6 +34,7 @@ export const VIP_TIER_PROGRESS_CARD_TEST_IDS = {
   PROGRESS_BAR: 'vip-tier-progress-card-bar',
   PROGRESS_FILL: 'vip-tier-progress-card-fill',
   SUBLINE: 'vip-tier-progress-card-subline',
+  MAINTAIN_SUBLINE: 'vip-tier-progress-card-maintain-subline',
 } as const;
 
 interface VipTierProgressCardProps {
@@ -41,6 +42,13 @@ interface VipTierProgressCardProps {
   programName?: string;
   progress: VipProgressDto;
   subline: string;
+  /**
+   * Optional secondary line under `subline` stating the points needed to
+   * maintain the current tier (e.g. "250k points to maintain this tier").
+   * Rendered only when non-empty — omitted for tier-1/unset tiers and in
+   * environments where no maintain threshold is configured.
+   */
+  maintainSubline?: string;
   memberIdTitle: string;
   memberId: string;
   onPress?: () => void;
@@ -61,6 +69,7 @@ const VipTierProgressCard: React.FC<VipTierProgressCardProps> = ({
   programName,
   progress,
   subline,
+  maintainSubline,
   memberIdTitle,
   memberId,
   onPress,
@@ -165,6 +174,15 @@ const VipTierProgressCard: React.FC<VipTierProgressCardProps> = ({
               >
                 {subline}
               </Text>
+              {maintainSubline ? (
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                  testID={VIP_TIER_PROGRESS_CARD_TEST_IDS.MAINTAIN_SUBLINE}
+                >
+                  {maintainSubline}
+                </Text>
+              ) : null}
             </Box>
           </Box>
         </LinearGradient>

--- a/app/components/UI/Rewards/components/Vip/VipTierRow.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierRow.test.tsx
@@ -25,9 +25,46 @@ jest.mock('../../../../../../locales/i18n', () => ({
     if (key === 'rewards.vip.bps_value' && params) {
       return `${params.bps} bps`;
     }
+    if (key === 'rewards.vip.maintain_threshold_label') {
+      return 'Maintain threshold';
+    }
     return key;
   },
 }));
+
+/**
+ * Collects, in render order, the testIDs of the elements matching `ids` from
+ * the rendered tree. Used to assert the maintain-threshold row is the LAST
+ * detail row.
+ */
+const collectOrderedTestIds = (
+  node: unknown,
+  ids: readonly string[],
+): string[] => {
+  const found: string[] = [];
+  const walk = (current: unknown): void => {
+    if (!current || typeof current !== 'object') {
+      return;
+    }
+    if (Array.isArray(current)) {
+      current.forEach(walk);
+      return;
+    }
+    const treeNode = current as {
+      props?: { testID?: string };
+      children?: unknown;
+    };
+    const testID = treeNode.props?.testID;
+    if (typeof testID === 'string' && ids.includes(testID)) {
+      found.push(testID);
+    }
+    if (treeNode.children) {
+      walk(treeNode.children);
+    }
+  };
+  walk(node);
+  return found;
+};
 
 const baseTier = {
   id: 'mock-tier-alpha-3',
@@ -38,6 +75,7 @@ const baseTier = {
   swapsBps: 11,
   perpsBps: 7,
   referralCarryoverBps: 4242,
+  maintainPointsRequirement: null,
   status: 'current' as const,
 };
 
@@ -163,5 +201,36 @@ describe('VipTierRow', () => {
       />,
     );
     expect(queryByTestId(VIP_TIER_ROW_TEST_IDS.THRESHOLDS)).toBeNull();
+  });
+
+  it('renders the maintain threshold as the last detail row when set', () => {
+    const tier = { ...baseTier, maintainPointsRequirement: 30_000 };
+    const { getByTestId, toJSON } = render(
+      <VipTierRow tier={tier} localizedText={localizedText} />,
+    );
+
+    const maintainRow = getByTestId(VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD);
+    expect(maintainRow).toBeOnTheScreen();
+    expect(maintainRow).toHaveTextContent(/30k points/);
+
+    const orderedDetailRows = collectOrderedTestIds(toJSON(), [
+      VIP_TIER_ROW_TEST_IDS.REVENUE_SHARE_FEE,
+      VIP_TIER_ROW_TEST_IDS.SWAPS_FEE,
+      VIP_TIER_ROW_TEST_IDS.PERPS_FEE,
+      VIP_TIER_ROW_TEST_IDS.REFERRAL_POINTS,
+      VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD,
+    ]);
+    expect(orderedDetailRows[orderedDetailRows.length - 1]).toBe(
+      VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD,
+    );
+  });
+
+  it('omits the maintain threshold row when maintainPointsRequirement is null', () => {
+    const tier = { ...baseTier, maintainPointsRequirement: null };
+    const { queryByTestId } = render(
+      <VipTierRow tier={tier} localizedText={localizedText} />,
+    );
+
+    expect(queryByTestId(VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD)).toBeNull();
   });
 });

--- a/app/components/UI/Rewards/components/Vip/VipTierRow.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierRow.test.tsx
@@ -233,4 +233,13 @@ describe('VipTierRow', () => {
 
     expect(queryByTestId(VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD)).toBeNull();
   });
+
+  it('omits the maintain threshold row when maintainPointsRequirement is 0', () => {
+    const tier = { ...baseTier, maintainPointsRequirement: 0 };
+    const { queryByTestId } = render(
+      <VipTierRow tier={tier} localizedText={localizedText} />,
+    );
+
+    expect(queryByTestId(VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD)).toBeNull();
+  });
 });

--- a/app/components/UI/Rewards/components/Vip/VipTierRow.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierRow.tsx
@@ -46,6 +46,7 @@ export const VIP_TIER_ROW_TEST_IDS = {
   SWAPS_FEE: 'vip-tier-row-swaps-fee',
   PERPS_FEE: 'vip-tier-row-perps-fee',
   REFERRAL_POINTS: 'vip-tier-row-referral-points',
+  MAINTAIN_THRESHOLD: 'vip-tier-row-maintain-threshold',
   CURRENT_TIER_GRADIENT: 'vip-tier-row-current-tier-gradient',
 } as const;
 
@@ -253,6 +254,15 @@ const VipTierRow: React.FC<VipTierRowProps> = ({
               value={`${referralPointsPercentage}%`}
               testID={VIP_TIER_ROW_TEST_IDS.REFERRAL_POINTS}
             />
+            {tier.maintainPointsRequirement != null ? (
+              <VipTierDetailRow
+                label={strings('rewards.vip.maintain_threshold_label')}
+                value={strings('rewards.vip.tier_thresholds', {
+                  points: formatCompactValue(tier.maintainPointsRequirement),
+                })}
+                testID={VIP_TIER_ROW_TEST_IDS.MAINTAIN_THRESHOLD}
+              />
+            ) : null}
           </Box>
         </Animated.View>
       ) : null}

--- a/app/components/UI/Rewards/components/Vip/VipTierRow.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipTierRow.tsx
@@ -254,7 +254,8 @@ const VipTierRow: React.FC<VipTierRowProps> = ({
               value={`${referralPointsPercentage}%`}
               testID={VIP_TIER_ROW_TEST_IDS.REFERRAL_POINTS}
             />
-            {tier.maintainPointsRequirement != null ? (
+            {tier.maintainPointsRequirement != null &&
+            tier.maintainPointsRequirement !== 0 ? (
               <VipTierDetailRow
                 label={strings('rewards.vip.maintain_threshold_label')}
                 value={strings('rewards.vip.tier_thresholds', {

--- a/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
@@ -130,6 +130,7 @@ describe('useVipDashboard', () => {
         swapsBps: 11,
         perpsBps: 7,
         referralCarryoverBps: 4242,
+        maintainPointsRequirement: null,
         status: 'current',
       },
     ],

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7430,6 +7430,7 @@ describe('RewardsController', () => {
           swapsBps: 11,
           perpsBps: 7,
           referralCarryoverBps: 4242,
+          maintainPointsRequirement: null,
           status: 'current',
         },
       ],

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -4450,6 +4450,7 @@ describe('RewardsDataService', () => {
           swapsBps: 11,
           perpsBps: 7,
           referralCarryoverBps: 4242,
+          maintainPointsRequirement: null,
           status: 'current',
         },
       ],

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -93,6 +93,13 @@ export type VipTierDto = {
   name: string;
   tier: number;
   pointsRequirement: number;
+  /**
+   * Lower 30d-points threshold to KEEP this tier once held (vs
+   * `pointsRequirement` to REACH it). `null` when no maintain threshold is
+   * configured for the tier — the reach requirement then also governs keeping
+   * it. Sourced from `/vip/me` (backend PR #737).
+   */
+  maintainPointsRequirement: number | null;
   swapsBps: number;
   perpsBps: number;
   revenueShareBps: number;

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4924,6 +4924,7 @@ describe('setVipDashboard', () => {
         swapsBps: 11,
         perpsBps: 7,
         referralCarryoverBps: 4242,
+        maintainPointsRequirement: null,
         status: 'current',
       },
     ],

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3247,6 +3247,7 @@ describe('Rewards selectors', () => {
           swapsBps: 11,
           perpsBps: 7,
           referralCarryoverBps: 4242,
+          maintainPointsRequirement: null,
           status: 'current',
         },
       ],

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9563,6 +9563,7 @@
       "tiers_title": "Tiers",
       "tier_thresholds": "{{points}} points",
       "maintain_threshold_label": "Maintain threshold",
+      "maintain_this_tier": "{{points}} points to maintain this tier",
       "bps_value": "{{bps}} bps",
       "referee_splash_continue": "Continue",
       "referee_referred_by": "Referred by {{code}}",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9562,6 +9562,7 @@
       "retry_button": "Retry",
       "tiers_title": "Tiers",
       "tier_thresholds": "{{points}} points",
+      "maintain_threshold_label": "Maintain threshold",
       "bps_value": "{{bps}} bps",
       "referee_splash_continue": "Continue",
       "referee_referred_by": "Referred by {{code}}",


### PR DESCRIPTION
## **Description**

Surfaces the VIP **maintain-tier threshold** on mobile in **two** places, per product (Director of Product) direction in Figma:

1. **Tiers page (tier ladder)** — each VIP tier shows a **"Maintain threshold"** row as the **last item** in that tier's expanded detail list (immediately after "Referral points").
2. **VIP dashboard hero card (`VipTierProgressCard`)** — an additional line under the existing progress subline stating the points needed to maintain the **current** tier: **"{{points}} points to maintain this tier"** (e.g. `250k points to maintain this tier`).

In both places the value is the tier's **absolute** `maintainPointsRequirement` formatted with `formatCompactValue` (matching how the reach threshold renders) — not a remaining-to-threshold calculation. Both are **threshold-display only**: there is no "at risk" / "you'll be demoted" warning, and the existing "points to reach next tier" copy is untouched.

The maintain threshold comes from the `/vip/me` contract (backend PR #737, merged): each tier object now carries `maintainPointsRequirement: number | null`. Each surface renders **only when that value is non-null** for the relevant tier; when it is `null` (no maintain threshold configured, or an environment where the field isn't populated) the row/line is omitted and the reach requirement continues to govern keeping the tier. Tier-1/unset tiers therefore show no extra line.

Changes:
- `types.ts` — mirror the new `maintainPointsRequirement: number | null` field on `VipTierDto` (type-only; the value already arrives over the wire).
- `VipTierRow.tsx` — render the maintain-threshold detail row as the last child of the expanded details, gated on `maintainPointsRequirement != null`; add a `MAINTAIN_THRESHOLD` test ID.
- `VipTierProgressCard.tsx` — add an optional `maintainSubline?: string` prop rendered as a line under the existing subline (same Text variant/color); add a `MAINTAIN_SUBLINE` test ID; renders nothing when the prop is absent/empty.
- `RewardsVipView.tsx` — derive the hero-card maintain line from `currentTierDetails?.maintainPointsRequirement` (only when non-null) and pass it as `maintainSubline`.
- `en.json` — add `rewards.vip.maintain_threshold_label` ("Maintain threshold") and `rewards.vip.maintain_this_tier` ("{{points}} points to maintain this tier").
- Unit tests + fixture updates for the new field and both surfaces.

## **Changelog**

CHANGELOG entry: Show the maintain-points threshold for each VIP tier — on the tier ladder rows and as a "points to maintain this tier" line on the VIP dashboard hero card.

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Open the Rewards → VIP dashboard with a VIP-enrolled account whose current tier has a non-null `maintainPointsRequirement` in the `/vip/me` response.
2. On the hero card, confirm a line **"{{points}} points to maintain this tier"** (e.g. `250k points to maintain this tier`) appears directly under the existing progress subline.
3. Go to the Tiers list and expand that tier; confirm a **"Maintain threshold"** row appears as the **last** row of the expanded details, after "Referral points", formatted as `{{points}} points`.
4. Confirm a tier whose `maintainPointsRequirement` is `null` shows **no** maintain row, and that a current tier with `null` maintain shows **no** hero-card maintain line.
5. Confirm the "points to reach tier" copy is unchanged.

## **Screenshots/Recordings**

### **Before**

_Screenshots pending — emulator capture skipped for this PR. Before this change, an expanded tier's details end at the "Referral points" row, and the hero card shows only the "points to next tier" subline._

### **After**

_Screenshots pending — emulator capture skipped for this PR. This change adds (1) a "Maintain threshold · N pts" row as the last item in each tier's expanded details and (2) a "N points to maintain this tier" line under the hero-card subline — both rendered only when the relevant tier has a non-null `maintainPointsRequirement`._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rewards VIP display-only UI and type alignment with an existing API field; no auth, payments, or business-logic changes beyond conditional rendering.
> 
> **Overview**
> Adds support for the `/vip/me` **`maintainPointsRequirement`** field on `VipTierDto` and surfaces it in two VIP UI spots when the value is non-null and non-zero.
> 
> On the **tier ladder**, expanded tier details gain a **Maintain threshold** row as the last item (after referral points), showing the absolute points via `formatCompactValue`. On the **VIP dashboard hero**, `VipTierProgressCard` accepts an optional **`maintainSubline`**; `RewardsVipView` derives it from the current tier’s maintain requirement (e.g. “250k points to maintain this tier”) without changing existing “points to next tier” copy.
> 
> New strings in `en.json` (`maintain_threshold_label`, `maintain_this_tier`). Test fixtures and unit tests cover both surfaces and null/0 omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9dcb394a61792b67801aaf8b154a431588dcde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->