### PR TITLE
feat(social-leaderboard): extend open-position chart range to now and add a reset-zoom button

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -675,6 +675,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
               timeMs,
               ...(options?.spanMs != null ? { spanMs: options.spanMs } : {}),
               ...(options?.animate != null ? { animate: options.animate } : {}),
+              ...(options?.force != null ? { force: options.force } : {}),
             },
           });
         },

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -849,7 +849,7 @@ export interface AdvancedChartRef {
    */
   focusTime: (
     timeMs: number,
-    options?: { spanMs?: number; animate?: boolean },
+    options?: { spanMs?: number; animate?: boolean; force?: boolean },
   ) => void;
   /**
    * Briefly pulse the trade marker with this `id` (matches {@link TradeMarker.id})

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -4597,8 +4597,10 @@ function handleFocusTime(payload) {
         return;
     const centerSec = payload.timeMs / 1000;
     const current = readVisibleRangeSec(chart);
-    // Already comfortably visible → don't move (caller pulses separately).
-    if (current) {
+    // Already comfortably visible → don't move (caller pulses separately). The
+    // reset-to-fit button passes \`force\` to skip this: it must restore the
+    // default range even when its center is currently on screen.
+    if (current && !payload.force) {
         const inset = (current.to - current.from) * VISIBLE_INSET;
         if (centerSec >= current.from + inset && centerSec <= current.to - inset) {
             return;

--- a/app/components/UI/Charts/AdvancedChart/webview/src/messages/contract.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/messages/contract.ts
@@ -176,6 +176,12 @@ export interface FocusTimePayload {
   spanMs?: number;
   /** false disables the slide animation (jump instead). Default true. */
   animate?: boolean;
+  /**
+   * Skip the "already comfortably visible → don't move" guard and always
+   * re-frame. Used by the reset-to-fit button, which must restore the default
+   * range even when its center is currently on screen (e.g. after zooming in).
+   */
+  force?: boolean;
 }
 
 // ----- Position Lines (Perps) ------------------------------------------------

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/focusTime/__tests__/focusTime.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/focusTime/__tests__/focusTime.test.ts
@@ -86,6 +86,22 @@ describe('handleFocusTime', () => {
     expect(stub.setRangeCalls).toHaveLength(0);
   });
 
+  it('re-frames even when comfortably visible if force is set', () => {
+    // Target 5 sits inside the "comfortably visible" band [0.8, 9.2], which
+    // normally returns without moving — but the reset button's `force` flag
+    // must bypass that guard and re-apply the (default) range.
+    const stub = makeStubChart({ from: 0, to: 10 });
+    installWidget(stub.chart);
+    handleFocusTime({
+      timeMs: 5_000,
+      spanMs: 4_000,
+      animate: false,
+      force: true,
+    });
+    // spanSec = 4, center = 5 → from = 3, to = 7.
+    expect(stub.setRangeCalls).toEqual([{ from: 3, to: 7 }]);
+  });
+
   it('jumps immediately when animate=false', () => {
     const stub = makeStubChart({ from: 0, to: 10 });
     installWidget(stub.chart);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/focusTime/index.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/focusTime/index.ts
@@ -82,8 +82,10 @@ export function handleFocusTime(payload: FocusTimePayload): void {
   const centerSec = payload.timeMs / 1000;
   const current = readVisibleRangeSec(chart);
 
-  // Already comfortably visible → don't move (caller pulses separately).
-  if (current) {
+  // Already comfortably visible → don't move (caller pulses separately). The
+  // reset-to-fit button passes `force` to skip this: it must restore the
+  // default range even when its center is currently on screen.
+  if (current && !payload.force) {
     const inset = (current.to - current.from) * VISIBLE_INSET;
     if (centerSec >= current.from + inset && centerSec <= current.to - inset) {
       return;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.testIds.ts
@@ -15,6 +15,7 @@ export const TraderPositionViewSelectorsIDs = {
   COPY_TOKEN_ADDRESS_BUTTON: 'trader-position-view-copy-token-address-button',
   TOKEN_INFO_ROW: 'trader-position-view-token-info-row',
   PINNED_CHART_OVERLAY: 'trader-position-view-pinned-chart-overlay',
+  CHART_FIT_BUTTON: 'trader-position-view-chart-fit-button',
   STICKY_DAY_HEADER: 'trader-position-view-sticky-day-header',
   SKELETON: 'trader-position-skeleton',
   FALLBACK: 'trader-position-fallback',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -330,6 +330,15 @@ const TraderPositionView = () => {
     // Legacy (perp) chart scrub: price readout not wired for the SVG chart.
   }, []);
 
+  // Tapping the pill-row "fit" button resets the chart zoom/pan to its default
+  // fit range. Bumping the nonce is picked up by TraderAdvancedChart, which
+  // re-frames the viewport imperatively (the same default framing computed on
+  // first render — wrapping the trades, extended to now for open positions).
+  const [resetRangeNonce, setResetRangeNonce] = useState(0);
+  const handleResetChartRange = useCallback(() => {
+    setResetRangeNonce((nonce) => nonce + 1);
+  }, []);
+
   // Crosshair % change reported by the spot AdvancedChart while scrubbing.
   // Overrides the header percent until the crosshair leaves the chart.
   const [scrubPercent, setScrubPercent] = useState<number | null>(null);
@@ -749,6 +758,8 @@ const TraderPositionView = () => {
                   isPerp={isPerp}
                   activeTimePeriod={activeTimePeriod}
                   shouldAutoRequestTimePeriod={isTimePeriodAutoSelected}
+                  isClosed={isClosed}
+                  resetRangeNonce={resetRangeNonce}
                   onScrubPercentChange={setScrubPercent}
                   focusRequest={focusRequest}
                   onRequestTimePeriod={handleRequestFocusTimePeriod}
@@ -760,6 +771,12 @@ const TraderPositionView = () => {
                   timePeriods={timePeriods}
                   activeTimePeriod={activeTimePeriod}
                   onSelectPeriod={setActiveTimePeriod}
+                  onResetRange={
+                    chartAssetId || isPerp ? handleResetChartRange : undefined
+                  }
+                  resetRangeTestID={
+                    TraderPositionViewSelectorsIDs.CHART_FIT_BUTTON
+                  }
                 />
               </View>
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.test.tsx
@@ -301,7 +301,7 @@ describe('TraderAdvancedChart', () => {
     expect(lastCall.visibleToMs).toBe(bars[bars.length - 1].time);
   });
 
-  it('frames the first→last loaded trade with padding instead of a fixed period-wide window', () => {
+  it('frames the first→last loaded trade with padding for a CLOSED position (not a fixed period-wide window)', () => {
     const bars = makeDailyBars(12);
     setOHLCV(bars);
 
@@ -330,6 +330,7 @@ describe('TraderAdvancedChart', () => {
       <TraderAdvancedChart
         {...defaultProps}
         activeTimePeriod="1W"
+        isClosed
         trades={trades}
       />,
     );
@@ -339,11 +340,60 @@ describe('TraderAdvancedChart', () => {
       visibleToMs: number;
     };
     // Window is sized to the trades + padding (not the full 1W `durationMs`),
-    // so a short position fills the screen without a blank gap.
+    // so a short closed position fills the screen without a blank gap. A closed
+    // position wraps to its final trade, so the right edge stays at `maxT + pad`.
     const span = lastTradeTime - firstTradeTime;
     const pad = Math.max(span, 7 * DAY_MS * 0.5) * 0.2;
     expect(lastCall.visibleFromMs).toBe(firstTradeTime - pad);
     expect(lastCall.visibleToMs).toBe(lastTradeTime + pad);
+  });
+
+  it('extends the visible range to the latest candle (now) for an OPEN position', () => {
+    const bars = makeDailyBars(12);
+    setOHLCV(bars);
+
+    const firstTradeTime = bars[2].time;
+    const lastTradeTime = bars[5].time;
+    const trades: Trade[] = [
+      {
+        intent: 'enter',
+        direction: 'buy',
+        tokenAmount: 1,
+        usdCost: 100,
+        timestamp: firstTradeTime / 1000,
+        transactionHash: '0xbuy',
+      },
+      {
+        intent: 'exit',
+        direction: 'sell',
+        tokenAmount: 1,
+        usdCost: 110,
+        timestamp: lastTradeTime / 1000,
+        transactionHash: '0xsell',
+      },
+    ];
+
+    render(
+      <TraderAdvancedChart
+        {...defaultProps}
+        activeTimePeriod="1W"
+        isClosed={false}
+        trades={trades}
+      />,
+    );
+
+    const lastCall = mockAdvancedChart.mock.calls.at(-1)?.[0] as {
+      visibleFromMs: number;
+      visibleToMs: number;
+    };
+    // The left edge still frames the first trade (unchanged)...
+    const span = lastTradeTime - firstTradeTime;
+    const pad = Math.max(span, 7 * DAY_MS * 0.5) * 0.2;
+    expect(lastCall.visibleFromMs).toBe(firstTradeTime - pad);
+    // ...but the right edge extends to the latest loaded candle ("now") instead
+    // of stopping at `lastTradeTime + pad`, so the still-live price stays visible.
+    expect(lastCall.visibleToMs).toBe(bars[bars.length - 1].time);
+    expect(lastCall.visibleToMs).not.toBe(lastTradeTime + pad);
   });
 
   it('clamps the viewport to the oldest loaded candle when no older history can be paginated (no blank gap)', () => {
@@ -489,6 +539,68 @@ describe('TraderAdvancedChart', () => {
     );
     expect(mockFocusTime).toHaveBeenCalledTimes(2);
     expect(mockPulseTradeMarker).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-frames the viewport to the default fit range when resetRangeNonce changes', () => {
+    const bars = makeDailyBars(12);
+    setOHLCV(bars);
+
+    const firstTradeTime = bars[2].time;
+    const lastTradeTime = bars[5].time;
+    const trades: Trade[] = [
+      {
+        intent: 'enter',
+        direction: 'buy',
+        tokenAmount: 1,
+        usdCost: 100,
+        timestamp: firstTradeTime / 1000,
+        transactionHash: '0xbuy',
+      },
+      {
+        intent: 'exit',
+        direction: 'sell',
+        tokenAmount: 1,
+        usdCost: 110,
+        timestamp: lastTradeTime / 1000,
+        transactionHash: '0xsell',
+      },
+    ];
+
+    const { rerender } = render(
+      <TraderAdvancedChart
+        {...defaultProps}
+        activeTimePeriod="1W"
+        trades={trades}
+        resetRangeNonce={0}
+      />,
+    );
+    // Mounting at nonce 0 must not fire a reset.
+    expect(mockFocusTime).not.toHaveBeenCalled();
+
+    // The default fit range for this OPEN position: left edge frames the first
+    // trade, right edge extends to the latest candle (now).
+    const span = lastTradeTime - firstTradeTime;
+    const pad = Math.max(span, 7 * DAY_MS * 0.5) * 0.2;
+    const visibleFromMs = firstTradeTime - pad;
+    const visibleToMs = bars[bars.length - 1].time;
+    const spanMs = visibleToMs - visibleFromMs;
+    const center = (visibleFromMs + visibleToMs) / 2;
+
+    rerender(
+      <TraderAdvancedChart
+        {...defaultProps}
+        activeTimePeriod="1W"
+        trades={trades}
+        resetRangeNonce={1}
+      />,
+    );
+
+    // Bumping the nonce focuses the fit range's midpoint at its full span,
+    // reproducing [visibleFromMs, visibleToMs].
+    expect(mockFocusTime).toHaveBeenCalledWith(center, {
+      spanMs,
+      animate: true,
+    });
   });
 
   it('still focuses a pending trade after the active period changes (not pinned to the tap-time period)', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.test.tsx
@@ -596,10 +596,12 @@ describe('TraderAdvancedChart', () => {
     );
 
     // Bumping the nonce focuses the fit range's midpoint at its full span,
-    // reproducing [visibleFromMs, visibleToMs].
+    // reproducing [visibleFromMs, visibleToMs]. `force` bypasses the
+    // "already visible → don't move" guard so a reset always re-frames.
     expect(mockFocusTime).toHaveBeenCalledWith(center, {
       spanMs,
       animate: true,
+      force: true,
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.tsx
@@ -656,9 +656,13 @@ const TraderAdvancedChart = ({
     const spanMs = visibleToMs - visibleFromMs;
     if (!(spanMs > 0)) return;
 
+    // `force` bypasses focusTime's "already visible → don't move" guard so the
+    // reset always re-frames to the full default range, even when the range's
+    // center is currently on screen (e.g. after zooming into the middle).
     chartRef.current?.focusTime((visibleFromMs + visibleToMs) / 2, {
       spanMs,
       animate: true,
+      force: true,
     });
   }, [resetRangeNonce, shouldFallback, visibleFromMs, visibleToMs]);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderAdvancedChart.tsx
@@ -206,6 +206,19 @@ export interface TraderAdvancedChartProps {
   activeTimePeriod: TimePeriod;
   /** Allow automatic period widening when the current interval lacks trade-date candles. */
   shouldAutoRequestTimePeriod?: boolean;
+  /**
+   * Whether the position is closed. Closed positions frame the first→last trade
+   * (the final trade is the meaningful right edge); open positions extend the
+   * initial viewport's right edge to the latest candle ("now") so the still-live
+   * price action stays on screen. Defaults to `false` (open).
+   */
+  isClosed?: boolean;
+  /**
+   * Increment to reset the chart zoom/pan back to its default fit range. Each
+   * change re-frames the viewport to `[visibleFromMs, visibleToMs]` via the
+   * imperative focus. Left unset (or `0`) it never fires.
+   */
+  resetRangeNonce?: number;
   /** Trades to render as open/close circles. */
   trades: readonly Trade[];
   /** When set, the chart slides to center this trade's time (see {@link TradeFocusRequest}). */
@@ -249,6 +262,8 @@ const TraderAdvancedChart = ({
   isPerp = false,
   activeTimePeriod,
   shouldAutoRequestTimePeriod = false,
+  isClosed = false,
+  resetRangeNonce,
   trades,
   focusRequest,
   onRequestTimePeriod,
@@ -264,6 +279,7 @@ const TraderAdvancedChart = ({
   const vsCurrency = CHART_VS_CURRENCY;
   const chartRef = useRef<AdvancedChartRef>(null);
   const handledFocusNonceRef = useRef<number | null>(null);
+  const handledResetNonceRef = useRef<number | undefined>(resetRangeNonce);
 
   const timeRange = SOCIAL_PERIOD_TO_TIME_RANGE[activeTimePeriod];
   const config = TIME_RANGE_CONFIGS[timeRange];
@@ -519,12 +535,18 @@ const TraderAdvancedChart = ({
     // candles can still be paginated in, so a position older than the first
     // page is still framed once the WebView datafeed pages it into view.
     const canPaginateOlder = !isPerp && Boolean(ohlcvPagination?.hasMore);
+    // Open positions are still live, so extend the right edge to the latest
+    // candle ("now") — framing only to `maxT + pad` would cut off the ongoing
+    // price action (the last trade can be weeks before the newest candle).
+    // Closed positions wrap to their final trade, so keep the trade-framed `to`.
+    // The final `Math.min(..., lastBarTime)` still never overshoots the data.
+    const effectiveTo = isClosed ? to : Math.max(to, lastBarTime);
     return {
       visibleFromMs:
         allTradeTimeRange && canPaginateOlder
           ? from
           : Math.max(from, firstBarTime),
-      visibleToMs: Math.min(to, lastBarTime),
+      visibleToMs: Math.min(effectiveTo, lastBarTime),
     };
   }, [
     lastBarTime,
@@ -533,6 +555,7 @@ const TraderAdvancedChart = ({
     framingMarkers,
     config.durationMs,
     isPerp,
+    isClosed,
     ohlcvPagination,
   ]);
 
@@ -617,6 +640,27 @@ const TraderAdvancedChart = ({
     onRequestTimePeriod,
     shouldFallback,
   ]);
+
+  // Reset-to-fit: when `resetRangeNonce` changes (the pill-row fit button was
+  // tapped) re-frame the viewport back to the default fit range. The declarative
+  // `visibleFromMs/To` props don't change after a user pan/zoom, so we drive the
+  // reset imperatively — focus the range's midpoint at its full span, which
+  // reproduces `[visibleFromMs, visibleToMs]` (open positions end at now). The
+  // nonce guard fires exactly once per tap.
+  useEffect(() => {
+    if (resetRangeNonce == null) return;
+    if (handledResetNonceRef.current === resetRangeNonce) return;
+    handledResetNonceRef.current = resetRangeNonce;
+
+    if (shouldFallback || visibleFromMs == null || visibleToMs == null) return;
+    const spanMs = visibleToMs - visibleFromMs;
+    if (!(spanMs > 0)) return;
+
+    chartRef.current?.focusTime((visibleFromMs + visibleToMs) / 2, {
+      spanMs,
+      animate: true,
+    });
+  }, [resetRangeNonce, shouldFallback, visibleFromMs, visibleToMs]);
 
   if (shouldFallback) {
     return (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderChartFitButton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderChartFitButton.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback } from 'react';
+import { Pressable } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+
+/** Spring the button scale settles back on with after a press (tactile feedback). */
+const PRESS_SPRING = { damping: 14, stiffness: 420, mass: 0.6 } as const;
+
+export interface TraderChartFitButtonProps {
+  /** Fired when tapped — resets the chart zoom/pan to its default fit range. */
+  onPress: () => void;
+  testID?: string;
+}
+
+/**
+ * Square "fit" button that sits at the right end of the timeframe pill row and
+ * resets the position chart's zoom/pan back to its default framing (wrap first→
+ * latest trade, and — for open positions — extend to now). The four-corner
+ * bracket (ScanFocus) icon reads as "fit to frame".
+ *
+ * Reanimated drives a spring on the button's scale for press feedback: pressing
+ * dips the scale, releasing springs it back via {@link withSpring}. The range
+ * reset itself is handed to the chart's imperative focus (TradingView's own
+ * viewport animation across the WebView bridge) — the spring here animates only
+ * the button, not the chart viewport.
+ */
+const TraderChartFitButton: React.FC<TraderChartFitButtonProps> = ({
+  onPress,
+  testID,
+}) => {
+  const tw = useTailwind();
+  const pressScale = useSharedValue(1);
+
+  const handlePressIn = useCallback(() => {
+    pressScale.value = withTiming(0.88, { duration: 90 });
+  }, [pressScale]);
+
+  const handlePressOut = useCallback(() => {
+    pressScale.value = withSpring(1, PRESS_SPRING);
+  }, [pressScale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pressScale.value }],
+  }));
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={strings(
+        'social_leaderboard.trader_position.reset_chart_zoom_accessibility_label',
+      )}
+      testID={testID}
+    >
+      <Animated.View
+        style={[
+          tw.style('h-8 w-8 items-center justify-center rounded'),
+          animatedStyle,
+        ]}
+      >
+        <Icon
+          name={IconName.ScanFocus}
+          size={IconSize.Sm}
+          color={IconColor.IconAlternative}
+        />
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+export default TraderChartFitButton;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.test.tsx
@@ -65,6 +65,21 @@ describe('TraderPositionChartSection', () => {
     expect(getByTestId('price-chart-mock')).toBeOnTheScreen();
   });
 
+  it('forwards isClosed and resetRangeNonce to the advanced chart', () => {
+    render(
+      <TraderPositionChartSection
+        {...defaultProps}
+        assetId="eip155:8453/erc20:0x1"
+        isClosed
+        resetRangeNonce={3}
+      />,
+    );
+
+    expect(mockAdvancedChart).toHaveBeenCalledWith(
+      expect.objectContaining({ isClosed: true, resetRangeNonce: 3 }),
+    );
+  });
+
   it('forwards scrollPassthrough to the advanced chart', () => {
     render(
       <TraderPositionChartSection

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.tsx
@@ -39,6 +39,15 @@ export interface TraderPositionChartSectionProps {
   activeTimePeriod: TimePeriod;
   /** Whether the selected period is still controlled by automatic trade framing. */
   shouldAutoRequestTimePeriod?: boolean;
+  /**
+   * Whether the position is closed. Open positions extend the advanced chart's
+   * initial viewport to the latest candle ("now"); closed positions frame the
+   * first→last trade. Only forwarded to the advanced chart (the legacy SVG
+   * fallback has no windowed viewport).
+   */
+  isClosed?: boolean;
+  /** Increment to reset the advanced chart's zoom/pan back to its default fit range. */
+  resetRangeNonce?: number;
   /** Crosshair % change while scrubbing the AdvancedChart. */
   onScrubPercentChange?: (percent: number | null) => void;
   /** When set, the AdvancedChart slides to center this trade. */
@@ -64,6 +73,8 @@ const TraderPositionChartSection: React.FC<TraderPositionChartSectionProps> = ({
   isPerp,
   activeTimePeriod,
   shouldAutoRequestTimePeriod,
+  isClosed,
+  resetRangeNonce,
   onScrubPercentChange,
   focusRequest,
   onRequestTimePeriod,
@@ -78,6 +89,8 @@ const TraderPositionChartSection: React.FC<TraderPositionChartSectionProps> = ({
           isPerp={isPerp}
           activeTimePeriod={activeTimePeriod}
           shouldAutoRequestTimePeriod={shouldAutoRequestTimePeriod}
+          isClosed={isClosed}
+          resetRangeNonce={resetRangeNonce}
           trades={trades}
           focusRequest={focusRequest}
           onRequestTimePeriod={onRequestTimePeriod}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTimePeriodSelector.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTimePeriodSelector.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import TraderTimePeriodSelector from './TraderTimePeriodSelector';
+import type { TimePeriod } from '../useTraderPositionData';
+
+const TIME_PERIODS: readonly TimePeriod[] = ['1H', '1D', '1W', '1M', 'All'];
+const FIT_TEST_ID = 'chart-fit-button';
+
+describe('TraderTimePeriodSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders a button for every time period', () => {
+    renderWithProvider(
+      <TraderTimePeriodSelector
+        timePeriods={TIME_PERIODS}
+        activeTimePeriod="1D"
+        onSelectPeriod={jest.fn()}
+      />,
+    );
+
+    TIME_PERIODS.forEach((period) => {
+      expect(screen.getByText(period)).toBeOnTheScreen();
+    });
+  });
+
+  it('invokes onSelectPeriod with the tapped period', () => {
+    const onSelectPeriod = jest.fn();
+    renderWithProvider(
+      <TraderTimePeriodSelector
+        timePeriods={TIME_PERIODS}
+        activeTimePeriod="1D"
+        onSelectPeriod={onSelectPeriod}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('1W'));
+
+    expect(onSelectPeriod).toHaveBeenCalledWith('1W');
+  });
+
+  it('renders the fit button at the end of the pill row and fires onResetRange when tapped', () => {
+    const onResetRange = jest.fn();
+    renderWithProvider(
+      <TraderTimePeriodSelector
+        timePeriods={TIME_PERIODS}
+        activeTimePeriod="1D"
+        onSelectPeriod={jest.fn()}
+        onResetRange={onResetRange}
+        resetRangeTestID={FIT_TEST_ID}
+      />,
+    );
+
+    const fitButton = screen.getByTestId(FIT_TEST_ID);
+    expect(fitButton).toBeOnTheScreen();
+
+    fireEvent.press(fitButton);
+
+    expect(onResetRange).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the fit button when onResetRange is not provided', () => {
+    renderWithProvider(
+      <TraderTimePeriodSelector
+        timePeriods={TIME_PERIODS}
+        activeTimePeriod="1D"
+        onSelectPeriod={jest.fn()}
+        resetRangeTestID={FIT_TEST_ID}
+      />,
+    );
+
+    expect(screen.queryByTestId(FIT_TEST_ID)).toBeNull();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTimePeriodSelector.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTimePeriodSelector.tsx
@@ -7,17 +7,28 @@ import {
 } from '@metamask/design-system-react-native';
 import type { TimePeriod } from '../useTraderPositionData';
 import TimePeriodButton from './TimePeriodButton';
+import TraderChartFitButton from './TraderChartFitButton';
 
 export interface TraderTimePeriodSelectorProps {
   timePeriods: readonly TimePeriod[];
   activeTimePeriod: TimePeriod;
   onSelectPeriod: (period: TimePeriod) => void;
+  /**
+   * Fired when the trailing "fit" button is tapped — resets the chart zoom/pan
+   * to its default fit range. Omit to hide the button (e.g. the legacy chart,
+   * which has no zoomable viewport to reset).
+   */
+  onResetRange?: () => void;
+  /** testID for the trailing fit button. */
+  resetRangeTestID?: string;
 }
 
 const TraderTimePeriodSelector: React.FC<TraderTimePeriodSelectorProps> = ({
   timePeriods,
   activeTimePeriod,
   onSelectPeriod,
+  onResetRange,
+  resetRangeTestID,
 }) => (
   <Box
     flexDirection={BoxFlexDirection.Row}
@@ -33,6 +44,9 @@ const TraderTimePeriodSelector: React.FC<TraderTimePeriodSelectorProps> = ({
         onPress={() => onSelectPeriod(period)}
       />
     ))}
+    {onResetRange ? (
+      <TraderChartFitButton onPress={onResetRange} testID={resetRangeTestID} />
+    ) : null}
   </Box>
 );
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1240,7 +1240,8 @@
       "long": "Long",
       "short": "Short",
       "opened": "Opened",
-      "closed_action": "Closed"
+      "closed_action": "Closed",
+      "reset_chart_zoom_accessibility_label": "Reset chart zoom"
     },
     "quick_buy": {
       "title": "Buy {{symbol}}",


### PR DESCRIPTION
## **Description**

Two related chart-framing improvements on the trader position chart:

1. **Open-position range to "now".** The chart's default viewport wraps the first→latest trade (correct for closed positions). For **open** positions it now also extends the right edge to the latest candle ("now"), so the still-live price action stays on screen — which is the decision-relevant part when deciding whether to follow. Closed positions are byte-for-byte unchanged (gated on `isClosed`).

2. **Reset-zoom / fit button.** A small square fit button (four-corner-bracket `ScanFocus` icon) sits at the right end of the timeframe pill row (`1H · 1D · 1W · 1M · All · ⟦fit⟧`). Tapping it re-frames the chart back to that default fit range.

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: Open-position charts now include the current time in the default range, and a fit/reset-zoom button was added to the chart.

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: Open-position chart range and reset-zoom

  Scenario: open position chart includes now
    Given I am viewing a trader's OPEN perps position
    Then the chart's default range extends to the current time

  Scenario: user resets the zoom
    Given I have panned or zoomed the position chart
    When I tap the fit button at the end of the timeframe row
    Then the chart re-frames back to its default fit range
    And the button gives a spring press animation
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified via unit tests; on-device capture deferred to review.

## **Reviewer notes**

**What the spring animates:** a true spring-driven *range* transition across the TradingView WebView bridge isn't cleanly feasible (the viewport lives in the WebView; a JS-thread reanimated value can't drive it per-frame). Per the fallback guidance, the spring (`withSpring`) animates the **button scale** for press feedback; the **range reset is imperative** via the chart's `focusTime` (TradingView's own native viewport animation), nonce-guarded to fire once per tap.

**Reset reliability fix:** `focusTime` has an "already comfortably visible → don't move" guard, which made the reset a no-op when the default-range center was on screen (e.g. after zooming into the middle) — i.e. the button appeared to do nothing. Added a `force` flag to the `FOCUS_TIME` webview message that bypasses that guard; the reset passes it so it always re-frames to the default fit range. The auto-generated `chartLogicString.ts` bundle was regenerated for this. If the advanced chart internally falls back to the legacy SVG chart (insufficient OHLCV), the button still renders but the reset harmlessly no-ops.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)