### PR TITLE
feat(money): add jwt based rate limiting support to money account api

### DIFF
--- a/app/core/Engine/messengers/money-account-api-data-service-messenger.test.ts
+++ b/app/core/Engine/messengers/money-account-api-data-service-messenger.test.ts
@@ -1,0 +1,39 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+  MOCK_ANY_NAMESPACE,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import type { MoneyAccountApiDataServiceMessenger } from '@metamask/money-account-api-data-service';
+import { getMoneyAccountApiDataServiceMessenger } from './money-account-api-data-service-messenger';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<MoneyAccountApiDataServiceMessenger>,
+  MessengerEvents<MoneyAccountApiDataServiceMessenger>
+>;
+
+function getRootMessenger(): RootMessenger {
+  return new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+}
+
+describe('getMoneyAccountApiDataServiceMessenger', () => {
+  it('delegates AuthenticationController:getBearerToken to the service messenger', async () => {
+    const rootMessenger = getRootMessenger();
+    rootMessenger.registerActionHandler(
+      'AuthenticationController:getBearerToken',
+      jest.fn().mockResolvedValue('test-bearer-token'),
+    );
+    const serviceMessenger =
+      getMoneyAccountApiDataServiceMessenger(rootMessenger);
+
+    const token = await serviceMessenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+
+    expect(token).toBe('test-bearer-token');
+  });
+});

--- a/app/core/Engine/messengers/money-account-api-data-service-messenger.ts
+++ b/app/core/Engine/messengers/money-account-api-data-service-messenger.ts
@@ -19,7 +19,7 @@ export function getMoneyAccountApiDataServiceMessenger(
     MessengerEvents<MoneyAccountApiDataServiceMessenger>
   >,
 ): MoneyAccountApiDataServiceMessenger {
-  const messenger = new Messenger({
+  const messenger: MoneyAccountApiDataServiceMessenger = new Messenger({
     namespace: 'MoneyAccountApiDataService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/money-account-api-data-service-messenger.ts
+++ b/app/core/Engine/messengers/money-account-api-data-service-messenger.ts
@@ -19,8 +19,14 @@ export function getMoneyAccountApiDataServiceMessenger(
     MessengerEvents<MoneyAccountApiDataServiceMessenger>
   >,
 ): MoneyAccountApiDataServiceMessenger {
-  return new Messenger({
+  const messenger = new Messenger({
     namespace: 'MoneyAccountApiDataService',
     parent: rootMessenger,
   });
+  rootMessenger.delegate({
+    actions: ['AuthenticationController:getBearerToken'],
+    events: [],
+    messenger,
+  });
+  return messenger;
 }

--- a/package.json
+++ b/package.json
@@ -317,7 +317,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-api-data-service": "^0.3.0",
+    "@metamask/money-account-api-data-service": "^0.4.0",
     "@metamask/money-account-balance-service": "^2.3.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9313,9 +9313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-api-data-service@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@metamask/money-account-api-data-service@npm:0.3.0"
+"@metamask/money-account-api-data-service@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@metamask/money-account-api-data-service@npm:0.4.0"
   dependencies:
     "@metamask/base-data-service": "npm:^0.1.3"
     "@metamask/controller-utils": "npm:^12.3.0"
@@ -9323,7 +9323,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^4.43.0"
-  checksum: 10/eed99d9167d85215e64706714c4c3efa8556bdd772d6f2df83ca5ac08989316d8269c2a136c1545a47dacee20519a2bd94acf9905a284bb6910bd1565119728f
+  checksum: 10/cb3106f2c40e776a9876844aaa5778f79308b23a7f0ff9eaee8cc2c7fbdf0489532b7bd2463e740051c1b7da0fb980aa59ad3f5272a3c19898744294d89a002a
   languageName: node
   linkType: hard
 
@@ -35930,7 +35930,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-api-data-service": "npm:^0.3.0"
+    "@metamask/money-account-api-data-service": "npm:^0.4.0"
     "@metamask/money-account-balance-service": "npm:^2.3.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^3.0.0"


### PR DESCRIPTION
## **Description**

Updates `@metamask/money-account-api-data-service` from `^0.3.0` to `^0.4.0`.

The new version adds best-effort profile JWT authentication to Money Account API requests. When a profile token is available, requests include `Authorization: Bearer <token>` so edge rate limiting can use per-user buckets instead of shared IP-based buckets. Locked or signed-out wallets continue to make unauthenticated requests.

### Changes

- Bumped `@metamask/money-account-api-data-service` to `^0.4.0`
- Updated the Yarn lockfile
- Delegated `AuthenticationController:getBearerToken` to the service's scoped messenger
- Added coverage for bearer-token action delegation

## **Changelog**

CHANGELOG entry: Updated Money Account API requests to use profile authentication when available

## **Related issues**

- Upstream implementation: https://github.com/MetaMask/core/pull/9661
- Upstream release: https://github.com/MetaMask/core/pull/9677

## **Manual testing steps**

```gherkin
Feature: Authenticated Money Account API requests

  Scenario: Signed-in wallet sends authenticated requests
    Given the user is signed in to their MetaMask profile
    And the user has a Money Account

    When the user opens Money home
    Then Money Account API requests include the profile bearer token
    And Money Account data loads successfully

  Scenario: Profile token is unavailable
    Given the user is signed out or the wallet is locked
    And the user opens Money home

    Then Money Account API requests proceed without an Authorization header
    And existing unauthenticated behavior is preserved
```

## **Screenshots/Recordings**

Not applicable; this dependency update has no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication token plumbing for Money Account API traffic; behavior is additive (optional Bearer header) with tests, but mis-delegation could break authenticated Money flows.
> 
> **Overview**
> Upgrades **`@metamask/money-account-api-data-service`** to **^0.4.0** so Money Account API calls can attach a profile JWT when one exists (per-user rate limiting upstream); signed-out or locked wallets stay unauthenticated.
> 
> **`getMoneyAccountApiDataServiceMessenger`** now **`delegate`s** **`AuthenticationController:getBearerToken`** from the root messenger into the scoped service messenger—the same wiring pattern used for assets and other controllers. A new unit test asserts that bearer-token requests on the service messenger reach the root handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9600fc448d9015da4e837ba08498fd972475430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->