### PR TITLE
fix(login): end Login User Interaction on biometric unlock

### DIFF
--- a/app/components/Views/Login/index.test.tsx
+++ b/app/components/Views/Login/index.test.tsx
@@ -34,6 +34,11 @@ import {
   VAULT_ERROR,
   DENY_PIN_ERROR_ANDROID,
 } from './constants';
+import {
+  LOGIN_APP_START_TYPE,
+  LOGIN_CONTENT_STATE,
+  resetLoginAppStartTypeForTesting,
+} from './loginPerformanceTags';
 import trackErrorAsAnalytics from '../../../util/metrics/TrackError/trackErrorAsAnalytics';
 import { trackVaultCorruption } from '../../../util/analytics/vaultCorruptionTracking';
 import { downloadStateLogs } from '../../../util/logs';
@@ -345,6 +350,7 @@ describe('Login', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetLoginAppStartTypeForTesting();
     Alert.alert = mockAlertAlert;
     mockNavigate.mockClear();
     mockReplace.mockClear();
@@ -1795,7 +1801,27 @@ describe('Login', () => {
   });
 
   describe('Trace integration', () => {
-    it('calls trace for AuthenticateUser during login', async () => {
+    it('starts LoginUserInteraction with locked and app_start_type tags', () => {
+      mockRoute.mockReturnValue({
+        params: { locked: true, oauthLoginSuccess: false },
+      });
+
+      renderWithProvider(<Login />);
+
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.LoginUserInteraction,
+        op: TraceOperation.Login,
+        tags: {
+          locked: true,
+          app_start_type: LOGIN_APP_START_TYPE.COLD,
+        },
+      });
+    });
+
+    it('ends LoginUserInteraction with content_state on password unlock', async () => {
+      mockRoute.mockReturnValue({
+        params: { locked: false, oauthLoginSuccess: false },
+      });
       const { getByTestId } = renderWithProvider(<Login />);
       const passwordInput = getByTestId(LoginViewSelectors.PASSWORD_INPUT);
 
@@ -1806,16 +1832,69 @@ describe('Login', () => {
         fireEvent(passwordInput, 'submitEditing');
       });
 
-      expect(mockTrace).toHaveBeenCalledTimes(2);
-      expect(mockTrace).toHaveBeenNthCalledWith(1, {
+      expect(mockEndTrace).toHaveBeenCalledWith({
         name: TraceName.LoginUserInteraction,
-        op: TraceOperation.Login,
+        data: {
+          success: true,
+          content_state: LOGIN_CONTENT_STATE.FILLED,
+        },
       });
-      expect(mockTrace).toHaveBeenNthCalledWith(
-        2,
+      expect(mockTrace).toHaveBeenCalledWith(
         {
           name: TraceName.AuthenticateUser,
           op: TraceOperation.Login,
+          tags: {
+            locked: false,
+            app_start_type: LOGIN_APP_START_TYPE.COLD,
+          },
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('ends LoginUserInteraction on device authentication unlock', async () => {
+      mockRoute.mockReturnValue({
+        params: { locked: false, oauthLoginSuccess: false },
+      });
+      mockUseAuthCapabilities.mockReturnValue({
+        capabilities: defaultCapabilities,
+        isLoading: false,
+      });
+      mockGetAuthType.mockResolvedValue({
+        currentAuthType: AUTHENTICATION_TYPE.DEVICE_AUTHENTICATION,
+        availableBiometryType: 'TouchID',
+      });
+      mockUnlockWallet.mockResolvedValueOnce(true);
+
+      const { getByTestId } = renderWithProvider(<Login />);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      const biometryButton = getByTestId(
+        LoginViewSelectors.DEVICE_AUTHENTICATION_ICON,
+      );
+
+      await act(async () => {
+        fireEvent.press(biometryButton);
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.LoginUserInteraction,
+        data: {
+          success: true,
+          content_state: LOGIN_CONTENT_STATE.FILLED,
+        },
+      });
+      expect(mockTrace).toHaveBeenCalledWith(
+        {
+          name: TraceName.LoginBiometricAuthentication,
+          op: TraceOperation.Login,
+          tags: {
+            locked: false,
+            app_start_type: LOGIN_APP_START_TYPE.COLD,
+          },
         },
         expect.any(Function),
       );

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -94,6 +94,11 @@ import {
   isBiometricUnlockCancelledByUser,
 } from '../../../core/Authentication/utils';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
+import {
+  getLoginInteractionEndData,
+  getLoginPerformanceTags,
+  markLoginInteractionCompleted,
+} from './loginPerformanceTags';
 
 interface LoginRouteParams {
   locked: boolean;
@@ -128,11 +133,14 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     checkIsSeedlessPasswordOutdated,
   } = useAuthentication();
   const { capabilities } = useAuthCapabilities();
+  const isLocked = Boolean(route.params?.locked);
+  const loginPerformanceTags = useRef(getLoginPerformanceTags(isLocked));
 
   useEffect(() => {
     trace({
       name: TraceName.LoginUserInteraction,
       op: TraceOperation.Login,
+      tags: loginPerformanceTags.current,
     });
     trackOnboarding(MetaMetricsEvents.LOGIN_SCREEN_VIEWED, saveOnboardingEvent);
     setStartFoxAnimation('Start');
@@ -300,13 +308,18 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     setLoading(true);
     setError(null);
 
-    endTrace({ name: TraceName.LoginUserInteraction });
+    endTrace({
+      name: TraceName.LoginUserInteraction,
+      data: getLoginInteractionEndData(),
+    });
+    markLoginInteractionCompleted();
 
     try {
       await trace(
         {
           name: TraceName.AuthenticateUser,
           op: TraceOperation.Login,
+          tags: loginPerformanceTags.current,
         },
         async () => {
           const isSeedlessPasswordOutdated =
@@ -358,11 +371,18 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     setLoading(true);
     setError(null);
 
+    endTrace({
+      name: TraceName.LoginUserInteraction,
+      data: getLoginInteractionEndData(),
+    });
+    markLoginInteractionCompleted();
+
     try {
       await trace(
         {
           name: TraceName.LoginBiometricAuthentication,
           op: TraceOperation.Login,
+          tags: loginPerformanceTags.current,
         },
         async () => {
           await unlockWallet();

--- a/app/components/Views/Login/loginPerformanceTags.test.ts
+++ b/app/components/Views/Login/loginPerformanceTags.test.ts
@@ -1,0 +1,73 @@
+import {
+  getLoginAppStartType,
+  getLoginInteractionEndData,
+  getLoginPerformanceTags,
+  LOGIN_APP_START_TYPE,
+  LOGIN_CONTENT_STATE,
+  markLoginInteractionCompleted,
+  resetLoginAppStartTypeForTesting,
+} from './loginPerformanceTags';
+
+describe('loginPerformanceTags', () => {
+  beforeEach(() => {
+    resetLoginAppStartTypeForTesting();
+  });
+
+  describe('getLoginAppStartType', () => {
+    it('returns cold before any login interaction completes', () => {
+      const result = getLoginAppStartType();
+
+      expect(result).toBe(LOGIN_APP_START_TYPE.COLD);
+    });
+
+    it('returns warm after a login interaction completes', () => {
+      markLoginInteractionCompleted();
+
+      const result = getLoginAppStartType();
+
+      expect(result).toBe(LOGIN_APP_START_TYPE.WARM);
+    });
+  });
+
+  describe('getLoginPerformanceTags', () => {
+    it('includes locked and cold app_start_type before unlock', () => {
+      const result = getLoginPerformanceTags(true);
+
+      expect(result).toEqual({
+        locked: true,
+        app_start_type: LOGIN_APP_START_TYPE.COLD,
+      });
+    });
+
+    it('includes warm app_start_type after unlock completes', () => {
+      markLoginInteractionCompleted();
+
+      const result = getLoginPerformanceTags(false);
+
+      expect(result).toEqual({
+        locked: false,
+        app_start_type: LOGIN_APP_START_TYPE.WARM,
+      });
+    });
+  });
+
+  describe('getLoginInteractionEndData', () => {
+    it('returns success with filled content_state by default', () => {
+      const result = getLoginInteractionEndData();
+
+      expect(result).toEqual({
+        success: true,
+        content_state: LOGIN_CONTENT_STATE.FILLED,
+      });
+    });
+
+    it('returns the provided content_state', () => {
+      const result = getLoginInteractionEndData(LOGIN_CONTENT_STATE.EMPTY);
+
+      expect(result).toEqual({
+        success: true,
+        content_state: LOGIN_CONTENT_STATE.EMPTY,
+      });
+    });
+  });
+});

--- a/app/components/Views/Login/loginPerformanceTags.ts
+++ b/app/components/Views/Login/loginPerformanceTags.ts
@@ -50,6 +50,7 @@ export function resetLoginAppStartTypeForTesting(): void {
 export interface LoginPerformanceTags {
   locked: boolean;
   app_start_type: LoginAppStartType;
+  [key: string]: boolean | string;
 }
 
 export function getLoginPerformanceTags(locked: boolean): LoginPerformanceTags {

--- a/app/components/Views/Login/loginPerformanceTags.ts
+++ b/app/components/Views/Login/loginPerformanceTags.ts
@@ -1,0 +1,69 @@
+/**
+ * Login span tags for Sentry (TO-981).
+ *
+ * `app_start_type` is process-scoped: Login mounts before the first unlock
+ * interaction completes are `cold`; mounts after that are `warm` (e.g. lock
+ * then unlock again in the same process).
+ */
+
+export const LOGIN_APP_START_TYPE = {
+  COLD: 'cold',
+  WARM: 'warm',
+} as const;
+
+export type LoginAppStartType =
+  (typeof LOGIN_APP_START_TYPE)[keyof typeof LOGIN_APP_START_TYPE];
+
+export const LOGIN_CONTENT_STATE = {
+  FILLED: 'filled',
+  EMPTY: 'empty',
+} as const;
+
+export type LoginContentState =
+  (typeof LOGIN_CONTENT_STATE)[keyof typeof LOGIN_CONTENT_STATE];
+
+let hasCompletedLoginInteractionInProcess = false;
+
+/**
+ * Returns cold until the first login interaction ends in this process, then warm.
+ * Exported for unit tests.
+ */
+export function getLoginAppStartType(): LoginAppStartType {
+  return hasCompletedLoginInteractionInProcess
+    ? LOGIN_APP_START_TYPE.WARM
+    : LOGIN_APP_START_TYPE.COLD;
+}
+
+/**
+ * Marks that a login interaction has completed so later mounts read as warm.
+ * Exported for unit tests.
+ */
+export function markLoginInteractionCompleted(): void {
+  hasCompletedLoginInteractionInProcess = true;
+}
+
+/** Reset process-scoped start-type tracking. Exported for unit tests. */
+export function resetLoginAppStartTypeForTesting(): void {
+  hasCompletedLoginInteractionInProcess = false;
+}
+
+export interface LoginPerformanceTags {
+  locked: boolean;
+  app_start_type: LoginAppStartType;
+}
+
+export function getLoginPerformanceTags(locked: boolean): LoginPerformanceTags {
+  return {
+    locked,
+    app_start_type: getLoginAppStartType(),
+  };
+}
+
+export function getLoginInteractionEndData(
+  contentState: LoginContentState = LOGIN_CONTENT_STATE.FILLED,
+): { success: true; content_state: LoginContentState } {
+  return {
+    success: true,
+    content_state: contentState,
+  };
+}


### PR DESCRIPTION
## **Description**

`Login User Interaction` started on Login mount but only ended on the password unlock path. Biometric unlock left the span open until the 5-minute cleanup, which inflates Sentry p95 and blocks cold/warm and locked/unlocked splits for [TO-960](https://consensyssoftware.atlassian.net/browse/TO-960).

This change:
- Calls `endTrace(LoginUserInteraction)` on biometric unlock (matching password unlock)
- Tags login spans with `locked`, `app_start_type` (`cold`/`warm`), and terminal `content_state`
- Adds unit coverage for both unlock paths and the tag helpers

**Code owners:** `app/components/Views/Login` is owned by `@MetaMask/mobile-core-ux` — please include that team in review.

Related: [TO-981](https://consensyssoftware.atlassian.net/browse/TO-981) (parent [TO-893](https://consensyssoftware.atlassian.net/browse/TO-893))

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TO-981

## **Manual testing steps**

```gherkin
Feature: Login User Interaction span lifecycle

  Scenario: Password unlock ends the interaction span
    Given the Login screen is shown
    When the user unlocks with password
    Then Login User Interaction ends with content_state filled
    And Authenticate User is tagged with locked and app_start_type

  Scenario: Biometric unlock ends the interaction span
    Given the Login screen is shown with device authentication available
    When the user unlocks with biometrics
    Then Login User Interaction ends with content_state filled
    And Login Biometrics Authentication is tagged with locked and app_start_type
```

## **Screenshots/Recordings**

### **Before**

N/A (measurement-only change)

### **After**

N/A (measurement-only change)

### **Validation evidence**

**Unit tests:** `yarn jest app/components/Views/Login/` — 71 passed (span start tags, password `endTrace`, biometric `endTrace`, `loginPerformanceTags` cold/warm helpers).

**Sentry baseline (prod, 14d, pre-fix — shows why this is needed):**

| Span | p50 | p95 | Count |
| --- | --- | --- | --- |
| Authenticate User | ~706 ms | ~6.3 s | ~1.8M |
| Login User Interaction | ~12.2 s | ~321 s | ~1.6M |
| Login Biometrics Authentication | ~1.1 s | ~8.9 s | ~115K |

Explore: [login spans 14d](https://metamask.sentry.io/explore/traces/?query=is_transaction%3Atrue+AND+%28transaction%3A%22Login+User+Interaction%22+OR+transaction%3A%22Authenticate+User%22+OR+transaction%3A%22Login+Biometrics+Authentication%22%29&project=2299799&aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p50%28span.duration%29%22%2C%22p95%28span.duration%29%22%2C%22count%28%29%22%5D%7D&mode=aggregate&sort=-count%28%29&statsPeriod=14d&table=span)

`Login User Interaction` p95 (~321 s) tracks the 5-minute cleanup artifact from biometric sessions that never called `endTrace`. After merge, sample queries for `app_start_type` / `locked` / `content_state` should become populated for TO-960.

**iOS Simulator (iPhone 17) — validated after rebuild:**

1. Initial crash `Cannot read property 'keyrings' of undefined` was **not** a vault bug — local CocoaPods were stale after branch switch (`RNPermissions` 3.10.1 vs JS-expected 5.6.0). Fixed with `yarn install` + `pod install` + native rebuild/reinstall.
2. Created a fresh wallet, relaunched to Login, unlocked with password.
3. Device logs confirmed span lifecycle on password unlock:

```
[Tracing] Finishing "login" root span "Login User Interaction" with ID b877c6c9e5d36c61
[Tracing] Starting sampled root span … name: Authenticate User … ID: 87d30ee76badf11d
[Tracing] Finishing "login" root span "Authenticate User" with ID 87d30ee76badf11d
```

Biometric unlock UI was not exercised in this pass (device auth button not shown on this fresh create-password wallet); biometric `endTrace` is covered by unit tests.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A for this validation pass — measurement-only change; iOS Simulator used for local verification (Android emulator occupied)
- [x] I've tested with a power user scenario
  - N/A — span lifecycle/tags do not depend on account/token count
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Yes — `Login User Interaction` / unlock spans tagged with `locked`, `app_start_type`, `content_state`

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TO-960]: https://consensyssoftware.atlassian.net/browse/TO-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-981]: https://consensyssoftware.atlassian.net/browse/TO-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TO-893]: https://consensyssoftware.atlassian.net/browse/TO-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ