### PR TITLE
ci: exclude Sonar binaries and raise JS heap to fix OOM

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,8 @@ sonar.organization=metamask
 sonar.sources=app/
 
 # Excluded project files from analysis.
-sonar.exclusions=**.stories.**, **/*.perf-test.tsx, e2e/**, tests/**, wdio/**, app/components/UI/Perps/utils/e2eBridgePerps.ts
+# Binary assets are excluded so the scanner does not probe them as UTF-8 text.
+sonar.exclusions=**.stories.**, **/*.perf-test.tsx, e2e/**, tests/**, wdio/**, app/components/UI/Perps/utils/e2eBridgePerps.ts, **/*.png, **/*.jpg, **/*.jpeg, **/*.gif, **/*.webp, **/*.mp4, **/*.otf, **/*.ttf, **/*.woff, **/*.woff2, **/*.riv
 
 # Inclusions for test files.
 sonar.test.inclusions=**.test.**
@@ -20,6 +21,9 @@ sonar.cpd.exclusions=**SampleFeature/e2e/**, app/util/test/testSetupView.js, app
 
 # Test coverage path in GitHub action
 sonar.javascript.lcov.reportPaths=/coverage/lcov.info
+
+# Raise JS/TS analyzer heap to avoid OOM on large PRs (default ~4GB).
+sonar.javascript.node.maxspace=8192
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Exclude binary assets (`png`/`jpg`/`otf`/`riv`/etc.) from `sonar.exclusions` so Sonar stops probing them as UTF-8 text
- Set `sonar.javascript.node.maxspace=8192` to prevent JS/TS analyzer OOM that left quality gate stuck on `NONE`

## Context
SonarCloud scan was OOMing at ~4.3GB heap. With `continue-on-error: true` on the scan step, the analysis job still passed, but quality gate polling timed out on `NONE` and failed CI (seen on #33934).

## Test plan
- [ ] CI SonarCloud analysis completes without Node OOM
- [ ] SonarCloud quality gate status leaves `NONE` and passes (or reports a real gate result)
- [ ] Binary UTF-8 `Invalid character` warnings are gone from Sonar logs

Made with [Cursor](https://cursor.com)