### PR TITLE
fix: show Coinbase ramp orders in Activity when network is a name string cp-8.5.0

### DIFF
--- a/app/util/activity-adapters/adapters/dedup.test.ts
+++ b/app/util/activity-adapters/adapters/dedup.test.ts
@@ -77,4 +77,17 @@ describe('mergeActivityItems', () => {
       mergeActivityItems([localCopy], [confirmedCopy], [], [], [], [rampCopy]),
     ).toEqual([rampCopy]);
   });
+
+  it('keeps two ramp items that share a placeholder 0x hash from collapsing', () => {
+    // Placeholder provider hashes must not be used as Activity keys — see
+    // isPlausibleRampTxHash. After that filter, rows fall back to distinct
+    // order ids, so mergeActivityItems must keep both.
+    const first = makeItem('rampOrder', 2, 'coinbase-m/orders/order-a');
+    const second = makeItem('rampOrder', 1, 'coinbase-m/orders/order-b');
+
+    expect(mergeActivityItems([], [], [], [], [], [first, second])).toEqual([
+      first,
+      second,
+    ]);
+  });
 });

--- a/app/util/activity-adapters/adapters/ramp-order-helpers.ts
+++ b/app/util/activity-adapters/adapters/ramp-order-helpers.ts
@@ -69,11 +69,48 @@ export function toRampOrderCaipChainId(network: string): CaipChainId | null {
   }
 }
 
+/**
+ * Extracts the CAIP-2 chain id from a CAIP-19 asset id
+ * (`eip155:1/slip44:60` → `eip155:1`).
+ */
+export function caipChainIdFromAssetId(
+  assetId: string | undefined,
+): CaipChainId | null {
+  if (!assetId) {
+    return null;
+  }
+  const slash = assetId.indexOf('/');
+  const chainPart = slash === -1 ? assetId : assetId.slice(0, slash);
+  return toRampOrderCaipChainId(chainPart);
+}
+
+/**
+ * Returns true when `txHash` looks like a real on-chain hash. Provider
+ * placeholders such as `""`, `"0x"`, and all-zero hashes must not be used as
+ * Activity row keys — they collide across orders in `mergeActivityItems`.
+ */
+export function isPlausibleRampTxHash(
+  txHash: string | undefined | null,
+): txHash is string {
+  if (!txHash) {
+    return false;
+  }
+  const normalized = txHash.trim().toLowerCase();
+  if (!normalized || normalized === '0x') {
+    return false;
+  }
+  if (/^0x0+$/u.test(normalized)) {
+    return false;
+  }
+  return true;
+}
+
 export function getRampOrderTransactionHash(
   order: FiatOrder,
   kind: RampActivityKind,
 ): string | undefined {
-  return kind === 'sell' ? order.sellTxHash : order.txHash;
+  const txHash = kind === 'sell' ? order.sellTxHash : order.txHash;
+  return isPlausibleRampTxHash(txHash) ? txHash : undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/app/util/activity-adapters/adapters/ramp-order.test.ts
+++ b/app/util/activity-adapters/adapters/ramp-order.test.ts
@@ -143,6 +143,27 @@ describe('mapRampOrder', () => {
     ).toBeNull();
   });
 
+  it('falls through an unparseable network name to cryptoCurrency.assetId', () => {
+    const order = {
+      ...baseOrder,
+      network: 'ethereum',
+      data: {
+        cryptoCurrency: {
+          symbol: 'ETH',
+          assetId: 'eip155:1/slip44:60',
+        },
+      },
+    } as FiatOrder;
+
+    expect(mapRampOrder({ order })?.chainId).toBe('eip155:1');
+  });
+
+  it('treats placeholder txHash values as missing and falls back to order id', () => {
+    expect(mapRampOrder({ order: { ...baseOrder, txHash: '0x' } })?.hash).toBe(
+      'order-1',
+    );
+  });
+
   it('maps orders with a non-EVM CAIP-2 network', () => {
     const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 

--- a/app/util/activity-adapters/adapters/ramp-order.ts
+++ b/app/util/activity-adapters/adapters/ramp-order.ts
@@ -3,10 +3,12 @@
  * unified Activity list. Lives in mobile until shared
  * `@metamask/activity-adapters` publishes an equivalent.
  */
+import type { CaipChainId } from '@metamask/utils';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { FiatOrder } from '../../../reducers/fiatOrders/types';
 import type { ActivityListItem } from '../types';
 import {
+  caipChainIdFromAssetId,
   getRampOrderTransactionHash,
   mapRampOrderStatus,
   mapRampOrderType,
@@ -16,6 +18,35 @@ import {
 
 export interface MapRampOrderArgs {
   order: FiatOrder;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Resolves CAIP-2 for a legacy FiatOrder. Falls through an unparseable
+ * network name string (e.g. `"ethereum"`) to cryptoCurrency metadata.
+ */
+function toFiatOrderCaipChainId(order: FiatOrder): CaipChainId | null {
+  const fromNetwork = toRampOrderCaipChainId(order.network);
+  if (fromNetwork) {
+    return fromNetwork;
+  }
+
+  const cryptoCurrency = asRecord(asRecord(order.data)?.cryptoCurrency);
+  const chainId = cryptoCurrency?.chainId;
+  if (typeof chainId === 'string') {
+    const fromChain = toRampOrderCaipChainId(chainId);
+    if (fromChain) {
+      return fromChain;
+    }
+  }
+
+  const assetId = cryptoCurrency?.assetId;
+  return typeof assetId === 'string' ? caipChainIdFromAssetId(assetId) : null;
 }
 
 /**
@@ -34,7 +65,7 @@ export function mapRampOrder({
     return null;
   }
 
-  const chainId = toRampOrderCaipChainId(order.network);
+  const chainId = toFiatOrderCaipChainId(order);
   if (!chainId) {
     return null;
   }

--- a/app/util/activity-adapters/adapters/ramps-order-helpers.ts
+++ b/app/util/activity-adapters/adapters/ramps-order-helpers.ts
@@ -1,13 +1,9 @@
 import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
-import {
-  isCaipChainId,
-  parseCaipChainId,
-  toCaipChainId,
-  type CaipChainId,
-} from '@metamask/utils';
-import { getDecimalChainId } from '../../../util/networks';
+import type { CaipChainId } from '@metamask/utils';
 import type { Status, TokenAmount } from '../types';
 import {
+  caipChainIdFromAssetId,
+  isPlausibleRampTxHash,
   toRampOrderCaipChainId,
   type RampActivityKind,
 } from './ramp-order-helpers';
@@ -66,41 +62,50 @@ export function getRampsOrderCreatedAt(order: RampsOrder): number {
 }
 
 /**
- * Resolves CAIP-2 chain id from `network` (object or decimal/CAIP string) or
- * `cryptoCurrency.chainId`.
+ * Resolves CAIP-2 chain id for a RampsController order.
+ *
+ * Tries each source in order and falls through when a value is present but
+ * unparseable (e.g. Coinbase's network name string `"ethereum"`). Generic
+ * providers often return a free-form network name while still attaching a
+ * real CAIP `cryptoCurrency.chainId` / `assetId`.
+ *
+ * Precedence:
+ * 1. `network.chainId` when `network` is an object
+ * 2. `network` when it is a decimal or CAIP string
+ * 3. `cryptoCurrency.chainId`
+ * 4. chain segment of `cryptoCurrency.assetId`
  */
 export function toRampsOrderCaipChainId(order: RampsOrder): CaipChainId | null {
   const network = order.network as RampsOrder['network'] | string | null;
-  if (network && typeof network === 'object' && network.chainId) {
-    return toRampOrderCaipChainId(network.chainId);
-  }
-  if (typeof network === 'string' && network) {
-    return toRampOrderCaipChainId(network);
-  }
 
-  const cryptoChainId = order.cryptoCurrency?.chainId;
-  if (cryptoChainId) {
-    try {
-      if (isCaipChainId(cryptoChainId)) {
-        const { namespace, reference } = parseCaipChainId(cryptoChainId);
-        return toCaipChainId(namespace, reference);
-      }
-      const chainReference = getDecimalChainId(cryptoChainId);
-      if (chainReference && !Number.isNaN(Number(chainReference))) {
-        return toCaipChainId('eip155', chainReference);
-      }
-    } catch {
-      return null;
+  if (network && typeof network === 'object' && network.chainId) {
+    const fromObject = toRampOrderCaipChainId(network.chainId);
+    if (fromObject) {
+      return fromObject;
     }
   }
 
-  return null;
+  if (typeof network === 'string' && network) {
+    const fromString = toRampOrderCaipChainId(network);
+    if (fromString) {
+      return fromString;
+    }
+  }
+
+  if (order.cryptoCurrency?.chainId) {
+    const fromCrypto = toRampOrderCaipChainId(order.cryptoCurrency.chainId);
+    if (fromCrypto) {
+      return fromCrypto;
+    }
+  }
+
+  return caipChainIdFromAssetId(order.cryptoCurrency?.assetId);
 }
 
 export function getRampsOrderTransactionHash(
   order: RampsOrder,
 ): string | undefined {
-  return order.txHash || undefined;
+  return isPlausibleRampTxHash(order.txHash) ? order.txHash : undefined;
 }
 
 export function toRampsOrderToken(

--- a/app/util/activity-adapters/adapters/ramps-order.test.ts
+++ b/app/util/activity-adapters/adapters/ramps-order.test.ts
@@ -158,6 +158,106 @@ describe('mapRampsOrder', () => {
     expect(mapRampsOrder({ order })?.chainId).toBe('eip155:1');
   });
 
+  it('falls through an unparseable network name to cryptoCurrency.chainId', () => {
+    // Coinbase (and other generic providers) return network as a free-form
+    // name string while still attaching a CAIP cryptoCurrency.chainId.
+    // Regression: TRAM-3822 / state log v8.5.0 (6225) order …b03d98.
+    const order: RampsOrder = {
+      ...baseOrder,
+      id: 'coinbase-m/orders/c-d599b5708a6011f197a0374abeb03d98',
+      providerOrderId: 'c-d599b5708a6011f197a0374abeb03d98',
+      network: 'ethereum' as unknown as RampsOrder['network'],
+      txHash: '0x',
+      cryptoAmount: 0.00112678,
+      fiatAmount: 2,
+      cryptoCurrency: {
+        assetId: 'eip155:1/slip44:60',
+        chainId: 'eip155:1',
+        name: 'Ethereum',
+        symbol: 'ETH',
+        decimals: 18,
+      },
+      fiatCurrency: {
+        id: 'eur',
+        symbol: 'EUR',
+        name: 'Euro',
+        decimals: 2,
+      },
+    };
+
+    expect(mapRampsOrder({ order })).toMatchObject({
+      type: 'buy',
+      chainId: 'eip155:1',
+      status: 'success',
+      hash: 'coinbase-m/orders/c-d599b5708a6011f197a0374abeb03d98',
+      data: {
+        token: {
+          amount: '0.00112678',
+          symbol: 'ETH',
+          assetId: 'eip155:1/slip44:60',
+          direction: 'in',
+        },
+      },
+    });
+  });
+
+  it('falls through an unparseable network name to cryptoCurrency.assetId', () => {
+    const order = {
+      ...baseOrder,
+      network: 'ethereum' as unknown as RampsOrder['network'],
+      cryptoCurrency: {
+        symbol: 'ETH',
+        assetId: 'eip155:1/slip44:60',
+      },
+    };
+
+    expect(mapRampsOrder({ order })?.chainId).toBe('eip155:1');
+  });
+
+  it('returns null when network is an unparseable name and crypto currency has no chain', () => {
+    expect(
+      mapRampsOrder({
+        order: {
+          ...baseOrder,
+          network: 'ethereum' as unknown as RampsOrder['network'],
+          cryptoCurrency: undefined,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('treats placeholder txHash values as missing and falls back to order id', () => {
+    expect(mapRampsOrder({ order: { ...baseOrder, txHash: '0x' } })?.hash).toBe(
+      baseOrder.id,
+    );
+    expect(
+      mapRampsOrder({ order: { ...baseOrder, txHash: '0x0000' } })?.hash,
+    ).toBe(baseOrder.id);
+  });
+
+  it('keeps distinct placeholder-hash orders from collapsing under the same key', () => {
+    const first = mapRampsOrder({
+      order: {
+        ...baseOrder,
+        id: 'coinbase-m/orders/order-a',
+        txHash: '0x',
+        network: 'ethereum' as unknown as RampsOrder['network'],
+      },
+    });
+    const second = mapRampsOrder({
+      order: {
+        ...baseOrder,
+        id: 'coinbase-m/orders/order-b',
+        txHash: '0x',
+        network: 'ethereum' as unknown as RampsOrder['network'],
+      },
+    });
+
+    expect(first?.hash).toBe('coinbase-m/orders/order-a');
+    expect(second?.hash).toBe('coinbase-m/orders/order-b');
+    expect(first?.hash).not.toBe(second?.hash);
+  });
+
   it('maps non-EVM CAIP-2 network metadata', () => {
     const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
     expect(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready for Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fix Activity list dropping completed Coinbase (and similar generic-provider) ramp orders when the on-ramp API returns `network` as a free-form provider name (e.g. `"ethereum"`) instead of a CAIP-2 object with `chainId`.

**What changed:**
- `toRampsOrderCaipChainId` falls through unparseable `network` values to `cryptoCurrency.chainId`, then the chain segment of `cryptoCurrency.assetId`, instead of early-returning `null`
- Placeholder `txHash` values (`""`, `"0x"`, all-zero) are treated as missing so activity rows key on `order.id` and do not collide in `mergeActivityItems`
- Same chain / hash fallbacks applied to the legacy `FiatOrder` adapter for parity

**Note:** This is the 8.5 CP unblocker. Durable fix is tracked in [TRAM-3836](https://consensyssoftware.atlassian.net/browse/TRAM-3836) — API should canonicalize `network` to CAIP-2 for SDK ≥2.1.0 and clients should remove this mapping.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed ramp orders from providers like Coinbase not appearing in the Activity tab when the API network field is a provider name string

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3822

Refs: https://consensyssoftware.atlassian.net/browse/TRAM-3836

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Coinbase ramp orders in Activity (8.5 CP)

  Scenario: completed Coinbase buy appears in Activity
    Given tmcuActivityRedesignEnabled and tmcuTransactionsRedesignEnabled are enabled
    And the user completes a Coinbase buy on an 8.5 build with this CP

    When the user opens the Activity tab
    Then the completed Coinbase order appears under Buy/Sell
    And opening the row shows order details

  Scenario: sibling ID_EXPIRED stub stays hidden
    Given a Coinbase flow that creates an ID_EXPIRED stub alongside the real order

    When the user opens Activity
    Then only the real order is shown (stub remains hidden)

  Scenario: Transak native regression
    Given a completed Transak native order with object network and real chainId

    When the user opens Activity
    Then the order still appears and details load correctly
```

Unit tests:
- [x] `yarn jest app/util/activity-adapters/adapters/ramps-order.test.ts app/util/activity-adapters/adapters/ramp-order.test.ts app/util/activity-adapters/adapters/dedup.test.ts`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — behavior verified via unit tests and manual QA on 8.5 RC (Coinbase buy flow). No before/after screenshots attached to this CP.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TRAM-3836]: https://consensyssoftware.atlassian.net/browse/TRAM-3836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ