### PR TITLE
test: MMQA - 2021 - [Mobile] Remove getTestElement functions from page objects SolanaTestDapp and BitcoinTestdapp

### DIFF
--- a/tests/framework/Matchers.ts
+++ b/tests/framework/Matchers.ts
@@ -1,4 +1,5 @@
 import { web, system } from 'detox';
+import { BrowserViewSelectorsIDs } from '../../app/components/Views/BrowserTab/BrowserView.testIds';
 import { type EncapsulatedElementType } from './EncapsulatedElement.ts';
 import { FrameworkDetector } from './FrameworkDetector.ts';
 import { resolve } from './Selector.ts';
@@ -181,6 +182,25 @@ export default class Matchers {
     }
     const myWebView = this.getWebViewByID(webviewID);
     return myWebView.element(by.web.xpath(xpath));
+  }
+
+  /**
+   * Get a browser WebView test element by data-testid.
+   * @param dataTestId - The data-testid of the element
+   * @param options.tag - The tag of the element having the data-testid attribute (e.g. 'div', 'input'). Defaults to 'div'
+   * @param options.extraXPath - Extra xpath suffix (e.g. '/div/button') for elements without a data-testid
+   */
+  static getTestElement(
+    dataTestId: string,
+    options: { extraXPath?: string; tag?: string } = {},
+  ): Promise<DetoxElement | WebElement | PlaywrightElement> {
+    const { tag = 'div', extraXPath = '' } = options;
+    const xpath = `//${tag}[@data-testid="${dataTestId}"]${extraXPath}`;
+
+    return this.getElementByXPath(
+      BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
+      xpath,
+    );
   }
 
   /**

--- a/tests/page-objects/Browser/BitcoinTestDapp.ts
+++ b/tests/page-objects/Browser/BitcoinTestDapp.ts
@@ -1,46 +1,26 @@
 import { dataTestIds } from '@metamask/test-dapp-bitcoin';
 import { getDappUrl } from '../../framework/fixtures/FixtureUtils';
 import Matchers from '../../framework/Matchers';
-import type { PlaywrightElement } from '../../framework/PlaywrightAdapter';
 import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
 import Gestures from '../../framework/Gestures';
 import Browser from './BrowserView';
 import Utilities, { BASE_DEFAULTS } from '../../framework/Utilities';
-/**
- * Get a test element by data-testid
- * @param dataTestId - The data-testid of the element
- * @param options.tag - The tag of the element having the data-testid attribute (e.g. 'div', 'input', etc.). Defaults to 'div'
- * @param options.extraXPath - The extra xpath to the element (e.g. '/div/button'), useful for accessing elements we aren't able to assign a data-testid to
- * @returns The test element
- */
-function getTestElement(
-  dataTestId: string,
-  options: { extraXPath?: string; tag?: string } = {},
-): Promise<DetoxElement | WebElement | PlaywrightElement> {
-  const { tag = 'div', extraXPath = '' } = options;
-  const xpath = `//${tag}[@data-testid="${dataTestId}"]${extraXPath}`;
-
-  return Matchers.getElementByXPath(
-    BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-    xpath,
-  );
-}
 
 class BitcoinTestDapp {
   get connectButtonSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.header.connect, {
+    return Matchers.getTestElement(dataTestIds.testPage.header.connect, {
       tag: 'button',
     });
   }
 
   get disconnectButtonSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.header.disconnect, {
+    return Matchers.getTestElement(dataTestIds.testPage.header.disconnect, {
       tag: 'button',
     });
   }
 
   get walletButtonSelector(): WebElement {
-    return getTestElement(
+    return Matchers.getTestElement(
       dataTestIds.testPage.walletSelectionModal.walletOption,
       {
         tag: 'button',
@@ -49,7 +29,7 @@ class BitcoinTestDapp {
   }
 
   get standardButtonSelector(): WebElement {
-    return getTestElement(
+    return Matchers.getTestElement(
       dataTestIds.testPage.walletSelectionModal.standardButton,
       {
         tag: 'button',
@@ -58,9 +38,12 @@ class BitcoinTestDapp {
   }
 
   get signMessageButtonSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.signMessage.signMessage, {
-      tag: 'button',
-    });
+    return Matchers.getTestElement(
+      dataTestIds.testPage.signMessage.signMessage,
+      {
+        tag: 'button',
+      },
+    );
   }
 
   get confirmSignMessageButtonSelector(): WebElement {
@@ -153,13 +136,13 @@ class BitcoinTestDapp {
         await this.tapButton(this.standardButtonSelector);
       },
       getConnectionStatus: async () => {
-        const connectionStatusDiv = await getTestElement(
+        const connectionStatusDiv = await Matchers.getTestElement(
           dataTestIds.testPage.header.connectionStatus,
         );
         return await connectionStatusDiv.getText();
       },
       getAccount: async () => {
-        const account = await getTestElement(
+        const account = await Matchers.getTestElement(
           dataTestIds.testPage.header.account,
           { extraXPath: '/a' },
         );
@@ -175,7 +158,7 @@ class BitcoinTestDapp {
   async verifyConnectedAccount(connectionStatus: string): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        const account = await getTestElement(
+        const account = await Matchers.getTestElement(
           dataTestIds.testPage.header.account,
           {
             extraXPath: '/a',
@@ -199,7 +182,7 @@ class BitcoinTestDapp {
   async verifyConnectionStatus(connectionStatus: string): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        const connectionStatusDiv = await getTestElement(
+        const connectionStatusDiv = await Matchers.getTestElement(
           dataTestIds.testPage.header.connectionStatus,
         );
         const actualText = await connectionStatusDiv.getText();
@@ -220,7 +203,7 @@ class BitcoinTestDapp {
   async verifySignedMessage(signedMessage: string): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        const signedMessageElement = await getTestElement(
+        const signedMessageElement = await Matchers.getTestElement(
           dataTestIds.testPage.signMessage.signedMessage,
           {
             tag: 'pre',

--- a/tests/page-objects/Browser/SolanaTestDApp.ts
+++ b/tests/page-objects/Browser/SolanaTestDApp.ts
@@ -1,6 +1,5 @@
 import { dataTestIds } from '@metamask/test-dapp-solana';
 import Matchers from '../../framework/Matchers';
-import type { PlaywrightElement } from '../../framework/PlaywrightAdapter';
 import { BrowserViewSelectorsIDs } from '../../../app/components/Views/BrowserTab/BrowserView.testIds';
 import Browser from './BrowserView';
 import Gestures from '../../framework/Gestures';
@@ -10,43 +9,23 @@ import { getDappUrl } from '../../framework/fixtures/FixtureUtils';
 import { Utilities } from '../../framework';
 
 /**
- * Get a test element by data-testid
- * @param dataTestId - The data-testid of the element
- * @param options.tag - The tag of the element having the data-testid attribute (e.g. 'div', 'input', etc.). Defaults to 'div'
- * @param options.extraXPath - The extra xpath to the element (e.g. '/div/button'), useful for accessing elements we aren't able to assign a data-testid to
- * @returns The test element
- */
-function getTestElement(
-  dataTestId: string,
-  options: { extraXPath?: string; tag?: string } = {},
-): Promise<DetoxElement | WebElement | PlaywrightElement> {
-  const { tag = 'div', extraXPath = '' } = options;
-  const xpath = `//${tag}[@data-testid="${dataTestId}"]${extraXPath}`;
-
-  return Matchers.getElementByXPath(
-    BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
-    xpath,
-  );
-}
-
-/**
  * Class to interact with the Multichain Test DApp via the WebView
  */
 class SolanaTestDApp {
   get connectButtonSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.header.connect, {
+    return Matchers.getTestElement(dataTestIds.testPage.header.connect, {
       extraXPath: '/div/button',
     });
   }
 
   get disconnectButtonSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.header.disconnect, {
+    return Matchers.getTestElement(dataTestIds.testPage.header.disconnect, {
       extraXPath: '/button',
     });
   }
 
   get endpointSelector(): WebElement {
-    return getTestElement(dataTestIds.testPage.header.endpoint, {
+    return Matchers.getTestElement(dataTestIds.testPage.header.endpoint, {
       tag: 'input',
     });
   }
@@ -108,13 +87,13 @@ class SolanaTestDApp {
         await this.tapButton(this.walletButtonSelector);
       },
       getConnectionStatus: async () => {
-        const connectionStatusDiv = await getTestElement(
+        const connectionStatusDiv = await Matchers.getTestElement(
           dataTestIds.testPage.header.connectionStatus,
         );
         return await connectionStatusDiv.getText();
       },
       getAccount: async () => {
-        const account = await getTestElement(
+        const account = await Matchers.getTestElement(
           dataTestIds.testPage.header.account,
           { extraXPath: '/a' },
         );
@@ -127,15 +106,18 @@ class SolanaTestDApp {
     return {
       signMessage: async () => {
         await this.tapButton(
-          getTestElement(dataTestIds.testPage.signMessage.signMessage, {
-            tag: 'button',
-          }),
+          Matchers.getTestElement(
+            dataTestIds.testPage.signMessage.signMessage,
+            {
+              tag: 'button',
+            },
+          ),
         );
       },
       getSignedMessage: () =>
         Utilities.executeWithRetry(
           async () => {
-            const el = await getTestElement(
+            const el = await Matchers.getTestElement(
               dataTestIds.testPage.signMessage.signedMessage,
               { tag: 'pre' },
             );
@@ -150,29 +132,41 @@ class SolanaTestDApp {
     return {
       signTransaction: async () => {
         await this.tapButton(
-          getTestElement(dataTestIds.testPage.sendSol.signTransaction, {
-            tag: 'button',
-          }),
+          Matchers.getTestElement(
+            dataTestIds.testPage.sendSol.signTransaction,
+            {
+              tag: 'button',
+            },
+          ),
         );
       },
       sendTransaction: async () => {
         await this.tapButton(
-          getTestElement(dataTestIds.testPage.sendSol.sendTransaction, {
-            tag: 'button',
-          }),
+          Matchers.getTestElement(
+            dataTestIds.testPage.sendSol.sendTransaction,
+            {
+              tag: 'button',
+            },
+          ),
         );
       },
       getSignedTransaction: async () =>
         (
-          await getTestElement(dataTestIds.testPage.sendSol.signedTransaction, {
-            tag: 'pre',
-          })
+          await Matchers.getTestElement(
+            dataTestIds.testPage.sendSol.signedTransaction,
+            {
+              tag: 'pre',
+            },
+          )
         ).getText(),
       getTransactionHash: async () =>
         (
-          await getTestElement(dataTestIds.testPage.sendSol.transactionHash, {
-            tag: 'pre',
-          })
+          await Matchers.getTestElement(
+            dataTestIds.testPage.sendSol.transactionHash,
+            {
+              tag: 'pre',
+            },
+          )
         ).getText(),
     };
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

## Extract shared `getTestElement` from Solana/Bitcoin test dapp page objects

Identical local `getTestElement` helpers were duplicated in the Solana and Bitcoin browser test-dapp page objects (MMQA-365 / MMQA-2021). This PR moves that shared data-testid → XPath WebView lookup into `Matchers`, next to the existing `getElementByXPath` API.

- Added `Matchers.getTestElement` in `tests/framework/Matchers.ts` (same `tag` / `extraXPath` options and browser WebView targeting as before)
- Removed the local `getTestElement` functions from `SolanaTestDApp.ts` and `BitcoinTestDapp.ts`
- Updated all call sites in those page objects to use `Matchers.getTestElement`
- No selector, timeout, or product behavior changes

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MMQA-365 / MMQA-2021
https://consensyssoftware.atlassian.net/browse/MMQA-2021

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — pure structural E2E helper extraction; selectors and options are unchanged. Verified with lint on the touched files.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes; test-framework / page-object refactor only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-framework refactor only; no app or selector logic changes.
> 
> **Overview**
> **Centralizes duplicated browser WebView `data-testid` lookups** by adding `Matchers.getTestElement`, which builds the same XPath (`tag` / `extraXPath` options) and targets the browser WebView via `BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID`.
> 
> **Solana and Bitcoin test-dapp page objects** drop their local `getTestElement` helpers and call `Matchers.getTestElement` everywhere instead. Selector strings, XPath options, and timeouts are unchanged—this is structural deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20542ef8ca90f3be19ea2b9359811271d8c5138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->