### PR TITLE
perf(money): virtualize the potential earnings token list (MUSD-1231)

### DIFF
--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.perf-test.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.perf-test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { measureRenders } from 'reassure';
+import configureStore from '../../../../../util/test/configureStore';
+import initialRootState from '../../../../../util/test/initial-root-state';
+import { mockTheme, ThemeContext } from '../../../../../util/theme';
+import type { AssetType } from '../../../../Views/confirmations/types/token';
+import MoneyPotentialEarningsView from './MoneyPotentialEarningsView';
+
+// The scaling axis for this screen is eligible token count, not account count:
+// every row is built up-front because the list is not virtualised.
+const SMALL_TOKEN_COUNT = 5;
+const LARGE_TOKEN_COUNT = 60;
+
+const CHAIN_IDS = ['0x1', '0xa4b1', '0x2105', '0x38', '0xe708'];
+
+const buildTokens = (count: number): AssetType[] =>
+  Array.from({ length: count }, (_value, index) => {
+    const balance = 5000 - index * 50;
+    return {
+      name: `Stablecoin ${index + 1}`,
+      symbol: `STBL${index + 1}`,
+      address: `0x${(index + 1).toString(16).padStart(40, '0')}`,
+      chainId: CHAIN_IDS[index % CHAIN_IDS.length],
+      decimals: 6,
+      balanceInSelectedCurrency: `$${balance}.00`,
+      fiat: { balance, currency: 'usd' },
+    } as unknown as AssetType;
+  });
+
+let mockTokens: AssetType[] = [];
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useMoneyDepositTokens', () => ({
+  useMoneyDepositTokens: () => ({
+    tokens: mockTokens,
+    isNoFeeToken: () => true,
+  }),
+}));
+
+jest.mock('../../hooks/useMoneyAccountBalance', () => ({
+  __esModule: true,
+  default: () => ({ apyDecimal: 0.04, apyPercent: 4 }),
+}));
+
+jest.mock('../../hooks/useMoneyAccount', () => ({
+  useMoneyAccountDeposit: () => ({
+    initiateDeposit: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+jest.mock('../../hooks/useMoneyAnalytics', () => ({
+  useMoneyAnalytics: () => ({
+    trackScreenViewed: jest.fn(),
+    trackTokenButtonClicked: jest.fn(),
+    trackTokenSurfaceClicked: jest.fn(),
+    trackTooltipClicked: jest.fn(),
+  }),
+}));
+
+// FlashList measures its viewport natively, which reports zero under Jest and
+// would make it render every row — masking the windowing this screen relies on.
+// Mirrors @shopify/flash-list's own jestSetup: a 400x900 viewport with 100px
+// rows, i.e. roughly one screenful. Scoped to this file so the unit suite keeps
+// asserting that every eligible token is reachable.
+jest.mock('@shopify/flash-list/dist/recyclerview/utils/measureLayout', () => ({
+  ...jest.requireActual(
+    '@shopify/flash-list/dist/recyclerview/utils/measureLayout',
+  ),
+  measureParentSize: () => ({ x: 0, y: 0, width: 400, height: 900 }),
+  measureFirstChildLayout: () => ({ x: 0, y: 0, width: 400, height: 900 }),
+  measureItemLayout: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+}));
+
+// Native-backed leaves inside each row. Mocked to keep the measurement on the
+// list itself rather than on RN internals these rows only pass through.
+jest.mock(
+  '../../../../UI/Assets/components/AssetLogo/AssetLogo',
+  () => 'AssetLogo',
+);
+jest.mock('../../../../UI/AssetOverview/Balance/Balance', () => ({
+  NetworkBadgeSource: () => null,
+}));
+jest.mock('react-native-linear-gradient', () => 'LinearGradient');
+jest.mock('@react-native-masked-view/masked-view', () => 'MaskedView');
+
+const store = configureStore(initialRootState);
+
+const ProvidersWrapper = ({ children }: { children: React.ReactElement }) => (
+  <Provider store={store}>
+    <ThemeContext.Provider value={mockTheme}>{children}</ThemeContext.Provider>
+  </Provider>
+);
+
+test(`MoneyPotentialEarningsView mount performance with ${SMALL_TOKEN_COUNT} eligible tokens`, async () => {
+  mockTokens = buildTokens(SMALL_TOKEN_COUNT);
+
+  await measureRenders(<MoneyPotentialEarningsView />, {
+    wrapper: ProvidersWrapper,
+  });
+});
+
+test(`MoneyPotentialEarningsView mount performance with ${LARGE_TOKEN_COUNT} eligible tokens`, async () => {
+  mockTokens = buildTokens(LARGE_TOKEN_COUNT);
+
+  await measureRenders(<MoneyPotentialEarningsView />, {
+    wrapper: ProvidersWrapper,
+  });
+});

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import { ScrollView } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
@@ -184,6 +184,87 @@ const MoneyPotentialEarningsView = () => {
     [eligibleTokens.length, initiateDeposit, trackTokenSurfaceClicked],
   );
 
+  const listHeader = useMemo(
+    () => (
+      <Box twClassName="px-4 py-3 gap-3">
+        <Text variant={TextVariant.HeadingMd}>
+          {strings('money.potential_earnings.title')}
+        </Text>
+
+        {isPositiveNumber(projectedAmount) &&
+        isPositiveNumber(totalAssetsFiat) ? (
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Regular}
+            color={TextColor.TextAlternative}
+            testID={MoneyPotentialEarningsViewTestIds.DESCRIPTION}
+          >
+            {`${strings(
+              'money.potential_earnings.description_with_amounts_prefix',
+            )} `}
+            <SensitiveText
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Regular}
+              color={TextColor.TextAlternative}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Medium}
+              testID={MoneyPotentialEarningsViewTestIds.TOTAL}
+            >
+              {moneyFormatFiat(new BigNumber(totalAssetsFiat), currency)}
+            </SensitiveText>
+            {` ${strings(
+              'money.potential_earnings.description_with_amounts_middle',
+            )} `}
+            <SensitiveText
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.SuccessDefault}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+              testID={MoneyPotentialEarningsViewTestIds.PROJECTED}
+            >
+              {`+${moneyFormatFiat(new BigNumber(projectedAmount), currency)}`}
+            </SensitiveText>
+            {` ${strings(
+              'money.potential_earnings.description_with_amounts_suffix',
+            )}`}
+          </Text>
+        ) : (
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Regular}
+            color={TextColor.TextAlternative}
+            testID={MoneyPotentialEarningsViewTestIds.DESCRIPTION}
+          >
+            {strings('money.potential_earnings.description')}
+          </Text>
+        )}
+      </Box>
+    ),
+    [projectedAmount, totalAssetsFiat, currency, privacyMode],
+  );
+
+  const renderTokenRow = useCallback(
+    ({ item, index }: { item: AssetType; index: number }) => (
+      <PotentialEarningsTokenRow
+        token={item}
+        hasSubsidizedFee={isNoFeeToken(item)}
+        apyDecimal={apyDecimalForProjection}
+        onCardPress={handleTokenCardPress(item, index)}
+        onButtonPress={handleTokenButtonPress(item, index)}
+        testID={MoneyPotentialEarningsViewTestIds.TOKEN_ROW(index)}
+        privacyMode={privacyMode}
+      />
+    ),
+    [
+      isNoFeeToken,
+      apyDecimalForProjection,
+      handleTokenCardPress,
+      handleTokenButtonPress,
+      privacyMode,
+    ],
+  );
+
   return (
     <Box
       style={[styles.safeArea, { paddingTop: insets.top }]}
@@ -209,78 +290,16 @@ const MoneyPotentialEarningsView = () => {
           testID={MoneyPotentialEarningsViewTestIds.INFO_BUTTON}
         />
       </Box>
-      <ScrollView
-        testID={MoneyPotentialEarningsViewTestIds.SCROLL_VIEW}
-        showsVerticalScrollIndicator={false}
-      >
-        <Box twClassName="px-4 py-3 gap-3">
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('money.potential_earnings.title')}
-          </Text>
-
-          {isPositiveNumber(projectedAmount) &&
-          isPositiveNumber(totalAssetsFiat) ? (
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Regular}
-              color={TextColor.TextAlternative}
-              testID={MoneyPotentialEarningsViewTestIds.DESCRIPTION}
-            >
-              {`${strings(
-                'money.potential_earnings.description_with_amounts_prefix',
-              )} `}
-              <SensitiveText
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Regular}
-                color={TextColor.TextAlternative}
-                isHidden={privacyMode}
-                length={SensitiveTextLength.Medium}
-                testID={MoneyPotentialEarningsViewTestIds.TOTAL}
-              >
-                {moneyFormatFiat(new BigNumber(totalAssetsFiat), currency)}
-              </SensitiveText>
-              {` ${strings(
-                'money.potential_earnings.description_with_amounts_middle',
-              )} `}
-              <SensitiveText
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.SuccessDefault}
-                isHidden={privacyMode}
-                length={SensitiveTextLength.Short}
-                testID={MoneyPotentialEarningsViewTestIds.PROJECTED}
-              >
-                {`+${moneyFormatFiat(new BigNumber(projectedAmount), currency)}`}
-              </SensitiveText>
-              {` ${strings(
-                'money.potential_earnings.description_with_amounts_suffix',
-              )}`}
-            </Text>
-          ) : (
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Regular}
-              color={TextColor.TextAlternative}
-              testID={MoneyPotentialEarningsViewTestIds.DESCRIPTION}
-            >
-              {strings('money.potential_earnings.description')}
-            </Text>
-          )}
-        </Box>
-
-        {eligibleTokens.map((token, index) => (
-          <PotentialEarningsTokenRow
-            key={`${token.address}-${token.chainId}`}
-            token={token}
-            hasSubsidizedFee={isNoFeeToken(token)}
-            apyDecimal={apyDecimalForProjection}
-            onCardPress={handleTokenCardPress(token, index)}
-            onButtonPress={handleTokenButtonPress(token, index)}
-            testID={MoneyPotentialEarningsViewTestIds.TOKEN_ROW(index)}
-            privacyMode={privacyMode}
-          />
-        ))}
-      </ScrollView>
+      <Box twClassName="flex-1">
+        <FlashList
+          testID={MoneyPotentialEarningsViewTestIds.SCROLL_VIEW}
+          data={eligibleTokens}
+          renderItem={renderTokenRow}
+          keyExtractor={(token) => `${token.address}-${token.chainId}`}
+          ListHeaderComponent={listHeader}
+          showsVerticalScrollIndicator={false}
+        />
+      </Box>
       <Box
         twClassName="px-4 pt-3"
         style={{ paddingBottom: insets.bottom + 12 }}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "View all" potential earnings screen (`MoneyPotentialEarningsView`) renders every eligible deposit token row up-front inside a plain `ScrollView`, so its mount cost scales linearly with the size of the user's portfolio. Each row builds a token logo, network badge, "No fee" tag, CTA button and a projected-earnings figure, and none of that work is deferred — the whole list is constructed before the screen can appear.

This renders the rows through `FlashList` v2 instead, moving the description block into `ListHeaderComponent`. Render cost is now bounded by the viewport rather than by token count.

Measured with Reassure (`MoneyPotentialEarningsView.perf-test.tsx`), mean of 10 runs:

| Fixture | Before | After | Δ |
| --- | --- | --- | --- |
| 60 eligible tokens | 45.86 ms (stdev 19.97) | 19.20 ms (stdev 0.49) | **−58%** |
| 5 eligible tokens | 6.92 ms (stdev 0.31) | 11.38 ms (stdev 0.35) | **+64%** |

The small-list regression is `FlashList`'s fixed multi-pass layout cost, paid regardless of list size. It is a deliberate trade: both small-list figures stay under the 16.6 ms frame budget, while the large-list case drops from roughly three frames to just over one. Run-to-run variance also collapses — the `ScrollView` path ranged 29–88 ms at 60 tokens, `FlashList` is a consistent ~19 ms.

The Reassure test is committed so CI gates future regressions on this screen. It mocks `FlashList`'s native layout measurement, which reports zero under Jest and would otherwise render every row and mask the windowing being measured.

Found by the Performance Skill audit in MUSD-1108, where it was the only finding judged plausibly perceptible to users.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved the loading performance of the Money potential earnings list for wallets holding many tokens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1231

## **Manual testing steps**

```gherkin
Feature: Money potential earnings list

  Scenario: user opens View all with a large portfolio
    Given the user has a wallet holding many eligible deposit tokens across chains
    And the user is on the Money home screen

    When user taps the "Potential earnings" section header or "View all"
    Then the potential earnings screen opens without a visible delay
    And every eligible token is reachable by scrolling
    And scrolling the list stays smooth

  Scenario: user opens View all with a small portfolio
    Given the user has a wallet holding a handful of eligible deposit tokens
    And the user is on the Money home screen

    When user taps the "Potential earnings" section header or "View all"
    Then the list renders exactly as before, with no visual change

  Scenario: user acts on a token row
    Given the user is on the potential earnings screen

    When user taps a token row or its "Add" button
    Then the deposit flow opens with that token preselected
    And the "No fee" tag, balance and projected earnings match the previous behaviour
```

Note: device verification is still outstanding. The scaling axis for this screen is **eligible token count**, not account count, so a power-user wallet needs a wide multi-chain stablecoin spread to exercise the change.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — this changes how the list is rendered, not what it renders. The screen is visually identical; the difference is mount time and scroll smoothness, captured in the Reassure numbers above.

### **After**

N/A — see above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only list virtualization with preserved test IDs and deposit/analytics handlers; small-list overhead is an accepted trade-off with no auth or data-path changes.
> 
> **Overview**
> **MoneyPotentialEarningsView** no longer mounts every eligible deposit token inside a `ScrollView`. Token rows are rendered through **`FlashList`**, with the title and earnings description moved into **`ListHeaderComponent`** (`useMemo`) and row rendering extracted to a stable **`renderItem`** callback.
> 
> A new **Reassure** perf suite (`MoneyPotentialEarningsView.perf-test.tsx`) benchmarks mount time at **5** vs **60** tokens and mocks FlashList layout measurement (and heavy row children) so Jest reflects viewport windowing instead of rendering the full list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3e5c55c7a77deb8a437a4c0f1395a1f0eb7d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->