### PR TITLE
chore: bump rive-react-native to 9.8.5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3856,10 +3856,10 @@ PODS:
     - SocketRocket
   - ReactNativePayments (2.0.2):
     - React
-  - rive-react-native (9.8.3):
+  - rive-react-native (9.8.5):
     - React-Core
-    - RiveRuntime (= 6.18.2)
-  - RiveRuntime (6.18.2)
+    - RiveRuntime (= 6.21.1)
+  - RiveRuntime (6.21.1)
   - RNCAsyncStorage (2.2.0):
     - boost
     - DoubleConversion
@@ -5257,8 +5257,8 @@ SPEC CHECKSUMS:
   ReactCodegen: c8db9328177bc793ed2e3a217931689c594c5cf8
   ReactCommon: e788387a0b387a927a2a5d041fab09472fe8dedc
   ReactNativePayments: b501b8e13b52a7ee532634414b92c5c8790a6b58
-  rive-react-native: 3692bf8b8b617c8c801e6af54d961a2574fdbf38
-  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
+  rive-react-native: 0fad980aaaff989d45befe808c33de7dbec3f135
+  RiveRuntime: b762bd437b7de47d34d0f8e670112d0b9143f8d6
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNCCheckbox: 33b44487ca8008394ce658cc32b26eab04f426ef
   RNCClipboard: 889577746cd7ba699bd497e61a7668e6c0790e7f

--- a/package.json
+++ b/package.json
@@ -567,7 +567,7 @@
     "redux-saga": "^1.3.0",
     "redux-thunk": "^2.4.2",
     "reselect": "^5.1.1",
-    "rive-react-native": "^9.8.0",
+    "rive-react-native": "9.8.5",
     "rxjs": "^7.8.1",
     "semver": "^7.7.3",
     "socket.io-client": "^4.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36304,7 +36304,7 @@ __metadata:
     redux-thunk: "npm:^2.4.2"
     regenerator-runtime: "npm:0.13.9"
     reselect: "npm:^5.1.1"
-    rive-react-native: "npm:^9.8.0"
+    rive-react-native: "npm:9.8.5"
     rxjs: "npm:^7.8.1"
     semver: "npm:^7.7.3"
     serve-handler: "npm:^6.1.5"
@@ -42477,13 +42477,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rive-react-native@npm:^9.8.0":
-  version: 9.8.3
-  resolution: "rive-react-native@npm:9.8.3"
+"rive-react-native@npm:9.8.5":
+  version: 9.8.5
+  resolution: "rive-react-native@npm:9.8.5"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/b646d50dfa235965f7c28e0fc036a0f606469e54039ae89330124d2bc1bb7af5313e7c833cab826015ad9c5ae2e0c36ef60f15ae08fb8d564567d3b2f46ccd44
+  checksum: 10/67b47eb920405ed5e1bff4b28e819c86801bf51330feefdfea475992817fd92313837ea890528f097c510cc72ab85a6ba0490f9fa99f6bb18850ce5ba740d147
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `rive-react-native` from `^9.8.0` (lockfile-resolved 9.8.3) to an exact `9.8.5`.

**Why:** MUSD-1200 — the card education animation on the Spend-and-Earn screen renders with an incorrect viewport. Rive support (via #rive-support) diagnosed this as a bug in the legacy-bundled RiveRuntime we ship, not in the `.riv` file, and confirmed it does not reproduce on newer runtimes.

**What this changes:** the 9.8.x wrapper line contains no JS/API changes — each release only bumps the pinned native runtimes. This bump moves us:

- iOS `RiveRuntime` 6.18.2 → **6.21.1**
- Android `app.rive:rive-android` 11.4.1 → **11.7.2**

These are the exact same native runtime versions bundled by the new `@rive-app/react-native` (Nitro) package, so this delivers the runtime fix without the full Nitro migration (which is planned separately — it requires an atomic port of all 20 Rive call sites and a `react-native-nitro-modules` bump).

Version is now pinned exact (was caret) so future native-runtime changes are explicit, since behavior depends on the bundled runtime version.

**Verification done:**
- `yarn lint:tsc` clean
- 112 test suites / 1647 unit tests passing across all 20 Rive call-site directories (Money, Perps, Rewards, Onboarding, FoxLoader/FoxAnimation, hardware-wallet flows, Carousel, SocialLeaderboard, WalletHome)
- `pod install` regenerated Podfile.lock; only RiveRuntime changed

**Pending before un-drafting:** on-device verification that MUSD-1200's viewport issue is fixed (iOS + Android), plus smoke of the highest-traffic Rive surfaces.

## **Changelog**

CHANGELOG entry: Fixed the card education animation rendering with an incorrect viewport on the Spend and Earn screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1200

## **Manual testing steps**

```gherkin
Feature: Card education animation viewport

  Scenario: user views the Spend and Earn card education screen
    Given the app is installed and the user reaches the Spend and Earn (card education) screen

    When the sequenced card and text animation plays
    Then the Rive animation renders with the correct viewport/scale (card fully visible, correctly sized)

  Scenario: user encounters other Rive animations
    Given the bump changes only the bundled Rive native runtimes

    When the user views the Fox loader, onboarding animation, Perps tutorial carousel, and Rewards points animation
    Then all animations render and play as before (no regressions)
```

## **Screenshots/Recordings**

### **Before**

Broken viewport on card education animation — see MUSD-1200 / #rive-support thread (screenshot in ticket).

### **After**

N/A — pending on-device verification; will be attached before marking ready for review.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.