### PR TITLE
chore: bump react-native-nitro-modules from 0.35.5 to 0.35.10

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -634,7 +634,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroModules (0.35.5):
+  - NitroModules (0.35.10):
     - boost
     - DoubleConversion
     - fast_float
@@ -5151,7 +5151,7 @@ SPEC CHECKSUMS:
   NativeUtils: 1856148c08a042bbbca306acbe2771db8a9be99b
   NitroFetch: 232232e9d216dc35be48f6478cf9f6cebd077916
   NitroFetchWebsockets: 8ce4909248acd869f7002be2c9b1eefcbb60544a
-  NitroModules: ea5dc6c43666f4a75e71e372eaca6d3605856e51
+  NitroModules: b5c5baefa71a65c40e129876a8b7943a9aef6aa5
   NitroTextDecoder: 9b50be860ed7488349bc31791b6fe96778a43db0
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/package.json
+++ b/package.json
@@ -526,7 +526,7 @@
     "react-native-mmkv": "^3.2.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-nitro-fetch": "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.10",
     "react-native-nitro-text-decoder": "^0.2.0",
     "react-native-nitro-websockets": "^1.0.3",
     "react-native-os": "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36253,7 +36253,7 @@ __metadata:
     react-native-mmkv: "npm:^3.2.0"
     react-native-modal: "npm:^14.0.0-rc.1"
     react-native-nitro-fetch: "patch:react-native-nitro-fetch@npm%3A1.3.3#~/.yarn/patches/react-native-nitro-fetch-npm-1.3.3-b43385194a.patch"
-    react-native-nitro-modules: "npm:0.35.5"
+    react-native-nitro-modules: "npm:0.35.10"
     react-native-nitro-text-decoder: "npm:^0.2.0"
     react-native-nitro-websockets: "npm:^1.0.3"
     react-native-os: "patch:react-native-os@npm%3A1.2.6#~/.yarn/patches/react-native-os-npm-1.2.6-65c52ed3dc.patch"
@@ -40732,13 +40732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-nitro-modules@npm:0.35.5":
-  version: 0.35.5
-  resolution: "react-native-nitro-modules@npm:0.35.5"
+"react-native-nitro-modules@npm:0.35.10":
+  version: 0.35.10
+  resolution: "react-native-nitro-modules@npm:0.35.10"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/4fec58f90b9a69b33d935c5e733e162b67eb91662421a50e76a854c61140c7c1c5fc9e4fab498bf538420e1e9a43bb867aa411653b442541fdf52f0a5b14d22d
+  checksum: 10/b0600cea67c37ca10e47d3f80ad9fef5c24451a5b5e7a2f92ca81e0e51279323371f8bd42a3ce82e6bf1c5fffe53409644ee5c49fe6ccab09e41977ce8e28884
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `react-native-nitro-modules` from `0.35.5` to `0.35.10` (exact pin kept), the latest release of the 0.35.x line.

**Why:**

1. **Prerequisite for the Rive Nitro migration.** `@rive-app/react-native` (the new Nitro-based Rive runtime we are migrating to, replacing `rive-react-native`) peers on `react-native-nitro-modules >=0.35.10 <0.36`. Landing the core bump in isolation lets the upcoming Rive migration PR stay focused on the API port, and gives this infra change its own soak/revert unit.
2. **Pure bug-fix line.** 0.35.6 → 0.35.10 contains no API changes: fixes for Swift Promise races, ThreadPool mutex, ByteBuffer cursor handling, Kotlin `dispose` reset, and codegen for nested arrays. 0.35.10 additionally hardens thread-safety (it is the reason the Rive package raised its peer floor to this version).

**Compatibility (verified against npm peer metadata):**

| Consumer | Peer range | 0.35.10 |
| --- | --- | --- |
| react-native-nitro-fetch 1.3.3 | `^0.35.2` | OK |
| react-native-nitro-websockets | `*` | OK |
| react-native-nitro-text-decoder 0.2.x | `^0.35.2` | OK |
| rive (current 9.8.5) | no nitro dep | N/A |

Diff is deps-only: `package.json`, `yarn.lock`, `ios/Podfile.lock` (NitroModules pod 0.35.5 → 0.35.10). No code changes.

**Local verification:** `yarn lint:tsc` clean; nitro consumer suites (`NitroFetchSetup`, `NitroFetchDependency`, `NitroWebSocketSetup`) — 3 suites / 76 tests passing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/rive-app/rive-nitro-react-native

## **Manual testing steps**

```gherkin
Feature: Nitro-modules core runtime bump

  Scenario: user performs network requests over Nitro Fetch
    Given the app is built with react-native-nitro-modules 0.35.10
    When the user browses the app (token balances, dapp connections, price data)
    Then all network requests resolve as before with no crashes or hangs

  Scenario: user uses WebSocket-backed features
    Given the app is running a build of this branch
    When live price updates / WS-backed features are active
    Then wss:// connections behave as before (dev-scheme routing unchanged)
```

## **Screenshots/Recordings**

### **Before**

N/A — dependency-only bump, no UI changes.

### **After**

N/A — dependency-only bump, no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.