### PR TITLE
fix(social-leaderboard): apply pressed state to entire Weekly Top Traders card

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -294,7 +294,7 @@ describe('TopTradersSection', () => {
   it('navigates to the trader profile with correct params when a card is tapped', () => {
     renderWithProvider(<TopTradersSection {...defaultProps} />);
 
-    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    fireEvent.press(screen.getByTestId('top-trader-card-trader-1'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.SOCIAL_LEADERBOARD.PROFILE,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import { screen, fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TopTraderCard from './TopTraderCard';
@@ -194,8 +194,8 @@ describe('TopTraderCard', () => {
     }
     const styleFn = node?.props.style as (state: {
       pressed: boolean;
-    }) => unknown;
-    return StyleSheet.flatten(styleFn({ pressed }))?.backgroundColor;
+    }) => StyleProp<ViewStyle>;
+    return StyleSheet.flatten(styleFn({ pressed })).backgroundColor;
   };
 
   it('applies a pressed background to the whole card when pressed', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -185,9 +185,10 @@ describe('TopTraderCard', () => {
   // host View, so climb to the Pressable that owns the style *function* and
   // invoke it for each state to compare the resolved backgroundColor.
   const cardBackgroundColor = (pressed: boolean) => {
-    let node = screen.getByTestId('top-trader-card-trader-1') as
-      | { props: { style?: unknown }; parent: unknown }
-      | null;
+    let node = screen.getByTestId('top-trader-card-trader-1') as {
+      props: { style?: unknown };
+      parent: unknown;
+    } | null;
     while (node && typeof node.props?.style !== 'function') {
       node = node.parent as typeof node;
     }

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { screen, fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TopTraderCard from './TopTraderCard';
@@ -116,7 +117,7 @@ describe('TopTraderCard', () => {
       />,
     );
 
-    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    fireEvent.press(screen.getByTestId('top-trader-card-trader-1'));
 
     expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'alpha.eth', 1);
   });
@@ -149,7 +150,7 @@ describe('TopTraderCard', () => {
       />,
     );
 
-    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    fireEvent.press(screen.getByTestId('top-trader-card-trader-1'));
 
     expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'alpha.eth', 50);
   });
@@ -159,7 +160,7 @@ describe('TopTraderCard', () => {
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
 
-    fireEvent.press(screen.getByTestId('top-trader-card-pressable-trader-1'));
+    fireEvent.press(screen.getByTestId('top-trader-card-trader-1'));
 
     expect(mockOnTraderPress).not.toHaveBeenCalled();
   });
@@ -177,6 +178,43 @@ describe('TopTraderCard', () => {
 
     expect(mockOnFollowPress).toHaveBeenCalledWith('trader-1');
     expect(mockOnTraderPress).not.toHaveBeenCalled();
+  });
+
+  // The whole card is a single Pressable whose `style` render-prop swaps the
+  // background between pressed / not-pressed. getByTestId returns the resolved
+  // host View, so climb to the Pressable that owns the style *function* and
+  // invoke it for each state to compare the resolved backgroundColor.
+  const cardBackgroundColor = (pressed: boolean) => {
+    let node = screen.getByTestId('top-trader-card-trader-1') as
+      | { props: { style?: unknown }; parent: unknown }
+      | null;
+    while (node && typeof node.props?.style !== 'function') {
+      node = node.parent as typeof node;
+    }
+    const styleFn = node?.props.style as (state: {
+      pressed: boolean;
+    }) => unknown;
+    return StyleSheet.flatten(styleFn({ pressed }))?.backgroundColor;
+  };
+
+  it('applies a pressed background to the whole card when pressed', () => {
+    renderWithProvider(
+      <TopTraderCard
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+
+    expect(cardBackgroundColor(true)).not.toBe(cardBackgroundColor(false));
+  });
+
+  it('does not apply the pressed background when the card is not interactive', () => {
+    renderWithProvider(
+      <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+
+    expect(cardBackgroundColor(true)).toBe(cardBackgroundColor(false));
   });
 
   it('displays negative PnL values with correct sign', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -12,7 +12,7 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -61,60 +61,60 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
   const isPnlPositive = trader.pnlValue >= 0;
 
   return (
-    <Box
-      twClassName={`relative w-[${TOP_TRADER_CARD_WIDTH}px] rounded-xl bg-muted overflow-hidden`}
+    <Pressable
+      onPress={
+        onTraderPress
+          ? () => onTraderPress(trader.id, trader.username, trader.overallRank)
+          : undefined
+      }
+      disabled={!onTraderPress}
+      accessibilityRole={onTraderPress ? 'button' : undefined}
       testID={testID ?? `top-trader-card-${trader.id}`}
+      style={({ pressed }) =>
+        tw.style(
+          `relative w-[${TOP_TRADER_CARD_WIDTH}px] rounded-xl overflow-hidden`,
+          pressed && onTraderPress ? 'bg-muted-pressed' : 'bg-muted',
+        )
+      }
     >
-      <TouchableOpacity
-        activeOpacity={onTraderPress ? 0.7 : 1}
-        onPress={
-          onTraderPress
-            ? () =>
-                onTraderPress(trader.id, trader.username, trader.overallRank)
-            : undefined
-        }
-        disabled={!onTraderPress}
-        testID={`top-trader-card-pressable-${trader.id}`}
-      >
-        <Box twClassName="gap-4 p-4">
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="gap-2"
-          >
-            <TraderAvatar
-              imageUrl={trader.avatarUri}
-              address={trader.address}
-              size={AVATAR_SIZE}
-              testID={`top-trader-avatar-${trader.id}`}
-            />
+      <Box twClassName="gap-4 p-4">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-2"
+        >
+          <TraderAvatar
+            imageUrl={trader.avatarUri}
+            address={trader.address}
+            size={AVATAR_SIZE}
+            testID={`top-trader-avatar-${trader.id}`}
+          />
 
-            <Box twClassName="flex-1 min-w-0">
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {trader.username}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                numberOfLines={1}
-                twClassName={
-                  isPnlPositive ? 'text-success-default' : 'text-error-default'
-                }
-              >
-                {pnlText}
-              </Text>
-            </Box>
+          <Box twClassName="flex-1 min-w-0">
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {trader.username}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              numberOfLines={1}
+              twClassName={
+                isPnlPositive ? 'text-success-default' : 'text-error-default'
+              }
+            >
+              {pnlText}
+            </Text>
           </Box>
-
-          <Box style={{ height: FOLLOW_BUTTON_HEIGHT }} />
         </Box>
-      </TouchableOpacity>
+
+        <Box style={{ height: FOLLOW_BUTTON_HEIGHT }} />
+      </Box>
 
       <View
         pointerEvents="box-none"
@@ -133,7 +133,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
             : strings('social_leaderboard.follow')}
         </Button>
       </View>
-    </Box>
+    </Pressable>
   );
 };
 


### PR DESCRIPTION
## **Description**

On the Homepage **Weekly Top Traders** carousel, pressing a card previously only dimmed the inner content (avatar, username, PnL) via an inner `TouchableOpacity`, while the card's `bg-muted` background stayed static — so the press feedback felt partial.

This converts the card into a **single `Pressable`** that owns both the tap handler and the background, swapping `bg-muted → bg-muted-pressed` across the **entire** card on press (matching the existing `HomepageActionButton` convention). The Follow/Following button stays an independent overlay child, so tapping it still never triggers the card press.

Scoped entirely to the top-traders / follow-trading feature (`TopTraderCard`).

## **Changelog**

CHANGELOG entry: Fixed the Weekly Top Traders cards so the whole card shows a pressed state when tapped, not just the avatar and name.

## **Related issues**

Refs: N/A (internal follow-trading polish backlog)

## **Manual testing steps**

```gherkin
Feature: Weekly Top Traders card press feedback

  Scenario: user presses a trader card
    Given I am on the Homepage with the Weekly Top Traders carousel visible
    When I press and hold anywhere on a trader card
    Then the entire card background dims to the pressed state
    And releasing over the card navigates to that trader's profile

  Scenario: user presses the Follow button
    Given I am on the Homepage with the Weekly Top Traders carousel visible
    When I press the Follow / Following button on a card
    Then only the follow action fires
    And the card does not navigate to the trader profile
```

## **Screenshots/Recordings**

### **Before**

<img width="477" height="1011" alt="image" src="https://github.com/user-attachments/assets/e8a800b3-05ba-4d34-a100-3e4f93510c80" />

### **After**

<img width="414" height="864" alt="image" src="https://github.com/user-attachments/assets/8319ad30-57e2-4bfc-9d97-8a83ae08f123" />

N/A — visual-only change verified via unit tests (resolved pressed vs unpressed `backgroundColor` differ); on-device capture deferred to review.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interaction polish in the Top Traders carousel with no auth, data, or API changes; behavior covered by updated unit tests.
> 
> **Overview**
> **Weekly Top Traders** cards now use one outer `Pressable` instead of an inner `TouchableOpacity`, so press feedback applies to the **full card** background (`bg-muted` → `bg-muted-pressed`) when `onTraderPress` is set, aligned with `HomepageActionButton`. Navigation and follow behavior are unchanged: the Follow button stays an overlay and does not trigger profile navigation.
> 
> Tests target the consolidated `top-trader-card-{id}` testID and assert pressed vs unpressed background when the card is interactive vs non-interactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4d75dd86dab2ded4496146a198b4598b5d9655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->