### PR TITLE
fix: harden Appium wallet-home readiness for SmokeAccounts (MMQA-2139)

### DIFF
--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -57,10 +57,8 @@ import { fetchProductionFeatureFlags } from '../performance/feature-flag-helper'
 import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.testIds';
 import {
   isLoginScreenDisplayed,
-  isWalletHomeReadyOnAndroid,
   isWalletHomeReadyOnAndroidStable,
   isWalletHomeReadyOnAppium,
-  isWalletHomeReadyOnIOS,
 } from './wallet-home-readiness';
 
 const logger = createLogger({
@@ -81,22 +79,19 @@ export const waitForWalletHomePlaywright = async (
 ): Promise<void> => {
   const deadline = Date.now() + timeout;
   const isAndroid = PlatformDetector.isAndroid();
+  const platform = isAndroid ? 'Android' : 'iOS';
 
   while (Date.now() < deadline) {
-    if (isAndroid) {
-      if (await isWalletHomeReadyOnAndroid()) {
-        logger.debug('Wallet home ready on Android');
-        return;
-      }
-      await dismissAndroidSystemOverlaysPlaywright();
-    } else if (await isWalletHomeReadyOnIOS()) {
-      logger.debug('Wallet home ready on iOS');
+    if (await isWalletHomeReadyOnAppium()) {
+      logger.debug(`Wallet home ready on ${platform}`);
       return;
+    }
+    if (isAndroid) {
+      await dismissAndroidSystemOverlaysPlaywright();
     }
     await sleep(WALLET_HOME_POLL_INTERVAL_MS);
   }
 
-  const platform = isAndroid ? 'Android' : 'iOS';
   throw new Error(
     `Wallet home not ready within ${timeout}ms (${platform} wallet readiness indicators not satisfied)`,
   );
@@ -140,10 +135,7 @@ export const ensureAccountListOpenPlaywright = async (
       // list not visible yet
     }
 
-    const isWalletHomeReady = PlatformDetector.isAndroid()
-      ? await isWalletHomeReadyOnAndroid()
-      : await isWalletHomeReadyOnIOS();
-    if (isWalletHomeReady) {
+    if (await isWalletHomeReadyOnAppium()) {
       await WalletView.tapIdenticon();
       await Assertions.expectElementToBeVisible(
         AccountListBottomSheet.accountList,
@@ -153,6 +145,10 @@ export const ensureAccountListOpenPlaywright = async (
         },
       );
       return;
+    }
+
+    if (PlatformDetector.isAndroid()) {
+      await dismissAndroidSystemOverlaysPlaywright();
     }
 
     try {
@@ -176,11 +172,12 @@ export const dismissToWalletHomePlaywright = async (
   const deadline = Date.now() + timeout;
 
   while (Date.now() < deadline) {
-    const isWalletHomeReady = PlatformDetector.isAndroid()
-      ? await isWalletHomeReadyOnAndroid()
-      : await isWalletHomeReadyOnIOS();
-    if (isWalletHomeReady) {
+    if (await isWalletHomeReadyOnAppium()) {
       return;
+    }
+
+    if (PlatformDetector.isAndroid()) {
+      await dismissAndroidSystemOverlaysPlaywright();
     }
 
     try {
@@ -809,12 +806,10 @@ export const loginAndOpenAccountList = async (
   options: {
     scenarioType?: string;
     dismissModals?: boolean;
-    walletTimeout?: number;
     accountListDescription?: string;
   } = {},
 ): Promise<void> => {
   const {
-    walletTimeout = resolveE2EWaitTimeoutMs(30_000),
     accountListDescription = 'Account list should be visible',
     ...loginOptions
   } = options;

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -57,6 +57,7 @@ import { fetchProductionFeatureFlags } from '../performance/feature-flag-helper'
 import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.testIds';
 import {
   isLoginScreenDisplayed,
+  isWalletHomeReadyOnAndroid,
   isWalletHomeReadyOnAndroidStable,
   isWalletHomeReadyOnAppium,
   isWalletHomeReadyOnIOS,
@@ -72,32 +73,32 @@ const WALLET_HOME_POLL_INTERVAL_MS = 250;
  * Waits for the wallet home screen to be ready after login.
  * On iOS, `wallet-screen` may exist but report `displayed === false` while
  * child indicators are visible — mirrors Detox `toExist` readiness checks.
+ * On Android, polls readiness helpers and re-dismisses system overlays during
+ * the wait (avoids a single visibility assert that can fail under shade/overlays).
  */
 export const waitForWalletHomePlaywright = async (
   timeout: number = resolveE2EWaitTimeoutMs(30_000),
 ): Promise<void> => {
-  if (PlatformDetector.isAndroid()) {
-    await PlaywrightAssertions.expectElementToBeVisible(
-      asPlaywrightElement(WalletView.container),
-      {
-        description: 'Wallet should be visible',
-        timeout,
-      },
-    );
-    return;
-  }
-
   const deadline = Date.now() + timeout;
+  const isAndroid = PlatformDetector.isAndroid();
+
   while (Date.now() < deadline) {
-    if (await isWalletHomeReadyOnIOS()) {
+    if (isAndroid) {
+      if (await isWalletHomeReadyOnAndroid()) {
+        logger.debug('Wallet home ready on Android');
+        return;
+      }
+      await dismissAndroidSystemOverlaysPlaywright();
+    } else if (await isWalletHomeReadyOnIOS()) {
       logger.debug('Wallet home ready on iOS');
       return;
     }
     await sleep(WALLET_HOME_POLL_INTERVAL_MS);
   }
 
+  const platform = isAndroid ? 'Android' : 'iOS';
   throw new Error(
-    `Wallet home not ready within ${timeout}ms (iOS wallet readiness indicators not satisfied)`,
+    `Wallet home not ready within ${timeout}ms (${platform} wallet readiness indicators not satisfied)`,
   );
 };
 
@@ -139,7 +140,10 @@ export const ensureAccountListOpenPlaywright = async (
       // list not visible yet
     }
 
-    if (PlatformDetector.isAndroid() || (await isWalletHomeReadyOnIOS())) {
+    const isWalletHomeReady = PlatformDetector.isAndroid()
+      ? await isWalletHomeReadyOnAndroid()
+      : await isWalletHomeReadyOnIOS();
+    if (isWalletHomeReady) {
       await WalletView.tapIdenticon();
       await Assertions.expectElementToBeVisible(
         AccountListBottomSheet.accountList,
@@ -172,7 +176,10 @@ export const dismissToWalletHomePlaywright = async (
   const deadline = Date.now() + timeout;
 
   while (Date.now() < deadline) {
-    if (PlatformDetector.isAndroid() || (await isWalletHomeReadyOnIOS())) {
+    const isWalletHomeReady = PlatformDetector.isAndroid()
+      ? await isWalletHomeReadyOnAndroid()
+      : await isWalletHomeReadyOnIOS();
+    if (isWalletHomeReady) {
       return;
     }
 
@@ -807,14 +814,12 @@ export const loginAndOpenAccountList = async (
   } = {},
 ): Promise<void> => {
   const {
-    walletTimeout = 15_000,
+    walletTimeout = resolveE2EWaitTimeoutMs(30_000),
     accountListDescription = 'Account list should be visible',
     ...loginOptions
   } = options;
 
   await loginToAppPlaywright(loginOptions);
-
-  await waitForWalletHomePlaywright(walletTimeout);
 
   await WalletView.tapIdenticon();
 

--- a/tests/smoke-appium/accounts/multi-srp.spec.ts
+++ b/tests/smoke-appium/accounts/multi-srp.spec.ts
@@ -50,7 +50,6 @@ appiumTest.describe(SmokeAccounts('Account syncing - Multiple SRPs'), () => {
         async ({ userStorageMockttpController }) => {
           await loginAndOpenAccountList({
             scenarioType: 'e2e',
-            walletTimeout: 15_000,
           });
           await assertAccountCount(DEFAULT_ACCOUNT_NAME, 1);
 
@@ -103,7 +102,6 @@ appiumTest.describe(SmokeAccounts('Account syncing - Multiple SRPs'), () => {
       await withIdentityFixtures(fixtureOptions, async () => {
         await loginAndOpenAccountList({
           scenarioType: 'e2e',
-          walletTimeout: 15_000,
         });
         await openImportSrpFromAccountList();
         await ImportSrpView.enterSrp(IDENTITY_TEAM_SEED_PHRASE_2);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Hardens shared Appium wallet-home readiness in `tests/flows/wallet.flow.ts` to address SmokeAccounts flakes/timeouts at the `wallet-screen` gate (MMQA-2139).

### Changes
1. **Android `waitForWalletHomePlaywright`** — polls `isWalletHomeReadyOnAndroid()` and dismisses Android system overlays during the wait, instead of a single `expectElementToBeVisible(wallet-screen)` assert.
2. **`loginAndOpenAccountList`** — removes the redundant second wallet-home wait after `loginToAppPlaywright` (login already waits); aligns `walletTimeout` default to `resolveE2EWaitTimeoutMs(30_000)`.
3. **`ensureAccountListOpenPlaywright` / `dismissToWalletHomePlaywright`** — replaces Android platform early-return with a real `isWalletHomeReadyOnAndroid()` check, matching the iOS readiness gate.

### Local validation
- Android: `delete-account`, `account-syncing-settings-toggle`, `add-and-rename-accounts` passed after each kept step.
- iOS: `SmokeAccounts: Account syncing - Setting` (1 passed, 3.0m) and `SmokeAccounts: Add and rename accounts` (2 passed, 6.1m).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MMQA-2139

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — Appium framework-only change. Verified locally with:

```bash
# Android
ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk \
ANDROID_AVD_NAME=Pixel_5_Pro_API_34 \
yarn appium-smoke:android --grep "SmokeAccounts: Account syncing - Setting"

ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk \
ANDROID_AVD_NAME=Pixel_5_Pro_API_34 \
yarn appium-smoke:android --grep "SmokeAccounts: Add and rename accounts"

# iOS
IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
IOS_SIMULATOR_UDID="$IOS_SIMULATOR_UDID" \
yarn appium-smoke:ios --grep "SmokeAccounts: Account syncing - Setting"

IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
IOS_SIMULATOR_UDID="$IOS_SIMULATOR_UDID" \
yarn appium-smoke:ios --grep "SmokeAccounts: Add and rename accounts"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-framework-only change; no product UI diff.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)